### PR TITLE
GH-37584: [Go] Add value len function to string array

### DIFF
--- a/go/arrow/array/string.go
+++ b/go/arrow/array/string.go
@@ -73,6 +73,14 @@ func (a *String) ValueOffset64(i int) int64 {
 	return int64(a.ValueOffset(i))
 }
 
+func (a *String) ValueLen(i int) int {
+	if i < 0 || i >= a.array.data.length {
+		panic("arrow/array: index out of range")
+	}
+	beg := a.array.data.offset + i
+	return int(a.offsets[beg+1] - a.offsets[beg])
+}
+
 func (a *String) ValueOffsets() []int32 {
 	beg := a.array.data.offset
 	end := beg + a.array.data.length + 1

--- a/go/arrow/array/string_test.go
+++ b/go/arrow/array/string_test.go
@@ -594,3 +594,28 @@ func TestLargeStringStringRoundTrip(t *testing.T) {
 
 	assert.True(t, array.Equal(arr, arr1))
 }
+
+func TestStringValueLen(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "", "", "hijk", "lm", "", "opq", "", "tu"}
+	valids := []bool{true, true, false, false, true, true, true, true, false, true}
+
+	b := array.NewStringBuilder(mem)
+	defer b.Release()
+
+	b.AppendStringValues(values, valids)
+
+	arr := b.NewArray().(*array.String)
+	defer arr.Release()
+
+	slice := array.NewSlice(arr, 2, 9).(*array.String)
+	defer slice.Release()
+
+	vs := values[2:9]
+
+	for i, v := range vs {
+		assert.Equal(t, len(v), slice.ValueLen(i))
+	}
+}


### PR DESCRIPTION
### Rationale for this change

The binary array already has this function, and it's a useful mechanism when all one needs is the length of a value and not the value itself (for pre-allocation of a new buffer for example).

### What changes are included in this PR?

Add function to return only the length of the string at index position `i`.

### Are these changes tested?

Yes tested by including this in https://parca.dev/

### Are there any user-facing changes?

This is a new API mirroring the same API that already exists on the binary array.
* Closes: #37584