### PR TITLE
GH-37391: [MATLAB] Implement the `isequal()` method on `arrow.array.Array`

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -35,9 +35,11 @@ namespace arrow::matlab::array::proxy {
         REGISTER_METHOD(Array, length);
         REGISTER_METHOD(Array, valid);
         REGISTER_METHOD(Array, type);
+        REGISTER_METHOD(Array, isEqual);
+
     }
 
-    std::shared_ptr<arrow::Array> Array::getArray() {
+    std::shared_ptr<arrow::Array> Array::unwrap() {
         return array;
     }
 
@@ -90,5 +92,27 @@ namespace arrow::matlab::array::proxy {
 
         context.outputs[0] = factory.createScalar(proxy_id);
         context.outputs[1] = factory.createScalar(static_cast<int64_t>(type_id));
+    }
+
+    void Array::isEqual(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+
+        const mda::TypedArray<uint64_t> array_proxy_ids = context.inputs[0];
+
+        bool is_equal = true;
+        const auto equals_options = arrow::EqualOptions::Defaults();
+        for (const auto& array_proxy_id : array_proxy_ids) {
+           // Retrieve the proxy::Array proxy from the ProxyManager
+            auto proxy = libmexclass::proxy::ProxyManager::getProxy(array_proxy_id);
+            auto array_proxy = static_pointer_cast<proxy::Array>(proxy);
+            auto array_to_compare = array_proxy->unwrap();
+
+            if (!array->Equals(array_to_compare, equals_options)) {
+                is_equal = false;
+                break;
+            }
+        }
+        mda::ArrayFactory factory;
+        context.outputs[0] = factory.createScalar(is_equal);
     }
 }

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -102,7 +102,7 @@ namespace arrow::matlab::array::proxy {
         bool is_equal = true;
         const auto equals_options = arrow::EqualOptions::Defaults();
         for (const auto& array_proxy_id : array_proxy_ids) {
-           // Retrieve the proxy::Array proxy from the ProxyManager
+           // Retrieve the Array proxy from the ProxyManager
             auto proxy = libmexclass::proxy::ProxyManager::getProxy(array_proxy_id);
             auto array_proxy = std::static_pointer_cast<proxy::Array>(proxy);
             auto array_to_compare = array_proxy->unwrap();

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -104,7 +104,7 @@ namespace arrow::matlab::array::proxy {
         for (const auto& array_proxy_id : array_proxy_ids) {
            // Retrieve the proxy::Array proxy from the ProxyManager
             auto proxy = libmexclass::proxy::ProxyManager::getProxy(array_proxy_id);
-            auto array_proxy = static_pointer_cast<proxy::Array>(proxy);
+            auto array_proxy = std::static_pointer_cast<proxy::Array>(proxy);
             auto array_to_compare = array_proxy->unwrap();
 
             if (!array->Equals(array_to_compare, equals_options)) {

--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.h
@@ -30,7 +30,7 @@ class Array : public libmexclass::proxy::Proxy {
     
         virtual ~Array() {}
 
-        std::shared_ptr<arrow::Array> getArray();
+        std::shared_ptr<arrow::Array> unwrap();
 
     protected:
 
@@ -43,6 +43,8 @@ class Array : public libmexclass::proxy::Proxy {
         void type(libmexclass::proxy::method::Context& context);
 
         virtual void toMATLAB(libmexclass::proxy::method::Context& context) = 0;
+
+        void isEqual(libmexclass::proxy::method::Context& context);
 
         std::shared_ptr<arrow::Array> array;
 };

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -81,7 +81,7 @@ namespace arrow::matlab::tabular::proxy {
         for (const auto& arrow_array_proxy_id : arrow_array_proxy_ids) {
             auto proxy = libmexclass::proxy::ProxyManager::getProxy(arrow_array_proxy_id);
             auto arrow_array_proxy = std::static_pointer_cast<arrow::matlab::array::proxy::Array>(proxy);
-            auto arrow_array = arrow_array_proxy->getArray();
+            auto arrow_array = arrow_array_proxy->unwrap();
             arrow_arrays.push_back(arrow_array);
         }
 

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -69,5 +69,24 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
             disp(obj.toString());
         end
     end
+
+    methods
+        function tf = isequal(obj, varargin)
+            narginchk(2, inf);
+            tf = false;
+            % Extract each array's proxy ID
+            proxyIDs = zeros(numel(varargin), 1, "uint64");
+            for ii = 1:numel(varargin)
+                array = varargin{ii};
+                if ~isa(array, "arrow.array.Array")
+                    % Return early if array is not a arrow.array.Array
+                    return;
+                end
+                proxyIDs(ii) = array.Proxy.ID;
+            end
+            % Invoke isEqual proxy object method
+            tf = obj.Proxy.isEqual(proxyIDs);
+        end
+    end
 end
 

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -154,7 +154,7 @@ classdef hNumericArray < matlab.unittest.TestCase
             % Verifies isequal returns true when expected. Two are 
             % considered equal if:
             %   1. They have the same type
-            %   2. The have the same length
+            %   2. They have the same length
             %   3. The same elements are valid
             %   4. Corresponding valid elements are equal.
             
@@ -173,7 +173,7 @@ classdef hNumericArray < matlab.unittest.TestCase
             % Verify isequal returns false when expected. Two arrays are
             % considered not equal if one of the conditions is met:
             %   1. They have different types
-            %   2. The have different lengths
+            %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
             

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -188,10 +188,10 @@ classdef hNumericArray < matlab.unittest.TestCase
             % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % Their Type properties are not equal.
+            % Their Type properties are not equal
             tc.verifyFalse(isequal(array1, array4));
 
-            % Their Length properties are not equal.
+            % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
             % Comparing an arrow.array.Array to a MATLAB data

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -151,7 +151,7 @@ classdef hNumericArray < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc)
-            % Verifies isequal returns true when expected. Two are 
+            % Verifies isequal returns true when expected. Two arrays are 
             % considered equal if:
             %   1. They have the same type
             %   2. They have the same length
@@ -171,7 +171,8 @@ classdef hNumericArray < matlab.unittest.TestCase
 
         function TestIsEqualFalse(tc)
             % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the conditions is met:
+            % considered not equal if one of the following conditions is 
+            % met:
             %   1. They have different types
             %   2. They have different lengths
             %   3. Different elements are valid

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -149,5 +149,60 @@ classdef hNumericArray < matlab.unittest.TestCase
             arrowArray = tc.ArrowArrayConstructorFcn(data);
             tc.verifyEqual(arrowArray.Type.ID, tc.ArrowType.ID);
         end
+
+        function TestIsEqualTrue(tc)
+            % Verifies isequal returns true when expected. Two are 
+            % considered equal if:
+            %   1. They have the same type
+            %   2. The have the same length
+            %   3. The same elements are valid
+            %   4. Corresponding valid elements are equal.
+            
+            data1 = tc.MatlabArrayFcn([1 2 3 4]);
+            data2 = tc.MatlabArrayFcn([1 2 5 4]);
+            array1 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array3 = tc.ArrowArrayConstructorFcn(data2, Valid=[1 2 4]);
+            
+            tc.verifyTrue(isequal(array1, array2));
+            tc.verifyTrue(isequal(array1, array3));
+            tc.verifyTrue(isequal(array1, array2, array3)); 
+        end
+
+        function TestIsEqualFalse(tc)
+            % Verify isequal returns false when expected. Two arrays are
+            % considered not equal if one of the conditions is met:
+            %   1. They have different types
+            %   2. The have different lengths
+            %   3. Different elements are valid
+            %   4. The corresponding valid elements are not equal.
+            
+            data1 = tc.MatlabArrayFcn([1 2 3 4]);
+            data2 = tc.MatlabArrayFcn([5 2 3 4]);
+            data3 = tc.MatlabArrayFcn([1 2 3 4 5]);
+            array1 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 4]);
+            array3 = tc.ArrowArrayConstructorFcn(data2, Valid=[1 2 4]);
+            array4 = arrow.array([true false true false]);
+            array5 = tc.ArrowArrayConstructorFcn(data3, Valid=[1 2 4]);
+
+            % The same elements are not valid.
+            tc.verifyFalse(isequal(array1, array2));
+
+            % Corresponding elements are not equal.
+            tc.verifyFalse(isequal(array1, array3));
+
+            % The arrays have different types.
+            tc.verifyFalse(isequal(array1, array4));
+
+            % The arrays have different lengths.
+            tc.verifyFalse(isequal(array1, array5));
+
+            % Comparing an arrow.array.BooleanArray to a double
+            tc.verifyFalse(isequal(array1, 1));
+
+            % Supply more than two input arguments to isequal
+            tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
+        end
     end
 end

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -194,7 +194,7 @@ classdef hNumericArray < matlab.unittest.TestCase
             % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.Array to a MATLAB data
+            % Comparing an arrow.array.Array to a MATLAB double
             tc.verifyFalse(isequal(array1, 1));
 
             % Test supplying more than two arrays to isequal

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -151,13 +151,13 @@ classdef hNumericArray < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc)
-            % Verifies isequal returns true when expected. Two arrays are 
-            % considered equal if:
-            %   1. They have the same type
-            %   2. They have the same length
-            %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal.
-            
+            % Verifies arrays are considered equal if:
+            %
+            %  1. They have the same arrow.array.Type
+            %  2. They have the same length (i.e. their Length properties are equal)
+            %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
+            %  4. All corresponding valid elements have the same values
+
             data1 = tc.MatlabArrayFcn([1 2 3 4]);
             data2 = tc.MatlabArrayFcn([1 2 5 4]);
             array1 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
@@ -166,18 +166,13 @@ classdef hNumericArray < matlab.unittest.TestCase
             
             tc.verifyTrue(isequal(array1, array2));
             tc.verifyTrue(isequal(array1, array3));
+
+            % Test supplying more than two arrays to isequal
             tc.verifyTrue(isequal(array1, array2, array3)); 
         end
 
         function TestIsEqualFalse(tc)
-            % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the following conditions is 
-            % met:
-            %   1. They have different types
-            %   2. They have different lengths
-            %   3. Different elements are valid
-            %   4. The corresponding valid elements are not equal.
-            
+            % Verify isequal returns false when expected. 
             data1 = tc.MatlabArrayFcn([1 2 3 4]);
             data2 = tc.MatlabArrayFcn([5 2 3 4]);
             data3 = tc.MatlabArrayFcn([1 2 3 4 5]);
@@ -187,22 +182,22 @@ classdef hNumericArray < matlab.unittest.TestCase
             array4 = arrow.array([true false true false]);
             array5 = tc.ArrowArrayConstructorFcn(data3, Valid=[1 2 4]);
 
-            % The same elements are not valid.
+            % Their validity bitmaps are not equal
             tc.verifyFalse(isequal(array1, array2));
 
-            % Corresponding elements are not equal.
+            % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % The arrays have different types.
+            % Their Type properties are not equal.
             tc.verifyFalse(isequal(array1, array4));
 
-            % The arrays have different lengths.
+            % Their Length properties are not equal.
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.BooleanArray to a double
+            % Comparing an arrow.array.Array to a MATLAB data
             tc.verifyFalse(isequal(array1, 1));
 
-            % Supply more than two input arguments to isequal
+            % Test supplying more than two arrays to isequal
             tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
         end
     end

--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -153,7 +153,7 @@ classdef hNumericArray < matlab.unittest.TestCase
         function TestIsEqualTrue(tc)
             % Verifies arrays are considered equal if:
             %
-            %  1. They have the same arrow.array.Type
+            %  1. Their Type properties are equal
             %  2. They have the same length (i.e. their Length properties are equal)
             %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
             %  4. All corresponding valid elements have the same values

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -162,7 +162,7 @@ classdef tBooleanArray < matlab.unittest.TestCase
         function TestIsEqualTrue(tc)
             % Verifies arrays are considered equal if:
             %
-            %  1. They have the same arrow.array.Type
+            %  1. Their Type properties are equal
             %  2. They have the same length (i.e. their Length properties are equal)
             %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
             %  4. All corresponding valid elements have the same values

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -163,7 +163,7 @@ classdef tBooleanArray < matlab.unittest.TestCase
             % Verifies isequal returns true when expected. Two are 
             % considered equal if:
             %   1. They have the same type
-            %   2. The have the same length
+            %   2. They have the same length
             %   3. The same elements are valid
             %   4. Corresponding valid elements are equal.
             
@@ -182,7 +182,7 @@ classdef tBooleanArray < matlab.unittest.TestCase
             % Verify isequal returns false when expected. Two arrays are
             % considered not equal if one of the conditions is met:
             %   1. They have different types
-            %   2. The have different lengths
+            %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
             

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -160,12 +160,13 @@ classdef tBooleanArray < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc)
-            % Verifies isequal returns true when expected. Two arrays are 
-            % considered equal if:
-            %   1. They have the same type
-            %   2. They have the same length
-            %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal.
+            % Verifies arrays are considered equal if:
+            %
+            %  1. They have the same arrow.array.Type
+            %  2. They have the same length (i.e. their Length properties are equal)
+            %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
+            %  4. All corresponding valid elements have the same values
+
             
             data1 = tc.MatlabArrayFcn([true false true false]);
             data2 = tc.MatlabArrayFcn([true false false false]);
@@ -175,18 +176,14 @@ classdef tBooleanArray < matlab.unittest.TestCase
             
             tc.verifyTrue(isequal(array1, array2));
             tc.verifyTrue(isequal(array1, array3));
+
+            % Test supplying more than two arrays to isequal
             tc.verifyTrue(isequal(array1, array2, array3)); 
         end
 
         function TestIsEqualFalse(tc)
-            % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the following conditions is
-            % met:
-            %   1. They have different types
-            %   2. They have different lengths
-            %   3. Different elements are valid
-            %   4. The corresponding valid elements are not equal.
-            
+            % Verify isequal returns false when expected. 
+
             data1 = tc.MatlabArrayFcn([true false true false]);
             data2 = tc.MatlabArrayFcn([false false true false]);
             data3 = tc.MatlabArrayFcn([true false true false false]);
@@ -196,22 +193,22 @@ classdef tBooleanArray < matlab.unittest.TestCase
             array4 = arrow.array([1 2 3 4]);
             array5 = tc.ArrowArrayConstructorFcn(data3, Valid=[1 2 4]);
 
-            % The same elements are not valid.
+            % Their validity bitmaps are not equal
             tc.verifyFalse(isequal(array1, array2));
 
-            % Corresponding elements are not equal.
+            % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % The arrays have different types.
+            % Their Type properties are not equal
             tc.verifyFalse(isequal(array1, array4));
 
-            % The arrays have different lengths.
+            % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.BooleanArray to a double
+            % Comparing an arrow.array.Array to a MATLAB data
             tc.verifyFalse(isequal(array1, 1));
 
-            % Supply more than two input arguments to isequal
+            % Test supplying more than two arrays to isequal
             tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
         end
     end

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -160,7 +160,7 @@ classdef tBooleanArray < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc)
-            % Verifies isequal returns true when expected. Two are 
+            % Verifies isequal returns true when expected. Two arrays are 
             % considered equal if:
             %   1. They have the same type
             %   2. They have the same length

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -180,7 +180,8 @@ classdef tBooleanArray < matlab.unittest.TestCase
 
         function TestIsEqualFalse(tc)
             % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the conditions is met:
+            % considered not equal if one of the following conditions is
+            % met:
             %   1. They have different types
             %   2. They have different lengths
             %   3. Different elements are valid

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -158,5 +158,60 @@ classdef tBooleanArray < matlab.unittest.TestCase
             arrowArray = tc.ArrowArrayConstructorFcn(data);
             tc.verifyEqual(arrowArray.Type.ID, tc.ArrowType.ID);
         end
+
+        function TestIsEqualTrue(tc)
+            % Verifies isequal returns true when expected. Two are 
+            % considered equal if:
+            %   1. They have the same type
+            %   2. The have the same length
+            %   3. The same elements are valid
+            %   4. Corresponding valid elements are equal.
+            
+            data1 = tc.MatlabArrayFcn([true false true false]);
+            data2 = tc.MatlabArrayFcn([true false false false]);
+            array1 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array3 = tc.ArrowArrayConstructorFcn(data2, Valid=[1 2 4]);
+            
+            tc.verifyTrue(isequal(array1, array2));
+            tc.verifyTrue(isequal(array1, array3));
+            tc.verifyTrue(isequal(array1, array2, array3)); 
+        end
+
+        function TestIsEqualFalse(tc)
+            % Verify isequal returns false when expected. Two arrays are
+            % considered not equal if one of the conditions is met:
+            %   1. They have different types
+            %   2. The have different lengths
+            %   3. Different elements are valid
+            %   4. The corresponding valid elements are not equal.
+            
+            data1 = tc.MatlabArrayFcn([true false true false]);
+            data2 = tc.MatlabArrayFcn([false false true false]);
+            data3 = tc.MatlabArrayFcn([true false true false false]);
+            array1 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 4]);
+            array3 = tc.ArrowArrayConstructorFcn(data2, Valid=[1 2 4]);
+            array4 = arrow.array([1 2 3 4]);
+            array5 = tc.ArrowArrayConstructorFcn(data3, Valid=[1 2 4]);
+
+            % The same elements are not valid.
+            tc.verifyFalse(isequal(array1, array2));
+
+            % Corresponding elements are not equal.
+            tc.verifyFalse(isequal(array1, array3));
+
+            % The arrays have different types.
+            tc.verifyFalse(isequal(array1, array4));
+
+            % The arrays have different lengths.
+            tc.verifyFalse(isequal(array1, array5));
+
+            % Comparing an arrow.array.BooleanArray to a double
+            tc.verifyFalse(isequal(array1, 1));
+
+            % Supply more than two input arguments to isequal
+            tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
+        end
     end
 end

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -205,7 +205,7 @@ classdef tBooleanArray < matlab.unittest.TestCase
             % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.Array to a MATLAB data
