### PR TITLE
GH-37259: [Ruby] Add explicit csv gem dependency

### DIFF
--- a/ruby/red-arrow/red-arrow.gemspec
+++ b/ruby/red-arrow/red-arrow.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["ext/arrow/extconf.rb"]
 
   spec.add_runtime_dependency("bigdecimal", ">= 3.1.0")
+  spec.add_runtime_dependency("csv")
   spec.add_runtime_dependency("extpp", ">= 0.1.1")
   spec.add_runtime_dependency("gio2", ">= 3.5.0")
   spec.add_runtime_dependency("native-package-installer")


### PR DESCRIPTION
### Rationale for this change

The "csv" gem is a default gem for now but it will be a bundled gem in Ruby 3.4.
Bundled gem requires an explicit gem dependency.

This will cause failure when we do `require "csv"` in Ruby 3.4 (this means in master branch of Ruby = ruby 3.3.0dev for now). See examples in #37259.


### What changes are included in this PR?

Added `gem "csv"` in gemspec's runtime dependency of Red Arrow.


### Are these changes tested?

Yes.

### Are there any user-facing changes?

Users will use 'csv' gem from rubygems, not bundled, for Ruby < 3.4 .



* Closes: #37259