### PR TITLE
GH-37515: [C++] Remove memory address optimization from `ChunkedArray::Equals(const std::shared_ptr<arrow::ChunkedArray>& other)` if the `ChunkedArray` can have `NaN` values

### DIFF
--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -127,7 +127,7 @@ bool mayHaveNaN(const arrow::DataType& type) {
   return false;
 }
 
-} //  namespace
+}  //  namespace
 
 bool ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other) const {
   if (!other) {

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -120,7 +120,7 @@ namespace {
       // Only floating types support NaN
       supports_nan |= is_floating(type.id());
     } else {
-      for(const auto& field : type.fields()) {
+      for (const auto& field : type.fields()) {
         supports_nan |= supportsNaN(*field->type());
         if (supports_nan) {
           break;

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -130,7 +130,7 @@ bool supportsNaN(const arrow::DataType& type) {
   return supports_nan;
 }
 
-} // namespace
+} //  namespace
 
 bool ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other) const {
   if (!other) {

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -113,22 +113,23 @@ bool ChunkedArray::Equals(const ChunkedArray& other) const {
 }
 
 namespace {
-  bool supportsNaN(const arrow::DataType& type) {
-    bool supports_nan = false;
 
-    if (type.num_fields() == 0) {
-      // Only floating types support NaN
-      supports_nan |= is_floating(type.id());
-    } else {
-      for (const auto& field : type.fields()) {
-        supports_nan |= supportsNaN(*field->type());
-        if (supports_nan) {
-          break;
-        }
+bool supportsNaN(const arrow::DataType& type) {
+  bool supports_nan = false;
+  if (type.num_fields() == 0) {
+    // Only floating types support NaN
+    supports_nan |= is_floating(type.id());
+  } else {
+    for (const auto& field : type.fields()) {
+      supports_nan |= supportsNaN(*field->type());
+      if (supports_nan) {
+        break;
       }
     }
-    return supports_nan;
   }
+  return supports_nan;
+}
+
 } // namespace
 
 bool ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other) const {

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -147,30 +147,32 @@ TEST_F(TestChunkedArray, EqualsDifferingMetadata) {
 }
 
 TEST_F(TestChunkedArray, EqualsSameAddressWithNaNs) {
-  auto chunk0 = ArrayFromJSON(float64(), "[0, 1, 2, NaN]");
-  auto chunk1 = ArrayFromJSON(float64(), "[3, 4, 5]");
-  ASSERT_OK_AND_ASSIGN(auto result0, ChunkedArray::Make({chunk0, chunk1}, float64()));
-  // result0 has NaN values
-  ASSERT_FALSE(result0->Equals(result0));
+  auto chunk_with_nan1 = ArrayFromJSON(float64(), "[0, 1, 2, NaN]");
+  auto chunk_without_nan1 = ArrayFromJSON(float64(), "[3, 4, 5]");
+  ArrayVector chunks1 = {chunk_with_nan1, chunk_without_nan1};
+  ASSERT_OK_AND_ASSIGN(auto chunked_array_with_nan1, ChunkedArray::Make(chunks1));
+  ASSERT_FALSE(chunked_array_with_nan1->Equals(chunked_array_with_nan1));
 
-  auto chunk2 = ArrayFromJSON(float64(), "[6, 7, 8, 9]");
-  ASSERT_OK_AND_ASSIGN(auto result1, ChunkedArray::Make({chunk1, chunk2}, float64()));
-  // result1 does not have NaN values
-  ASSERT_TRUE(result1->Equals(result1));
+  auto chunk_without_nan2 = ArrayFromJSON(float64(), "[6, 7, 8, 9]");
+  ArrayVector chunks2 = {chunk_without_nan1, chunk_without_nan2};
+  ASSERT_OK_AND_ASSIGN(auto chunked_array_without_nan1, ChunkedArray::Make(chunks2));
+  ASSERT_TRUE(chunked_array_without_nan1->Equals(chunked_array_without_nan1));
 
-  auto array0 = ArrayFromJSON(int32(), "[0, 1, 2]");
-  auto array1 = ArrayFromJSON(float64(), "[0, 1, NaN]");
+  auto int32_array = ArrayFromJSON(int32(), "[0, 1, 2]");
+  auto float64_array_with_nan = ArrayFromJSON(float64(), "[0, 1, NaN]");
+  ArrayVector arrays1 = {int32_array, float64_array_with_nan};
   std::vector<std::string> fieldnames = {"Int32Type", "Float64Type"};
-  ASSERT_OK_AND_ASSIGN(auto struct0, StructArray::Make({array0, array1}, fieldnames));
-  ASSERT_OK_AND_ASSIGN(auto result2, ChunkedArray::Make({struct0}, struct0->type()));
-  // result2 has NaN values
-  ASSERT_FALSE(result2->Equals(result2));
+  ASSERT_OK_AND_ASSIGN(auto struct_with_nan, StructArray::Make(arrays1, fieldnames));
+  ArrayVector chunks3 = {struct_with_nan};
+  ASSERT_OK_AND_ASSIGN(auto chunked_array_with_nan2, ChunkedArray::Make(chunks3));
+  ASSERT_FALSE(chunked_array_with_nan2->Equals(chunked_array_with_nan2));
 
-  auto array2 = ArrayFromJSON(float64(), "[0, 1, 2]");
-  ASSERT_OK_AND_ASSIGN(auto struct1, StructArray::Make({array0, array2}, fieldnames));
-  ASSERT_OK_AND_ASSIGN(auto result3, ChunkedArray::Make({struct1}, struct1->type()));
-  // result3 does not have NaN values
-  ASSERT_TRUE(result3->Equals(result3));
+  auto float64_array_without_nan = ArrayFromJSON(float64(), "[0, 1, 2]");
+  ArrayVector arrays2 = {int32_array, float64_array_without_nan};
+  ASSERT_OK_AND_ASSIGN(auto struct_without_nan, StructArray::Make(arrays2, fieldnames));
+  ArrayVector chunks4 = {struct_without_nan};
+  ASSERT_OK_AND_ASSIGN(auto chunked_array_without_nan2, ChunkedArray::Make(chunks4));
+  ASSERT_TRUE(chunked_array_without_nan2->Equals(chunked_array_without_nan2));
 }
 
 TEST_F(TestChunkedArray, SliceEquals) {

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -146,6 +146,32 @@ TEST_F(TestChunkedArray, EqualsDifferingMetadata) {
   ASSERT_TRUE(left.Equals(right));
 }
 
+TEST_F(TestChunkedArray, EqualsSameAddressWithNaNs) {
+  auto chunk0 = ArrayFromJSON(float64(), "[0, 1, 2, NaN]");
+  auto chunk1 = ArrayFromJSON(float64(), "[3, 4, 5]");
+  ASSERT_OK_AND_ASSIGN(auto result0, ChunkedArray::Make({chunk0, chunk1}, float64()));
+  // result0 has NaN values
+  ASSERT_FALSE(result0->Equals(result0));
+  
+  auto chunk2 = ArrayFromJSON(float64(), "[6, 7, 8, 9]");
+  ASSERT_OK_AND_ASSIGN(auto result1, ChunkedArray::Make({chunk1, chunk2}, float64()));
+  // result1 does not have NaN values
+  ASSERT_TRUE(result1->Equals(result1));
+
+  auto array0 = ArrayFromJSON(int32(), "[0, 1, 2]");
+  auto array1 = ArrayFromJSON(float64(), "[0, 1, NaN]");
+  ASSERT_OK_AND_ASSIGN(auto struct0, StructArray::Make({array0, array1}, {"Int32Type", "Float64Type"}));
+  ASSERT_OK_AND_ASSIGN(auto result2, ChunkedArray::Make({struct0}, struct0->type()));
+  // result2 has NaN values
+  ASSERT_FALSE(result2->Equals(result2));
+  
+  auto array2 = ArrayFromJSON(float64(), "[0, 1, 2]");
+  ASSERT_OK_AND_ASSIGN(auto struct1, StructArray::Make({array0, array2}, {"Int32Type", "Float64Type"}));
+  ASSERT_OK_AND_ASSIGN(auto result3, ChunkedArray::Make({struct1}, struct1->type()));
+  // result3 does not have NaN values
+  ASSERT_TRUE(result3->Equals(result3));
+}
+
 TEST_F(TestChunkedArray, SliceEquals) {
   random::RandomArrayGenerator gen(42);
 

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -160,13 +160,14 @@ TEST_F(TestChunkedArray, EqualsSameAddressWithNaNs) {
 
   auto array0 = ArrayFromJSON(int32(), "[0, 1, 2]");
   auto array1 = ArrayFromJSON(float64(), "[0, 1, NaN]");
-  ASSERT_OK_AND_ASSIGN(auto struct0, StructArray::Make({array0, array1}, {"Int32Type", "Float64Type"}));
+  std::vector<std::string> fieldnames = {"Int32Type", "Float64Type"};
+  ASSERT_OK_AND_ASSIGN(auto struct0, StructArray::Make({array0, array1}, fieldnames));
   ASSERT_OK_AND_ASSIGN(auto result2, ChunkedArray::Make({struct0}, struct0->type()));
   // result2 has NaN values
   ASSERT_FALSE(result2->Equals(result2));
   
   auto array2 = ArrayFromJSON(float64(), "[0, 1, 2]");
-  ASSERT_OK_AND_ASSIGN(auto struct1, StructArray::Make({array0, array2}, {"Int32Type", "Float64Type"}));
+  ASSERT_OK_AND_ASSIGN(auto struct1, StructArray::Make({array0, array2}, fieldnames));
   ASSERT_OK_AND_ASSIGN(auto result3, ChunkedArray::Make({struct1}, struct1->type()));
   // result3 does not have NaN values
   ASSERT_TRUE(result3->Equals(result3));

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -152,7 +152,7 @@ TEST_F(TestChunkedArray, EqualsSameAddressWithNaNs) {
   ASSERT_OK_AND_ASSIGN(auto result0, ChunkedArray::Make({chunk0, chunk1}, float64()));
   // result0 has NaN values
   ASSERT_FALSE(result0->Equals(result0));
-  
+
   auto chunk2 = ArrayFromJSON(float64(), "[6, 7, 8, 9]");
   ASSERT_OK_AND_ASSIGN(auto result1, ChunkedArray::Make({chunk1, chunk2}, float64()));
   // result1 does not have NaN values
@@ -165,7 +165,7 @@ TEST_F(TestChunkedArray, EqualsSameAddressWithNaNs) {
   ASSERT_OK_AND_ASSIGN(auto result2, ChunkedArray::Make({struct0}, struct0->type()));
   // result2 has NaN values
   ASSERT_FALSE(result2->Equals(result2));
-  
+
   auto array2 = ArrayFromJSON(float64(), "[0, 1, 2]");
   ASSERT_OK_AND_ASSIGN(auto struct1, StructArray::Make({array0, array2}, fieldnames));
   ASSERT_OK_AND_ASSIGN(auto result3, ChunkedArray::Make({struct1}, struct1->type()));


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

`ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other)` assumes that if the two `ChunkedArray`s share the same memory address, then they must be equal. However, this optimization doesn't take into account that `NaN` values are not considered equal by default. Consequently, this can lead to surprising, inconsistent results from a user's perspective. For example, `ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other)`  and `ChunkedArray::Equals(const ChunkedArray& other)` may return different results.

 The program below illustrates this inconsistency:

```c++
#include <arrow/api.h>
#include <arrow/type.h>

#include <iostream>
#include <math.h>
#include <sstream>

arrow::Result<std::shared_ptr<arrow::ChunkedArray>> make_chunked_array() {
    arrow::NumericBuilder<arrow::DoubleType> builder;
    
    std::shared_ptr<arrow::Array> array;
    ARROW_RETURN_NOT_OK(builder.AppendValues({0, 1, NAN, 2, 4}));
    ARROW_RETURN_NOT_OK(builder.Finish(&array));
    
    return arrow::ChunkedArray::Make({array});
}

int main(int argc, char *argv[])
{
    auto maybe_chunked_array = make_chunked_array();
    if (!maybe_chunked_array.ok()) {
        return -1;
    }
    auto chunked_array = std::move(maybe_chunked_array).ValueUnsafe();
    auto array = chunked_array->chunk(0);
    
    std::stringstream stream;

    stream << "chunked_array contents: ";
    stream << "\n\n";
    stream << chunked_array->ToString();
    stream << "\n\n";
    stream << "chunked_array->Equals(chunked_array): ";
    stream << chunked_array->Equals(chunked_array);
    stream << "chunked_array->Equals(*chunked_array): ";
    stream << chunked_array->Equals(*chunked_array);
    
    std::cout << stream.str() << std::endl;
}
```

Here is the output of this program:

```shell
chunked_array contents: 

[
  [
    0,
    1,
    nan,
    2,
    4
  ]
]

chunked_array->Equals(chunked_array): 1
chunked_array->Equals(*chunked_array): 0
```

### What changes are included in this PR?

Updated `ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other)` to only return `true` early IF:
   - The two share the same address AND
   - They cannot have `NaN` values 

If both of those conditions are not satisfied, `ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other)` will do the element-by-element comparison.

### Are these changes tested?

Yes. I added a new test case called `EqualsSameAddressWithNaNs` to `chunked_array_test.cc`.

### Are there any user-facing changes?

Yes. `ChunkedArray::Equals(const std::shared_ptr<arrow::ChunkedArray>& other)` may return `false` even if the two `ChunkedArray`s have the same memory address. This will only occur if the `ChunkedArray`'s contain `NaN` values.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37515