### PR TITLE
GH-37480: [Python] Bump pandas version that contains regression for pandas issue 50127

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -457,7 +457,7 @@ class TestConvertMetadata:
                                         preserve_index=True)
 
     def test_binary_column_name(self):
-        if Version("2.0.0") <= Version(pd.__version__) < Version("2.1.0"):
+        if Version("2.0.0") <= Version(pd.__version__) < Version("2.2.0"):
             # TODO: regression in pandas, hopefully fixed in next version
             # https://issues.apache.org/jira/browse/ARROW-18394
             # https://github.com/pandas-dev/pandas/issues/50127
@@ -3083,7 +3083,7 @@ def _fully_loaded_dataframe_example():
 
 @pytest.mark.parametrize('columns', ([b'foo'], ['foo']))
 def test_roundtrip_with_bytes_unicode(columns):
-    if Version("2.0.0") <= Version(pd.__version__) < Version("2.1.0"):
+    if Version("2.0.0") <= Version(pd.__version__) < Version("2.2.0"):
         # TODO: regression in pandas, hopefully fixed in next version
         # https://issues.apache.org/jira/browse/ARROW-18394
         # https://github.com/pandas-dev/pandas/issues/50127


### PR DESCRIPTION
### Rationale for this change

The pandas issue is now marked for v2.1.1 release.

### What changes are included in this PR?

Bump the pandas version when skipping relevant pytests.

### Are these changes tested?

Yes, CI will verify.

### Are there any user-facing changes?

No
* Closes: #37480