### PR TITLE
GH-34105: [R] Provide extra output for failed builds

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -473,17 +473,19 @@ build_libarrow <- function(src_dir, dst_dir) {
   env_vars <- env_vars_as_string(env_var_list)
 
   cat("**** arrow", ifelse(quietly, "", paste("with", env_vars)), "\n")
-  status <- suppressWarnings(system(
+
+  status <- suppressWarnings(system2(
     paste(env_vars, "inst/build_arrow_static.sh"),
-    ignore.stdout = quietly, ignore.stderr = quietly
+    stdout = ifelse(quietly, NULL, TRUE),
+    stderr = ifelse(quietly, NULL, TRUE)
   ))
-  if (status != 0) {
+  if (!is.null(attr(status, "status"))) {
     # It failed :(
-    cat(
-      "**** Error building Arrow C++.",
-      ifelse(env_is("ARROW_R_DEV", "true"), "", "Re-run with ARROW_R_DEV=true for debug information."),
-      "\n"
-    )
+    cat("**** Error building Arrow C++.", "\n")
+    if (!env_is("ARROW_R_DEV", "true")) {
+      cat(status, fill = TRUE)
+      cat("Re-run with ARROW_R_DEV=true for more detailed debug information.")
+    }
   }
   invisible(status)
 }

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -486,7 +486,6 @@ build_libarrow <- function(src_dir, dst_dir) {
     cat("**** Error building Arrow C++.", "\n")
     if (quietly) {
       cat(status, fill = TRUE)
-      cat("Re-run with ARROW_R_DEV=true for more detailed debug information.")
     }
   }
   invisible(status)

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -475,9 +475,11 @@ build_libarrow <- function(src_dir, dst_dir) {
   cat("**** arrow", ifelse(quietly, "", paste("with", env_vars)), "\n")
 
   status <- suppressWarnings(system2(
-    paste(env_vars, "inst/build_arrow_static.sh"),
-    stdout = ifelse(quietly, NULL, TRUE),
-    stderr = ifelse(quietly, NULL, TRUE)
+    "bash",
+    "inst/build_arrow_static.sh",
+    env = env_vars,
+    stdout = ifelse(quietly, TRUE, ""),
+    stderr = ifelse(quietly, TRUE, "")
   ))
   if (!is.null(attr(status, "status"))) {
     # It failed :(

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -474,18 +474,23 @@ build_libarrow <- function(src_dir, dst_dir) {
 
   cat("**** arrow", ifelse(quietly, "", paste("with", env_vars)), "\n")
 
+  build_log_path <- tempfile(fileext = ".log")
   status <- suppressWarnings(system2(
     "bash",
     "inst/build_arrow_static.sh",
     env = env_vars,
-    stdout = ifelse(quietly, TRUE, ""),
-    stderr = ifelse(quietly, TRUE, "")
+    stdout = ifelse(quietly, build_log_path, ""),
+    stderr = ifelse(quietly, build_log_path, "")
   ))
-  if (!is.null(attr(status, "status"))) {
+
+  if (status != 0) {
     # It failed :(
     cat("**** Error building Arrow C++.", "\n")
     if (quietly) {
-      cat(status, fill = TRUE)
+      cat("**** Printing contents of build log because the build failed", 
+          "while ARROW_R_DEV was set to FALSE\n")
+      cat(readLines(build_log_path), sep = "\n")
+      cat("**** Complete build log is available at", build_log_path, "\n")
     }
   }
   invisible(status)

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -484,7 +484,7 @@ build_libarrow <- function(src_dir, dst_dir) {
   if (!is.null(attr(status, "status"))) {
     # It failed :(
     cat("**** Error building Arrow C++.", "\n")
-    if (!env_is("ARROW_R_DEV", "true")) {
+    if (quietly) {
       cat(status, fill = TRUE)
       cat("Re-run with ARROW_R_DEV=true for more detailed debug information.")
     }

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -490,7 +490,7 @@ build_libarrow <- function(src_dir, dst_dir) {
       cat("**** Printing contents of build log because the build failed", 
           "while ARROW_R_DEV was set to FALSE\n")
       cat(readLines(build_log_path), sep = "\n")
-      cat("**** Complete build log is available at", build_log_path, "\n")
+      cat("**** Complete build log may still be present at", build_log_path, "\n")
     }
   }
   invisible(status)


### PR DESCRIPTION
### Rationale for this change

This is a replacement for the previous PR https://github.com/apache/arrow/pull/37698. The rationale for this PR is providing extra output for R package builds where the C++ build fails


### What changes are included in this PR?

Update the system call to save output when building Arrow C++ from the R package and output it if it's failed


### Are these changes tested?

No automated tests but the changes have been tested manually.

### Are there any user-facing changes?

Yes, but only for users building the R package from source which is hopefully not common.
* Closes: #34105