### PR TITLE
GH-37463:  [R] CRAN incoming checks fail due to test run length 

### DIFF
--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -19,6 +19,7 @@ library(dplyr, warn.conflicts = FALSE)
 suppressPackageStartupMessages(library(bit64))
 
 skip_if_not_available("acero")
+skip_on_cran()
 
 tbl <- example_data
 tbl$verses <- verses[[1]]

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -19,6 +19,7 @@ library(dplyr, warn.conflicts = FALSE)
 suppressPackageStartupMessages(library(bit64))
 
 skip_if_not_available("acero")
+# Skip these tests on CRAN due to build times > 10 mins
 skip_on_cran()
 
 tbl <- example_data

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -22,6 +22,7 @@ library(lubridate, warn.conflicts = FALSE)
 library(dplyr, warn.conflicts = FALSE)
 
 skip_if_not_available("acero")
+# Skip these tests on CRAN due to build times > 10 mins
 skip_on_cran()
 
 # base::strptime() defaults to local timezone

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -22,6 +22,7 @@ library(lubridate, warn.conflicts = FALSE)
 library(dplyr, warn.conflicts = FALSE)
 
 skip_if_not_available("acero")
+skip_on_cran()
 
 # base::strptime() defaults to local timezone
 # but arrow's strptime defaults to UTC.

--- a/r/tests/testthat/test-dplyr-funcs-math.R
+++ b/r/tests/testthat/test-dplyr-funcs-math.R
@@ -18,6 +18,7 @@
 library(dplyr, warn.conflicts = FALSE)
 
 skip_if_not_available("acero")
+skip_on_cran()
 
 test_that("abs()", {
   df <- tibble(x = c(-127, -10, -1, -0, 0, 1, 10, 127, NA))

--- a/r/tests/testthat/test-dplyr-funcs-math.R
+++ b/r/tests/testthat/test-dplyr-funcs-math.R
@@ -18,6 +18,7 @@
 library(dplyr, warn.conflicts = FALSE)
 
 skip_if_not_available("acero")
+# Skip these tests on CRAN due to build times > 10 mins
 skip_on_cran()
 
 test_that("abs()", {

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -17,6 +17,7 @@
 
 skip_if_not_available("utf8proc")
 skip_if_not_available("acero")
+skip_on_cran()
 
 library(dplyr, warn.conflicts = FALSE)
 library(lubridate)

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -17,6 +17,7 @@
 
 skip_if_not_available("utf8proc")
 skip_if_not_available("acero")
+# Skip these tests on CRAN due to build times > 10 mins
 skip_on_cran()
 
 library(dplyr, warn.conflicts = FALSE)

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -20,6 +20,7 @@ suppressPackageStartupMessages(library(bit64))
 suppressPackageStartupMessages(library(lubridate))
 
 skip_if_not_available("acero")
+# Skip these tests on CRAN due to build times > 10 mins
 skip_on_cran()
 
 tbl <- example_data

--- a/r/tests/testthat/test-dplyr-funcs-type.R
+++ b/r/tests/testthat/test-dplyr-funcs-type.R
@@ -20,6 +20,7 @@ suppressPackageStartupMessages(library(bit64))
 suppressPackageStartupMessages(library(lubridate))
 
 skip_if_not_available("acero")
+skip_on_cran()
 
 tbl <- example_data
 

--- a/r/tests/testthat/test-dplyr-funcs.R
+++ b/r/tests/testthat/test-dplyr-funcs.R
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+skip_on_cran()
 
 test_that("register_binding()/unregister_binding() works", {
   fake_registry <- new.env(parent = emptyenv())

--- a/r/tests/testthat/test-dplyr-funcs.R
+++ b/r/tests/testthat/test-dplyr-funcs.R
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+# Skip these tests on CRAN due to build times > 10 mins
 skip_on_cran()
 
 test_that("register_binding()/unregister_binding() works", {


### PR DESCRIPTION
### Rationale for this change

Initial CRAN checks fail as it takes too long to run

### What changes are included in this PR?

Skip tests for dplyr function bindings on CRAN

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #37463