### PR TITLE
GH-36111: [C++] Refactor dict_internal.h to use Result

### DIFF
--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -284,7 +284,7 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     // Build unified dictionary array
     std::shared_ptr<ArrayData> data;
     RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                                     0 /* start_offset */, &data));
+                                                     0 /* start_offset */, &data).status());
     *out_dict = MakeArray(data);
     return Status::OK();
   }
@@ -301,7 +301,7 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     // Build unified dictionary array
     std::shared_ptr<ArrayData> data;
     RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                                     0 /* start_offset */, &data));
+                                                     0 /* start_offset */, &data).status());
     *out_dict = MakeArray(data);
     return Status::OK();
   }

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -284,7 +284,8 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     // Build unified dictionary array
     std::shared_ptr<ArrayData> data;
     RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                                     0 /* start_offset */, &data).status());
+                                                     0 /* start_offset */, &data)
+                      .status());
     *out_dict = MakeArray(data);
     return Status::OK();
   }
@@ -301,7 +302,8 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     // Build unified dictionary array
     std::shared_ptr<ArrayData> data;
     RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                                     0 /* start_offset */, &data).status());
+                                                     0 /* start_offset */, &data)
+                      .status());
     *out_dict = MakeArray(data);
     return Status::OK();
   }

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -282,8 +282,9 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     *out_type = arrow::dictionary(index_type, value_type_);
 
     // Build unified dictionary array
-    ARROW_ASSIGN_OR_RAISE(auto data, DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                              0 /* start_offset */));
+    ARROW_ASSIGN_OR_RAISE(
+        auto data, DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
+                                                      0 /* start_offset */));
     *out_dict = MakeArray(data);
     return Status::OK();
   }
@@ -298,8 +299,9 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     }
 
     // Build unified dictionary array
-    ARROW_ASSIGN_OR_RAISE(auto data ,DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                              0 /* start_offset */));
+    ARROW_ASSIGN_OR_RAISE(
+        auto data, DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
+                                                      0 /* start_offset */));
     *out_dict = MakeArray(data);
     return Status::OK();
   }

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -282,11 +282,11 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     *out_type = arrow::dictionary(index_type, value_type_);
 
     // Build unified dictionary array
-    std::shared_ptr<ArrayData> data;
-    RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                                     0 /* start_offset */, &data)
-                      .status());
-    *out_dict = MakeArray(data);
+    Result<std::shared_ptr<ArrayData>> data;
+    data = DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
+                                              0 /* start_offset */);
+    RETURN_NOT_OK(data.status());
+    *out_dict = MakeArray(data.ValueOrDie());
     return Status::OK();
   }
 
@@ -300,11 +300,11 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     }
 
     // Build unified dictionary array
-    std::shared_ptr<ArrayData> data;
-    RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                                     0 /* start_offset */, &data)
-                      .status());
-    *out_dict = MakeArray(data);
+    Result<std::shared_ptr<ArrayData>> data;
+    data = DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
+                                              0 /* start_offset */);
+    RETURN_NOT_OK(data.status());
+    *out_dict = MakeArray(data.ValueOrDie());
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -282,11 +282,9 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     *out_type = arrow::dictionary(index_type, value_type_);
 
     // Build unified dictionary array
-    Result<std::shared_ptr<ArrayData>> data;
-    data = DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                              0 /* start_offset */);
-    RETURN_NOT_OK(data.status());
-    *out_dict = MakeArray(data.ValueOrDie());
+    ARROW_ASSIGN_OR_RAISE(auto data, DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
+                                              0 /* start_offset */));
+    *out_dict = MakeArray(data);
     return Status::OK();
   }
 
@@ -300,11 +298,9 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     }
 
     // Build unified dictionary array
