### PR TITLE
GH-37404: [Python] Add RecordBatchReader python wrappers

### DIFF
--- a/docs/source/python/integration/extending.rst
+++ b/docs/source/python/integration/extending.rst
@@ -183,6 +183,10 @@ may be returned if the input object doesn't have the expected type.
 
    Unwrap and return the Arrow C++ :class:`Table` pointer from *obj*.
 
+.. function:: Result<std::shared_ptr<RecordBatchReader>> arrow::py::unwrap_record_batch_reader(PyObject* obj)
+
+   Unwrap and return the Arrow C++ :class:`RecordBatchReader` pointer from *obj*.
+
 .. function:: Result<std::shared_ptr<Tensor>> arrow::py::unwrap_tensor(PyObject* obj)
 
    Unwrap and return the Arrow C++ :class:`Tensor` pointer from *obj*.
@@ -239,6 +243,10 @@ On error, NULL is returned and a Python exception is set.
 .. function:: PyObject* arrow::py::wrap_table(const std::shared_ptr<Table>& table)
 
    Wrap the Arrow C++ *table* in a :py:class:`pyarrow.Table` instance.
+
+.. function:: PyObject* arrow::py::wrap_record_batch_reader(const std::shared_ptr<RecordBatchReader>& record_batch_reader)
+
+   Wrap the Arrow C++ *record_batch_reader* in a :py:class:`pyarrow.RecordBatchReader` instance.
 
 .. function:: PyObject* arrow::py::wrap_tensor(const std::shared_ptr<Tensor>& tensor)
 
@@ -316,6 +324,10 @@ an exception) if the input is not of the right type.
 
    Unwrap the Arrow C++ :cpp:class:`Table` pointer from *obj*.
 
+.. function:: pyarrow_unwrap_record_batch_reader(obj) -> shared_ptr[CRecordBatchReader]
+
+   Unwrap the Arrow C++ :cpp:class:`RecordBatchReader` pointer from *obj*.
+
 .. function:: pyarrow_unwrap_tensor(obj) -> shared_ptr[CTensor]
 
    Unwrap the Arrow C++ :cpp:class:`Tensor` pointer from *obj*.
@@ -375,6 +387,10 @@ pyarray object of the corresponding type.  An exception is raised on error.
 .. function:: pyarrow_wrap_table(const shared_ptr[CTable]& table) -> object
 
    Wrap the Arrow C++ *table* in a Python :class:`pyarrow.Table` instance.
+
+.. function:: pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& sp_record_batch_reader) -> object
+
+   Wrap the Arrow C++ *record_batch_reader* in a Python :class:`pyarrow.RecordBatchReader` instance.
 
 .. function:: pyarrow_wrap_tensor(const shared_ptr[CTensor]& tensor) -> object
 

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -724,6 +724,7 @@ cdef public object pyarrow_wrap_tensor(const shared_ptr[CTensor]& sp_tensor)
 
 cdef public object pyarrow_wrap_batch(const shared_ptr[CRecordBatch]& cbatch)
 cdef public object pyarrow_wrap_table(const shared_ptr[CTable]& ctable)
+cdef public object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& sp_record_batch_reader)
 
 # Unwrapping Python -> C++
 
@@ -751,3 +752,4 @@ cdef public shared_ptr[CTensor] pyarrow_unwrap_tensor(object tensor)
 
 cdef public shared_ptr[CRecordBatch] pyarrow_unwrap_batch(object batch)
 cdef public shared_ptr[CTable] pyarrow_unwrap_table(object table)
+cdef public shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object record_batch_reader)

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -441,3 +441,22 @@ cdef api object pyarrow_wrap_batch(
     cdef RecordBatch batch = RecordBatch.__new__(RecordBatch)
     batch.init(cbatch)
     return batch
+
+
+cdef api bint pyarrow_is_record_batch_reader(object record_batch_reader):
+    return isinstance(record_batch_reader, RecordBatchReader)
+
+
+cdef api shared_ptr[CRecordBatchReader] pyarrow_unwrap_record_batch_reader(object record_batch_reader):
+    cdef RecordBatchReader reader
+    if pyarrow_is_record_batch_reader(record_batch_reader):
+        reader = <RecordBatchReader>(record_batch_reader)
+        return reader.reader
+
+    return shared_ptr[CRecordBatchReader]()
+
+
+cdef api object pyarrow_wrap_record_batch_reader(const shared_ptr[CRecordBatchReader]& sp_record_batch_reader):
+    cdef RecordBatchReader reader = RecordBatchReader.__new__(RecordBatchReader)
+    reader.reader = sp_record_batch_reader
+    return reader

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -83,6 +83,7 @@ DEFINE_WRAP_FUNCTIONS(tensor, Tensor)
 
 DEFINE_WRAP_FUNCTIONS(batch, RecordBatch)
 DEFINE_WRAP_FUNCTIONS(table, Table)
+DEFINE_WRAP_FUNCTIONS(record_batch_reader, RecordBatchReader)
 
 #undef DEFINE_WRAP_FUNCTIONS
 

--- a/python/pyarrow/src/arrow/python/pyarrow.h
+++ b/python/pyarrow/src/arrow/python/pyarrow.h
@@ -70,6 +70,7 @@ DECLARE_WRAP_FUNCTIONS(tensor, Tensor)
 
 DECLARE_WRAP_FUNCTIONS(batch, RecordBatch)
 DECLARE_WRAP_FUNCTIONS(table, Table)
+DECLARE_WRAP_FUNCTIONS(record_batch_reader, RecordBatchReader)
 
 #undef DECLARE_WRAP_FUNCTIONS
 


### PR DESCRIPTION
### Rationale for this change

See #37404.

### What changes are included in this PR?

Additional Cython wrappers to allow types to move between Python and C++

### Are these changes tested?

I have verified this with my internal custom RecordBatchReader (like an ORC RecordBatchReader) to Python. I don't see any unit tests for other wrappers, so not sure how much value tests to convert back and will add.

### Are there any user-facing changes?

Yes, this places RecordBatchReader and RecordBatchWriter as public facing interop APIs. Previously devs could not easily move these types between C++ and Python easily.

* Closes: #37404

NOTE This PR does not address RecordBatchWriter, which will be a separate PR