### PR TITLE
GH-37553: [Java] Allow FlightInfo#Schema to be nullable for long-running queries

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightProducer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightProducer.java
@@ -77,7 +77,12 @@ public interface FlightProducer {
    */
   default SchemaResult getSchema(CallContext context, FlightDescriptor descriptor) {
     FlightInfo info = getFlightInfo(context, descriptor);
-    return new SchemaResult(info.getSchema());
+    return new SchemaResult(info
+            .getSchemaOptional()
+            .orElseThrow(() ->
+                    CallStatus
+                            .INVALID_ARGUMENT
+                            .withDescription("No schema is present in FlightInfo").toRuntimeException()));
   }
 
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SchemaResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SchemaResult.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.util.Objects;
 
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.vector.ipc.ReadChannel;
@@ -52,6 +53,7 @@ public class SchemaResult {
    * Create a schema result with specific IPC options for serialization.
    */
   public SchemaResult(Schema schema, IpcOption option) {
+    Objects.requireNonNull(schema);
     MetadataV4UnionChecker.checkForUnion(schema.getFields().iterator(), option.metadataVersion);
     this.schema = schema;
     this.option = option;

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
@@ -17,13 +17,20 @@
 
 package org.apache.arrow.flight;
 
+import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
+import static org.apache.arrow.flight.Location.forGrpcInsecure;
 import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -121,5 +128,30 @@ public class TestFlightService {
     flightService.doGetCustom(Flight.Ticket.newBuilder().build(), observer);
 
     // fail() would have been called if an error happened during doGetCustom(), so this test passed.
+  }
+
+  @Test
+  public void supportsNullSchemas() throws Exception
+  {
+    final FlightProducer producer = new NoOpFlightProducer() {
+      @Override
+      public FlightInfo getFlightInfo(CallContext context,
+              FlightDescriptor descriptor) {
+        return new FlightInfo(null, descriptor, Collections.emptyList(), 0, 0);
+      }
+    };
+
+    try (final FlightServer s =
+            FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), producer).build().start();
+            final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
+      FlightInfo flightInfo = client.getInfo(FlightDescriptor.path("test"));
+      Assertions.assertEquals(Optional.empty(), flightInfo.getSchemaOptional());
+      Assertions.assertEquals(new Schema(Collections.emptyList()), flightInfo.getSchema());
+
+      Exception e = Assertions.assertThrows(
+          FlightRuntimeException.class,
+          () -> client.getSchema(FlightDescriptor.path("test")));
+      Assertions.assertEquals("No schema is present in FlightInfo", e.getMessage());
+    }
   }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestMetadataVersion.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestMetadataVersion.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -72,7 +73,7 @@ public class TestMetadataVersion {
     try (final FlightServer server = startServer(optionV4);
          final FlightClient client = connect(server)) {
       final FlightInfo result = client.getInfo(FlightDescriptor.command(new byte[0]));
-      assertEquals(schema, result.getSchema());
+      assertEquals(Optional.of(schema), result.getSchemaOptional());
     }
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
@@ -123,7 +123,7 @@ public final class ArrowFlightJdbcFlightStreamResultSet
     final FlightInfo flightInfo = ((ArrowFlightInfoStatement) statement).executeFlightInfoQuery();
 
     if (flightInfo != null) {
-      schema = flightInfo.getSchema();
+      schema = flightInfo.getSchemaOptional().orElse(null);
       execute(flightInfo);
     }
     return this;

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import org.apache.arrow.flight.sql.FlightSqlClient;
@@ -177,13 +178,15 @@ public class TestFlightSql {
   @Test
   public void testGetTablesSchema() {
     final FlightInfo info = sqlClient.getTables(null, null, null, null, true);
-    MatcherAssert.assertThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA));
+    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA)));
   }
 
   @Test
   public void testGetTablesSchemaExcludeSchema() {
     final FlightInfo info = sqlClient.getTables(null, null, null, null, false);
-    MatcherAssert.assertThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA));
+    MatcherAssert.assertThat(
+            info.getSchemaOptional(),
+            is(Optional.of(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA)));
   }
 
   @Test
