### PR TITLE
GH-37345: [MATLAB] Add function handle to `fromMATLAB` static construction methods to `TypeTraits` classes

### DIFF
--- a/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/BooleanTraits.m
@@ -19,7 +19,8 @@ classdef BooleanTraits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.BooleanArray
         ArrayClassName = "arrow.array.BooleanArray"
         ArrayProxyClassName = "arrow.array.proxy.BooleanArray"
-        TypeConstructor = @arrow.type.BooleanType;
+        ArrayStaticConstructor = @arrow.array.BooleanArray.fromMATLAB
+        TypeConstructor = @arrow.type.BooleanType
         TypeClassName = "arrow.type.BooleanType"
         TypeProxyClassName = "arrow.type.proxy.BooleanType"
         MatlabConstructor = @logical

--- a/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float32Traits.m
@@ -19,7 +19,8 @@ classdef Float32Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Float32Array
         ArrayClassName = "arrow.array.Float32Array"
         ArrayProxyClassName = "arrow.array.proxy.Float32Array"
-        TypeConstructor = @arrow.type.Float32Type;
+        ArrayStaticConstructor = @arrow.array.Float32Array.fromMATLAB
+        TypeConstructor = @arrow.type.Float32Type
         TypeClassName = "arrow.type.Float32Type"
         TypeProxyClassName = "arrow.type.proxy.Float32Type"
         MatlabConstructor = @single

--- a/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Float64Traits.m
@@ -19,7 +19,8 @@ classdef Float64Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Float64Array
         ArrayClassName = "arrow.array.Float64Array"
         ArrayProxyClassName = "arrow.array.proxy.Float64Array"
-        TypeConstructor = @arrow.type.Float64Type;
+        ArrayStaticConstructor = @arrow.array.Float64Array.fromMATLAB
+        TypeConstructor = @arrow.type.Float64Type
         TypeClassName = "arrow.type.Float64Type"
         TypeProxyClassName = "arrow.type.proxy.Float64Type"
         MatlabConstructor = @double

--- a/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int16Traits.m
@@ -19,7 +19,8 @@ classdef Int16Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Int16Array
         ArrayClassName = "arrow.array.Int16Array"
         ArrayProxyClassName = "arrow.array.proxy.Int16Array"
-        TypeConstructor = @arrow.type.Int16Type;
+        ArrayStaticConstructor = @arrow.array.Int16Array.fromMATLAB
+        TypeConstructor = @arrow.type.Int16Type
         TypeClassName = "arrow.type.Int16Type"
         TypeProxyClassName = "arrow.type.proxy.Int16Type"
         MatlabConstructor = @int16

--- a/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int32Traits.m
@@ -19,6 +19,7 @@ classdef Int32Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Int32Array
         ArrayClassName = "arrow.array.Int32Array"
         ArrayProxyClassName = "arrow.array.proxy.Int32Array"
+        ArrayStaticConstructor = @arrow.array.Int32Array.fromMATLAB
         TypeConstructor = @arrow.type.Int32Type;
         TypeClassName = "arrow.type.Int32Type"
         TypeProxyClassName = "arrow.type.proxy.Int32Type"

--- a/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int64Traits.m
@@ -19,7 +19,8 @@ classdef Int64Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Int64Array
         ArrayClassName = "arrow.array.Int64Array"
         ArrayProxyClassName = "arrow.array.proxy.Int64Array"
-        TypeConstructor = @arrow.type.Int64Type;
+        ArrayStaticConstructor = @arrow.array.Int64Array.fromMATLAB
+        TypeConstructor = @arrow.type.Int64Type
         TypeClassName = "arrow.type.Int64Type"
         TypeProxyClassName = "arrow.type.proxy.Int64Type"
         MatlabConstructor = @int64

--- a/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Int8Traits.m
@@ -19,7 +19,8 @@ classdef Int8Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Int8Array
         ArrayClassName = "arrow.array.Int8Array"
         ArrayProxyClassName = "arrow.array.proxy.Int8Array"
-        TypeConstructor = @arrow.type.Int8Type;
+        ArrayStaticConstructor = @arrow.array.Int8Array.fromMATLAB
+        TypeConstructor = @arrow.type.Int8Type
         TypeClassName = "arrow.type.Int8Type"
         TypeProxyClassName = "arrow.type.proxy.Int8Type"
         MatlabConstructor = @int8

