### PR TITLE
GH-37367: [MATLAB] Add `arrow.array.Date32Array` class

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/numeric_array.h
@@ -56,7 +56,7 @@ class NumericArray : public arrow::matlab::array::proxy::Array {
             
             auto data_buffer = std::make_shared<MatlabBuffer>(numeric_mda);
 
-            const auto data_type = arrow::CTypeTraits<CType>::type_singleton();
+            const auto data_type = arrow::TypeTraits<ArrowType>::type_singleton();
             const auto length = static_cast<int64_t>(numeric_mda.getNumberOfElements()); // cast size_t to int64_t
 
             // Pack the validity bitmap values.

--- a/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/wrap.cc
@@ -55,6 +55,8 @@ namespace arrow::matlab::array::proxy {
                 return std::make_shared<proxy::NumericArray<arrow::Time32Type>>(std::static_pointer_cast<arrow::Time32Array>(array));
             case ID::TIME64:
                 return std::make_shared<proxy::NumericArray<arrow::Time64Type>>(std::static_pointer_cast<arrow::Time64Array>(array));
+            case ID::DATE32:
+                return std::make_shared<proxy::NumericArray<arrow::Date32Type>>(std::static_pointer_cast<arrow::Date32Array>(array));
             case ID::STRING:
                 return std::make_shared<proxy::StringArray>(std::static_pointer_cast<arrow::StringArray>(array));
             default:

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -54,6 +54,7 @@ libmexclass::proxy::MakeResult Factory::make_proxy(const ClassName& class_name, 
     REGISTER_PROXY(arrow.array.proxy.TimestampArray, arrow::matlab::array::proxy::NumericArray<arrow::TimestampType>);
     REGISTER_PROXY(arrow.array.proxy.Time32Array   , arrow::matlab::array::proxy::NumericArray<arrow::Time32Type>);
     REGISTER_PROXY(arrow.array.proxy.Time64Array   , arrow::matlab::array::proxy::NumericArray<arrow::Time64Type>);
+    REGISTER_PROXY(arrow.array.proxy.Date32Array   , arrow::matlab::array::proxy::NumericArray<arrow::Date32Type>);
     REGISTER_PROXY(arrow.tabular.proxy.RecordBatch , arrow::matlab::tabular::proxy::RecordBatch);
     REGISTER_PROXY(arrow.tabular.proxy.Schema      , arrow::matlab::tabular::proxy::Schema);
     REGISTER_PROXY(arrow.type.proxy.Field          , arrow::matlab::type::proxy::Field);

--- a/matlab/src/cpp/arrow/matlab/type/proxy/traits.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/traits.h
@@ -23,6 +23,7 @@
 #include "arrow/matlab/type/proxy/timestamp_type.h"
 #include "arrow/matlab/type/proxy/time32_type.h"
 #include "arrow/matlab/type/proxy/time64_type.h"
+#include "arrow/matlab/type/proxy/date32_type.h"
 #include "arrow/matlab/type/proxy/string_type.h"
 
 namespace arrow::matlab::type::proxy {
@@ -98,5 +99,10 @@ namespace arrow::matlab::type::proxy {
     template <>
     struct Traits<arrow::Time64Type> {
         using TypeProxy = Time64Type;
+    };
+
+    template <>
+    struct Traits<arrow::Date32Type> {
+        using TypeProxy = Date32Type;
     };
 }

--- a/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/wrap.cc
@@ -21,6 +21,7 @@
 #include "arrow/matlab/type/proxy/timestamp_type.h"
 #include "arrow/matlab/type/proxy/time32_type.h"
 #include "arrow/matlab/type/proxy/time64_type.h"
+#include "arrow/matlab/type/proxy/date32_type.h"
 #include "arrow/matlab/type/proxy/string_type.h"
 
 namespace arrow::matlab::type::proxy {
@@ -56,6 +57,8 @@ namespace arrow::matlab::type::proxy {
                 return std::make_shared<Time32Type>(std::static_pointer_cast<arrow::Time32Type>(type));
             case ID::TIME64:
                 return std::make_shared<Time64Type>(std::static_pointer_cast<arrow::Time64Type>(type));
+            case ID::DATE32:
+                return std::make_shared<Date32Type>(std::static_pointer_cast<arrow::Date32Type>(type));
             case ID::STRING:
                 return std::make_shared<StringType>(std::static_pointer_cast<arrow::StringType>(type));
             default:

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -43,8 +43,8 @@ classdef Date32Array < arrow.array.Array
             dates(~obj.Valid) = obj.NullSubstitutionValue;
         end
 
-        function times = datetime(obj)
-            times = obj.toMATLAB();
+        function dates = datetime(obj)
+            dates = obj.toMATLAB();
         end
 
     end

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -73,6 +73,14 @@ classdef Date32Array < arrow.array.Array
                 unixEpoch = datetime(0, ConvertFrom="posixtime");
             end
 
+            % Explicitly round down (i.e. floor) to the nearest whole number
+            % of days because durations and datetimes are not guaranteed
+            % to encode "whole" number dates / times (e.g. 1.5 days is a valid duration)
+            % and the int32 function rounds to the nearest whole number.
+            % Rounding to the nearest whole number without flooring first would result in a
+            % "round up error" of 1 whole day in cases where the fractional part of
+            % the duration is large enough to result in rounding up (e.g. 1.5 days would
+            % become 2 days).
             numDays = int32(floor(days(data - unixEpoch)));
             args = struct(MatlabArray=numDays, Valid=validElements);
             proxy = arrow.internal.proxy.create("arrow.array.proxy.Date32Array", args);

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -35,11 +35,10 @@ classdef Date32Array < arrow.array.Array
             import arrow.type.DateUnit
 
             matlabArray = obj.Proxy.toMATLAB();
-            % UNIX Epoch (January 1st, 1970)
+            % UNIX Epoch (January 1st, 1970).
             unixEpoch = datetime(0, ConvertFrom="posixtime");
-            % Date32 value represents the number of days before
-            % or after the Unix Epoch. This works for negative values
-            % too.
+            % A Date32 value encodes a certain number of whole days
+            % before or after the UNIX Epoch.
             dates = unixEpoch + days(matlabArray);
             dates(~obj.Valid) = obj.NullSubstitutionValue;
         end
@@ -66,7 +65,8 @@ classdef Date32Array < arrow.array.Array
 
             validElements = arrow.internal.validate.parseValidElements(data, opts);
 
-            % UNIX Epoch (January 1st, 1970)
+            % If the input MATLAB datetime array is zoned (i.e. has a TimeZone),
+            % then the datetime representing the UNIX Epoch must also have a TimeZone.
             if ~isempty(data.TimeZone)
                 unixEpoch = datetime(0, ConvertFrom="posixtime", TimeZone="UTC");
             else

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -65,8 +65,14 @@ classdef Date32Array < arrow.array.Array
             arrow.internal.validate.shape(data);
 
             validElements = arrow.internal.validate.parseValidElements(data, opts);
+
             % UNIX Epoch (January 1st, 1970)
-            unixEpoch = datetime(0, ConvertFrom="posixtime");
+            if ~isempty(data.TimeZone)
+                unixEpoch = datetime(0, ConvertFrom="posixtime", TimeZone="UTC");
+            else
+                unixEpoch = datetime(0, ConvertFrom="posixtime");
+            end
+
             numDays = int32(floor(days(data - unixEpoch)));
             args = struct(MatlabArray=numDays, Valid=validElements);
             proxy = arrow.internal.proxy.create("arrow.array.proxy.Date32Array", args);

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -74,7 +74,7 @@ classdef Date32Array < arrow.array.Array
             validElements = arrow.internal.validate.parseValidElements(data, opts);
             % UNIX Epoch (January 1st, 1970)
             unixEpoch = datetime(0, ConvertFrom="posixtime");
-            numDays = days(data - unixEpoch);
+            numDays = int32(days(data - unixEpoch));
             args = struct(MatlabArray=numDays, Valid=validElements);
             proxy = arrow.internal.proxy.create("arrow.array.proxy.Date32Array", args);
             array = Date32Array(proxy);

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -22,6 +22,7 @@ classdef Date32Array < arrow.array.Array
     end
 
     methods
+
         function obj = Date32Array(proxy)
             arguments
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.array.proxy.Date32Array")}
@@ -46,19 +47,11 @@ classdef Date32Array < arrow.array.Array
         function times = datetime(obj)
             times = obj.toMATLAB();
         end
-    end
 
-    methods(Static, Access=private)
-        function ticks = convertDurationToTicks(data, timeUnit)
-            if (timeUnit == arrow.type.TimeUnit.Second)
-                ticks = cast(seconds(data), "int32");
-            else
-                ticks = cast(milliseconds(data), "int32");
-            end
-        end
     end
 
     methods(Static)
+
         function array = fromMATLAB(data, opts)
             arguments
                 data
@@ -79,6 +72,7 @@ classdef Date32Array < arrow.array.Array
             proxy = arrow.internal.proxy.create("arrow.array.proxy.Date32Array", args);
             array = Date32Array(proxy);
         end
+
     end
 
 end

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -81,38 +81,4 @@ classdef Date32Array < arrow.array.Array
         end
     end
 
-    methods (Access=protected)
-
-        function displayScalarObject(obj)
-            maxLength = 20;
-            openBracket = "[";
-            closeBracket = "]";
-            indent = "  ";
-            data = obj.toMATLAB();
-            data.Format = "yyyy-MM-dd";
-            % Abbreviate with ellipsis if more than maxLength elements.
-            if obj.Length > maxLength
-                firstTenElements = data(1:10);
-                lastTenElements = data(end-9:end);
-                ellipsis = "...";
-                beforeEllipsis = indent + strjoin(string(firstTenElements), "," + newline + indent) + ",";
-                afterEllipsis = indent + strjoin(string(lastTenElements), "," + newline + indent);
-                str = ...
-                    openBracket + newline + ...
-                    beforeEllipsis + newline + ...
-                    indent + ellipsis + newline + ...
-                    afterEllipsis + newline + ...
-                    closeBracket;
-                disp(str);
-
-            else
-                str = openBracket + newline + ...
-                    indent + strjoin(string(data), "," + newline + indent) + newline + ...
-                    closeBracket;
-                disp(str);
-            end
-        end
-
-    end
-
 end

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -74,10 +74,45 @@ classdef Date32Array < arrow.array.Array
             validElements = arrow.internal.validate.parseValidElements(data, opts);
             % UNIX Epoch (January 1st, 1970)
             unixEpoch = datetime(0, ConvertFrom="posixtime");
-            numDays = int32(days(data - unixEpoch));
+            numDays = int32(floor(days(data - unixEpoch)));
             args = struct(MatlabArray=numDays, Valid=validElements);
             proxy = arrow.internal.proxy.create("arrow.array.proxy.Date32Array", args);
             array = Date32Array(proxy);
         end
     end
+
+    methods (Access=protected)
+
+        function displayScalarObject(obj)
+            maxLength = 20;
+            openBracket = "[";
+            closeBracket = "]";
+            indent = "  ";
+            data = obj.toMATLAB();
+            data.Format = "yyyy-MM-dd";
+            % Abbreviate with ellipsis if more than maxLength elements.
+            if obj.Length > maxLength
+                firstTenElements = data(1:10);
+                lastTenElements = data(end-9:end);
+                ellipsis = "...";
+                beforeEllipsis = indent + strjoin(string(firstTenElements), "," + newline + indent) + ",";
+                afterEllipsis = indent + strjoin(string(lastTenElements), "," + newline + indent);
+                str = ...
+                    openBracket + newline + ...
+                    beforeEllipsis + newline + ...
+                    indent + ellipsis + newline + ...
+                    afterEllipsis + newline + ...
+                    closeBracket;
+                disp(str);
+
+            else
+                str = openBracket + newline + ...
+                    indent + strjoin(string(data), "," + newline + indent) + newline + ...
+                    closeBracket;
+                disp(str);
+            end
+        end
+
+    end
+
 end

--- a/matlab/src/matlab/+arrow/+array/Date32Array.m
+++ b/matlab/src/matlab/+arrow/+array/Date32Array.m
@@ -1,0 +1,83 @@
+% arrow.array.Date32Array
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Date32Array < arrow.array.Array
+
+    properties(Access=private)
+        NullSubstitutionValue = NaT
+    end
+
+    methods
+        function obj = Date32Array(proxy)
+            arguments
+                proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.array.proxy.Date32Array")}
+            end
+            import arrow.internal.proxy.validate
+            obj@arrow.array.Array(proxy);
+        end
+
+        function dates = toMATLAB(obj)
+            import arrow.type.DateUnit
+
+            matlabArray = obj.Proxy.toMATLAB();
+            % UNIX Epoch (January 1st, 1970)
+            unixEpoch = datetime(0, ConvertFrom="posixtime");
+            % Date32 value represents the number of days before
+            % or after the Unix Epoch. This works for negative values
+            % too.
+            dates = unixEpoch + days(matlabArray);
+            dates(~obj.Valid) = obj.NullSubstitutionValue;
+        end
+
+        function times = datetime(obj)
+            times = obj.toMATLAB();
+        end
+    end
+
+    methods(Static, Access=private)
+        function ticks = convertDurationToTicks(data, timeUnit)
+            if (timeUnit == arrow.type.TimeUnit.Second)
+                ticks = cast(seconds(data), "int32");
+            else
+                ticks = cast(milliseconds(data), "int32");
+            end
+        end
+    end
+
+    methods(Static)
+        function array = fromMATLAB(data, opts)
+            arguments
+                data
+                opts.InferNulls(1, 1) logical = true
+                opts.Valid
+            end
+
+            import arrow.array.Date32Array
+
+            arrow.internal.validate.type(data, "datetime");
+            arrow.internal.validate.shape(data);
+
+            validElements = arrow.internal.validate.parseValidElements(data, opts);
+            % UNIX Epoch (January 1st, 1970)
+            unixEpoch = datetime(0, ConvertFrom="posixtime");
+            numDays = days(data - unixEpoch);
+            args = struct(MatlabArray=numDays, Valid=validElements);
+            proxy = arrow.internal.proxy.create("arrow.array.proxy.Date32Array", args);
+            array = Date32Array(proxy);
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
@@ -91,8 +91,8 @@ function timeClasses = getTimeArrayClasses()
     timeClasses = compose("arrow.array.Time%dArray", [32 64]);
 end
 
-function timeClasses = getDateArrayClasses()
-    timeClasses = compose("arrow.array.Date%dArray", 32);
+function dateClasses = getDateArrayClasses()
+    dateClasses = compose("arrow.array.Date%dArray", 32);
 end
 
 function number = randomNumbers(numberType, numElements)

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
@@ -32,6 +32,7 @@ function [arrowArrays, matlabData] = createAllSupportedArrayTypes(opts)
     matlabData  = cell(numClasses, 1);
     
     timeClasses = getTimeArrayClasses();
+    dateClasses = getDateArrayClasses();
     numericArrayToMatlabTypeDict = getNumericArrayToMatlabDictionary();
 
     for ii = 1:numel(classes)
@@ -52,6 +53,10 @@ function [arrowArrays, matlabData] = createAllSupportedArrayTypes(opts)
             arrowArrays{ii} = TimestampArray.fromMATLAB(matlabData{ii});
         elseif ismember(name, timeClasses)
             matlabData{ii} = randomDurations(opts.NumRows);
+            cmd = compose("%s.fromMATLAB(matlabData{ii})", name);
+            arrowArrays{ii} = eval(cmd);
+        elseif ismember(name, dateClasses)
+            matlabData{ii} = randomDatetimes(opts.NumRows);
             cmd = compose("%s.fromMATLAB(matlabData{ii})", name);
             arrowArrays{ii} = eval(cmd);
         else
@@ -84,6 +89,10 @@ end
 
 function timeClasses = getTimeArrayClasses()
     timeClasses = compose("arrow.array.Time%dArray", [32 64]);
+end
+
+function timeClasses = getDateArrayClasses()
+    timeClasses = compose("arrow.array.Date%dArray", 32);
 end
 
 function number = randomNumbers(numberType, numElements)

--- a/matlab/src/matlab/+arrow/+type/+traits/Date32Traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/Date32Traits.m
@@ -1,0 +1,30 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Date32Traits < arrow.type.traits.TypeTraits
+
+    properties (Constant)
+        ArrayConstructor = @arrow.array.Date32Array
+        ArrayClassName = "arrow.array.Date32Array"
+        ArrayProxyClassName = "arrow.array.proxy.Date32Array"
+        ArrayStaticConstructor = @arrow.array.Date32Array.fromMATLAB
+        TypeConstructor = @arrow.type.Date32Type;
+        TypeClassName = "arrow.type.Date32Type"
+        TypeProxyClassName = "arrow.type.proxy.Date32Type"
+        MatlabConstructor = @datetime
+        MatlabClassName = "datetime"
+    end
+
+end

--- a/matlab/src/matlab/+arrow/+type/+traits/traits.m
+++ b/matlab/src/matlab/+arrow/+type/+traits/traits.m
@@ -52,6 +52,8 @@ function typeTraits = traits(type)
                 typeTraits = Time32Traits();
             case ID.Time64
                 typeTraits = Time64Traits();
+            case ID.Date32
+                typeTraits = Date32Traits();
             otherwise
                 error("arrow:type:traits:UnsupportedArrowTypeID", "Unsupported Arrow type ID: " + type);
         end

--- a/matlab/test/arrow/array/tDate32Array.m
+++ b/matlab/test/arrow/array/tDate32Array.m
@@ -79,7 +79,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(datetime(array), dates');
         end
 
-        function InferNullsTrueNVPair(testCase)
+        function TestInferNullsTrueNVPair(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() behaves as
             % expected when InferNulls=true is provided.
             dates = testCase.MissingDates;
@@ -90,7 +90,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(datetime(array), dates');
         end
 
-        function InferNullsFalseNVPair(testCase)
+        function TestInferNullsFalseNVPair(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() behaves as
             % expected when InferNulls=false is provided.
             dates = testCase.MissingDates;
@@ -126,7 +126,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(toMATLAB(array), expectedDates);
         end
 
-        function EmptyDatetimeVector(testCase)
+        function TestEmptyDatetimeVector(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() accepts any
             % empty-shaped datetime as input.
 
@@ -144,7 +144,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(toMATLAB(array), datetime.empty(0, 1));
         end
 
-        function ErrorIfNonVector(testCase)
+        function TestErrorIfNonVector(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() throws an error
             % if the input provided is not a vector.
 
@@ -158,7 +158,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyError(fcn, "arrow:array:InvalidShape");
         end
 
-        function ErrorIfNonDatetime(testCase)
+        function TestErrorIfNonDatetime(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() throws an error
             % if not given a datetime as input.
 
@@ -171,7 +171,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyError(fcn, "arrow:array:InvalidType");
         end
 
-        function Int32MaxDays(testCase)
+        function TestInt32MaxDays(testCase)
             % Verify that no precision is lost when trying to round-trip a
             % datetime value that is within abs(intmin("int32")) days before
             % and intmax("int32") days after the UNIX epoch.
@@ -193,10 +193,10 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(actualAfter, expectedAfter);
         end
 
-        function GreaterThanInt32MaxDays(testCase)
+        function TestGreaterThanInt32MaxDays(testCase)
             % Verify that precision is lost when trying to round-trip a
             % datetime that is more than abs(intmin("int32")) days before
-            % or more than intmax("int32") after after the UNIX epoch.
+            % or more than intmax("int32") after the UNIX epoch.
 
             % Cast to int64 before taking the absolute value to avoid loss
             % of precision.
@@ -215,7 +215,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyNotEqual(actualAfter, expectedAfter);
         end
 
-        function ZonedDatetime(testCase)
+        function TestZonedDatetime(testCase)
             % Verify that zoned datetimes are supported as inputs to the
             % fromMATLAB method and that the output datetime returned by
             % the toMATLAB method is unzoned.
@@ -229,7 +229,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(actual, expected);
         end
 
-        function Int32MaxDaysZoned(testCase)
+        function TestInt32MaxDaysZoned(testCase)
             % Verify that zoned datetimes which are within abs(intmin("int32")) days
             % before and intmax("int32") days after the UNIX epoch are round-tripped
             % (not including the TimeZone).
@@ -260,7 +260,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(actualAfter, expectedUnzonedAfter);
         end
 
-        function NonWholeDaysRoundDown(testCase)
+        function TestNonWholeDaysRoundDown(testCase)
             % Verify that datetimes which are not whole days (i.e. are not
             % datetimes with zero hours, zero minutes, and zero seconds),
             % round down to the nearest whole day when round-tripping with

--- a/matlab/test/arrow/array/tDate32Array.m
+++ b/matlab/test/arrow/array/tDate32Array.m
@@ -173,10 +173,13 @@ classdef tDate32Array < matlab.unittest.TestCase
 
         function Int32MaxDays(testCase)
             % Verify that no precision is lost when trying to round-trip a
-            % datetime value that is within intmax("int32") - 1 days before
+            % datetime value that is within abs(intmin("int32")) days before
             % and intmax("int32") days after the UNIX epoch.
-            numDaysBefore = uint64(intmax("int32")) + 1;
-            numDaysAfter = uint64(intmax("int32"));
+
+            % Cast to int64 before taking the absolute value to avoid loss
+            % of precision.
+            numDaysBefore = abs(int64(intmin("int32")));
+            numDaysAfter = intmax("int32");
 
             expectedBefore = testCase.UnixEpoch - days(numDaysBefore);
             expectedAfter = testCase.UnixEpoch + days(numDaysAfter);
@@ -192,10 +195,13 @@ classdef tDate32Array < matlab.unittest.TestCase
 
         function GreaterThanInt32MaxDays(testCase)
             % Verify that precision is lost when trying to round-trip a
-            % datetime that is greater than intmax("int32") + 1 days before
-            % or greater than intmax("int32") after after the UNIX epoch.
-            numDaysBefore = uint64(intmax("int32")) + 2;
-            numDaysAfter = uint64(intmax("int32")) + 1;
+            % datetime that is more than abs(intmin("int32")) days before
+            % or more than intmax("int32") after after the UNIX epoch.
+
+            % Cast to int64 before taking the absolute value to avoid loss
+            % of precision.
+            numDaysBefore = abs(int64(intmin("int32"))) + 1;
+            numDaysAfter = int64(intmax("int32")) + 1;
 
             expectedBefore = testCase.UnixEpoch - days(numDaysBefore);
             expectedAfter = testCase.UnixEpoch + days(numDaysAfter);
@@ -224,11 +230,14 @@ classdef tDate32Array < matlab.unittest.TestCase
         end
 
         function Int32MaxDaysZoned(testCase)
-            % Verify that zoned datetimes which are within intmax("int32") + 1 days
+            % Verify that zoned datetimes which are within abs(intmin("int32")) days
             % before and intmax("int32") days after the UNIX epoch are round-tripped
             % (not including the TimeZone).
-            numDaysBefore = uint64(intmax("int32")) + 1;
-            numDaysAfter = uint64(intmax("int32"));
+
+            % Cast to int64 before taking the absolute value to avoid loss
+            % of precision.
+            numDaysBefore = abs(int64(intmin("int32")));
+            numDaysAfter = intmax("int32");
 
             expectedZonedBefore = testCase.UnixEpoch - days(numDaysBefore);
             expectedZonedAfter = testCase.UnixEpoch + days(numDaysAfter);
@@ -252,9 +261,9 @@ classdef tDate32Array < matlab.unittest.TestCase
         end
 
         function NonWholeDaysRoundDown(testCase)
-            % Verify that datetimes which are not whole days (i.e. are not datetimes
-            % with zero hours, zero minutes, and zero seconds), round down
-            % to the nearest whole day when round-tripping with
+            % Verify that datetimes which are not whole days (i.e. are not
+            % datetimes with zero hours, zero minutes, and zero seconds),
+            % round down to the nearest whole day when round-tripping with
             % Date32Array.
             dates = testCase.UnixEpoch + days(10) + hours(20) + minutes(30) + seconds(40) + milliseconds(50);
             % Round down to the nearest whole day when round-tripping.

--- a/matlab/test/arrow/array/tDate32Array.m
+++ b/matlab/test/arrow/array/tDate32Array.m
@@ -1,0 +1,186 @@
+%TDATE32ARRAY Unit tests for arrow.array.Date32Array
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tDate32Array < matlab.unittest.TestCase
+
+    properties
+        ArrowArrayConstructorFcn = @arrow.array.Date32Array.fromMATLAB
+    end
+
+    properties (Constant)
+        unixEpoch = datetime(0, ConvertFrom="posixtime");
+        missingDates = [datetime(2023, 1, 1), NaT, NaT, datetime(2022, 1, 1), NaT];
+    end
+
+    methods (Test)
+
+        function TestBasic(testCase)
+            dates = testCase.unixEpoch + days(1:10);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyInstanceOf(array, "arrow.array.Date32Array");
+        end
+
+        function TestTypeIsDate32(testCase)
+            dates = testCase.unixEpoch + days(1:10);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyDate32Type(array.Type);
+        end
+
+        function TestLength(testCase)
+            dates = datetime.empty(0, 1);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyEqual(array.Length, int64(0));
+
+            dates = datetime(2023, 1, 1);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyEqual(array.Length, int64(1));
+
+            dates = testCase.unixEpoch + days(1:10);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyEqual(array.Length, int64(10));
+        end
+
+        function TestToMATLAB(testCase)
+            % Verify toMATLAB() round-trips the original datetime array.
+            dates = testCase.unixEpoch + days(1:10);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            values = toMATLAB(array);
+            testCase.verifyEqual(values, dates');
+        end
+
+        function TestDatetime(testCase)
+            % Verify datetime() round-trips the original datetime array.
+            dates = testCase.unixEpoch + days(1:10);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            values = datetime(array);
+            testCase.verifyEqual(values, dates');
+        end
+
+        function TestValid(testCase)
+            % Verify the Valid property returns the expected logical vector.
+            dates = testCase.missingDates;
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyEqual(array.Valid, [true; false; false; true; false]);
+            testCase.verifyEqual(toMATLAB(array), dates');
+            testCase.verifyEqual(datetime(array), dates');
+        end
+
+        function InferNullsTrueNVPair(testCase)
+            % Verify arrow.array.Date32Array.fromMATLAB() behaves as
+            % expected when InferNulls=true is provided.
+            dates = testCase.missingDates;
+            array = testCase.ArrowArrayConstructorFcn(dates, InferNulls=true);
+            expectedValid = [true; false; false; true; false];
+            testCase.verifyEqual(array.Valid, expectedValid);
+            testCase.verifyEqual(toMATLAB(array), dates');
+            testCase.verifyEqual(datetime(array), dates');
+        end
+
+        function InferNullsFalseNVPair(testCase)
+            % Verify arrow.array.Date32Array.fromMATLAB() behaves as
+            % expected when InferNulls=false is provided.
+            dates = testCase.missingDates;
+            array = testCase.ArrowArrayConstructorFcn(dates, InferNulls=false);
+            expectedValid = [true; true; true; true; true];
+            testCase.verifyEqual(array.Valid, expectedValid);
+
+            % If NaT datetimes were not considered null values, then they
+            % are treated like int32(0) - i.e. the Unix epoch.
+            expectedDates = dates';
+            expectedDates([2, 3, 5]) = testCase.unixEpoch;
+            testCase.verifyEqual(toMATLAB(array), expectedDates);
+            testCase.verifyEqual(datetime(array), expectedDates);
+        end
+
+        function TestValidNVPair(testCase)
+            % Verify arrow.array.Date32Array.fromMATLAB() accepts the Valid
+            % nv-pair, and it behaves as expected.
+            dates = testCase.missingDates;
+
+            % Supply the Valid name-value pair as vector of indices.
+            array = testCase.ArrowArrayConstructorFcn(dates, Valid=[1, 2, 3]);
+            testCase.verifyEqual(array.Valid, [true; true; true; false; false]);
+            expectedDates = dates';
+            expectedDates([2, 3]) = testCase.unixEpoch;
+            expectedDates([4, 5]) = NaT;
+            testCase.verifyEqual(toMATLAB(array), expectedDates);
+
+            % Supply the Valid name-value pair as a logical scalar.
+            array = testCase.ArrowArrayConstructorFcn(dates, Valid=false);
+            testCase.verifyEqual(array.Valid, [false; false; false; false; false]);
+            expectedDates(:) = NaT;
+            testCase.verifyEqual(toMATLAB(array), expectedDates);
+        end
+
+        function EmptyDatetimeVector(testCase)
+            % Verify arrow.array.Date32Array.fromMATLAB() accepts any
+            % empty-shaped datetime as input.
+
+            dates = datetime.empty(0, 0);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyEqual(array.Length, int64(0));
+            testCase.verifyEqual(array.Valid, logical.empty(0, 1));
+            testCase.verifyEqual(toMATLAB(array), datetime.empty(0, 1));
+
+            % Test with an N-Dimensional empty array
+            dates = datetime.empty(0, 1, 0);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyEqual(array.Length, int64(0));
+            testCase.verifyEqual(array.Valid, logical.empty(0, 1));
+            testCase.verifyEqual(toMATLAB(array), datetime.empty(0, 1));
+        end
+
+        function ErrorIfNonVector(testCase)
+            % Verify arrow.array.Date32Array.fromMATLAB() throws an error
+            % if the input provided is not a vector.
+
+            dates = datetime(2023, 1, 1) + days(1:12);
+            dates = reshape(dates, 2, 6);
+            fcn = @() testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyError(fcn, "arrow:array:InvalidShape");
+
+            dates = reshape(dates, 3, 2, 2);
+            fcn = @() testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyError(fcn, "arrow:array:InvalidShape");
+        end
+
+        function ErrorIfNonDatetime(testCase)
+            % Verify arrow.array.Date32Array.fromMATLAB() throws an error
+            % if not given a datetime as input.
+
+            dates = duration(1, 2, 3);
+            fcn = @() testCase.ArrowArrayConstructorFcn(dates);
+            testCase.verifyError(fcn, "arrow:array:InvalidType");
+
+            numbers = [1; 2; 3; 4];
+            fcn = @() testCase.ArrowArrayConstructorFcn(numbers);
+            testCase.verifyError(fcn, "arrow:array:InvalidType");
+        end
+
+    end
+
+    methods
+
+        function verifyDate32Type(testCase, actual)
+            testCase.verifyInstanceOf(actual, "arrow.type.Date32Type");
+            testCase.verifyEqual(actual.ID, arrow.type.ID.Date32);
+            testCase.verifyEqual(actual.DateUnit, arrow.type.DateUnit.Day);
+        end
+
+    end
+
+end

--- a/matlab/test/arrow/array/tDate32Array.m
+++ b/matlab/test/arrow/array/tDate32Array.m
@@ -22,20 +22,20 @@ classdef tDate32Array < matlab.unittest.TestCase
     end
 
     properties (Constant)
-        unixEpoch = datetime(0, ConvertFrom="posixtime");
-        missingDates = [datetime(2023, 1, 1), NaT, NaT, datetime(2022, 1, 1), NaT];
+        UnixEpoch = datetime(0, ConvertFrom="posixtime");
+        MissingDates = [datetime(2023, 1, 1), NaT, NaT, datetime(2022, 1, 1), NaT];
     end
 
     methods (Test)
 
         function TestBasic(testCase)
-            dates = testCase.unixEpoch + days(1:10);
+            dates = testCase.UnixEpoch + days(1:10);
             array = testCase.ArrowArrayConstructorFcn(dates);
             testCase.verifyInstanceOf(array, "arrow.array.Date32Array");
         end
 
         function TestTypeIsDate32(testCase)
-            dates = testCase.unixEpoch + days(1:10);
+            dates = testCase.UnixEpoch + days(1:10);
             array = testCase.ArrowArrayConstructorFcn(dates);
             testCase.verifyDate32Type(array.Type);
         end
@@ -49,14 +49,14 @@ classdef tDate32Array < matlab.unittest.TestCase
             array = testCase.ArrowArrayConstructorFcn(dates);
             testCase.verifyEqual(array.Length, int64(1));
 
-            dates = testCase.unixEpoch + days(1:10);
+            dates = testCase.UnixEpoch + days(1:10);
             array = testCase.ArrowArrayConstructorFcn(dates);
             testCase.verifyEqual(array.Length, int64(10));
         end
 
         function TestToMATLAB(testCase)
             % Verify toMATLAB() round-trips the original datetime array.
-            dates = testCase.unixEpoch + days(1:10);
+            dates = testCase.UnixEpoch + days(1:10);
             array = testCase.ArrowArrayConstructorFcn(dates);
             values = toMATLAB(array);
             testCase.verifyEqual(values, dates');
@@ -64,7 +64,7 @@ classdef tDate32Array < matlab.unittest.TestCase
 
         function TestDatetime(testCase)
             % Verify datetime() round-trips the original datetime array.
-            dates = testCase.unixEpoch + days(1:10);
+            dates = testCase.UnixEpoch + days(1:10);
             array = testCase.ArrowArrayConstructorFcn(dates);
             values = datetime(array);
             testCase.verifyEqual(values, dates');
@@ -72,7 +72,7 @@ classdef tDate32Array < matlab.unittest.TestCase
 
         function TestValid(testCase)
             % Verify the Valid property returns the expected logical vector.
-            dates = testCase.missingDates;
+            dates = testCase.MissingDates;
             array = testCase.ArrowArrayConstructorFcn(dates);
             testCase.verifyEqual(array.Valid, [true; false; false; true; false]);
             testCase.verifyEqual(toMATLAB(array), dates');
@@ -82,7 +82,7 @@ classdef tDate32Array < matlab.unittest.TestCase
         function InferNullsTrueNVPair(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() behaves as
             % expected when InferNulls=true is provided.
-            dates = testCase.missingDates;
+            dates = testCase.MissingDates;
             array = testCase.ArrowArrayConstructorFcn(dates, InferNulls=true);
             expectedValid = [true; false; false; true; false];
             testCase.verifyEqual(array.Valid, expectedValid);
@@ -93,7 +93,7 @@ classdef tDate32Array < matlab.unittest.TestCase
         function InferNullsFalseNVPair(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() behaves as
             % expected when InferNulls=false is provided.
-            dates = testCase.missingDates;
+            dates = testCase.MissingDates;
             array = testCase.ArrowArrayConstructorFcn(dates, InferNulls=false);
             expectedValid = [true; true; true; true; true];
             testCase.verifyEqual(array.Valid, expectedValid);
@@ -101,7 +101,7 @@ classdef tDate32Array < matlab.unittest.TestCase
             % If NaT datetimes were not considered null values, then they
             % are treated like int32(0) - i.e. the Unix epoch.
             expectedDates = dates';
-            expectedDates([2, 3, 5]) = testCase.unixEpoch;
+            expectedDates([2, 3, 5]) = testCase.UnixEpoch;
             testCase.verifyEqual(toMATLAB(array), expectedDates);
             testCase.verifyEqual(datetime(array), expectedDates);
         end
@@ -109,13 +109,13 @@ classdef tDate32Array < matlab.unittest.TestCase
         function TestValidNVPair(testCase)
             % Verify arrow.array.Date32Array.fromMATLAB() accepts the Valid
             % nv-pair, and it behaves as expected.
-            dates = testCase.missingDates;
+            dates = testCase.MissingDates;
 
             % Supply the Valid name-value pair as vector of indices.
             array = testCase.ArrowArrayConstructorFcn(dates, Valid=[1, 2, 3]);
             testCase.verifyEqual(array.Valid, [true; true; true; false; false]);
             expectedDates = dates';
-            expectedDates([2, 3]) = testCase.unixEpoch;
+            expectedDates([2, 3]) = testCase.UnixEpoch;
             expectedDates([4, 5]) = NaT;
             testCase.verifyEqual(toMATLAB(array), expectedDates);
 
@@ -169,6 +169,106 @@ classdef tDate32Array < matlab.unittest.TestCase
             numbers = [1; 2; 3; 4];
             fcn = @() testCase.ArrowArrayConstructorFcn(numbers);
             testCase.verifyError(fcn, "arrow:array:InvalidType");
+        end
+
+        function Int32MaxDays(testCase)
+            % Verify that no precision is lost when trying to round-trip a
+            % datetime value that is within intmax("int32") - 1 days before
+            % and intmax("int32") days after the UNIX epoch.
+            numDaysBefore = uint64(intmax("int32")) + 1;
+            numDaysAfter = uint64(intmax("int32"));
+
+            expectedBefore = testCase.UnixEpoch - days(numDaysBefore);
+            expectedAfter = testCase.UnixEpoch + days(numDaysAfter);
+
+            array = testCase.ArrowArrayConstructorFcn(expectedBefore);
+            actualBefore = array.toMATLAB();
+            testCase.verifyEqual(actualBefore, expectedBefore);
+
+            array = testCase.ArrowArrayConstructorFcn(expectedAfter);
+            actualAfter = array.toMATLAB();
+            testCase.verifyEqual(actualAfter, expectedAfter);
+        end
+
+        function GreaterThanInt32MaxDays(testCase)
+            % Verify that precision is lost when trying to round-trip a
+            % datetime that is greater than intmax("int32") + 1 days before
+            % or greater than intmax("int32") after after the UNIX epoch.
+            numDaysBefore = uint64(intmax("int32")) + 2;
+            numDaysAfter = uint64(intmax("int32")) + 1;
+
+            expectedBefore = testCase.UnixEpoch - days(numDaysBefore);
+            expectedAfter = testCase.UnixEpoch + days(numDaysAfter);
+
+            array = testCase.ArrowArrayConstructorFcn(expectedBefore);
+            actualBefore = array.toMATLAB();
+            testCase.verifyNotEqual(actualBefore, expectedBefore);
+
+            array = testCase.ArrowArrayConstructorFcn(expectedAfter);
+            actualAfter = array.toMATLAB();
+            testCase.verifyNotEqual(actualAfter, expectedAfter);
+        end
+
+        function ZonedDatetime(testCase)
+            % Verify that zoned datetimes are supported as inputs to the
+            % fromMATLAB method and that the output datetime returned by
+            % the toMATLAB method is unzoned.
+            expectedZoned = testCase.UnixEpoch + days(10);
+            expectedZoned.TimeZone = "America/New_York";
+            expected = expectedZoned;
+            expected.TimeZone = char.empty(0, 0);
+
+            array = testCase.ArrowArrayConstructorFcn(expectedZoned);
+            actual = array.toMATLAB();
+            testCase.verifyEqual(actual, expected);
+        end
+
+        function Int32MaxDaysZoned(testCase)
+            % Verify that zoned datetimes which are within intmax("int32") + 1 days
+            % before and intmax("int32") days after the UNIX epoch are round-tripped
+            % (not including the TimeZone).
+            numDaysBefore = uint64(intmax("int32")) + 1;
+            numDaysAfter = uint64(intmax("int32"));
+
+            expectedZonedBefore = testCase.UnixEpoch - days(numDaysBefore);
+            expectedZonedAfter = testCase.UnixEpoch + days(numDaysAfter);
+
+            expectedZonedBefore.TimeZone = "UTC";
+            expectedZonedAfter.TimeZone = "UTC";
+
+            expectedUnzonedBefore = expectedZonedBefore;
+            expectedUnzonedBefore.TimeZone = char.empty(0, 0);
+
+            expectedUnzonedAfter = expectedZonedAfter;
+            expectedUnzonedAfter.TimeZone = char.empty(0, 0);
+
+            array = testCase.ArrowArrayConstructorFcn(expectedZonedBefore);
+            actualBefore = array.toMATLAB();
+            testCase.verifyEqual(actualBefore, expectedUnzonedBefore);
+
+            array = testCase.ArrowArrayConstructorFcn(expectedUnzonedAfter);
+            actualAfter = array.toMATLAB();
+            testCase.verifyEqual(actualAfter, expectedUnzonedAfter);
+        end
+
+        function NonWholeDaysRoundDown(testCase)
+            % Verify that datetimes which are not whole days (i.e. are not datetimes
+            % with zero hours, zero minutes, and zero seconds), round down
+            % to the nearest whole day when round-tripping with
+            % Date32Array.
+            dates = testCase.UnixEpoch + days(10) + hours(20) + minutes(30) + seconds(40) + milliseconds(50);
+            % Round down to the nearest whole day when round-tripping.
+            expected = testCase.UnixEpoch + days(10);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            actual = array.toMATLAB();
+            testCase.verifyEqual(actual, expected);
+
+            dates = testCase.UnixEpoch + days(10) + hours(10) + minutes(20) + seconds(30) + milliseconds(20);
+            % Round down to the nearest whole day when round-tripping.
+            expected = testCase.UnixEpoch + days(10);
+            array = testCase.ArrowArrayConstructorFcn(dates);
+            actual = array.toMATLAB();
+            testCase.verifyEqual(actual, expected);
         end
 
     end

--- a/matlab/test/arrow/array/tTime32Array.m
+++ b/matlab/test/arrow/array/tTime32Array.m
@@ -108,10 +108,10 @@ classdef tTime32Array < matlab.unittest.TestCase
         function TestValid(testCase, Unit)
             % Verify the Valid property returns the expected logical vector.
             times = seconds([100 200 NaN 355 NaN 400]);
-            arrray = testCase.ArrowArrayConstructorFcn(times, TImeUnit=Unit);
-            testCase.verifyEqual(arrray.Valid, [true; true; false; true; false; true]);
-            testCase.verifyEqual(toMATLAB(arrray), times');
-            testCase.verifyEqual(duration(arrray), times');
+            array = testCase.ArrowArrayConstructorFcn(times, TimeUnit=Unit);
+            testCase.verifyEqual(array.Valid, [true; true; false; true; false; true]);
+            testCase.verifyEqual(toMATLAB(array), times');
+            testCase.verifyEqual(duration(array), times');
         end
 
         function InferNullsTrueNVPair(testCase, Unit)

--- a/matlab/test/arrow/type/traits/tDate32Traits.m
+++ b/matlab/test/arrow/type/traits/tDate32Traits.m
@@ -1,0 +1,33 @@
+%TDATE32TRAITS Unit tests for arrow.type.traits.Date32Traits
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tDate32Traits < hTypeTraits
+
+    properties
+        TraitsConstructor = @arrow.type.traits.Date32Traits
+        ArrayConstructor = @arrow.array.Date32Array
+        ArrayClassName = "arrow.array.Date32Array"
+        ArrayProxyClassName = "arrow.array.proxy.Date32Array"
+        ArrayStaticConstructor = @arrow.array.Date32Array.fromMATLAB
+        TypeConstructor = @arrow.type.Date32Type
+        TypeClassName = "arrow.type.Date32Type"
+        TypeProxyClassName = "arrow.type.proxy.Date32Type"
+        MatlabConstructor = @datetime
+        MatlabClassName = "datetime"
+    end
+
+end

--- a/matlab/test/arrow/type/traits/ttraits.m
+++ b/matlab/test/arrow/type/traits/ttraits.m
@@ -175,6 +175,18 @@ classdef ttraits < matlab.unittest.TestCase
             testCase.verifyEqual(actualTraits, expectedTraits); 
         end
 
+        function TestDate32(testCase)
+            import arrow.type.traits.*
+            import arrow.type.*
+
+            type = ID.Date32;
+            expectedTraits = Date32Traits();
+
+            actualTraits = traits(type);
+
+            testCase.verifyEqual(actualTraits, expectedTraits);
+        end
+
         function TestMatlabUInt8(testCase)
             import arrow.type.traits.*
 


### PR DESCRIPTION
### Rationale for this change

Now that `arrow.type.Date32Type` class has been added to the MATLAB Interface (#37348), we can add the `arrow.array.Date32Array` class.

`Date32Array`s can be created from MATLAB [`datetime`](https://www.mathworks.com/help/matlab/ref/datetime.html) values. 

### What changes are included in this PR?

1. Added a new `arrow.array.Date32Array` class.
2. Added a new `arrow.type.traits.Date32Traits` class.
3. Added `arrow.type.Date32Type` support to `arrow.type.traits.traits` function.
4. Fixed typo `arrray` in `tTime32Array` test class.
5. Fixed bug in `numeric_array.h` where the `CType` rather than the `ArrowType` was being used to determine the `DataType` of an array class that is a `NumericArray<T>`.

`Date32Array`s can be created from MATLAB [`datetime`](https://www.mathworks.com/help/matlab/ref/datetime.html) values using the `fromMATLAB` method. `Date32Array`s can be converted to MATLAB `datetime` values using the `toMATLAB` method.

**Example**
```matlab
>> dates = [datetime(2021, 1, 2, 3, 4, 5), datetime(2023, 1, 1), datetime(1989, 2, 3, 10, 10, 10)]'

dates = 

  3x1 datetime array

   02-Jan-2021 03:04:05
   01-Jan-2023 00:00:00
   03-Feb-1989 10:10:10

>> array = arrow.array.Date32Array.fromMATLAB(dates)                                               

array = 

[
  2021-01-02,
  2023-01-01,
  1989-02-03
]

>> array.toMATLAB()                                                                                

ans = 

  3x1 datetime array

   02-Jan-2021
   01-Jan-2023
   03-Feb-1989
``` 

### Are these changes tested?

Yes.

1. Added a new `tDate32Array` test class.
2. Added `Date32` related test to `ttraits.m`.
6. Added a new `tDate32Traits.m` test class.

### Are there any user-facing changes?

Yes.

1. Users can now create `arrow.array.Date32Array`s  from MATLAB `datetime`s.

### Future Directions

1. #37230
2. Add `arrow.array.Date64Array`.
3. Add a way to extract the raw `int32` values from an `arrow.array.Date32Array` without converting to a MATLAB `datetime` using `toMATLAB`.

### Notes

1. Thank you @sgilmore10 for your help with this pull request!
* Closes: #37367