### PR TITLE
GH-37704: [Java] Add schema IPC serialization methods

### DIFF
--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -18,7 +18,6 @@
 package org.apache.arrow.flight.perf;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -115,7 +114,7 @@ public class PerformanceTestServer implements AutoCloseable {
         try {
           Token token = Token.parseFrom(ticket.getBytes());
           Perf perf = token.getDefinition();
-          Schema schema = Schema.deserialize(ByteBuffer.wrap(perf.getSchema().toByteArray()));
+          Schema schema = Schema.deserializeMessage(perf.getSchema().asReadOnlyByteBuffer());
           root = VectorSchemaRoot.create(schema, allocator);
           BigIntVector a = (BigIntVector) root.getVector("a");
           BigIntVector b = (BigIntVector) root.getVector("b");

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
@@ -65,7 +65,8 @@ public class TestPerf {
         Field.nullable("d", MinorType.BIGINT.getType())
     ));
 
-    ByteString serializedSchema = ByteString.copyFrom(pojoSchema.toByteArray());
+    byte[] bytes = pojoSchema.serializeAsMessage();
+    ByteString serializedSchema = ByteString.copyFrom(bytes);
 
     return FlightDescriptor.command(Perf.newBuilder()
         .setRecordsPerStream(recordCount)


### PR DESCRIPTION
### Rationale for this change

The methods in the Schema class in Java serialize the schema in a way that is inconsistent with other languages. This can cause integration issues when using a Java-serialized schema in another language via IPC or Arrow Flight or vice-versa.


### What changes are included in this PR?

Added the serializeAsMessage() and deserializeMessage() methods to Schema for serialization Schemas to the standard IPC format (wrapped in an IPC Message).

Marked the methods that serialize to raw FlatBuffer objects as deprecated (toByteArray() and deserialize()).

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37704