### PR TITLE
GH-37804: [R] Fix with_language test helper

### DIFF
--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -34,19 +34,25 @@ Sys.setenv(LANGUAGE = "en")
 options(arrow.pull_as_vector = FALSE)
 
 with_language <- function(lang, expr) {
-  old <- Sys.getenv("LANGUAGE")
-  # Check what this message is before changing languages; this will
-  # trigger caching the transations if the OS does that (some do).
-  # If the OS does cache, then we can't test changing languages safely.
-  before <- i18ize_error_messages()
-  Sys.setenv(LANGUAGE = lang)
-  on.exit({
-    Sys.setenv(LANGUAGE = old)
+  # We know we're LANGUAGE=en because we just set it above.
+  # We only need to check whether we can change languages if we're not "en".
+  if (!identical(lang, "en")) {
     .cache$i18ized_error_pattern <<- NULL
-  })
-  if (!identical(before, i18ize_error_messages())) {
-    skip(paste("This OS either does not support changing languages to", lang, "or it caches translations"))
+    old <- Sys.getenv("LANGUAGE")
+    # Check what this message is before changing languages; this will
+    # trigger caching the transations if the OS does that (some do).
+    # If the OS does cache, then we can't test changing languages safely.
+    before <- i18ize_error_messages()
+    Sys.setenv(LANGUAGE = lang)
+    on.exit({
+      Sys.setenv(LANGUAGE = old)
+      .cache$i18ized_error_pattern <<- NULL
+    })
+    if (identical(before, i18ize_error_messages())) {
+      skip(paste("This OS either does not support changing languages to", lang, "or it caches translations"))
+    }
   }
+
   force(expr)
 }
 


### PR DESCRIPTION
### Rationale for this change

Proper fix for #37804. Turns out the `with_language()` helper was wrong, but usually in an innocuous way that would make it skip more than it should. 

### Are these changes tested?

Yes, though we'll want to watch the nightlies and may need to add another nightly that uses rocker/r-devel in order to ensure (such that we can) that whatever changed on CRAN is covered. It's not clear that the R-hub job we test that uses R devel is getting updated nightly anymore.

### Are there any user-facing changes?

No.
* Closes: #37804