### PR TITLE
GH-37434: [C++] IO: Refactor BufferedInputStream::Read for small input

### DIFF
--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -390,7 +390,7 @@ class BufferedInputStream::Impl : public BufferedBase {
     }
 
     // 2. Read from storage.
-    DCHECK_NE(0, remain_bytes);
+    DCHECK_EQ(0, bytes_buffered_);
     if (remain_bytes > buffer_size_) {
       // 2.1. If read is larger than buffer size, read directly from storage.
       ARROW_ASSIGN_OR_RAISE(int64_t bytes_read,

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -385,20 +385,16 @@ class BufferedInputStream::Impl : public BufferedBase {
       ConsumeBuffer(pre_buffer_copy_bytes);
     }
     int64_t remaining_bytes = nbytes - pre_buffer_copy_bytes;
-    if (remaining_bytes == 0) {
-      return nbytes;
-    }
-
-    DCHECK_EQ(0, bytes_buffered_);
     if (raw_read_bound_ >= 0) {
       remaining_bytes = std::min(remaining_bytes, raw_read_bound_ - raw_read_total_);
-      if (remaining_bytes == 0) {
-        return pre_buffer_copy_bytes;
-      }
     }
+    if (remaining_bytes == 0) {
+      return pre_buffer_copy_bytes;
+    }
+    DCHECK_EQ(0, bytes_buffered_);
 
     // 2. Read from storage.
-    if (remaining_bytes > buffer_size_) {
+    if (remaining_bytes >= buffer_size_) {
       // 2.1. If read is larger than buffer size, read directly from storage.
       ARROW_ASSIGN_OR_RAISE(int64_t bytes_read,
                             raw_->Read(remaining_bytes, reinterpret_cast<uint8_t*>(out) +

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -342,23 +342,28 @@ class BufferedInputStream::Impl : public BufferedBase {
     buffer_pos_ = bytes_buffered_ = 0;
   }
 
+  Status DoBuffer() {
+    // Fill buffer
+    if (!buffer_) {
+      RETURN_NOT_OK(ResetBuffer());
+    }
+
+    int64_t bytes_to_buffer = buffer_size_;
+    if (raw_read_bound_ >= 0) {
+      bytes_to_buffer = std::min(buffer_size_, raw_read_bound_ - raw_read_total_);
+    }
+    ARROW_ASSIGN_OR_RAISE(bytes_buffered_, raw_->Read(bytes_to_buffer, buffer_data_));
+    buffer_pos_ = 0;
+    raw_read_total_ += bytes_buffered_;
+
+    // Do not make assumptions about the raw stream position
+    raw_pos_ = -1;
+    return Status::OK();
+  }
+
   Status BufferIfNeeded() {
     if (bytes_buffered_ == 0) {
-      // Fill buffer
-      if (!buffer_) {
-        RETURN_NOT_OK(ResetBuffer());
-      }
-
-      int64_t bytes_to_buffer = buffer_size_;
-      if (raw_read_bound_ >= 0) {
-        bytes_to_buffer = std::min(buffer_size_, raw_read_bound_ - raw_read_total_);
-      }
-      ARROW_ASSIGN_OR_RAISE(bytes_buffered_, raw_->Read(bytes_to_buffer, buffer_data_));
-      buffer_pos_ = 0;
-      raw_read_total_ += bytes_buffered_;
-
-      // Do not make assumptions about the raw stream position
-      raw_pos_ = -1;
+      return DoBuffer();
     }
     return Status::OK();
   }
@@ -373,33 +378,35 @@ class BufferedInputStream::Impl : public BufferedBase {
       return Status::Invalid("Bytes to read must be positive. Received:", nbytes);
     }
 
-    if (nbytes < buffer_size_) {
-      // Pre-buffer for small reads
-      RETURN_NOT_OK(BufferIfNeeded());
+    // 1. First consume pre-buffered data.
+    int64_t pre_buffer_copy_bytes = std::min(nbytes, bytes_buffered_);
+    if (pre_buffer_copy_bytes > 0) {
+      memcpy(out, buffer_data_ + buffer_pos_, pre_buffer_copy_bytes);
+      ConsumeBuffer(pre_buffer_copy_bytes);
+      if (pre_buffer_copy_bytes == nbytes) {
+        return nbytes;
+      }
     }
 
-    if (nbytes > bytes_buffered_) {
-      // Copy buffered bytes into out, then read rest
-      memcpy(out, buffer_data_ + buffer_pos_, bytes_buffered_);
-
-      int64_t bytes_to_read = nbytes - bytes_buffered_;
-      if (raw_read_bound_ >= 0) {
-        bytes_to_read = std::min(bytes_to_read, raw_read_bound_ - raw_read_total_);
-      }
-      ARROW_ASSIGN_OR_RAISE(
-          int64_t bytes_read,
-          raw_->Read(bytes_to_read, reinterpret_cast<uint8_t*>(out) + bytes_buffered_));
+    // 2. Read from storage.
+    int64_t remain_bytes = nbytes - pre_buffer_copy_bytes;
+    if (remain_bytes > buffer_size_) {
+      // 2.1. If read is larger than buffer size, read directly from storage.
+      ARROW_ASSIGN_OR_RAISE(int64_t bytes_read,
+                            raw_->Read(remain_bytes, reinterpret_cast<uint8_t*>(out) +
+                                                         pre_buffer_copy_bytes));
       raw_read_total_ += bytes_read;
-
-      // Do not make assumptions about the raw stream position
-      raw_pos_ = -1;
-      bytes_read += bytes_buffered_;
+      bytes_read += pre_buffer_copy_bytes;
       RewindBuffer();
       return bytes_read;
     } else {
-      memcpy(out, buffer_data_ + buffer_pos_, nbytes);
-      ConsumeBuffer(nbytes);
-      return nbytes;
+      // 2.2. If read is smaller than buffer size, fill buffer and copy from buffer.
+      RETURN_NOT_OK(DoBuffer());
+      int64_t bytes_copy_after_buffer = std::min(bytes_buffered_, remain_bytes);
+      memcpy(reinterpret_cast<uint8_t*>(out) + pre_buffer_copy_bytes,
+             buffer_data_ + buffer_pos_, bytes_copy_after_buffer);
+      ConsumeBuffer(bytes_copy_after_buffer);
+      return pre_buffer_copy_bytes + bytes_copy_after_buffer;
     }
   }
 

--- a/cpp/src/arrow/io/buffered_test.cc
+++ b/cpp/src/arrow/io/buffered_test.cc
@@ -866,7 +866,7 @@ class TestBufferedInputStreamRandom : public ::testing::Test {
     tracked_.reset();
     // Read from a copy of data, so that data_.substr() below doesn't invalidate it
     raw_ = BufferReader::FromString(data_);
-    tracked_ = std::move(TrackedRandomAccessFile::Make(raw_.get()));
+    tracked_ = TrackedRandomAccessFile::Make(raw_.get());
     EXPECT_OK_AND_ASSIGN(buffered_,
                          BufferedInputStream::Create(buffer_size, default_memory_pool(),
                                                      tracked_, read_bound.value_or(-1)));

--- a/cpp/src/arrow/io/buffered_test.cc
+++ b/cpp/src/arrow/io/buffered_test.cc
@@ -320,7 +320,7 @@ TEST_F(TestBufferedOutputStream, TruncatesFile) {
 // ----------------------------------------------------------------------
 // BufferedInputStream tests
 
-const char kExample1[] = "informaticacrobaticsimmolation";
+const std::string_view kExample1 = "informaticacrobaticsimmolation";
 
 class TestBufferedInputStream : public FileTestFixture<BufferedInputStream> {
  public:
@@ -671,6 +671,8 @@ TEST_F(TestBufferedInputStreamBound, BufferExactlyExhausted) {
   }
 }
 
+// These tests exercise the buffering algorithm by checking the reads issued
+// to the underlying raw stream.
 class TestBufferedInputStreamChunk : public TestBufferedInputStream {
  public:
   void SetUp() { TestBufferedInputStream::SetUp(); }
@@ -681,9 +683,10 @@ class TestBufferedInputStreamChunk : public TestBufferedInputStream {
     raw_ = nullptr;
   }
 
-  void MakeExample(int64_t buffer_size, MemoryPool* pool = default_memory_pool(),
+  void MakeExample(int64_t buffer_size,
                    std::optional<int64_t> read_bound = std::nullopt) {
     test_data_ = kExample1;
+    MemoryPool* pool = default_memory_pool();
 
     ASSERT_OK_AND_ASSIGN(auto file_out, FileOutputStream::Open(path_));
     ASSERT_OK(file_out->Write(test_data_));
@@ -692,108 +695,247 @@ class TestBufferedInputStreamChunk : public TestBufferedInputStream {
     ASSERT_OK_AND_ASSIGN(auto file_in, ReadableFile::Open(path_));
     raw_ = file_in;
     tracked_ = TrackedRandomAccessFile::Make(dynamic_cast<RandomAccessFile*>(raw_.get()));
-    if (read_bound.has_value()) {
-      ASSERT_OK_AND_ASSIGN(
-          buffered_,
-          BufferedInputStream::Create(buffer_size, pool, tracked_, read_bound.value()));
-    } else {
-      ASSERT_OK_AND_ASSIGN(buffered_,
-                           BufferedInputStream::Create(buffer_size, pool, tracked_));
-    }
+    ASSERT_OK_AND_ASSIGN(buffered_,
+                         BufferedInputStream::Create(buffer_size, pool, tracked_,
+                                                     read_bound.value_or(-1)));
   }
 
  protected:
   std::shared_ptr<TrackedRandomAccessFile> tracked_;
 };
 
-// Read bytes greater than buffer_size would not buffer.
-TEST_F(TestBufferedInputStreamChunk, NotBufferLargeRead) {
+TEST_F(TestBufferedInputStreamChunk, NoRead) {
   const int64_t kBufferSize = 5;
   MakeExample(kBufferSize);
 
+  EXPECT_TRUE(tracked_->get_read_ranges().empty());
+}
+
+TEST_F(TestBufferedInputStreamChunk, LargeRead) {
+  const int64_t kBufferSize = 5;
+  MakeExample(kBufferSize);
+
+  // Read bytes greater than buffer_size would not buffer.
   ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(6));
-  EXPECT_EQ(6, buf->size());
+  AssertBufferEqual(*buf, kExample1.substr(0, 6));
+
   EXPECT_EQ(0, buffered_->bytes_buffered());
-  std::vector<io::ReadRange> read_ranges = {io::ReadRange{0, 6}};
+  std::vector<ReadRange> read_ranges = {ReadRange{0, 6}};
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
 }
 
-TEST_F(TestBufferedInputStreamChunk, NotBufferLargeRead2) {
+TEST_F(TestBufferedInputStreamChunk, SmallReadThenLargeRead) {
   const int64_t kBufferSize = 5;
   MakeExample(kBufferSize);
 
-  // small read would trigger buffer the whole chunk
+  // Small read would trigger buffer the whole chunk
   ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(1));
-  EXPECT_EQ(1, buf->size());
+  AssertBufferEqual(*buf, kExample1.substr(0, 1));
   EXPECT_EQ(4, buffered_->bytes_buffered());
-  std::vector<io::ReadRange> read_ranges = {io::ReadRange{0, 5}};
+  std::vector<ReadRange> read_ranges = {ReadRange{0, 5}};
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
 
   // Large read with pre-buffered will copy the
-  // pre-buffered data first, then read the remaining.
+  // pre-buffered data first, then read the remaining without filling
+  // the buffer.
   ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(20));
-  EXPECT_EQ(20, buf->size());
+  AssertBufferEqual(*buf, kExample1.substr(1, 20));
   EXPECT_EQ(0, buffered_->bytes_buffered());
-  read_ranges.push_back(io::ReadRange{5, 16});
+  read_ranges.push_back(ReadRange{5, 16});
+  EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+
+  // Small read again
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(2));
+  AssertBufferEqual(*buf, kExample1.substr(21, 2));
+  EXPECT_EQ(kBufferSize - 2, buffered_->bytes_buffered());
+  read_ranges.push_back(ReadRange{21, 5});
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
 }
 
-// Will buffer during small IO
 TEST_F(TestBufferedInputStreamChunk, BufferWholeChunk) {
   const int64_t kBufferSize = 5;
   MakeExample(kBufferSize);
 
+  // Small read
   ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(1));
-  EXPECT_EQ(1, buf->size());
+  AssertBufferEqual(*buf, kExample1.substr(0, 1));
   EXPECT_EQ(kBufferSize - 1, buffered_->bytes_buffered());
-  std::vector<io::ReadRange> read_ranges = {io::ReadRange{0, 5}};
+  std::vector<ReadRange> read_ranges = {ReadRange{0, 5}};
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
 
-  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(5));
-  EXPECT_EQ(5, buf->size());
-  EXPECT_EQ(kBufferSize - 1, buffered_->bytes_buffered());
-  read_ranges.push_back(io::ReadRange{5, 5});
+  // Whole read size is larger than buffer size, but raw read size would be
+  // smaller than buffer size => buffer is filled anew
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(6));
+  AssertBufferEqual(*buf, kExample1.substr(1, 6));
+  EXPECT_EQ(kBufferSize * 2 - 1 - 6, buffered_->bytes_buffered());
+  read_ranges.push_back(ReadRange{5, 5});
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
 }
 
-TEST_F(TestBufferedInputStreamChunk, BufferLargeThenFileSize) {
-  const int64_t kBufferSize = 40;
+TEST_F(TestBufferedInputStreamChunk, BufferLargerThanFileSize) {
+  const int64_t kFileSize = static_cast<int64_t>(kExample1.size());
+  const int64_t kBufferSize = kFileSize + 10;
   MakeExample(kBufferSize);
 
   ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(1));
-  EXPECT_EQ(1, buf->size());
-  EXPECT_EQ(1, tracked_->num_reads());
-  EXPECT_EQ(test_data_.size() - 1, buffered_->bytes_buffered());
-  // Note: read_ranges here is different from bounded read.
-  // It will send the whole read-request to the source.
-  std::vector<io::ReadRange> read_ranges = {io::ReadRange{0, kBufferSize}};
+  AssertBufferEqual(*buf, kExample1.substr(0, 1));
+  EXPECT_EQ(kFileSize - 1, buffered_->bytes_buffered());
+  std::vector<ReadRange> read_ranges = {ReadRange{0, kBufferSize}};
+  EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(kFileSize - 3));
+  AssertBufferEqual(*buf, kExample1.substr(1, kFileSize - 3));
+  EXPECT_EQ(2, buffered_->bytes_buffered());
+  EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+
+  // Short read up to EOF
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(20));
+  AssertBufferEqual(*buf, kExample1.substr(kFileSize - 2, 2));
+  EXPECT_EQ(0, buffered_->bytes_buffered());
+  read_ranges.push_back(ReadRange{kFileSize, kBufferSize});
+  EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+
+  // EOF
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(20));
+  AssertBufferEqual(*buf, "");
+  EXPECT_EQ(0, buffered_->bytes_buffered());
+  // (BufferedInputStream still tries to fetch more bytes)
+  read_ranges.push_back(ReadRange{kFileSize, kBufferSize});
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
 }
 
-// Trigger small IO with buffer will not exceed the bound.
-TEST_F(TestBufferedInputStreamChunk, BufferWithBound) {
+TEST_F(TestBufferedInputStreamChunk, BufferLargerThanReadBound) {
   const int64_t kBufferSize = 6;
   const int64_t kReadBound = 5;
-  MakeExample(kBufferSize, default_memory_pool(), kReadBound);
+  MakeExample(kBufferSize, kReadBound);
 
+  // Small read
   ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(1));
-  EXPECT_EQ(1, buf->size());
+  AssertBufferEqual(*buf, kExample1.substr(0, 1));
   EXPECT_EQ(kReadBound - 1, buffered_->bytes_buffered());
-  std::vector<io::ReadRange> read_ranges = {io::ReadRange{0, 5}};
+  std::vector<ReadRange> read_ranges = {ReadRange{0, 5}};
+  EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+
+  // Longer read, but truncated due to the read bound
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(10));
+  AssertBufferEqual(*buf, kExample1.substr(1, 4));
+  EXPECT_EQ(0, buffered_->bytes_buffered());
+  // Due to the read bound, no more row reads were issued
+  EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+
+  // EOF
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(10));
+  AssertBufferEqual(*buf, "");
+  EXPECT_EQ(0, buffered_->bytes_buffered());
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
 }
 
-// Trigger large IO without buffer will not exceed the bound.
-TEST_F(TestBufferedInputStreamChunk, BufferWithBound2) {
+TEST_F(TestBufferedInputStreamChunk, BufferSmallerThanReadBound) {
   const int64_t kBufferSize = 3;
   const int64_t kReadBound = 5;
-  MakeExample(kBufferSize, default_memory_pool(), kReadBound);
+  MakeExample(kBufferSize, kReadBound);
 
   ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(6));
-  EXPECT_EQ(5, buf->size());
+  AssertBufferEqual(*buf, kExample1.substr(0, 5));
   EXPECT_EQ(0, buffered_->bytes_buffered());
-  std::vector<io::ReadRange> read_ranges = {io::ReadRange{0, 5}};
+  std::vector<ReadRange> read_ranges = {ReadRange{0, 5}};
   EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+
+  // EOF
+  ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(10));
+  AssertBufferEqual(*buf, "");
+  EXPECT_EQ(0, buffered_->bytes_buffered());
+  EXPECT_EQ(tracked_->get_read_ranges(), read_ranges);
+}
+
+class TestBufferedInputStreamRandom : public ::testing::Test {
+ public:
+  void MakeBuffered(int64_t data_size, int64_t buffer_size,
+                    std::optional<int64_t> read_bound = std::nullopt) {
+    buffer_size_ = buffer_size;
+    data_.clear();
+    data_.reserve(data_size);
+    while (data_.size() < static_cast<size_t>(data_size)) {
+      data_.append(kExample1, /*pos*/ 0,
+                   /*count*/ static_cast<size_t>(data_size) - data_.size());
+    }
+    EXPECT_EQ(data_.size(), data_size);
+
+    // Clear dependent streams in reverse order
+    buffered_.reset();
+    tracked_.reset();
+    // Read from a copy of data, so that data_.substr() below doesn't invalidate it
+    raw_ = BufferReader::FromString(data_);
+    tracked_ = std::move(TrackedRandomAccessFile::Make(raw_.get()));
+    EXPECT_OK_AND_ASSIGN(buffered_,
+                         BufferedInputStream::Create(buffer_size, default_memory_pool(),
+                                                     tracked_, read_bound.value_or(-1)));
+    if (read_bound) {
+      data_ = data_.substr(0, *read_bound);
+    }
+  }
+
+  void TestReads() {
+    std::default_random_engine gen(/*seed*/ 42);
+    std::uniform_int_distribution<int64_t> read_len_dist(1, 80);
+
+    int64_t pos = 0;
+    const int64_t size = static_cast<int64_t>(data_.size());
+    while (pos < size) {
+      const int64_t read_len = read_len_dist(gen);
+      ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(read_len));
+      AssertBufferEqual(*buf, std::string_view(data_).substr(pos, read_len));
+      pos += buf->size();
+    }
+
+    // EOF was reached
+    ASSERT_EQ(pos, size);
+
+    // Number of reads should not be excessive given the buffer size
+    int64_t max_reads = (size + buffer_size_ - 1) / buffer_size_;
+    EXPECT_LE(tracked_->num_reads(), max_reads);
+    const auto& read_ranges = tracked_->get_read_ranges();
+    pos = 0;
+    for (size_t i = 0; i < read_ranges.size(); ++i) {
+      const auto cur = read_ranges[i];
+      ASSERT_EQ(cur.offset, pos);
+      // Never read less than buffer size bytes, except perhaps if fewer bytes remain
+      ASSERT_GE(cur.length, std::min(buffer_size_, size - pos));
+      // Bump actual position in the file
+      pos += std::min(cur.length, size - pos);
+    }
+
+    // Further reads return an empty buffer
+    ASSERT_OK_AND_ASSIGN(auto buf, buffered_->Read(buffer_size_ - 1));
+    AssertBufferEqual(*buf, "");
+    ASSERT_OK_AND_ASSIGN(buf, buffered_->Read(buffer_size_ + 1));
+    AssertBufferEqual(*buf, "");
+  }
+
+ protected:
+  std::string data_;
+  int64_t buffer_size_;
+  std::shared_ptr<RandomAccessFile> raw_;
+  std::shared_ptr<TrackedRandomAccessFile> tracked_;
+  std::shared_ptr<BufferedInputStream> buffered_;
+};
+
+TEST_F(TestBufferedInputStreamRandom, ReadsWithoutReadBound) {
+  constexpr int kNumIters = 10;
+
+  for (int i = 0; i < kNumIters; ++i) {
+    MakeBuffered(/*data_size=*/3000, /*buffer_size=*/11);
+    TestReads();
+  }
+}
+
+TEST_F(TestBufferedInputStreamRandom, ReadsWithReadBound) {
+  constexpr int kNumIters = 10;
+
+  for (int i = 0; i < kNumIters; ++i) {
+    MakeBuffered(/*data_size=*/3000, /*buffer_size=*/11, /*read_bound=*/2000);
+    TestReads();
+  }
 }
 
 }  // namespace arrow::io

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -214,7 +214,7 @@ void AssertBufferEqual(const Buffer& buffer, const std::vector<uint8_t>& expecte
   }
 }
 