+            % Comparing an arrow.array.Array to a MATLAB double
             tc.verifyFalse(isequal(array1, 1));
 
             % Test supplying more than two arrays to isequal

--- a/matlab/test/arrow/array/tDate32Array.m
+++ b/matlab/test/arrow/array/tDate32Array.m
@@ -281,12 +281,13 @@ classdef tDate32Array < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc)
-            % Verifies isequal returns true when expected. Two are 
-            % considered equal if:
-            %   1. They have the same type
-            %   2. They have the same length
-            %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal.
+            % Verifies arrays are considered equal if:
+            %
+            %  1. They have the same arrow.array.Type
+            %  2. They have the same length (i.e. their Length properties are equal)
+            %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
+            %  4. All corresponding valid elements have the same values
+
             
             dates1 = datetime(2023, 6, 22)  + days(0:4);
             dates2 = datetime(2023, 6, 22) + days([0 1 5 3 4]);
@@ -297,18 +298,13 @@ classdef tDate32Array < matlab.unittest.TestCase
 
             tc.verifyTrue(isequal(array1, array2));
             tc.verifyTrue(isequal(array1, array3));
+
+            % Test supplying more than two arrays to isequal
             tc.verifyTrue(isequal(array1, array2, array3)); 
         end
 
         function TestIsEqualFalse(tc)
