### PR TITLE
MINOR: [Test] Triggering dumb CI to test k8s upgrade on self-hosted runners

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 # Stray comment to trigger Go workflows to test self-hosted runners
-# kubernetes upgrade.
+# kubernetes upgrade. Now with k8s 1.26.
 
 name: Go
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Stray comment to trigger Go workflows to test self-hosted runners
+# kubernetes upgrade.
+
 name: Go
 
 on:


### PR DESCRIPTION
DO NOT MERGE

This is only to trigger CI to test k8s upgrade on self-hosted runners.