### PR TITLE
GH-37614: [R][CI] Update CI jobs due to duckdb repo moving

### DIFF
--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -47,7 +47,7 @@ ${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran
 
 # Install DuckDB from github when requested
 if [ ${R_DUCKDB_DEV} == "true" ]; then
-  ${R_BIN} -e "remotes::install_github('duckdb/duckdb', subdir = '/tools/rpkg', build = FALSE)"
+  ${R_BIN} -e "remotes::install_github('duckdb/duckdb-r', subdir = '/tools/rpkg', build = FALSE)"
 fi
 
 # Separately install the optional/test dependencies but don't error on them,

--- a/ci/scripts/r_deps.sh
+++ b/ci/scripts/r_deps.sh
@@ -47,7 +47,7 @@ ${R_BIN} -e "options(warn=2); install.packages('remotes'); remotes::install_cran
 
 # Install DuckDB from github when requested
 if [ ${R_DUCKDB_DEV} == "true" ]; then
-  ${R_BIN} -e "remotes::install_github('duckdb/duckdb-r', subdir = '/tools/rpkg', build = FALSE)"
+  ${R_BIN} -e "remotes::install_github('duckdb/duckdb-r', build = FALSE)"
 fi
 
 # Separately install the optional/test dependencies but don't error on them,


### PR DESCRIPTION
### Rationale for this change

Duckdb have moved the R package to a separate repo

### What changes are included in this PR?

Updates the duckdb R package dev repo 

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #37614