-            % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the following conditions is
-            % met:
-            %   1. They have different types
-            %   2. They have different lengths
-            %   3. Different elements are valid
-            %   4. The corresponding valid elements are not equal.
-
+            % Verify isequal returns false when expected. 
             dates1 = datetime(2023, 6, 22) + days(0:4);
             dates2 = datetime(2023, 6, 22) + days([1 1 2 3 4]);
             dates3 = datetime(2023, 6, 22) + days(0:5);
@@ -318,22 +314,22 @@ classdef tDate32Array < matlab.unittest.TestCase
             array4 = arrow.array([true false true false]);
             array5 = tc.ArrowArrayConstructorFcn(dates3, Valid=[1 2 4]);
 
-            % The same elements are not valid.
+            % Their validity bitmaps are not equal
             tc.verifyFalse(isequal(array1, array2));
 
-            % Corresponding elements are not equal.
+            % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % The arrays have different types.
+            % Their Type properties are not equal
             tc.verifyFalse(isequal(array1, array4));
 
-            % The arrays have different lengths.
+            % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.BooleanArray to a double
+            % Comparing an arrow.array.Array to a MATLAB double
             tc.verifyFalse(isequal(array1, 1));
 
-            % Supply more than two input arguments to isequal
+            % Test supplying more than two arrays to isequal
             tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
         end
 

