### PR TITLE
GH-37576: [R] Use `SafeCallIntoR()` to call garbage collector after a failed allocation

### DIFF
--- a/r/tests/testthat/test-arrow.R
+++ b/r/tests/testthat/test-arrow.R
@@ -64,6 +64,6 @@ test_that("MemoryPool calls gc() to free memory when allocation fails (ARROW-100
   on.exit(suppressMessages(untrace(gc)))
   # We expect this should fail because we don't have this much memory,
   # but it should gc() and retry (and fail again)
-  expect_error(BufferOutputStream$create(2**60))
+  expect_error(BufferOutputStream$create(2**60), "Out of memory")
   expect_true(env$gc_was_called)
 })


### PR DESCRIPTION
### Rationale for this change

The `gc_memory_pool()` is the one we use almost everywhere in the R package. It uses a special allocation mechanism that calls into R to run the garbage collector after a failed allocation (in case there are any large objects that can be removed). In the case where an allocation happens on another thread (most of the time when running exec plans), the call into R may cause a crash: even though the memory pool was ensuring serialized access using a mutex, this is not sufficient for R (for reasons I don't understand).

### What changes are included in this PR?

Use `SafeCallIntoR()` to run the garbage collector instead. This ensures that the calling thread is used for any call into R (or errors if this is not possible).

### Are these changes tested?

Yes: there is an existing test that ensures this code path occurs at least once.

### Are there any user-facing changes?

No.
* Closes: #37576