### PR TITLE
MINOR: [Go] Export IndexBuilder struct

### DIFF
--- a/go/arrow/array/dictionary.go
+++ b/go/arrow/array/dictionary.go
@@ -314,13 +314,13 @@ func arrayApproxEqualDict(l, r *Dictionary, opt equalOption) bool {
 }
 
 // helper for building the properly typed indices of the dictionary builder
-type indexBuilder struct {
+type IndexBuilder struct {
 	Builder
 	Append func(int)
 }
 
-func createIndexBuilder(mem memory.Allocator, dt arrow.FixedWidthDataType) (ret indexBuilder, err error) {
-	ret = indexBuilder{Builder: NewBuilder(mem, dt)}
+func createIndexBuilder(mem memory.Allocator, dt arrow.FixedWidthDataType) (ret IndexBuilder, err error) {
+	ret = IndexBuilder{Builder: NewBuilder(mem, dt)}
 	switch dt.ID() {
 	case arrow.INT8:
 		ret.Append = func(idx int) {
@@ -420,7 +420,7 @@ type dictionaryBuilder struct {
 	dt          *arrow.DictionaryType
 	deltaOffset int
 	memoTable   hashing.MemoTable
-	idxBuilder  indexBuilder
+	idxBuilder  IndexBuilder
 }
 
 // NewDictionaryBuilderWithDict initializes a dictionary builder and inserts the values from `init` as the first
@@ -946,7 +946,7 @@ func (b *dictionaryBuilder) AppendArray(arr arrow.Array) error {
 	return nil
 }
 
-func (b *dictionaryBuilder) IndexBuilder() Builder {
+func (b *dictionaryBuilder) IndexBuilder() IndexBuilder {
 	return b.idxBuilder
 }
 


### PR DESCRIPTION
We allow accessing the IndexBuilder since GH-37416 merged. While the `Builder` interface functions can be accessed, the actual array builder cannot.

### Rationale for this change

#37416 added the function to access the index builder, but since it returns the `Builder` interface, we can't actually access the underlying builder as the unexported `IndexBuilder` is unexported.

Alternatives could be:

* Return `indexBuilder.Builder` instead in the `IndexBuilder()` function
* Return the unexported `indexBuilder` type, but this tends to be more awkward to use

### What changes are included in this PR?

Exporting the type so it can be type asserted.

### Are these changes tested?

Yes, rolled this out in our infra.

### Are there any user-facing changes?

Yes, but this API hasn't been released yet.