--- a/matlab/test/arrow/array/tDate32Array.m
+++ b/matlab/test/arrow/array/tDate32Array.m
@@ -280,6 +280,63 @@ classdef tDate32Array < matlab.unittest.TestCase
             testCase.verifyEqual(actual, expected);
         end
 
+        function TestIsEqualTrue(tc)
+            % Verifies isequal returns true when expected. Two are 
+            % considered equal if:
+            %   1. They have the same type
+            %   2. They have the same length
+            %   3. The same elements are valid
+            %   4. Corresponding valid elements are equal.
+            
+            dates1 = datetime(2023, 6, 22)  + days(0:4);
+            dates2 = datetime(2023, 6, 22) + days([0 1 5 3 4]);
+
+            array1 = tc.ArrowArrayConstructorFcn(dates1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(dates1, Valid=[1 2 4]);
+            array3 = tc.ArrowArrayConstructorFcn(dates2, Valid=[1 2 4]);
+
+            tc.verifyTrue(isequal(array1, array2));
+            tc.verifyTrue(isequal(array1, array3));
+            tc.verifyTrue(isequal(array1, array2, array3)); 
+        end
+
+        function TestIsEqualFalse(tc)
+            % Verify isequal returns false when expected. Two arrays are
+            % considered not equal if one of the following conditions is
+            % met:
+            %   1. They have different types
+            %   2. They have different lengths
+            %   3. Different elements are valid
+            %   4. The corresponding valid elements are not equal.
+
+            dates1 = datetime(2023, 6, 22) + days(0:4);
+            dates2 = datetime(2023, 6, 22) + days([1 1 2 3 4]);
+            dates3 = datetime(2023, 6, 22) + days(0:5);
+            array1 = tc.ArrowArrayConstructorFcn(dates1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(dates1, Valid=[1 4]);
+            array3 = tc.ArrowArrayConstructorFcn(dates2, Valid=[1 2 4]);
+            array4 = arrow.array([true false true false]);
+            array5 = tc.ArrowArrayConstructorFcn(dates3, Valid=[1 2 4]);
+
+            % The same elements are not valid.
+            tc.verifyFalse(isequal(array1, array2));
+
+            % Corresponding elements are not equal.
+            tc.verifyFalse(isequal(array1, array3));
+
+            % The arrays have different types.
+            tc.verifyFalse(isequal(array1, array4));
+
+            % The arrays have different lengths.
+            tc.verifyFalse(isequal(array1, array5));
+
+            % Comparing an arrow.array.BooleanArray to a double
+            tc.verifyFalse(isequal(array1, 1));
+
+            % Supply more than two input arguments to isequal
+            tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
+        end
+
     end
 
     methods

--- a/matlab/test/arrow/array/tDate32Array.m
+++ b/matlab/test/arrow/array/tDate32Array.m
@@ -283,7 +283,7 @@ classdef tDate32Array < matlab.unittest.TestCase
         function TestIsEqualTrue(tc)
             % Verifies arrays are considered equal if:
             %
-            %  1. They have the same arrow.array.Type
+            %  1. Their Type properties are equal
             %  2. They have the same length (i.e. their Length properties are equal)
             %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
             %  4. All corresponding valid elements have the same values

--- a/matlab/test/arrow/array/tFloat32Array.m
+++ b/matlab/test/arrow/array/tFloat32Array.m
@@ -110,5 +110,12 @@ classdef tFloat32Array < hNumericArray
             testCase.verifyEqual(arrowArray.Valid, [true; false; true]);
             testCase.verifyEqual(toMATLAB(arrowArray), single([1; NaN; 3]));
         end
+
+        function TestNanIsEqualFalse(testCase)
+            % Verify corresponding NaN values are not considered equal.
+            matlabArray = single([1 2 NaN 4]);
+            arrowArray = testCase.ArrowArrayConstructorFcn(matlabArray, InferNulls=false);
+            testCase.verifyFalse(isequal(arrowArray, arrowArray));
+        end
     end
 end

--- a/matlab/test/arrow/array/tFloat64Array.m
+++ b/matlab/test/arrow/array/tFloat64Array.m
@@ -115,5 +115,12 @@ classdef tFloat64Array < hNumericArray
             testCase.verifyEqual(arrowArray.Valid, [true; false; true]);
             testCase.verifyEqual(toMATLAB(arrowArray), [1; NaN; 3]);
         end
+
+        function TestNanIsEqualFalse(testCase)
+            % Verify corresponding NaN values are not considered equal.
+            matlabArray = [1 2 NaN 4];
+            arrowArray = testCase.ArrowArrayConstructorFcn(matlabArray, InferNulls=false);
+            testCase.verifyFalse(isequal(arrowArray, arrowArray));
+        end
     end
 end

--- a/matlab/test/arrow/array/tStringArray.m
+++ b/matlab/test/arrow/array/tStringArray.m
@@ -230,12 +230,12 @@ classdef tStringArray < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc)
-            % Verifies isequal returns true when expected. Two are 
-            % considered equal if:
-            %   1. They have the same type
-            %   2. They have the same length
-            %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal.
+            % Verifies arrays are considered equal if:
+            %
+            %  1. Their Type properties are equal
+            %  2. They have the same length (i.e. their Length properties are equal)
+            %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
+            %  4. All corresponding valid elements have the same values
             
             data1 = tc.MatlabArrayFcn(["1" "2" "3" "4"]);
             data2 = tc.MatlabArrayFcn(["1" "2" "5" "4"]);
@@ -245,18 +245,13 @@ classdef tStringArray < matlab.unittest.TestCase
             
             tc.verifyTrue(isequal(array1, array2));
             tc.verifyTrue(isequal(array1, array3));
+
+            % Test supplying more than two arrays to isequal
             tc.verifyTrue(isequal(array1, array2, array3)); 
         end
 
         function TestIsEqualFalse(tc)
-            % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the following conditions is
-            % met:
-            %   1. They have different types
-            %   2. They have different lengths
-            %   3. Different elements are valid
-            %   4. The corresponding valid elements are not equal.
-            
+            % Verify isequal returns false when expected.
             data1 = tc.MatlabArrayFcn(["1" "2" "3" "4"]);
             data2 = tc.MatlabArrayFcn(["5" "2" "3" "4"]);
             data3 = tc.MatlabArrayFcn(["1" "2" "3" "4" "5"]);
@@ -266,22 +261,22 @@ classdef tStringArray < matlab.unittest.TestCase
             array4 = arrow.array([true false true false]);
             array5 = tc.ArrowArrayConstructorFcn(data3, Valid=[1 2 4]);
 
-            % The same elements are not valid.
+            % Their validity bitmaps are not equal
             tc.verifyFalse(isequal(array1, array2));
 
-            % Corresponding elements are not equal.
+            % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % The arrays have different types.
+            % Their Type properties are not equal
             tc.verifyFalse(isequal(array1, array4));
 
-            % The arrays have different lengths.
+            % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.BooleanArray to a double
+            % Comparing an arrow.array.Array to a MATLAB double
             tc.verifyFalse(isequal(array1, 1));
 
-            % Supply more than two input arguments to isequal
+            % Test supplying more than two arrays to isequal
             tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
         end
     end

--- a/matlab/test/arrow/array/tStringArray.m
+++ b/matlab/test/arrow/array/tStringArray.m
@@ -250,7 +250,8 @@ classdef tStringArray < matlab.unittest.TestCase
 
         function TestIsEqualFalse(tc)
             % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the conditions is met:
+            % considered not equal if one of the following conditions is
+            % met:
             %   1. They have different types
             %   2. They have different lengths
             %   3. Different elements are valid

--- a/matlab/test/arrow/array/tStringArray.m
+++ b/matlab/test/arrow/array/tStringArray.m
@@ -228,5 +228,60 @@ classdef tStringArray < matlab.unittest.TestCase
             matlabArray = char.empty(1, 0);
             tc.verifyError(@() tc.ArrowArrayConstructorFcn(matlabArray), "arrow:array:InvalidType");
         end
+
+        function TestIsEqualTrue(tc)
+            % Verifies isequal returns true when expected. Two are 
+            % considered equal if:
+            %   1. They have the same type
+            %   2. The have the same length
+            %   3. The same elements are valid
+            %   4. Corresponding valid elements are equal.
+            
+            data1 = tc.MatlabArrayFcn(["1" "2" "3" "4"]);
+            data2 = tc.MatlabArrayFcn(["1" "2" "5" "4"]);
+            array1 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array3 = tc.ArrowArrayConstructorFcn(data2, Valid=[1 2 4]);
+            
+            tc.verifyTrue(isequal(array1, array2));
+            tc.verifyTrue(isequal(array1, array3));
+            tc.verifyTrue(isequal(array1, array2, array3)); 
+        end
+
+        function TestIsEqualFalse(tc)
+            % Verify isequal returns false when expected. Two arrays are
+            % considered not equal if one of the conditions is met:
+            %   1. They have different types
+            %   2. The have different lengths
+            %   3. Different elements are valid
+            %   4. The corresponding valid elements are not equal.
+            
+            data1 = tc.MatlabArrayFcn(["1" "2" "3" "4"]);
+            data2 = tc.MatlabArrayFcn(["5" "2" "3" "4"]);
+            data3 = tc.MatlabArrayFcn(["1" "2" "3" "4" "5"]);
+            array1 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(data1, Valid=[1 4]);
+            array3 = tc.ArrowArrayConstructorFcn(data2, Valid=[1 2 4]);
+            array4 = arrow.array([true false true false]);
+            array5 = tc.ArrowArrayConstructorFcn(data3, Valid=[1 2 4]);
+
+            % The same elements are not valid.
+            tc.verifyFalse(isequal(array1, array2));
+
+            % Corresponding elements are not equal.
+            tc.verifyFalse(isequal(array1, array3));
+
+            % The arrays have different types.
+            tc.verifyFalse(isequal(array1, array4));
+
+            % The arrays have different lengths.
+            tc.verifyFalse(isequal(array1, array5));
+
+            % Comparing an arrow.array.BooleanArray to a double
+            tc.verifyFalse(isequal(array1, 1));
+
+            % Supply more than two input arguments to isequal
+            tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
+        end
     end
 end

--- a/matlab/test/arrow/array/tStringArray.m
+++ b/matlab/test/arrow/array/tStringArray.m
@@ -233,7 +233,7 @@ classdef tStringArray < matlab.unittest.TestCase
             % Verifies isequal returns true when expected. Two are 
             % considered equal if:
             %   1. They have the same type
-            %   2. The have the same length
+            %   2. They have the same length
             %   3. The same elements are valid
             %   4. Corresponding valid elements are equal.
             
@@ -252,7 +252,7 @@ classdef tStringArray < matlab.unittest.TestCase
             % Verify isequal returns false when expected. Two arrays are
             % considered not equal if one of the conditions is met:
             %   1. They have different types
-            %   2. The have different lengths
+            %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
             

--- a/matlab/test/arrow/array/tTime32Array.m
+++ b/matlab/test/arrow/array/tTime32Array.m
@@ -232,7 +232,8 @@ classdef tTime32Array < matlab.unittest.TestCase
 
         function TestIsEqualFalse(tc, Unit)
             % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the conditions is met:
+            % considered not equal if one of the following conditions is
+            % met:
             %   1. They have different types
             %   2. They have different lengths
             %   3. Different elements are valid

--- a/matlab/test/arrow/array/tTime32Array.m
+++ b/matlab/test/arrow/array/tTime32Array.m
@@ -210,13 +210,12 @@ classdef tTime32Array < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc, Unit)
-            % Verifies isequal returns true when expected. Two are 
-            % considered equal if:
-            %   1. They have the same type
-            %   2. They have the same length
-            %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal
-            %   5. They have the same TimeUnit
+            % Verifies arrays are considered equal if:
+            %
+            %  1. Their Type properties are equal
+            %  2. They have the same length (i.e. their Length properties are equal)
+            %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
+            %  4. All corresponding valid elements have the same values
 
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 2 10 4]);
@@ -227,18 +226,13 @@ classdef tTime32Array < matlab.unittest.TestCase
 
             tc.verifyTrue(isequal(array1, array2));
             tc.verifyTrue(isequal(array1, array3));
