### PR TITLE
GH-37569: [MATLAB] Implement `isequal` for the `arrow.type.Field` MATLAB class

### DIFF
--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -53,9 +53,7 @@ classdef Field < matlab.mixin.CustomDisplay
         function tf = isequal(obj, varargin)
             narginchk(2, inf);
             tf = false;
-            
-            names = [obj(:).Name];
-            types = 
+             
             namesToCompare = strings(numel(obj), numel(varargin));
             typesToCompare = cell([1 numel(varargin)]);
 
@@ -69,7 +67,7 @@ classdef Field < matlab.mixin.CustomDisplay
 
                 % field(:) flattens N-dimensional arrays into column vectors.
                 namesToCompare(:, ii) = [field(:).Name];
-                typesToCompare(1, ii) = {field(:).Type};
+                typesToCompare{1, ii} = [field(:).Type];
             end
 
             names = [obj(:).Name];

--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -50,6 +50,37 @@ classdef Field < matlab.mixin.CustomDisplay
             name = obj.Proxy.getName();
         end
 
+        function tf = isequal(obj, varargin)
+            narginchk(2, inf);
+            tf = false;
+            
+            names = [obj(:).Name];
+            types = 
+            namesToCompare = strings(numel(obj), numel(varargin));
+            typesToCompare = cell([1 numel(varargin)]);
+
+            for ii = 1:numel(varargin)
+                field = varargin{ii};
+                if ~isa(field, "arrow.type.Field") || ~isequal(size(obj), size(field))
+                    % Return early if field is not an arrow.type.Field
+                    % or if the dimensions of obj and field do not match.
+                    return;
+                end
+
+                % field(:) flattens N-dimensional arrays into column vectors.
+                namesToCompare(:, ii) = [field(:).Name];
+                typesToCompare(1, ii) = {field(:).Type};
+            end
+
+            names = [obj(:).Name];
+            if any(names ~= namesToCompare, "all")
+                % Return early if the field names don't match
+                return;
+            end
+
+            types = [obj(:).Type];
+            tf = isequal(types, typesToCompare{:});
+        end
     end
 
     methods (Access = private)

--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -65,17 +65,18 @@ classdef Field < matlab.mixin.CustomDisplay
                     return;
                 end
 
-                % field(:) flattens N-dimensional arrays into column vectors.
                 namesToCompare(:, ii) = [field(:).Name];
                 typesToCompare{1, ii} = [field(:).Type];
             end
 
-            names = [obj(:).Name];
+            names = [obj(:).Name]';
             if any(names ~= namesToCompare, "all")
-                % Return early if the field names don't match
+                % Return false early if the field names are not equal.
                 return;
             end
 
+            % Field names were equal. Check if their corresponding types
+            % are equal and return the result.
             types = [obj(:).Type];
             tf = isequal(types, typesToCompare{:});
         end

--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -54,7 +54,7 @@ classdef Field < matlab.mixin.CustomDisplay
         function tf = isequal(obj, varargin)
             narginchk(2, inf);
             tf = false;
-             
+
             namesToCompare = strings(numel(obj), numel(varargin));
             typesToCompare = cell([1 numel(varargin)]);
 
@@ -70,16 +70,22 @@ classdef Field < matlab.mixin.CustomDisplay
                 typesToCompare{1, ii} = [field(:).Type];
             end
 
-            names = [obj(:).Name]';
-            if any(names ~= namesToCompare, "all")
-                % Return false early if the field names are not equal.
-                return;
+            if isempty(obj)
+                % Return true early if the Field array is empty. Already
+                % confirmed all the Field arrays have the same shape.
+                tf = true;
+            else
+                names = [obj(:).Name]';
+                if any(names ~= namesToCompare, "all")
+                    % Return false early if the field names are not equal.
+                    return;
+                end
+    
+                % Field names were equal. Check if their corresponding types
+                % are equal and return the result.
+                types = [obj(:).Type];
+                tf = isequal(types, typesToCompare{:});
             end
-
-            % Field names were equal. Check if their corresponding types
-            % are equal and return the result.
-            types = [obj(:).Type];
-            tf = isequal(types, typesToCompare{:});
         end
     end
 

--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -71,8 +71,10 @@ classdef Field < matlab.mixin.CustomDisplay
             end
 
             if isempty(obj)
