### PR TITLE
MINOR: [C++][Python] [Docs] clearer description of q argument of quantiles

### DIFF
--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -138,7 +138,7 @@ class ARROW_EXPORT QuantileOptions : public FunctionOptions {
   static constexpr char const kTypeName[] = "QuantileOptions";
   static QuantileOptions Defaults() { return QuantileOptions{}; }
 
-  /// quantile must be between 0 and 1 inclusive
+  /// probability level of quantile must be between 0 and 1 inclusive
   std::vector<double> q;
   enum Interpolation interpolation;
   /// If true (the default), null values are ignored. Otherwise, if any value is null,
@@ -162,7 +162,7 @@ class ARROW_EXPORT TDigestOptions : public FunctionOptions {
   static constexpr char const kTypeName[] = "TDigestOptions";
   static TDigestOptions Defaults() { return TDigestOptions{}; }
 
-  /// quantile must be between 0 and 1 inclusive
+  /// probability level of quantile must be between 0 and 1 inclusive
   std::vector<double> q;
   /// compression parameter, default 100
   uint32_t delta;

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2145,7 +2145,8 @@ class QuantileOptions(_QuantileOptions):
     Parameters
     ----------
     q : double or sequence of double, default 0.5
-        Quantiles to compute. All values must be in [0, 1].
+        Probability levels of the quantiles to compute. All values must be in
+        [0, 1].
     interpolation : str, default "linear"
         How to break ties between competing data points for a given quantile.
         Accepted values are:
@@ -2182,7 +2183,8 @@ class TDigestOptions(_TDigestOptions):
     Parameters
     ----------
     q : double or sequence of double, default 0.5
-        Quantiles to approximate. All values must be in [0, 1].
+        Probability levels of the quantiles to approximate. All values must be
+        in [0, 1].
     delta : int, default 100
         Compression parameter for the T-digest algorithm.
     buffer_size : int, default 500


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Documention of the `q` parameter of quantiles is made more precise.

### What changes are included in this PR?
Only documentation changes.

### Are these changes tested?
No

### Are there any user-facing changes?
No