+
+            % Test supplying more than two arrays to isequal
             tc.verifyTrue(isequal(array1, array2, array3)); 
         end
 
         function TestIsEqualFalse(tc, Unit)
-            % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the following conditions is
-            % met:
-            %   1. They have different types
-            %   2. They have different lengths
-            %   3. Different elements are valid
-            %   4. The corresponding valid elements are not equal.
-            
+            % Verify isequal returns false when expected.
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 1 2 3]);
             times3 = seconds([1 2 3 4 5]);
@@ -249,22 +243,22 @@ classdef tTime32Array < matlab.unittest.TestCase
             array4 = arrow.array([true false true false]);
             array5 = tc.ArrowArrayConstructorFcn(times3, Valid=[1 2 4]);
 
-            % The same elements are not valid.
+            % Their validity bitmaps are not equal
             tc.verifyFalse(isequal(array1, array2));
 
-            % Corresponding elements are not equal.
+            % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % The arrays have different types.
+            % Their Type properties are not equal
             tc.verifyFalse(isequal(array1, array4));
 
-            % The arrays have different lengths.
+            % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.BooleanArray to a double
+            % Comparing an arrow.array.Array to a MATLAB double
             tc.verifyFalse(isequal(array1, 1));
 
-            % Supply more than two input arguments to isequal
+            % Test supplying more than two arrays to isequal
             tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
         end
 

