### PR TITLE
GH-37447: [C++][Docs] Document `ARROW_SUBSTRAIT` CMake flag

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -374,7 +374,8 @@ boolean flags to ``cmake``.
   ``ARROW_FILESYSTEM``, ``ARROW_HDFS``, and ``ARROW_JSON`` directly
   instead.
 * ``-DARROW_S3=ON``: Support for Amazon S3-compatible filesystems
-* ``-DARROW_WITH_RE2=ON`` Build with support for regular expressions using the re2 
+* ``-DARROW_SUBSTRAIT=ON``: Build with support for Substrait
+* ``-DARROW_WITH_RE2=ON``: Build with support for regular expressions using the re2 
   library, on by default and used when ``ARROW_COMPUTE`` or ``ARROW_GANDIVA`` is ``ON``
 * ``-DARROW_WITH_UTF8PROC=ON``: Build with support for Unicode properties using
   the utf8proc library, on by default and used when ``ARROW_COMPUTE`` or ``ARROW_GANDIVA``


### PR DESCRIPTION
Documents the `ARROW_SUBSTRAIT` flag added in #31565 / #12915 and adds a missing seimcolon to the docs entry for `ARROW_WITH_RE2`.
* Closes: #37447