### PR TITLE
GH-37670: [C++] IO FileInterface extend from enable_shared_from_this

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1372,7 +1372,8 @@ class ObjectInputFile final : public io::RandomAccessFile {
 static constexpr int64_t kPartUploadSize = 10 * 1024 * 1024;
 
 // An OutputStream that writes to a S3 object
-class ObjectOutputStream final : public io::OutputStream {
+class ObjectOutputStream final : public io::OutputStream,
+                                 public std::enable_shared_from_this<ObjectOutputStream> {
  protected:
   struct UploadState;
 
@@ -1472,8 +1473,7 @@ class ObjectOutputStream final : public io::OutputStream {
       RETURN_NOT_OK(UploadPart("", 0));
     }
 
-    auto self =
-        ::arrow::internal::checked_pointer_cast<ObjectOutputStream>(shared_from_this());
+    auto self = shared_from_this();
     // Wait for in-progress uploads to finish (if async writes are enabled)
     return FlushAsync().Then([self]() {
       ARROW_ASSIGN_OR_RAISE(auto client_lock, self->holder_->Lock());

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -596,7 +596,9 @@ class TestS3FS : public S3TestMixin {
     ASSERT_OK(stream->Write("new data"));
     // Destructor implicitly closes stream and completes the multipart upload.
     // GH-37670: Testing it doesn't matter whether flush is triggered asynchronously
-    // after CloseAsync or synchronously after stream.reset().
+    // after CloseAsync or synchronously after stream.reset() since we're just
+    // checking that `closeAsyncFut` keeps the stream alive until completion
+    // rather than segfaulting on a dangling stream
     auto closeAsyncFut = stream->CloseAsync();
     stream.reset();
     ASSERT_OK(closeAsyncFut.MoveResult());

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -595,6 +595,8 @@ class TestS3FS : public S3TestMixin {
     ASSERT_OK_AND_ASSIGN(stream, fs_->OpenOutputStream("bucket/somefile"));
     ASSERT_OK(stream->Write("new data"));
     // Destructor implicitly closes stream and completes the multipart upload.
+    // GH-37670: Testing it doesn't matter whether flush is triggered asynchronously
+    // after CloseAsync or synchronously after stream.reset().
     auto closeAsyncFut = stream->CloseAsync();
     stream.reset();
     ASSERT_OK(closeAsyncFut.MoveResult());

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -200,7 +200,9 @@ class ARROW_EXPORT Readable {
   virtual const IOContext& io_context() const;
 };
 
-class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writable {
+class ARROW_EXPORT OutputStream : virtual public FileInterface,
+                                  public Writable,
+                                  public std::enable_shared_from_this<OutputStream> {
  protected:
   OutputStream() = default;
 };

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -200,9 +200,7 @@ class ARROW_EXPORT Readable {
   virtual const IOContext& io_context() const;
 };
 
-class ARROW_EXPORT OutputStream : virtual public FileInterface,
-                                  public Writable,
-                                  public std::enable_shared_from_this<OutputStream> {
+class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writable {
  protected:
   OutputStream() = default;
 };


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

S3 `FlushAsync` might has lifetime problem, this patch fixes that.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Move `enable_shared_from_this` to `FileInterface`
2. Update S3 `FlushAsync`
3. Implement sync Flush to avoid call `share_from_this` in dtor.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

no

### Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37670