### PR TITLE
GH-37449: [Python] Catch error importing `pyarrow.dataset` in `python/pyarrow/tests/test_substrait.py`

### DIFF
--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -933,9 +933,9 @@ def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
 
 @pytest.mark.parametrize("expr", [
-    pc.equal(pc.field('x'), 7)",
-    pc.equal(pc.field('x'), pc.field('y'))",
-    pc.field('x') > 50"
+    pc.equal(pc.field('x'), 7),
+    pc.equal(pc.field('x'), pc.field('y')),
+    pc.field('x') > 50
 ])
 def test_serializing_expressions(expr):
     schema = pa.schema([

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -934,7 +934,7 @@ def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
 @pytest.mark.parametrize("expr", [
     pc.equal(pc.field("x"), 7),
-    pc.equal(pc.field("x"), pc.field("x")),
+    pc.equal(pc.field("x"), pc.field("y")),
     pc.field("x") > 50
 ])
 def test_serializing_expressions(expr):

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -933,9 +933,18 @@ def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
 
 @pytest.mark.parametrize("expr", [
-    pc.equal(ds.field("x"), 7),
-    pc.equal(ds.field("x"), ds.field("y")),
-    ds.field("x") > 50
+    pytest.param(
+        pc.equal(ds.field("x"), 7),
+        marks=pytest.mark.skipif(ds is None, reason="requires dataset")
+    ),
+    pytest.param(
+        pc.equal(ds.field("x"), ds.field("y")),
+        marks=pytest.mark.skipif(ds is None, reason="requires dataset")
+    ),
+    pytest.param(
+        ds.field("x") > 50,
+        marks=pytest.mark.skipif(ds is None, reason="requires dataset")
+    )
 ])
 def test_serializing_expressions(expr):
     schema = pa.schema([

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -933,9 +933,9 @@ def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
 
 @pytest.mark.parametrize("expr", [
-    pc.equal(pc.field('x'), 7),
-    pc.equal(pc.field('x'), pc.field('y')),
-    pc.field('x') > 50
+    pc.equal(pc.field("x"), 7),
+    pc.equal(pc.field("x"), pc.field("x")),
+    pc.field("x") > 50
 ])
 def test_serializing_expressions(expr):
     schema = pa.schema([

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -933,20 +933,12 @@ def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
 
 @pytest.mark.parametrize("expr", [
-    pytest.param(
-        pc.equal(ds.field("x"), 7),
-        marks=pytest.mark.skipif(ds is None, reason="requires dataset")
-    ),
-    pytest.param(
-        pc.equal(ds.field("x"), ds.field("y")),
-        marks=pytest.mark.skipif(ds is None, reason="requires dataset")
-    ),
-    pytest.param(
-        ds.field("x") > 50,
-        marks=pytest.mark.skipif(ds is None, reason="requires dataset")
-    )
+    "pc.equal(ds.field('x'), 7)",
+    "pc.equal(ds.field('x'), ds.field('y'))",
+    "ds.field('x') > 50"
 ])
 def test_serializing_expressions(expr):
+    expr = eval(expr)
     schema = pa.schema([
         pa.field("x", pa.int32()),
         pa.field("y", pa.int32())

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -26,19 +26,13 @@ from pyarrow.lib import tobytes
 from pyarrow.lib import ArrowInvalid, ArrowNotImplementedError
 
 try:
-    import pyarrow.dataset as ds
-except ImportError:
-    ds = None
-
-try:
     import pyarrow.substrait as substrait
 except ImportError:
     substrait = None
 
 # Marks all of the tests in this module
-# Ignore these with pytest ... -m 'not dataset'
 # Ignore these with pytest ... -m 'not substrait'
-pytestmark = [pytest.mark.dataset, pytest.mark.substrait]
+pytestmark = pytest.mark.substrait
 
 
 def mock_udf_context(batch_length=10):
@@ -955,8 +949,8 @@ def test_invalid_expression_ser_des():
         pa.field("x", pa.int32()),
         pa.field("y", pa.int32())
     ])
-    expr = pc.equal(ds.field("x"), 7)
-    bad_expr = pc.equal(ds.field("z"), 7)
+    expr = pc.equal(pc.field("x"), 7)
+    bad_expr = pc.equal(pc.field("z"), 7)
     # Invalid number of names
     with pytest.raises(ValueError) as excinfo:
         pa.substrait.serialize_expressions([expr], [], schema)
@@ -975,13 +969,13 @@ def test_serializing_multiple_expressions():
         pa.field("x", pa.int32()),
         pa.field("y", pa.int32())
     ])
-    exprs = [pc.equal(ds.field("x"), 7), pc.equal(ds.field("x"), ds.field("y"))]
+    exprs = [pc.equal(pc.field("x"), 7), pc.equal(pc.field("x"), pc.field("y"))]
     buf = pa.substrait.serialize_expressions(exprs, ["first", "second"], schema)
     returned = pa.substrait.deserialize_expressions(buf)
     assert schema == returned.schema
     assert len(returned.expressions) == 2
 
-    norm_exprs = [pc.equal(ds.field(0), 7), pc.equal(ds.field(0), ds.field(1))]
+    norm_exprs = [pc.equal(pc.field(0), 7), pc.equal(pc.field(0), pc.field(1))]
     assert str(returned.expressions["first"]) == str(norm_exprs[0])
     assert str(returned.expressions["second"]) == str(norm_exprs[1])
 
@@ -991,8 +985,8 @@ def test_serializing_with_compute():
         pa.field("x", pa.int32()),
         pa.field("y", pa.int32())
     ])
-    expr = pc.equal(ds.field("x"), 7)
-    expr_norm = pc.equal(ds.field(0), 7)
+    expr = pc.equal(pc.field("x"), 7)
+    expr_norm = pc.equal(pc.field(0), 7)
     buf = expr.to_substrait(schema)
     returned = pa.substrait.deserialize_expressions(buf)
 

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -933,12 +933,11 @@ def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
 
 @pytest.mark.parametrize("expr", [
-    "pc.equal(ds.field('x'), 7)",
-    "pc.equal(ds.field('x'), ds.field('y'))",
-    "ds.field('x') > 50"
+    pc.equal(pc.field('x'), 7)",
+    pc.equal(pc.field('x'), pc.field('y'))",
+    pc.field('x') > 50"
 ])
 def test_serializing_expressions(expr):
-    expr = eval(expr)
     schema = pa.schema([
         pa.field("x", pa.int32()),
         pa.field("y", pa.int32())

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -22,9 +22,13 @@ import pytest
 
 import pyarrow as pa
 import pyarrow.compute as pc
-import pyarrow.dataset as ds
 from pyarrow.lib import tobytes
 from pyarrow.lib import ArrowInvalid, ArrowNotImplementedError
+
+try:
+    import pyarrow.dataset as ds
+except ImportError:
+    ds = None
 
 try:
     import pyarrow.substrait as substrait
@@ -32,6 +36,7 @@ except ImportError:
     substrait = None
 
 # Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not dataset'
 # Ignore these with pytest ... -m 'not substrait'
 pytestmark = [pytest.mark.dataset, pytest.mark.substrait]
 


### PR DESCRIPTION
This catches an error importing `pyarrow.dataset` which is causing a CI failure.
* Closes: #37449