### PR TITLE
GH-37597: [MATLAB] Add `toMATLAB` method to `arrow.array.ChunkedArray` class

### DIFF
--- a/matlab/src/matlab/+arrow/+array/ChunkedArray.m
+++ b/matlab/src/matlab/+arrow/+array/ChunkedArray.m
@@ -60,6 +60,17 @@ classdef ChunkedArray < matlab.mixin.CustomDisplay & ...
             array = traits.ArrayConstructor(proxy);
         end
 
+        function data = toMATLAB(obj)
+            data = preallocateMATLABArray(obj.Type,  obj.Length);
+            startIndex = 1;
+            for ii = 1:obj.NumChunks
+                chunk = obj.chunk(ii);
+                endIndex = startIndex + chunk.Length - 1;
+                data(startIndex:endIndex) = toMATLAB(chunk);
+                startIndex = endIndex + 1;
+            end
+        end
+
         function tf = isequal(obj, varargin)
             narginchk(2, inf);
 

--- a/matlab/src/matlab/+arrow/+type/BooleanType.m
+++ b/matlab/src/matlab/+arrow/+type/BooleanType.m
@@ -32,4 +32,10 @@ classdef BooleanType < arrow.type.FixedWidthType
             groups = matlab.mixin.util.PropertyGroup(targets);
         end
     end
+
+    methods(Hidden)
+        function data = preallocateMATLABArray(~, length)
+            data = false([length 1]);
+        end
+    end
 end

--- a/matlab/src/matlab/+arrow/+type/DateType.m
+++ b/matlab/src/matlab/+arrow/+type/DateType.m
@@ -42,4 +42,10 @@ classdef DateType < arrow.type.TemporalType
         end
     end
 
+    methods(Hidden)
+        function data = preallocateMATLABArray(~, length)
+            data = NaT([length 1]);
+        end
+    end
+
 end

--- a/matlab/src/matlab/+arrow/+type/Float32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float32Type.m
@@ -1,3 +1,5 @@
+%FLOAT32TYPE Type class for float32 data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Float32Type < arrow.type.FixedWidthType
-%FLOAT32TYPE Type class for float32 data.
+classdef Float32Type < arrow.type.NumericType
     
     methods 
         function obj = Float32Type(proxy)
@@ -22,7 +23,7 @@ classdef Float32Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Float32Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/Float32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float32Type.m
@@ -26,11 +26,4 @@ classdef Float32Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end

--- a/matlab/src/matlab/+arrow/+type/Float64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float64Type.m
@@ -26,11 +26,4 @@ classdef Float64Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end

--- a/matlab/src/matlab/+arrow/+type/Float64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Float64Type.m
@@ -1,3 +1,5 @@
+%FLOAT64TYPE Type class for float64 data. 
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Float64Type < arrow.type.FixedWidthType
-%FLOAT64Type Type class for float64 data. 
+classdef Float64Type < arrow.type.NumericType
     
     methods 
         function obj = Float64Type(proxy)
@@ -22,7 +23,7 @@ classdef Float64Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Float64Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/Int16Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int16Type.m
@@ -26,12 +26,5 @@ classdef Int16Type < arrow.type.NumericType
             obj@arrow.type.FixedWidthType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end
 

--- a/matlab/src/matlab/+arrow/+type/Int16Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int16Type.m
@@ -1,3 +1,5 @@
+%INT16TYPE Type class for int16 data. 
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,11 +15,10 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int16Type < arrow.type.FixedWidthType
-%INT16TYPE Type class for int8 data. 
+classdef Int16Type < arrow.type.NumericType
     
     methods 
-        function obj = Int16Type(proxy)
+        function obj = NumericType(proxy)
             arguments
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Int16Type")}
             end

--- a/matlab/src/matlab/+arrow/+type/Int16Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int16Type.m
@@ -18,12 +18,12 @@
 classdef Int16Type < arrow.type.NumericType
     
     methods 
-        function obj = NumericType(proxy)
+        function obj = Int16Type(proxy)
             arguments
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Int16Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+type/Int32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int32Type.m
@@ -1,3 +1,5 @@
+%INT32TYPE Type class for int32 data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int32Type < arrow.type.FixedWidthType
-%INT32TYPE Type class for int32 data.
+classdef Int32Type < arrow.type.NumericType
 
     methods 
         function obj = Int32Type(proxy)
