### PR TITLE
GH-37570: [MATLAB] Implement `isequal` for the `arrow.tabular.RecordBatch` MATLAB class

### DIFF
--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -106,32 +106,18 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
             end
 
             if ~isequal(obj.Schema, schemasToCompare{:})
-                % Return early if the Schemas are not all equal
+                % If the Schemas are not equal, the RecordBatches are not
+                % equal. Return false early.
                 return;
             end
 
-            numColumns = obj.NumColumns;
-            %columnsToCompare = cell([numel(varargin) numColumns]);
-
-            for ii = 1:numColumns
+            for ii = 1:obj.NumColumns
                 columnsToCompare = arrayfun(@(idx) varargin{idx}.column(ii), 1:numel(varargin), UniformOutput=false);
                 if ~isequal(obj.column(ii), columnsToCompare{:})
                     return;
                 end
             end
             tf = true;
-
-            % 
-            %     columnsToCompare(ii, :) = arrayfun(@(idx) rb.column(idx), 1:numColumns, UniformOutput=false);
-            % end
-            % 
-            % for ii = 1:numColumns
-            %     if ~isequal(obj.column(ii), columnsToCompare{:, ii})
-            %         return;
-            %     end
-            % end
-            % 
-            % tf = true;
         end
     end
 

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -106,7 +106,7 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
             end
 
             if ~isequal(obj.Schema, schemasToCompare{:})
-                % If the Schemas are not equal, the RecordBatches are not
+                % If the Schemas are not equal, the RecordBatch's are not
                 % equal. Return false early.
                 return;
             end

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -1,3 +1,7 @@
+%RECORDBATCH A tabular data structure representing a set of 
+%arrow.array.Array objects with a fixed schema.
+
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -15,8 +19,6 @@
 
 classdef RecordBatch < matlab.mixin.CustomDisplay & ...
                        matlab.mixin.Scalar
-%arrow.tabular.RecordBatch A tabular data structure representing
-% a set of arrow.array.Array objects with a fixed schema.
 
     properties (Dependent, SetAccess=private, GetAccess=public)
         NumColumns
@@ -100,19 +102,31 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
             for ii = 1:numel(varargin)
                 rb = varargin{ii};
                 if ~isa(rb, "arrow.tabular.RecordBatch")
+                    % If rb is not a RecordBatch, than it cannot be equal
+                    % to obj. Return false early.
                     return;
                 end
                 schemasToCompare{ii} = rb.Schema;
             end
 
             if ~isequal(obj.Schema, schemasToCompare{:})
-                % If the Schemas are not equal, the RecordBatch's are not
+                % If the schemas are not equal, the record batches are not
                 % equal. Return false early.
                 return;
             end
 
+            % Function that extracts the column stored at colIndex from the
+            % record batch stored at rbIndex in varargin.
+            getColulmnFcn = @(rbIndex, colIndex) varargin{rbIndex}.column(colIndex);
+
+            rbIndices = 1:numel(varargin);
             for ii = 1:obj.NumColumns
-                columnsToCompare = arrayfun(@(idx) varargin{idx}.column(ii), 1:numel(varargin), UniformOutput=false);
+                colIndices = repmat(ii, [1 numel(rbIndices)]);
+                % Gather all columns at index ii across within the record
+                % batches stored in varargin. Compare these columns with
+                % the corresponding column in obj. If they are not equal,
+                % then the record batches are not equal. Return false.
+                columnsToCompare = arrayfun(getColulmnFcn, rbIndices, colIndices, UniformOutput=false);
                 if ~isequal(obj.column(ii), columnsToCompare{:})
                     return;
                 end

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -102,7 +102,7 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
             for ii = 1:numel(varargin)
                 rb = varargin{ii};
                 if ~isa(rb, "arrow.tabular.RecordBatch")
-                    % If rb is not a RecordBatch, than it cannot be equal
+                    % If rb is not a RecordBatch, then it cannot be equal
                     % to obj. Return false early.
                     return;
                 end
@@ -117,16 +117,16 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
 
             % Function that extracts the column stored at colIndex from the
             % record batch stored at rbIndex in varargin.
-            getColulmnFcn = @(rbIndex, colIndex) varargin{rbIndex}.column(colIndex);
+            getColumnFcn = @(rbIndex, colIndex) varargin{rbIndex}.column(colIndex);
 
             rbIndices = 1:numel(varargin);
             for ii = 1:obj.NumColumns
                 colIndices = repmat(ii, [1 numel(rbIndices)]);
-                % Gather all columns at index ii across within the record
+                % Gather all columns at index ii across the record
                 % batches stored in varargin. Compare these columns with
                 % the corresponding column in obj. If they are not equal,
                 % then the record batches are not equal. Return false.
-                columnsToCompare = arrayfun(getColulmnFcn, rbIndices, colIndices, UniformOutput=false);
+                columnsToCompare = arrayfun(getColumnFcn, rbIndices, colIndices, UniformOutput=false);
                 if ~isequal(obj.column(ii), columnsToCompare{:})
                     return;
                 end

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -91,6 +91,48 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
         function T = toMATLAB(obj)
             T = obj.table();
         end
