### PR TITLE
GH-37472: [MATLAB] Implement the `isequal()` method on `arrow.type.Type`

### DIFF
--- a/matlab/src/cpp/arrow/matlab/type/proxy/type.h
+++ b/matlab/src/cpp/arrow/matlab/type/proxy/type.h
@@ -37,6 +37,8 @@ class Type : public libmexclass::proxy::Proxy {
 
         void numFields(libmexclass::proxy::method::Context& context);
 
+        void isEqual(libmexclass::proxy::method::Context& context);
+
         std::shared_ptr<arrow::DataType> data_type;
 };
 

--- a/matlab/src/matlab/+arrow/+type/Type.m
+++ b/matlab/src/matlab/+arrow/+type/Type.m
@@ -48,5 +48,35 @@ classdef (Abstract) Type < matlab.mixin.CustomDisplay
           propgrp = matlab.mixin.util.PropertyGroup(proplist);
         end
     end
-    
+
+    methods
+        function tf = isequal(obj, varargin)
+
+            narginchk(2, inf);
+            tf = false;
+            
+            proxyIDs = zeros([numel(obj) numel(varargin)], "uint64");
+
+            for ii = 1:numel(varargin)
+                type = varargin{ii};
+                if ~isa(type, "arrow.type.Type") || ~isequal(size(obj), size(type))
+                    % Return early if type is not an arrow.type.Type or if
+                    % the dimensions of obj and type do not matchx
+                    return;
+                end
+
+                proxies = [type(:).Proxy];
+                proxyIDs(:, ii) = [proxies.ID];
+            end
+
+            for ii = 1:numel(obj)
+                % Invoke isEqual proxy method on each Type 
+                % in the object array
+                tf = obj(ii).Proxy.isEqual(proxyIDs(ii, :));
+                if ~tf
+                    return;
+                end
+            end
+        end
+    end
 end

--- a/matlab/src/matlab/+arrow/+type/Type.m
+++ b/matlab/src/matlab/+arrow/+type/Type.m
@@ -61,7 +61,7 @@ classdef (Abstract) Type < matlab.mixin.CustomDisplay
                 type = varargin{ii};
                 if ~isa(type, "arrow.type.Type") || ~isequal(size(obj), size(type))
                     % Return early if type is not an arrow.type.Type or if
-                    % the dimensions of obj and type do not matchx
+                    % the dimensions of obj and type do not match.
                     return;
                 end
 

--- a/matlab/src/matlab/+arrow/+type/Type.m
+++ b/matlab/src/matlab/+arrow/+type/Type.m
@@ -65,6 +65,9 @@ classdef (Abstract) Type < matlab.mixin.CustomDisplay
                     return;
                 end
 
+                % type(:) flattens N-dimensional arrays into a column
+                % vector before collecting the Proxy properties into a
+                % row vector.
                 proxies = [type(:).Proxy];
                 proxyIDs(:, ii) = [proxies.ID];
             end

--- a/matlab/test/arrow/type/tBooleanType.m
+++ b/matlab/test/arrow/type/tBooleanType.m
@@ -22,4 +22,40 @@ classdef tBooleanType < hFixedWidthType
         BitWidth = int32(1)
         ClassName = "arrow.type.BooleanType"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+        % Verifies isequal method of arrow.type.BooleanType returns true if
+        % these conditions are met:
+        %
+        % 1. All input arguments have a class type arrow.type.BooleanType
+        % 2. All inputs have the same size
+
+            % Scalar BooleanType arrays
+            boolType1 = arrow.boolean();
+            boolType2 = arrow.boolean();
+            testCase.verifyTrue(isequal(boolType1, boolType2));
+
+            % Non-scalar BooleanType arrays
+            typeArray1 = [boolType1 boolType1];
+            typeArray2 = [boolType2 boolType2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+        % Verifies the isequal method of arrow.type.BooleanType returns
+        % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            boolType = arrow.boolean();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(boolType, int32Type));
+            testCase.verifyFalse(isequal([boolType boolType], [int32Type int32Type]));
+
+            % BooleanType arrays have different sizes
+            typeArray1 = [boolType boolType];
+            typeArray2 = [boolType boolType]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tBooleanType.m
+++ b/matlab/test/arrow/type/tBooleanType.m
@@ -25,11 +25,11 @@ classdef tBooleanType < hFixedWidthType
 
     methods(Test)
         function IsEqualTrue(testCase)
-        % Verifies isequal method of arrow.type.BooleanType returns true if
-        % these conditions are met:
-        %
-        % 1. All input arguments have a class type arrow.type.BooleanType
-        % 2. All inputs have the same size
+            % Verifies isequal method of arrow.type.BooleanType returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.BooleanType
+            % 2. All inputs have the same size
 
             % Scalar BooleanType arrays
             boolType1 = arrow.boolean();
@@ -43,8 +43,8 @@ classdef tBooleanType < hFixedWidthType
         end
 
         function IsEqualFalse(testCase)