@@ -22,7 +23,7 @@ classdef Int32Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Int32Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/Int32Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int32Type.m
@@ -26,12 +26,5 @@ classdef Int32Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end
 

--- a/matlab/src/matlab/+arrow/+type/Int64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int64Type.m
@@ -1,3 +1,5 @@
+%INT64TYPE Type class for int64 data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int64Type < arrow.type.FixedWidthType
-%INT64TYPE Type class for int64 data.
+classdef Int64Type < arrow.type.NumericType
 
     methods 
         function obj = Int64Type(proxy)
@@ -22,7 +23,7 @@ classdef Int64Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Int64Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/Int64Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int64Type.m
@@ -26,11 +26,4 @@ classdef Int64Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end

--- a/matlab/src/matlab/+arrow/+type/Int8Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int8Type.m
@@ -1,3 +1,5 @@
+%INT8TYPE Type class for int8 data. 
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Int8Type < arrow.type.FixedWidthType
-%INT8TYPE Type class for int8 data. 
+classdef Int8Type < arrow.type.NumericType
     
     methods 
         function obj = Int8Type(proxy)
@@ -22,7 +23,7 @@ classdef Int8Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.Int8Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/Int8Type.m
+++ b/matlab/src/matlab/+arrow/+type/Int8Type.m
@@ -26,12 +26,5 @@ classdef Int8Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end
 

--- a/matlab/src/matlab/+arrow/+type/NumericType.m
+++ b/matlab/src/matlab/+arrow/+type/NumericType.m
@@ -1,0 +1,19 @@
+classdef NumericType < arrow.type.FixedWidthType
+
+    methods
+        function obj = NumericType(proxy)
+            arguments
+                proxy(1, 1) libmexclass.proxy.Proxy
+            end
+
+            obj@arrow.type.FixedWidthType(proxy);
+        end
+    end
+
+    methods(Hidden)
+        function data = preallocateMATLABArray(obj, length)
+            traits = arrow.type.traits.traits(obj.Type.ID);
+            data = zeros([length 1], traits.MatlabClassName);
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+type/NumericType.m
+++ b/matlab/src/matlab/+arrow/+type/NumericType.m
@@ -12,7 +12,7 @@ classdef NumericType < arrow.type.FixedWidthType
 
     methods(Hidden)
         function data = preallocateMATLABArray(obj, length)
-            traits = arrow.type.traits.traits(obj.Type.ID);
+            traits = arrow.type.traits.traits(obj.ID);
             data = zeros([length 1], traits.MatlabClassName);
         end
     end

--- a/matlab/src/matlab/+arrow/+type/NumericType.m
+++ b/matlab/src/matlab/+arrow/+type/NumericType.m
@@ -1,3 +1,20 @@
+%NUMERICTYPE Type class for numeric data
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
 classdef NumericType < arrow.type.FixedWidthType
 
     methods

--- a/matlab/src/matlab/+arrow/+type/NumericType.m
+++ b/matlab/src/matlab/+arrow/+type/NumericType.m
@@ -16,4 +16,11 @@ classdef NumericType < arrow.type.FixedWidthType
             data = zeros([length 1], traits.MatlabClassName);
         end
     end
+
+    methods (Access=protected)
+        function groups = getDisplayPropertyGroups(~)
+            targets = "ID";
+            groups = matlab.mixin.util.PropertyGroup(targets);
+        end
+    end
 end

--- a/matlab/src/matlab/+arrow/+type/StringType.m
+++ b/matlab/src/matlab/+arrow/+type/StringType.m
@@ -32,5 +32,11 @@ classdef StringType < arrow.type.Type
             groups = matlab.mixin.util.PropertyGroup(targets);
         end
     end
+
+    methods(Hidden)
+        function data = preallocateMATLABArray(~, length)
+            data = strings(length, 1);
+        end
+    end
 end
 

--- a/matlab/src/matlab/+arrow/+type/TimeType.m
+++ b/matlab/src/matlab/+arrow/+type/TimeType.m
@@ -42,4 +42,11 @@ classdef TimeType < arrow.type.TemporalType
         end
     end
 
+    methods(Hidden)
+        function data = preallocateMATLABArray(~, length)
+            data = NaN([length 1]);
+            data = seconds(data);
+        end
+    end
+
 end

--- a/matlab/src/matlab/+arrow/+type/TimestampType.m
+++ b/matlab/src/matlab/+arrow/+type/TimestampType.m
@@ -47,4 +47,10 @@ classdef TimestampType < arrow.type.TemporalType
             groups = matlab.mixin.util.PropertyGroup(targets);
         end
     end
