### PR TITLE
GH-37384: [R] Set _R_CHECK_STOP_ON_INVALID_NUMERIC_VERSION_INPUTS_ = TRUE on CI

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -305,7 +305,8 @@ jobs:
             RWINLIB_LOCAL = file.path(Sys.getenv("GITHUB_WORKSPACE"), "r", "windows", "libarrow.zip"),
             MAKEFLAGS = paste0("-j", parallel::detectCores()),
             ARROW_R_DEV = TRUE,
-            "_R_CHECK_FORCE_SUGGESTS_" = FALSE
+            "_R_CHECK_FORCE_SUGGESTS_" = FALSE,
+            "_R_CHECK_STOP_ON_INVALID_NUMERIC_VERSION_INPUTS_" = TRUE
           )
           rcmdcheck::rcmdcheck(".",
             build_args = '--no-build-vignettes',

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -65,6 +65,8 @@ export _R_CHECK_DONTTEST_EXAMPLES_=TRUE
 export _R_CHECK_FORCE_SUGGESTS_=FALSE
 export _R_CHECK_LIMIT_CORES_=FALSE
 export _R_CHECK_TESTS_NLINES_=0
+# This can cause failures on CRAN but needs to be set here so issues an error not a warning
+export _R_CHECK_STOP_ON_INVALID_NUMERIC_VERSION_INPUTS_=TRUE
 
 # By default, aws-sdk tries to contact a non-existing local ip host
 # to retrieve metadata. Disable this so that S3FileSystem tests run faster.


### PR DESCRIPTION
### Rationale for this change

Checks fail on CRAN which don't fail on our CI - we should make them fail on our CI instead of just issue a warning

### What changes are included in this PR?

Update settings for R builds so these checks raise error not warning

### Are these changes tested?

Nope 

### Are there any user-facing changes?

No
* Closes: #37384