--- a/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/StringTraits.m
@@ -19,7 +19,8 @@ classdef StringTraits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.StringArray
         ArrayClassName = "arrow.array.StringArray"
         ArrayProxyClassName = "arrow.array.proxy.StringArray"
-        TypeConstructor = @arrow.type.StringType;
+        ArrayStaticConstructor = @arrow.array.StringArray.fromMATLAB
+        TypeConstructor = @arrow.type.StringType
         TypeClassName = "arrow.type.StringType"
         TypeProxyClassName = "arrow.type.proxy.StringType"
         MatlabConstructor = @string

--- a/matlab/src/matlab/+arrow/+type/+traits/Time32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Time32Traits.m
@@ -19,6 +19,7 @@ classdef Time32Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Time32Array
         ArrayClassName = "arrow.array.Time32Array"
         ArrayProxyClassName = "arrow.array.proxy.Time32Array"
+        ArrayStaticConstructor = @arrow.array.Time32Array.fromMATLAB
         TypeConstructor = @arrow.type.Time32Type;
         TypeClassName = "arrow.type.Time32Type"
         TypeProxyClassName = "arrow.type.proxy.Time32Type"

--- a/matlab/src/matlab/+arrow/+type/+traits/Time64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Time64Traits.m
@@ -19,6 +19,7 @@ classdef Time64Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.Time64Array
         ArrayClassName = "arrow.array.Time64Array"
         ArrayProxyClassName = "arrow.array.proxy.Time64Array"
+        ArrayStaticConstructor = @arrow.array.Time64Array.fromMATLAB
         TypeConstructor = @arrow.type.Time64Type;
         TypeClassName = "arrow.type.Time64Type"
         TypeProxyClassName = "arrow.type.proxy.Time64Type"

--- a/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/TimestampTraits.m
@@ -19,7 +19,8 @@ classdef TimestampTraits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.TimestampArray
         ArrayClassName = "arrow.array.TimestampArray"
         ArrayProxyClassName = "arrow.array.proxy.TimestampArray"
-        TypeConstructor = @arrow.type.TimestampType;
+        ArrayStaticConstructor = @arrow.array.TimestampArray.fromMATLAB
+        TypeConstructor = @arrow.type.TimestampType
         TypeClassName = "arrow.type.TimestampType"
         TypeProxyClassName = "arrow.type.proxy.TimestampType"
         MatlabConstructor = @datetime

--- a/matlab/src/matlab/+arrow/+type/+traits/TypeTraits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/TypeTraits.m
@@ -19,6 +19,7 @@ classdef TypeTraits
         ArrayConstructor
         ArrayClassName
         ArrayProxyClassName
+        ArrayStaticConstructor
         TypeConstructor
         TypeClassName
         TypeProxyClassName

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
@@ -19,6 +19,7 @@ classdef UInt16Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.UInt16Array
         ArrayClassName = "arrow.array.UInt16Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt16Array"
+        ArrayStaticConstructor = @arrow.array.UInt16Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt16Type;
         TypeClassName = "arrow.type.UInt16Type"
         TypeProxyClassName = "arrow.type.proxy.UInt16Type"

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt16Traits.m
@@ -20,7 +20,7 @@ classdef UInt16Traits < arrow.type.traits.TypeTraits
         ArrayClassName = "arrow.array.UInt16Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt16Array"
         ArrayStaticConstructor = @arrow.array.UInt16Array.fromMATLAB
-        TypeConstructor = @arrow.type.UInt16Type;
+        TypeConstructor = @arrow.type.UInt16Type
         TypeClassName = "arrow.type.UInt16Type"
         TypeProxyClassName = "arrow.type.proxy.UInt16Type"
         MatlabConstructor = @uint16

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
@@ -19,6 +19,7 @@ classdef UInt32Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.UInt32Array
         ArrayClassName = "arrow.array.UInt32Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt32Array"
+        ArrayStaticConstructor = @arrow.array.UInt32Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt32Type;
         TypeClassName = "arrow.type.UInt32Type"
         TypeProxyClassName = "arrow.type.proxy.UInt32Type"

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt32Traits.m
@@ -20,7 +20,7 @@ classdef UInt32Traits < arrow.type.traits.TypeTraits
         ArrayClassName = "arrow.array.UInt32Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt32Array"
         ArrayStaticConstructor = @arrow.array.UInt32Array.fromMATLAB