+    
+    methods(Hidden)
+        function data = preallocateMATLABArray(obj, length)
+            data = NaT([length, 1], TimeZone=obj.TimeZone);
+        end
+    end
 end

--- a/matlab/src/matlab/+arrow/+type/Type.m
+++ b/matlab/src/matlab/+arrow/+type/Type.m
@@ -93,6 +93,10 @@ classdef (Abstract) Type < matlab.mixin.CustomDisplay & ...
         end
     end
 
+    methods(Abstract, Hidden)
+        data = preallocateMATLABArray(obj, length)
+    end
+
     methods (Sealed)
         function tf = isequal(obj, varargin)
 

--- a/matlab/src/matlab/+arrow/+type/UInt16Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt16Type.m
@@ -26,12 +26,4 @@ classdef UInt16Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt16Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt16Type.m
@@ -1,3 +1,5 @@
+%UINT16TYPE Type class for uint16 data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt16Type < arrow.type.FixedWidthType
-%UINT16TYPE Type class for uint16 data.
+classdef UInt16Type < arrow.type.NumericType
     
     methods 
         function obj = UInt16Type(proxy)
@@ -22,7 +23,7 @@ classdef UInt16Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.UInt16Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/UInt32Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt32Type.m
@@ -26,12 +26,4 @@ classdef UInt32Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt32Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt32Type.m
@@ -1,3 +1,5 @@
+%UINT32TYPE Type class for uint32 data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt32Type < arrow.type.FixedWidthType
-%UINT32TYPE Type class for uint32 data.
+classdef UInt32Type < arrow.type.NumericType
     
     methods 
         function obj = UInt32Type(proxy)
@@ -22,7 +23,7 @@ classdef UInt32Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.UInt32Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/UInt64Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt64Type.m
@@ -26,11 +26,4 @@ classdef UInt64Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end

--- a/matlab/src/matlab/+arrow/+type/UInt64Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt64Type.m
@@ -1,3 +1,5 @@
+%UINT64TYPE Type class for uint64 data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt64Type < arrow.type.FixedWidthType
-%UINT64TYPE Type class for uint64 data.
+classdef UInt64Type < arrow.type.NumericType
     
     methods 
         function obj = UInt64Type(proxy)
@@ -22,7 +23,7 @@ classdef UInt64Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.UInt64Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/UInt8Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt8Type.m
@@ -1,3 +1,5 @@
+%UINT8TYPE Type class for uint8 data.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -13,8 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef UInt8Type < arrow.type.FixedWidthType
-%UINT8TYPE Type class for uint8 data.
+classdef UInt8Type < arrow.type.NumericType
     
     methods 
         function obj = UInt8Type(proxy)
@@ -22,7 +23,7 @@ classdef UInt8Type < arrow.type.FixedWidthType
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.type.proxy.UInt8Type")}
             end
             import arrow.internal.proxy.validate
