### PR TITLE
GH-33807: [R] Add a message if we detect running under emulation

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -200,7 +200,7 @@ configure_tzdb <- function() {
     # On MacOS only, Check if we are running in under emulation, and warn this will not work
     rosetta <- identical(sysname, "darwin") && identical(system("sysctl -n sysctl.proc_translated", intern = TRUE), "1")
     if (rosetta) {
-            packageStartupMessage(
+      packageStartupMessage(
         paste(
           "It appears that you are running R and Arrow in emulation",
           "(typically, this is running an x86 build of R on an ARM or",

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -196,6 +196,20 @@ configure_tzdb <- function() {
         )
       )
     }
+
+    # On MacOS only, Check if we are running in under emulation, and warn this will not work
+    rosetta <- identical(sysname, "darwin") && identical(system("sysctl -n sysctl.proc_translated", intern = TRUE), "1")
+    if (rosetta) {
+            packageStartupMessage(
+        paste(
+          "It appears that you are running R and Arrow in emulation",
+          "(typically, this is running an x86 build of R on an ARM or",
+          "M processor based mac). This configuration is not supported",
+          "by arrow and we highly recommend you install a native (arm64)",
+          "build of R and use arrow with that."
+        )
+      )
+    }
   })
 }
 

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -242,7 +242,7 @@ on_macos_10_13_or_lower <- function() {
 }
 
 on_rosetta <- function() {
-  identical(tolower(Sys.info()[["sysname"]]), "darwin") && 
+  identical(tolower(Sys.info()[["sysname"]]), "darwin") &&
     identical(system("sysctl -n sysctl.proc_translated", intern = TRUE), "1")
 }
 

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -183,6 +183,22 @@ configure_tzdb <- function() {
   # Just to be extra safe, let's wrap this in a try();
   # we don't want a failed startup message to prevent the package from loading
   try({
+        # On MacOS only, Check if we are running in under emulation, and warn this will not work
+    if (on_rosetta()) {
+      packageStartupMessage(
+        paste(
+          "Warning:",
+          "  It appears that you are running R and Arrow in emulation (i.e. you're",
+          "  running an Intel version of R on a non-Intel mac). This configuration is",
+          "  not supported by arrow, you should install a native (arm64) build of R",
+          "  and use arrow with that. See https://cran.r-project.org/bin/macosx/",
+          "",
+          sep = "\n"
+        )
+      )
+    }
+
+
     features <- arrow_info()$capabilities
     # That has all of the #ifdef features, plus the compression libs and the
     # string libraries (but not the memory allocators, they're added elsewhere)
@@ -193,20 +209,6 @@ configure_tzdb <- function() {
         paste(
           "Some features are not enabled in this build of Arrow.",
           "Run `arrow_info()` for more information."
-        )
-      )
-    }
-
-    # On MacOS only, Check if we are running in under emulation, and warn this will not work
-    rosetta <- identical(sysname, "darwin") && identical(system("sysctl -n sysctl.proc_translated", intern = TRUE), "1")
-    if (rosetta) {
-      packageStartupMessage(
-        paste(
-          "It appears that you are running R and Arrow in emulation",
-          "(typically, this is running an x86 build of R on an ARM or",
-          "M processor based mac). This configuration is not supported",
-          "by arrow and we highly recommend you install a native (arm64)",
-          "build of R and use arrow with that."
         )
       )
     }
@@ -237,6 +239,11 @@ on_linux_dev <- function() {
 on_macos_10_13_or_lower <- function() {
   identical(unname(Sys.info()["sysname"]), "Darwin") &&
     package_version(unname(Sys.info()["release"])) < "18.0.0"
+}
+
+on_rosetta <- function() {
+  identical(tolower(Sys.info()[["sysname"]]), "darwin") && 
+    identical(system("sysctl -n sysctl.proc_translated", intern = TRUE), "1")
 }
 
 option_use_threads <- function() {

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -61,7 +61,6 @@ install_arrow <- function(nightly = FALSE,
                           verbose = Sys.getenv("ARROW_R_DEV", FALSE),
                           repos = getOption("repos"),
                           ...) {
-  sysname <- tolower(Sys.info()[["sysname"]])
   conda <- isTRUE(grepl("conda", R.Version()$platform))
 
   if (conda) {
@@ -80,8 +79,7 @@ install_arrow <- function(nightly = FALSE,
     # On the M1, we can't use the usual autobrew, which pulls Intel dependencies
     apple_m1 <- grepl("arm-apple|aarch64.*darwin", R.Version()$platform)
     # On Rosetta, we have to build without JEMALLOC, so we also can't autobrew
-    rosetta <- identical(sysname, "darwin") && identical(system("sysctl -n sysctl.proc_translated", intern = TRUE), "1")
-    if (rosetta) {
+    if (on_rosetta()) {
       Sys.setenv(ARROW_JEMALLOC = "OFF")
     }
     if (apple_m1 || rosetta) {

--- a/r/README.md
+++ b/r/README.md
@@ -73,6 +73,8 @@ additional steps should be required.
 
 There are some special cases to note:
 
+- On macOS, the R you use with Arrow should match the architecture of the machine you are using. If you're using an ARM (aka M1, M2, etc.) processor use R compiled for arm64. If you're using an Intel based mac, use R compiled for x86. Using R and Arrow compiled for Intel based macs on an ARM based mac will result in segfaults and crashes. 
+
 - On Linux the installation process can sometimes be more involved because 
 CRAN does not host binaries for Linux. For more information please see the [installation guide](https://arrow.apache.org/docs/r/articles/install.html).
 


### PR DESCRIPTION
Resolves #33807 and #37034

### Rationale for this change

If someone is running R under emulation, arrow segfaults without error. We can detect this when we load so can also warn people that this is not recommended. Though the version of R being run is not directly an arrow issue, arrow fails very quickly in this configuration.

### What changes are included in this PR?

Detect when running under rosetta (on macOS only) and warn when the library is attached

### Are these changes tested?

No, given the paucity of ARM-based mac CI, testing this organically would be difficult. But the logic is straightforward.

### Are there any user-facing changes?

Yes, a warning when someone loads arrow under emulation.
* Closes: #33807