-void AssertBufferEqual(const Buffer& buffer, const std::string& expected) {
+void AssertBufferEqual(const Buffer& buffer, std::string_view expected) {
   ASSERT_EQ(static_cast<size_t>(buffer.size()), expected.length())
       << "Mismatching buffer size";
   const uint8_t* buffer_data = buffer.data();

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -232,7 +232,7 @@ ARROW_TESTING_EXPORT void AssertChunkedApproxEquivalent(
 ARROW_TESTING_EXPORT void AssertBufferEqual(const Buffer& buffer,
                                             const std::vector<uint8_t>& expected);
 ARROW_TESTING_EXPORT void AssertBufferEqual(const Buffer& buffer,
-                                            const std::string& expected);
+                                            std::string_view expected);
 ARROW_TESTING_EXPORT void AssertBufferEqual(const Buffer& buffer, const Buffer& expected);
 
 ARROW_TESTING_EXPORT void AssertTypeEqual(const DataType& lhs, const DataType& rhs,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

If we Set BufferSize == 100k, and read 3k bytes per IO. When we read the 34 times, the IO would be (99k, 102k]

In Read, it will read buffered (99k, 100k], issue IO for (100k, 102k]. Rather than (100k, 200k]. 

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Refactor `BufferedInputStream::Read` to optimize small IO.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Already has tests?

### Are there any user-facing changes?

User might get io-pattern changed. It can be optimization or downgrade.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37434