### PR TITLE
GH-37858: [Docs][JS] Fix check of remote URL to generate JS docs

### DIFF
--- a/ci/scripts/js_build.sh
+++ b/ci/scripts/js_build.sh
@@ -32,12 +32,14 @@ yarn lint:ci
 yarn build
 
 if [ "${BUILD_DOCS_JS}" == "ON" ]; then
-  if [[ "$(git config --get remote.origin.url)" =~ "https://github.com/apache/arrow" ]]; then
-    yarn doc
+  # If apache or upstream are defined use those as remote.
+  # Otherwise use origin which could be a fork on PRs.
+  if [ "$(git config --get remote.apache.url)" == "git@github.com:apache/arrow.git" ]; then
+    yarn doc --gitRemote apache
   elif [[ "$(git config --get remote.upstream.url)" =~ "https://github.com/apache/arrow" ]]; then
     yarn doc --gitRemote upstream
-  elif [ "$(git config --get remote.apache.url)" == "git@github.com:apache/arrow.git" ]; then
-    yarn doc --gitRemote apache
+  elif [[ "$(basename -s .git $(git config --get remote.origin.url))" == "arrow" ]]; then
+    yarn doc
   else
     echo "Failed to build docs because the remote is not set correctly. Please set the origin or upstream remote to https://github.com/apache/arrow.git or the apache remote to git@github.com:apache/arrow.git."
     exit 0

--- a/ci/scripts/js_build.sh
+++ b/ci/scripts/js_build.sh
@@ -32,9 +32,9 @@ yarn lint:ci
 yarn build
 
 if [ "${BUILD_DOCS_JS}" == "ON" ]; then
-  if [ "$(git config --get remote.origin.url)" == "https://github.com/apache/arrow.git" ]; then
+  if [[ "$(git config --get remote.origin.url)" =~ "https://github.com/apache/arrow" ]]; then
     yarn doc
-  elif [ "$(git config --get remote.upstream.url)" == "https://github.com/apache/arrow.git" ]; then
+  elif [[ "$(git config --get remote.upstream.url)" =~ "https://github.com/apache/arrow" ]]; then
     yarn doc --gitRemote upstream
   elif [ "$(git config --get remote.apache.url)" == "git@github.com:apache/arrow.git" ]; then
     yarn doc --gitRemote apache


### PR DESCRIPTION
### Rationale for this change

JS Docs are currently not being generated.

### What changes are included in this PR?

Use a regex check instead of an equality to cover both remote set with `.git` and without for upstream. Added also a fix to generate docs from origin from forks if necessary.

### Are these changes tested?

Via archery

### Are there any user-facing changes?
No
* Closes: #37858