### PR TITLE
MINOR: [Docs][Java] Fix typo in javadoc

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -78,7 +78,7 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
   }
 
   /**
-   *  Base coonstructor that sets default conflict policy to APPEND.
+   *  Base constructor that sets default conflict policy to APPEND.
    */
   protected AbstractStructVector(String name,
                                  BufferAllocator allocator,


### PR DESCRIPTION
Hey folks - while I wouldn't normally submit a PR for a small javadoc typo, this one was [rather unfortunate](https://dictionary.cambridge.org/dictionary/english/coon)...

(I, of course, have no doubt that it was unintentional!)

James