### PR TITLE
GH-37408: [C++] Install arrow-compute.pc only when ARROW_COMPUTE=ON

### DIFF
--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -19,8 +19,10 @@ add_custom_target(arrow_compute)
 
 arrow_install_all_headers("arrow/compute")
 
-# pkg-config support
-arrow_add_pkg_config("arrow-compute")
+if(ARROW_COMPUTE)
+  # pkg-config support
+  arrow_add_pkg_config("arrow-compute")
+endif()
 
 #
 # Unit tests

--- a/cpp/src/arrow/compute/arrow-compute.pc.in
+++ b/cpp/src/arrow/compute/arrow-compute.pc.in
@@ -20,6 +20,6 @@ includedir=@ARROW_PKG_CONFIG_INCLUDEDIR@
 libdir=@ARROW_PKG_CONFIG_LIBDIR@
 
 Name: Apache Arrow Compute
-Description: Compute modules for Apache Arrow
+Description: All compute kernels for Apache Arrow
 Version: @ARROW_VERSION@
 Requires: arrow


### PR DESCRIPTION
### Rationale for this change

GH-34295  changed meaning of `ARROW_COMPUTE`. `ARROW_COMPUTE=ON` means that "all compute kerenels are enabled" not "compute module is enabled".

`arrow-compute.pc`  is for detecting `ARROW_COMPUTE`. So `arrow-compute.pc` should be installed only when `ARROW_COMPUTE=ON`.

### What changes are included in this PR?

Add missing `if (ARROW_COMPUTE)`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #37408