### PR TITLE
GH-35600: [Python] Allow setting path to timezone db through python API

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -142,7 +142,6 @@ python setup.py develop -q || exit /B
 
 set PYTHONDEVMODE=1
 
-@rem Configure the path of the timesone database to a new location
 py.test -r sxX --durations=15 --pyargs pyarrow.tests || exit /B
 
 @rem

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -132,12 +132,8 @@ set ARROW_HOME=%CONDA_PREFIX%\Library
 @rem ARROW-3075; pkgconfig is broken for Parquet for now
 set PARQUET_HOME=%CONDA_PREFIX%\Library
 
-@rem Move tzdata to a non-standard location to test the
-@rem configurability of the timezone database path
-@REM mkdir %USERPROFILE%\Downloads\test\tzdata
-@REM move %USERPROFILE%\Downloads\tzdata %USERPROFILE%\Downloads\test\tzdata
-
-@rem Download IANA Timezone Database to another location
+@rem Download IANA Timezone Database to a non-standard location to
+@rem test the configurability of the timezone database path
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz || exit /B
 mkdir tzdata
 tar --extract --file tzdata.tar.gz --directory tzdata
@@ -146,9 +142,6 @@ move tzdata %USERPROFILE%\Downloads\test\
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml || exit /B
 set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
-@echo == PYARROW_TZDATA_PATH contents ==
-dir /n %PYARROW_TZDATA_PATH%
-@echo == /PYARROW_TZDATA_PATH contents ==
 
 python setup.py develop -q || exit /B
 

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -141,6 +141,7 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
 mkdir tzdata
 tar --extract --file tzdata.tar.gz --directory tzdata
+mkdir %USERPROFILE%\Downloads\test
 move tzdata %USERPROFILE%\Downloads\test\
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -146,6 +146,9 @@ move tzdata %USERPROFILE%\Downloads\test\tzdata
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml
 set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
+@echo == PYARROW_TZDATA_PATH contents ==
+dir /n %PYARROW_TZDATA_PATH%
+@echo == /PYARROW_TZDATA_PATH contents ==
 
 python setup.py develop -q || exit /B
 

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -139,6 +139,10 @@ mkdir %USERPROFILE%\Downloads\test\tzdata
 tar --extract --file tzdata.tar.gz --directory %USERPROFILE%\Downloads\test\tzdata
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml || exit /B
+@rem Remove the database from the default location
+rmdir /s /q %USERPROFILE%\Downloads\tzdata
+@rem Set the env var for the non-standard location of the database
+@rem (only needed for testing purposes)
 set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
 
 python setup.py develop -q || exit /B

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -134,9 +134,9 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 
 @rem Move tzdata to a non-standard location to test the
 @rem configurability of the timezone database path
-mkdir %USERPROFILE%\Downloads\test\tzdata
-move %USERPROFILE%\Downloads\tzdata %USERPROFILE%\Downloads\test\tzdata
-set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
+@REM mkdir %USERPROFILE%\Downloads\test\tzdata
+@REM move %USERPROFILE%\Downloads\tzdata %USERPROFILE%\Downloads\test\tzdata
+set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\tzdata
 
 python setup.py develop -q || exit /B
 

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -136,13 +136,13 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 @rem configurability of the timezone database path
 mkdir %USERPROFILE%\Downloads\test\tzdata
 move %USERPROFILE%\Downloads\tzdata %USERPROFILE%\Downloads\test\tzdata
+set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
 
 python setup.py develop -q || exit /B
 
 set PYTHONDEVMODE=1
 
 @rem Configure the path of the timesone database to a new location
-python -c "import pyarrow;import os;path = os.path.expandvars(r'%USERPROFILE%\Downloads\test\tzdata');pa.set_timezone_db_path(path)"
 py.test -r sxX --durations=15 --pyargs pyarrow.tests || exit /B
 
 @rem

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -136,7 +136,15 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 @rem configurability of the timezone database path
 @REM mkdir %USERPROFILE%\Downloads\test\tzdata
 @REM move %USERPROFILE%\Downloads\tzdata %USERPROFILE%\Downloads\test\tzdata