--- a/matlab/test/arrow/array/tTime32Array.m
+++ b/matlab/test/arrow/array/tTime32Array.m
@@ -215,8 +215,9 @@ classdef tTime32Array < matlab.unittest.TestCase
             %   1. They have the same type
             %   2. They have the same length
             %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal.
-            
+            %   4. Corresponding valid elements are equal
+            %   5. They have the same TimeUnit
+
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 2 10 4]);
 
@@ -236,7 +237,6 @@ classdef tTime32Array < matlab.unittest.TestCase
             %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
-            %   5. They have the same TimeUnit.
             
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 1 2 3]);

--- a/matlab/test/arrow/array/tTime32Array.m
+++ b/matlab/test/arrow/array/tTime32Array.m
@@ -236,6 +236,7 @@ classdef tTime32Array < matlab.unittest.TestCase
             %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
+            %   5. They have the same TimeUnit.
             
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 1 2 3]);

--- a/matlab/test/arrow/array/tTime32Array.m
+++ b/matlab/test/arrow/array/tTime32Array.m
@@ -208,6 +208,75 @@ classdef tTime32Array < matlab.unittest.TestCase
             fcn = @() testCase.ArrowArrayConstructorFcn(numbers);
             testCase.verifyError(fcn, "arrow:array:InvalidType");
         end
+
+        function TestIsEqualTrue(tc, Unit)
+            % Verifies isequal returns true when expected. Two are 
+            % considered equal if:
+            %   1. They have the same type
+            %   2. The have the same length
+            %   3. The same elements are valid
+            %   4. Corresponding valid elements are equal.
+            
+            times1 = seconds([1 2 3 4]);
+            times2 = seconds([1 2 10 4]);
+
+            array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 2 4]);
+            array3 = tc.ArrowArrayConstructorFcn(times2, TimeUnit=Unit, Valid=[1 2 4]);
+
+            tc.verifyTrue(isequal(array1, array2));
+            tc.verifyTrue(isequal(array1, array3));
+            tc.verifyTrue(isequal(array1, array2, array3)); 
+        end
+
+        function TestIsEqualFalse(tc, Unit)
+            % Verify isequal returns false when expected. Two arrays are
+            % considered not equal if one of the conditions is met:
+            %   1. They have different types
+            %   2. The have different lengths
+            %   3. Different elements are valid
+            %   4. The corresponding valid elements are not equal.
+            
+            times1 = seconds([1 2 3 4]);
+            times2 = seconds([1 1 2 3]);
+            times3 = seconds([1 2 3 4 5]);
+
+            array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 4]);
+            array3 = tc.ArrowArrayConstructorFcn(times2,  TimeUnit=Unit, Valid=[1 2 4]);
+            array4 = arrow.array([true false true false]);
+            array5 = tc.ArrowArrayConstructorFcn(times3, Valid=[1 2 4]);
+
+            % The same elements are not valid.
+            tc.verifyFalse(isequal(array1, array2));
+
+            % Corresponding elements are not equal.
+            tc.verifyFalse(isequal(array1, array3));
+
+            % The arrays have different types.
+            tc.verifyFalse(isequal(array1, array4));
+
+            % The arrays have different lengths.
+            tc.verifyFalse(isequal(array1, array5));
+
+            % Comparing an arrow.array.BooleanArray to a double
+            tc.verifyFalse(isequal(array1, 1));
+
+            % Supply more than two input arguments to isequal
+            tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
+        end
+
+        function TestIsEqualFalseTimeUnitMistmatch(tc)
+            % Verify two TimestampArrays are not considered equal if one
+            % has a TimeZone and one does not. 
+            times1 = seconds([1 2 3 4]);
+
+            array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit="Second");
+            array2 = tc.ArrowArrayConstructorFcn(times1, TimeUnit="Millisecond");
+
+            % arrays are not equal
+            tc.verifyFalse(isequal(array1, array2));
+        end
     end
 
     methods

--- a/matlab/test/arrow/array/tTime32Array.m
+++ b/matlab/test/arrow/array/tTime32Array.m
@@ -213,7 +213,7 @@ classdef tTime32Array < matlab.unittest.TestCase
             % Verifies isequal returns true when expected. Two are 
             % considered equal if:
             %   1. They have the same type
-            %   2. The have the same length
+            %   2. They have the same length
             %   3. The same elements are valid
             %   4. Corresponding valid elements are equal.
             
@@ -233,7 +233,7 @@ classdef tTime32Array < matlab.unittest.TestCase
             % Verify isequal returns false when expected. Two arrays are
             % considered not equal if one of the conditions is met:
             %   1. They have different types
-            %   2. The have different lengths
+            %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
             
@@ -267,8 +267,9 @@ classdef tTime32Array < matlab.unittest.TestCase
         end
 
         function TestIsEqualFalseTimeUnitMistmatch(tc)
-            % Verify two TimestampArrays are not considered equal if one
-            % has a TimeZone and one does not. 
+            % Verify two Time32Arrays are not considered equal if they have
+            % different TimeUnit values.
+
             times1 = seconds([1 2 3 4]);
 
             array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit="Second");

--- a/matlab/test/arrow/array/tTime64Array.m
+++ b/matlab/test/arrow/array/tTime64Array.m
@@ -225,11 +225,11 @@ classdef tTime64Array < matlab.unittest.TestCase
             testCase.verifyEqual(duration(array), expected);
         end
 
-                function TestIsEqualTrue(tc, Unit)
+        function TestIsEqualTrue(tc, Unit)
             % Verifies isequal returns true when expected. Two are 
             % considered equal if:
             %   1. They have the same type
-            %   2. The have the same length
+            %   2. They have the same length
             %   3. The same elements are valid
             %   4. Corresponding valid elements are equal.
             
@@ -249,7 +249,7 @@ classdef tTime64Array < matlab.unittest.TestCase
             % Verify isequal returns false when expected. Two arrays are
             % considered not equal if one of the conditions is met:
             %   1. They have different types
-            %   2. The have different lengths
+            %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
             
@@ -283,8 +283,8 @@ classdef tTime64Array < matlab.unittest.TestCase
         end
 
         function TestIsEqualFalseTimeUnitMistmatch(tc)
-            % Verify two TimestampArrays are not considered equal if one
-            % has a TimeZone and one does not. 
+            % Verify two Time64Arrays are not considered equal they have
+            % different TimeUnit values.
             times1 = seconds([1 2 3 4]);
 
             array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit="Nanosecond");

--- a/matlab/test/arrow/array/tTime64Array.m
+++ b/matlab/test/arrow/array/tTime64Array.m
@@ -224,6 +224,75 @@ classdef tTime64Array < matlab.unittest.TestCase
             expected = milliseconds(1.0030030);
             testCase.verifyEqual(duration(array), expected);
         end
