### PR TITLE
GH-37364: [C++][GPU] Add CUDA impl of Device Event/Stream

### DIFF
--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1173,7 +1173,9 @@ class MyDevice : public Device {
 
     virtual ~MySyncEvent() = default;
     Status Wait() override { return Status::OK(); }
-    Status Record(const Device::Stream&) override { return Status::OK(); }
+    Status Record(const Device::Stream&, const unsigned int) override {
+      return Status::OK();
+    }
   };
 
  protected:

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -117,6 +117,9 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     /// event is completed without blocking the CPU.
     virtual Status WaitEvent(const SyncEvent&) = 0;
 
+    /// \brief Blocks until a stream's remaining tasks are completed
+    virtual Status Synchronize() const = 0;
+
    protected:
     Stream() = default;
     virtual ~Stream() = default;

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -109,7 +110,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// should be trivially constructible from it's device-specific counterparts.
   class ARROW_EXPORT Stream {
    public:
-    using release_fn_t = void (*)(void*);
+    using release_fn_t = std::function<void(void*)>;
 
     virtual ~Stream() = default;
 
@@ -156,7 +157,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// \brief EXPERIMENTAL: An object that provides event/stream sync primitives
   class ARROW_EXPORT SyncEvent {
    public:
-    using release_fn_t = void (*)(void*);
+    using release_fn_t = std::function<void(void*)>;
 
     virtual ~SyncEvent() = default;
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -131,7 +131,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     std::unique_ptr<void, release_fn_t> stream_;
   };
 
-  virtual Result<std::shared_ptr<Stream>> MakeStream() { return nullptr; }
+  virtual Result<std::shared_ptr<Stream>> MakeStream() { return NULLPTR; }
 
   /// \brief Create a new device stream
   ///
@@ -139,7 +139,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// derived from Device::Stream to allow for stream ordered events
   /// and memory allocations.
   virtual Result<std::shared_ptr<Stream>> MakeStream(unsigned int flags) {
-    return nullptr;
+    return NULLPTR;
   };
 
   /// @brief Wrap an existing device stream alongside a release function
@@ -150,7 +150,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   ///        externally
   virtual Result<std::shared_ptr<Stream>> WrapStream(void* device_stream,
                                                      Stream::release_fn_t release_fn) {
-    return nullptr;
+    return NULLPTR;
   }
 
   /// \brief EXPERIMENTAL: An object that provides event/stream sync primitives

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -140,7 +140,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// and memory allocations.
   virtual Result<std::shared_ptr<Stream>> MakeStream(unsigned int flags) {
     return NULLPTR;
-  };
+  }
 
   /// @brief Wrap an existing device stream alongside a release function
   ///
@@ -258,7 +258,7 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
 
   /// \brief Wrap an event into a SyncEvent.
   ///
