### PR TITLE
GH-37805: [CI][MATLAB] Hard-code `release` to `R2023a` for `matlab-actions/setup-matlab` action in MATLAB CI workflows

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -53,6 +53,7 @@ jobs:
         run: sudo apt-get install ninja-build
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+          release: R2023a
       - name: Install ccache
         run: sudo apt-get install ccache
       - name: Setup ccache
@@ -99,6 +100,7 @@ jobs:
         run: brew install ninja
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+          release: R2023a
       - name: Install ccache
         run: brew install ccache
       - name: Setup ccache
@@ -135,6 +137,7 @@ jobs:
           fetch-depth: 0
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+          release: R2023a
       - name: Download Timezone Database
         shell: bash
         run: ci/scripts/download_tz_database.sh

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -53,6 +53,7 @@ jobs:
         run: sudo apt-get install ninja-build
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+        with:
           release: R2023a
       - name: Install ccache
         run: sudo apt-get install ccache
@@ -100,6 +101,7 @@ jobs:
         run: brew install ninja
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+        with:
           release: R2023a
       - name: Install ccache
         run: brew install ccache
@@ -137,6 +139,7 @@ jobs:
           fetch-depth: 0
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v1
+        with:
           release: R2023a
       - name: Download Timezone Database
         shell: bash


### PR DESCRIPTION
### Rationale for this change

Due to a recent change to default to `R2023b` by default for the `[matlab-actions/setup-matlab`](https://github.com/matlab-actions/setup-matlab) action in GitHub Actions, the MATLAB CI workflows are failing.

Example failure logs:

https://github.com/apache/arrow/actions/runs/6250586979/job/16970596069?pr=37773#step:9:70

Our preferred solution to address this in the short term is to explicitly specify the [`release` parameter](https://github.com/matlab-actions/setup-matlab#set-up-matlab) to the `setup-matlab` action to be `R2023a`.

In the long term, we can work on figuring out why the build is failing on Windows with `R2023b`.

For reference - it appears that the `FindMatlab` CMake module only recently added R2023b to its list of recognized versions:

https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8804

### What changes are included in this PR?

1. Hard-coded MATLAB `release` to `R2023a` for the [`matlab-actions/setup-matlab`](https://github.com/matlab-actions/setup-matlab) action in the MATLAB CI workflows.

### Are these changes tested?

Yes.

1. [MATLAB CI workflows are passing on all platforms in `mathworks/arrow`](https://github.com/mathworks/arrow/actions/runs/6251345588).

### Are there any user-facing changes?

No.

This change only impacts the MATLAB CI workflows which were defaulting to `R2023a` by default in the past.

### Future Directions

1. #37809
* Closes: #37805