### PR TITLE
GH-36124: [C++] Export compile_commands.json by default

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -11,7 +11,8 @@
       "hidden": true,
       "generator": "Ninja",
       "cacheVariables": {
-        "ARROW_BUILD_STATIC": "OFF"
+        "ARROW_BUILD_STATIC": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }
     },
     {


### PR DESCRIPTION
`CMakePresets.json` does not export `compile_commands.json` by default, which is used by all clang tooling. Adding it as a default ensures that new developers (or any others who forget to specifically specify the option) will still be able to use their language servers without regenerating the cmake build dir.

The relevant option is `"CMAKE_EXPORT_COMPILE_COMMANDS": "ON"`, and causes generation of a ~1MB file at build time.
* Closes: #36124