### PR TITLE
MINOR: [Go] Make `arrow.TimestampType.GetToTimeFunc` similar to `arrow.Timestamp.ToTime`

### DIFF
--- a/go/arrow/datatype_fixedwidth.go
+++ b/go/arrow/datatype_fixedwidth.go
@@ -374,9 +374,9 @@ func (t *TimestampType) Fingerprint() string {
 // BitWidth returns the number of bits required to store a single element of this data type in memory.
 func (*TimestampType) BitWidth() int { return 64 }
 
-func (TimestampType) Bytes() int { return Int64SizeBytes }
+func (*TimestampType) Bytes() int { return Int64SizeBytes }
 
-func (TimestampType) Layout() DataTypeLayout {
+func (*TimestampType) Layout() DataTypeLayout {
 	return DataTypeLayout{Buffers: []BufferSpec{SpecBitmap(), SpecFixedWidth(TimestampSizeBytes)}}
 }
 
@@ -444,15 +444,9 @@ func (t *TimestampType) GetToTimeFunc() (func(Timestamp) time.Time, error) {
 	case Second:
 		return func(v Timestamp) time.Time { return time.Unix(int64(v), 0).In(tz) }, nil
 	case Millisecond:
-		factor := int64(time.Second / time.Millisecond)
-		return func(v Timestamp) time.Time {
-			return time.Unix(int64(v)/factor, (int64(v)%factor)*int64(time.Millisecond)).In(tz)
-		}, nil
+		return func(v Timestamp) time.Time { return time.UnixMilli(int64(v)).In(tz) }, nil
 	case Microsecond:
-		factor := int64(time.Second / time.Microsecond)
-		return func(v Timestamp) time.Time {
-			return time.Unix(int64(v)/factor, (int64(v)%factor)*int64(time.Microsecond)).In(tz)
-		}, nil
+		return func(v Timestamp) time.Time { return time.UnixMicro(int64(v)).In(tz) }, nil
 	case Nanosecond:
 		return func(v Timestamp) time.Time { return time.Unix(0, int64(v)).In(tz) }, nil
 	}

--- a/go/arrow/datatype_fixedwidth_test.go
+++ b/go/arrow/datatype_fixedwidth_test.go
@@ -166,6 +166,20 @@ func TestTimestampToTime(t *testing.T) {
 	assert.Equal(t, "2345-12-30 00:00:00", tm.Format("2006-01-02 15:04:05.999"))
 }
 
+func TestTimestampType_GetToTimeFunc(t *testing.T) {
+	typUTC := &arrow.TimestampType{Unit: arrow.Millisecond}
+	toTimeUTC, err := typUTC.GetToTimeFunc()
+	assert.NoError(t, err)
+
+	typNY := &arrow.TimestampType{Unit: arrow.Millisecond, TimeZone: "America/New_York"}
+	toTimeNY, err := typNY.GetToTimeFunc()
+	assert.NoError(t, err)
+
+	ts := arrow.Timestamp(11865225600000)
+	assert.Equal(t, "2345-12-30T00:00:00Z", toTimeUTC(ts).Format(time.RFC3339))
+	assert.Equal(t, "2345-12-29T19:00:00-05:00", toTimeNY(ts).Format(time.RFC3339))
+}
+
 func TestTime32Type(t *testing.T) {
 	for _, tc := range []struct {
 		unit arrow.TimeUnit


### PR DESCRIPTION
### Rationale for this change

Follow-up for https://github.com/apache/arrow/pull/36964

### What changes are included in this PR?

Make the `arrow.TimestampType.GetToTimeFunc` similar to `arrow.Timestamp.ToTime` in order not to get overflows.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No.