### PR TITLE
GH-37523: [C++][CI][CUDA] Don't use newer API and add missing CUDA dependencies

### DIFF
--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -70,7 +70,6 @@ export PYARROW_WITH_SUBSTRAIT=${ARROW_SUBSTRAIT:-OFF}
 export PYARROW_PARALLEL=${n_jobs}
 
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
-export CMAKE_PREFIX_PATH=${ARROW_HOME}:${CMAKE_PREFIX_PATH}
 
 pushd ${source_dir}
 # - Cannot call setup.py as it may install in the wrong directory

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -70,6 +70,7 @@ export PYARROW_WITH_SUBSTRAIT=${ARROW_SUBSTRAIT:-OFF}
 export PYARROW_PARALLEL=${n_jobs}
 
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
+export CMAKE_PREFIX_PATH=${ARROW_HOME}:${CMAKE_PREFIX_PATH}
 
 pushd ${source_dir}
 # - Cannot call setup.py as it may install in the wrong directory

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1222,7 +1222,7 @@ class MyDevice : public Device {
 
     virtual ~MySyncEvent() = default;
     Status Wait() override { return Status::OK(); }
-    Status Record(const Device::Stream&, const unsigned int) override {
+    Status Record(const Device::Stream&) override {
       return Status::OK();
     }
   };

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1222,9 +1222,7 @@ class MyDevice : public Device {
 
     virtual ~MySyncEvent() = default;
     Status Wait() override { return Status::OK(); }
-    Status Record(const Device::Stream&) override {
-      return Status::OK();
-    }
+    Status Record(const Device::Stream&) override { return Status::OK(); }
   };
 
  protected:

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -164,7 +164,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     void* get_raw() { return sync_event_.get(); }
 
     /// @brief Block until sync event is completed.
-    virtual Status Wait() = 0;    
+    virtual Status Wait() = 0;
 
     /// @brief Record the wrapped event on the stream so it triggers
     /// the event when the stream gets to that point in its queue.

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -164,13 +164,11 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
     void* get_raw() { return sync_event_.get(); }
 
     /// @brief Block until sync event is completed.
-    virtual Status Wait() = 0;
-
-    inline Status Record(const Stream& st) { return Record(st, 0); }
+    virtual Status Wait() = 0;    
 
     /// @brief Record the wrapped event on the stream so it triggers
     /// the event when the stream gets to that point in its queue.
-    virtual Status Record(const Stream&, const unsigned int flags) = 0;
+    virtual Status Record(const Stream&) = 0;
 
    protected:
     /// If creating this with a passed in event, the caller must ensure

--- a/cpp/src/arrow/gpu/ArrowCUDAConfig.cmake.in
+++ b/cpp/src/arrow/gpu/ArrowCUDAConfig.cmake.in
@@ -30,6 +30,10 @@ include(CMakeFindDependencyMacro)
 find_dependency(Arrow)
 if(CMAKE_VERSION VERSION_LESS 3.17)
   find_package(CUDA REQUIRED)
+  add_library(ArrowCUDA::cuda_driver SHARED IMPORTED)
+  set_target_properties(ArrowCUDA::cuda_driver
+                        PROPERTIES IMPORTED_LOCATION "${CUDA_CUDA_LIBRARY}"
+                                   INTERFACE_INCLUDE_DIRECTORIES "${CUDA_INCLUDE_DIRS}")
 else()
   find_package(CUDAToolkit REQUIRED)
 endif()

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -33,7 +33,7 @@ set(ARROW_CUDA_LINK_LIBS arrow::flatbuffers)
 if(CMAKE_VERSION VERSION_LESS 3.17)
   find_package(CUDA REQUIRED)
   add_library(ArrowCUDA::cuda_driver SHARED IMPORTED)
-  set_target_properties(ArrowCUDA::cuda_driver 
+  set_target_properties(ArrowCUDA::cuda_driver
                         PROPERTIES IMPORTED_LOCATION "${CUDA_CUDA_LIBRARY}"
                                    INTERFACE_INCLUDE_DIRECTORIES "${CUDA_INCLUDE_DIRS}")
   set(ARROW_CUDA_SHARED_LINK_LIBS ArrowCUDA::cuda_driver)

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -32,8 +32,11 @@ endif()
 set(ARROW_CUDA_LINK_LIBS arrow::flatbuffers)
 if(CMAKE_VERSION VERSION_LESS 3.17)
   find_package(CUDA REQUIRED)
-  set(ARROW_CUDA_SHARED_LINK_LIBS ${CUDA_CUDA_LIBRARY})
-  include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
+  add_library(ArrowCUDA::cuda_driver SHARED IMPORTED)
+  set_target_properties(ArrowCUDA::cuda_driver 
+                        PROPERTIES IMPORTED_LOCATION "${CUDA_CUDA_LIBRARY}"
+                                   INTERFACE_INCLUDE_DIRECTORIES "${CUDA_INCLUDE_DIRS}")
+  set(ARROW_CUDA_SHARED_LINK_LIBS ArrowCUDA::cuda_driver)
 else()
   # find_package(CUDA) is deprecated, and for newer CUDA, it doesn't
   # recognize that the CUDA driver library is in the "stubs" dir, but
@@ -61,6 +64,7 @@ add_arrow_lib(arrow_cuda
               ${ARROW_CUDA_SHARED_LINK_LIBS}
               SHARED_INSTALL_INTERFACE_LIBS
               Arrow::arrow_shared
+              ${ARROW_CUDA_SHARED_LINK_LIBS}
               # Static arrow_cuda must also link against CUDA shared libs
               STATIC_LINK_LIBS
               ${ARROW_CUDA_LINK_LIBS}

--- a/cpp/src/arrow/gpu/arrow-cuda.pc.in
+++ b/cpp/src/arrow/gpu/arrow-cuda.pc.in
@@ -22,6 +22,6 @@ libdir=@ARROW_PKG_CONFIG_LIBDIR@
 Name: Apache Arrow CUDA
 Description: CUDA integration library for Apache Arrow
 Version: @ARROW_VERSION@
-Requires: arrow
+Requires: arrow cuda
 Libs: -L${libdir} -larrow_cuda
 Cflags: -I${includedir}

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -340,15 +340,14 @@ Status CudaDevice::SyncEvent::Wait() {
   return Status::OK();
 }
 
-Status CudaDevice::SyncEvent::Record(const Device::Stream& st, const unsigned int flags) {
+Status CudaDevice::SyncEvent::Record(const Device::Stream& st) {
   auto cuda_stream = checked_cast<const CudaDevice::Stream*, const Device::Stream*>(&st);
   if (!cuda_stream) {
     return Status::Invalid("CudaDevice::Event cannot record on non-cuda stream");
   }
 
   ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
-  CU_RETURN_NOT_OK("cuEventRecordWithFlags",
-                   cuEventRecordWithFlags(value(), cuda_stream->value(), flags));
+  CU_RETURN_NOT_OK("cuEventRecord", cuEventRecord(value(), cuda_stream->value()));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -323,7 +323,7 @@ Status CudaDevice::Stream::WaitEvent(const Device::SyncEvent& event) {
 
   ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
   CU_RETURN_NOT_OK("cuStreamWaitEvent",
-                   cuStreamWaitEvent(value(), cu_event, CU_EVENT_WAIT_DEFAULT));
+                   cuStreamWaitEvent(value(), cu_event, CU_EVENT_DEFAULT));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -324,8 +324,7 @@ Status CudaDevice::Stream::WaitEvent(const Device::SyncEvent& event) {
   ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
   // we are currently building with CUDA toolkit 11.0.3 which doesn't have enum
   // values for the flags yet. The "flags" param *must* be 0 for now.
-  CU_RETURN_NOT_OK("cuStreamWaitEvent",
-                   cuStreamWaitEvent(value(), cu_event, 0));
+  CU_RETURN_NOT_OK("cuStreamWaitEvent", cuStreamWaitEvent(value(), cu_event, 0));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -322,8 +322,10 @@ Status CudaDevice::Stream::WaitEvent(const Device::SyncEvent& event) {
   }
 
   ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
+  // we are currently building with CUDA toolkit 11.0.3 which doesn't have enum
+  // values for the flags yet. The "flags" param *must* be 0 for now.
   CU_RETURN_NOT_OK("cuStreamWaitEvent",
-                   cuStreamWaitEvent(value(), cu_event, CU_EVENT_DEFAULT));
+                   cuStreamWaitEvent(value(), cu_event, 0));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -212,7 +212,7 @@ class ARROW_EXPORT CudaDevice : public Device {
     ///
     /// Once the stream completes the tasks previously added to it,
     /// it will trigger the event.
-    Status Record(const Device::Stream&, const unsigned int) override;
+    Status Record(const Device::Stream&) override;
 
    protected:
     friend class CudaMemoryManager;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
#37365 was built locally using a newer version of the CUDA driver API than the crossbow builds run with causing the crossbow build to fail due to a change in macro names. This puts the macro name back to allow it to build with the older version of the cuda driver api.

* Closes: #37523