### PR TITLE
GH-37722: [Java][FlightRPC] Deprecate stateful login methods

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ClientAuthHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ClientAuthHandler.java
@@ -19,9 +19,16 @@ package org.apache.arrow.flight.auth;
 
 import java.util.Iterator;
 
+import org.apache.arrow.flight.FlightClient;
+
 /**
  * Implement authentication for Flight on the client side.
+ *
+ * @deprecated As of 14.0.0. This implements a stateful "login" flow that does not play well with
+ *     distributed or stateless systems. It will not be removed, but should not be used. Instead
+ *     see {@link FlightClient#authenticateBasicToken(String, String)}.
  */
+@Deprecated
 public interface ClientAuthHandler {
   /**
    * Handle the initial handshake with the server.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthHandler.java
@@ -20,9 +20,18 @@ package org.apache.arrow.flight.auth;
 import java.util.Iterator;
 import java.util.Optional;
 
+import org.apache.arrow.flight.FlightServer;
+import org.apache.arrow.flight.auth2.CallHeaderAuthenticator;
+
 /**
  * Interface for Server side authentication handlers.
+ *
+ * @deprecated As of 14.0.0. This implements a stateful "login" flow that does not play well with
+ *     distributed or stateless systems. It will not be removed, but should not be used. Instead,
+ *     see {@link FlightServer.Builder#headerAuthenticator(CallHeaderAuthenticator)}
+ *     and {@link CallHeaderAuthenticator}.
  */
+@Deprecated
 public interface ServerAuthHandler {
 
   /**


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The existence of these interfaces confuses users and leads them to antipatterns.

### What changes are included in this PR?

Deprecate (but not for removal) the old interfaces.

### Are these changes tested?

N/A

### Are there any user-facing changes?

Yes.
* Closes: #37722