+
+                function TestIsEqualTrue(tc, Unit)
+            % Verifies isequal returns true when expected. Two are 
+            % considered equal if:
+            %   1. They have the same type
+            %   2. The have the same length
+            %   3. The same elements are valid
+            %   4. Corresponding valid elements are equal.
+            
+            times1 = seconds([1 2 3 4]);
+            times2 = seconds([1 2 10 4]);
+
+            array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 2 4]);
+            array3 = tc.ArrowArrayConstructorFcn(times2, TimeUnit=Unit, Valid=[1 2 4]);
+
+            tc.verifyTrue(isequal(array1, array2));
+            tc.verifyTrue(isequal(array1, array3));
+            tc.verifyTrue(isequal(array1, array2, array3)); 
+        end
+
+        function TestIsEqualFalse(tc, Unit)
+            % Verify isequal returns false when expected. Two arrays are
+            % considered not equal if one of the conditions is met:
+            %   1. They have different types
+            %   2. The have different lengths
+            %   3. Different elements are valid
+            %   4. The corresponding valid elements are not equal.
+            
+            times1 = seconds([1 2 3 4]);
+            times2 = seconds([1 1 2 3]);
+            times3 = seconds([1 2 3 4 5]);
+
+            array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 2 4]);
+            array2 = tc.ArrowArrayConstructorFcn(times1, TimeUnit=Unit, Valid=[1 4]);
+            array3 = tc.ArrowArrayConstructorFcn(times2,  TimeUnit=Unit, Valid=[1 2 4]);
+            array4 = arrow.array([true false true false]);
+            array5 = tc.ArrowArrayConstructorFcn(times3, Valid=[1 2 4]);
+
+            % The same elements are not valid.
+            tc.verifyFalse(isequal(array1, array2));
+
+            % Corresponding elements are not equal.
+            tc.verifyFalse(isequal(array1, array3));
+
+            % The arrays have different types.
+            tc.verifyFalse(isequal(array1, array4));
+
+            % The arrays have different lengths.
+            tc.verifyFalse(isequal(array1, array5));
+
+            % Comparing an arrow.array.BooleanArray to a double
+            tc.verifyFalse(isequal(array1, 1));
+
+            % Supply more than two input arguments to isequal
+            tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
+        end
+
+        function TestIsEqualFalseTimeUnitMistmatch(tc)
+            % Verify two TimestampArrays are not considered equal if one
+            % has a TimeZone and one does not. 
+            times1 = seconds([1 2 3 4]);
+
+            array1 = tc.ArrowArrayConstructorFcn(times1, TimeUnit="Nanosecond");
+            array2 = tc.ArrowArrayConstructorFcn(times1, TimeUnit="Microsecond");
+
+            % arrays are not equal
+            tc.verifyFalse(isequal(array1, array2));
+        end
     end
 
     methods

--- a/matlab/test/arrow/array/tTime64Array.m
+++ b/matlab/test/arrow/array/tTime64Array.m
@@ -226,12 +226,13 @@ classdef tTime64Array < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc, Unit)
-            % Verifies isequal returns true when expected. Two are 
+            % Verifies isequal returns true when expected. Two arrays are 
             % considered equal if:
             %   1. They have the same type
             %   2. They have the same length
             %   3. The same elements are valid
             %   4. Corresponding valid elements are equal.
+            %   5. They have the same TimeUnit
             
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 2 10 4]);
@@ -283,7 +284,7 @@ classdef tTime64Array < matlab.unittest.TestCase
         end
 
         function TestIsEqualFalseTimeUnitMistmatch(tc)
-            % Verify two Time64Arrays are not considered equal they have
+            % Verify two Time64Arrays are not considered equal if they have
             % different TimeUnit values.
             times1 = seconds([1 2 3 4]);
 

--- a/matlab/test/arrow/array/tTime64Array.m
+++ b/matlab/test/arrow/array/tTime64Array.m
@@ -248,7 +248,8 @@ classdef tTime64Array < matlab.unittest.TestCase
 
         function TestIsEqualFalse(tc, Unit)
             % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the conditions is met:
+            % considered not equal if one of the following conditions is
+            % met:
             %   1. They have different types
             %   2. They have different lengths
             %   3. Different elements are valid

--- a/matlab/test/arrow/array/tTime64Array.m
+++ b/matlab/test/arrow/array/tTime64Array.m
@@ -226,13 +226,12 @@ classdef tTime64Array < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc, Unit)
-            % Verifies isequal returns true when expected. Two arrays are 
-            % considered equal if:
-            %   1. They have the same type
-            %   2. They have the same length
-            %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal.
-            %   5. They have the same TimeUnit
+            % Verifies arrays are considered equal if:
+            %
+            %  1. Their Type properties are equal
+            %  2. They have the same length (i.e. their Length properties are equal)
+            %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
+            %  4. All corresponding valid elements have the same values
             
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 2 10 4]);
@@ -243,18 +242,14 @@ classdef tTime64Array < matlab.unittest.TestCase
 
             tc.verifyTrue(isequal(array1, array2));
             tc.verifyTrue(isequal(array1, array3));
+
+            % Test supplying more than two arrays to isequal
             tc.verifyTrue(isequal(array1, array2, array3)); 
         end
 
         function TestIsEqualFalse(tc, Unit)
-            % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the following conditions is
-            % met:
-            %   1. They have different types
-            %   2. They have different lengths
-            %   3. Different elements are valid
-            %   4. The corresponding valid elements are not equal.
-            
+            % Verify isequal returns false when expected.
+
             times1 = seconds([1 2 3 4]);
             times2 = seconds([1 1 2 3]);
             times3 = seconds([1 2 3 4 5]);
@@ -265,22 +260,22 @@ classdef tTime64Array < matlab.unittest.TestCase
             array4 = arrow.array([true false true false]);
             array5 = tc.ArrowArrayConstructorFcn(times3, Valid=[1 2 4]);
 
-            % The same elements are not valid.
+            % Their validity bitmaps are not equal
             tc.verifyFalse(isequal(array1, array2));
 
-            % Corresponding elements are not equal.
+            % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % The arrays have different types.
+            % Their Type properties are not equal
             tc.verifyFalse(isequal(array1, array4));
 
-            % The arrays have different lengths.
+            % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.BooleanArray to a double
+            % Comparing an arrow.array.Array to a MATLAB double
             tc.verifyFalse(isequal(array1, 1));
 
-            % Supply more than two input arguments to isequal
+            % Test supplying more than two arrays to isequal
             tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
         end
 

--- a/matlab/test/arrow/array/tTimestampArray.m
+++ b/matlab/test/arrow/array/tTimestampArray.m
@@ -182,12 +182,12 @@ classdef tTimestampArray < matlab.unittest.TestCase
         end
 
         function TestIsEqualTrue(tc, TimeZone)
