### PR TITLE
GH-37056: [Java] Fix importing an empty data array from c-data

### DIFF
--- a/java/c/src/main/java/org/apache/arrow/c/BufferImportTypeVisitor.java
+++ b/java/c/src/main/java/org/apache/arrow/c/BufferImportTypeVisitor.java
@@ -80,45 +80,46 @@ class BufferImportTypeVisitor implements ArrowType.ArrowTypeVisitor<List<ArrowBu
   }
 
   @VisibleForTesting
-  long getBufferPtr(ArrowType type, int index) {
+  ArrowBuf importBuffer(ArrowType type, int index, long capacity) {
     checkState(
-        buffers.length > index,
-        "Expected at least %s buffers for type %s, but found %s", index + 1, type, buffers.length);
-    if (buffers[index] == NULL) {
-      throw new IllegalStateException(String.format("Buffer %s for type %s cannot be null", index, type));
+            buffers.length > index,
+            "Expected at least %s buffers for type %s, but found %s", index + 1, type, buffers.length);
+    long bufferPtr = buffers[index];
+
+    if (bufferPtr == NULL) {
+      // C array may be NULL if it holds nothing, field length is 0
+      if (fieldNode.getLength() != 0) {
+        throw new IllegalStateException(
+                String.format("Buffer %s for type %s cannot be null", index, type)
+        );
+      } else {
+        // no data in the C array, return an empty buffer
+        return allocator.getEmpty();
+      }
     }
-    return buffers[index];
+
+    ArrowBuf buf = underlyingAllocation.unsafeAssociateAllocation(allocator, capacity, bufferPtr);
+    imported.add(buf);
+    return buf;
   }
 
   private ArrowBuf importFixedBits(ArrowType type, int index, long bitsPerSlot) {
-    final long bufferPtr = getBufferPtr(type, index);
     final long capacity = DataSizeRoundingUtil.divideBy8Ceil(bitsPerSlot * fieldNode.getLength());
-    ArrowBuf buf = underlyingAllocation.unsafeAssociateAllocation(allocator, capacity, bufferPtr);
-    this.imported.add(buf);
-    return buf;
+    return importBuffer(type, index, capacity);
   }
 
   private ArrowBuf importFixedBytes(ArrowType type, int index, long bytesPerSlot) {
-    final long bufferPtr = getBufferPtr(type, index);
     final long capacity = bytesPerSlot * fieldNode.getLength();
-    ArrowBuf buf = underlyingAllocation.unsafeAssociateAllocation(allocator, capacity, bufferPtr);
-    this.imported.add(buf);
-    return buf;
+    return importBuffer(type, index, capacity);
   }
 
   private ArrowBuf importOffsets(ArrowType type, long bytesPerSlot) {
-    final long bufferPtr = getBufferPtr(type, 1);
     final long capacity = bytesPerSlot * (fieldNode.getLength() + 1);
-    ArrowBuf buf = underlyingAllocation.unsafeAssociateAllocation(allocator, capacity, bufferPtr);
-    this.imported.add(buf);
-    return buf;
+    return importBuffer(type, 1, capacity);
   }
 
   private ArrowBuf importData(ArrowType type, long capacity) {
-    final long bufferPtr = getBufferPtr(type, 2);
-    ArrowBuf buf = underlyingAllocation.unsafeAssociateAllocation(allocator, capacity, bufferPtr);
-    this.imported.add(buf);
-    return buf;
+    return importBuffer(type, 2, capacity);
   }
 
   private ArrowBuf maybeImportBitmap(ArrowType type) {

--- a/java/c/src/main/java/org/apache/arrow/c/BufferImportTypeVisitor.java
+++ b/java/c/src/main/java/org/apache/arrow/c/BufferImportTypeVisitor.java
@@ -87,11 +87,9 @@ class BufferImportTypeVisitor implements ArrowType.ArrowTypeVisitor<List<ArrowBu
     long bufferPtr = buffers[index];
 
     if (bufferPtr == NULL) {
-      // C array may be NULL if it holds nothing, field length is 0
-      if (fieldNode.getLength() != 0) {
-        throw new IllegalStateException(
-                String.format("Buffer %s for type %s cannot be null", index, type)
-        );
+      // C array may be NULL but only accept that if expected capacity is zero too
+      if (capacity != 0) {
+        throw new IllegalStateException(String.format("Buffer %s for type %s cannot be null", index, type));
       } else {
         // no data in the C array, return an empty buffer
         return allocator.getEmpty();

--- a/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
@@ -56,18 +56,29 @@ class ArrowArrayUtilityTest {
   // BufferImportTypeVisitor
 
   @Test
-  void getBufferPtr() throws Exception {
+  void importBuffer() throws Exception {
     // Note values are all dummy values here
-    try (BufferImportTypeVisitor visitor =
-        new BufferImportTypeVisitor(allocator, dummyHandle, new ArrowFieldNode(0, 0), new long[]{0})) {
+    try (BufferImportTypeVisitor notEmptyDataVisitor =
+        new BufferImportTypeVisitor(allocator, dummyHandle, new ArrowFieldNode(/* length= */ 1, 0), new long[]{0})) {
 
       // Too few buffers
-      assertThrows(IllegalStateException.class, () -> visitor.getBufferPtr(new ArrowType.Bool(), 1));
+      assertThrows(IllegalStateException.class, () -> notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 1, 1));
 
       // Null where one isn't expected
-      assertThrows(IllegalStateException.class, () -> visitor.getBufferPtr(new ArrowType.Bool(), 0));
+      assertThrows(IllegalStateException.class, () -> notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
+    }
+
+    try (BufferImportTypeVisitor emptyDataVisitor =
+        new BufferImportTypeVisitor(allocator, dummyHandle, new ArrowFieldNode(/* length= */ 0, 0), new long[]{0})) {
+
+      // Too few buffers
+      assertThrows(IllegalStateException.class, () -> emptyDataVisitor.importBuffer(new ArrowType.Bool(), 1, 1));
+
+      // empty if c arry ptr is NULL (zero) and expected capacity is also zero
+      assertThat(emptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 4)).isEqualTo(allocator.getEmpty());
     }
   }
+
 
   @Test
   void cleanupAfterFailure() throws Exception {

--- a/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
@@ -70,7 +70,7 @@ class ArrowArrayUtilityTest {
       // Expected capacity not zero but c array ptr is NULL (zero)
       assertThrows(IllegalStateException.class, () -> notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
 
-      // Expected capacity is zero and c arry ptr is NULL (zero)
+      // Expected capacity is zero and c array ptr is NULL (zero)
       assertThat(notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 0)).isEqualTo(allocator.getEmpty());
     }
 
@@ -80,10 +80,10 @@ class ArrowArrayUtilityTest {
       // Too few buffers
       assertThrows(IllegalStateException.class, () -> emptyDataVisitor.importBuffer(new ArrowType.Bool(), 1, 1));
 
-      // Expected capacity not zero but c arry ptr is NULL (zero)
+      // Expected capacity not zero but c array ptr is NULL (zero)
       assertThrows(IllegalStateException.class, () -> emptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
 
-      // Expected capacity is zero and c arry ptr is NULL (zero)
+      // Expected capacity is zero and c array ptr is NULL (zero)
       assertThat(emptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 0)).isEqualTo(allocator.getEmpty());
     }
   }

--- a/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
@@ -67,7 +67,7 @@ class ArrowArrayUtilityTest {
       // Null where one isn't expected
       assertThrows(IllegalStateException.class, () -> notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
 
-      // Expected capacity not zero but c arry ptr is NULL (zero)
+      // Expected capacity not zero but c array ptr is NULL (zero)
       assertThrows(IllegalStateException.class, () -> notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
 
       // Expected capacity is zero and c arry ptr is NULL (zero)

--- a/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/ArrowArrayUtilityTest.java
@@ -66,6 +66,12 @@ class ArrowArrayUtilityTest {
 
       // Null where one isn't expected
       assertThrows(IllegalStateException.class, () -> notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
+
+      // Expected capacity not zero but c arry ptr is NULL (zero)
+      assertThrows(IllegalStateException.class, () -> notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
+
+      // Expected capacity is zero and c arry ptr is NULL (zero)
+      assertThat(notEmptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 0)).isEqualTo(allocator.getEmpty());
     }
 
     try (BufferImportTypeVisitor emptyDataVisitor =
@@ -74,8 +80,11 @@ class ArrowArrayUtilityTest {
       // Too few buffers
       assertThrows(IllegalStateException.class, () -> emptyDataVisitor.importBuffer(new ArrowType.Bool(), 1, 1));
 
-      // empty if c arry ptr is NULL (zero) and expected capacity is also zero
-      assertThat(emptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 4)).isEqualTo(allocator.getEmpty());
+      // Expected capacity not zero but c arry ptr is NULL (zero)
+      assertThrows(IllegalStateException.class, () -> emptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 1));
+
+      // Expected capacity is zero and c arry ptr is NULL (zero)
+      assertThat(emptyDataVisitor.importBuffer(new ArrowType.Bool(), 0, 0)).isEqualTo(allocator.getEmpty());
     }
   }
 

--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -537,6 +537,7 @@ public class RoundtripTest {
   @Test
   public void testEmptyListVector() {
     try (final ListVector vector = ListVector.empty("v", allocator)) {
+      setVector(vector, new ArrayList<Integer>());
       assertTrue(roundtrip(vector, ListVector.class));
     }
   }

--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -535,6 +535,13 @@ public class RoundtripTest {
   }
 
   @Test
+  public void testEmptyListVector() {
+    try (final ListVector vector = ListVector.empty("v", allocator)) {
+      assertTrue(roundtrip(vector, ListVector.class));
+    }
+  }
+
+  @Test
   public void testLargeListVector() {
     try (final LargeListVector vector = LargeListVector.empty("v", allocator)) {
       setVector(vector, Arrays.stream(new int[] { 1, 2 }).boxed().collect(Collectors.toList()),

--- a/java/c/src/test/python/integration_tests.py
+++ b/java/c/src/test/python/integration_tests.py
@@ -120,6 +120,10 @@ class Bridge:
 
 
 class TestPythonIntegration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        setup_jvm()
+
     def setUp(self):
         gc.collect()
         self.old_allocated_python = pa.total_allocated_bytes()
@@ -198,16 +202,24 @@ class TestPythonIntegration(unittest.TestCase):
         ), check_metadata=False)
 
     def test_empty_list_array(self):
+        """Validates GH-37056 fix.
+        Empty list of int32 produces a vector with empty child data buffer, however with non-zero capacity.
+        Using streaming forces the c-data array which represent the child data buffer to be NULL (pointer is 0).
+        On Java side, an attempt to import such array triggered an exception described in GH-37056.
+        """
         with pa.BufferOutputStream() as bos:
             schema = pa.schema([pa.field("f0", pa.list_(pa.int32()), True)])
             with ipc.new_stream(bos, schema) as writer:
                 src = pa.RecordBatch.from_arrays([pa.array([[]])], schema=schema)
                 writer.write(src)
-        with pa.input_stream(bos.getvalue()) as ios:
-            with ipc.open_stream(ios) as reader:
-                batch = reader.read_next_batch()
+        data_bytes = bos.getvalue()
 
-        self.round_trip_record_batch(lambda: batch)
+        def recreate_batch():
+            with pa.input_stream(data_bytes) as ios:
+                with ipc.open_stream(ios) as reader:
+                    return reader.read_next_batch()
+
+        self.round_trip_record_batch(recreate_batch)
 
     def test_struct_array(self):
         fields = [
@@ -286,5 +298,4 @@ class TestPythonIntegration(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    setup_jvm()
     unittest.main(verbosity=2)


### PR DESCRIPTION

### Rationale for this change

Fix java lib bug that prevents from importing specific data via c-data interface.
Currently an attempt to load a vector with empty data buffer results in an IllegalStateException error.

### What changes are included in this PR?
Updated BufferImportTypeVisitor to correctly handle a situation when underlying c-data array pointer is NULL (0) and the expected length of data is zero (0). 

### Are these changes tested?
Yes, updated the existing unit tests

### Are there any user-facing changes?
No

* Closes: #37056