### PR TITLE
MINOR: [Python][Docs] Fix a code example rendering

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4135,6 +4135,7 @@ def binary(int length=-1):
     FixedSizeBinaryType(fixed_size_binary[3])
 
     and use the fixed-length binary type to create an array:
+
     >>> pa.array(['foo', 'bar', 'baz'], type=pa.binary(3))
     <pyarrow.lib.FixedSizeBinaryArray object at ...>
     [


### PR DESCRIPTION
Add the required empty line before a code example of binary.


### Rationale for this change

The last code example of [pyarrow.binary](https://arrow.apache.org/docs/python/generated/pyarrow.binary.html#pyarrow.binary) was not rendered correctly in documentation.


### What changes are included in this PR?

Added one line break to make the code example render correctly.


### Are these changes tested?

No

### Are there any user-facing changes?

[pyarrow.binary](https://arrow.apache.org/docs/python/generated/pyarrow.binary.html#pyarrow.binary) documentation only.