-  /// @param sync_event passed in sync_event (should be a CUevent*)
+  /// @param sync_event passed in sync_event (should be a pointer to the appropriate type)
   /// @param release_sync_event destructor to free sync_event. `nullptr` may be
   ///        passed to indicate that no destruction/freeing is necessary
   virtual Result<std::shared_ptr<Device::SyncEvent>> WrapDeviceSyncEvent(

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -338,7 +338,7 @@ Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSyncEven
   CUevent ev;
   CU_RETURN_NOT_OK("cuEventCreate", cuEventCreate(&ev, CU_EVENT_DEFAULT));
 
-  return std::make_shared<CudaDevice::SyncEvent>(new CUevent(ev), [](void* ev) {    
+  return std::make_shared<CudaDevice::SyncEvent>(new CUevent(ev), [](void* ev) {
     auto typed_event = reinterpret_cast<CUevent*>(ev);
     auto result = cuEventDestroy(*typed_event);
     if (result != CUDA_SUCCESS) {

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -29,6 +29,7 @@
 #include "arrow/gpu/cuda_internal.h"
 #include "arrow/gpu/cuda_memory.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 
@@ -271,6 +272,35 @@ bool IsCudaDevice(const Device& device) {
   return device.type_name() == kCudaDeviceTypeName;
 }
 
+Result<std::shared_ptr<Device::Stream>> CudaDevice::MakeStream(unsigned int flags) {
+  ARROW_ASSIGN_OR_RAISE(auto context, GetContext());
+  ContextSaver set_temporary(reinterpret_cast<CUcontext>(context.get()->handle()));
+
+  CUstream stream;
+  CU_RETURN_NOT_OK("cuStreamCreate", cuStreamCreate(&stream, flags));
+  return std::shared_ptr<Device::Stream>(
+      new CudaDevice::Stream(context, new CUstream(stream), [](void* st) {
+        auto typed_stream = reinterpret_cast<CUstream*>(st);
+        // DCHECK_OK still evaluates its argument in release mode
+        // but in debug mode it'll also throw if it fails
+        DCHECK_OK(
+            internal::StatusFromCuda(cuStreamDestroy(*typed_stream), "cuStreamDestroy"));
+        delete typed_stream;
+      }));
+}
+
+Result<std::shared_ptr<Device::Stream>> CudaDevice::WrapStream(
+    void* stream, Device::Stream::release_fn_t release_fn) {
+  if (!release_fn) {
+    release_fn = [](void*) {};
+  }
+
+  auto cu_stream = reinterpret_cast<CUstream*>(stream);
+  ARROW_ASSIGN_OR_RAISE(auto context, GetContext());
+  return std::shared_ptr<Device::Stream>(
+      new CudaDevice::Stream(context, cu_stream, release_fn));
+}
+
 Result<std::shared_ptr<CudaDevice>> AsCudaDevice(const std::shared_ptr<Device>& device) {
   if (IsCudaDevice(*device)) {
     return checked_pointer_cast<CudaDevice>(device);
@@ -291,34 +321,33 @@ Status CudaDevice::Stream::WaitEvent(const Device::SyncEvent& event) {
     return Status::Invalid("Cuda Stream cannot wait on null event");
   }
 
-  ContextSaver set_temporary((CUcontext)(context_.get()->handle()));
-  // TODO: do we need to account for CUevent_capture_flags??
+  ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
   CU_RETURN_NOT_OK("cuStreamWaitEvent",
-                   cuStreamWaitEvent(stream_, cu_event, CU_EVENT_WAIT_DEFAULT));
+                   cuStreamWaitEvent(value(), cu_event, CU_EVENT_WAIT_DEFAULT));
   return Status::OK();
 }
 
 Status CudaDevice::Stream::Synchronize() const {
-  ContextSaver set_temporary((CUcontext)(context_.get()->handle()));
-  CU_RETURN_NOT_OK("cuStreamSynchronize", cuStreamSynchronize(stream_));
+  ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
+  CU_RETURN_NOT_OK("cuStreamSynchronize", cuStreamSynchronize(value()));
   return Status::OK();
 }
 
 Status CudaDevice::SyncEvent::Wait() {
-  ContextSaver set_temporary((CUcontext)(context_.get()->handle()));
+  ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
   CU_RETURN_NOT_OK("cuEventSynchronize", cuEventSynchronize(value()));
   return Status::OK();
 }
 
-Status CudaDevice::SyncEvent::Record(const Device::Stream& st) {
+Status CudaDevice::SyncEvent::Record(const Device::Stream& st, const unsigned int flags) {
   auto cuda_stream = checked_cast<const CudaDevice::Stream*, const Device::Stream*>(&st);
   if (!cuda_stream) {
     return Status::Invalid("CudaDevice::Event cannot record on non-cuda stream");
   }
 
-  ContextSaver set_temporary((CUcontext)(context_.get()->handle()));
-  CU_RETURN_NOT_OK("cuEventRecord", cuEventRecord(value(), cuda_stream->value()));
-  // TODO: there is also cuEventRecordWithFlags, do we want to allow flags?
+  ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
+  CU_RETURN_NOT_OK("cuEventRecordWithFlags",
+                   cuEventRecordWithFlags(value(), cuda_stream->value(), flags));
   return Status::OK();
 }
 
@@ -336,26 +365,29 @@ std::shared_ptr<CudaDevice> CudaMemoryManager::cuda_device() const {
 
 Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::MakeDeviceSyncEvent() {
   ARROW_ASSIGN_OR_RAISE(auto context, cuda_device()->GetContext());
-  ContextSaver set_temporary((CUcontext)(context.get()->handle()));
+  ContextSaver set_temporary(reinterpret_cast<CUcontext>(context.get()->handle()));
 
-  // TODO: event creation flags??
+  // TODO: event creation flags
   CUevent ev;
   CU_RETURN_NOT_OK("cuEventCreate", cuEventCreate(&ev, CU_EVENT_DEFAULT));
 
   return std::shared_ptr<Device::SyncEvent>(
       new CudaDevice::SyncEvent(context, new CUevent(ev), [](void* ev) {
         auto typed_event = reinterpret_cast<CUevent*>(ev);
-        auto result = cuEventDestroy(*typed_event);
-        if (result != CUDA_SUCCESS) {
-          // should we throw? I think that would automatically terminate
-          // if you throw in a destructor. What should we do with this error?
-        }
+        // DCHECK_OK still evaluates its argument in release mode
+        // but in debug mode it'll also throw if it fails
+        DCHECK_OK(
+            internal::StatusFromCuda(cuEventDestroy(*typed_event), "cuEventDestroy"));
         delete typed_event;
       }));
 }
 
 Result<std::shared_ptr<Device::SyncEvent>> CudaMemoryManager::WrapDeviceSyncEvent(
     void* sync_event, Device::SyncEvent::release_fn_t release_sync_event) {
+  if (!release_sync_event) {
+    release_sync_event = [](void*) {};
+  }
+
   auto ev = reinterpret_cast<CUevent*>(sync_event);
   ARROW_ASSIGN_OR_RAISE(auto context, cuda_device()->GetContext());
   return std::shared_ptr<Device::SyncEvent>(
@@ -502,7 +534,7 @@ class CudaDeviceManager::Impl {
   Status AllocateHost(int device_number, int64_t nbytes, uint8_t** out) {
     RETURN_NOT_OK(CheckDeviceNum(device_number));
     ARROW_ASSIGN_OR_RAISE(auto ctx, GetContext(device_number));
-    ContextSaver set_temporary((CUcontext)(ctx.get()->handle()));
+    ContextSaver set_temporary(reinterpret_cast<CUcontext>(ctx.get()->handle()));
     CU_RETURN_NOT_OK("cuMemHostAlloc", cuMemHostAlloc(reinterpret_cast<void**>(out),
                                                       static_cast<size_t>(nbytes),
                                                       CU_MEMHOSTALLOC_PORTABLE));

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -190,7 +190,7 @@ class ARROW_EXPORT CudaDevice : public Device {
     Status Record(const Device::Stream&) override;
 
     explicit SyncEvent(CUevent* ev, Device::SyncEvent::release_fn_t release_ev)
-        : Device::SyncEvent(reinterpret_cast<void*>(ev), release_ev) {}   
+        : Device::SyncEvent(reinterpret_cast<void*>(ev), release_ev) {}
   };
 
  protected:

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -151,15 +151,16 @@ class ARROW_EXPORT CudaDevice : public Device {
   class ARROW_EXPORT Stream : public Device::Stream {
    public:
     explicit Stream(std::shared_ptr<CudaContext> ctx) noexcept
-      : context_{std::move(ctx)}, stream_{} {}
+        : context_{std::move(ctx)}, stream_{} {}
 
     ~Stream() = default;
-    explicit Stream(std::shared_ptr<CudaContext> ctx, CUstream stream) noexcept 
-      : context_{std::move(ctx)}, stream_{stream} {}
+    explicit Stream(std::shared_ptr<CudaContext> ctx, CUstream stream) noexcept
+        : context_{std::move(ctx)}, stream_{stream} {}
 
     // disable construction from literal 0
-    explicit Stream(std::shared_ptr<CudaContext>, int) = delete;             // Prevent cast from 0
-    explicit Stream(std::shared_ptr<CudaContext>, std::nullptr_t) = delete;  // Prevent cast from nullptr
+    explicit Stream(std::shared_ptr<CudaContext>, int) = delete;  // Prevent cast from 0
+    explicit Stream(std::shared_ptr<CudaContext>,
+                    std::nullptr_t) = delete;  // Prevent cast from nullptr
 
     [[nodiscard]] constexpr CUstream value() const { return stream_; }
     constexpr operator CUstream() const noexcept { return value(); }
@@ -197,9 +198,11 @@ class ARROW_EXPORT CudaDevice : public Device {
    protected:
     friend class CudaMemoryManager;
 
-    explicit SyncEvent(std::shared_ptr<CudaContext> ctx, CUevent* ev, Device::SyncEvent::release_fn_t release_ev)
-        : Device::SyncEvent(reinterpret_cast<void*>(ev), release_ev), context_{std::move(ctx)} {}
-   
+    explicit SyncEvent(std::shared_ptr<CudaContext> ctx, CUevent* ev,
+                       Device::SyncEvent::release_fn_t release_ev)
+        : Device::SyncEvent(reinterpret_cast<void*>(ev), release_ev),
+          context_{std::move(ctx)} {}
+
    private:
     std::shared_ptr<CudaContext> context_;
   };

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -43,8 +43,8 @@ using internal::checked_pointer_cast;
 
 namespace cuda {
 
-using internal::StatusFromCuda;
 using internal::ContextSaver;
+using internal::StatusFromCuda;
 
 #define ASSERT_CUDA_OK(expr) ASSERT_OK(::arrow::cuda::internal::StatusFromCuda((expr)))
 
@@ -218,7 +218,7 @@ TEST_F(TestCudaDevice, Copy) {
 TEST_F(TestCudaDevice, CreateSyncEvent) {
   ASSERT_OK_AND_ASSIGN(auto ev, mm_->MakeDeviceSyncEvent());
   ASSERT_TRUE(ev);
-  auto cuda_ev = checked_pointer_cast<CudaDevice::SyncEvent>(ev);  
+  auto cuda_ev = checked_pointer_cast<CudaDevice::SyncEvent>(ev);
   ASSERT_EQ(CUDA_SUCCESS, cuEventQuery(*cuda_ev));
 }
 
@@ -236,7 +236,7 @@ TEST_F(TestCudaDevice, WrapDeviceSyncEvent) {
     ASSERT_TRUE(ev);
     // verify it's the same event we passed in
     ASSERT_EQ(ev->get_raw(), &event);
-    auto cuda_ev = checked_pointer_cast<CudaDevice::SyncEvent>(ev);  
+    auto cuda_ev = checked_pointer_cast<CudaDevice::SyncEvent>(ev);
     ASSERT_EQ(CUDA_SUCCESS, cuEventQuery(*cuda_ev));
   }
 

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -259,7 +259,7 @@ TEST_F(TestCudaDevice, DefaultStream) {
 TEST_F(TestCudaDevice, ExplicitStream) {
   // need a context to call cuEventCreate
   ContextSaver set_temporary((CUcontext)(context_.get()->handle()));
-  
+
   CUstream cu_stream;
   ASSERT_CUDA_OK(cuStreamCreate(&cu_stream, CU_STREAM_NON_BLOCKING));
 

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -246,6 +246,17 @@ TEST_F(TestCudaDevice, WrapDeviceSyncEvent) {
   ASSERT_CUDA_OK(cuEventDestroy(event));
 }
 
+
+TEST_F(TestCudaDevice, DefaultStream) {
+  CudaDevice::Stream stream{context_};
+  ASSERT_OK_AND_ASSIGN(auto ev, mm_->MakeDeviceSyncEvent());
+
+  ASSERT_OK(ev->Record(stream));
+  ASSERT_OK(stream.WaitEvent(*ev));
+  ASSERT_OK(ev->Wait());
+  ASSERT_OK(stream.Synchronize());
+}
+
 // ------------------------------------------------------------------------
 // Test CudaContext
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### What changes are included in this PR?
Adding `CudaDevice::SyncEvent` and `CudaDevice::Stream` implementations which provide more idiomatic handling of Events and Streams.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Simple SyncEvent test added. More stream tests still being added.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

* Closes: #37364