### PR TITLE
GH-37643: [C++] Enhance arrow::Datum::ToString

### DIFF
--- a/c_glib/test/test-array-datum.rb
+++ b/c_glib/test/test-array-datum.rb
@@ -61,7 +61,7 @@ class TestArrayDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("Array", @datum.to_s)
+    assert_equal("Array([\n" + "  true,\n" + "  false\n" + "])", @datum.to_s)
   end
 
   def test_value

--- a/c_glib/test/test-chunked-array-datum.rb
+++ b/c_glib/test/test-chunked-array-datum.rb
@@ -49,7 +49,7 @@ class TestChunkedArrayDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("ChunkedArray", @datum.to_s)
+    assert_equal("ChunkedArray([\n" + "  [\n" + "    true,\n" + "    false\n" + "  ]\n" + "])", @datum.to_s)
   end
 
   def test_value

--- a/c_glib/test/test-record-batch-datum.rb
+++ b/c_glib/test/test-record-batch-datum.rb
@@ -49,7 +49,7 @@ class TestRecordBatchDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("RecordBatch", @datum.to_s)
+    assert_equal("RecordBatch(visible:   [\n" + "    true,\n" + "    false\n" + "  ]\n" + ")", @datum.to_s)
   end
 
   def test_value

--- a/c_glib/test/test-scalar-datum.rb
+++ b/c_glib/test/test-scalar-datum.rb
@@ -60,7 +60,7 @@ class TestScalarDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("Scalar", @datum.to_s)
+    assert_equal("Scalar(true)", @datum.to_s)
   end
 
   def test_value

--- a/c_glib/test/test-table-datum.rb
+++ b/c_glib/test/test-table-datum.rb
@@ -49,7 +49,16 @@ class TestTableDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("Table", @datum.to_s)
+    assert_equal("Table(visible: bool\n" +
+    "----\n" +
+    "visible:\n" +
+    "  [\n" +
+    "    [\n" +
+    "      true,\n" +
+    "      false\n" +
+    "    ]\n" +
+    "  ]\n" +
+    ")", @datum.to_s)
   end
 
   def test_value

--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -182,15 +182,15 @@ std::string Datum::ToString() const {
     case Datum::NONE:
       return "nullptr";
     case Datum::SCALAR:
-      return "Scalar";
+      return "Scalar(" + scalar()->ToString() + ")";
     case Datum::ARRAY:
-      return "Array";
+      return "Array(" + make_array()->ToString() + ")";
     case Datum::CHUNKED_ARRAY:
-      return "ChunkedArray";
+      return "ChunkedArray(" + chunked_array()->ToString() + ")";
     case Datum::RECORD_BATCH:
-      return "RecordBatch";
+      return "RecordBatch(" + record_batch()->ToString() + ")";
     case Datum::TABLE:
-      return "Table";
+      return "Table(" + table()->ToString() + ")";
     default:
       DCHECK(false);
       return "";

--- a/cpp/src/arrow/datum.h
+++ b/cpp/src/arrow/datum.h
@@ -301,7 +301,6 @@ struct ARROW_EXPORT Datum {
   bool operator==(const Datum& other) const { return Equals(other); }
   bool operator!=(const Datum& other) const { return !Equals(other); }
 
-  /// \brief Return a string representation of the kind of datum stored.
   std::string ToString() const;
 };
 

--- a/cpp/src/arrow/datum_test.cc
+++ b/cpp/src/arrow/datum_test.cc
@@ -154,8 +154,8 @@ TEST(Datum, ToString) {
   Datum v1(arr);
   Datum v2(std::make_shared<Int8Scalar>(1));
 
-  ASSERT_EQ("Array", v1.ToString());
-  ASSERT_EQ("Scalar", v2.ToString());
+  ASSERT_EQ("Array([\n  1,\n  2,\n  3,\n  4\n])", v1.ToString());
+  ASSERT_EQ("Scalar(1)", v2.ToString());
 }
 
 TEST(Datum, TotalBufferSize) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Add print child fields for `arrow::Datum::ToString`. Because previously it just print a type.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add detail in `arrow::Datum::ToString`

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

no

### Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37643