-        % Verifies the isequal method of arrow.type.BooleanType returns
-        % false when expected.
+            % Verifies the isequal method of arrow.type.BooleanType returns
+            % false when expected.
             
             % Pass a different arrow.type.Type subclass to isequal
             boolType = arrow.boolean();

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -77,11 +77,11 @@ classdef tDate32Type < hFixedWidthType
         end
 
         function IsEqualTrue(testCase)
-        % Verifies isequal method of arrow.type.Date32Type returns true if
-        % these conditions are met:
-        %
-        % 1. All input arguments have a class type arrow.type.Date32Type
-        % 2. All inputs have the same size
+            % Verifies isequal method of arrow.type.Date32Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Date32Type
+            % 2. All inputs have the same size
 
             % Scalar Date32Type arrays
             date32Type1 = arrow.date32();
@@ -95,8 +95,8 @@ classdef tDate32Type < hFixedWidthType
         end
 
         function IsEqualFalse(testCase)
-        % Verifies the isequal method of arrow.type.Date32Type returns
-        % false when expected.
+            % Verifies the isequal method of arrow.type.Date32Type returns
+            % false when expected.
             
             % Pass a different arrow.type.Type subclass to isequal
             date32Type = arrow.date32();

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -99,7 +99,7 @@ classdef tDate32Type < hFixedWidthType
         % false when expected.
             
             % Pass a different arrow.type.Type subclass to isequal
-            date32Type = arrow.boolean();
+            date32Type = arrow.date32();
             int32Type = arrow.int32();
             testCase.verifyFalse(isequal(date32Type, int32Type));
             testCase.verifyFalse(isequal([date32Type date32Type], [int32Type int32Type]));

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -76,6 +76,40 @@ classdef tDate32Type < hFixedWidthType
             testCase.verifyError(@() arrow.type.Date32Type(proxy), "arrow:proxy:ProxyNameMismatch");
         end
 
