### PR TITLE
GH-37555: [Python] Update get_file_info_selector to ignore base directory

### DIFF
--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -356,7 +356,12 @@ class FSSpecHandler(FileSystemHandler):
             selector.base_dir, maxdepth=maxdepth, withdirs=True, detail=True
         )
         for path, info in selected_files.items():
-            infos.append(self._create_file_info(path, info))
+            # Need to exclude base directory from selected files if present
+            # (fsspec filesystems, see GH-37555)
+            if (path != selector.base_dir and
+                path != "/" + selector.base_dir[:len(selector.base_dir)-1] and
+                    path != selector.base_dir[:len(selector.base_dir)-1]):
+                infos.append(self._create_file_info(path, info))
 
         return infos
 

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -356,11 +356,17 @@ class FSSpecHandler(FileSystemHandler):
             selector.base_dir, maxdepth=maxdepth, withdirs=True, detail=True
         )
         for path, info in selected_files.items():
+            start = start_p = 0
+            end = len(selector.base_dir)
+            if path.startswith("/"):
+                start_p += 1
+            if selector.base_dir.startswith("/"):
+                start += 1
+            if selector.base_dir.endswith("/"):
+                end -= 1
             # Need to exclude base directory from selected files if present
             # (fsspec filesystems, see GH-37555)
-            if (path != selector.base_dir and
-                path != "/" + selector.base_dir[:len(selector.base_dir)-1] and
-                    path != selector.base_dir[:len(selector.base_dir)-1]):
+            if path[start_p:] != selector.base_dir[start:end]:
                 infos.append(self._create_file_info(path, info))
 
         return infos

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -356,17 +356,11 @@ class FSSpecHandler(FileSystemHandler):
             selector.base_dir, maxdepth=maxdepth, withdirs=True, detail=True
         )
         for path, info in selected_files.items():
-            start = start_p = 0
-            end = len(selector.base_dir)
-            if path.startswith("/"):
-                start_p += 1
-            if selector.base_dir.startswith("/"):
-                start += 1
-            if selector.base_dir.endswith("/"):
-                end -= 1
+            _path = path.strip("/")
+            base_dir = selector.base_dir.strip("/")
             # Need to exclude base directory from selected files if present
             # (fsspec filesystems, see GH-37555)
-            if path[start_p:] != selector.base_dir[start:end]:
+            if _path != base_dir:
                 infos.append(self._create_file_info(path, info))
 
         return infos

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -717,9 +717,9 @@ def test_get_file_info_with_selector(fs, pathfn):
             elif (info.path.rstrip("/").endswith(dir_a) or
                   info.path.rstrip("/").endswith(dir_b)):
                 assert info.type == FileType.Directory
