### PR TITLE
GH-37414: [Release][CI] Update references to wrong apache-arrow Homebrew formula path

### DIFF
--- a/dev/release/post-04-ruby.sh
+++ b/dev/release/post-04-ruby.sh
@@ -39,7 +39,7 @@ homebrew_version=$(
   curl \
     --fail \
     --no-progress-meter \
-    https://raw.githubusercontent.com/Homebrew/homebrew-core/HEAD/Formula/apache-arrow-glib.rb | \
+    https://raw.githubusercontent.com/Homebrew/homebrew-core/HEAD/Formula/a/apache-arrow-glib.rb | \
     grep url | \
     grep -o "[0-9]*\.[0-9]*\.[0-9]*" | \
     head -n 1)

--- a/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow-glib.rb
@@ -24,7 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# https://github.com/Homebrew/homebrew-core/blob/-/Formula/apache-arrow-glib.rb
+# https://github.com/Homebrew/homebrew-core/blob/-/Formula/a/apache-arrow-glib.rb
 
 class ApacheArrowGlib < Formula
   desc "GLib bindings for Apache Arrow"

--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -24,7 +24,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# https://github.com/Homebrew/homebrew-core/blob/-/Formula/apache-arrow.rb
+# https://github.com/Homebrew/homebrew-core/blob/-/Formula/a/apache-arrow.rb
 
 class ApacheArrow < Formula
   desc "Columnar in-memory analytics layer designed to accelerate big data"

--- a/dev/tasks/r/github.macos.brew.yml
+++ b/dev/tasks/r/github.macos.brew.yml
@@ -41,7 +41,7 @@ jobs:
 
           # TODO(ARROW-16907): apache/arrow@main seems to be installed already
           # so this does nothing on a branch/PR
-          brew install -v --HEAD {{ '$(brew --repository homebrew/core)/Formula/apache-arrow.rb' }}
+          brew install -v --HEAD {{ '$(brew --repository homebrew/core)/Formula/a/apache-arrow.rb' }}
 
           mkdir -p homebrew-logs
           cp -a ~/Library/Logs/Homebrew/apache-arrow homebrew-logs/


### PR DESCRIPTION
### Rationale for this change

There are currently some references to the wrong homebrew-core arrow and arrow-glib formula paths.

### What changes are included in this PR?

Changing to the correct path.

### Are these changes tested?

The `post-04-ruby.sh` script has been used locally for the post release tasks. The other changes via archery.

### Are there any user-facing changes?

No
* Closes: #37414