+        function IsEqualTrue(testCase)
+        % Verifies isequal method of arrow.type.Date32Type returns true if
+        % these conditions are met:
+        %
+        % 1. All input arguments have a class type arrow.type.Date32Type
+        % 2. All inputs have the same size
+
+            % Scalar Date32Type arrays
+            date32Type1 = arrow.date32();
+            date32Type2 = arrow.date32();
+            testCase.verifyTrue(isequal(date32Type1, date32Type2));
+
+            % Non-scalar Date32Type arrays
+            typeArray1 = [date32Type1 date32Type1];
+            typeArray2 = [date32Type2 date32Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+        % Verifies the isequal method of arrow.type.Date32Type returns
+        % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            date32Type = arrow.boolean();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(date32Type, int32Type));
+            testCase.verifyFalse(isequal([date32Type date32Type], [int32Type int32Type]));
+
+            % Date32Type arrays have different sizes
+            typeArray1 = [date32Type date32Type];
+            typeArray2 = [date32Type date32Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    
     end
 
 end

--- a/matlab/test/arrow/type/tFloat32Type.m
+++ b/matlab/test/arrow/type/tFloat32Type.m
@@ -22,4 +22,40 @@ classdef tFloat32Type < hFixedWidthType
         BitWidth = int32(32)
         ClassName = "arrow.type.Float32Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+        % Verifies isequal method of arrow.type.Float32Type returns true if
+        % these conditions are met:
+        %
+        % 1. All input arguments have a class type arrow.type.Float32Type
+        % 2. All inputs have the same size
+
+            % Scalar Float32Type arrays
+            float32Type1 = arrow.float32();
+            float32Type2 = arrow.float32();
+            testCase.verifyTrue(isequal(float32Type1, float32Type2));
+
+            % Non-scalar Float32Type arrays
+            typeArray1 = [float32Type1 float32Type1];
+            typeArray2 = [float32Type2 float32Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+        % Verifies the isequal method of arrow.type.Float32Type returns
+        % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            float32Type = arrow.float32();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(float32Type, int32Type));
+            testCase.verifyFalse(isequal([float32Type float32Type], [int32Type int32Type]));
+
+            % Float32Type arrays have different sizes
+            typeArray1 = [float32Type float32Type];
+            typeArray2 = [float32Type float32Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tFloat32Type.m
+++ b/matlab/test/arrow/type/tFloat32Type.m
@@ -25,11 +25,11 @@ classdef tFloat32Type < hFixedWidthType
 
     methods(Test)
         function IsEqualTrue(testCase)
-        % Verifies isequal method of arrow.type.Float32Type returns true if
-        % these conditions are met:
-        %
-        % 1. All input arguments have a class type arrow.type.Float32Type
-        % 2. All inputs have the same size
+            % Verifies isequal method of arrow.type.Float32Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Float32Type
+            % 2. All inputs have the same size
 
             % Scalar Float32Type arrays
             float32Type1 = arrow.float32();
@@ -43,8 +43,8 @@ classdef tFloat32Type < hFixedWidthType
         end
 
         function IsEqualFalse(testCase)
-        % Verifies the isequal method of arrow.type.Float32Type returns
-        % false when expected.
+            % Verifies the isequal method of arrow.type.Float32Type returns
+            % false when expected.
             
             % Pass a different arrow.type.Type subclass to isequal
             float32Type = arrow.float32();

--- a/matlab/test/arrow/type/tFloat64Type.m
+++ b/matlab/test/arrow/type/tFloat64Type.m
@@ -21,6 +21,41 @@ classdef tFloat64Type < hFixedWidthType
         TypeID = arrow.type.ID.Float64
         BitWidth = int32(64)
         ClassName = "arrow.type.Float64Type"
+    end
 
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.Float64Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Float64Type
+            % 2. All inputs have the same size
+
+            % Scalar Float64Type arrays
+            float64Type1 = arrow.float64();
+            float64Type2 = arrow.float64();
+            testCase.verifyTrue(isequal(float64Type1, float64Type2));
+
+            % Non-scalar Float64Type arrays
+            typeArray1 = [float64Type1 float64Type1];
+            typeArray2 = [float64Type2 float64Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.Float64Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            float64Type = arrow.float64();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(float64Type, int32Type));
+            testCase.verifyFalse(isequal([float64Type float64Type], [int32Type int32Type]));
+
+            % Float64Type arrays have different sizes
+            typeArray1 = [float64Type float64Type];
+            typeArray2 = [float64Type float64Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
     end
 end

--- a/matlab/test/arrow/type/tInt16Type.m
+++ b/matlab/test/arrow/type/tInt16Type.m
@@ -22,4 +22,40 @@ classdef tInt16Type < hFixedWidthType
         BitWidth = int32(16)
         ClassName = "arrow.type.Int16Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.Int16Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Int16Type
+            % 2. All inputs have the same size
+
+            % Scalar Int16Type arrays
+            int16Type1 = arrow.int16();
+            int16Type2 = arrow.int16();
+            testCase.verifyTrue(isequal(int16Type1, int16Type2));
+
+            % Non-scalar Int16Type arrays
+            typeArray1 = [int16Type1 int16Type1];
+            typeArray2 = [int16Type2 int16Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.Int16Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            int16Type = arrow.int16();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(int16Type, int32Type));
+            testCase.verifyFalse(isequal([int16Type int16Type], [int32Type int32Type]));
+
+            % Int16Type arrays have different sizes
+            typeArray1 = [int16Type int16Type];
+            typeArray2 = [int16Type int16Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tInt32Type.m
+++ b/matlab/test/arrow/type/tInt32Type.m
@@ -22,4 +22,40 @@ classdef tInt32Type < hFixedWidthType
         BitWidth = int32(32)
         ClassName = "arrow.type.Int32Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.Int32Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Int32Type
+            % 2. All inputs have the same size
+
+            % Scalar Int32Type arrays
+            int32Type1 = arrow.int32();
+            int32Type2 = arrow.int32();
+            testCase.verifyTrue(isequal(int32Type1, int32Type2));
+
+            % Non-scalar Int32Type arrays
+            typeArray1 = [int32Type1 int32Type1];
+            typeArray2 = [int32Type2 int32Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.Int32Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            int32Type = arrow.int32();
+            int64Type = arrow.int64();
+            testCase.verifyFalse(isequal(int32Type, int64Type));
+            testCase.verifyFalse(isequal([int32Type int32Type], [int64Type int64Type]));
+
+            % Int32Type arrays have different sizes
+            typeArray1 = [int32Type int32Type];
+            typeArray2 = [int32Type int32Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tInt64Type.m
+++ b/matlab/test/arrow/type/tInt64Type.m
@@ -22,4 +22,40 @@ classdef tInt64Type < hFixedWidthType
         BitWidth = int32(64)
         ClassName = "arrow.type.Int64Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.Int64Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Int64Type
+            % 2. All inputs have the same size
+
+            % Scalar Int64Type arrays
+            int64Type1 = arrow.int64();
+            int64Type2 = arrow.int64();
+            testCase.verifyTrue(isequal(int64Type1, int64Type2));
+
+            % Non-scalar Int64Type arrays
+            typeArray1 = [int64Type1 int64Type1];
+            typeArray2 = [int64Type2 int64Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.Int64Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            int64Type = arrow.int64();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(int64Type, int32Type));
+            testCase.verifyFalse(isequal([int64Type int64Type], [int32Type int32Type]));
+
+            % Int64Type arrays have different sizes
+            typeArray1 = [int64Type int64Type];
+            typeArray2 = [int64Type int64Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tInt8Type.m
+++ b/matlab/test/arrow/type/tInt8Type.m
@@ -22,4 +22,40 @@ classdef tInt8Type < hFixedWidthType
         BitWidth = int32(8)
         ClassName = "arrow.type.Int8Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.Int8Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Int8Type
+            % 2. All inputs have the same size
+
+            % Scalar Int8Type arrays
+            int8Type1 = arrow.int8();
+            int8Type2 = arrow.int8();
+            testCase.verifyTrue(isequal(int8Type1, int8Type2));
+
+            % Non-scalar Int8Type arrays
+            typeArray1 = [int8Type1 int8Type1];
+            typeArray2 = [int8Type2 int8Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.Int8Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            int8Type = arrow.int8();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(int8Type, int32Type));
+            testCase.verifyFalse(isequal([int8Type int8Type], [int32Type int32Type]));
+
+            % Int8Type arrays have different sizes
+            typeArray1 = [int8Type int8Type];
+            typeArray2 = [int8Type int8Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tStringType.m
+++ b/matlab/test/arrow/type/tStringType.m
@@ -30,6 +30,40 @@ classdef tStringType < matlab.unittest.TestCase
             tc.verifyEqual(type.NumFields, int32(0));
         end
 
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.StringType returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.StringType
+            % 2. All inputs have the same size
+
+            % Scalar StringType arrays
+            stringType1 = arrow.string();
+            stringType2 = arrow.string();
+            testCase.verifyTrue(isequal(stringType1, stringType2));
+
+            % Non-scalar StringType arrays
+            typeArray1 = [stringType1 stringType1];
+            typeArray2 = [stringType2 stringType2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.StringType returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            stringType = arrow.string();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(stringType, int32Type));
+            testCase.verifyFalse(isequal([stringType stringType], [int32Type int32Type]));
+
+            % StringType arrays have different sizes
+            typeArray1 = [stringType stringType];
+            typeArray2 = [stringType stringType]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+
     end
 
 end

--- a/matlab/test/arrow/type/tTime32Type.m
+++ b/matlab/test/arrow/type/tTime32Type.m
@@ -125,7 +125,7 @@ classdef tTime32Type < hFixedWidthType
             %
             % 1. All input arguments have a class type arrow.type.Time32Type
             % 2. All inputs have the same size
-            % 3. The TimeUnit values of elements at corresponding positions in the arrays are equal.
+            % 3. The TimeUnit values of elements at corresponding positions in the arrays are equal
 
             % Scalar Time32Type arrays
             time32Type1 = arrow.time32(TimeUnit="Second");

--- a/matlab/test/arrow/type/tTime32Type.m
+++ b/matlab/test/arrow/type/tTime32Type.m
@@ -120,7 +120,7 @@ classdef tTime32Type < hFixedWidthType
         end
 
         function IsEqualTrue(testCase)
-            % Verifies isequal method of arrow.type.Int8Type returns true if
+            % Verifies isequal method of arrow.type.Time32Type returns true if
             % these conditions are met:
             %
             % 1. All input arguments have a class type arrow.type.Time32Type
@@ -149,7 +149,7 @@ classdef tTime32Type < hFixedWidthType
             testCase.verifyFalse(isequal(time32Type1, time32Type2));
             testCase.verifyFalse(isequal(time32Type1, int32Type));
 
-            % arrays have different dimensions
+            % Arrays have different dimensions
             typeArray1 = [time32Type1 time32Type2];
             typeArray2 = [time32Type1 time32Type2]';
             testCase.verifyFalse(isequal(typeArray1, typeArray2));

--- a/matlab/test/arrow/type/tTime32Type.m
+++ b/matlab/test/arrow/type/tTime32Type.m
@@ -119,6 +119,53 @@ classdef tTime32Type < hFixedWidthType
             testCase.verifyError(@() arrow.type.Time32Type(proxy), "arrow:proxy:ProxyNameMismatch");
         end
 
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.Int8Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Time32Type
+            % 2. All inputs have the same size
+            % 3. The TimeUnit values of elements at corresponding positions in the arrays are equal.
+
+            % Scalar Time32Type arrays
+            time32Type1 = arrow.time32(TimeUnit="Second");
+            time32Type2 = arrow.time32(TimeUnit="Second");
+            time32Type3 = arrow.time32(TimeUnit="Millisecond");
+            time32Type4 = arrow.time32(TimeUnit="Millisecond");
+            testCase.verifyTrue(isequal(time32Type1, time32Type2));
+            testCase.verifyTrue(isequal(time32Type3, time32Type4));
+
+            % Non-scalar Time32Type arrays
+            typeArray1 = [time32Type1 time32Type3];
+            typeArray2 = [time32Type2 time32Type4];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verify isequal returns false when expected.
+            time32Type1 = arrow.time32(TimeUnit="Second");
+            time32Type2 = arrow.time32(TimeUnit="Millisecond");
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(time32Type1, time32Type2));
+            testCase.verifyFalse(isequal(time32Type1, int32Type));
+
+            % arrays have different dimensions
+            typeArray1 = [time32Type1 time32Type2];
+            typeArray2 = [time32Type1 time32Type2]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+
+            % Corresponding elements have different TimeUnit values
+            typeArray3 = [time32Type2 time32Type1];
+            typeArray4 = [time32Type1 time32Type2]';
+            testCase.verifyFalse(isequal(typeArray3, typeArray4));
+
+            % Compare a nonscalar Time32Type array with a nonscalar
+            % Int32Type array.
+            typeArray5 = [int32Type int32Type];
+            testCase.verifyFalse(isequal(typeArray3, typeArray5));
+
+        end
+
     end
 
 end

--- a/matlab/test/arrow/type/tTime64Type.m
+++ b/matlab/test/arrow/type/tTime64Type.m
@@ -120,6 +120,52 @@ classdef tTime64Type < hFixedWidthType
             testCase.verifyError(@() arrow.type.Time64Type(proxy), "arrow:proxy:ProxyNameMismatch");
         end
 
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.Time64Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.Time64Type
+            % 2. All inputs have the same size
+            % 3. The TimeUnit values of elements at corresponding positions in the arrays are equal
+
+            % Scalar Time64Type arrays
+            time64Type1 = arrow.time64(TimeUnit="Microsecond");
+            time64Type2 = arrow.time64(TimeUnit="Microsecond");
+            time64Type3 = arrow.time64(TimeUnit="Nanosecond");
+            time64Type4 = arrow.time64(TimeUnit="Nanosecond");
+            testCase.verifyTrue(isequal(time64Type1, time64Type2));
+            testCase.verifyTrue(isequal(time64Type3, time64Type4));
+
+            % Non-scalar Time64Type arrays
+            typeArray1 = [time64Type1 time64Type3];
+            typeArray2 = [time64Type2 time64Type4];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verify isequal returns false when expected.
+            time64Type1 = arrow.time64(TimeUnit="Microsecond");
+            time64Type2 = arrow.time64(TimeUnit="Nanosecond");
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(time64Type1, time64Type2));
+            testCase.verifyFalse(isequal(time64Type1, int32Type));
+
+            % arrays have different dimensions
+            typeArray1 = [time64Type1 time64Type2];
+            typeArray2 = [time64Type1 time64Type2]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+
+            % Corresponding elements have different TimeUnit values
+            typeArray3 = [time64Type2 time64Type1];
+            typeArray4 = [time64Type1 time64Type2]';
+            testCase.verifyFalse(isequal(typeArray3, typeArray4));
+
+            % Compare a nonscalar Time64Type array with a nonscalar
+            % Int32Type array.
+            typeArray5 = [int32Type int32Type];
+            testCase.verifyFalse(isequal(typeArray3, typeArray5));
+        end
+
     end
 
 end

--- a/matlab/test/arrow/type/tTimestampType.m
+++ b/matlab/test/arrow/type/tTimestampType.m
@@ -23,6 +23,10 @@ classdef tTimestampType < hFixedWidthType
         ClassName = "arrow.type.TimestampType"
     end
 
+    properties(TestParameter)
+        TimeZone={'America/Anchorage', ''}
+    end
+
     methods(Test)
         function TestClass(testCase)
         % Verify ArrowType is an object of the expected class type.
@@ -127,6 +131,68 @@ classdef tTimestampType < hFixedWidthType
             expectedDisplay = char(strjoin([header body' footer], newline));
             actualDisplay = evalc('disp(type)');
             testCase.verifyEqual(actualDisplay, expectedDisplay);
+        end
+
+        function IsEqualTrue(testCase, TimeZone)
+            % Verifies isequal method of arrow.type.TimestampType returns 
+            % true if these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.TimestampType
+            % 2. All inputs have the same size
+            % 3. The TimeUnit values of elements at corresponding positions in the arrays are equal
+            % 3. The TimeZone values of elements at corresponding positions in the arrays are equal
+
+            % Scalar TimestampType arrays
+            time64Type1 = arrow.timestamp(TimeUnit="Second", TimeZone=TimeZone);
+            time64Type2 = arrow.timestamp(TimeUnit="Second", TimeZone=TimeZone);
+
+            time64Type3 = arrow.timestamp(TimeUnit="Millisecond", TimeZone=TimeZone);
+            time64Type4 = arrow.timestamp(TimeUnit="Millisecond", TimeZone=TimeZone);
+
+            time64Type5 = arrow.timestamp(TimeUnit="Microsecond", TimeZone=TimeZone);
+            time64Type6 = arrow.timestamp(TimeUnit="Microsecond", TimeZone=TimeZone);
+
+            time64Type7 = arrow.timestamp(TimeUnit="Nanosecond", TimeZone=TimeZone);
+            time64Type8 = arrow.timestamp(TimeUnit="Nanosecond", TimeZone=TimeZone);
+
+            % Scalar TimestampType arrays
+            testCase.verifyTrue(isequal(time64Type1, time64Type2));
+            testCase.verifyTrue(isequal(time64Type3, time64Type4));
+            testCase.verifyTrue(isequal(time64Type5, time64Type6));
+            testCase.verifyTrue(isequal(time64Type7, time64Type8));
+
+            % Non-scalar TimestampType arrays
+            typeArray1 = [time64Type1 time64Type3 time64Type5 time64Type7];
+            typeArray2 = [time64Type2 time64Type4 time64Type6 time64Type8];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verify isequal returns false when expected.
+
+            time64Type1 = arrow.timestamp(TimeUnit="Second");
+            time64Type2 = arrow.timestamp(TimeUnit="Millisecond");
+            time64Type3 = arrow.timestamp(TimeUnit="Second", TimeZone="America/New_York");
+            time64Type4 = arrow.timestamp(TimeUnit="Second", TimeZone="Pacific/Fiji");
+            time64Type5 = arrow.timestamp(TimeUnit="Millisecond", TimeZone="America/New_York");
+
+            % TimeUnit values differ
+            testCase.verifyFalse(isequal(time64Type1, time64Type2));
+            testCase.verifyFalse(isequal(time64Type4, time64Type5));
+
+            % TimeZone values differ
+            testCase.verifyFalse(isequal(time64Type1, time64Type3));
+            testCase.verifyFalse(isequal(time64Type3, time64Type4));
+
+            % Different dimensions
+            typeArray1 = [time64Type1 time64Type2 time64Type3];
+            typeArray2 = [time64Type1 time64Type2 time64Type3]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+
+            % Different TimestampType values at corresponding elements
+            typeArray3 = [time64Type1 time64Type3 time64Type4];
+            typeArray4 = [time64Type1 time64Type2 time64Type4];
+            testCase.verifyFalse(isequal(typeArray3, typeArray4));
         end
     end
 end

--- a/matlab/test/arrow/type/tTimestampType.m
+++ b/matlab/test/arrow/type/tTimestampType.m
@@ -24,6 +24,8 @@ classdef tTimestampType < hFixedWidthType
     end
 
     properties(TestParameter)
+        % Test against both "Zoned" (i.e. non-empty TimeZone value) 
+        % and "Unzoned" (i.e. empty TimeZone value).
         TimeZone={'America/Anchorage', ''}
     end
 
@@ -140,58 +142,60 @@ classdef tTimestampType < hFixedWidthType
             % 1. All input arguments have a class type arrow.type.TimestampType
             % 2. All inputs have the same size
             % 3. The TimeUnit values of elements at corresponding positions in the arrays are equal
-            % 3. The TimeZone values of elements at corresponding positions in the arrays are equal
+            % 4. The TimeZone values of elements at corresponding positions in the arrays are equal
 
             % Scalar TimestampType arrays
-            time64Type1 = arrow.timestamp(TimeUnit="Second", TimeZone=TimeZone);
-            time64Type2 = arrow.timestamp(TimeUnit="Second", TimeZone=TimeZone);
+            timestampType1 = arrow.timestamp(TimeUnit="Second", TimeZone=TimeZone);
+            timestampType2 = arrow.timestamp(TimeUnit="Second", TimeZone=TimeZone);
 
-            time64Type3 = arrow.timestamp(TimeUnit="Millisecond", TimeZone=TimeZone);
+            timestampType3 = arrow.timestamp(TimeUnit="Millisecond", TimeZone=TimeZone);
             time64Type4 = arrow.timestamp(TimeUnit="Millisecond", TimeZone=TimeZone);
 
-            time64Type5 = arrow.timestamp(TimeUnit="Microsecond", TimeZone=TimeZone);
-            time64Type6 = arrow.timestamp(TimeUnit="Microsecond", TimeZone=TimeZone);
+            timestampType5 = arrow.timestamp(TimeUnit="Microsecond", TimeZone=TimeZone);
+            timestampType6 = arrow.timestamp(TimeUnit="Microsecond", TimeZone=TimeZone);
 
-            time64Type7 = arrow.timestamp(TimeUnit="Nanosecond", TimeZone=TimeZone);
-            time64Type8 = arrow.timestamp(TimeUnit="Nanosecond", TimeZone=TimeZone);
+            timestampType7 = arrow.timestamp(TimeUnit="Nanosecond", TimeZone=TimeZone);
+            timestampType8 = arrow.timestamp(TimeUnit="Nanosecond", TimeZone=TimeZone);
 
             % Scalar TimestampType arrays
-            testCase.verifyTrue(isequal(time64Type1, time64Type2));
-            testCase.verifyTrue(isequal(time64Type3, time64Type4));
-            testCase.verifyTrue(isequal(time64Type5, time64Type6));
-            testCase.verifyTrue(isequal(time64Type7, time64Type8));
+            testCase.verifyTrue(isequal(timestampType1, timestampType2));
+            testCase.verifyTrue(isequal(timestampType3, time64Type4));
+            testCase.verifyTrue(isequal(timestampType5, timestampType6));
+            testCase.verifyTrue(isequal(timestampType7, timestampType8));
 
             % Non-scalar TimestampType arrays
-            typeArray1 = [time64Type1 time64Type3 time64Type5 time64Type7];
-            typeArray2 = [time64Type2 time64Type4 time64Type6 time64Type8];
+            typeArray1 = [timestampType1 timestampType3 timestampType5 timestampType7];
+            typeArray2 = [timestampType2 time64Type4 timestampType6 timestampType8];
             testCase.verifyTrue(isequal(typeArray1, typeArray2));
         end
 
         function IsEqualFalse(testCase)
             % Verify isequal returns false when expected.
 
-            time64Type1 = arrow.timestamp(TimeUnit="Second");
-            time64Type2 = arrow.timestamp(TimeUnit="Millisecond");
-            time64Type3 = arrow.timestamp(TimeUnit="Second", TimeZone="America/New_York");
-            time64Type4 = arrow.timestamp(TimeUnit="Second", TimeZone="Pacific/Fiji");
-            time64Type5 = arrow.timestamp(TimeUnit="Millisecond", TimeZone="America/New_York");
+            timestampType1 = arrow.timestamp(TimeUnit="Second");
+            timestampType2 = arrow.timestamp(TimeUnit="Millisecond");
+            timestampType3 = arrow.timestamp(TimeUnit="Second", TimeZone="America/New_York");
+            timestampType4 = arrow.timestamp(TimeUnit="Second", TimeZone="Pacific/Fiji");
+            timestampType5 = arrow.timestamp(TimeUnit="Millisecond", TimeZone="America/New_York");
 
             % TimeUnit values differ
-            testCase.verifyFalse(isequal(time64Type1, time64Type2));
-            testCase.verifyFalse(isequal(time64Type4, time64Type5));
+            testCase.verifyFalse(isequal(timestampType1, timestampType2));
+            testCase.verifyFalse(isequal(timestampType4, timestampType5));
 
-            % TimeZone values differ
-            testCase.verifyFalse(isequal(time64Type1, time64Type3));
-            testCase.verifyFalse(isequal(time64Type3, time64Type4));
+            % One TimestampType is zoned, while the other is unzoned.
+            testCase.verifyFalse(isequal(timestampType1, timestampType3));
+
+            % Both TimestampTypes are zoned, but have different values.
+            testCase.verifyFalse(isequal(timestampType3, timestampType4));
 
             % Different dimensions
-            typeArray1 = [time64Type1 time64Type2 time64Type3];
-            typeArray2 = [time64Type1 time64Type2 time64Type3]';
+            typeArray1 = [timestampType1 timestampType2 timestampType3];
+            typeArray2 = [timestampType1 timestampType2 timestampType3]';
             testCase.verifyFalse(isequal(typeArray1, typeArray2));
 
             % Different TimestampType values at corresponding elements
-            typeArray3 = [time64Type1 time64Type3 time64Type4];
-            typeArray4 = [time64Type1 time64Type2 time64Type4];
+            typeArray3 = [timestampType1 timestampType3 timestampType4];
+            typeArray4 = [timestampType1 timestampType2 timestampType4];
             testCase.verifyFalse(isequal(typeArray3, typeArray4));
         end
     end

--- a/matlab/test/arrow/type/tUInt16Type.m
+++ b/matlab/test/arrow/type/tUInt16Type.m
@@ -22,4 +22,40 @@ classdef tUInt16Type < hFixedWidthType
         BitWidth = int32(16)
         ClassName = "arrow.type.UInt16Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.UInt16Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.UInt16Type
+            % 2. All inputs have the same size
+
+            % Scalar UInt16Type arrays
+            uint16Type1 = arrow.uint16();
+            uint16Type2 = arrow.uint16();
+            testCase.verifyTrue(isequal(uint16Type1, uint16Type2));
+
+            % Non-scalar UInt16Type arrays
+            typeArray1 = [uint16Type1 uint16Type1];
+            typeArray2 = [uint16Type2 uint16Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.UInt16Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            uint16Type = arrow.uint16();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(uint16Type, int32Type));
+            testCase.verifyFalse(isequal([uint16Type uint16Type], [int32Type int32Type]));
+
+            % UInt16Type arrays have different sizes
+            typeArray1 = [uint16Type uint16Type];
+            typeArray2 = [uint16Type uint16Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tUInt32Type.m
+++ b/matlab/test/arrow/type/tUInt32Type.m
@@ -22,4 +22,40 @@ classdef tUInt32Type < hFixedWidthType
         BitWidth = int32(32)
         ClassName = "arrow.type.UInt32Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.UInt32Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.UInt32Type
+            % 2. All inputs have the same size
+
+            % Scalar UInt32Type arrays
+            uint32Type1 = arrow.uint32();
+            uint32Type2 = arrow.uint32();
+            testCase.verifyTrue(isequal(uint32Type1, uint32Type2));
+
+            % Non-scalar UInt32Type arrays
+            typeArray1 = [uint32Type1 uint32Type1];
+            typeArray2 = [uint32Type2 uint32Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.UInt32Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            uint32Type = arrow.uint32();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(uint32Type, int32Type));
+            testCase.verifyFalse(isequal([uint32Type uint32Type], [int32Type int32Type]));
+
+            % UInt32Type arrays have different sizes
+            typeArray1 = [uint32Type uint32Type];
+            typeArray2 = [uint32Type uint32Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tUInt64Type.m
+++ b/matlab/test/arrow/type/tUInt64Type.m
@@ -47,14 +47,14 @@ classdef tUInt64Type < hFixedWidthType
             % false when expected.
             
             % Pass a different arrow.type.Type subclass to isequal
-            uint8Type = arrow.uint64();
+            uint64Type = arrow.uint64();
             int32Type = arrow.int32();
-            testCase.verifyFalse(isequal(uint8Type, int32Type));
-            testCase.verifyFalse(isequal([uint8Type uint8Type], [int32Type int32Type]));
+            testCase.verifyFalse(isequal(uint64Type, int32Type));
+            testCase.verifyFalse(isequal([uint64Type uint64Type], [int32Type int32Type]));
 
             % UInt64Type arrays have different sizes
-            typeArray1 = [uint8Type uint8Type];
-            typeArray2 = [uint8Type uint8Type]';
+            typeArray1 = [uint64Type uint64Type];
+            typeArray2 = [uint64Type uint64Type]';
             testCase.verifyFalse(isequal(typeArray1, typeArray2));
         end
     end

--- a/matlab/test/arrow/type/tUInt64Type.m
+++ b/matlab/test/arrow/type/tUInt64Type.m
@@ -22,4 +22,40 @@ classdef tUInt64Type < hFixedWidthType
         BitWidth = int32(64)
         ClassName = "arrow.type.UInt64Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.UInt64Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.UInt64Type
+            % 2. All inputs have the same size
+
+            % Scalar UInt64Type arrays
+            uint64Type1 = arrow.uint64();
+            uint64Type2 = arrow.uint64();
+            testCase.verifyTrue(isequal(uint64Type1, uint64Type2));
+
+            % Non-scalar UInt64Type arrays
+            typeArray1 = [uint64Type1 uint64Type1];
+            typeArray2 = [uint64Type2 uint64Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.UInt64Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            uint8Type = arrow.uint64();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(uint8Type, int32Type));
+            testCase.verifyFalse(isequal([uint8Type uint8Type], [int32Type int32Type]));
+
+            % UInt64Type arrays have different sizes
+            typeArray1 = [uint8Type uint8Type];
+            typeArray2 = [uint8Type uint8Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end

--- a/matlab/test/arrow/type/tUInt8Type.m
+++ b/matlab/test/arrow/type/tUInt8Type.m
@@ -22,4 +22,40 @@ classdef tUInt8Type < hFixedWidthType
         BitWidth = int32(8)
         ClassName = "arrow.type.UInt8Type"
     end
+
+    methods(Test)
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of arrow.type.UInt8Type returns true if
+            % these conditions are met:
+            %
+            % 1. All input arguments have a class type arrow.type.UInt8Type
+            % 2. All inputs have the same size
+
+            % Scalar UInt8Type arrays
+            uint8Type1 = arrow.uint8();
+            uint8Type2 = arrow.uint8();
+            testCase.verifyTrue(isequal(uint8Type1, uint8Type2));
+
+            % Non-scalar UInt8Type arrays
+            typeArray1 = [uint8Type1 uint8Type1];
+            typeArray2 = [uint8Type2 uint8Type2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of arrow.type.UInt8Type returns
+            % false when expected.
+            
+            % Pass a different arrow.type.Type subclass to isequal
+            uint8Type = arrow.uint8();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(uint8Type, int32Type));
+            testCase.verifyFalse(isequal([uint8Type uint8Type], [int32Type int32Type]));
+
+            % UInt8Type arrays have different sizes
+            typeArray1 = [uint8Type uint8Type];
+            typeArray2 = [uint8Type uint8Type]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
 end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Currently, it's not possible to determine if two `arrow.type.Type` instances are equal because the `isequal()` method always returns `false` by default:

```matlab

>> t = arrow.int32()

t = 

  Int32Type with properties:

    ID: Int32

% Compare a with itself
>> tf = isequal(t, t)

tf =

  logical

   0

```

### What changes are included in this PR?

1. Implemented the `isequal` method on all concrete subclasses of `arrow.type.Type` 
2. Added a new method called `isEqual()` on the `arrow::matlab::type::proxy::Type` class.

**Example Usage**

```matlab
>> t1 = arrow.timestamp(TimeUnit="Second");
>> t2 = arrow.timestamp(TimeUnit="Microsecond");
>> t3 = arrow.timestamp(TimeUnit="Second");

% Compare t1 and t2
>> tf1 = isequal(t1, t2)

tf1 =

  logical

   0

% Compare t1 and t3
>> tf2 = isequal(t1, t3)

tf2 =

  logical

   1
```

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. Added test cases verifying `isequal` behaves as expected for all concrete subclasses of `arrow.type.Type`.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes. Users can now use the `isequal` method to compare `arrow.type.Type` instances for equality.


### Future Directions

1. Implement the `isequal` method for `arrow.type.Field`
2. Implement the `isequal` method for `arrow.tabular.Schema` 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37472