### PR TITLE
GH-37567: [C++] Migrate JSON Integration code to Result<>

### DIFF
--- a/cpp/src/arrow/flight/integration_tests/test_integration_client.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration_client.cc
@@ -56,11 +56,10 @@ namespace integration_tests {
 /// \brief Helper to read all batches from a JsonReader
 Status ReadBatches(std::unique_ptr<testing::IntegrationJsonReader>& reader,
                    std::vector<std::shared_ptr<RecordBatch>>* chunks) {
-  std::shared_ptr<RecordBatch> chunk;
   for (int i = 0; i < reader->num_record_batches(); i++) {
-    RETURN_NOT_OK(reader->ReadRecordBatch(i, &chunk));
+    ARROW_ASSIGN_OR_RAISE(auto chunk, reader->ReadRecordBatch(i));
     RETURN_NOT_OK(chunk->ValidateFull());
-    chunks->push_back(chunk);
+    chunks->push_back(std::move(chunk));
   }
   return Status::OK();
 }
@@ -150,11 +149,10 @@ class IntegrationTestScenario : public Scenario {
     FlightDescriptor descr{FlightDescriptor::PATH, "", {FLAGS_path}};
 
     // 1. Put the data to the server.
-    std::unique_ptr<testing::IntegrationJsonReader> reader;
     std::cout << "Opening JSON file '" << FLAGS_path << "'" << std::endl;
     auto in_file = *io::ReadableFile::Open(FLAGS_path);
-    ABORT_NOT_OK(
-        testing::IntegrationJsonReader::Open(default_memory_pool(), in_file, &reader));
+    ARROW_ASSIGN_OR_RAISE(auto reader, testing::IntegrationJsonReader::Open(
+                                           default_memory_pool(), in_file));
 
     std::shared_ptr<Schema> original_schema = reader->schema();
     std::vector<std::shared_ptr<RecordBatch>> original_data;

--- a/cpp/src/arrow/ipc/type_fwd.h
+++ b/cpp/src/arrow/ipc/type_fwd.h
@@ -56,6 +56,9 @@ class RecordBatchStreamReader;
 class RecordBatchFileReader;
 class RecordBatchWriter;
 
+class DictionaryFieldMapper;
+class DictionaryMemo;
+
 namespace feather {
 
 class Reader;

--- a/cpp/src/arrow/testing/json_integration.h
+++ b/cpp/src/arrow/testing/json_integration.h
@@ -22,21 +22,12 @@
 #include <memory>
 #include <string>
 
-#include "arrow/status.h"
+#include "arrow/io/type_fwd.h"
+#include "arrow/result.h"
 #include "arrow/testing/visibility.h"
+#include "arrow/type_fwd.h"
 
-namespace arrow {
-
-class Buffer;
-class MemoryPool;
-class RecordBatch;
-class Schema;
-
-namespace io {
-class ReadableFile;
-}  // namespace io
-
-namespace testing {
+namespace arrow::testing {
 
 /// \class IntegrationJsonWriter
 /// \brief Write the JSON representation of an Arrow record batch file or stream
@@ -51,8 +42,8 @@ class ARROW_TESTING_EXPORT IntegrationJsonWriter {
   /// \param[in] schema the schema of record batches
   /// \param[out] out the returned writer object
   /// \return Status
-  static Status Open(const std::shared_ptr<Schema>& schema,
-                     std::unique_ptr<IntegrationJsonWriter>* out);
+  static Result<std::unique_ptr<IntegrationJsonWriter>> Open(
+      const std::shared_ptr<Schema>& schema);
 
   /// \brief Append a record batch
   Status WriteRecordBatch(const RecordBatch& batch);
@@ -61,7 +52,7 @@ class ARROW_TESTING_EXPORT IntegrationJsonWriter {
   ///
   /// \param[out] result the JSON as as a std::string
   /// \return Status
-  Status Finish(std::string* result);
+  Result<std::string> Finish();
 
  private:
   explicit IntegrationJsonWriter(const std::shared_ptr<Schema>& schema);
@@ -83,27 +74,24 @@ class ARROW_TESTING_EXPORT IntegrationJsonReader {
   ///
   /// \param[in] pool a MemoryPool to use for buffer allocations
   /// \param[in] data a Buffer containing the JSON data
-  /// \param[out] reader the returned reader object
-  /// \return Status
-  static Status Open(MemoryPool* pool, const std::shared_ptr<Buffer>& data,
-                     std::unique_ptr<IntegrationJsonReader>* reader);
+  /// \return the created JSON reader
+  static Result<std::unique_ptr<IntegrationJsonReader>> Open(
+      MemoryPool* pool, std::shared_ptr<Buffer> data);
 
   /// \brief Create a new JSON reader that uses the default memory pool
   ///
   /// \param[in] data a Buffer containing the JSON data
-  /// \param[out] reader the returned reader object
-  /// \return Status
-  static Status Open(const std::shared_ptr<Buffer>& data,
-                     std::unique_ptr<IntegrationJsonReader>* reader);
+  /// \return the created JSON reader
+  static Result<std::unique_ptr<IntegrationJsonReader>> Open(
+      std::shared_ptr<Buffer> data);
 
   /// \brief Create a new JSON reader from a file
   ///
   /// \param[in] pool a MemoryPool to use for buffer allocations
   /// \param[in] in_file a ReadableFile containing JSON data
-  /// \param[out] reader the returned reader object
-  /// \return Status
-  static Status Open(MemoryPool* pool, const std::shared_ptr<io::ReadableFile>& in_file,
-                     std::unique_ptr<IntegrationJsonReader>* reader);
+  /// \return the created JSON reader
+  static Result<std::unique_ptr<IntegrationJsonReader>> Open(
+      MemoryPool* pool, const std::shared_ptr<io::ReadableFile>& in_file);
 
   /// \brief Return the schema read from the JSON
   std::shared_ptr<Schema> schema() const;
@@ -115,15 +103,14 @@ class ARROW_TESTING_EXPORT IntegrationJsonReader {
   ///
   /// \param[in] i the record batch index, does not boundscheck
   /// \param[out] batch the read record batch
-  Status ReadRecordBatch(int i, std::shared_ptr<RecordBatch>* batch) const;
+  Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(int i) const;
 
  private:
-  IntegrationJsonReader(MemoryPool* pool, const std::shared_ptr<Buffer>& data);
+  IntegrationJsonReader(MemoryPool* pool, std::shared_ptr<Buffer> data);
 
   // Hide RapidJSON details from public API
   class Impl;
   std::unique_ptr<Impl> impl_;
 };
 
-}  // namespace testing
-}  // namespace arrow
+}  // namespace arrow::testing

--- a/cpp/src/arrow/testing/json_integration.h
+++ b/cpp/src/arrow/testing/json_integration.h
@@ -40,8 +40,7 @@ class ARROW_TESTING_EXPORT IntegrationJsonWriter {
   /// \brief Create a new JSON writer that writes to memory
   ///
   /// \param[in] schema the schema of record batches
-  /// \param[out] out the returned writer object
-  /// \return Status
+  /// \return the creater writer object
   static Result<std::unique_ptr<IntegrationJsonWriter>> Open(
       const std::shared_ptr<Schema>& schema);
 
@@ -50,8 +49,7 @@ class ARROW_TESTING_EXPORT IntegrationJsonWriter {
 
   /// \brief Finish the JSON payload and return as a std::string
   ///
-  /// \param[out] result the JSON as as a std::string
-  /// \return Status
+  /// \return the JSON payload as a string
   Result<std::string> Finish();
 
  private:
@@ -102,7 +100,7 @@ class ARROW_TESTING_EXPORT IntegrationJsonReader {
   /// \brief Read a particular record batch from the file
   ///
   /// \param[in] i the record batch index, does not boundscheck
-  /// \param[out] batch the read record batch
+  /// \return the record batch read
   Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(int i) const;
 
  private:

--- a/cpp/src/arrow/testing/json_internal.h
+++ b/cpp/src/arrow/testing/json_internal.h
@@ -30,9 +30,10 @@
 #include <rapidjson/stringbuffer.h>  // IWYU pragma: export
 #include <rapidjson/writer.h>        // IWYU pragma: export
 
-#include "arrow/status.h"  // IWYU pragma: export
+#include "arrow/ipc/type_fwd.h"
+#include "arrow/result.h"
 #include "arrow/testing/visibility.h"
-#include "arrow/type_fwd.h"  // IWYU pragma: keep
+#include "arrow/type_fwd.h"
 
 namespace rj = arrow::rapidjson;
 using RjWriter = rj::Writer<rj::StringBuffer>;
@@ -74,23 +75,7 @@ using RjObject = rj::Value::ConstObject;
     return Status::Invalid("field was not an object line ", __LINE__); \
   }
 
-namespace arrow {
-
-class Array;
-class Field;
-class MemoryPool;
-class RecordBatch;
-class Schema;
-
-namespace ipc {
-
-class DictionaryFieldMapper;
-class DictionaryMemo;
-
-}  // namespace ipc
-
-namespace testing {
-namespace json {
+namespace arrow::testing::json {
 
 /// \brief Append integration test Schema format to rapidjson writer
 ARROW_TESTING_EXPORT
@@ -108,19 +93,17 @@ ARROW_TESTING_EXPORT
 Status WriteArray(const std::string& name, const Array& array, RjWriter* writer);
 
 ARROW_TESTING_EXPORT
-Status ReadSchema(const rj::Value& json_obj, MemoryPool* pool,
-                  ipc::DictionaryMemo* dictionary_memo, std::shared_ptr<Schema>* schema);
+Result<std::shared_ptr<Schema>> ReadSchema(const rj::Value& json_obj, MemoryPool* pool,
+                                           ipc::DictionaryMemo* dictionary_memo);
 
 ARROW_TESTING_EXPORT
-Status ReadRecordBatch(const rj::Value& json_obj, const std::shared_ptr<Schema>& schema,
-                       ipc::DictionaryMemo* dict_memo, MemoryPool* pool,
-                       std::shared_ptr<RecordBatch>* batch);
+Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
+    const rj::Value& json_obj, const std::shared_ptr<Schema>& schema,
+    ipc::DictionaryMemo* dict_memo, MemoryPool* pool);
 
 // NOTE: Doesn't work with dictionary arrays, use ReadRecordBatch instead.
 ARROW_TESTING_EXPORT
-Status ReadArray(MemoryPool* pool, const rj::Value& json_obj,
-                 const std::shared_ptr<Field>& type, std::shared_ptr<Array>* array);
+Result<std::shared_ptr<Array>> ReadArray(MemoryPool* pool, const rj::Value& json_obj,
+                                         const std::shared_ptr<Field>& field);
 
-}  // namespace json
-}  // namespace testing
-}  // namespace arrow
+}  // namespace arrow::testing::json

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -764,10 +764,8 @@ def integration(with_all=False, random_seed=12345, **args):
             enabled_languages += 1
 
     if gen_path:
-        # XXX this option is only used by the JS test suite.
-        # It also has not been updated to generate more data types,
-        # and JS is now part of the integration test suite, so it's
-        # not obvious how useful the option still is.
+        # XXX See GH-37575: this option is only used by the JS test suite
+        # and might not be useful anymore.
         os.makedirs(gen_path, exist_ok=True)
         write_js_test_json(gen_path)
     else:

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -764,6 +764,10 @@ def integration(with_all=False, random_seed=12345, **args):
             enabled_languages += 1
 
     if gen_path:
+        # XXX this option is only used by the JS test suite.
+        # It also has not been updated to generate more data types,
+        # and JS is now part of the integration test suite, so it's
+        # not obvious how useful the option still is.
         os.makedirs(gen_path, exist_ok=True)
         write_js_test_json(gen_path)
     else:


### PR DESCRIPTION
### Rationale for this change

The JSON Integration APIs still use the old-style of returning `Status` together with a `T*` out-parameter.
While those are internal APIs, it would still improve ease of us to migrate them to the newer idiom of returning a `Result<T>`.

### What changes are included in this PR?

Migrate the relevant APIs from `Status` to `Result`. Since the APIs are internal, no deprecation period is introduced.

Also, some very minor style and testing cleanups here and there.

### Are these changes tested?

By existing tests.

### Are there any user-facing changes?

No.

* Closes: #37567