### PR TITLE
GH-26685: [Python] use IPC for pickle serialisation

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1405,6 +1405,7 @@ def chunked_array(arrays, type=None):
         c_result = GetResultValue(CChunkedArray.Make(c_arrays, c_type))
     return pyarrow_wrap_chunked_array(c_result)
 
+
 def _reconstruct_chunked_array(restore_table, buffer):
     """
     Restore an IPC serialized ChunkedArray.

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1985,35 +1985,21 @@ def test_cast_identities(ty, values):
 
 
 pickle_test_parametrize = pytest.mark.parametrize(
-    ('data', 'typ'),
-    [
-        # Int array
-        (list(range(999)) + [None], pa.int64()),
-        # Float array
-        (list(map(float, range(999))) + [None], pa.float64()),
-        # Boolean array
-        ([True, False, None, True] * 250, pa.bool_()),
-        # String array
-        (['a', 'b', 'cd', None, 'efg'] * 200, pa.string()),
-        # List array
-        ([[1, 2], [3], [None, 4, 5], [6]] * 250, pa.list_(pa.int64())),
-        # Large list array
-        (
-            [[4, 5], [6], [None, 7], [8, 9, 10]] * 250,
-            pa.large_list(pa.int16())
-        ),
-        # String list array
-        (
-            [['a'], None, ['b', 'cd'], ['efg']] * 250,
-            pa.list_(pa.string())
-        ),
-        # Struct array
-        (
-            [(1, 'a'), (2, 'c'), None, (3, 'b')] * 250,
-            pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())])
-        ),
-        # Empty array
-    ])
+        ('data', 'typ'),
+        [
+            ([True, False, True, True], pa.bool_()),
+            ([1, 2, 4, 6], pa.int64()),
+            ([1.0, 2.5, None], pa.float64()),
+            (['a', None, 'b'], pa.string()),
+            ([], None),
+            ([[1, 2], [3]], pa.list_(pa.int64())),
+            ([[4, 5], [6]], pa.large_list(pa.int16())),
+            ([['a'], None, ['b', 'c']], pa.list_(pa.string())),
+            ([(1, 'a'), (2, 'c'), None],
+                pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())]))
+        ]
+    )
+
 
 
 @pickle_test_parametrize
@@ -2065,7 +2051,37 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
         assert result_addresses == addresses
 
 
-@pickle_test_parametrize
+@pytest.mark.parametrize(
+    ('data', 'typ'),
+    [
+        # Int array
+        (list(range(999)) + [None], pa.int64()),
+        # Float array
+        (list(map(float, range(999))) + [None], pa.float64()),
+        # Boolean array
+        ([True, False, None, True] * 250, pa.bool_()),
+        # String array
+        (['a', 'b', 'cd', None, 'efg'] * 200, pa.string()),
+        # List array
+        ([[1, 2], [3], [None, 4, 5], [6]] * 250, pa.list_(pa.int64())),
+        # Large list array
+        (
+            [[4, 5], [6], [None, 7], [8, 9, 10]] * 250,
+            pa.large_list(pa.int16())
+        ),
+        # String list array
+        (
+            [['a'], None, ['b', 'cd'], ['efg']] * 250,
+            pa.list_(pa.string())
+        ),
+        # Struct array
+        (
+            [(1, 'a'), (2, 'c'), None, (3, 'b')] * 250,
+            pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())])
+        ),
+        # Empty array
+    ])
+
 def test_array_pickle_slice_truncation(data, typ, pickle_module):
     arr = pa.array(data, type=typ)
     serialized_arr = pickle_module.dumps(arr)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1985,20 +1985,20 @@ def test_cast_identities(ty, values):
 
 
 pickle_test_parametrize = pytest.mark.parametrize(
-        ('data', 'typ'),
-        [
-            ([True, False, True, True], pa.bool_()),
-            ([1, 2, 4, 6], pa.int64()),
-            ([1.0, 2.5, None], pa.float64()),
-            (['a', None, 'b'], pa.string()),
-            ([], None),
-            ([[1, 2], [3]], pa.list_(pa.int64())),
-            ([[4, 5], [6]], pa.large_list(pa.int16())),
-            ([['a'], None, ['b', 'c']], pa.list_(pa.string())),
-            ([(1, 'a'), (2, 'c'), None],
-                pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())]))
-        ]
-    )
+    ('data', 'typ'),
+    [
+        ([True, False, True, True], pa.bool_()),
+        ([1, 2, 4, 6], pa.int64()),
+        ([1.0, 2.5, None], pa.float64()),
+        (['a', None, 'b'], pa.string()),
+        ([], None),
+        ([[1, 2], [3]], pa.list_(pa.int64())),
+        ([[4, 5], [6]], pa.large_list(pa.int16())),
+        ([['a'], None, ['b', 'c']], pa.list_(pa.string())),
+        ([(1, 'a'), (2, 'c'), None],
+            pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())]))
+    ]
+)
 
 
 
@@ -2081,7 +2081,6 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
         ),
         # Empty array
     ])
-
 def test_array_pickle_slice_truncation(data, typ, pickle_module):
     arr = pa.array(data, type=typ)
     serialized_arr = pickle_module.dumps(arr)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1985,35 +1985,35 @@ def test_cast_identities(ty, values):
 
 
 pickle_test_parametrize = pytest.mark.parametrize(
-        ('data', 'typ'),
-        [
-            # Int array
-            (list(range(999)) + [None], pa.int64()),
-            # Float array
-            (list(map(float, range(999))) + [None], pa.float64()),
-            # Boolean array
-            ([True, False, None, True] * 250, pa.bool_()),
-            # String array
-            (['a', 'b', 'cd', None, 'efg'] * 200, pa.string()),
-            # List array
-            ([[1, 2], [3], [None, 4, 5], [6]] * 250, pa.list_(pa.int64())),
-            # Large list array
-            (
-                [[4, 5], [6], [None, 7], [8, 9, 10]] * 250,
-                pa.large_list(pa.int16())
-            ),
-            # String list array
-            (
-                [['a'], None, ['b', 'cd'], ['efg']] * 250,
-                pa.list_(pa.string())
-            ),
-            # Struct array
-            (
-                [(1, 'a'), (2, 'c'), None, (3, 'b')] * 250,
-                pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())])
-            ),
-            # Empty array
-        ])
+    ('data', 'typ'),
+    [
+        # Int array
+        (list(range(999)) + [None], pa.int64()),
+        # Float array
+        (list(map(float, range(999))) + [None], pa.float64()),
+        # Boolean array
+        ([True, False, None, True] * 250, pa.bool_()),
+        # String array
+        (['a', 'b', 'cd', None, 'efg'] * 200, pa.string()),
+        # List array
+        ([[1, 2], [3], [None, 4, 5], [6]] * 250, pa.list_(pa.int64())),
+        # Large list array
+        (
+            [[4, 5], [6], [None, 7], [8, 9, 10]] * 250,
+            pa.large_list(pa.int16())
+        ),
+        # String list array
+        (
+            [['a'], None, ['b', 'cd'], ['efg']] * 250,
+            pa.list_(pa.string())
+        ),
+        # Struct array
+        (
+            [(1, 'a'), (2, 'c'), None, (3, 'b')] * 250,
+            pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())])
+        ),
+        # Empty array
+    ])
 
 
 @pickle_test_parametrize
@@ -2064,6 +2064,7 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
                             for buf in result.buffers()]
         assert result_addresses == addresses
 
+
 @pickle_test_parametrize
 def test_array_pickle_slice_truncation(data, typ, pickle_module):
     arr = pa.array(data, type=typ)
@@ -2083,11 +2084,11 @@ def test_array_pickle_slice_truncation(data, typ, pickle_module):
     # Check that pickling reset the offset
     assert post_pickle_slice.offset == 0
 
-    # Check that after pickling the slice buffer was trimmed to only contain the sliced data
+    # After pickling the slice buffer trimmed to only contain the sliced data
     buf_size = arr.get_total_buffer_size()
     post_pickle_slice_buf_size = post_pickle_slice.get_total_buffer_size()
-    assert buf_size / post_pickle_slice_buf_size - len(arr) / len(post_pickle_slice) < 10
-
+    assert buf_size / post_pickle_slice_buf_size - \
+        len(arr) / len(post_pickle_slice) < 10
 
 
 @pytest.mark.parametrize(

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2068,15 +2068,15 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
 @pickle_test_parametrize
 def test_array_pickle_slice_truncation(data, typ, pickle_module):
     arr = pa.array(data, type=typ)
-    serialized = pickle_module.dumps(arr)
+    serialized_arr = pickle_module.dumps(arr)
 
     slice_arr = arr.slice(10, 2)
-    serialized = pickle_module.dumps(slice_arr)
+    serialized_slice = pickle_module.dumps(slice_arr)
 
     # Check truncation upon serialization
-    assert len(serialized) <= 0.2 * len(serialized)
+    assert len(serialized_slice) <= 0.2 * len(serialized_arr)
 
-    post_pickle_slice = pickle_module.loads(serialized)
+    post_pickle_slice = pickle_module.loads(serialized_slice)
 
     # Check for post-roundtrip equality
     assert post_pickle_slice.equals(slice_arr)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -286,7 +286,35 @@ def test_chunked_array_equals():
     assert not pa.chunked_array([], type=pa.int32()).equals(None)
 
 
-pickle_test_parametrize = pytest.mark.parametrize(
+
+
+@pytest.mark.parametrize(
+    ('data', 'typ'),
+    [
+        ([True, False, True, True], pa.bool_()),
+        ([1, 2, 4, 6], pa.int64()),
+        ([1.0, 2.5, None], pa.float64()),
+        (['a', None, 'b'], pa.string()),
+        ([], pa.list_(pa.uint8())),
+        ([[1, 2], [3]], pa.list_(pa.int64())),
+        ([['a'], None, ['b', 'c']], pa.list_(pa.string())),
+        ([(1, 'a'), (2, 'c'), None],
+            pa.struct([pa.field('a', pa.int64()), pa.field('b', pa.string())]))
+    ]
+)
+def test_chunked_array_pickle(data, typ, pickle_module):
+    arrays = []
+    while data:
+        arrays.append(pa.array(data[:2], type=typ))
+        data = data[2:]
+    array = pa.chunked_array(arrays, type=typ)
+    array.validate()
+    result = pickle_module.loads(pickle_module.dumps(array))
+    result.validate()
+    assert result.equals(array)
+
+
+@pytest.mark.parametrize(
     ('data', 'typ'),
     [
         # Int array
@@ -316,22 +344,6 @@ pickle_test_parametrize = pytest.mark.parametrize(
         ),
     ]
 )
-
-
-@pickle_test_parametrize
-def test_chunked_array_pickle(data, typ, pickle_module):
-    arrays = []
-    while data:
-        arrays.append(pa.array(data[:2], type=typ))
-        data = data[2:]
-    array = pa.chunked_array(arrays, type=typ)
-    array.validate()
-    result = pickle_module.loads(pickle_module.dumps(array))
-    result.validate()
-    assert result.equals(array)
-
-
-@pickle_test_parametrize
 def test_chunked_array_pickle_slice_truncation(data, typ, pickle_module):
     # create chunked array
     arrays = []

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -286,8 +286,6 @@ def test_chunked_array_equals():
     assert not pa.chunked_array([], type=pa.int32()).equals(None)
 
 
-
-
 @pytest.mark.parametrize(
     ('data', 'typ'),
     [

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -285,8 +285,9 @@ def test_chunked_array_equals():
     # ARROW-4822
     assert not pa.chunked_array([], type=pa.int32()).equals(None)
 
+
 pickle_test_parametrize = pytest.mark.parametrize(
-        ('data', 'typ'),
+    ('data', 'typ'),
     [
         # Int array
         (list(range(999)) + [None], pa.int64()),
@@ -316,6 +317,7 @@ pickle_test_parametrize = pytest.mark.parametrize(
     ]
 )
 
+
 @pickle_test_parametrize
 def test_chunked_array_pickle(data, typ, pickle_module):
     arrays = []
@@ -328,6 +330,7 @@ def test_chunked_array_pickle(data, typ, pickle_module):
     result.validate()
     assert result.equals(array)
 
+
 @pickle_test_parametrize
 def test_chunked_array_pickle_slice_truncation(data, typ, pickle_module):
     # create chunked array
@@ -339,7 +342,7 @@ def test_chunked_array_pickle_slice_truncation(data, typ, pickle_module):
     array.validate()
     serialised_array = pickle_module.dumps(array)
 
-    slice_array =  array.slice(10, 20)
+    slice_array = array.slice(10, 20)
     serialised_slice = pickle_module.dumps(slice_array)
 
     # Check truncation upon serialisation
@@ -356,9 +359,8 @@ def test_chunked_array_pickle_slice_truncation(data, typ, pickle_module):
     # Check that after pickling the slice buffer was trimmed to only contain sliced data
     buf_size = array.get_total_buffer_size()
     post_pickle_slice_buf_size = post_pickle_slice.get_total_buffer_size()
-    assert buf_size / post_pickle_slice_buf_size - len(array) / len(post_pickle_slice) < 10
-
-
+    assert buf_size / post_pickle_slice_buf_size - \
+        len(array) / len(post_pickle_slice) < 10
 
 
 @pytest.mark.pandas
@@ -727,6 +729,7 @@ def test_recordbatch_pickle(pickle_module):
     assert result.equals(batch)
     assert result.schema == schema
 
+
 def test_recordbatch_pickle_slice_truncation(pickle_module):
     data = [
         # Int array
@@ -752,14 +755,14 @@ def test_recordbatch_pickle_slice_truncation(pickle_module):
     ]
 
     fields = [
-            pa.field('ints', pa.int64()),
-            pa.field('floats', pa.float64()),
-            pa.field('bools', pa.bool_()),
-            pa.field("strs", pa.string()),
-            pa.field("lists", pa.list_(pa.int64())),
-            pa.field("large-lists", pa.large_list(pa.int16())),
-            pa.field("str-list", pa.list_(pa.string())),
-        ]
+        pa.field('ints', pa.int64()),
+        pa.field('floats', pa.float64()),
+        pa.field('bools', pa.bool_()),
+        pa.field("strs", pa.string()),
+        pa.field("lists", pa.list_(pa.int64())),
+        pa.field("large-lists", pa.large_list(pa.int16())),
+        pa.field("str-list", pa.list_(pa.string())),
+    ]
 
     schema = pa.schema(fields, metadata={b'foo': b'bar'})
     batch = pa.record_batch(data, schema=schema)
@@ -783,7 +786,8 @@ def test_recordbatch_pickle_slice_truncation(pickle_module):
     # Post-pickle slice buffer should only contain the sliced data
     buf_size = batch.get_total_buffer_size()
     post_pickle_slice_buf_size = post_pickle_slice.get_total_buffer_size()
-    assert buf_size / post_pickle_slice_buf_size - len(batch) / len(post_pickle_slice) < 10
+    assert buf_size / post_pickle_slice_buf_size - \
+        len(batch) / len(post_pickle_slice) < 10
 
 
 def test_recordbatch_get_field():
@@ -1142,6 +1146,7 @@ def test_table_pickle(pickle_module):
     result.validate()
     assert result.equals(table)
 
+
 def test_table_pickle_slice_truncation(pickle_module):
     data = [
         # Int array
@@ -1153,7 +1158,8 @@ def test_table_pickle_slice_truncation(pickle_module):
         # String array
         pa.chunked_array([['a', 'b', 'cd', None, 'efg']] * 200, type=pa.string()),
         # List array
-        pa.chunked_array([[[1, 2], [3], [None, 4, 5], [6]]] * 250, type=pa.list_(pa.int64())),
+        pa.chunked_array([[[1, 2], [3], [None, 4, 5], [6]]]
+                         * 250, type=pa.list_(pa.int64())),
         # Large list array
         pa.chunked_array(
             [[[4, 5], [6], [None, 7], [8, 9, 10]]] * 250,
@@ -1167,16 +1173,16 @@ def test_table_pickle_slice_truncation(pickle_module):
     ]
 
     fields = [
-            pa.field('ints', pa.int64()),
-            pa.field('floats', pa.float64()),
-            pa.field('bools', pa.bool_()),
-            pa.field("strings", pa.string()),
-            pa.field("lists", pa.list_(pa.int64())),
-            pa.field("large-lists", pa.large_list(pa.int16())),
-            pa.field("string-list", pa.list_(pa.string())),
-        ]
+        pa.field('ints', pa.int64()),
+        pa.field('floats', pa.float64()),
+        pa.field('bools', pa.bool_()),
+        pa.field("strings", pa.string()),
+        pa.field("lists", pa.list_(pa.int64())),
+        pa.field("large-lists", pa.large_list(pa.int16())),
+        pa.field("string-list", pa.list_(pa.string())),
+    ]
 
-    schema = pa.schema(fields, metadata= {b'foo': b'bar'})
+    schema = pa.schema(fields, metadata={b'foo': b'bar'})
 
     table = pa.Table.from_arrays(data, schema=schema)
     serialised_table = pickle_module.dumps(table)
@@ -1200,7 +1206,8 @@ def test_table_pickle_slice_truncation(pickle_module):
     # Post-pickle slice buffer only contains slice data
     buf_size = table.get_total_buffer_size()
     post_pickle_slice_buf_size = post_pickle_slice.get_total_buffer_size()
-    assert buf_size / post_pickle_slice_buf_size - len(table) / len(post_pickle_slice) < 10
+    assert buf_size / post_pickle_slice_buf_size - \
+        len(table) / len(post_pickle_slice) < 10
 
 
 def test_table_get_field():


### PR DESCRIPTION
### Rationale for this change
Existing pickling serialises the whole buffer, even if the Array is sliced.

### What changes are included in this PR?

Changes use Arrow's buffer truncation implemented for IPC serialization for pickling and restoring.

Relies on a RecordBatch wrapper, adding ~230 bytes to the pickled payload per Array chunk.

Chunks are not automatically combined pre-pickling.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #26685