### PR TITLE
GH-37715: [Packaging][CentOS] Use default g++ on CentOS 9 Stream

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-9-stream/Dockerfile
@@ -18,15 +18,12 @@
 ARG FROM=quay.io/centos/centos:stream9
 FROM ${FROM}
 
-ENV SCL=gcc-toolset-12
-
 ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} epel-release && \
   dnf install --enablerepo=crb -y ${quiet} \
-    ${SCL} \
     bison \
     boost-devel \
     brotli-devel \
@@ -46,7 +43,6 @@ RUN \
     libarchive \
     libzstd-devel \
     llvm-devel \
-    llvm-static \
     lz4-devel \
     make \
     ncurses-devel \
@@ -65,11 +61,3 @@ RUN \
     vala \
     zlib-devel && \
   dnf clean ${quiet} all
-
-# Workaround: We can remove this once redhat-rpm-config uses "annobin"
-# not "gcc-annobin".
-RUN \
-  sed \
-    -i \
-    -e 's/gcc-annobin/annobin/g' \
-    /usr/lib/rpm/redhat/redhat-annobin-select-gcc-built-plugin


### PR DESCRIPTION
### Rationale for this change

We can use default g++ by using shared LLVM library.

### What changes are included in this PR?

Use default g++ and remove needless `llvm-static`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #37715