### PR TITLE
GH-37431: [R] Tests failing for R versions < 4.0 because of use of base pipe (|>) in tests

### DIFF
--- a/r/tests/testthat/test-dataset-write.R
+++ b/r/tests/testthat/test-dataset-write.R
@@ -945,7 +945,7 @@ test_that("Dataset can write flat files using readr::write_csv() options.", {
   dst_dir <- make_temp_dir()
   write_dataset(df, dst_dir, format = "csv", quoting_style = "AllValid")
   ds <- open_dataset(dst_dir, format = "csv")
-  expect_equal(df, ds |> collect())
+  expect_equal(df, ds %>% collect())
 
   lines <- paste(readLines(paste0(dst_dir, "/part-0.csv")), sep = "\n")
   expect_equal(lines[2], "\"1\",\"1\",\"true\",\"a\"")
@@ -995,7 +995,7 @@ test_that("Dataset write wrappers can write flat files using readr::write_csv() 
   dst_dir <- make_temp_dir()
   write_csv_dataset(df, dst_dir, quote = "all", delim = ";")
   ds <- open_dataset(dst_dir, format = "csv", delim = ";")
-  expect_equal(df, ds |> collect())
+  expect_equal(df, ds %>% collect())
 
   lines <- paste(readLines(paste0(dst_dir, "/part-0.csv")), sep = "\n")
   expect_equal(lines[2], "\"1\";\"1\";\"true\";\"a\"")
@@ -1003,13 +1003,13 @@ test_that("Dataset write wrappers can write flat files using readr::write_csv() 
   dst_dir <- make_temp_dir()
   write_tsv_dataset(df, dst_dir, quote = "all", eol = "\r\n")
   ds <- open_dataset(dst_dir, format = "tsv")
-  expect_equal(df, ds |> collect())
+  expect_equal(df, ds %>% collect())
 
   lines <- paste(readLines(paste0(dst_dir, "/part-0.tsv")), sep = "\n")
   expect_equal(lines[2], "\"1\"\t\"1\"\t\"true\"\t\"a\"")
   dst_dir <- make_temp_dir()
   write_tsv_dataset(df, dst_dir, na = "NOVALUE")
-  ds <- open_dataset(dst_dir, format = "tsv") |> collect()
+  ds <- open_dataset(dst_dir, format = "tsv") %>% collect()
 
   expect_equal(
     ds$lgl,


### PR DESCRIPTION
### Rationale for this change

Nightly builds using R versions < 4.0 fail due usage of newer syntax 

### What changes are included in this PR?

Use older syntax

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #37431