-        TypeConstructor = @arrow.type.UInt32Type;
+        TypeConstructor = @arrow.type.UInt32Type
         TypeClassName = "arrow.type.UInt32Type"
         TypeProxyClassName = "arrow.type.proxy.UInt32Type"
         MatlabConstructor = @uint32

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
@@ -20,7 +20,7 @@ classdef UInt64Traits < arrow.type.traits.TypeTraits
         ArrayClassName = "arrow.array.UInt64Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt64Array"
         ArrayStaticConstructor = @arrow.array.UInt64Array.fromMATLAB
-        TypeConstructor = @arrow.type.UInt64Type;
+        TypeConstructor = @arrow.type.UInt64Type
         TypeClassName = "arrow.type.UInt64Type"
         TypeProxyClassName = "arrow.type.proxy.UInt64Type"
         MatlabConstructor = @uint64

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt64Traits.m
@@ -19,6 +19,7 @@ classdef UInt64Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.UInt64Array
         ArrayClassName = "arrow.array.UInt64Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt64Array"
+        ArrayStaticConstructor = @arrow.array.UInt64Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt64Type;
         TypeClassName = "arrow.type.UInt64Type"
         TypeProxyClassName = "arrow.type.proxy.UInt64Type"

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
@@ -19,6 +19,7 @@ classdef UInt8Traits < arrow.type.traits.TypeTraits
         ArrayConstructor = @arrow.array.UInt8Array
         ArrayClassName = "arrow.array.UInt8Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt8Array"
+        ArrayStaticConstructor = @arrow.array.UInt8Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt8Type;
         TypeClassName = "arrow.type.UInt8Type"
         TypeProxyClassName = "arrow.type.proxy.UInt8Type"

--- a/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/UInt8Traits.m
@@ -20,7 +20,7 @@ classdef UInt8Traits < arrow.type.traits.TypeTraits
         ArrayClassName = "arrow.array.UInt8Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt8Array"
         ArrayStaticConstructor = @arrow.array.UInt8Array.fromMATLAB
-        TypeConstructor = @arrow.type.UInt8Type;
+        TypeConstructor = @arrow.type.UInt8Type
         TypeClassName = "arrow.type.UInt8Type"
         TypeProxyClassName = "arrow.type.proxy.UInt8Type"
         MatlabConstructor = @uint8

--- a/matlab/test/arrow/type/traits/hTypeTraits.m
+++ b/matlab/test/arrow/type/traits/hTypeTraits.m
@@ -22,6 +22,7 @@ classdef hTypeTraits < matlab.unittest.TestCase
         ArrayConstructor
         ArrayClassName
         ArrayProxyClassName
+        ArrayStaticConstructor
         TypeConstructor
         TypeClassName
         TypeProxyClassName
@@ -51,6 +52,10 @@ classdef hTypeTraits < matlab.unittest.TestCase
 
         function TestArrayProxyClassName(testCase)
             testCase.verifyEqual(testCase.Traits.ArrayProxyClassName, testCase.ArrayProxyClassName);
+        end
+
+        function TestArrayStaticConstructor(testCase)
+            testCase.verifyEqual(testCase.Traits.ArrayStaticConstructor, testCase.ArrayStaticConstructor);
         end
 
         function TestTypeConstructor(testCase)

--- a/matlab/test/arrow/type/traits/tBooleanTraits.m
+++ b/matlab/test/arrow/type/traits/tBooleanTraits.m
@@ -20,6 +20,7 @@ classdef tBooleanTraits < hTypeTraits
         ArrayConstructor = @arrow.array.BooleanArray
         ArrayClassName = "arrow.array.BooleanArray"
         ArrayProxyClassName = "arrow.array.proxy.BooleanArray"
+        ArrayStaticConstructor = @arrow.array.BooleanArray.fromMATLAB
         TypeConstructor = @arrow.type.BooleanType
         TypeClassName = "arrow.type.BooleanType"
         TypeProxyClassName = "arrow.type.proxy.BooleanType"

--- a/matlab/test/arrow/type/traits/tInt16Traits.m
+++ b/matlab/test/arrow/type/traits/tInt16Traits.m
@@ -20,6 +20,7 @@ classdef tInt16Traits < hTypeTraits
         ArrayConstructor = @arrow.array.Int16Array
         ArrayClassName = "arrow.array.Int16Array"
         ArrayProxyClassName = "arrow.array.proxy.Int16Array"