-            obj@arrow.type.FixedWidthType(proxy);
+            obj@arrow.type.NumericType(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/UInt8Type.m
+++ b/matlab/src/matlab/+arrow/+type/UInt8Type.m
@@ -26,11 +26,4 @@ classdef UInt8Type < arrow.type.NumericType
             obj@arrow.type.NumericType(proxy);
         end
     end
-
-    methods (Access=protected)
-        function groups = getDisplayPropertyGroups(~)
-            targets = "ID";
-            groups = matlab.mixin.util.PropertyGroup(targets);
-        end
-    end
 end

--- a/matlab/test/arrow/array/tChunkedArray.m
+++ b/matlab/test/arrow/array/tChunkedArray.m
@@ -315,7 +315,7 @@ classdef tChunkedArray < matlab.unittest.TestCase
         end
 
         function ToMATLABFloatTypes(testCase, FloatMatlabClass)
-             % Verify toMATLAB returns the expected MATLAB array when the
+            % Verify toMATLAB returns the expected MATLAB array when the
             % Chunked Array contains float arrays.
             import arrow.array.ChunkedArray
 

--- a/matlab/test/arrow/array/tChunkedArray.m
+++ b/matlab/test/arrow/array/tChunkedArray.m
@@ -24,6 +24,21 @@ classdef tChunkedArray < matlab.unittest.TestCase
         Float64Type = arrow.float64()
     end
 
+    properties(TestParameter)
+        IntegerMatlabClass = {"uint8", ...
+                              "uint16", ...
+                              "uint32", ...
+                              "uint64", ...
+                              "int8", ...
+                              "int16", ...
+                              "int32", ...
+                              "int64"};
+
+        FloatMatlabClass = {"single", "double"}
+
+        TimeZone = {"America/New_York", ""}
+    end
+
     methods (Test)
         function FromArraysTooFewInputsError(testCase)
             % Verify an error is thrown when neither the Type nv-pair nor
@@ -239,6 +254,214 @@ classdef tChunkedArray < matlab.unittest.TestCase
 
             fcn = @() chunkedArray.chunk(2);
             testCase.verifyError(fcn, "arrow:chunkedarray:NumericIndexWithEmptyChunkedArray");
+        end
+
+        function ToMATLABBooleanType(testCase)
+            % Verify toMATLAB returns the expected MATLAB array when the
+            % Chunked Array contains boolean arrays.
+            import arrow.array.ChunkedArray
+
+            bools = true([1 11]);
+            bools([2 3 7 8 9]) = false;
+            a1 = arrow.array(bools(1:8));
+            a2 = arrow.array(bools(8:7));
+            a3 = arrow.array(bools(9:11));
+
+            % ChunkedArray with three chunks and nonzero length
+            chunkedArray1 = ChunkedArray.fromArrays(a1, a2, a3);
+            actualArray1 = toMATLAB(chunkedArray1);
+            expectedArray1 = bools';
+            testCase.verifyEqual(actualArray1, expectedArray1);
+
+            % ChunkedArray with zero chunks and zero length
+            chunkedArray2 = ChunkedArray.fromArrays(Type=a1.Type);
+            actualArray2 = toMATLAB(chunkedArray2);
+            expectedArray2 = logical.empty(0, 1);
+            testCase.verifyEqual(actualArray2, expectedArray2);
+
+            % ChunkedArray with two chunks and zero length
+            chunkedArray3 = ChunkedArray.fromArrays(a2, a2);
+            actualArray3 = toMATLAB(chunkedArray3);
+            expectedArray3 = logical.empty(0, 1);
+            testCase.verifyEqual(actualArray3, expectedArray3);
+        end
+
+        function ToMATLABIntegerTypes(testCase, IntegerMatlabClass)
+            % Verify toMATLAB returns the expected MATLAB array when the
+            % Chunked Array contains integer arrays.
+            import arrow.array.ChunkedArray
+
+            a1 = arrow.array(cast([1 2 3 4], IntegerMatlabClass));
+            a2 = arrow.array(cast([], IntegerMatlabClass));
+            a3 = arrow.array(cast([5 6 7 8 9], IntegerMatlabClass));
+
+            % ChunkedArray with three chunks and nonzero length
+            chunkedArray1 = ChunkedArray.fromArrays(a1, a2, a3);
+            actualArray1 = toMATLAB(chunkedArray1);
+            expectedArray1 = cast((1:9)', IntegerMatlabClass);
+            testCase.verifyEqual(actualArray1, expectedArray1);
+
+            % ChunkedArray with zero chunks and zero length
+            chunkedArray2 = ChunkedArray.fromArrays(Type=a1.Type);
+            actualArray2 = toMATLAB(chunkedArray2);
+            expectedArray2 = cast(double.empty(0, 1), IntegerMatlabClass);
+            testCase.verifyEqual(actualArray2, expectedArray2);
+
+            % ChunkedArray with two chunks and zero length
+            chunkedArray3 = ChunkedArray.fromArrays(a2, a2);
+            actualArray3 = toMATLAB(chunkedArray3);
+            expectedArray3 = cast(double.empty(0, 1), IntegerMatlabClass);
+            testCase.verifyEqual(actualArray3, expectedArray3);
+        end
+
+        function ToMATLABFloatTypes(testCase, FloatMatlabClass)
+             % Verify toMATLAB returns the expected MATLAB array when the
+            % Chunked Array contains float arrays.
+            import arrow.array.ChunkedArray
+
+            a1 = arrow.array(cast([1 NaN 3 4], FloatMatlabClass));
+            a2 = arrow.array(cast([], FloatMatlabClass));
+            a3 = arrow.array(cast([5 6 7 NaN 9], FloatMatlabClass));
+
+            % ChunkedArray with three chunks and nonzero length
+            chunkedArray1 = ChunkedArray.fromArrays(a1, a2, a3);
+            actualArray1 = toMATLAB(chunkedArray1);
+            expectedArray1 = cast((1:9)', FloatMatlabClass);
+            expectedArray1([2 8]) = NaN;
+            testCase.verifyEqual(actualArray1, expectedArray1);
+
+            % ChunkedArray with zero chunks and zero length
+            chunkedArray2 = ChunkedArray.fromArrays(Type=a1.Type);
+            actualArray2 = toMATLAB(chunkedArray2);
+            expectedArray2 = cast(double.empty(0, 1), FloatMatlabClass);
+            testCase.verifyEqual(actualArray2, expectedArray2);
+
+            % ChunkedArray with two chunks and zero length
+            chunkedArray3 = ChunkedArray.fromArrays(a2, a2);
+            actualArray3 = toMATLAB(chunkedArray3);
+            expectedArray3 = cast(double.empty(0, 1), FloatMatlabClass);
+            testCase.verifyEqual(actualArray3, expectedArray3);
+        end
+
+        function ToMATLABTimeTypes(testCase)
+            % Verify toMATLAB returns the expected MATLAB array when the
+            % Chunked Array contains time arrays.
+            import arrow.array.ChunkedArray
+
+            a1 = arrow.array(seconds([1 NaN 3 4]));
+            a2 = arrow.array(seconds([]));
+            a3 = arrow.array(seconds([5 6 7 NaN 9]));
+
+            % ChunkedArray with three chunks and nonzero length
+            chunkedArray1 = ChunkedArray.fromArrays(a1, a2, a3);
+            actualArray1 = toMATLAB(chunkedArray1);
+            expectedArray1 = seconds((1:9)');
+            expectedArray1([2 8]) = NaN;
+            testCase.verifyEqual(actualArray1, expectedArray1);
+
+            % ChunkedArray with zero chunks and zero length
+            chunkedArray2 = ChunkedArray.fromArrays(Type=a1.Type);
+            actualArray2 = toMATLAB(chunkedArray2);
+            expectedArray2 = duration.empty(0, 1);
+            testCase.verifyEqual(actualArray2, expectedArray2);
+
+            % ChunkedArray with two chunks and zero length
+            chunkedArray3 = ChunkedArray.fromArrays(a2, a2);
+            actualArray3 = toMATLAB(chunkedArray3);
+            expectedArray3 = duration.empty(0, 1);
+            testCase.verifyEqual(actualArray3, expectedArray3);
+        end
+
+        function ToMATLABDateTypes(testCase)
+            % Verify toMATLAB returns the expected MATLAB array when the
+            % Chunked Array contains date arrays.
+            import arrow.array.*
+
+            dates = datetime(2023, 9, 7) + days(0:10);
+            dates([5 9]) = NaT;
+            a1 = Date64Array.fromMATLAB(dates(1:5));
+            a2 = Date64Array.fromMATLAB(dates(6:5));
+            a3 = Date64Array.fromMATLAB(dates(6:end));
+
+            % ChunkedArray with three chunks and nonzero length
+            chunkedArray1 = ChunkedArray.fromArrays(a1, a2, a3);
+            actualArray1 = toMATLAB(chunkedArray1);
+            expectedArray1 = dates';
+            testCase.verifyEqual(actualArray1, expectedArray1);
+
+            % ChunkedArray with zero chunks and zero length
+            chunkedArray2 = ChunkedArray.fromArrays(Type=a1.Type);
+            actualArray2 = toMATLAB(chunkedArray2);
+            expectedArray2 = datetime.empty(0, 1);
+            testCase.verifyEqual(actualArray2, expectedArray2);
+
+            % ChunkedArray with two chunks and zero length
+            chunkedArray3 = ChunkedArray.fromArrays(a2, a2);
+            actualArray3 = toMATLAB(chunkedArray3);
+            expectedArray3 = datetime.empty(0, 1);
+            testCase.verifyEqual(actualArray3, expectedArray3);
+        end
+
+        function ToMATLABTimestampType(testCase, TimeZone)
+            % Verify toMATLAB returns the expected MATLAB array when the
+            % Chunked Array contains timestamp arrays.
+            import arrow.array.ChunkedArray
+
+            dates = datetime(2023, 9, 7, TimeZone=TimeZone) + days(0:10);
+            dates([5 9]) = NaT;
+            a1 = arrow.array(dates(1:5));
+            a2 = arrow.array(dates(6:5));
+            a3 = arrow.array(dates(6:end));
+
+            % ChunkedArray with three chunks and nonzero length
+            chunkedArray1 = ChunkedArray.fromArrays(a1, a2, a3);
+            actualArray1 = toMATLAB(chunkedArray1);
+            expectedArray1 = dates';
+            testCase.verifyEqual(actualArray1, expectedArray1);
+
+            % ChunkedArray with zero chunks and zero length
+            chunkedArray2 = ChunkedArray.fromArrays(Type=a1.Type);
+            actualArray2 = toMATLAB(chunkedArray2);
+            expectedArray2 = datetime.empty(0, 1);
+            expectedArray2.TimeZone = TimeZone;
+            testCase.verifyEqual(actualArray2, expectedArray2);
+
+            % ChunkedArray with two chunks and zero length
+            chunkedArray3 = ChunkedArray.fromArrays(a2, a2);
+            actualArray3 = toMATLAB(chunkedArray3);
+            expectedArray3 = datetime.empty(0, 1);
+            expectedArray3.TimeZone = TimeZone;
+            testCase.verifyEqual(actualArray3, expectedArray3);
+        end
+
+        function ToMATLABStringType(testCase)
+            % Verify toMATLAB returns the expected MATLAB array when the
+            % Chunked Array contains string arrays.
+            import arrow.array.*
+
+            strs = compose("%d", 1:11);
+            strs([5 9]) = missing;
+            a1 = arrow.array(strs(1:7));
+            a2 = arrow.array(strs(7:6));
+            a3 = arrow.array(strs(8:11));
+
+            % ChunkedArray with three chunks and nonzero length
+            chunkedArray1 = ChunkedArray.fromArrays(a1, a2, a3);
+            actualArray1 = toMATLAB(chunkedArray1);
+            expectedArray1 = strs';
+            testCase.verifyEqual(actualArray1, expectedArray1);
+
+            % ChunkedArray with zero chunks and zero length
+            chunkedArray2 = ChunkedArray.fromArrays(Type=a1.Type);
+            actualArray2 = toMATLAB(chunkedArray2);
+            expectedArray2 = string.empty(0, 1);
+            testCase.verifyEqual(actualArray2, expectedArray2);
+
+            % ChunkedArray with two chunks and zero length
+            chunkedArray3 = ChunkedArray.fromArrays(a2, a2);
+            actualArray3 = toMATLAB(chunkedArray3);
+            expectedArray3 = string.empty(0, 1);
+            testCase.verifyEqual(actualArray3, expectedArray3);
         end
     end
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Currently, there is no way to easily convert an `arrow.array.ChunkedArray` into a corresponding MATLAB array, other than (1) manually iterating chunk by chunk, (2) calling `toMATLAB` on each chunk, and then (3) concatenating all of the converted chunks together into one contiguous MATLAB array.

It would be helpful to add a toMATLAB method to `arrow.array.ChunkedArray` that abstracts away all of these steps.

### What changes are included in this PR?

1. Added `toMATLAB` method to `arrow.array.ChunkedArray` class
2. Added `preallocateMATLABArray` abstract method to `arrow.type.Type` class. This method is used by the `ChunkedArray` `toMATLAB` to pre-allocate a MATLAB array of the expected class type and shape. This is necessary to ensure `toMATLAB` returns the correct MATLAB array when the `ChunkedArray` has zero chunks. If `toMATLAB` stored the result of calling `toMATLAB` on each chunk in a `cell` array before concatenating the values, `toMATLAB` would return a 0x0 `double` array for zero-chunked arrays. The pre-allocation approach avoids this issue.
3. Implement `preallocateMATLABArray` on all `arrow.type.Type` classes.
4. Added an abstract class `arrow.type.NumericType` that all classes representing numeric data types inherit from. `NumericType` implements `preallocateMATLABArray` for its subclasses.

### Are these changes tested?

Yes. Added unit tests to `tChunkedArray.m`.

### Are there any user-facing changes?

Yes. Users can now call `toMATLAB` on `ChunkedArray`s.

**Example**

```matlab

>> a = arrow.array([1 2 NaN 4 5]);
>> b = arrow.array([6 7 8 9 NaN 11]);
>> c = arrow.array.ChunkedArray.fromArrays(a, b);
>> data = toMATLAB(c)

data =

     1
     2
   NaN
     4
     5
     6
     7
     8
     9
   NaN
    11


```
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37597