### PR TITLE
MINOR: [C++] Mark more files generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,11 @@
+cpp/src/arrow/util/bpacking_*_generated.h linguist-generated=true
+cpp/src/generated/*.cpp linguist-generated=true
+cpp/src/generated/*.h linguist-generated=true
+go/**/*.s linguist-generated=true
+go/arrow/unionmode_string.go linguist-generated=true
 r/R/RcppExports.R linguist-generated=true
 r/R/arrowExports.R linguist-generated=true
 r/src/RcppExports.cpp linguist-generated=true
 r/src/arrowExports.cpp linguist-generated=true
 r/man/*.Rd linguist-generated=true
-cpp/src/generated/*.h linguist-generated=true
 r/NEWS.md merge=union
-go/**/*.s linguist-generated=true
-go/arrow/unionmode_string.go linguist-generated=true


### PR DESCRIPTION
### Rationale for this change

Some generated files, such as Thrift C++ implementation files, can be shown by default in PR diff views.

### What changes are included in this PR?

Mark more files generated.

### Are these changes tested?

No tests required.

### Are there any user-facing changes?

No.