### PR TITLE
MINOR: [R][CI] Add previous version of package to CI backwards comaptibility job

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -73,6 +73,7 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
+        - { old_arrow_version: '12.0.1.1', r: '4.3' }
         - { old_arrow_version: '11.0.0.3', r: '4.2' }
         - { old_arrow_version: '10.0.1', r: '4.2' }
         - { old_arrow_version: '9.0.0', r: '4.2' }


### PR DESCRIPTION
### Rationale for this change

Add previous version of R package to backward compatibility job so we can ensure we don't make breaking changes

### What changes are included in this PR?

Add 12.0.1.1 to CI job

### Are these changes tested?

No
### Are there any user-facing changes?

No