### PR TITLE
GH-37648: [Packaging][Linux] Fix libarrow-glib-dev/arrow-glib-devel dependencies

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/debian/control.in
+++ b/dev/tasks/linux-packages/apache-arrow/debian/control.in
@@ -317,7 +317,7 @@ Multi-Arch: same
 Depends:
   ${misc:Depends},
   libglib2.0-dev,
-  libarrow-dev (= ${binary:Version}),
+  libarrow-acero-dev (= ${binary:Version}),
   libarrow-glib1400 (= ${binary:Version}),
   gir1.2-arrow-1.0 (= ${binary:Version})
 Suggests: libarrow-glib-doc

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -562,7 +562,7 @@ This package contains the libraries for Apache Arrow GLib.
 %package glib-devel
 Summary:	Libraries and header files for Apache Arrow GLib
 License:	Apache-2.0
-Requires:	%{name}-devel = %{version}-%{release}
+Requires:	%{name}-acero-devel = %{version}-%{release}
 Requires:	%{name}%{major_version}-glib-libs = %{version}-%{release}
 Requires:	glib2-devel
 Requires:	gobject-introspection-devel


### PR DESCRIPTION
### Rationale for this change

Apache Arrow C GLib depends on Acero. So `libarrow-glib-dev`/`arrow-glib-devel` should depend on `libarrow-acero-dev`/`arrow-acero-devel`.

### What changes are included in this PR?

Fix dependencies.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #37648