-set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\tzdata
+
+@rem Download IANA Timezone Database to another location
+curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
+mkdir tzdata
+tar --extract --file tzdata.tar.gz --directory tzdata
+move tzdata %USERPROFILE%\Downloads\test\tzdata
+curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
+  --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml
+set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
 
 python setup.py develop -q || exit /B
 

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -141,6 +141,7 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
 mkdir tzdata
 tar --extract --file tzdata.tar.gz --directory tzdata
+mkdir %USERPROFILE%\Downloads\test\tzdata
 move tzdata %USERPROFILE%\Downloads\test\tzdata
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -135,10 +135,8 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 @rem Download IANA Timezone Database to a non-standard location to
 @rem test the configurability of the timezone database path
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz || exit /B
-mkdir tzdata
-tar --extract --file tzdata.tar.gz --directory tzdata
-mkdir %USERPROFILE%\Downloads\test
-move tzdata %USERPROFILE%\Downloads\test\
+mkdir %USERPROFILE%\Downloads\test\tzdata
+tar --extract --file tzdata.tar.gz --directory %USERPROFILE%\Downloads\test\tzdata
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml || exit /B
 set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -138,13 +138,13 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 @REM move %USERPROFILE%\Downloads\tzdata %USERPROFILE%\Downloads\test\tzdata
 
 @rem Download IANA Timezone Database to another location
-curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
+curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz || exit /B
 mkdir tzdata
 tar --extract --file tzdata.tar.gz --directory tzdata
 mkdir %USERPROFILE%\Downloads\test
 move tzdata %USERPROFILE%\Downloads\test\
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
-  --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml
+  --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml || exit /B
 set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
 @echo == PYARROW_TZDATA_PATH contents ==
 dir /n %PYARROW_TZDATA_PATH%

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -141,8 +141,7 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
 mkdir tzdata
 tar --extract --file tzdata.tar.gz --directory tzdata
-mkdir %USERPROFILE%\Downloads\test\tzdata
-move tzdata %USERPROFILE%\Downloads\test\tzdata
+move tzdata %USERPROFILE%\Downloads\test\
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
   --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml
 set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -136,6 +136,7 @@ python setup.py develop -q || exit /B
 
 set PYTHONDEVMODE=1
 
+python -c "import pyarrow;import os;path = os.path.expandvars(r'%USERPROFILE%\Downloads\test\tzdata');pa.set_timezone_db_path(path)"
 py.test -r sxX --durations=15 --pyargs pyarrow.tests || exit /B
 
 @rem

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -132,10 +132,16 @@ set ARROW_HOME=%CONDA_PREFIX%\Library
 @rem ARROW-3075; pkgconfig is broken for Parquet for now
 set PARQUET_HOME=%CONDA_PREFIX%\Library
 
+@rem Move tzdata to a non-standard location to test the
+@rem configurability of the timezone database path
+mkdir %USERPROFILE%\Downloads\test\tzdata
+move %USERPROFILE%\Downloads\tzdata %USERPROFILE%\Downloads\test\tzdata
+
 python setup.py develop -q || exit /B
 
 set PYTHONDEVMODE=1
 
