### PR TITLE
MINOR: [Python][Documentation] Fix docstring of `preserve_index` in `Schema.from_pandas`

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2637,7 +2637,7 @@ cdef class Schema(_Weakrefable):
         
         preserve_index : bool, optional
             Whether to store the index as an additional column (or columns, 
-            for MultiIndex)in the resulting ``Schema``. The default of None
+            for MultiIndex) in the resulting ``Schema``. The default of None
             will store the index as a column, except for RangeIndex which 
             is stored as metadata only. Use ``preserve_index=True`` to force
             it to be stored as a column.

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2634,13 +2634,14 @@ cdef class Schema(_Weakrefable):
         Parameters
         ----------
         df : pandas.DataFrame
-        preserve_index : bool, default True
-            Whether to store the index as an additional column (or columns, for
-            MultiIndex) in the resulting `Table`.
-            The default of None will store the index as a column, except for
-            RangeIndex which is stored as metadata only. Use
-            ``preserve_index=True`` to force it to be stored as a column.
-
+        
+        preserve_index : bool, optional
+            Whether to store the index as an additional column (or columns, 
+            for MultiIndex)in the resulting ``Schema``. The default of None
+            will store the index as a column, except for RangeIndex which 
+            is stored as metadata only. Use ``preserve_index=True`` to force
+            it to be stored as a column.
+        
         Returns
         -------
         pyarrow.Schema

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2636,11 +2636,10 @@ cdef class Schema(_Weakrefable):
         df : pandas.DataFrame
         
         preserve_index : bool, optional
-            Whether to store the index as an additional field (or fields, 
-            for MultiIndex) in the resulting ``Schema``. The default of None
-            will store the index as a field, except for RangeIndex which 
-            is stored as metadata only. Use ``preserve_index=True`` to force
-            it to be stored as a field.
+            Whether to store the index as an additional field in the resulting
+            ``Schema``. The default of None will store the index as a field,
+            except for RangeIndex which is stored as metadata only. Use
+            ``preserve_index=True`` to force it to be stored as a field.
         
         Returns
         -------

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2636,11 +2636,11 @@ cdef class Schema(_Weakrefable):
         df : pandas.DataFrame
         
         preserve_index : bool, optional
-            Whether to store the index as an additional column (or columns, 
+            Whether to store the index as an additional field (or fields, 
             for MultiIndex) in the resulting ``Schema``. The default of None
-            will store the index as a column, except for RangeIndex which 
+            will store the index as a field, except for RangeIndex which 
             is stored as metadata only. Use ``preserve_index=True`` to force
-            it to be stored as a column.
+            it to be stored as a field.
         
         Returns
         -------

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2634,13 +2634,13 @@ cdef class Schema(_Weakrefable):
         Parameters
         ----------
         df : pandas.DataFrame
-        
+
         preserve_index : bool, optional
             Whether to store the index as an additional field in the resulting
             ``Schema``. The default of None will store the index as a field,
             except for RangeIndex which is stored as metadata only. Use
             ``preserve_index=True`` to force it to be stored as a field.
-        
+
         Returns
         -------
         pyarrow.Schema


### PR DESCRIPTION
### Rationale for this change

The documentation of the `preserve_index` keyword does not match its default behavior. This PR updates it to match the behavior also described in `Table.from_pandas`.

### What changes are included in this PR?

Updated documentation

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

No, documentation only

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Documentation only
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->