### PR TITLE
GH-37779: [Go] Link to the pkg.go.dev site for Go reference docs

### DIFF
--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -276,6 +276,34 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       next if hunks.empty?
       expected_changes << {hunks: hunks, path: path}
     end
+    if release_type == :major
+      expected_changes << {
+        hunks: [
+          [
+            "-[![Go Reference](https://pkg.go.dev/badge/github.com/apache/arrow/go/v#{@snapshot_major_version}.svg)](https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version})",
+            "+[![Go Reference](https://pkg.go.dev/badge/github.com/apache/arrow/go/v#{@next_major_version}.svg)](https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version})",
+          ],
+        ],
+        path: "go/README.md",
+      }
+      expected_changes << {
+        hunks: [
+          [
+            "-* Installation via `go get -u github.com/apache/arrow/go/v#{@snapshot_major_version}/arrow/flight/flightsql`",
+            "+* Installation via `go get -u github.com/apache/arrow/go/v#{@next_major_version}/arrow/flight/flightsql`",
+          ],
+          [
+            "-    _ \"github.com/apache/arrow/go/v#{@snapshot_major_version}/arrow/flight/flightsql\"",
+            "+    _ \"github.com/apache/arrow/go/v#{@next_major_version}/arrow/flight/flightsql\"",
+          ],
+          [
+            "-    \"github.com/apache/arrow/go/v#{@snapshot_major_version}/arrow/flight/flightsql\"",
+            "+    \"github.com/apache/arrow/go/v#{@next_major_version}/arrow/flight/flightsql\"",
+          ],
+        ],
+        path: "go/arrow/flight/flightsql/driver/README.md",
+      }
+    end
 
     Dir.glob("java/**/pom.xml") do |path|
       version = "<version>#{@snapshot_version}</version>"

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -235,7 +235,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       ]
     end
 
