### PR TITLE
GH-37397: [C++] Feature: support nested loop join.

### DIFF
--- a/cpp/src/arrow/acero/CMakeLists.txt
+++ b/cpp/src/arrow/acero/CMakeLists.txt
@@ -40,6 +40,8 @@ set(ARROW_ACERO_SRCS
     hash_join.cc
     hash_join_dict.cc
     hash_join_node.cc
+    nested_loop_join.cc
+    nested_loop_node.cc
     map_node.cc
     options.cc
     order_by_node.cc

--- a/cpp/src/arrow/acero/exec_plan.cc
+++ b/cpp/src/arrow/acero/exec_plan.cc
@@ -1114,6 +1114,7 @@ void RegisterAggregateNode(ExecFactoryRegistry*);
 void RegisterSinkNode(ExecFactoryRegistry*);
 void RegisterHashJoinNode(ExecFactoryRegistry*);
 void RegisterAsofJoinNode(ExecFactoryRegistry*);
+void RegisterNestedLoopJoinNode(ExecFactoryRegistry*);
 
 }  // namespace internal
 
@@ -1132,6 +1133,7 @@ ExecFactoryRegistry* default_exec_factory_registry() {
       internal::RegisterSinkNode(this);
       internal::RegisterHashJoinNode(this);
       internal::RegisterAsofJoinNode(this);
+      internal::RegisterNestedLoopJoinNode(this);
     }
 
     Result<Factory> GetFactory(const std::string& factory_name) override {

--- a/cpp/src/arrow/acero/nested_loop_join.cc
+++ b/cpp/src/arrow/acero/nested_loop_join.cc
@@ -1,0 +1,332 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/acero/nested_loop_join.h"
+
+#include "arrow/acero/task_util.h"
+#include "arrow/array/concatenate.h"
+#include "arrow/builder.h"
+#include "arrow/util/tracing_internal.h"
+
+namespace arrow {
+namespace acero {
+Status NestedLoopJoinImpl::Init(QueryContext* ctx, JoinType join_type, size_t num_threads,
+                                const NestedLoopJoinProjectionMaps* proj_map_left,
+                                const NestedLoopJoinProjectionMaps* proj_map_right,
+                                Expression filter,
+                                RegisterTaskGroupCallback register_task_group_callback,
+                                StartTaskGroupCallback start_task_group_callback,
+                                OutputBatchCallback output_batch_callback,
+                                FinishedCallback finished_callback) {
+  num_threads_ = num_threads;
+  ctx_ = ctx;
+  join_type_ = join_type;
+  schema_[0] = proj_map_left;
+  schema_[1] = proj_map_right;
+  filter_ = std::move(filter);
+  register_task_group_callback_ = std::move(register_task_group_callback);
+  start_task_group_callback_ = std::move(start_task_group_callback);
+  output_batch_callback_ = std::move(output_batch_callback);
+  finished_callback_ = std::move(finished_callback);
+  pool_ = default_memory_pool();
+
+  output_batch_nums_ = 0;
+  cancelled_ = false;
+
+  task_cross_product_ = register_task_group_callback_(
+      [this](size_t thread_index, int64_t task_id) -> Status {
+        return CrossProductTask(thread_index, task_id);
+      },
+      [this](size_t thread_index) -> Status { return FinishCallBack(thread_index); });
+
+  return Status::OK();
+}
+
+Status NestedLoopJoinImpl::StartCrossProduct(size_t /*thread_index*/,
+                                             AccumulationQueue inner_batches,
+                                             AccumulationQueue outer_batches) {
+  inner_batches_ = std::move(inner_batches);
+  outer_batches_ = std::move(outer_batches);
+  return start_task_group_callback_(task_cross_product_,
+                                    /*num_tasks=*/outer_batches_.batch_count());
+}
+
+Status NestedLoopJoinImpl::CrossProductTask(size_t thread_id, int64_t task_id) {
+  const ExecBatch& left_batch = outer_batches_[task_id];
+  int64_t left_rows = left_batch.length;
+  ARROW_DCHECK(left_rows != 0);
+
+  SchemaProjectionMap left_f_to_i =
+      schema_[0]->map(HashJoinProjection::FILTER, HashJoinProjection::INPUT);
+  SchemaProjectionMap right_f_to_i =
+      schema_[1]->map(HashJoinProjection::FILTER, HashJoinProjection::INPUT);
+
+  // There is no corresponding column, and it does not satisfy the true expression, we
+  // should do nothing.
+  if (filter_ != literal(true) && !left_f_to_i.num_cols && !right_f_to_i.num_cols) {
+    // do nothing
+    return Status::OK();
+  }
+
+  if (!inner_batches_.batch_count()) {
+    return CrossProductInnerEmpty(thread_id, left_batch);
+  }
+
+  bool already_output = false;
+  std::set<int64_t> match_idx;
+  size_t right_total_batchs = inner_batches_.batch_count();
+  // use match_idx to filter no match rows when we traverse to the last line of the outer
+  // batch.
+  bool is_last_row = false;
+  for (size_t right_idx = 0; right_idx < right_total_batchs; right_idx++) {
+    std::vector<int64_t> no_match, match, match_left, match_right;
+    MatchState state{no_match, match, match_left, match_right};
+    const ExecBatch& right_batch = inner_batches_[right_idx];
+    int64_t right_rows = right_batch.length;
+    ARROW_DCHECK(right_rows != 0);
+    // right batch isn't an emtpy batch.
+    for (int64_t i = 0; i < left_rows; i++) {
+      // doesn't have filter.
+      if (filter_ == literal(true)) {
+        // for semi, we just output once.
+        if (already_output && (join_type_ == JoinType::LEFT_SEMI)) {
+          break;
+        }
+        state.match_left.clear();
+        state.match_right.clear();
+        state.match.clear();
+        for (int64_t j = 0; j < right_rows; j++) {
+          state.match_left.push_back(i);
+          state.match_right.push_back(j);
+        }
+        state.match.push_back(i);
+        if (i == left_rows - 1) {
+          already_output = true;
+        }
+      } else {
+        ExecBatch cross_batch;
+        for (int left_col = 0; left_col < left_f_to_i.num_cols; left_col++) {
+          int key_idx = left_f_to_i.get(left_col);
+          std::shared_ptr<Array> result;
+          auto type = left_batch.values[key_idx].type();
+          std::unique_ptr<arrow::ArrayBuilder> builder;
+          RETURN_NOT_OK(MakeBuilder(pool_, type, &builder));
+          for (int64_t j = 0; j < right_rows; j++) {
+            RETURN_NOT_OK(
+                builder->AppendArraySlice(*left_batch.values[key_idx].array(), i, 1));
+          }
+          RETURN_NOT_OK(builder->Finish(&result));
+          cross_batch.values.push_back(result);
+        }
+        for (int right_col = 0; right_col < right_f_to_i.num_cols; right_col++) {
+          int key_idx = right_f_to_i.get(right_col);
+          cross_batch.values.push_back(right_batch.values[key_idx]);
+        }
+        cross_batch.length = right_rows;
+        is_last_row = i + 1 == left_rows && right_idx + 1 == right_total_batchs;
+        ARROW_RETURN_NOT_OK(
+            ExecuteFilter(cross_batch, state, i, is_last_row, left_rows, match_idx));
+      }
+      ARROW_RETURN_NOT_OK(CrossBatchOutputAll(left_batch, right_batch, state));
+    }
+  }
+  return Status::OK();
+}
+
+Status NestedLoopJoinImpl::CrossProductInnerEmpty(size_t thread_id,
+                                                  const ExecBatch& left_batch) {
+  int64_t left_rows = left_batch.length;
+  ARROW_DCHECK(left_rows != 0);
+  std::vector<int64_t> no_match, match, match_left, match_right;
+  MatchState state{no_match, match, match_left, match_right};
+  for (int64_t i = 0; i < left_rows; i++) {
+    state.no_match.push_back(i);
+  }
+  RETURN_NOT_OK(CrossBatchOutputAll(left_batch, ExecBatch{}, state));
+  return Status::OK();
+}
+
+Status NestedLoopJoinImpl::ExecuteFilter(const ExecBatch& cross_batch,
+                                         const MatchState& state, int64_t left_row_idx,
+                                         bool is_last_row, int64_t left_rows,
+                                         std::set<int64_t>& match_idx) {
+  int64_t cross_rows = cross_batch.length;
+  ARROW_ASSIGN_OR_RAISE(
+      Datum mask, ExecuteScalarExpression(filter_, cross_batch, ctx_->exec_context()));
+  ARROW_DCHECK(mask.is_array());
+  state.no_match.clear();
+  state.match.clear();
+  state.match_left.clear();
+  state.match_right.clear();
+  ARROW_DCHECK_EQ(mask.array()->offset, 0);
+  ARROW_DCHECK_EQ(mask.array()->length, cross_rows);
+  const uint8_t* validity =
+      mask.array()->buffers[0] ? mask.array()->buffers[0]->data() : nullptr;
+  const uint8_t* comparisons = mask.array()->buffers[1]->data();
+
+  bool passed = false;
+  for (int64_t irow = 0; irow < cross_rows; irow++) {
+    bool is_valid = !validity || bit_util::GetBit(validity, irow);
+    bool is_cmp_true = bit_util::GetBit(comparisons, irow);
+    // We treat a null comparison result as false, like in SQL
+    if (is_valid && is_cmp_true) {
+      state.match_left.push_back(left_row_idx);
+      state.match_right.push_back(irow);
+      match_idx.insert(left_row_idx);
+      passed = true;
+    }
+  }
+
+  if (passed) {
+    state.match.push_back(left_row_idx);
+  }
+
+  // we can output no match when we scan last row in local left batch and right last batch
+  // row.
+  if (is_last_row) {
+    for (int irow = 0; irow < left_rows; irow++) {
+      if (!match_idx.count(irow)) state.no_match.push_back(irow);
+    }
+  }
+  return Status::OK();
+}
+Status NestedLoopJoinImpl::CrossBatchOutputAll(const ExecBatch& left_batch,
+                                               const ExecBatch& right_batch,
+                                               const MatchState& state) {
+  if (join_type_ == JoinType::RIGHT_SEMI || join_type_ == JoinType::RIGHT_ANTI) {
+    // Nothing to output
+    return Status::OK();
+  }
+
+  if (join_type_ == JoinType::LEFT_ANTI || join_type_ == JoinType::LEFT_SEMI) {
+    const std::vector<int64_t>& out_ids =
+        (join_type_ == JoinType::LEFT_SEMI) ? state.match : state.no_match;
+    for (size_t start = 0; start < out_ids.size(); start += output_batch_size_) {
+      int64_t batch_size_next = std::min(static_cast<int64_t>(out_ids.size() - start),
+                                         static_cast<int64_t>(output_batch_size_));
+      if (join_type_ == JoinType::LEFT_ANTI || join_type_ == JoinType::LEFT_SEMI) {
+        RETURN_NOT_OK(CrossBatchOutputOne(left_batch, right_batch, batch_size_next,
+                                          out_ids.data() + start, nullptr));
+      }
+    }
+  } else {
+    if (join_type_ == JoinType::LEFT_OUTER || join_type_ == JoinType::FULL_OUTER) {
+      for (size_t i = 0; i < state.no_match.size(); ++i) {
+        state.match_left.push_back(state.no_match[i]);
+        state.match_right.push_back(kRowIdNull);
+      }
+    }
+    ARROW_DCHECK(state.match_left.size() == state.match_right.size());
+
+    for (size_t start = 0; start < state.match_left.size(); start += output_batch_size_) {
+      int64_t batch_size_next =
+          std::min(static_cast<int64_t>(state.match_left.size() - start),
+                   static_cast<int64_t>(output_batch_size_));
+      RETURN_NOT_OK(CrossBatchOutputOne(left_batch, right_batch, batch_size_next,
+                                        state.match_left.data() + start,
+                                        state.match_right.data() + start));
+    }
+  }
+  return Status::OK();
+}
+
+Status NestedLoopJoinImpl::CrossBatchOutputOne(const ExecBatch& left_batch,
+                                               const ExecBatch& right_batch,
+                                               int64_t batch_size_next,
+                                               const int64_t* opt_left_ids,
+                                               const int64_t* opt_right_ids) {
+  if (batch_size_next == 0 || (!opt_left_ids && !opt_right_ids)) {
+    return Status::OK();
+  }
+
+  ExecBatch result({}, batch_size_next);
+
+  int num_out_cols_left = schema_[0]->num_cols(HashJoinProjection::OUTPUT);
+  int num_out_cols_right = schema_[1]->num_cols(HashJoinProjection::OUTPUT);
+
+  result.values.resize(num_out_cols_left + num_out_cols_right);
+
+  bool has_left =
+      (join_type_ != JoinType::RIGHT_SEMI && join_type_ != JoinType::RIGHT_ANTI &&
+       schema_[0]->num_cols(HashJoinProjection::OUTPUT) > 0);
+  bool has_right =
+      (join_type_ != JoinType::LEFT_SEMI && join_type_ != JoinType::LEFT_ANTI &&
+       schema_[1]->num_cols(HashJoinProjection::OUTPUT) > 0);
+
+  auto left_from_input =
+      schema_[0]->map(HashJoinProjection::OUTPUT, HashJoinProjection::INPUT);
+  auto right_from_input =
+      schema_[1]->map(HashJoinProjection::OUTPUT, HashJoinProjection::INPUT);
+
+  if (has_left) {
+    RETURN_NOT_OK(AppendOutputColumn(result, left_from_input, left_batch, 0, opt_left_ids,
+                                     batch_size_next, 0));
+  }
+
+  if (has_right) {
+    RETURN_NOT_OK(AppendOutputColumn(result, right_from_input, right_batch, 1,
+                                     opt_right_ids, batch_size_next, num_out_cols_left));
+  }
+
+  ARROW_RETURN_NOT_OK(output_batch_callback_(0, std::move(result)));
+  output_batch_nums_++;
+
+  return Status::OK();
+}
+
+Status NestedLoopJoinImpl::AppendOutputColumn(ExecBatch& result,
+                                              const SchemaProjectionMap& from_input,
+                                              const ExecBatch& batch, int side,
+                                              const int64_t* opt_ids, int64_t nrows,
+                                              int out_col_offset) {
+  int num_cols = schema_[side]->num_cols(HashJoinProjection::OUTPUT);
+  for (int icol = 0; icol < num_cols; ++icol) {
+    std::shared_ptr<Array> col_array;
+    std::unique_ptr<arrow::ArrayBuilder> builder;
+    int input_field_id = from_input.get(icol);
+    const std::shared_ptr<DataType>& input_data_type =
+        schema_[side]->data_type(NestedLoopJoinProjection::INPUT, input_field_id);
+    RETURN_NOT_OK(MakeBuilder(pool_, input_data_type, &builder));
+    for (int i = 0; i < nrows; i++) {
+      int64_t irow = opt_ids[i];
+      if (irow == kRowIdNull || input_data_type->id() == Type::NA) {
+        RETURN_NOT_OK(builder->AppendNull());
+      } else {
+        ARROW_DCHECK(batch.num_values() > 0);
+        RETURN_NOT_OK(
+            builder->AppendArraySlice(*batch.values[input_field_id].array(), irow, 1));
+      }
+    }
+    RETURN_NOT_OK(builder->Finish(&col_array));
+    result.values[icol + out_col_offset] = col_array;
+  }
+  return Status::OK();
+}
+
+Status NestedLoopJoinImpl::FinishCallBack(size_t thread_index) {
+  return finished_callback_(output_batch_nums_);
+}
+
+void NestedLoopJoinImpl::Abort(TaskScheduler::AbortContinuationImpl pos_abort_callback) {
+  EVENT(span_, "Abort");
+  END_SPAN(span_);
+  cancelled_ = true;
+  pos_abort_callback();
+}
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/nested_loop_join.h
+++ b/cpp/src/arrow/acero/nested_loop_join.h
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <set>
+#include <vector>
+
+#include "arrow/acero/accumulation_queue.h"
+#include "arrow/acero/options.h"
+#include "arrow/acero/query_context.h"
+#include "arrow/acero/schema_util.h"
+#include "arrow/acero/task_util.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/type.h"
+
+namespace arrow {
+
+namespace acero {
+
+using util::AccumulationQueue;
+
+struct MatchState {
+  std::vector<int64_t>& no_match;
+  std::vector<int64_t>& match;
+  std::vector<int64_t>& match_left;
+  std::vector<int64_t>& match_right;
+};
+
+class NestedLoopJoinImpl {
+ public:
+  using OutputBatchCallback = std::function<Status(int64_t, ExecBatch)>;
+  using FinishedCallback = std::function<Status(int64_t)>;
+  using RegisterTaskGroupCallback = std::function<int(
+      std::function<Status(size_t, int64_t)>, std::function<Status(size_t)>)>;
+  using StartTaskGroupCallback = std::function<Status(int, int64_t)>;
+  static constexpr int64_t kRowIdNull = -1;
+
+  Status Init(QueryContext* ctx, JoinType join_type, size_t num_threads,
+              const NestedLoopJoinProjectionMaps* proj_map_left,
+              const NestedLoopJoinProjectionMaps* proj_map_right, Expression filter,
+              RegisterTaskGroupCallback register_task_group_callback,
+              StartTaskGroupCallback start_task_group_callback,
+              OutputBatchCallback output_batch_callback,
+              FinishedCallback finished_callback);
+
+  Status StartCrossProduct(size_t /*thread_index*/, AccumulationQueue inner_batches,
+                           AccumulationQueue outer_batches);
+
+  Status CrossProductTask(size_t thread_id, int64_t task_id);
+
+  Status CrossProductInnerEmpty(size_t thread_id, const ExecBatch& left_batch);
+
+  Status ExecuteFilter(const ExecBatch& cross_batch, const MatchState& state,
+                       int64_t left_row_idx, bool is_last_row, int64_t left_rows,
+                       std::set<int64_t>& match_idx);
+  Status FinishCallBack(size_t thread_index);
+
+  Status CrossBatchOutputAll(const ExecBatch& left_batch, const ExecBatch& right_batch,
+                             const MatchState& state);
+
+  void Abort(TaskScheduler::AbortContinuationImpl pos_abort_callback);
+
+ protected:
+  arrow::util::tracing::Span span_;
+
+ private:
+  void InitTaskGroups();
+  Status CrossBatchOutputOne(const ExecBatch& left_batch, const ExecBatch& right_batch,
+                             int64_t batch_size_next, const int64_t* opt_left_ids,
+                             const int64_t* opt_right_ids);
+  Status AppendOutputColumn(ExecBatch& result, const SchemaProjectionMap& from_input,
+                            const ExecBatch& batch, int side, const int64_t* opt_ids,
+                            int64_t nrows, int out_col_offset);
+
+  static constexpr int64_t output_batch_size_ = 32 * 1024;
+
+  // Metadata
+  QueryContext* ctx_;
+  JoinType join_type_;
+  size_t num_threads_;
+  const NestedLoopJoinProjectionMaps* schema_[2];
+  Expression filter_;
+  int task_cross_product_;
+  MemoryPool* pool_;
+
+  // Callbacks
+  OutputBatchCallback output_batch_callback_;
+  FinishedCallback finished_callback_;
+  RegisterTaskGroupCallback register_task_group_callback_;
+  StartTaskGroupCallback start_task_group_callback_;
+
+  // Batches
+  AccumulationQueue inner_batches_;
+  AccumulationQueue outer_batches_;
+
+  // Output batch num for next node
+  int64_t output_batch_nums_;
+
+  bool cancelled_;
+};
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/nested_loop_node.cc
+++ b/cpp/src/arrow/acero/nested_loop_node.cc
@@ -1,0 +1,508 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/acero/nested_loop_node.h"
+
+#include <unordered_set>
+#include <vector>
+
+#include "arrow/acero/accumulation_queue.h"
+#include "arrow/acero/exec_plan.h"
+#include "arrow/acero/nested_loop_join.h"
+#include "arrow/acero/options.h"
+#include "arrow/acero/query_context.h"
+#include "arrow/acero/schema_util.h"
+#include "arrow/acero/task_util.h"
+#include "arrow/acero/util.h"
+#include "arrow/compute/exec.h"
+#include "arrow/compute/expression.h"
+#include "arrow/datum.h"
+#include "arrow/result.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/future.h"
+#include "arrow/util/thread_pool.h"
+#include "arrow/util/tracing_internal.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+
+namespace acero {
+
+Status NestedLoopJoinSchema::Init(JoinType join_type, const Schema& left_schema,
+                                  const Schema& right_schema, const Expression& filter,
+                                  const std::string& left_field_name_suffix,
+                                  const std::string& right_field_name_suffix) {
+  std::vector<FieldRef> left_output;
+  if (join_type != JoinType::RIGHT_SEMI && join_type != JoinType::RIGHT_ANTI) {
+    const FieldVector& left_fields = left_schema.fields();
+    left_output.resize(left_fields.size());
+    for (size_t i = 0; i < left_fields.size(); ++i) {
+      left_output[i] = FieldRef(static_cast<int>(i));
+    }
+  }
+  // Repeat the same for the right side
+  std::vector<FieldRef> right_output;
+  if (join_type != JoinType::LEFT_SEMI && join_type != JoinType::LEFT_ANTI) {
+    const FieldVector& right_fields = right_schema.fields();
+    right_output.resize(right_fields.size());
+    for (size_t i = 0; i < right_fields.size(); ++i) {
+      right_output[i] = FieldRef(static_cast<int>(i));
+    }
+  }
+  return Init(join_type, left_schema, left_output, right_schema, right_output, filter,
+              left_field_name_suffix, right_field_name_suffix);
+}
+
+Status NestedLoopJoinSchema::Init(JoinType join_type, const Schema& left_schema,
+                                  const std::vector<FieldRef>& left_output,
+                                  const Schema& right_schema,
+                                  const std::vector<FieldRef>& right_output,
+                                  const Expression& filter,
+                                  const std::string& left_field_name_suffix,
+                                  const std::string& right_field_name_suffix) {
+  RETURN_NOT_OK(
+      ValidateSchemas(join_type, left_schema, left_output, right_schema, right_output));
+
+  std::vector<NestedLoopJoinProjection> handles;
+  std::vector<const std::vector<FieldRef>*> field_refs;
+
+  std::vector<FieldRef> left_filter, right_filter;
+  RETURN_NOT_OK(
+      CollectFilterColumns(left_filter, right_filter, filter, left_schema, right_schema));
+
+  handles.push_back(NestedLoopJoinProjection::FILTER);
+  field_refs.push_back(&left_filter);
+
+  handles.push_back(NestedLoopJoinProjection::OUTPUT);
+  field_refs.push_back(&left_output);
+
+  RETURN_NOT_OK(proj_maps[0].Init(NestedLoopJoinProjection::INPUT, left_schema, handles,
+                                  field_refs));
+
+  handles.clear();
+  field_refs.clear();
+
+  handles.push_back(NestedLoopJoinProjection::FILTER);
+  field_refs.push_back(&right_filter);
+
+  handles.push_back(NestedLoopJoinProjection::OUTPUT);
+  field_refs.push_back(&right_output);
+
+  RETURN_NOT_OK(proj_maps[1].Init(NestedLoopJoinProjection::INPUT, right_schema, handles,
+                                  field_refs));
+
+  return Status::OK();
+}
+
+Status NestedLoopJoinSchema::ValidateSchemas(JoinType join_type,
+                                             const Schema& left_schema,
+                                             const std::vector<FieldRef>& left_output,
+                                             const Schema& right_schema,
+                                             const std::vector<FieldRef>& right_output) {
+  // Check for output fields:
+  // 1. Output field refs must match exactly one input field
+  // 2. At least one output field
+  // 3. Dictionary type is not supported in an output field
+  // 4. Left semi/anti join (right semi/anti join) must not output fields from right
+  // (left)
+  // 5. No name collisions in output fields after adding (potentially empty)
+  // suffixes to left and right output
+  //
+  if (left_output.empty() && right_output.empty()) {
+    return Status::Invalid("Join must output at least one field");
+  }
+  if (join_type == JoinType::LEFT_SEMI || join_type == JoinType::LEFT_ANTI) {
+    if (!right_output.empty()) {
+      return Status::Invalid(
+          join_type == JoinType::LEFT_SEMI ? "Left semi join " : "Left anti-semi join ",
+          "may not output fields from right side");
+    }
+  }
+  if (join_type == JoinType::RIGHT_SEMI || join_type == JoinType::RIGHT_ANTI) {
+    if (!left_output.empty()) {
+      return Status::Invalid(join_type == JoinType::RIGHT_SEMI ? "Right semi join "
+                                                               : "Right anti-semi join ",
+                             "may not output fields from left side");
+    }
+  }
+  for (size_t i = 0; i < left_output.size() + right_output.size(); ++i) {
+    bool left_side = i < left_output.size();
+    const FieldRef& field_ref =
+        left_side ? left_output[i] : right_output[i - left_output.size()];
+    Result<FieldPath> result = field_ref.FindOne(left_side ? left_schema : right_schema);
+    if (!result.ok()) {
+      return Status::Invalid("No match or multiple matches for output field reference ",
+                             field_ref.ToString(), left_side ? " on left " : " on right ",
+                             "side of the join");
+    }
+  }
+  return Status::OK();
+}
+
+std::shared_ptr<Schema> NestedLoopJoinSchema::MakeOutputSchema(
+    const std::string& left_field_name_suffix,
+    const std::string& right_field_name_suffix) {
+  std::vector<std::shared_ptr<Field>> fields;
+  int left_size = proj_maps[0].num_cols(NestedLoopJoinProjection::OUTPUT);
+  int right_size = proj_maps[1].num_cols(NestedLoopJoinProjection::OUTPUT);
+  fields.resize(left_size + right_size);
+
+  std::unordered_multimap<std::string, int> left_field_map;
+  left_field_map.reserve(left_size);
+  for (int i = 0; i < left_size; ++i) {
+    int side = 0;  // left
+    int input_field_id =
+        proj_maps[side]
+            .map(NestedLoopJoinProjection::OUTPUT, NestedLoopJoinProjection::INPUT)
+            .get(i);
+    const std::string& input_field_name =
+        proj_maps[side].field_name(NestedLoopJoinProjection::INPUT, input_field_id);
+    const std::shared_ptr<DataType>& input_data_type =
+        proj_maps[side].data_type(NestedLoopJoinProjection::INPUT, input_field_id);
+    left_field_map.insert({input_field_name, i});
+    // insert left table field
+    fields[i] =
+        std::make_shared<Field>(input_field_name, input_data_type, true /*nullable*/);
+  }
+
+  for (int i = 0; i < right_size; ++i) {
+    int side = 1;  // right
+    int input_field_id =
+        proj_maps[side]
+            .map(NestedLoopJoinProjection::OUTPUT, NestedLoopJoinProjection::INPUT)
+            .get(i);
+    const std::string& input_field_name =
+        proj_maps[side].field_name(NestedLoopJoinProjection::INPUT, input_field_id);
+    const std::shared_ptr<DataType>& input_data_type =
+        proj_maps[side].data_type(NestedLoopJoinProjection::INPUT, input_field_id);
+    // search the map and add suffix to the elements which
+    // are present both in left and right tables
+    auto search_it = left_field_map.equal_range(input_field_name);
+    bool match_found = false;
+    for (auto search = search_it.first; search != search_it.second; ++search) {
+      match_found = true;
+      auto left_val = search->first;
+      auto left_index = search->second;
+      auto left_field = fields[left_index];
+      // update left table field with suffix
+      fields[left_index] =
+          std::make_shared<Field>(input_field_name + left_field_name_suffix,
+                                  left_field->type(), true /*nullable*/);
+      // insert right table field with suffix
+      fields[left_size + i] = std::make_shared<Field>(
+          input_field_name + right_field_name_suffix, input_data_type, true /*nullable*/);
+    }
+
+    if (!match_found) {
+      // insert right table field without suffix
+      fields[left_size + i] =
+          std::make_shared<Field>(input_field_name, input_data_type, true /*nullable*/);
+    }
+  }
+  return std::make_shared<Schema>(std::move(fields));
+}
+
+Status NestedLoopJoinSchema::CollectFilterColumns(std::vector<FieldRef>& left_filter,
+                                                  std::vector<FieldRef>& right_filter,
+                                                  const Expression& filter,
+                                                  const Schema& left_schema,
+                                                  const Schema& right_schema) {
+  std::vector<FieldRef> nonunique_refs = FieldsInExpression(filter);
+
+  std::unordered_set<FieldPath, FieldPath::Hash> left_seen_paths;
+  std::unordered_set<FieldPath, FieldPath::Hash> right_seen_paths;
+  for (const FieldRef& ref : nonunique_refs) {
+    if (const FieldPath* path = ref.field_path()) {
+      std::vector<int> indices = path->indices();
+      if (indices[0] >= left_schema.num_fields()) {
+        indices[0] -= left_schema.num_fields();
+        FieldPath corrected_path(std::move(indices));
+        if (right_seen_paths.find(*path) == right_seen_paths.end()) {
+          right_filter.push_back(corrected_path);
+          right_seen_paths.emplace(std::move(corrected_path));
+        }
+      } else if (left_seen_paths.find(*path) == left_seen_paths.end()) {
+        left_filter.push_back(ref);
+        left_seen_paths.emplace(std::move(indices));
+      }
+    } else {
+      ARROW_DCHECK(ref.IsName());
+      ARROW_ASSIGN_OR_RAISE(auto left_match, ref.FindOneOrNone(left_schema));
+      ARROW_ASSIGN_OR_RAISE(auto right_match, ref.FindOneOrNone(right_schema));
+      bool in_left = !left_match.empty();
+      bool in_right = !right_match.empty();
+      if (in_left && in_right) {
+        return Status::Invalid("FieldRef", ref.ToString(),
+                               "was found in both left and right schemas");
+      } else if (!in_left && !in_right) {
+        return Status::Invalid("FieldRef", ref.ToString(),
+                               "was not found in either left or right schema");
+      }
+
+      ARROW_DCHECK(in_left != in_right);
+      auto& target_array = in_left ? left_filter : right_filter;
+      auto& target_set = in_left ? left_seen_paths : right_seen_paths;
+      auto& target_match = in_left ? left_match : right_match;
+
+      if (target_set.find(target_match) == target_set.end()) {
+        target_array.push_back(ref);
+        target_set.emplace(std::move(target_match));
+      }
+    }
+  }
+  return Status::OK();
+}
+
+Result<Expression> NestedLoopJoinSchema::BindFilter(Expression filter,
+                                                    const Schema& left_schema,
+                                                    const Schema& right_schema,
+                                                    ExecContext* exec_context) {
+  if (filter.IsBound() || filter == literal(true)) {
+    return std::move(filter);
+  }
+  // Step 1: Construct filter schema
+  FieldVector fields;
+  auto left_f_to_i =
+      proj_maps[0].map(NestedLoopJoinProjection::FILTER, NestedLoopJoinProjection::INPUT);
+  auto right_f_to_i =
+      proj_maps[1].map(NestedLoopJoinProjection::FILTER, NestedLoopJoinProjection::INPUT);
+
+  auto AppendFieldsInMap = [&fields](const SchemaProjectionMap& map,
+                                     const Schema& schema) {
+    for (int i = 0; i < map.num_cols; i++) {
+      int input_idx = map.get(i);
+      fields.push_back(schema.fields()[input_idx]);
+    }
+  };
+  AppendFieldsInMap(left_f_to_i, left_schema);
+  AppendFieldsInMap(right_f_to_i, right_schema);
+  Schema filter_schema(fields);
+
+  // Step 2: Bind
+  ARROW_ASSIGN_OR_RAISE(filter, filter.Bind(filter_schema, exec_context));
+  if (filter.type()->id() != Type::BOOL) {
+    return Status::TypeError("Filter expression must evaluate to bool, but ",
+                             filter.ToString(), " evaluates to ",
+                             filter.type()->ToString());
+  }
+  return std::move(filter);
+}
+
+class NestedLoopJoinNode : public ExecNode {
+ public:
+  NestedLoopJoinNode(ExecPlan* plan, NodeVector inputs,
+                     const NestedLoopJoinNodeOptions& join_options,
+                     std::shared_ptr<Schema> output_schema,
+                     std::unique_ptr<NestedLoopJoinSchema> schema_mgr, Expression filter,
+                     std::unique_ptr<NestedLoopJoinImpl> impl)
+      : ExecNode(plan, inputs, {"left", "right"},
+                 /*output_schema=*/std::move(output_schema)),
+        join_type_(join_options.join_type),
+        filter_(std::move(filter)),
+        schema_mgr_(std::move(schema_mgr)),
+        impl_(std::move(impl)) {
+    complete_.store(false);
+  }
+
+  Status Init() override {
+    QueryContext* ctx = plan_->query_context();
+    if (ctx->options().use_legacy_batching) {
+      return Status::Invalid(
+          "The plan was configured to use legacy batching but contained a nestedloop "
+          "node "
+          "which is incompatible with legacy batching");
+    }
+
+    size_t num_threads = GetCpuThreadPoolCapacity();
+    RETURN_NOT_OK(impl_->Init(
+        ctx, join_type_, num_threads, &(schema_mgr_->proj_maps[0]),
+        &(schema_mgr_->proj_maps[1]), filter_,
+        [ctx](std::function<Status(size_t, int64_t)> fn,
+              std::function<Status(size_t)> on_finished) {
+          return ctx->RegisterTaskGroup(std::move(fn), std::move(on_finished));
+        },
+        [ctx](int task_group_id, int64_t num_tasks) {
+          return ctx->StartTaskGroup(task_group_id, num_tasks);
+        },
+        [this](int64_t, ExecBatch batch) { return this->OutputBatchCallback(batch); },
+        [this](int64_t total_num_batches) {
+          return this->FinishedCallback(total_num_batches);
+        }));
+
+    return Status::OK();
+  }
+
+  static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
+                                const ExecNodeOptions& options) {
+    RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 2, "NestedLoopJoinNode"));
+
+    std::unique_ptr<NestedLoopJoinSchema> schema_mgr =
+        std::make_unique<NestedLoopJoinSchema>();
+
+    const auto& join_options = checked_cast<const NestedLoopJoinNodeOptions&>(options);
+    const auto& left_schema = *(inputs[0]->output_schema());
+    const auto& right_schema = *(inputs[1]->output_schema());
+    // This will also validate input schemas
+    if (join_options.output_all) {
+      RETURN_NOT_OK(schema_mgr->Init(
+          join_options.join_type, left_schema, right_schema, join_options.filter,
+          join_options.output_suffix_for_left, join_options.output_suffix_for_right));
+    } else {
+      RETURN_NOT_OK(schema_mgr->Init(
+          join_options.join_type, left_schema, join_options.left_output, right_schema,
+          join_options.right_output, join_options.filter,
+          join_options.output_suffix_for_left, join_options.output_suffix_for_right));
+    }
+
+    ARROW_ASSIGN_OR_RAISE(
+        Expression filter,
+        schema_mgr->BindFilter(join_options.filter, left_schema, right_schema,
+                               plan->query_context()->exec_context()));
+
+    // Generate output schema
+    std::shared_ptr<Schema> output_schema = schema_mgr->MakeOutputSchema(
+        join_options.output_suffix_for_left, join_options.output_suffix_for_right);
+
+    std::unique_ptr<NestedLoopJoinImpl> impl{new NestedLoopJoinImpl()};
+    return plan->EmplaceNode<NestedLoopJoinNode>(
+        plan, std::move(inputs), join_options, std::move(output_schema),
+        std::move(schema_mgr), std::move(filter), std::move(impl));
+  }
+
+  const char* kind_name() const override { return "NestedLoopJoinNode"; }
+
+  Status InputReceived(ExecNode* input, ExecBatch batch) override {
+    size_t thread_index = plan_->query_context()->GetThreadIndex();
+    int side = (input == inputs_[0]) ? 0 : 1;
+
+    if (side == 0) {
+      ARROW_RETURN_NOT_OK(OnOuterSideBatch(thread_index, std::move(batch)));
+    } else {
+      ARROW_RETURN_NOT_OK(OnInnerSideBatch(thread_index, std::move(batch)));
+    }
+
+    if (batch_count_[side].Increment()) {
+      if (side == 0) {
+        return OnOuterSideFinished(thread_index);
+      } else {
+        return OnInnerSideFinished(thread_index);
+      }
+    }
+    return Status::OK();
+  }
+
+  Status InputFinished(ExecNode* input, int total_batches) override {
+    ARROW_DCHECK(std::find(inputs_.begin(), inputs_.end(), input) != inputs_.end());
+    size_t thread_index = plan_->query_context()->GetThreadIndex();
+    int side = (input == inputs_[0]) ? 0 : 1;
+
+    if (batch_count_[side].SetTotal(total_batches)) {
+      if (side == 0) {
+        return OnOuterSideFinished(thread_index);
+      } else {
+        return OnInnerSideFinished(thread_index);
+      }
+    }
+    return Status::OK();
+  }
+
+  Status StartProducing() override {
+    START_COMPUTE_SPAN(span_, std::string(kind_name()) + ":" + label(),
+                       {{"node.label", label()},
+                        {"node.detail", ToString()},
+                        {"node.kind", kind_name()}});
+    return Status::OK();
+  }
+
+  void PauseProducing(ExecNode* output, int32_t counter) override {
+    EVENT(span_, "PauseProducing");
+  }
+
+  void ResumeProducing(ExecNode* output, int32_t counter) override {
+    EVENT(span_, "ResumeProducing");
+  }
+
+  Status StopProducingImpl() override {
+    bool expected = false;
+    if (complete_.compare_exchange_strong(expected, true)) {
+      impl_->Abort([]() {});
+    }
+    return Status::OK();
+  }
+
+ protected:
+  std::string ToStringExtra(int indent = 0) const override { return "NestedLoopJoin"; }
+
+ private:
+  Status OnInnerSideBatch(size_t thread_index, ExecBatch batch) {
+    if (batch.length) {
+      inner_accumulator_.InsertBatch(std::move(batch));
+    }
+    return Status::OK();
+  }
+
+  Status OnOuterSideBatch(size_t thread_index, ExecBatch batch) {
+    if (batch.length) {
+      outer_accumulator_.InsertBatch(std::move(batch));
+    }
+    return Status::OK();
+  }
+
+  Status OnInnerSideFinished(size_t thread_index) { return Status::OK(); }
+
+  Status OnOuterSideFinished(size_t thread_index) {
+    return impl_->StartCrossProduct(thread_index, std::move(inner_accumulator_),
+                                    std::move(outer_accumulator_));
+  }
+
+  Status FinishedCallback(int64_t total_num_batches) {
+    bool expected = false;
+    if (complete_.compare_exchange_strong(expected, true)) {
+      return output_->InputFinished(this, static_cast<int>(total_num_batches));
+    }
+    return Status::OK();
+  }
+
+  Status OutputBatchCallback(ExecBatch batch) {
+    return output_->InputReceived(this, std::move(batch));
+  }
+
+ protected:
+  arrow::util::tracing::Span span_;
+
+ private:
+  AtomicCounter batch_count_[2];
+  std::atomic<bool> complete_;
+  JoinType join_type_;
+  Expression filter_;
+  std::unique_ptr<NestedLoopJoinSchema> schema_mgr_;
+  std::unique_ptr<NestedLoopJoinImpl> impl_;
+  util::AccumulationQueue inner_accumulator_;
+  util::AccumulationQueue outer_accumulator_;
+};
+
+namespace internal {
+
+void RegisterNestedLoopJoinNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory("nestedloopjoin", NestedLoopJoinNode::Make));
+}
+
+}  // namespace internal
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/nested_loop_node.h
+++ b/cpp/src/arrow/acero/nested_loop_node.h
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "arrow/acero/options.h"
+#include "arrow/acero/schema_util.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+
+namespace arrow {
+
+using compute::ExecContext;
+
+namespace acero {
+
+class ARROW_ACERO_EXPORT NestedLoopJoinSchema {
+ public:
+  Status Init(JoinType join_type, const Schema& left_schema, const Schema& right_schema,
+              const Expression& filter, const std::string& left_field_name_suffix,
+              const std::string& right_field_name_suffix);
+
+  Status Init(JoinType join_type, const Schema& left_schema,
+              const std::vector<FieldRef>& left_output, const Schema& right_schema,
+              const std::vector<FieldRef>& right_output, const Expression& filter,
+              const std::string& left_field_name_suffix,
+              const std::string& right_field_name_suffix);
+
+  static Status ValidateSchemas(JoinType join_type, const Schema& left_schema,
+                                const std::vector<FieldRef>& left_output,
+                                const Schema& right_schema,
+                                const std::vector<FieldRef>& right_output);
+
+  std::shared_ptr<Schema> MakeOutputSchema(const std::string& left_field_name_suffix,
+                                           const std::string& right_field_name_suffix);
+
+  SchemaProjectionMaps<NestedLoopJoinProjection> proj_maps[2];
+
+  Result<Expression> BindFilter(Expression filter, const Schema& left_schema,
+                                const Schema& right_schema, ExecContext* exec_context);
+
+ private:
+  Status CollectFilterColumns(std::vector<FieldRef>& left_filter,
+                              std::vector<FieldRef>& right_filter,
+                              const Expression& filter, const Schema& left_schema,
+                              const Schema& right_schema);
+};
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/nested_loop_node_test.cc
+++ b/cpp/src/arrow/acero/nested_loop_node_test.cc
@@ -1,0 +1,432 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gmock/gmock-matchers.h>
+
+#include "arrow/acero/options.h"
+#include "arrow/acero/test_util_internal.h"
+#include "arrow/acero/util.h"
+#include "arrow/api.h"
+#include "arrow/compute/kernels/test_util.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/matchers.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/thread_pool.h"
+
+namespace arrow {
+
+using compute::call;
+using compute::field_ref;
+using compute::SortIndices;
+using compute::SortKey;
+using compute::Take;
+
+namespace acero {
+
+BatchesWithSchema GenerateBatches(std::vector<ExecBatch> batches,
+                                  const std::shared_ptr<Schema>& schema) {
+  return BatchesWithSchema{batches, schema};
+}
+
+void CheckRunOutput(BatchesWithSchema left_input, BatchesWithSchema right_input,
+                    JoinType join_type, Expression filter, BatchesWithSchema exp_batches,
+                    bool parallel = false) {
+  Declaration left{"source",
+                   SourceNodeOptions{left_input.schema, left_input.gen(parallel,
+                                                                       /*slow=*/false)}};
+  Declaration right{
+      "source", SourceNodeOptions{right_input.schema, right_input.gen(parallel,
+                                                                      /*slow=*/false)}};
+  NestedLoopJoinNodeOptions join_options{join_type, filter};
+  Declaration join{"nestedloopjoin", {std::move(left), std::move(right)}, join_options};
+
+  ASSERT_OK_AND_ASSIGN(auto out_table, DeclarationToTable(std::move(join), parallel));
+
+  ASSERT_OK_AND_ASSIGN(auto exp_table,
+                       TableFromExecBatches(exp_batches.schema, exp_batches.batches));
+
+  if (exp_table->num_rows() == 0) {
+    ASSERT_EQ(exp_table->num_rows(), out_table->num_rows());
+  } else {
+    std::vector<SortKey> sort_keys;
+    for (auto&& f : exp_batches.schema->fields()) {
+      sort_keys.emplace_back(f->name());
+    }
+    ASSERT_OK_AND_ASSIGN(auto exp_table_sort_ids,
+                         SortIndices(exp_table, SortOptions(sort_keys)));
+    ASSERT_OK_AND_ASSIGN(auto exp_table_sorted, Take(exp_table, exp_table_sort_ids));
+    ASSERT_OK_AND_ASSIGN(auto out_table_sort_ids,
+                         SortIndices(out_table, SortOptions(sort_keys)));
+    ASSERT_OK_AND_ASSIGN(auto out_table_sorted, Take(out_table, out_table_sort_ids));
+
+    AssertTablesEqual(*exp_table_sorted.table(), *out_table_sorted.table(),
+                      /*same_chunk_layout=*/false, /*flatten=*/true);
+  }
+}
+
+void RunNormalBatchesTest(JoinType type, bool parallel) {
+  auto l_schema = schema({field("i", int32()), field("j", boolean())});
+  auto r_schema = schema({field("k", int32()), field("l", boolean())});
+  std::shared_ptr<Schema> exp_schema;
+  BatchesWithSchema l_batches, r_batches, exp_batches;
+  Expression filter = greater(call("add", {field_ref("i"), field_ref("k")}), literal(12));
+
+  l_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()}, "[[null, true], [4, false]]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[[5, true], [6, false], [7, false]]"),
+      },
+      l_schema);
+  r_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()}, "[[null, true], [4, false]]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[[5, true], [6, false], [7, false]]"),
+      },
+      r_schema);
+
+  switch (type) {
+    case JoinType::INNER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[6, false, 7, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[7, false, 6, false], [7, false, 7, false]])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_OUTER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[null, true, null, null], [4, false, null, null]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[6, false, 7, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[7, false, 6, false], [7, false, 7, false], [5, true, null, null]])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_SEMI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean()}, R"([[6, false]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[7, false]])"),
+          },
+          l_schema);
+      break;
+    case JoinType::LEFT_ANTI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean()}, R"([[null, true], [4, false]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[5, true]])"),
+          },
+          l_schema);
+      break;
+    default:
+      FAIL() << "join type not implemented!";
+  }
+  CheckRunOutput(l_batches, r_batches, type, filter, exp_batches);
+}
+
+void RunInnerEmptyBatchesTest(JoinType type, bool parallel) {
+  auto l_schema = schema({field("i", int32()), field("j", boolean())});
+  auto r_schema = schema({field("k", int32()), field("l", boolean())});
+  std::shared_ptr<Schema> exp_schema;
+  BatchesWithSchema l_batches, r_batches, exp_batches;
+  Expression filter = greater(call("add", {field_ref("i"), field_ref("k")}), literal(12));
+
+  l_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()}, "[[null, true], [4, false]]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[[5, true], [6, false], [7, false]]"),
+      },
+      l_schema);
+  r_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()}, "[]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[]"),
+      },
+      r_schema);
+
+  switch (type) {
+    case JoinType::INNER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()}, R"([])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()}, R"([])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_OUTER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[null, true, null, null], [4, false, null, null], [5, true, null, null], [6, false, null, null], [7, false, null, null]])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_SEMI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean()}, R"([])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([])"),
+          },
+          l_schema);
+      break;
+    case JoinType::LEFT_ANTI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON(
+                  {int32(), boolean()},
+                  R"([[null, true], [4, false], [5, true], [6, false], [7, false]])"),
+          },
+          l_schema);
+      break;
+    default:
+      FAIL() << "join type not implemented!";
+  }
+  CheckRunOutput(l_batches, r_batches, type, filter, exp_batches);
+}
+
+void RunMaybeEmptyBatchesTest(JoinType type, bool parallel) {
+  auto l_schema = schema({field("i", int32()), field("j", boolean())});
+  auto r_schema = schema({field("k", int32()), field("l", boolean())});
+  std::shared_ptr<Schema> exp_schema;
+  BatchesWithSchema l_batches, r_batches, exp_batches;
+  Expression filter = greater(call("add", {field_ref("i"), field_ref("k")}), literal(12));
+
+  l_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()}, "[[null, true], [4, false]]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[[5, true], [6, false], [7, false]]"),
+      },
+      l_schema);
+  r_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()},
+                            "[[5, true], [null, true], [7, false]]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[]"),
+      },
+      r_schema);
+
+  switch (type) {
+    case JoinType::INNER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[6, false, 7, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[7, false, 7, false]])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_OUTER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[null, true, null, null], [4, false, null, null]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[6, false, 7, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[7, false, 7, false], [5, true, null, null]])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_SEMI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean()}, R"([[6, false]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[7, false]])"),
+          },
+          l_schema);
+      break;
+    case JoinType::LEFT_ANTI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean()}, R"([[null, true], [4, false]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[5, true]])"),
+          },
+          l_schema);
+      break;
+    default:
+      FAIL() << "join type not implemented!";
+  }
+  CheckRunOutput(l_batches, r_batches, type, filter, exp_batches);
+}
+
+void RunLiteralTrueTest(JoinType type, bool parallel) {
+  auto l_schema = schema({field("i", int32()), field("j", boolean())});
+  auto r_schema = schema({field("k", int32()), field("l", boolean())});
+  std::shared_ptr<Schema> exp_schema;
+  BatchesWithSchema l_batches, r_batches, exp_batches;
+  Expression filter = literal(true);
+
+  l_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()}, "[[null, true], [4, false]]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[[5, true], [6, false], [7, false]]"),
+      },
+      l_schema);
+  r_batches = GenerateBatches(
+      {
+          ExecBatchFromJSON({int32(), boolean()}, "[[null, true], [4, false]]"),
+          ExecBatchFromJSON({int32(), boolean()}, "[[5, true], [6, false], [7, false]]"),
+      },
+      r_schema);
+
+  switch (type) {
+    case JoinType::INNER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[null, true, null, true], [null, true, 4, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[4, false, null, true], [4, false, 4, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[null, true, 5, true], [null, true, 6, false], [null, true, 7, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[4, false, 5, true], [4, false, 6, false], [4, false, 7, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[5, true, null, true], [5, true, 4, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[6, false, null, true], [6, false, 4, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[7, false, null, true], [7, false, 4, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[5, true, 5, true], [5, true, 6, false], [5, true, 7, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[6, false, 5, true], [6, false, 6, false], [6, false, 7, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[7, false, 5, true], [7, false, 6, false], [7, false, 7, false]])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_OUTER: {
+      exp_schema = schema({field("i", int32()), field("j", boolean()),
+                           field("k", int32()), field("l", boolean())});
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[null, true, null, true], [null, true, 4, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[4, false, null, true], [4, false, 4, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[null, true, 5, true], [null, true, 6, false], [null, true, 7, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[4, false, 5, true], [4, false, 6, false], [4, false, 7, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[5, true, null, true], [5, true, 4, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[6, false, null, true], [6, false, 4, false]])"),
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()},
+                                R"([[7, false, null, true], [7, false, 4, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[5, true, 5, true], [5, true, 6, false], [5, true, 7, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[6, false, 5, true], [6, false, 6, false], [6, false, 7, false]])"),
+              ExecBatchFromJSON(
+                  {int32(), boolean(), int32(), boolean()},
+                  R"([[7, false, 5, true], [7, false, 6, false], [7, false, 7, false]])"),
+          },
+          exp_schema);
+      break;
+    }
+    case JoinType::LEFT_SEMI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean()}, R"([[null, true]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[4, false]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[5, true]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[6, false]])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([[7, false]])"),
+          },
+          l_schema);
+      break;
+    case JoinType::LEFT_ANTI:
+      exp_batches = GenerateBatches(
+          {
+              ExecBatchFromJSON({int32(), boolean(), int32(), boolean()}, R"([])"),
+              ExecBatchFromJSON({int32(), boolean()}, R"([])"),
+          },
+          l_schema);
+      break;
+    default:
+      FAIL() << "join type not implemented!";
+  }
+  CheckRunOutput(l_batches, r_batches, type, filter, exp_batches);
+}
+
+class NestedLoopJoinTest : public testing::TestWithParam<std::tuple<JoinType, bool>> {};
+
+INSTANTIATE_TEST_SUITE_P(
+    NestedLoopJoinTest, NestedLoopJoinTest,
+    ::testing::Combine(::testing::Values(JoinType::INNER, JoinType::LEFT_OUTER,
+                                         JoinType::LEFT_SEMI, JoinType::LEFT_ANTI),
+                       ::testing::Values(false)));
+
+TEST_P(NestedLoopJoinTest, TestNormalBatchesJoins) {
+  RunNormalBatchesTest(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+
+TEST_P(NestedLoopJoinTest, TestInnerEmptyBatches) {
+  RunInnerEmptyBatchesTest(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+
+TEST_P(NestedLoopJoinTest, TestMaybeEmptyBatches) {
+  RunMaybeEmptyBatchesTest(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+
+TEST_P(NestedLoopJoinTest, TestFilterTrue) {
+  RunLiteralTrueTest(std::get<0>(GetParam()), std::get<1>(GetParam()));
+}
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/schema_util.h
+++ b/cpp/src/arrow/acero/schema_util.h
@@ -41,6 +41,8 @@ enum class HashJoinProjection : int {
   OUTPUT = 4
 };
 
+using NestedLoopJoinProjection = HashJoinProjection;
+
 struct SchemaProjectionMap {
   static constexpr int kMissingField = -1;
   int num_cols;
@@ -221,6 +223,7 @@ class SchemaProjectionMaps {
 };
 
 using HashJoinProjectionMaps = SchemaProjectionMaps<HashJoinProjection>;
+using NestedLoopJoinProjectionMaps = SchemaProjectionMaps<NestedLoopJoinProjection>;
 
 }  // namespace acero
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

we add a node for acero, which also called nested loop join.

At present, acero lacks a nested loop join node. We completely implement the nested loop join that can run tpch and tpcds according to the implementation method of hashjoin. Currently, the following join types are supported.

INNER、LEFT_OUTER、LEFT_SEMI、LEFT_ANTI.

The NestedLoopJoin implementation is based on the HashJoin Basic implementation, constructing the match, no_match, match_left, and match_right arrays, and then output each batch.

In the future, we will support more join types and parallelization

### What changes are included in this PR?

- nestedloop node
- nestedloop implement
- nestedloop test

### Are these changes tested?

add cpp/src/arrow/acero/nested_loop_join.cc
add cpp/src/arrow/acero/nested_loop_join.h
add cpp/src/arrow/acero/nested_loop_node.cc
add cpp/src/arrow/acero/nested_loop_node.h
add cpp/src/arrow/acero/nested_loop_node_test.cc

### Are there any user-facing changes?

yes, tpch or tpcds include nested loop join plan.
* Closes: #37397