### PR TITLE
GH-37694: [Go] Add SetNull to array builders

### DIFF
--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -86,6 +86,9 @@ type Builder interface {
 	// IsNull returns if a previously appended value at a given index is null or not.
 	IsNull(i int) bool
 
+	// SetNull sets the value at index i to null.
+	SetNull(i int)
+
 	UnsafeAppendBoolToBitmap(bool)
 
 	init(capacity int)
@@ -124,6 +127,13 @@ func (b *builder) NullN() int { return b.nulls }
 
 func (b *builder) IsNull(i int) bool {
 	return b.nullBitmap.Len() != 0 && bitutil.BitIsNotSet(b.nullBitmap.Bytes(), i)
+}
+
+func (b *builder) SetNull(i int) {
+	if i < 0 || i >= b.length {
+		panic("arrow/array: index out of range")
+	}
+	bitutil.ClearBit(b.nullBitmap.Bytes(), i)
 }
 
 func (b *builder) init(capacity int) {

--- a/go/arrow/array/builder_test.go
+++ b/go/arrow/array/builder_test.go
@@ -19,10 +19,9 @@ package array
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/apache/arrow/go/v14/arrow/internal/testing/tools"
 	"github.com/apache/arrow/go/v14/arrow/memory"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuilder_Init(t *testing.T) {

--- a/go/arrow/array/builder_test.go
+++ b/go/arrow/array/builder_test.go
@@ -19,9 +19,10 @@ package array
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/apache/arrow/go/v14/arrow/internal/testing/tools"
 	"github.com/apache/arrow/go/v14/arrow/memory"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBuilder_Init(t *testing.T) {
@@ -95,5 +96,29 @@ func TestBuilder_IsNull(t *testing.T) {
 	}
 	for i := 0; i < n; i++ {
 		assert.Equal(t, i%2 != 0, b.IsNull(i))
+	}
+}
+
+func TestBuilder_SetNull(t *testing.T) {
+	b := &builder{mem: memory.NewGoAllocator()}
+	n := 32
+	b.init(n)
+
+	for i := 0; i < n; i++ {
+		// Set everything to true
+		b.UnsafeAppendBoolToBitmap(true)
+	}
+	for i := 0; i < n; i++ {
+		if i%2 == 0 { // Set all even numbers to null
+			b.SetNull(i)
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			assert.True(t, b.IsNull(i))
+		} else {
+			assert.False(t, b.IsNull(i))
+		}
 	}
 }

--- a/go/arrow/array/map.go
+++ b/go/arrow/array/map.go
@@ -234,6 +234,10 @@ func (b *MapBuilder) AppendNulls(n int) {
 	}
 }
 
+func (b *MapBuilder) SetNull(i int) {
+	b.listBuilder.SetNull(i)
+}
+
 func (b *MapBuilder) AppendEmptyValue() {
 	b.Append(true)
 }

--- a/go/arrow/array/map_test.go
+++ b/go/arrow/array/map_test.go
@@ -217,3 +217,38 @@ func TestMapStringRoundTrip(t *testing.T) {
 
 	assert.True(t, array.Equal(arr, arr1))
 }
+
+func TestMapBuilder_SetNull(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	var (
+		arr          *array.Map
+		equalValid   = []bool{true, true, true, true, true, true, true}
+		equalOffsets = []int32{0, 1, 2, 5, 6, 7, 8, 10}
+		equalKeys    = []string{"a", "a", "a", "b", "c", "a", "a", "a", "a", "b"}
+		equalValues  = []int32{1, 2, 3, 4, 5, 2, 2, 2, 5, 6}
+	)
+
+	bldr := array.NewMapBuilder(pool, arrow.BinaryTypes.String, arrow.PrimitiveTypes.Int32, false)
+	defer bldr.Release()
+
+	kb := bldr.KeyBuilder().(*array.StringBuilder)
+	ib := bldr.ItemBuilder().(*array.Int32Builder)
+
+	bldr.AppendValues(equalOffsets, equalValid)
+	for _, k := range equalKeys {
+		kb.Append(k)
+	}
+	ib.AppendValues(equalValues, nil)
+
+	bldr.SetNull(0)
+	bldr.SetNull(3)
+
+	arr = bldr.NewMapArray()
+	defer arr.Release()
+
+	assert.True(t, arr.IsNull(0))
+	assert.True(t, arr.IsValid(1))
+	assert.True(t, arr.IsNull(3))
+}


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

We are proposing to add a `SetNull(i int)` to the `Builder` interface.
The underlying `builder` type implements this for most types.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

The SetNull is added to the Builders type.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

* Closes: #37694