### PR TITLE
GH-37671: [R] legacy timezone symlinks cause CRAN failures

### DIFF
--- a/r/tests/testthat/helper-data.R
+++ b/r/tests/testthat/helper-data.R
@@ -59,9 +59,9 @@ haven_data <- tibble::tibble(
 example_with_times <- tibble::tibble(
   date = Sys.Date() + 1:10,
   posixct = lubridate::ymd_hms("2018-10-07 19:04:05") + 1:10,
-  posixct_tz = lubridate::ymd_hms("2018-10-07 19:04:05", tz = "US/Eastern") + 1:10,
+  posixct_tz = lubridate::ymd_hms("2018-10-07 19:04:05", tz = "America/New_York") + 1:10,
   posixlt = as.POSIXlt(lubridate::ymd_hms("2018-10-07 19:04:05") + 1:10),
-  posixlt_tz = as.POSIXlt(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "US/Eastern") + 1:10)
+  posixlt_tz = as.POSIXlt(lubridate::ymd_hms("2018-10-07 19:04:05", tz = "America/New_York") + 1:10)
 )
 
 verses <- list(

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -283,8 +283,8 @@ test_that("array supports POSIXct (ARROW-3340)", {
   times[5] <- NA
   expect_array_roundtrip(times, timestamp("us", "UTC"))
 
-  times2 <- lubridate::ymd_hms("2018-10-07 19:04:05", tz = "US/Eastern") + 1:10
-  expect_array_roundtrip(times2, timestamp("us", "US/Eastern"))
+  times2 <- lubridate::ymd_hms("2018-10-07 19:04:05", tz = "America/New_York") + 1:10
+  expect_array_roundtrip(times2, timestamp("us", "America/New_York"))
 })
 
 test_that("array uses local timezone for POSIXct without timezone", {

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -3606,7 +3606,7 @@ test_that("with_tz() and force_tz() works", {
     "2012-01-01 01:02:03"
   ), tz = "UTC")
 
-  timestamps_non_utc <- force_tz(timestamps, "US/Central")
+  timestamps_non_utc <- force_tz(timestamps, "America/Chicago")
 
   nonexistent <- as_datetime(c(
     "2015-03-29 02:30:00",
@@ -3622,10 +3622,10 @@ test_that("with_tz() and force_tz() works", {
     .input %>%
       mutate(
         timestamps_with_tz_1 = with_tz(timestamps, "UTC"),
-        timestamps_with_tz_2 = with_tz(timestamps, "US/Central"),
+        timestamps_with_tz_2 = with_tz(timestamps, "America/Chicago"),
         timestamps_with_tz_3 = with_tz(timestamps, "Asia/Kolkata"),
         timestamps_force_tz_1 = force_tz(timestamps, "UTC"),
-        timestamps_force_tz_2 = force_tz(timestamps, "US/Central"),
+        timestamps_force_tz_2 = force_tz(timestamps, "America/Chicago"),
         timestamps_force_tz_3 = force_tz(timestamps, "Asia/Kolkata")
       ) %>%
       collect(),
@@ -3636,7 +3636,7 @@ test_that("with_tz() and force_tz() works", {
     .input %>%
       mutate(
         timestamps_with_tz_1 = with_tz(timestamps, "UTC"),
-        timestamps_with_tz_2 = with_tz(timestamps, "US/Central"),
+        timestamps_with_tz_2 = with_tz(timestamps, "America/Chicago"),
         timestamps_with_tz_3 = with_tz(timestamps, "Asia/Kolkata")
       ) %>%
       collect(),
@@ -3733,17 +3733,17 @@ test_that("with_tz() and force_tz() can add timezone to timestamp without timezo
 
   expect_equal(
     arrow_table(timestamps = timestamps) %>%
-      mutate(timestamps = with_tz(timestamps, "US/Central")) %>%
+      mutate(timestamps = with_tz(timestamps, "America/Chicago")) %>%
       compute(),
-    arrow_table(timestamps = timestamps$cast(timestamp("s", "US/Central")))
+    arrow_table(timestamps = timestamps$cast(timestamp("s", "America/Chicago")))
   )
 
   expect_equal(
     arrow_table(timestamps = timestamps) %>%
-      mutate(timestamps = force_tz(timestamps, "US/Central")) %>%
+      mutate(timestamps = force_tz(timestamps, "America/Chicago")) %>%
       compute(),
     arrow_table(
-      timestamps = call_function("assume_timezone", timestamps, options = list(timezone = "US/Central"))
+      timestamps = call_function("assume_timezone", timestamps, options = list(timezone = "America/Chicago"))
     )
   )
 })


### PR DESCRIPTION
### Rationale for this change

A tzdata update causes our tests to fail on CRAN due to our use of legacy timezones (i.e. starting with "US/") in some of our tests

### What changes are included in this PR?

Update the timezones

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #37671