+@rem Configure the path of the timesone database to a new location
 python -c "import pyarrow;import os;path = os.path.expandvars(r'%USERPROFILE%\Downloads\test\tzdata');pa.set_timezone_db_path(path)"
 py.test -r sxX --durations=15 --pyargs pyarrow.tests || exit /B
 

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -102,11 +102,8 @@ if "%ARROW_S3%" == "ON" (
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
 mkdir tzdata
 tar --extract --file tzdata.tar.gz --directory tzdata
-@rem move tzdata to a non-standard location for testing purposes
-mkdir %USERPROFILE%\Downloads\test\tzdata
-move tzdata %USERPROFILE%\Downloads\test\tzdata
-@rem
+move tzdata %USERPROFILE%\Downloads\tzdata
 @rem Also need Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
-  --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml
+  --output %USERPROFILE%\Downloads\tzdata\windowsZones.xml
 @rem (Doc section: Download timezone database)

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -102,8 +102,11 @@ if "%ARROW_S3%" == "ON" (
 curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz
 mkdir tzdata
 tar --extract --file tzdata.tar.gz --directory tzdata
-move tzdata %USERPROFILE%\Downloads\tzdata
+@rem move tzdata to a non-standard location for testing purposes
+mkdir %USERPROFILE%\Downloads\test\tzdata
+move tzdata %USERPROFILE%\Downloads\test\tzdata
+@rem
 @rem Also need Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^
-  --output %USERPROFILE%\Downloads\tzdata\windowsZones.xml
+  --output %USERPROFILE%\Downloads\test\tzdata\windowsZones.xml
 @rem (Doc section: Download timezone database)

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -66,10 +66,10 @@ import pyarrow.lib as _lib
 if _gc_enabled:
     _gc.enable()
 
-from pyarrow.lib import (BuildInfo, RuntimeInfo, MonthDayNano,
-                         VersionInfo, cpp_build_info, cpp_version,
-                         cpp_version_info, runtime_info, cpu_count,
-                         set_cpu_count, enable_signal_handlers,
+from pyarrow.lib import (BuildInfo, RuntimeInfo, set_timezone_db_path,
+                         MonthDayNano, VersionInfo, cpp_build_info,
+                         cpp_version, cpp_version_info, runtime_info,
+                         cpu_count, set_cpu_count, enable_signal_handlers,
                          io_thread_count, set_io_thread_count)
 
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -157,15 +157,6 @@ def show_info():
         print(f"  {codec: <20}: {status: <8}")
 
 
-if _sys.platform == 'win32':
-    tzdata_set_path = os.environ.get('PYARROW_TZDATA_PATH', None)
-    if tzdata_set_path:
-        set_timezone_db_path(tzdata_set_path)
-    else:
-        if not os.path.exists(os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")):
-            _warnings.warn('The timezone database is not installed. Timezones '+
-                           'will not be available.', RuntimeWarning)
-
 from pyarrow.lib import (null, bool_,
                          int8, int16, int32, int64,
                          uint8, uint16, uint32, uint64,

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -157,6 +157,15 @@ def show_info():
         print(f"  {codec: <20}: {status: <8}")
 
 
+if _sys.platform == 'win32':
+    tzdata_set_path = os.environ.get('PYARROW_TZDATA_PATH', None)
+    if tzdata_set_path:
+        set_timezone_db_path(tzdata_set_path)
+    else:
+        if not os.path.exists(os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")):
+            _warnings.warn('The timezone database is not installed. Timezones '+
+                           'will not be available.', RuntimeWarning)
+
 from pyarrow.lib import (null, bool_,
                          int8, int16, int32, int64,
                          uint8, uint16, uint32, uint64,

--- a/python/pyarrow/config.pxi
+++ b/python/pyarrow/config.pxi
@@ -18,6 +18,7 @@
 from pyarrow.includes.libarrow cimport GetBuildInfo
 
 from collections import namedtuple
+import os
 
 
 VersionInfo = namedtuple('VersionInfo', ('major', 'minor', 'patch'))
@@ -76,7 +77,7 @@ def runtime_info():
         detected_simd_level=frombytes(c_info.detected_simd_level))
 
 
-def configure_tzdb(path):
+def set_timezone_db_path(path):
     """
     Configure the path to text timezone database on Windows.
 

--- a/python/pyarrow/config.pxi
+++ b/python/pyarrow/config.pxi
@@ -74,3 +74,21 @@ def runtime_info():
     return RuntimeInfo(
         simd_level=frombytes(c_info.simd_level),
         detected_simd_level=frombytes(c_info.detected_simd_level))
+
+
+def configure_tzdb(path):
+    """
+    Configure the path to text timezone database on Windows.
+
+    Parameters
+    ----------
+    path : str
+        Path to text timezone database.
+    """
+    cdef:
+        CGlobalOptions options
+
+    if path is not None:
+            options.timezone_db_path = <c_string>tobytes(path)
+
+    check_status(Initialize(options))

--- a/python/pyarrow/config.pxi
+++ b/python/pyarrow/config.pxi
@@ -89,6 +89,6 @@ def configure_tzdb(path):
         CGlobalOptions options
 
     if path is not None:
-            options.timezone_db_path = <c_string>tobytes(path)
+        options.timezone_db_path = <c_string>tobytes(path)
 
     check_status(Initialize(options))

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -80,6 +80,11 @@ cdef extern from "arrow/config.h" namespace "arrow" nogil:
 
     CRuntimeInfo GetRuntimeInfo()
 
+    cdef cppclass CGlobalOptions" arrow::GlobalOptions":
+        optional[c_string] timezone_db_path
+
+    CStatus Initialize(const CGlobalOptions& options)
+
 
 cdef extern from "arrow/util/future.h" namespace "arrow" nogil:
     cdef cppclass CFuture_Void" arrow::Future<>":

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -28,6 +28,7 @@ from pytest_lazyfixture import lazy_fixture
 import hypothesis as h
 from ..conftest import groups, defaults
 
+from pyarrow import set_timezone_db_path
 from pyarrow.util import find_free_port
 
 

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -48,6 +48,12 @@ h.settings.load_profile(os.environ.get('HYPOTHESIS_PROFILE', 'dev'))
 os.environ['AWS_CONFIG_FILE'] = "/dev/null"
 
 
+if sys.platform == 'win32':
+    tzdata_set_path = os.environ.get('PYARROW_TZDATA_PATH', None)
+    if tzdata_set_path:
+        set_timezone_db_path(tzdata_set_path)
+
+
 def pytest_addoption(parser):
     # Create options to selectively enable test groups
     def bool_env(name, default=None):

--- a/python/pyarrow/tests/test_misc.py
+++ b/python/pyarrow/tests/test_misc.py
@@ -22,6 +22,7 @@ import sys
 import pytest
 
 import pyarrow as pa
+from pyarrow.lib import ArrowInvalid
 
 
 def test_get_include():
@@ -114,6 +115,17 @@ def test_runtime_info():
                 info.detected_simd_level
             """
         subprocess.check_call([sys.executable, "-c", code], env=env)
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Path to timezone database is not configurable "
+                           "on non-Windows platforms")
+def test_set_timezone_db_path_non_windows():
+    # set_timezone_db_path raises an error on non-Windows platforms
+    with pytest.raises(ArrowInvalid,
+                       match="Arrow was set to use OS timezone "
+                             "database at compile time"):
+        pa.set_timezone_db_path("path")
 
 
 @pytest.mark.parametrize('klass', [

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -455,6 +455,11 @@ def windows_has_tzdata():
     This is the default location where tz.cpp will look for (until we make
     this configurable at run-time)
     """
-    tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
-    tzdata_set_path = os.environ.get('PYARROW_TZDATA_PATH', '')
-    return os.path.exists(tzdata_path) or os.path.exists(tzdata_set_path)
+    tzdata_bool = False
+    if "PYARROW_TZDATA_PATH" in os.environ:
+        tzdata_bool = os.path.exists(os.environ['PYARROW_TZDATA_PATH'])
+    if not tzdata_bool:
+        tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
+        tzdata_bool = os.path.exists(tzdata_path)
+
+    return tzdata_bool

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -456,4 +456,5 @@ def windows_has_tzdata():
     this configurable at run-time)
     """
     tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
-    return os.path.exists(tzdata_path)
+    tzdata_set_path = os.environ.get('PYARROW_TZDATA_PATH', '')
+    return os.path.exists(tzdata_path) or os.path.exists(tzdata_set_path)


### PR DESCRIPTION
### Rationale for this change

Add a function to change the path where timezone db should be found as a small wrapper around the setting of a C++ option `GlobalOptions`.

### What changes are included in this PR?

New function `configure_tzdb`.

### Are these changes tested?


### Are there any user-facing changes?

No.
* Closes: #35600