-    Result<std::shared_ptr<ArrayData>> data;
-    data = DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
-                                              0 /* start_offset */);
-    RETURN_NOT_OK(data.status());
-    *out_dict = MakeArray(data.ValueOrDie());
+    ARROW_ASSIGN_OR_RAISE(auto data ,DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
+                                              0 /* start_offset */));
+    *out_dict = MakeArray(data);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -106,11 +106,9 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
     enable_if_memoize<T, Status> Visit(const T&) {
       using ConcreteMemoTable = typename DictionaryTraits<T>::MemoTableType;
       auto memo_table = checked_cast<ConcreteMemoTable*>(memo_table_);
-      Result<std::shared_ptr<ArrayData>> data;
-      data = DictionaryTraits<T>::GetDictionaryArrayData(pool_, value_type_, *memo_table,
-                                                         start_offset_);
-      *out_ = data.ok() ? data.ValueOrDie() : nullptr;
-      return data.status();
+      ARROW_ASSIGN_OR_RAISE(*out_, DictionaryTraits<T>::GetDictionaryArrayData(pool_, value_type_, *memo_table,
+                                                         start_offset_));
+      return Status::OK();
     }
   };
 

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -106,9 +106,11 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
     enable_if_memoize<T, Status> Visit(const T&) {
       using ConcreteMemoTable = typename DictionaryTraits<T>::MemoTableType;
       auto memo_table = checked_cast<ConcreteMemoTable*>(memo_table_);
-      return DictionaryTraits<T>::GetDictionaryArrayData(pool_, value_type_, *memo_table,
-                                                         start_offset_, out_)
-          .status();
+      Result<std::shared_ptr<ArrayData>> data;
+      data = DictionaryTraits<T>::GetDictionaryArrayData(pool_, value_type_, *memo_table,
+                                                         start_offset_);
+      *out_ = data.ok() ? data.ValueOrDie() : nullptr;
+      return data.status();
     }
   };
 

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -106,8 +106,8 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
     enable_if_memoize<T, Status> Visit(const T&) {
       using ConcreteMemoTable = typename DictionaryTraits<T>::MemoTableType;
       auto memo_table = checked_cast<ConcreteMemoTable*>(memo_table_);
-      ARROW_ASSIGN_OR_RAISE(*out_, DictionaryTraits<T>::GetDictionaryArrayData(pool_, value_type_, *memo_table,
-                                                         start_offset_));
+      ARROW_ASSIGN_OR_RAISE(*out_, DictionaryTraits<T>::GetDictionaryArrayData(
+                                       pool_, value_type_, *memo_table, start_offset_));
       return Status::OK();
     }
   };

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -107,7 +107,8 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
       using ConcreteMemoTable = typename DictionaryTraits<T>::MemoTableType;
       auto memo_table = checked_cast<ConcreteMemoTable*>(memo_table_);
       return DictionaryTraits<T>::GetDictionaryArrayData(pool_, value_type_, *memo_table,
-                                                         start_offset_, out_).status();
+                                                         start_offset_, out_)
+          .status();
     }
   };
 

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -107,7 +107,7 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
       using ConcreteMemoTable = typename DictionaryTraits<T>::MemoTableType;
       auto memo_table = checked_cast<ConcreteMemoTable*>(memo_table_);
       return DictionaryTraits<T>::GetDictionaryArrayData(pool_, value_type_, *memo_table,
-                                                         start_offset_, out_);
+                                                         start_offset_, out_).status();
     }
   };
 

