### PR TITLE
GH-37386: [R] CRAN failures due to "invalid non-character version specification"

### DIFF
--- a/r/tests/testthat/test-data-type.R
+++ b/r/tests/testthat/test-data-type.R
@@ -609,7 +609,7 @@ test_that("DataType$code()", {
   expect_code_roundtrip(dictionary(index_type = int8(), value_type = large_utf8()))
   expect_code_roundtrip(dictionary(index_type = int8(), ordered = TRUE))
 
-  skip_if(packageVersion("rlang") < 1)
+  skip_if(packageVersion("rlang") < "1")
   # Are these unsupported for a reason?
   expect_error(
     eval(DayTimeInterval__initialize()$code()),

--- a/r/tests/testthat/test-schema.R
+++ b/r/tests/testthat/test-schema.R
@@ -43,7 +43,7 @@ test_that("Schema$code()", {
     schema(a = int32(), b = struct(c = double(), d = utf8()), e = list_of(binary()))
   )
 
-  skip_if(packageVersion("rlang") < 1)
+  skip_if(packageVersion("rlang") < "1")
   expect_error(
     eval(schema(x = int32(), y = DayTimeInterval__initialize())$code()),
     "Unsupported type"


### PR DESCRIPTION
### Rationale for this change

Package version comparison results in CRAN checks failing due to values being numeric not character

### What changes are included in this PR?

Changing numeric values to characters

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #37386