-            % Verifies isequal returns true when expected. Two are 
-            % considered equal if:
-            %   1. They have the same type
-            %   2. They have the same length
-            %   3. The same elements are valid
-            %   4. Corresponding valid elements are equal.
+            % Verifies arrays are considered equal if:
+            %
+            %  1. Their Type properties are equal
+            %  2. They have the same length (i.e. their Length properties are equal)
+            %  3. They have the same validity bitmap (i.e. their Valid properties are equal)
+            %  4. All corresponding valid elements have the same values
             
             dates1 = datetime(2023, 6, 22, TimeZone=TimeZone) + days(0:4);
             dates2 = datetime(2023, 6, 22, TimeZone=TimeZone) + days([0 1 5 3 4]);
@@ -198,17 +198,13 @@ classdef tTimestampArray < matlab.unittest.TestCase
 
             tc.verifyTrue(isequal(array1, array2));
             tc.verifyTrue(isequal(array1, array3));
+
+            % Test supplying more than two arrays to isequal
             tc.verifyTrue(isequal(array1, array2, array3)); 
         end
 
         function TestIsEqualFalse(tc, TimeZone)
-            % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the following conditions is
-            % met:
-            %   1. They have different types
-            %   2. They have different lengths
-            %   3. Different elements are valid
-            %   4. The corresponding valid elements are not equal.
+            % Verify isequal returns false when expected.
             
             dates1 = datetime(2023, 6, 22, TimeZone=TimeZone) + days(0:4);
             dates2 = datetime(2023, 6, 22, TimeZone=TimeZone) + days([1 1 2 3 4]);
@@ -219,22 +215,22 @@ classdef tTimestampArray < matlab.unittest.TestCase
             array4 = arrow.array([true false true false]);
             array5 = tc.ArrowArrayConstructorFcn(dates3, Valid=[1 2 4]);
 
-            % The same elements are not valid.
+            % Their validity bitmaps are not equal
             tc.verifyFalse(isequal(array1, array2));
 
-            % Corresponding elements are not equal.
+            % Not all corresponding valid elements are equal
             tc.verifyFalse(isequal(array1, array3));
 
-            % The arrays have different types.
+            % Their Type properties are not equal
             tc.verifyFalse(isequal(array1, array4));
 
-            % The arrays have different lengths.
+            % Their Length properties are not equal
             tc.verifyFalse(isequal(array1, array5));
 
-            % Comparing an arrow.array.BooleanArray to a double
+            % Comparing an arrow.array.Array to a MATLAB double
             tc.verifyFalse(isequal(array1, 1));
 
-            % Supply more than two input arguments to isequal
+            % Test supplying more than two arrays to isequal
             tc.verifyFalse(isequal(array1, array1, array3, array4, array5)); 
         end
 
@@ -268,8 +264,8 @@ classdef tTimestampArray < matlab.unittest.TestCase
         end
 
         function TestIsEqualFalseTimeUnitMistmatch(tc, TimeZone)
-             % Verify two TimestampArrays are not considered equal if their
-             % TimeUnit values differ.
+            % Verify two TimestampArrays are not considered equal if their
+            % TimeUnit values differ.
             dates1 = datetime(2023, 6, 22, TimeZone=TimeZone) + days(0:4);
             array1 = tc.ArrowArrayConstructorFcn(dates1, TimeUnit="Millisecond");
             array2 = tc.ArrowArrayConstructorFcn(dates1, TimeUnit="Microsecond");

--- a/matlab/test/arrow/array/tTimestampArray.m
+++ b/matlab/test/arrow/array/tTimestampArray.m
@@ -251,6 +251,21 @@ classdef tTimestampArray < matlab.unittest.TestCase
             tc.verifyFalse(isequal(array1, array2));
         end
 
+        function TestIsEqualSameInstantDifferentTimeZone(tc)
+            % Verify two TimestampArrays are not considered equal if
+            % they represent the same "instant in time", but have different
+            % TimeZone values.
+            dates1 = datetime(2023, 6, 22, TimeZone="America/Anchorage") + days(0:4);
+            dates2 = dates1;
+            dates2.TimeZone = "America/New_York";
+
+            array1 = tc.ArrowArrayConstructorFcn(dates1);
+            array2 = tc.ArrowArrayConstructorFcn(dates2);
+
+            % arrays are not equal
+            tc.verifyFalse(isequal(array1, array2));
+        end
+
         function TestIsEqualFalseTimeUnitMistmatch(tc, TimeZone)
              % Verify two TimestampArrays are not considered equal if their
              % TimeUnit values differ.

--- a/matlab/test/arrow/array/tTimestampArray.m
+++ b/matlab/test/arrow/array/tTimestampArray.m
@@ -203,7 +203,8 @@ classdef tTimestampArray < matlab.unittest.TestCase
 
         function TestIsEqualFalse(tc, TimeZone)
             % Verify isequal returns false when expected. Two arrays are
-            % considered not equal if one of the conditions is met:
+            % considered not equal if one of the following conditions is
+            % met:
             %   1. They have different types
             %   2. They have different lengths
             %   3. Different elements are valid

--- a/matlab/test/arrow/array/tTimestampArray.m
+++ b/matlab/test/arrow/array/tTimestampArray.m
@@ -185,7 +185,7 @@ classdef tTimestampArray < matlab.unittest.TestCase
             % Verifies isequal returns true when expected. Two are 
             % considered equal if:
             %   1. They have the same type
-            %   2. The have the same length
+            %   2. They have the same length
             %   3. The same elements are valid
             %   4. Corresponding valid elements are equal.
             
@@ -205,7 +205,7 @@ classdef tTimestampArray < matlab.unittest.TestCase
             % Verify isequal returns false when expected. Two arrays are
             % considered not equal if one of the conditions is met:
             %   1. They have different types
-            %   2. The have different lengths
+            %   2. They have different lengths
             %   3. Different elements are valid
             %   4. The corresponding valid elements are not equal.
             


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change


Currently, it's not possible to determine if two `arrow.array.Array` instances are equal because the `isequal()` method always returns `false` by default:

**Example**
 
```matlab
>> a = arrow.array([1 2 3])

a = 

[
  1,
  2,
  3
]

% Compare a with itself. 
>> tf = isequal(a, a)

tf =

  logical

   0
````

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Defined an `isequal()` overload on the `arrow.array.Array` super-class.
2. Added a new method called `isEqual()` on the `arrow::matlab::array::proxy::Array` class. 

Two arrays are considered equal in the MATLAB Interface if the following conditions are met:

 1. They have the same type
 2. They have the same length
 3. The same elements are valid
 4. Corresponding valid elements are equal.

**NOTE:** NaN values are not considered equal.

**Example**

```matlab
>> a = arrow.array([1 2 3])

a = 

[
  1,
  2,
  3
]

% Compare a with itself. 
>> tf = isequal(a, a)

tf =

  logical

   1

```


### Are these changes tested?

Yes. Added positive and negative `isequal` tests for all concrete subclasses of `arrow.array.Array`.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
7. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes. Users can now use `isequal()` with `arrow.array.Array` subclasses.

### Future Directions

1. Implement [`isequaln`](https://www.mathworks.com/help/matlab/ref/isequaln.html) so that users can test array equality with NaNs being treated as equal. 
* Closes: #37391