### PR TITLE
GH-37433: [CI][Release] Increase timeout for macOS

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -70,7 +70,7 @@ jobs:
     name: Source Release and Merge Script on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -78,10 +78,10 @@ jobs:
           - macos-latest
           - ubuntu-latest
     env:
-      GIT_AUTHOR_NAME: Github Actions
-      GIT_AUTHOR_EMAIL: github@actions
-      GIT_COMMITTER_NAME: Github Actions
-      GIT_COMMITTER_EMAIL: github@actions
+      GIT_AUTHOR_NAME: "github-actions[bot]"
+      GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
+      GIT_COMMITTER_NAME: "github-actions[bot]"
+      GIT_COMMITTER_EMAIL: "github-actions[bot]@users.noreply.github.com"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v3

--- a/ci/scripts/release_test.sh
+++ b/ci/scripts/release_test.sh
@@ -23,6 +23,6 @@ arrow_dir=${1}
 
 pushd ${arrow_dir}
 
-dev/release/run-test.rb
+dev/release/run-test.rb -vv
 
 popd


### PR DESCRIPTION
### Rationale for this change

It seems that running ci/scripts/release_test.sh on macOS may take 10+ minutes. (Normally, it's finished in 5-10 minutes.)

### What changes are included in this PR?

Increase timeout to 15 minutes.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37433