+
+        function tf = isequal(obj, varargin)
+            narginchk(2, inf);
+            tf = false;
+
+            schemasToCompare = cell([1 numel(varargin)]);
+            for ii = 1:numel(varargin)
+                rb = varargin{ii};
+                if ~isa(rb, "arrow.tabular.RecordBatch")
+                    return;
+                end
+                schemasToCompare{ii} = rb.Schema;
+            end
+
+            if ~isequal(obj.Schema, schemasToCompare{:})
+                % Return early if the Schemas are not all equal
+                return;
+            end
+
+            numColumns = obj.NumColumns;
+            %columnsToCompare = cell([numel(varargin) numColumns]);
+
+            for ii = 1:numColumns
+                columnsToCompare = arrayfun(@(idx) varargin{idx}.column(ii), 1:numel(varargin), UniformOutput=false);
+                if ~isequal(obj.column(ii), columnsToCompare{:})
+                    return;
+                end
+            end
+            tf = true;
+
+            % 
+            %     columnsToCompare(ii, :) = arrayfun(@(idx) rb.column(idx), 1:numColumns, UniformOutput=false);
+            % end
+            % 
+            % for ii = 1:numColumns
+            %     if ~isequal(obj.column(ii), columnsToCompare{:, ii})
+            %         return;
+            %     end
+            % end
+            % 
+            % tf = true;
+        end
     end
 
     methods (Access = private)

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -386,6 +386,78 @@ classdef tRecordBatch < matlab.unittest.TestCase
             testCase.verifyError(@() recordBatch.column(name), "arrow:badsubscript:NonScalar");
         end
 
+        function TestIsEqualTrue(testCase)
+            % Verify two record batches are considered equal if:
+            %   1. They have the same schema
+            %   2. Their corresponding columns are equal
+            import arrow.tabular.RecordBatch
+
+            a1 = arrow.array([1 2 3]);
+            a2 = arrow.array(["A" "B" "C"]);
+            a3 = arrow.array([true true false]);
+
+            rb1 = RecordBatch.fromArrays(a1, a2, a3, ...
+                ColumnNames=["A", "B", "C"]);
+            rb2 = RecordBatch.fromArrays(a1, a2, a3, ...
+                ColumnNames=["A", "B", "C"]);
+            testCase.verifyTrue(isequal(rb1, rb2));
+
+            % Compare zero-column record batches
+            rb3 = RecordBatch.fromArrays();
+            rb4 = RecordBatch.fromArrays();
+            testCase.verifyTrue(isequal(rb3, rb4));
+
+            % Compare zero-row record batches
+            a4 = arrow.array([]);
+            a5 = arrow.array(strings(0, 0));
+            rb5 = RecordBatch.fromArrays(a4, a5, ColumnNames=["D" "E"]);
+            rb6 = RecordBatch.fromArrays(a4, a5, ColumnNames=["D" "E"]);
+            testCase.verifyTrue(isequal(rb5, rb6));
+
+            % Call isequal with more than two arguments
+            testCase.verifyTrue(isequal(rb3, rb4, rb3, rb4));
+        end
+
+        function TestIsEqualFalse(testCase)
+            % Verify isequal returns false when expected.
+            import arrow.tabular.RecordBatch
+
+            a1 = arrow.array([1 2 3]);
+            a2 = arrow.array(["A" "B" "C"]);
+            a3 = arrow.array([true true false]);
+            a4 = arrow.array(["A" missing "C"]); 
+            a5 = arrow.array([1 2]);
+            a6 = arrow.array(["A" "B"]);
+            a7 = arrow.array([true true]);
+
+            rb1 = RecordBatch.fromArrays(a1, a2, a3, ...
+                ColumnNames=["A", "B", "C"]);
+            rb2 = RecordBatch.fromArrays(a1, a2, a3, ...
+                ColumnNames=["D", "E", "F"]);
+            rb3 = RecordBatch.fromArrays(a1, a4, a3, ...
+                ColumnNames=["A", "B", "C"]);
+            rb4 = RecordBatch.fromArrays(a5, a6, a7, ...
+                ColumnNames=["A", "B", "C"]);
+            rb5 = RecordBatch.fromArrays(a1, a2, a3, a1, ...
+                ColumnNames=["A", "B", "C", "D"]);
+
+            % The column names are not equal
+            testCase.verifyFalse(isequal(rb1, rb2));
+
+            % The columns are not equal
+            testCase.verifyFalse(isequal(rb1, rb3));
+
+            % The number of rows are not equal
+            testCase.verifyFalse(isequal(rb1, rb4));
+
+             % The number of columns are not equal
+            testCase.verifyFalse(isequal(rb1, rb5));
+
+            % Call isequal with more than two arguments
+            testCase.verifyFalse(isequal(rb1, rb2, rb3, rb4));
+        end
+
+
     end
 
     methods

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -450,7 +450,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
             % The number of rows are not equal
             testCase.verifyFalse(isequal(rb1, rb4));
 
-             % The number of columns are not equal
+            % The number of columns are not equal
             testCase.verifyFalse(isequal(rb1, rb5));
 
             % Call isequal with more than two arguments


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Following on to https://github.com/apache/arrow/pull/37474, https://github.com/apache/arrow/pull/37446, and https://github.com/apache/arrow/pull/37525, we should implement `isequal` for the `arrow.tabular.RecordBatch` MATLAB class.

### What changes are included in this PR?

1. Implemented `isequal` method for `arrow.tabular.RecordBatch`

### Are these changes tested?

Yes. Added `isequal` unit tests to `tRecordBatch.m`.

### Are there any user-facing changes?

Yes, users can now use `isequal` to compare `arrow.tabular.RecordBatch`es. 

**Example**

```matlab
>> t1 = table(1, "A", false, VariableNames=["Number",  "String", "Logical"]);
>> t2 = table([1; 2], ["A"; "B"], [false; false], VariableNames=["Number",  "String", "Logical"]); 
>> rb1 = arrow.recordBatch(t1);
>> rb2 = arrow.recordBatch(t2);
>> rb3 = arrow.recordBatch(t1);

>> isequal(rb1, rb2)

ans =

  logical

   0

>> isequal(rb1, rb3)

ans =

  logical

   1
```

### Future Directions
1. #37628
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37570