+        ArrayStaticConstructor = @arrow.array.Int16Array.fromMATLAB
         TypeConstructor = @arrow.type.Int16Type
         TypeClassName = "arrow.type.Int16Type"
         TypeProxyClassName = "arrow.type.proxy.Int16Type"

--- a/matlab/test/arrow/type/traits/tInt32Traits.m
+++ b/matlab/test/arrow/type/traits/tInt32Traits.m
@@ -20,6 +20,7 @@ classdef tInt32Traits < hTypeTraits
         ArrayConstructor = @arrow.array.Int32Array
         ArrayClassName = "arrow.array.Int32Array"
         ArrayProxyClassName = "arrow.array.proxy.Int32Array"
+        ArrayStaticConstructor = @arrow.array.Int32Array.fromMATLAB
         TypeConstructor = @arrow.type.Int32Type
         TypeClassName = "arrow.type.Int32Type"
         TypeProxyClassName = "arrow.type.proxy.Int32Type"

--- a/matlab/test/arrow/type/traits/tInt64Traits.m
+++ b/matlab/test/arrow/type/traits/tInt64Traits.m
@@ -20,6 +20,7 @@ classdef tInt64Traits < hTypeTraits
         ArrayConstructor = @arrow.array.Int64Array
         ArrayClassName = "arrow.array.Int64Array"
         ArrayProxyClassName = "arrow.array.proxy.Int64Array"
+        ArrayStaticConstructor = @arrow.array.Int64Array.fromMATLAB
         TypeConstructor = @arrow.type.Int64Type
         TypeClassName = "arrow.type.Int64Type"
         TypeProxyClassName = "arrow.type.proxy.Int64Type"

--- a/matlab/test/arrow/type/traits/tInt8Traits.m
+++ b/matlab/test/arrow/type/traits/tInt8Traits.m
@@ -20,6 +20,7 @@ classdef tInt8Traits < hTypeTraits
         ArrayConstructor = @arrow.array.Int8Array
         ArrayClassName = "arrow.array.Int8Array"
         ArrayProxyClassName = "arrow.array.proxy.Int8Array"
+        ArrayStaticConstructor = @arrow.array.Int8Array.fromMATLAB
         TypeConstructor = @arrow.type.Int8Type
         TypeClassName = "arrow.type.Int8Type"
         TypeProxyClassName = "arrow.type.proxy.Int8Type"

--- a/matlab/test/arrow/type/traits/tStringTraits.m
+++ b/matlab/test/arrow/type/traits/tStringTraits.m
@@ -20,6 +20,7 @@ classdef tStringTraits < hTypeTraits
         ArrayConstructor = @arrow.array.StringArray
         ArrayClassName = "arrow.array.StringArray"
         ArrayProxyClassName = "arrow.array.proxy.StringArray"
+        ArrayStaticConstructor = @arrow.array.StringArray.fromMATLAB
         TypeConstructor = @arrow.type.StringType
         TypeClassName = "arrow.type.StringType"
         TypeProxyClassName = "arrow.type.proxy.StringType"

--- a/matlab/test/arrow/type/traits/tTime32Traits.m
+++ b/matlab/test/arrow/type/traits/tTime32Traits.m
@@ -22,6 +22,7 @@ classdef tTime32Traits < hTypeTraits
         ArrayConstructor = @arrow.array.Time32Array
         ArrayClassName = "arrow.array.Time32Array"
         ArrayProxyClassName = "arrow.array.proxy.Time32Array"
+        ArrayStaticConstructor = @arrow.array.Time32Array.fromMATLAB
         TypeConstructor = @arrow.type.Time32Type
         TypeClassName = "arrow.type.Time32Type"
         TypeProxyClassName = "arrow.type.proxy.Time32Type"

--- a/matlab/test/arrow/type/traits/tTime64Traits.m
+++ b/matlab/test/arrow/type/traits/tTime64Traits.m
@@ -22,6 +22,7 @@ classdef tTime64Traits < hTypeTraits
         ArrayConstructor = @arrow.array.Time64Array
         ArrayClassName = "arrow.array.Time64Array"
         ArrayProxyClassName = "arrow.array.proxy.Time64Array"
+        ArrayStaticConstructor = @arrow.array.Time64Array.fromMATLAB
         TypeConstructor = @arrow.type.Time64Type
         TypeClassName = "arrow.type.Time64Type"
         TypeProxyClassName = "arrow.type.proxy.Time64Type"