--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -64,11 +64,10 @@ struct DictionaryTraits<BooleanType> {
   using T = BooleanType;
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(MemoryPool* pool,
-                                       const std::shared_ptr<DataType>& type,
-                                       const MemoTableType& memo_table,
-                                       int64_t start_offset,
-                                       std::shared_ptr<ArrayData>* out) {
+  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(
+      MemoryPool* pool, const std::shared_ptr<DataType>& type,
+      const MemoTableType& memo_table, int64_t start_offset,
+      std::shared_ptr<ArrayData>* out) {
     if (start_offset < 0) {
       return Status::Invalid("invalid start_offset ", start_offset);
     }
@@ -93,11 +92,10 @@ struct DictionaryTraits<T, enable_if_has_c_type<T>> {
   using c_type = typename T::c_type;
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(MemoryPool* pool,
-                                       const std::shared_ptr<DataType>& type,
-                                       const MemoTableType& memo_table,
-                                       int64_t start_offset,
-                                       std::shared_ptr<ArrayData>* out) {
+  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(
+      MemoryPool* pool, const std::shared_ptr<DataType>& type,
+      const MemoTableType& memo_table, int64_t start_offset,
+      std::shared_ptr<ArrayData>* out) {
     auto dict_length = static_cast<int64_t>(memo_table.size()) - start_offset;
     // This makes a copy, but we assume a dictionary array is usually small
     // compared to the size of the dictionary-using array.
@@ -123,11 +121,10 @@ template <typename T>
 struct DictionaryTraits<T, enable_if_base_binary<T>> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(MemoryPool* pool,
-                                       const std::shared_ptr<DataType>& type,
-                                       const MemoTableType& memo_table,
-                                       int64_t start_offset,
-                                       std::shared_ptr<ArrayData>* out) {
+  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(
+      MemoryPool* pool, const std::shared_ptr<DataType>& type,
+      const MemoTableType& memo_table, int64_t start_offset,
+      std::shared_ptr<ArrayData>* out) {
     using offset_type = typename T::offset_type;
 
     // Create the offsets buffer
@@ -162,11 +159,10 @@ template <typename T>
 struct DictionaryTraits<T, enable_if_fixed_size_binary<T>> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(MemoryPool* pool,
-                                       const std::shared_ptr<DataType>& type,
-                                       const MemoTableType& memo_table,
-                                       int64_t start_offset,
-                                       std::shared_ptr<ArrayData>* out) {
+  static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(
+      MemoryPool* pool, const std::shared_ptr<DataType>& type,
+      const MemoTableType& memo_table, int64_t start_offset,
+      std::shared_ptr<ArrayData>* out) {
     const T& concrete_type = internal::checked_cast<const T&>(*type);
 
     // Create the data buffer

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -286,7 +286,8 @@ class RegularHashKernel : public HashKernel {
 
   Status GetDictionary(std::shared_ptr<ArrayData>* out) override {
     return DictionaryTraits<Type>::GetDictionaryArrayData(pool_, type_, *memo_table_,
-                                                          0 /* start_offset */, out).status();
+                                                          0 /* start_offset */, out)
+        .status();
   }
 
   std::shared_ptr<DataType> value_type() const override { return type_; }

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -285,8 +285,8 @@ class RegularHashKernel : public HashKernel {
   Status FlushFinal(ExecResult* out) override { return action_.FlushFinal(out); }
 
   Status GetDictionary(std::shared_ptr<ArrayData>* out) override {
-    ARROW_ASSIGN_OR_RAISE(*out, DictionaryTraits<Type>::GetDictionaryArrayData(pool_, type_, *memo_table_,
-                                                          0 /* start_offset */));
+    ARROW_ASSIGN_OR_RAISE(*out, DictionaryTraits<Type>::GetDictionaryArrayData(
+                                    pool_, type_, *memo_table_, 0 /* start_offset */));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -285,11 +285,9 @@ class RegularHashKernel : public HashKernel {
   Status FlushFinal(ExecResult* out) override { return action_.FlushFinal(out); }
 
   Status GetDictionary(std::shared_ptr<ArrayData>* out) override {
-    Result<std::shared_ptr<ArrayData>> data;
-    data = DictionaryTraits<Type>::GetDictionaryArrayData(pool_, type_, *memo_table_,
-                                                          0 /* start_offset */);
-    *out = data.ok() ? data.ValueOrDie() : nullptr;
-    return data.status();
+    ARROW_ASSIGN_OR_RAISE(*out, DictionaryTraits<Type>::GetDictionaryArrayData(pool_, type_, *memo_table_,
+                                                          0 /* start_offset */));
+    return Status::OK();
   }
 
   std::shared_ptr<DataType> value_type() const override { return type_; }

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -286,7 +286,7 @@ class RegularHashKernel : public HashKernel {
 
   Status GetDictionary(std::shared_ptr<ArrayData>* out) override {
     return DictionaryTraits<Type>::GetDictionaryArrayData(pool_, type_, *memo_table_,
-                                                          0 /* start_offset */, out);
+                                                          0 /* start_offset */, out).status();
   }
 
   std::shared_ptr<DataType> value_type() const override { return type_; }

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -285,9 +285,11 @@ class RegularHashKernel : public HashKernel {
   Status FlushFinal(ExecResult* out) override { return action_.FlushFinal(out); }
 
   Status GetDictionary(std::shared_ptr<ArrayData>* out) override {
-    return DictionaryTraits<Type>::GetDictionaryArrayData(pool_, type_, *memo_table_,
-                                                          0 /* start_offset */, out)
-        .status();
+    Result<std::shared_ptr<ArrayData>> data;
+    data = DictionaryTraits<Type>::GetDictionaryArrayData(pool_, type_, *memo_table_,
+                                                          0 /* start_offset */);
+    *out = data.ok() ? data.ValueOrDie() : nullptr;
+    return data.status();
   }
 
   std::shared_ptr<DataType> value_type() const override { return type_; }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

This change addresses #36111 , updating the method GetDictionaryArrayData in dict_internal.h to return a Result instead of a Status type. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

This is a narrow interpretation of the above issue, only changing the return type with minimal updates to the call sites or their return types. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. The C++ test suite was run on the `ninja-debug` build target using the command `ctest -j16 --output-on-failure`. All tests not requiring parquet data passed. (I was unsure how to setup those tests based on the Arrow development guidelines.) 

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No. The only changes should be library-internal. 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36111 