### PR TITLE
GH-37466: [C++][Parquet] Fix Valgrind failure in DELTA_BYTE_ARRAY decoder

### DIFF
--- a/cpp/src/arrow/util/bit_stream_utils.h
+++ b/cpp/src/arrow/util/bit_stream_utils.h
@@ -113,29 +113,19 @@ class BitWriter {
 /// bytes in one read (e.g. encoded int).
 class BitReader {
  public:
-  /// 'buffer' is the buffer to read from.  The buffer's length is 'buffer_len'.
-  BitReader(const uint8_t* buffer, int buffer_len)
-      : buffer_(buffer), max_bytes_(buffer_len), byte_offset_(0), bit_offset_(0) {
-    int num_bytes = std::min(8, max_bytes_ - byte_offset_);
-    memcpy(&buffered_values_, buffer_ + byte_offset_, num_bytes);
-    buffered_values_ = arrow::bit_util::FromLittleEndian(buffered_values_);
-  }
+  BitReader() = default;
 
-  BitReader()
-      : buffer_(NULL),
-        max_bytes_(0),
-        buffered_values_(0),
-        byte_offset_(0),
-        bit_offset_(0) {}
+  /// 'buffer' is the buffer to read from.  The buffer's length is 'buffer_len'.
+  BitReader(const uint8_t* buffer, int buffer_len) : BitReader() {
+    Reset(buffer, buffer_len);
+  }
 
   void Reset(const uint8_t* buffer, int buffer_len) {
     buffer_ = buffer;
     max_bytes_ = buffer_len;
     byte_offset_ = 0;
     bit_offset_ = 0;
-    int num_bytes = std::min(8, max_bytes_ - byte_offset_);
-    memcpy(&buffered_values_, buffer_ + byte_offset_, num_bytes);
-    buffered_values_ = arrow::bit_util::FromLittleEndian(buffered_values_);
+    FillBufferedValues();
   }
 
   /// Gets the next value from the buffer.  Returns true if 'v' could be read or false if
@@ -190,15 +180,20 @@ class BitReader {
   static constexpr int kMaxVlqByteLengthForInt64 = 10;
 
  private:
-  const uint8_t* buffer_;
-  int max_bytes_;
+  template <typename T>
+  inline void GetOneValue(int num_bits, T* v);
 
-  /// Bytes are memcpy'd from buffer_ and values are read from this variable. This is
-  /// faster than reading values byte by byte directly from buffer_.
-  uint64_t buffered_values_;
+  void FillBufferedValues();
 
-  int byte_offset_;  // Offset in buffer_
-  int bit_offset_;   // Offset in buffered_values_
+  const uint8_t* buffer_ = NULLPTR;
+  int max_bytes_ = 0;
+
+  // Bytes are memcpy'd from buffer_ and values are read from this variable. This is
+  // faster than reading values byte by byte directly from buffer_.
+  uint64_t buffered_values_ = 0;
+
+  int byte_offset_ = 0;  // Offset in buffer_
+  int bit_offset_ = 0;   // Offset in buffered_values_
 };
 
 inline bool BitWriter::PutValue(uint64_t v, int num_bits) {
@@ -258,56 +253,50 @@ inline bool BitWriter::PutAligned(T val, int num_bytes) {
   return true;
 }
 
-namespace detail {
-
-inline void ResetBufferedValues_(const uint8_t* buffer, int byte_offset,
-                                 int bytes_remaining, uint64_t* buffered_values) {
-  if (ARROW_PREDICT_TRUE(bytes_remaining >= 8)) {
-    memcpy(buffered_values, buffer + byte_offset, 8);
+inline void BitReader::FillBufferedValues() {
+  uint64_t le_value = 0;
+  if (ARROW_PREDICT_TRUE(max_bytes_ - byte_offset_ >= 8)) {
+    memcpy(&le_value, buffer_ + byte_offset_, 8);
   } else {
-    memcpy(buffered_values, buffer + byte_offset, bytes_remaining);
+    memcpy(&le_value, buffer_ + byte_offset_, max_bytes_ - byte_offset_);
   }
-  *buffered_values = arrow::bit_util::FromLittleEndian(*buffered_values);
+  buffered_values_ = arrow::bit_util::FromLittleEndian(le_value);
 }
 
 template <typename T>
-inline void GetValue_(int num_bits, T* v, int max_bytes, const uint8_t* buffer,
-                      int* bit_offset, int* byte_offset, uint64_t* buffered_values) {
+inline void BitReader::GetOneValue(int num_bits, T* v) {
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4800)
 #endif
-  *v = static_cast<T>(bit_util::TrailingBits(*buffered_values, *bit_offset + num_bits) >>
-                      *bit_offset);
+  *v = static_cast<T>(bit_util::TrailingBits(buffered_values_, bit_offset_ + num_bits) >>
+                      bit_offset_);
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-  *bit_offset += num_bits;
-  if (*bit_offset >= 64) {
-    *byte_offset += 8;
-    *bit_offset -= 64;
-
-    ResetBufferedValues_(buffer, *byte_offset, max_bytes - *byte_offset, buffered_values);
+  bit_offset_ += num_bits;
+  if (bit_offset_ >= 64) {
+    byte_offset_ += 8;
+    bit_offset_ -= 64;
+    FillBufferedValues();
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4800 4805)
 #endif
     // Read bits of v that crossed into new buffered_values_
-    if (ARROW_PREDICT_TRUE(num_bits - *bit_offset < static_cast<int>(8 * sizeof(T)))) {
-      // if shift exponent(num_bits - *bit_offset) is not less than sizeof(T), *v will not
+    if (ARROW_PREDICT_TRUE(num_bits - bit_offset_ < static_cast<int>(8 * sizeof(T)))) {
+      // if shift exponent(num_bits - bit_offset) is not less than sizeof(T), *v will not
       // change and the following code may cause a runtime error that the shift exponent
       // is too large
-      *v = *v | static_cast<T>(bit_util::TrailingBits(*buffered_values, *bit_offset)
-                               << (num_bits - *bit_offset));
+      *v = *v | static_cast<T>(bit_util::TrailingBits(buffered_values_, bit_offset_)
+                               << (num_bits - bit_offset_));
     }
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-    DCHECK_LE(*bit_offset, 64);
+    DCHECK_LE(bit_offset_, 64);
   }
 }
-
-}  // namespace detail
 
 template <typename T>
 inline bool BitReader::GetValue(int num_bits, T* v) {
@@ -319,43 +308,44 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
   DCHECK(buffer_ != NULL);
   DCHECK_LE(num_bits, static_cast<int>(sizeof(T) * 8)) << "num_bits: " << num_bits;
 
-  int bit_offset = bit_offset_;
-  int byte_offset = byte_offset_;
-  uint64_t buffered_values = buffered_values_;
-  int max_bytes = max_bytes_;
-  const uint8_t* buffer = buffer_;
+//   int bit_offset = bit_offset_;
+//   int byte_offset = byte_offset_;
+//   uint64_t buffered_values = buffered_values_;
+//   int max_bytes = max_bytes_;
+//   const uint8_t* buffer = buffer_;
 
   const int64_t needed_bits = num_bits * static_cast<int64_t>(batch_size);
   constexpr uint64_t kBitsPerByte = 8;
   const int64_t remaining_bits =
-      static_cast<int64_t>(max_bytes - byte_offset) * kBitsPerByte - bit_offset;
+      static_cast<int64_t>(max_bytes_ - byte_offset_) * kBitsPerByte - bit_offset_;
   if (remaining_bits < needed_bits) {
     batch_size = static_cast<int>(remaining_bits / num_bits);
   }
 
   int i = 0;
-  if (ARROW_PREDICT_FALSE(bit_offset != 0)) {
-    for (; i < batch_size && bit_offset != 0; ++i) {
-      detail::GetValue_(num_bits, &v[i], max_bytes, buffer, &bit_offset, &byte_offset,
-                        &buffered_values);
+  if (ARROW_PREDICT_FALSE(bit_offset_ != 0)) {
+    for (; i < batch_size && bit_offset_ != 0; ++i) {
+      GetOneValue(num_bits, &v[i]);
+//       detail::GetValue_(num_bits, &v[i], max_bytes, buffer, &bit_offset, &byte_offset,
+//                         &buffered_values);
     }
   }
 
   if (sizeof(T) == 4) {
     int num_unpacked =
-        internal::unpack32(reinterpret_cast<const uint32_t*>(buffer + byte_offset),
+        internal::unpack32(reinterpret_cast<const uint32_t*>(buffer_ + byte_offset_),
                            reinterpret_cast<uint32_t*>(v + i), batch_size - i, num_bits);
     i += num_unpacked;
-    byte_offset += num_unpacked * num_bits / 8;
+    byte_offset_ += num_unpacked * num_bits / 8;
   } else if (sizeof(T) == 8 && num_bits > 32) {
     // Use unpack64 only if num_bits is larger than 32
     // TODO (ARROW-13677): improve the performance of internal::unpack64
     // and remove the restriction of num_bits
     int num_unpacked =
-        internal::unpack64(buffer + byte_offset, reinterpret_cast<uint64_t*>(v + i),
+        internal::unpack64(buffer_ + byte_offset_, reinterpret_cast<uint64_t*>(v + i),
                            batch_size - i, num_bits);
     i += num_unpacked;
-    byte_offset += num_unpacked * num_bits / 8;
+    byte_offset_ += num_unpacked * num_bits / 8;
   } else {
     // TODO: revisit this limit if necessary
     DCHECK_LE(num_bits, 32);
@@ -364,7 +354,7 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
     while (i < batch_size) {
       int unpack_size = std::min(buffer_size, batch_size - i);
       int num_unpacked =
-          internal::unpack32(reinterpret_cast<const uint32_t*>(buffer + byte_offset),
+          internal::unpack32(reinterpret_cast<const uint32_t*>(buffer_ + byte_offset_),
                              unpack_buffer, unpack_size, num_bits);
       if (num_unpacked == 0) {
         break;
@@ -380,21 +370,23 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
 #endif
       }
       i += num_unpacked;
-      byte_offset += num_unpacked * num_bits / 8;
+      byte_offset_ += num_unpacked * num_bits / 8;
     }
   }
 
-  detail::ResetBufferedValues_(buffer, byte_offset, max_bytes - byte_offset,
-                               &buffered_values);
+//   buffered_values = detail::ReadBitsAsLittleEndian(buffer + byte_offset, max_bytes - byte_offset);
 
+//   bit_offset_ = bit_offset;
+//   byte_offset_ = byte_offset;
+
+  FillBufferedValues();
   for (; i < batch_size; ++i) {
-    detail::GetValue_(num_bits, &v[i], max_bytes, buffer, &bit_offset, &byte_offset,
-                      &buffered_values);
+    GetOneValue(num_bits, &v[i]);
+//     detail::GetValue_(num_bits, &v[i], max_bytes, buffer, &bit_offset, &byte_offset,
+//                       &buffered_values);
   }
-
-  bit_offset_ = bit_offset;
-  byte_offset_ = byte_offset;
-  buffered_values_ = buffered_values;
+/*
+  buffered_values_ = buffered_values;*/
 
   return batch_size;
 }
@@ -425,8 +417,8 @@ inline bool BitReader::GetAligned(int num_bytes, T* v) {
   byte_offset_ += num_bytes;
 
   bit_offset_ = 0;
-  detail::ResetBufferedValues_(buffer_, byte_offset_, max_bytes_ - byte_offset_,
-                               &buffered_values_);
+  FillBufferedValues();
+//   buffered_values_ = detail::ReadBitsAsLittleEndian(buffer_ + byte_offset_, max_bytes_ - byte_offset_);
   return true;
 }
 
@@ -438,8 +430,7 @@ inline bool BitReader::Advance(int64_t num_bits) {
   }
   byte_offset_ += static_cast<int>(bits_required >> 3);
   bit_offset_ = static_cast<int>(bits_required & 7);
-  detail::ResetBufferedValues_(buffer_, byte_offset_, max_bytes_ - byte_offset_,
-                               &buffered_values_);
+  FillBufferedValues();
   return true;
 }
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2522,32 +2522,37 @@ class DeltaBitPackDecoder : public DecoderImpl, virtual public TypedDecoder<DTyp
     }
 
     int i = 0;
-    while (i < max_values) {
-      if (ARROW_PREDICT_FALSE(values_remaining_current_mini_block_ == 0)) {
-        if (ARROW_PREDICT_FALSE(!first_block_initialized_)) {
-          buffer[i++] = last_value_;
-          DCHECK_EQ(i, 1);  // we're at the beginning of the page
-          if (ARROW_PREDICT_FALSE(i == max_values)) {
-            // When block is uninitialized and i reaches max_values we have two
-            // different possibilities:
-            // 1. total_value_count_ == 1, which means that the page may have only
-            // one value (encoded in the header), and we should not initialize
-            // any block.
-            // 2. total_value_count_ != 1, which means we should initialize the
-            // incoming block for subsequent reads.
-            if (total_value_count_ != 1) {
-              InitBlock();
-            }
-            break;
-          }
+
+    if (ARROW_PREDICT_FALSE(!first_block_initialized_)) {
+      // This is the first time we decode this data page, first output the
+      // last value and initialize the first block.
+      buffer[i++] = last_value_;
+      if (ARROW_PREDICT_FALSE(i == max_values)) {
+        // When i reaches max_values here we have two different possibilities:
+        // 1. total_value_count_ == 1, which means that the page may have only
+        //    one value (encoded in the header), and we should not initialize
+        //    any block, nor should we skip any padding bits below.
+        // 2. total_value_count_ != 1, which means we should initialize the
+        //    incoming block for subsequent reads.
+        if (total_value_count_ != 1) {
           InitBlock();
+        }
+        total_values_remaining_ -= max_values;
+        this->num_values_ -= max_values;
+        return max_values;
+      }
+      InitBlock();
+    }
+
+    DCHECK(first_block_initialized_);
+    while (i < max_values) {
+      // Ensure we have an initialized mini-block
+      if (ARROW_PREDICT_FALSE(values_remaining_current_mini_block_ == 0)) {
+        ++mini_block_idx_;
+        if (mini_block_idx_ < mini_blocks_per_block_) {
+          InitMiniBlock(delta_bit_widths_->data()[mini_block_idx_]);
         } else {
-          ++mini_block_idx_;
-          if (mini_block_idx_ < mini_blocks_per_block_) {
-            InitMiniBlock(delta_bit_widths_->data()[mini_block_idx_]);
-          } else {
-            InitBlock();
-          }
+          InitBlock();
         }
       }
 


### PR DESCRIPTION
### Rationale for this change

Avoid skipping any padding bits where reading a one-value data page, as it doesn't contain any block (the value is encoded in the header).

### Are these changes tested?

Yes, by existing tests and CI jobs.

### Are there any user-facing changes?

No.

* Closes: #37466