### PR TITLE
GH-37751: [C++][Gandiva] Avoid registering exported functions multiple times in gandiva

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -238,6 +238,7 @@ add_gandiva_test(internals-test
                  tree_expr_test.cc
                  encrypt_utils_test.cc
                  expr_decomposer_test.cc
+                 exported_funcs_registry_test.cc
                  expression_registry_test.cc
                  selection_vector_test.cc
                  lru_cache_test.cc

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SRC_FILES
     expression.cc
     expression_registry.cc
     exported_funcs_registry.cc
+    exported_funcs.cc
     filter.cc
     function_ir_builder.cc
     function_registry.cc

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -92,6 +92,7 @@
 
 #include "gandiva/configuration.h"
 #include "gandiva/decimal_ir.h"
+#include "gandiva/exported_funcs.h"
 #include "gandiva/exported_funcs_registry.h"
 
 namespace gandiva {
@@ -103,6 +104,7 @@ std::once_flag llvm_init_once_flag;
 static bool llvm_init = false;
 static llvm::StringRef cpu_name;
 static llvm::SmallVector<std::string, 10> cpu_attrs;
+std::once_flag register_exported_funcs_flag;
 
 void Engine::InitOnce() {
   DCHECK_EQ(llvm_init, false);
@@ -142,6 +144,7 @@ Engine::Engine(const std::shared_ptr<Configuration>& conf,
       cached_(cached) {}
 
 Status Engine::Init() {
+  std::call_once(register_exported_funcs_flag, gandiva::RegisterExportedFuncs);
   // Add mappings for global functions that can be accessed from LLVM/IR module.
   AddGlobalMappings();
 

--- a/cpp/src/gandiva/exported_funcs.cc
+++ b/cpp/src/gandiva/exported_funcs.cc
@@ -15,37 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
-
-#include <memory>
-#include <vector>
-
-#include <gandiva/engine.h>
+#include <gandiva/exported_funcs.h>
+#include <gandiva/exported_funcs_registry.h>
 
 namespace gandiva {
-
-class ExportedFuncsBase;
-
-/// Registry for classes that export functions which can be accessed by
-/// LLVM/IR code.
-class ExportedFuncsRegistry {
- public:
-  using list_type = std::vector<std::shared_ptr<ExportedFuncsBase>>;
-
-  // Add functions from all the registered classes to the engine.
-  static void AddMappings(Engine* engine);
-
-  static bool Register(std::shared_ptr<ExportedFuncsBase> entry) {
-    registered().emplace_back(std::move(entry));
-    return true;
-  }
-
- private:
-  static list_type& registered();
-};
-
-#define REGISTER_EXPORTED_FUNCS(classname)               \
-  [[maybe_unused]] static bool _registered_##classname = \
-      ExportedFuncsRegistry::Register(std::make_shared<classname>())
-
+void RegisterExportedFuncs() {
+  REGISTER_EXPORTED_FUNCS(ExportedStubFunctions);
+  REGISTER_EXPORTED_FUNCS(ExportedContextFunctions);
+  REGISTER_EXPORTED_FUNCS(ExportedTimeFunctions);
+  REGISTER_EXPORTED_FUNCS(ExportedDecimalFunctions);
+  REGISTER_EXPORTED_FUNCS(ExportedStringFunctions);
+  REGISTER_EXPORTED_FUNCS(ExportedHashFunctions);
+}
 }  // namespace gandiva

--- a/cpp/src/gandiva/exported_funcs.h
+++ b/cpp/src/gandiva/exported_funcs.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <gandiva/exported_funcs_registry.h>
 #include <vector>
 
 namespace gandiva {
@@ -36,36 +35,32 @@ class ExportedFuncsBase {
 class ExportedStubFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
-REGISTER_EXPORTED_FUNCS(ExportedStubFunctions);
 
 // Class for exporting Context functions
 class ExportedContextFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
-REGISTER_EXPORTED_FUNCS(ExportedContextFunctions);
 
 // Class for exporting Time functions
 class ExportedTimeFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
-REGISTER_EXPORTED_FUNCS(ExportedTimeFunctions);
 
 // Class for exporting Decimal functions
 class ExportedDecimalFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
-REGISTER_EXPORTED_FUNCS(ExportedDecimalFunctions);
 
 // Class for exporting String functions
 class ExportedStringFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
-REGISTER_EXPORTED_FUNCS(ExportedStringFunctions);
 
 // Class for exporting Hash functions
 class ExportedHashFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
-REGISTER_EXPORTED_FUNCS(ExportedHashFunctions);
+
+void RegisterExportedFuncs();
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/exported_funcs.h
+++ b/cpp/src/gandiva/exported_funcs.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <vector>
+#include "gandiva/visibility.h"
 
 namespace gandiva {
 
@@ -61,6 +62,5 @@ class ExportedHashFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
 
-void RegisterExportedFuncs();
-
+GANDIVA_EXPORT void RegisterExportedFuncs();
 }  // namespace gandiva

--- a/cpp/src/gandiva/exported_funcs_registry.cc
+++ b/cpp/src/gandiva/exported_funcs_registry.cc
@@ -22,14 +22,18 @@
 namespace gandiva {
 
 void ExportedFuncsRegistry::AddMappings(Engine* engine) {
-  for (const auto& entry : registered()) {
+  for (const auto& entry : *registered()) {
     entry->AddMappings(engine);
   }
 }
 
-ExportedFuncsRegistry::list_type& ExportedFuncsRegistry::registered() {
+const ExportedFuncsRegistry::list_type& ExportedFuncsRegistry::Registered() {
+  return *registered();
+}
+
+ExportedFuncsRegistry::list_type* ExportedFuncsRegistry::registered() {
   static list_type registered_list;
-  return registered_list;
+  return &registered_list;
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/exported_funcs_registry.cc
+++ b/cpp/src/gandiva/exported_funcs_registry.cc
@@ -22,7 +22,7 @@
 namespace gandiva {
 
 void ExportedFuncsRegistry::AddMappings(Engine* engine) {
-  for (auto entry : registered()) {
+  for (const auto& entry : registered()) {
     entry->AddMappings(engine);
   }
 }

--- a/cpp/src/gandiva/exported_funcs_registry.cc
+++ b/cpp/src/gandiva/exported_funcs_registry.cc
@@ -27,4 +27,9 @@ void ExportedFuncsRegistry::AddMappings(Engine* engine) {
   }
 }
 
+ExportedFuncsRegistry::list_type& ExportedFuncsRegistry::registered() {
+  static list_type registered_list;
+  return registered_list;
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/exported_funcs_registry.h
+++ b/cpp/src/gandiva/exported_funcs_registry.h
@@ -37,11 +37,15 @@ class GANDIVA_EXPORT ExportedFuncsRegistry {
   static void AddMappings(Engine* engine);
 
   static bool Register(std::shared_ptr<ExportedFuncsBase> entry) {
-    registered().emplace_back(std::move(entry));
+    registered()->emplace_back(std::move(entry));
     return true;
   }
 
-  static list_type& registered();
+  // list all the registered ExportedFuncsBase
+  static const list_type& Registered();
+
+ private:
+  static list_type* registered();
 };
 
 #define REGISTER_EXPORTED_FUNCS(classname)               \

--- a/cpp/src/gandiva/exported_funcs_registry_test.cc
+++ b/cpp/src/gandiva/exported_funcs_registry_test.cc
@@ -22,7 +22,7 @@
 namespace gandiva {
 TEST(ExportedFuncsRegistry, RegistrationOnlyOnce) {
   gandiva::RegisterExportedFuncs();
-  auto const& registered_list = ExportedFuncsRegistry::registered();
+  auto const& registered_list = ExportedFuncsRegistry::Registered();
   EXPECT_EQ(registered_list.size(), 6);
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/exported_funcs_registry_test.cc
+++ b/cpp/src/gandiva/exported_funcs_registry_test.cc
@@ -15,37 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
-
-#include <memory>
-#include <vector>
-
-#include <gandiva/engine.h>
-#include <gandiva/visibility.h>
+#include "gandiva/exported_funcs_registry.h"
+#include <gtest/gtest.h>
+#include "gandiva/exported_funcs.h"
 
 namespace gandiva {
-
-class ExportedFuncsBase;
-
-/// Registry for classes that export functions which can be accessed by
-/// LLVM/IR code.
-class GANDIVA_EXPORT ExportedFuncsRegistry {
- public:
-  using list_type = std::vector<std::shared_ptr<ExportedFuncsBase>>;
-
-  // Add functions from all the registered classes to the engine.
-  static void AddMappings(Engine* engine);
-
-  static bool Register(std::shared_ptr<ExportedFuncsBase> entry) {
-    registered().emplace_back(std::move(entry));
-    return true;
-  }
-
-  static list_type& registered();
-};
-
-#define REGISTER_EXPORTED_FUNCS(classname)               \
-  [[maybe_unused]] static bool _registered_##classname = \
-      ExportedFuncsRegistry::Register(std::make_shared<classname>())
-
+TEST(ExportedFuncsRegistry, RegistrationOnlyOnce) {
+  gandiva::RegisterExportedFuncs();
+  auto const& registered_list = ExportedFuncsRegistry::registered();
+  EXPECT_EQ(registered_list.size(), 6);
+}
 }  // namespace gandiva


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Try to fix https://github.com/apache/arrow/issues/37751

### What changes are included in this PR?

The exported functions defined in gandiva are registered multiple times unnecessarily. This PR tries to address this issue.

### Are these changes tested?

Yes.

### Are there any user-facing changes?
No
* Closes: #37751