### PR TITLE
GH-37813: [R] add quoted_na argument to open_delim_dataset()

### DIFF
--- a/r/R/dataset-format.R
+++ b/r/R/dataset-format.R
@@ -235,7 +235,7 @@ check_unsupported_args <- function(args) {
   opt_names <- get_opt_names(args)
 
   # Filter out arguments meant for CsvConvertOptions/CsvReadOptions
-  supported_convert_opts <- c(names(formals(CsvConvertOptions$create)), "na")
+  supported_convert_opts <- c(names(formals(CsvConvertOptions$create)), "na", "quoted_na")
 
   supported_read_opts <- c(
     names(formals(CsvReadOptions$create)),
@@ -308,7 +308,8 @@ check_unrecognised_args <- function(opts) {
   readr_opts <- c(
     names(formals(readr_to_csv_parse_options)),
     names(formals(readr_to_csv_read_options)),
-    "na"
+    "na",
+    "quoted_na"
   )
 
   is_arrow_opt <- !is.na(pmatch(opt_names, arrow_opts))
@@ -390,7 +391,7 @@ check_schema <- function(schema, column_names) {
 csv_file_format_parse_opts <- function(...) {
   opts <- list(...)
   # Filter out arguments meant for CsvConvertOptions/CsvReadOptions
-  convert_opts <- c(names(formals(CsvConvertOptions$create)), "na", "convert_options")
+  convert_opts <- c(names(formals(CsvConvertOptions$create)), "na", "quoted_na", "convert_options")
   read_opts <- c(
     names(formals(CsvReadOptions$create)),
     names(formals(readr_to_csv_read_options)),
@@ -448,6 +449,11 @@ csv_file_format_convert_opts <- function(...) {
     opts[["na"]] <- NULL
   }
 
+  if ("quoted_na" %in% names(opts)) {
+    opts[["strings_can_be_null"]] <- opts[["quoted_na"]]
+    opts[["quoted_na"]] <- NULL
+  }
+
   do.call(CsvConvertOptions$create, opts)
 }
 
@@ -456,7 +462,7 @@ csv_file_format_read_opts <- function(schema = NULL, ...) {
   # Filter out arguments meant for CsvParseOptions/CsvConvertOptions
   arrow_opts <- c(names(formals(CsvParseOptions$create)), "parse_options")
   readr_opts <- names(formals(readr_to_csv_parse_options))
-  convert_opts <- c(names(formals(CsvConvertOptions$create)), "na", "convert_options")
+  convert_opts <- c(names(formals(CsvConvertOptions$create)), "na", "quoted_na", "convert_options")
   opts[arrow_opts] <- NULL
   opts[readr_opts] <- NULL
   opts[convert_opts] <- NULL
@@ -468,7 +474,6 @@ csv_file_format_read_opts <- function(schema = NULL, ...) {
 
   is_arrow_opt <- !is.na(match(opt_names, arrow_opts))
   is_readr_opt <- !is.na(match(opt_names, readr_opts))
-
   check_ambiguous_options(opt_names, arrow_opts, readr_opts)
 
   null_or_true <- function(x) {

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -276,7 +276,7 @@ open_delim_dataset <- function(sources,
                                convert_options = NULL,
                                read_options = NULL,
                                timestamp_parsers = NULL,
-                               quoted_na = TRUE){
+                               quoted_na = TRUE) {
   open_dataset(
     sources = sources,
     schema = schema,

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -240,7 +240,6 @@ open_dataset <- function(sources,
 #' @section Options currently supported by [read_delim_arrow()] which are not supported here:
 #' * `file` (instead, please specify files in `sources`)
 #' * `col_select` (instead, subset columns after dataset creation)
-#' * `quoted_na`
 #' * `as_data_frame` (instead, convert to data frame after dataset creation)
 #' * `parse_options`
 #'

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -276,7 +276,8 @@ open_delim_dataset <- function(sources,
                                skip = 0L,
                                convert_options = NULL,
                                read_options = NULL,
-                               timestamp_parsers = NULL) {
+                               timestamp_parsers = NULL,
+                               quoted_na = TRUE){
   open_dataset(
     sources = sources,
     schema = schema,
@@ -296,7 +297,8 @@ open_delim_dataset <- function(sources,
     skip = skip,
     convert_options = convert_options,
     read_options = read_options,
-    timestamp_parsers = timestamp_parsers
+    timestamp_parsers = timestamp_parsers,
+    quoted_na = quoted_na
   )
 }
 
@@ -318,7 +320,8 @@ open_csv_dataset <- function(sources,
                              skip = 0L,
                              convert_options = NULL,
                              read_options = NULL,
-                             timestamp_parsers = NULL) {
+                             timestamp_parsers = NULL,
+                             quoted_na = TRUE) {
   mc <- match.call()
   mc$delim <- ","
   mc[[1]] <- get("open_delim_dataset", envir = asNamespace("arrow"))
@@ -343,7 +346,8 @@ open_tsv_dataset <- function(sources,
                              skip = 0L,
                              convert_options = NULL,
                              read_options = NULL,
-                             timestamp_parsers = NULL) {
+                             timestamp_parsers = NULL,
+                             quoted_na = TRUE) {
   mc <- match.call()
   mc$delim <- "\t"
   mc[[1]] <- get("open_delim_dataset", envir = asNamespace("arrow"))

--- a/r/man/open_delim_dataset.Rd
+++ b/r/man/open_delim_dataset.Rd
@@ -24,7 +24,8 @@ open_delim_dataset(
   skip = 0L,
   convert_options = NULL,
   read_options = NULL,
-  timestamp_parsers = NULL
+  timestamp_parsers = NULL,
+  quoted_na = TRUE
 )
 
 open_csv_dataset(
@@ -44,7 +45,8 @@ open_csv_dataset(
   skip = 0L,
   convert_options = NULL,
   read_options = NULL,
-  timestamp_parsers = NULL
+  timestamp_parsers = NULL,
+  quoted_na = TRUE
 )
 
 open_tsv_dataset(
@@ -64,7 +66,8 @@ open_tsv_dataset(
   skip = 0L,
   convert_options = NULL,
   read_options = NULL,
-  timestamp_parsers = NULL
+  timestamp_parsers = NULL,
+  quoted_na = TRUE
 )
 }
 \arguments{
@@ -178,6 +181,11 @@ starting from the beginning of this vector. Possible values are:
 \item a character vector of \link[base:strptime]{strptime} parse strings
 \item a list of \link{TimestampParser} objects
 }}
+
+\item{quoted_na}{Should missing values inside quotes be treated as missing
+values (the default) or strings. (Note that this is different from the
+the Arrow C++ default for the corresponding convert option,
+\code{strings_can_be_null}.)}
 }
 \description{
 A wrapper around \link{open_dataset} which explicitly includes parameters mirroring \code{\link[=read_csv_arrow]{read_csv_arrow()}},
@@ -189,7 +197,6 @@ for opening single files and functions for opening datasets.
 \itemize{
 \item \code{file} (instead, please specify files in \code{sources})
 \item \code{col_select} (instead, subset columns after dataset creation)
-\item \code{quoted_na}
 \item \code{as_data_frame} (instead, convert to data frame after dataset creation)
 \item \code{parse_options}
 }

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -561,6 +561,18 @@ test_that("open_delim_dataset params passed through to open_dataset", {
 
   expect_named(ds, c("int", "dbl", "lgl", "chr", "fct", "ts"))
 
+  # quoted_na
+  dst_dir <- make_temp_dir()
+  dst_file <- file.path(dst_dir, "data.csv")
+  df <- data.frame(text = c('one', 'two', '', 'four'))
+  write.csv(df, dst_file, row.names = FALSE, quote = FALSE)
+
+  ds <- open_csv_dataset(dst_dir, quoted_na = TRUE) %>% collect()
+  expect_equal(ds$text, c('one', 'two', NA, 'four'))
+
+  ds <- open_csv_dataset(dst_dir, quoted_na = FALSE) %>% collect()
+  expect_equal(ds$text, c('one', 'two', '', 'four'))
+
   # timestamp_parsers
   skip("GH-33708: timestamp_parsers don't appear to be working properly")
 

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -220,7 +220,7 @@ test_that("readr parse options", {
 
   # With not yet supported readr parse options
   expect_error(
-    open_dataset(tsv_dir, partitioning = "part", delim = "\t", quoted_na = TRUE),
+    open_dataset(tsv_dir, partitioning = "part", delim = "\t", col_select = "integer"),
     "supported"
   )
 
@@ -253,7 +253,7 @@ test_that("readr parse options", {
       tsv_dir,
       partitioning = "part",
       format = "text",
-      quo = "\"",
+      del = ","
     ),
     "Ambiguous"
   )
@@ -564,7 +564,7 @@ test_that("open_delim_dataset params passed through to open_dataset", {
   # quoted_na
   dst_dir <- make_temp_dir()
   dst_file <- file.path(dst_dir, "data.csv")
-  df <- data.frame(text = c('one', 'two', '', 'four'))
+  df <- data.frame(text = c('one', 'two', '', 'four'), num = 1:4)
   write.csv(df, dst_file, row.names = FALSE, quote = FALSE)
 
   ds <- open_csv_dataset(dst_dir, quoted_na = TRUE) %>% collect()

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -564,7 +564,7 @@ test_that("open_delim_dataset params passed through to open_dataset", {
   # quoted_na
   dst_dir <- make_temp_dir()
   dst_file <- file.path(dst_dir, "data.csv")
-  writeLines('text,num\none,1\ntwo,2\n,3\nfour,4', dst_file)
+  writeLines("text,num\none,1\ntwo,2\n,3\nfour,4", dst_file)
   ds <- open_csv_dataset(dst_dir, quoted_na = TRUE) %>% collect()
   expect_equal(ds$text, c("one", "two", NA, "four"))
 

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -564,14 +564,14 @@ test_that("open_delim_dataset params passed through to open_dataset", {
   # quoted_na
   dst_dir <- make_temp_dir()
   dst_file <- file.path(dst_dir, "data.csv")
-  df <- data.frame(text = c('one', 'two', '', 'four'), num = 1:4)
+  df <- data.frame(text = c("one", "two", "", "four"), num = 1:4)
   write.csv(df, dst_file, row.names = FALSE, quote = FALSE)
 
   ds <- open_csv_dataset(dst_dir, quoted_na = TRUE) %>% collect()
-  expect_equal(ds$text, c('one', 'two', NA, 'four'))
+  expect_equal(ds$text, c("one", "two", NA, "four"))
 
   ds <- open_csv_dataset(dst_dir, quoted_na = FALSE) %>% collect()
-  expect_equal(ds$text, c('one', 'two', '', 'four'))
+  expect_equal(ds$text, c("one", "two", "", "four"))
 
   # timestamp_parsers
   skip("GH-33708: timestamp_parsers don't appear to be working properly")

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -564,9 +564,7 @@ test_that("open_delim_dataset params passed through to open_dataset", {
   # quoted_na
   dst_dir <- make_temp_dir()
   dst_file <- file.path(dst_dir, "data.csv")
-  df <- data.frame(text = c("one", "two", "", "four"), num = 1:4)
-  write.csv(df, dst_file, row.names = FALSE, quote = FALSE)
-
+  writeLines('text,num\none,1\ntwo,2\n,3\nfour,4', dst_file)
   ds <- open_csv_dataset(dst_dir, quoted_na = TRUE) %>% collect()
   expect_equal(ds$text, c("one", "two", NA, "four"))
 


### PR DESCRIPTION
### Rationale for this change

The `open_delim_dataset()` family of functions were implemented to have the same arguments as the `read_delim_arrow()` functions where possible, but `quoted_na` was missed.

### What changes are included in this PR?

Adding `quoted_na` to those functions.

### Are these changes tested?

Yes 

### Are there any user-facing changes?

Yes

**This PR includes breaking changes to public APIs.**

Empty strings in input datasets now default to being read in by `open_delim_dataset()` and its derivates as NAs and not empty string

* Closes: #37813