### PR TITLE
GH-37377: [C#] Throw OverflowException on overflow in TimestampArray.ConvertTo()

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -76,7 +76,7 @@ namespace Apache.Arrow
                 switch (DataType.Unit)
                 {
                     case TimeUnit.Nanosecond:
-                        return ticks * 100;
+                        return checked(ticks * 100);
                     case TimeUnit.Microsecond:
                         return ticks / 10;
                     case TimeUnit.Millisecond:


### PR DESCRIPTION
Throw `OverflowException` on overflow in `TimestampArray.ConvertTo()` when `DataType.Unit` is `Nanosecond` and `ticks` is large, instead of silently overflowing and returning the wrong value.
* Closes: #37377