### PR TITLE
GH-37849: [C++] Add cpp/src/**/*.cmake to cmake-format targets

### DIFF
--- a/cpp/src/arrow/arrow-config.cmake
+++ b/cpp/src/arrow/arrow-config.cmake
@@ -19,8 +19,7 @@ message(WARNING "find_package(arrow) is deprecated. Use find_package(Arrow) inst
 find_package(Arrow CONFIG)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(arrow
-                                  REQUIRED_VARS
-                                  ARROW_INCLUDE_DIR
-                                  VERSION_VAR
-                                  ARROW_VERSION)
+find_package_handle_standard_args(
+  arrow
+  REQUIRED_VARS ARROW_INCLUDE_DIR
+  VERSION_VAR ARROW_VERSION)

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -149,6 +149,7 @@ def cmake_linter(src, fix=False):
         include_patterns=[
             'ci/**/*.cmake',
             'cpp/CMakeLists.txt',
+            'cpp/src/**/*.cmake',
             'cpp/src/**/*.cmake.in',
             'cpp/src/**/CMakeLists.txt',
             'cpp/examples/**/CMakeLists.txt',


### PR DESCRIPTION
### Rationale for this change

In general, all our `.cmake` files should be `cmake-format` targets.

### What changes are included in this PR?

Add missing patterns for `cpp/src/**/*.cmake`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #37849