-                % Return true early if the Field array is empty. Already
-                % confirmed all the Field arrays have the same shape.
+                % At this point, since we have already confirmed all the 
+                % Fields have the same dimensions, if one of the Fields are
+                % empty, then they must all be empty. This means they must
+                % all be equal.
                 tf = true;
             else
                 names = [obj(:).Name]';

--- a/matlab/src/matlab/+arrow/+type/Field.m
+++ b/matlab/src/matlab/+arrow/+type/Field.m
@@ -1,3 +1,7 @@
+%FIELD A class representing a name and a type.
+% Fields are often used in tabular schemas for describing a column's
+% name and type.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -14,9 +18,6 @@
 % permissions and limitations under the License.
 
 classdef Field < matlab.mixin.CustomDisplay
-%FIELD A class representing a name and a type.
-% Fields are often used in tabular schemas for describing a column's
-% name and type.
 
     properties (GetAccess=public, SetAccess=private, Hidden)
         Proxy

--- a/matlab/test/arrow/type/tField.m
+++ b/matlab/test/arrow/type/tField.m
@@ -172,7 +172,7 @@ classdef tField < matlab.unittest.TestCase
             testCase.verifyTrue(isequal(fieldArray1, fieldArray2, fieldArray1));
         end
 
-         function TestIsEqualEmptyFields(testCase)
+        function TestIsEqualEmptyFields(testCase)
             % Verify isequal returns the expected value when at least one
             % of the inputs is empty.
             
@@ -204,7 +204,8 @@ classdef tField < matlab.unittest.TestCase
         end
 
         function TestIsEqualNonScalarFalse(testCase)
-            % Verifies isequal returns false when expected.
+            % Verifies isequal returns false when expected for non-scalar
+            % Field arrays.
             
             f1 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
             f2 = arrow.field("B", arrow.string());

--- a/matlab/test/arrow/type/tField.m
+++ b/matlab/test/arrow/type/tField.m
@@ -128,27 +128,77 @@ classdef tField < matlab.unittest.TestCase
         end
 
         function TestIsEqualScalarTrue(testCase)
+            % Two scalar arrow.type.Field objects are equal if:
+            %
+            %  1. Their Name properties are equal
+            %  2. Their Type properties are equal
+
             f1 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
             f2 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
             testCase.verifyTrue(isequal(f1, f2));
         end
 
         function TestIsEqualScalarFalse(testCase)
