### PR TITLE
GH-37587: [C++] Move integration machinery into its own directory and namespace

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -332,8 +332,6 @@ set(ARROW_TESTING_STATIC_LINK_LIBS arrow::flatbuffers rapidjson::rapidjson arrow
 set(ARROW_TESTING_SRCS
     io/test_common.cc
     ipc/test_common.cc
-    testing/json_integration.cc
-    testing/json_internal.cc
     testing/gtest_util.cc
     testing/random.cc
     testing/generator.cc
@@ -374,6 +372,10 @@ endif()
 #
 # Configure the base Arrow libraries
 #
+
+if(ARROW_BUILD_INTEGRATION OR ARROW_BUILD_TESTS)
+  list(APPEND ARROW_SRCS integration/json_integration.cc integration/json_internal.cc)
+endif()
 
 if(ARROW_CSV)
   list(APPEND
@@ -836,12 +838,15 @@ add_subdirectory(tensor)
 add_subdirectory(util)
 add_subdirectory(vendored)
 
-if(ARROW_CSV)
-  add_subdirectory(csv)
+if(ARROW_BUILD_INTEGRATION OR ARROW_BUILD_TESTS)
+  # We build tests for the JSON integration machinery even if integration
+  # is enabled, to ensure it's exercised in more builds than just the
+  # integration build.
+  add_subdirectory(integration)
 endif()
 
-if(ARROW_SUBSTRAIT)
-  add_subdirectory(engine)
+if(ARROW_CSV)
+  add_subdirectory(csv)
 endif()
 
 if(ARROW_ACERO)
@@ -875,6 +880,10 @@ endif()
 
 if(ARROW_ORC)
   add_subdirectory(adapters/orc)
+endif()
+
+if(ARROW_SUBSTRAIT)
+  add_subdirectory(engine)
 endif()
 
 if(ARROW_TENSORFLOW)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -840,7 +840,7 @@ add_subdirectory(vendored)
 
 if(ARROW_BUILD_INTEGRATION OR ARROW_BUILD_TESTS)
   # We build tests for the JSON integration machinery even if integration
-  # is enabled, to ensure it's exercised in more builds than just the
+  # is not enabled, to ensure it's exercised in more builds than just the
   # integration build.
   add_subdirectory(integration)
 endif()

--- a/cpp/src/arrow/flight/integration_tests/test_integration_client.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration_client.cc
@@ -29,6 +29,7 @@
 
 #include <gflags/gflags.h>
 
+#include "arrow/integration/json_integration.h"
 #include "arrow/io/file.h"
 #include "arrow/io/test_common.h"
 #include "arrow/ipc/dictionary.h"
@@ -37,7 +38,6 @@
 #include "arrow/table.h"
 #include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/testing/json_integration.h"
 #include "arrow/util/logging.h"
 
 #include "arrow/flight/api.h"
@@ -49,12 +49,14 @@ DEFINE_int32(port, 31337, "Server port to connect to");
 DEFINE_string(path, "", "Resource path to request");
 DEFINE_string(scenario, "", "Integration test scenario to run");
 
+using arrow::internal::integration::IntegrationJsonReader;
+
 namespace arrow {
 namespace flight {
 namespace integration_tests {
 
 /// \brief Helper to read all batches from a JsonReader
-Status ReadBatches(std::unique_ptr<testing::IntegrationJsonReader>& reader,
+Status ReadBatches(std::unique_ptr<IntegrationJsonReader>& reader,
                    std::vector<std::shared_ptr<RecordBatch>>* chunks) {
   for (int i = 0; i < reader->num_record_batches(); i++) {
     ARROW_ASSIGN_OR_RAISE(auto chunk, reader->ReadRecordBatch(i));
@@ -151,8 +153,8 @@ class IntegrationTestScenario : public Scenario {
     // 1. Put the data to the server.
     std::cout << "Opening JSON file '" << FLAGS_path << "'" << std::endl;
     auto in_file = *io::ReadableFile::Open(FLAGS_path);
-    ARROW_ASSIGN_OR_RAISE(auto reader, testing::IntegrationJsonReader::Open(
-                                           default_memory_pool(), in_file));
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          IntegrationJsonReader::Open(default_memory_pool(), in_file));
 
     std::shared_ptr<Schema> original_schema = reader->schema();
     std::vector<std::shared_ptr<RecordBatch>> original_data;

--- a/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
@@ -31,7 +31,6 @@
 #include "arrow/io/test_common.h"
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
-#include "arrow/testing/json_integration.h"
 #include "arrow/util/logging.h"
 
 #include "arrow/flight/integration_tests/test_integration.h"

--- a/cpp/src/arrow/flight/sql/test_server_cli.cc
+++ b/cpp/src/arrow/flight/sql/test_server_cli.cc
@@ -25,7 +25,6 @@
 #include "arrow/flight/server.h"
 #include "arrow/flight/sql/example/sqlite_server.h"
 #include "arrow/io/test_common.h"
-#include "arrow/testing/json_integration.h"
 #include "arrow/util/logging.h"
 
 DEFINE_int32(port, 31337, "Server port to listen on");

--- a/cpp/src/arrow/integration/CMakeLists.txt
+++ b/cpp/src/arrow/integration/CMakeLists.txt
@@ -15,8 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arrow_install_all_headers("arrow/testing")
+arrow_install_all_headers("arrow/integration")
 
+# json_integration_test is two things at the same time:
+# - an executable that can be called to answer integration test requests
+# - a self-(unit)test for the C++ side of integration testing
 if(ARROW_BUILD_TESTS)
-  add_arrow_test(random_test)
+  add_arrow_test(json_integration_test EXTRA_LINK_LIBS ${GFLAGS_LIBRARIES})
+  add_dependencies(arrow-integration arrow-json-integration-test)
+elseif(ARROW_BUILD_INTEGRATION)
+  add_executable(arrow-json-integration-test json_integration_test.cc)
+  target_link_libraries(arrow-json-integration-test ${ARROW_TEST_LINK_LIBS}
+                        ${GFLAGS_LIBRARIES} ${ARROW_GTEST_GTEST})
+
+  add_dependencies(arrow-json-integration-test arrow arrow_testing)
+  add_dependencies(arrow-integration arrow-json-integration-test)
 endif()

--- a/cpp/src/arrow/integration/json_integration.cc
+++ b/cpp/src/arrow/integration/json_integration.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/testing/json_integration.h"
+#include "arrow/integration/json_integration.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -24,25 +24,19 @@
 #include <utility>
 
 #include "arrow/buffer.h"
+#include "arrow/integration/json_internal.h"
 #include "arrow/io/file.h"
 #include "arrow/ipc/dictionary.h"
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/testing/json_internal.h"
 #include "arrow/type.h"
 #include "arrow/util/logging.h"
 
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+using arrow::ipc::DictionaryFieldMapper;
+using arrow::ipc::DictionaryMemo;
 
-namespace arrow {
-
-using ipc::DictionaryFieldMapper;
-using ipc::DictionaryMemo;
-
-namespace testing {
+namespace arrow::internal::integration {
 
 // ----------------------------------------------------------------------
 // Writer implementation
@@ -211,5 +205,4 @@ Result<std::shared_ptr<RecordBatch>> IntegrationJsonReader::ReadRecordBatch(int 
   return impl_->ReadRecordBatch(i);
 }
 
-}  // namespace testing
-}  // namespace arrow
+}  // namespace arrow::internal::integration

--- a/cpp/src/arrow/integration/json_integration.h
+++ b/cpp/src/arrow/integration/json_integration.h
@@ -24,16 +24,16 @@
 
 #include "arrow/io/type_fwd.h"
 #include "arrow/result.h"
-#include "arrow/testing/visibility.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/visibility.h"
 
-namespace arrow::testing {
+namespace arrow::internal::integration {
 
 /// \class IntegrationJsonWriter
 /// \brief Write the JSON representation of an Arrow record batch file or stream
 ///
 /// This is used for integration testing
-class ARROW_TESTING_EXPORT IntegrationJsonWriter {
+class ARROW_EXPORT IntegrationJsonWriter {
  public:
   ~IntegrationJsonWriter();
 
@@ -64,7 +64,7 @@ class ARROW_TESTING_EXPORT IntegrationJsonWriter {
 /// \brief Read the JSON representation of an Arrow record batch file or stream
 ///
 /// This is used for integration testing
-class ARROW_TESTING_EXPORT IntegrationJsonReader {
+class ARROW_EXPORT IntegrationJsonReader {
  public:
   ~IntegrationJsonReader();
 
@@ -111,4 +111,4 @@ class ARROW_TESTING_EXPORT IntegrationJsonReader {
   std::unique_ptr<Impl> impl_;
 };
 
-}  // namespace arrow::testing
+}  // namespace arrow::internal::integration

--- a/cpp/src/arrow/integration/json_integration_test.cc
+++ b/cpp/src/arrow/integration/json_integration_test.cc
@@ -31,6 +31,8 @@
 #include "arrow/array.h"
 #include "arrow/array/builder_binary.h"
 #include "arrow/array/builder_primitive.h"
+#include "arrow/integration/json_integration.h"
+#include "arrow/integration/json_internal.h"
 #include "arrow/io/file.h"
 #include "arrow/ipc/dictionary.h"
 #include "arrow/ipc/reader.h"
@@ -41,8 +43,6 @@
 #include "arrow/testing/builder.h"
 #include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/testing/json_integration.h"
-#include "arrow/testing/json_internal.h"
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
@@ -65,15 +65,13 @@ DEFINE_bool(validate_date64, true,
 DEFINE_bool(validate_times, true,
             "Validate that values for TIME32 and TIME64 are within their valid ranges");
 
-namespace arrow {
+namespace arrow::internal::integration {
 
-using internal::TemporaryDir;
-using ipc::DictionaryFieldMapper;
-using ipc::DictionaryMemo;
-using ipc::IpcWriteOptions;
-using ipc::MetadataVersion;
-
-namespace testing {
+using ::arrow::internal::TemporaryDir;
+using ::arrow::ipc::DictionaryFieldMapper;
+using ::arrow::ipc::DictionaryMemo;
+using ::arrow::ipc::IpcWriteOptions;
+using ::arrow::ipc::MetadataVersion;
 
 using namespace ::arrow::ipc::test;  // NOLINT
 
@@ -1176,8 +1174,7 @@ const std::vector<ipc::test::MakeRecordBatch*> kBatchCases = {
 INSTANTIATE_TEST_SUITE_P(TestJsonRoundTrip, TestJsonRoundTrip,
                          ::testing::ValuesIn(kBatchCases));
 
-}  // namespace testing
-}  // namespace arrow
+}  // namespace arrow::internal::integration
 
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -1186,7 +1183,7 @@ int main(int argc, char** argv) {
 
   if (FLAGS_integration) {
     arrow::Status result =
-        arrow::testing::RunCommand(FLAGS_json, FLAGS_arrow, FLAGS_mode);
+        arrow::internal::integration::RunCommand(FLAGS_json, FLAGS_arrow, FLAGS_mode);
     if (!result.ok()) {
       std::cout << "Error message: " << result.ToString() << std::endl;
       ret = 1;

--- a/cpp/src/arrow/integration/json_internal.cc
+++ b/cpp/src/arrow/integration/json_internal.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/testing/json_internal.h"
+#include "arrow/integration/json_internal.h"
 
 #include <cstdint>
 #include <cstdlib>
@@ -53,19 +53,16 @@
 #include "arrow/visit_array_inline.h"
 #include "arrow/visit_type_inline.h"
 
-namespace arrow {
+using arrow::internal::checked_cast;
+using arrow::internal::Enumerate;
+using arrow::internal::ParseValue;
+using arrow::internal::Zip;
 
-using internal::checked_cast;
-using internal::Enumerate;
-using internal::ParseValue;
-using internal::Zip;
+using arrow::ipc::DictionaryFieldMapper;
+using arrow::ipc::DictionaryMemo;
+using arrow::ipc::internal::FieldPosition;
 
-using ipc::DictionaryFieldMapper;
-using ipc::DictionaryMemo;
-using ipc::internal::FieldPosition;
-
-namespace testing {
-namespace json {
+namespace arrow::internal::integration::json {
 
 namespace {
 
@@ -1814,6 +1811,4 @@ Status WriteArray(const std::string& name, const Array& array, RjWriter* json_wr
   return converter.Write();
 }
 
-}  // namespace json
-}  // namespace testing
-}  // namespace arrow
+}  // namespace arrow::internal::integration::json

--- a/cpp/src/arrow/integration/json_internal.h
+++ b/cpp/src/arrow/integration/json_internal.h
@@ -32,8 +32,8 @@
 
 #include "arrow/ipc/type_fwd.h"
 #include "arrow/result.h"
-#include "arrow/testing/visibility.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/visibility.h"
 
 namespace rj = arrow::rapidjson;
 using RjWriter = rj::Writer<rj::StringBuffer>;
@@ -75,35 +75,35 @@ using RjObject = rj::Value::ConstObject;
     return Status::Invalid("field was not an object line ", __LINE__); \
   }
 
-namespace arrow::testing::json {
+namespace arrow::internal::integration::json {
 
 /// \brief Append integration test Schema format to rapidjson writer
-ARROW_TESTING_EXPORT
+ARROW_EXPORT
 Status WriteSchema(const Schema& schema, const ipc::DictionaryFieldMapper& mapper,
                    RjWriter* writer);
 
-ARROW_TESTING_EXPORT
+ARROW_EXPORT
 Status WriteDictionary(int64_t id, const std::shared_ptr<Array>& dictionary,
                        RjWriter* writer);
 
-ARROW_TESTING_EXPORT
+ARROW_EXPORT
 Status WriteRecordBatch(const RecordBatch& batch, RjWriter* writer);
 
-ARROW_TESTING_EXPORT
+ARROW_EXPORT
 Status WriteArray(const std::string& name, const Array& array, RjWriter* writer);
 
-ARROW_TESTING_EXPORT
+ARROW_EXPORT
 Result<std::shared_ptr<Schema>> ReadSchema(const rj::Value& json_obj, MemoryPool* pool,
                                            ipc::DictionaryMemo* dictionary_memo);
 
-ARROW_TESTING_EXPORT
+ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
     const rj::Value& json_obj, const std::shared_ptr<Schema>& schema,
     ipc::DictionaryMemo* dict_memo, MemoryPool* pool);
 
 // NOTE: Doesn't work with dictionary arrays, use ReadRecordBatch instead.
-ARROW_TESTING_EXPORT
+ARROW_EXPORT
 Result<std::shared_ptr<Array>> ReadArray(MemoryPool* pool, const rj::Value& json_obj,
                                          const std::shared_ptr<Field>& field);
 
-}  // namespace arrow::testing::json
+}  // namespace arrow::internal::integration::json


### PR DESCRIPTION
### Rationale for this change

The JSON integration machinery currently lives in the `arrow::testing` namespace and the corresponding directory, but it can be compiled and used even when testing is disabled.

### What changes are included in this PR?

Move the integration machinery source files into a new `arrow/integration` directory.

Move the integration APIs into a new `arrow::internal::integration` namespace.

### Are these changes tested?

By existing tests and CI jobs.

### Are there any user-facing changes?

No, as these are not supposed to be public-facing facilities.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37587