### PR TITLE
GH-37687: [Go] Don't copy in realloc when capacity is sufficient.

### DIFF
--- a/go/arrow/memory/go_allocator.go
+++ b/go/arrow/memory/go_allocator.go
@@ -32,10 +32,9 @@ func (a *GoAllocator) Allocate(size int) []byte {
 }
 
 func (a *GoAllocator) Reallocate(size int, b []byte) []byte {
-	if size == len(b) {
-		return b
+	if cap(b) >= size {
+		return b[:size]
 	}
-
 	newBuf := a.Allocate(size)
 	copy(newBuf, b)
 	return newBuf


### PR DESCRIPTION
This removes excessive copies observed in some benchmarks.


* Closes: #37687