--- a/matlab/test/arrow/type/traits/tTimestampTraits.m
+++ b/matlab/test/arrow/type/traits/tTimestampTraits.m
@@ -20,6 +20,7 @@ classdef tTimestampTraits < hTypeTraits
         ArrayConstructor = @arrow.array.TimestampArray
         ArrayClassName = "arrow.array.TimestampArray"
         ArrayProxyClassName = "arrow.array.proxy.TimestampArray"
+        ArrayStaticConstructor = @arrow.array.TimestampArray.fromMATLAB
         TypeConstructor = @arrow.type.TimestampType
         TypeClassName = "arrow.type.TimestampType"
         TypeProxyClassName = "arrow.type.proxy.TimestampType"

--- a/matlab/test/arrow/type/traits/tUInt16Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt16Traits.m
@@ -20,6 +20,7 @@ classdef tUInt16Traits < hTypeTraits
         ArrayConstructor = @arrow.array.UInt16Array
         ArrayClassName = "arrow.array.UInt16Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt16Array"
+        ArrayStaticConstructor = @arrow.array.UInt16Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt16Type
         TypeClassName = "arrow.type.UInt16Type"
         TypeProxyClassName = "arrow.type.proxy.UInt16Type"

--- a/matlab/test/arrow/type/traits/tUInt32Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt32Traits.m
@@ -20,6 +20,7 @@ classdef tUInt32Traits < hTypeTraits
         ArrayConstructor = @arrow.array.UInt32Array
         ArrayClassName = "arrow.array.UInt32Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt32Array"
+        ArrayStaticConstructor = @arrow.array.UInt32Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt32Type
         TypeClassName = "arrow.type.UInt32Type"
         TypeProxyClassName = "arrow.type.proxy.UInt32Type"

--- a/matlab/test/arrow/type/traits/tUInt64Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt64Traits.m
@@ -20,6 +20,7 @@ classdef tUInt64Traits < hTypeTraits
         ArrayConstructor = @arrow.array.UInt64Array
         ArrayClassName = "arrow.array.UInt64Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt64Array"
+        ArrayStaticConstructor = @arrow.array.UInt64Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt64Type
         TypeClassName = "arrow.type.UInt64Type"
         TypeProxyClassName = "arrow.type.proxy.UInt64Type"

--- a/matlab/test/arrow/type/traits/tUInt8Traits.m
+++ b/matlab/test/arrow/type/traits/tUInt8Traits.m
@@ -20,6 +20,7 @@ classdef tUInt8Traits < hTypeTraits
         ArrayConstructor = @arrow.array.UInt8Array
         ArrayClassName = "arrow.array.UInt8Array"
         ArrayProxyClassName = "arrow.array.proxy.UInt8Array"
+        ArrayStaticConstructor = @arrow.array.UInt8Array.fromMATLAB
         TypeConstructor = @arrow.type.UInt8Type
         TypeClassName = "arrow.type.UInt8Type"
         TypeProxyClassName = "arrow.type.proxy.UInt8Type"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Each concrete `arrow.array.Array` subclass has an associated `fromMATLAB `static construction method. It would be helpful if the `TypeTraits` classes had access to these corresponding fromMATLAB methods.

This would involve adding a new property like `ArrayStaticConstructor` to the TypeTraits classes.

For example:

```matlab
>> arrow.type.traits.Int8Traits

ans = 

  Int8Traits with properties:

       ArrayConstructor: @arrow.array.Int8Array
         ArrayClassName: "arrow.array.Int8Array"
    ArrayProxyClassName: "arrow.array.proxy.Int8Array"
 ArrayStaticConstructor: @arrow.array.Int8Array.fromMATLAB
        TypeConstructor: @arrow.type.Int8Type
          TypeClassName: "arrow.type.Int8Type"
     TypeProxyClassName: "arrow.type.proxy.Int8Type"
      MatlabConstructor: @int8
        MatlabClassName: "int8"
```
### What changes are included in this PR?

1. Added a new abstract property called `ArrayStaticConstructor` to the parent class `arrow.type.traits.TypeTraits`.
2. Defined the `ArrayStaticConstructor` property in all concrete classes of `ArrayStaticConstructor`.

### Are these changes tested?

Yes. Added a new test case to abstract test class `hTypeTraits.m`.


### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37345