-    Dir.glob("go/**/{go.mod,*.go,*.go.*}") do |path|
+    Dir.glob("go/**/{go.mod,*.go,*.go.*,README.md}") do |path|
       if path == "go/arrow/doc.go"
         expected_changes << {
           path: path,
@@ -253,19 +253,34 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       hunks = []
       if release_type == :major
         lines = File.readlines(path, chomp: true)
-        target_lines = lines.grep(/#{Regexp.escape(import_path)}/)
+        target_lines = lines.each_with_index.select do |line, i|
+          line.include?(import_path)
+        end
         next if target_lines.empty?
-        hunk = []
-        target_lines.each do |line|
-          hunk << "-#{line}"
-        end
-        target_lines.each do |line|
-          new_line = line.gsub("v#{@snapshot_major_version}") do
-            "v#{@next_major_version}"
+        n_context_lines = 3 # The default of Git's diff.context
+        target_hunks = [[target_lines.first[0]]]
+        previous_i = target_lines.first[1]
+        target_lines[1..-1].each do |line, i|
+          if i - previous_i < n_context_lines
+            target_hunks.last << line
+          else
+            target_hunks << [line]
           end
-          hunk << "+#{new_line}"
+          previous_i = i
         end
-        hunks << hunk
+        target_hunks.each do |lines|
+          hunk = []
+          lines.each do |line,|
+            hunk << "-#{line}"
+          end
+          lines.each do |line|
+            new_line = line.gsub("v#{@snapshot_major_version}") do
+              "v#{@next_major_version}"
+            end
+            hunk << "+#{new_line}"
+          end
+          hunks << hunk
+        end
       end
       if path == "go/parquet/writer_properties.go"
         hunks << [
@@ -275,34 +290,6 @@ class PostBumpVersionsTest < Test::Unit::TestCase
       end
       next if hunks.empty?
       expected_changes << {hunks: hunks, path: path}
-    end
-    if release_type == :major
-      expected_changes << {
-        hunks: [
-          [
-            "-[![Go Reference](https://pkg.go.dev/badge/github.com/apache/arrow/go/v#{@snapshot_major_version}.svg)](https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version})",
-            "+[![Go Reference](https://pkg.go.dev/badge/github.com/apache/arrow/go/v#{@next_major_version}.svg)](https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version})",
-          ],
-        ],
-        path: "go/README.md",
-      }
-      expected_changes << {
-        hunks: [
-          [
-            "-* Installation via `go get -u github.com/apache/arrow/go/v#{@snapshot_major_version}/arrow/flight/flightsql`",
-            "+* Installation via `go get -u github.com/apache/arrow/go/v#{@next_major_version}/arrow/flight/flightsql`",
-          ],
-          [
-            "-    _ \"github.com/apache/arrow/go/v#{@snapshot_major_version}/arrow/flight/flightsql\"",
-            "+    _ \"github.com/apache/arrow/go/v#{@next_major_version}/arrow/flight/flightsql\"",
-          ],
-          [
-            "-    \"github.com/apache/arrow/go/v#{@snapshot_major_version}/arrow/flight/flightsql\"",
-            "+    \"github.com/apache/arrow/go/v#{@next_major_version}/arrow/flight/flightsql\"",
-          ],
-        ],
-        path: "go/arrow/flight/flightsql/driver/README.md",
-      }
     end
 
     Dir.glob("java/**/pom.xml") do |path|

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -155,8 +155,8 @@ update_versions() {
   popd
 
   pushd "${ARROW_DIR}/go"
-  find . "(" -name "*.go*" -o -name "go.mod" ")" -exec sed -i.bak -E -e \
-    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|" {} \;
+  find . "(" -name "*.go*" -o -name "go.mod" -o -name README.md ")" -exec sed -i.bak -E -e \
+    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" {} \;
   # update parquet writer version
   sed -i.bak -E -e \
     "s/\"parquet-go version .+\"/\"parquet-go version ${version}\"/" \

--- a/go/README.md
+++ b/go/README.md
@@ -20,7 +20,7 @@
 Apache Arrow for Go
 ===================
 
-[![GoDoc](https://godoc.org/github.com/apache/arrow/go/arrow?status.svg)](https://godoc.org/github.com/apache/arrow/go/arrow)
+[![Go Reference](https://pkg.go.dev/badge/github.com/apache/arrow/go/v14.svg)](https://pkg.go.dev/github.com/apache/arrow/go/v14)
 
 [Apache Arrow][arrow] is a cross-language development platform for in-memory
 data. It specifies a standardized language-independent columnar memory format

--- a/go/arrow/flight/flightsql/driver/README.md
+++ b/go/arrow/flight/flightsql/driver/README.md
@@ -36,7 +36,7 @@ connection pooling, transactions combined with ease of use (see (#usage)).
 ## Prerequisites
 
 * Go 1.17+
-* Installation via `go get -u github.com/apache/arrow/go/v12/arrow/flight/flightsql`
+* Installation via `go get -u github.com/apache/arrow/go/v14/arrow/flight/flightsql`
 * Backend speaking FlightSQL
 
 ---------------------------------------
@@ -55,7 +55,7 @@ import (
     "database/sql"
     "time"
 
-    _ "github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+    _ "github.com/apache/arrow/go/v14/arrow/flight/flightsql"
 )
 
 // Open the connection to an SQLite backend
@@ -141,7 +141,7 @@ import (
     "log"
     "time"
 
-    "github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+    "github.com/apache/arrow/go/v14/arrow/flight/flightsql"
 )
 
 func main() {


### PR DESCRIPTION
### Rationale for this change

This change updates the Go `README.md` to point to the latest version of the reference documentation.

### What changes are included in this PR?

The Go `README.md` has been updated with a badge that points to [the v14 version](https://pkg.go.dev/github.com/apache/arrow/go/v14) of the docs.

In addition, the `dev/release/utils-prepare.sh` script has been modified so that the link in the Go `README.md` will be updated when the release version changes.

### Are these changes tested?

I tried running `PREPARE_CHANGELOG=0 ./dev/release/01-prepare.sh 14 15 1`, but I don't have `mvn` installed, so was not able to fully validate the changes.

In the `go` directory, I ran the following and confirmed that the changes looked like what I would expect:
```shell
find . "(" -name "*.go*" -o -name "go.mod" -o -name README.md ")" -exec sed -i.bak -E -e \
    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v15|g" {} \;
```

### Are there any user-facing changes?

Documentation changes only.
* Closes: #37779