### PR TITLE
GH-37406: [C++][FlightSQL] Add missing ArrowFlight::arrow_flight_{shared,static} dependencies

### DIFF
--- a/cpp/src/arrow/flight/sql/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/CMakeLists.txt
@@ -64,8 +64,12 @@ add_arrow_lib(arrow_flight_sql
               ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
               arrow_flight_shared
+              SHARED_INSTALL_INTERFACE_LIBS
+              ArrowFlight::arrow_flight_shared
               STATIC_LINK_LIBS
               arrow_flight_static
+              STATIC_INSTALL_INTERFACE_LIBS
+              ArrowFlight::arrow_flight_static
               PRIVATE_INCLUDES
               "${Protobuf_INCLUDE_DIRS}")
 


### PR DESCRIPTION
### Rationale for this change

`ArrowFlightSql::arrow_flight_sql_shared` must depend on `ArrowFlight::arrow_flight_shared` because `arrow/flight/sql/*.h` uses ` arrow/flight/*.h` and all users must use Flight RPC API with Flight SQL API.

### What changes are included in this PR?

Add missing `{SHARED,STATIC}_INSTALL_INTERFACE_LIBS`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #37406