+            % Verifies isequal returns false when expected. 
             f1 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
             f2 = arrow.field("B", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
             f3 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Millisecond"));
-            f3 = arrow.field("A", arrow.tim32());
+            f4 = arrow.field("A", arrow.time32());
 
-            % Field names are not equal
+            % Name properties are not equal
             testCase.verifyFalse(isequal(f1, f2));
 
-            % The Type properties are of the same class type, but their
-            % instances are not equal.
+            % Type properties are not equal
             testCase.verifyFalse(isequal(f1, f3));
 
-            % The Type 
+            % Type properties have different class types
+            testCase.verifyFalse(isequal(f1, f4));
+
+            % Compare arrow.type.Field and a string
+            testCase.verifyFalse(isequal(f1, "A"));
+        end
+
+        function TestIsEqualNonScalarTrue(testCase)
+            % Two nonscalar arrow.type.Field arrays are equal if:
+            %  1. They have the same shape
+            %  2. Their corresponding Field elements are equal
+            
+            f1 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
+            f2 = arrow.field("B", arrow.string());
+            fieldArray1 = [f1 f2 f1; f2 f1 f1];
+            fieldArray2 = [f1 f2 f1; f2 f1 f1];
+
+            testCase.verifyTrue(isequal(fieldArray1, fieldArray2));
+            testCase.verifyTrue(isequal(fieldArray1, fieldArray2, fieldArray1));
+
 
         end
 
+        function TestIsEqualNonScalarFalse(testCase)
+            % Verifies isequal returns false when expected.
+            
+            f1 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
+            f2 = arrow.field("B", arrow.string());
+            f3 = arrow.field("B", arrow.date32());
+            f4 = arrow.field("C", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
+
+            fieldArray1 = [f1 f2 f3; f4 f1 f2];
+            fieldArray2 = reshape(fieldArray1, [3 2]);
+            fieldArray3 = [f1 f3 f3; f4 f1 f2];
+            fieldArray4 = [f4 f2 f3; f4 f1 f2];
+            
+            % They have different shapes
+            testCase.verifyFalse(isequal(fieldArray1, fieldArray2));
+            testCase.verifyFalse(isequal(fieldArray1, fieldArray2, fieldArray1));
+
+            % Their corresponding elements are not equal - type mismatch
+            testCase.verifyFalse(isequal(fieldArray1, fieldArray3));
+
+            % Their corresponding elements are not equal - name mismatch
+            testCase.verifyFalse(isequal(fieldArray1, fieldArray4));
+
+            % Compare arrow.type.Field array and a string array
+            testCase.verifyFalse(isequal(f1, strings(size(f1))));
+        end
     end
 end

--- a/matlab/test/arrow/type/tField.m
+++ b/matlab/test/arrow/type/tField.m
@@ -127,5 +127,28 @@ classdef tField < matlab.unittest.TestCase
             testCase.verifyError(@() setfield(field, "Type", arrow.boolean), "MATLAB:class:noSetMethod")
         end
 
+        function TestIsEqualScalarTrue(testCase)
+            f1 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
+            f2 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
+            testCase.verifyTrue(isequal(f1, f2));
+        end
+
+        function TestIsEqualScalarFalse(testCase)
+            f1 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
+            f2 = arrow.field("B", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Second"));
+            f3 = arrow.field("A", arrow.timestamp(TimeZone="America/New_York", TimeUnit="Millisecond"));
+            f3 = arrow.field("A", arrow.tim32());
+
+            % Field names are not equal
+            testCase.verifyFalse(isequal(f1, f2));
+
+            % The Type properties are of the same class type, but their
+            % instances are not equal.
+            testCase.verifyFalse(isequal(f1, f3));
+
+            % The Type 
+
+        end
+
     end
 end

--- a/matlab/test/arrow/type/tField.m
+++ b/matlab/test/arrow/type/tField.m
@@ -170,8 +170,37 @@ classdef tField < matlab.unittest.TestCase
 
             testCase.verifyTrue(isequal(fieldArray1, fieldArray2));
             testCase.verifyTrue(isequal(fieldArray1, fieldArray2, fieldArray1));
+        end
 
+         function TestIsEqualEmptyFields(testCase)
+            % Verify isequal returns the expected value when at least one
+            % of the inputs is empty.
+            
+            f1 = arrow.type.Field.empty(1, 0);
+            f2 = arrow.type.Field.empty(0, 1);
+            f3 = arrow.type.Field.empty(0, 0);
+            f4 = arrow.field("B", arrow.string());
 
+            % Compare two 1x0 Field arrays
+            testCase.verifyTrue(isequal(f1, f1));
+            
+            % Compare two 0x1 Field arrays
+            testCase.verifyTrue(isequal(f2, f2));
+
+            % Compare two 0x0 Field arrays
+            testCase.verifyTrue(isequal(f3, f3));
+
+            % Compare 1x0 and 0x1 Field arrays
+            testCase.verifyFalse(isequal(f1, f2));
+
+            % Compare 1x0 and 0x0 Field arrays
+            testCase.verifyFalse(isequal(f1, f3));
+
+            % Compare 0x1 and 0x0 Field arrays
+            testCase.verifyFalse(isequal(f2, f3));
+
+            % Compare 1x0 and 1x1 Field arrays
+            testCase.verifyFalse(isequal(f1, f4));
         end
 
         function TestIsEqualNonScalarFalse(testCase)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Following on to https://github.com/apache/arrow/pull/37474, https://github.com/apache/arrow/pull/37446, and https://github.com/apache/arrow/pull/37525, we should implement `isequal` for the `arrow.type.Field` MATLAB class.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Implemented the `isequal` method for `arrow.type.Field`

### Are these changes tested?

Yes. Add new unit tests to `tField.m`

### Are there any user-facing changes?

Yes. Users can now call `isequal` on `arrow.type.Field`s to determine if two fields are equal.

**Example**
```matlab
>> f1 = arrow.field("A", arrow.time32(TimeUnit="Second"));
>> f2 = arrow.field("B", arrow.time32(TimeUnit="Second"));
>> f3 = arrow.field("A", arrow.time32(TimeUnit="Millisecond"));

>> isequal(f1, f1)

ans =

  logical

   1

% Name properties differ
>> isequal(f1, f2)

ans =

  logical

   0

% Type properties differ
>> isequal(f1, f3)

ans =

  logical

   0
```

### Future Directions

1. #37568
2. #37570

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37569