### PR TITLE
GH-37639: [CI] Fix checkout on older OSes

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -27,7 +27,7 @@ on:
 
 {%- macro github_checkout_arrow(fetch_depth=1, submodules="recursive", action_v="v4") -%}
   - name: Checkout Arrow
-    uses: actions/checkout@v{{ action_version }}
+    uses: actions/checkout@v{{ action_v }}
     with:
       fetch-depth: {{ fetch_depth }}
       path: arrow

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -25,7 +25,7 @@ on:
       - "*-github-*"
 {% endmacro %}
 
-{%- macro github_checkout_arrow(fetch_depth=1, submodules="recursive", action_v="v4") -%}
+{%- macro github_checkout_arrow(fetch_depth=1, submodules="recursive", action_v="4") -%}
   - name: Checkout Arrow
     uses: actions/checkout@v{{ action_v }}
     with:

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -27,7 +27,7 @@ on:
 
 {%- macro github_checkout_arrow(fetch_depth=1, submodules="recursive", action_v="v4") -%}
   - name: Checkout Arrow
-    uses: actions/checkout{{ action_v }}
+    uses: actions/checkout@v{{ action_version }}
     with:
       fetch-depth: {{ fetch_depth }}
       path: arrow

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -25,9 +25,9 @@ on:
       - "*-github-*"
 {% endmacro %}
 
-{%- macro github_checkout_arrow(fetch_depth=1, submodules="recursive") -%}
+{%- macro github_checkout_arrow(fetch_depth=1, submodules="recursive", action_v="v4") -%}
   - name: Checkout Arrow
-    uses: actions/checkout@v4
+    uses: actions/checkout{{ action_v }}
     with:
       fetch-depth: {{ fetch_depth }}
       path: arrow

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -34,7 +34,7 @@ jobs:
             - "{{ macros.r_release.ver }}"
             - "{{ macros.r_oldrel.ver }}"
     steps:
-      {{ macros.github_checkout_arrow()|indent }}
+      {{ macros.github_checkout_arrow(action_v='v3')|indent }}
       - name: Configure autobrew script
         run: |
           # minio and sccache are pre-installed on the self-hosted 10.13 runner

--- a/dev/tasks/r/github.macos.autobrew.yml
+++ b/dev/tasks/r/github.macos.autobrew.yml
@@ -34,7 +34,7 @@ jobs:
             - "{{ macros.r_release.ver }}"
             - "{{ macros.r_oldrel.ver }}"
     steps:
-      {{ macros.github_checkout_arrow(action_v='v3')|indent }}
+      {{ macros.github_checkout_arrow(action_v='3')|indent }}
       - name: Configure autobrew script
         run: |
           # minio and sccache are pre-installed on the self-hosted 10.13 runner

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -262,7 +262,7 @@ jobs:
       # Get the arrow checkout just for the docker config scripts
       # Don't need submodules for this (hence false arg to macro): they fail on
       # actions/checkout for some reason in this context
-      {{ macros.github_checkout_arrow(1, false)|indent }}
+      {{ macros.github_checkout_arrow(1, false, 'v3')|indent }}
       - name: Install system requirements
         env:
           ARROW_R_DEV: "TRUE" # To install curl/openssl in r_docker_configure.sh

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -262,7 +262,8 @@ jobs:
       # Get the arrow checkout just for the docker config scripts
       # Don't need submodules for this (hence false arg to macro): they fail on
       # actions/checkout for some reason in this context
-      {{ macros.github_checkout_arrow(1, false, 'v3')|indent }}
+      {{ macros.github_checkout_arrow(1, false, '3')|indent }}
+
       - name: Install system requirements
         env:
           ARROW_R_DEV: "TRUE" # To install curl/openssl in r_docker_configure.sh


### PR DESCRIPTION

### Rationale for this change

Jobs are failing due to not being supported by node 20

### What changes are included in this PR?

Using v3 where needed.

### Are these changes tested?

Crossbow
* Closes: #37639