### PR TITLE
GH-37539: [C++][FlightRPC] Fix binding to IPv6 addresses

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -245,7 +245,7 @@ TEST(TestFlight, ConnectUriUnix) {
 #endif
 
 // CI environments don't have an IPv6 interface configured
-TEST(TestFlight, IpV6Port) {
+TEST(TestFlight, DISABLED_IpV6Port) {
   std::unique_ptr<FlightServerBase> server = ExampleTestServer();
 
   ASSERT_OK_AND_ASSIGN(auto location, Location::ForGrpcTcp("[::1]", 0));

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -245,7 +245,7 @@ TEST(TestFlight, ConnectUriUnix) {
 #endif
 
 // CI environments don't have an IPv6 interface configured
-TEST(TestFlight, DISABLED_IpV6Port) {
+TEST(TestFlight, IpV6Port) {
   std::unique_ptr<FlightServerBase> server = ExampleTestServer();
 
   ASSERT_OK_AND_ASSIGN(auto location, Location::ForGrpcTcp("[::1]", 0));

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -620,9 +620,13 @@ class GrpcServerTransport : public internal::ServerTransport {
     }
 
     if (scheme == kSchemeGrpcTls) {
-      ARROW_ASSIGN_OR_RAISE(location_, Location::ForGrpcTls(uri.host(), port));
+      ARROW_ASSIGN_OR_RAISE(
+          location_,
+          Location::ForGrpcTls(arrow::internal::UriEncodeHost(uri.host()), port));
     } else if (scheme == kSchemeGrpc || scheme == kSchemeGrpcTcp) {
-      ARROW_ASSIGN_OR_RAISE(location_, Location::ForGrpcTcp(uri.host(), port));
+      ARROW_ASSIGN_OR_RAISE(
+          location_,
+          Location::ForGrpcTcp(arrow::internal::UriEncodeHost(uri.host()), port));
     }
     return Status::OK();
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Binding to an IPv6 address got broken along the way

### What changes are included in this PR?

Fix the binding and see if we can enable IPv6 testing in CI

### Are these changes tested?

If CI permits

### Are there any user-facing changes?

No
* Closes: #37539