### PR TITLE
GH-25271: [Website] Add a DOAP file

### DIFF
--- a/doap_Arrow.rdf
+++ b/doap_Arrow.rdf
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         https://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://arrow.apache.org">
+    <created>2023-09-25</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Arrow</name>
+    <homepage rdf:resource="https://arrow.apache.org" />
+    <asfext:pmc rdf:resource="https://arrow.apache.org" />
+    <shortdesc>Apache Arrow defines a language-independent columnar memory format for flat and hierarchical data, organized for efficient analytic operations on modern hardware like CPUs and GPUs. </shortdesc>
+    <description>Apache Arrow defines a language-independent columnar memory format for flat and hierarchical data, organized for efficient analytic operations on modern hardware like CPUs and GPUs. The Arrow memory format also supports zero-copy reads for lightning-fast data access without serialization overhead.
+
+Arrow's libraries implement the format and provide building blocks for a range of use cases, including high performance analytics. Many popular projects use Arrow to ship columnar data efficiently or as the basis for analytic engines.
+
+Libraries are available for C, C++, C#, Go, Java, JavaScript, Julia, MATLAB, Python, R, Ruby, and Rust. 
+
+Apache Arrow is software created by and for the developer community. We are dedicated to open, kind communication and consensus decision making. Our committers come from a range of organizations and backgrounds, and we welcome all to participate with us.</description>
+    <bug-database rdf:resource="https://github.com/apache/arrow/issues" />
+    <mailing-list rdf:resource="https://arrow.apache.org/community/" />
+    <download-page rdf:resource="https://arrow.apache.org/install/" />
+    <programming-language>C</programming-language>
+    <programming-language>C++</programming-language>
+    <programming-language>Go</programming-language>
+    <programming-language>Java</programming-language>
+    <programming-language>Python</programming-language>
+    <programming-language>R</programming-language>
+    <programming-language>Ruby</programming-language>
+    <programming-language>Rust</programming-language>
+    <category rdf:resource="https://projects.apache.org/category/big-data" />
+    <category rdf:resource="https://projects.apache.org/category/database" />
+    <category rdf:resource="https://projects.apache.org/category/data-engineering" />
+    <category rdf:resource="https://projects.apache.org/category/library" />
+    <category rdf:resource="https://projects.apache.org/category/network-client" />
+    <category rdf:resource="https://projects.apache.org/category/network-server" />
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://github.com/apache/arrow.git"/>
+        <browse rdf:resource="https://github.com/apache/arrow"/>
+      </GitRepository>
+    </repository>
+  </Project>
+</rdf:RDF>
+


### PR DESCRIPTION
### Rationale for this change

The Apache Community Development committee (ComDev) maintains a website [projects.apache.org](http://projects.apache.org/) which lists all ASF projects, and some basic details about them. These details are derived from DOAP (Description Of A Project) file that is maintained by each PMC.

### What changes are included in this PR?

Add a DOAP file for Arrow, created using https://projects.apache.org/create.html. 

Once / if this PR is merged, I will add the appropriate entry to
https://svn.apache.org/repos/asf/comdev/projects.apache.org/trunk/data/projects.xml as described on https://projects.apache.org/create.html

### Are these changes tested?

N/A

### Are there any user-facing changes?
No
* Closes: #25271