### PR TITLE
GH-37845: [Go][Parquet] Check the number of logical fields instead of physical columns

### DIFF
--- a/go/parquet/pqarrow/file_reader.go
+++ b/go/parquet/pqarrow/file_reader.go
@@ -394,8 +394,8 @@ func (fr *FileReader) ReadRowGroups(ctx context.Context, indices, rowGroups []in
 }
 
 func (fr *FileReader) getColumnReader(ctx context.Context, i int, colFactory itrFactory) (*ColumnReader, error) {
-	if i < 0 || i >= fr.rdr.MetaData().Schema.NumColumns() {
-		return nil, fmt.Errorf("invalid column index chosen %d, there are only %d columns", i, fr.rdr.MetaData().Schema.NumColumns())
+	if i < 0 || i >= len(fr.Manifest.Fields) {
+		return nil, fmt.Errorf("invalid column index chosen %d, there are only %d columns", i, len(fr.Manifest.Fields))
 	}
 
 	ctx = context.WithValue(ctx, rdrCtxKey{}, readerCtx{


### PR DESCRIPTION
### Rationale for this change

This makes it so trying to read with a column chunk reader consistently returns an error if the index is outside the bounds of the logical fields (currently it panics in some cases and returns an error in others).

### What changes are included in this PR?

This makes it so the column chunk reader checks the number of logical fields instead of the number of physical columns when checking if an index is out of range.

### Are these changes tested?

The new test will panics without the accompanying code change.

### Are there any user-facing changes?

Applications that used to panic will now have an error to handle instead.

* Closes: #37845