### PR TITLE
GH-37742: [Python] Enable Cython 3

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           gem install test-unit
-          pip install cython setuptools six pytest jira
+          pip install "cython>=0.29.31" setuptools six pytest jira
       - name: Run Release Test
         env:
           ARROW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           gem install test-unit
-          pip install "cython<3" setuptools six pytest jira
+          pip install cython setuptools six pytest jira
       - name: Run Release Test
         env:
           ARROW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -18,7 +18,7 @@
 # don't add pandas here, because it is not a mandatory test dependency
 boto3  # not a direct dependency of s3fs, but needed for our s3fs fixture
 cffi
-cython
+cython>=0.29.31
 cloudpickle
 fsspec
 hypothesis

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -18,7 +18,7 @@
 # don't add pandas here, because it is not a mandatory test dependency
 boto3  # not a direct dependency of s3fs, but needed for our s3fs fixture
 cffi
-cython<3
+cython
 cloudpickle
 fsspec
 hypothesis

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -666,7 +666,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv "cython<3" numpy "setuptools_scm<8.0.0" setuptools || exit 1
+  maybe_setup_virtualenv cython numpy "setuptools_scm<8.0.0" setuptools || exit 1
   maybe_setup_conda --file ci/conda_env_python.txt || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -666,7 +666,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv cython numpy "setuptools_scm<8.0.0" setuptools || exit 1
+  maybe_setup_virtualenv "cython>=0.29.31" numpy "setuptools_scm<8.0.0" setuptools || exit 1
   maybe_setup_conda --file ci/conda_env_python.txt || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@
 
 [build-system]
 requires = [
-    "cython >= 0.29.31,<3",
+    "cython >= 0.29.31",
     "oldest-supported-numpy>=0.14",
     "setuptools_scm < 8.0.0",
     "setuptools >= 40.1.0",

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29.31,<3
+cython>=0.29.31
 oldest-supported-numpy>=0.14
 setuptools_scm<8.0.0
 setuptools>=38.6.0

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,4 +1,4 @@
-cython>=0.29.31,<3
+cython>=0.29.31
 oldest-supported-numpy>=0.14
 setuptools_scm<8.0.0
 setuptools>=58

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,9 +40,9 @@ import Cython
 # Check if we're running 64-bit Python
 is_64_bit = sys.maxsize > 2**32
 
-if Cython.__version__ < '0.29.31' or Cython.__version__ >= '3.0':
+if Cython.__version__ < '0.29.31':
     raise Exception(
-        'Please update your Cython version. Supported Cython >= 0.29.31, < 3.0')
+        'Please update your Cython version. Supported Cython >= 0.29.31')
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -492,7 +492,7 @@ setup(
                                  'pyarrow/_generated_version.py'),
         'version_scheme': guess_next_dev_version
     },
-    setup_requires=['setuptools_scm < 8.0.0', 'cython >= 0.29.31,<3'] + setup_requires,
+    setup_requires=['setuptools_scm < 8.0.0', 'cython >= 0.29.31'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas', 'hypothesis'],
     python_requires='>=3.8',


### PR DESCRIPTION
### Rationale for this change

Enable Cython 3.

### What changes are included in this PR?

* Unpin Cython version in builds.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes, pyarrow will build with cython 3 by default.
* Closes: #37742