### PR TITLE
GH-37416: [Go] Allow accessing underlying index builder of dictionary builders

### DIFF
--- a/go/arrow/array/dictionary.go
+++ b/go/arrow/array/dictionary.go
@@ -946,6 +946,10 @@ func (b *dictionaryBuilder) AppendArray(arr arrow.Array) error {
 	return nil
 }
 
+func (b *dictionaryBuilder) IndexBuilder() Builder {
+	return b.idxBuilder
+}
+
 func (b *dictionaryBuilder) AppendIndices(indices []int, valid []bool) {
 	b.length += len(indices)
 	switch idxbldr := b.idxBuilder.Builder.(type) {


### PR DESCRIPTION
### Rationale for this change

See #37416 

### What changes are included in this PR?

Exposing the index builder of dictionary builders.

### Are these changes tested?

Tested by an external usage. Since this is about exporting something that seemed appropriate enough.

### Are there any user-facing changes?

A new API, so no.
* Closes: #37416