-            elif (fs.type_name == "py::fsspec+s3" and
+            elif ("py::fsspec" in fs.type_name and
                   info.path.rstrip("/").endswith("selector-dir")):
-                # s3fs can include base dir, see above
+                # fsspec can include base dir, see above
                 assert info.type == FileType.Directory
             else:
                 raise ValueError('unexpected path {}'.format(info.path))
@@ -729,7 +729,12 @@ def test_get_file_info_with_selector(fs, pathfn):
         selector = FileSelector(base_dir, recursive=False)
 
         infos = fs.get_file_info(selector)
-        assert len(infos) == 4
+        if fs.type_name in ["py::fsspec+file", 'py::fsspec+memory']:
+            # fsspec also lists root dir
+            # GH-37555
+            assert len(infos) == 5
+        else:
+            assert len(infos) == 4
 
     finally:
         fs.delete_dir(base_dir)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -738,40 +738,6 @@ def test_get_file_info_with_selector(fs, pathfn):
         fs.delete_dir(base_dir)
 
 
-def test_get_file_info_with_selector_sf3_comparison(py_fsspec_s3fs, s3fs):
-    # GH-36983
-
-    fs = py_fsspec_s3fs["fs"]
-    pathfn = py_fsspec_s3fs["pathfn"]
-    base_dir = pathfn('selector-dir/')
-    file_a = pathfn('selector-dir/test_file_a')
-
-    fs.create_dir(base_dir)
-    with fs.open_output_stream(file_a):
-        pass
-
-    selector = FileSelector(base_dir, recursive=True)
-    infos_fsspec = fs.get_file_info(selector)
-    fs.delete_dir(base_dir)
-
-    fs = s3fs["fs"]
-    pathfn = s3fs["pathfn"]
-    base_dir = pathfn('selector-dir/')
-    file_a = pathfn('selector-dir/test_file_a')
-
-    fs.create_dir(base_dir)
-    with fs.open_output_stream(file_a):
-        pass
-
-    selector = FileSelector(base_dir, recursive=True)
-    infos = fs.get_file_info(selector)
-    fs.delete_dir(base_dir)
-
-    assert len(infos) == len(infos_fsspec) == 1
-    assert infos_fsspec[0].path == infos[0].path
-    assert infos_fsspec[0].type == infos[0].type
-
-
 def test_create_dir(fs, pathfn):
     # s3fs fails deleting dir fails if it is empty
     # (https://github.com/dask/s3fs/issues/317)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -703,6 +703,10 @@ def test_get_file_info_with_selector(fs, pathfn):
             # on the s3fs/fsspec version combo, it includes the base_dir
             # (https://github.com/dask/s3fs/issues/393)
             assert (len(infos) == 4) or (len(infos) == 5)
+        elif fs.type_name in ["py::fsspec+file", 'py::fsspec+memory']:
+            # fsspec also lists root dir
+            # GH-37555
+            assert len(infos) == 6
         else:
             assert len(infos) == 5
 
@@ -725,14 +729,7 @@ def test_get_file_info_with_selector(fs, pathfn):
         selector = FileSelector(base_dir, recursive=False)
 
         infos = fs.get_file_info(selector)
-        if fs.type_name == "py::fsspec+s3":
-            # s3fs only lists directories if they are not empty
-            # + for s3fs 0.5.2 all directories are dropped because of buggy
-            # side-effect of previous find() call
-            # (https://github.com/dask/s3fs/issues/410)
-            assert (len(infos) == 3) or (len(infos) == 2)
-        else:
-            assert len(infos) == 4
+        assert len(infos) == 4
 
     finally:
         fs.delete_dir(base_dir)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -696,6 +696,7 @@ def test_get_file_info_with_selector(fs, pathfn):
         selector = FileSelector(base_dir, allow_not_found=False,
                                 recursive=True)
         assert selector.base_dir == base_dir
+
         infos = fs.get_file_info(selector)
         if fs.type_name == "py::fsspec+s3":
             # s3fs only lists directories if they are not empty, but depending

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -738,6 +738,40 @@ def test_get_file_info_with_selector(fs, pathfn):
         fs.delete_dir(base_dir)
 
 
+def test_get_file_info_with_selector_sf3_comparison(py_fsspec_s3fs, s3fs):
+    # GH-36983
+
+    fs = py_fsspec_s3fs["fs"]
+    pathfn = py_fsspec_s3fs["pathfn"]
+    base_dir = pathfn('selector-dir/')
+    file_a = pathfn('selector-dir/test_file_a')
+
+    fs.create_dir(base_dir)
+    with fs.open_output_stream(file_a):
+        pass
+
+    selector = FileSelector(base_dir, recursive=True)
+    infos_fsspec = fs.get_file_info(selector)
+    fs.delete_dir(base_dir)
+
+    fs = s3fs["fs"]
+    pathfn = s3fs["pathfn"]
+    base_dir = pathfn('selector-dir/')
+    file_a = pathfn('selector-dir/test_file_a')
+
+    fs.create_dir(base_dir)
+    with fs.open_output_stream(file_a):
+        pass
+
+    selector = FileSelector(base_dir, recursive=True)
+    infos = fs.get_file_info(selector)
+    fs.delete_dir(base_dir)
+
+    assert len(infos) == len(infos_fsspec) == 1
+    assert infos_fsspec[0].path == infos[0].path
+    assert infos_fsspec[0].type == infos[0].type
+
+
 def test_create_dir(fs, pathfn):
     # s3fs fails deleting dir fails if it is empty
     # (https://github.com/dask/s3fs/issues/317)


### PR DESCRIPTION
### Rationale for this change

There has been some changes in the way fsspec lists the directories with new version 2023.9.0, see https://github.com/fsspec/filesystem_spec/pull/1329, which caused our tests to start failing.

### What changes are included in this PR?

This PR updates the `get_file_info_selector` in [FSSpecHandler](https://arrow.apache.org/docs/_modules/pyarrow/fs.html#FSSpecHandler) class to keep the behaviour of our spec.

### Are there any user-facing changes?

No.

* Closes: #37555