@@ -364,7 +367,7 @@ public class TestFlightSql {
           },
           () -> {
             final FlightInfo info = preparedStatement.execute();
-            MatcherAssert.assertThat(info.getSchema(), is(SCHEMA_INT_TABLE));
+            MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(SCHEMA_INT_TABLE)));
           }
       );
     }
@@ -477,7 +480,7 @@ public class TestFlightSql {
   @Test
   public void testGetCatalogsSchema() {
     final FlightInfo info = sqlClient.getCatalogs();
-    MatcherAssert.assertThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA));
+    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA)));
   }
 
   @Test
@@ -497,7 +500,9 @@ public class TestFlightSql {
   @Test
   public void testGetTableTypesSchema() {
     final FlightInfo info = sqlClient.getTableTypes();
-    MatcherAssert.assertThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA));
+    MatcherAssert.assertThat(
+            info.getSchemaOptional(),
+            is(Optional.of(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA)));
   }
 
   @Test
@@ -526,7 +531,7 @@ public class TestFlightSql {
   @Test
   public void testGetSchemasSchema() {
     final FlightInfo info = sqlClient.getSchemas(null, null);
-    MatcherAssert.assertThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA));
+    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA)));
   }
 
   @Test
@@ -584,7 +589,7 @@ public class TestFlightSql {
   @Test
   public void testGetSqlInfoSchema() {
     final FlightInfo info = sqlClient.getSqlInfo();
-    MatcherAssert.assertThat(info.getSchema(), is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA));
+    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)));
   }
 
   @Test
@@ -848,7 +853,7 @@ public class TestFlightSql {
   @Test
   public void testCreateStatementSchema() throws Exception {
     final FlightInfo info = sqlClient.execute("SELECT * FROM intTable");
-    MatcherAssert.assertThat(info.getSchema(), is(SCHEMA_INT_TABLE));
+    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(SCHEMA_INT_TABLE)));
 
     // Consume statement to close connection before cache eviction
     try (FlightStream stream = sqlClient.getStream(info.getEndpoints().get(0).getTicket())) {


### PR DESCRIPTION
With apache/arrow#36155, implementations of Flight RPC may not return quickly via a newly added pollFlightInfo function. Sometimes, the system implementing this function may not know the output schema for some time--for example, after a lengthy queue time as elapsed, or after planning.

In proto3, fields may not be present, and it's a coding convention to require them 1. To support upcoming client integration work for pollFlightInfo, the schema field can be made optional so that it's not a requirement to populate the FlightInfo's schema on the first pollFlightInfo request.

We can modify our client code to allow this field to be optional. This is already the case for the Go code.

This changes the Java client code to allow the Schema to be null.  A new `getSchemaOptional` method returns `Optional<Schema>`, which is a backwards compatible change.  The existing method is deprecated, but will still return an empty schema if the schema is not present on wire (as it used to before).


### Rationale for this change

With apache/arrow#36155, implementations of Flight RPC may not return quickly via a newly added pollFlightInfo function. Sometimes, the system implementing this function may not know the output schema for some time--for example, after a lengthy queue time as elapsed, or after planning.

In proto3, fields may not be present, and it's a coding convention to require them 1. To support upcoming client integration work for pollFlightInfo, the schema field can be made optional so that it's not a requirement to populate the FlightInfo's schema on the first pollFlightInfo request.

CC: `@lidavidm`

### What changes are included in this PR?

This changes the Java client code to allow the Schema to be null.  `getSchema` is now deprecated and a new `getSchemaOptional` returns `Optional<Schema>`, which is a backwards compatible change.

### Are these changes tested?

Existing tests ensure serialization and deserialization continue to work.

### Are there any user-facing changes?

The `getSchema` methods are now deprecated in favor of `getSchemaOptional`.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: apache/arrow#37553
* GitHub Issue: #37553