### PR TITLE
GH-37876: [Format] Add list-view specification to arrow format

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -100,8 +100,8 @@ Arrays are defined by a few pieces of metadata and data:
 Nested arrays additionally have a sequence of one or more sets of
 these items, called the **child arrays**.
 
-Each logical data type has one or more well-defined physical layouts. Here
-are the different physical layouts defined by Arrow:
+Each logical data type has a well-defined physical layout. Here are
+the different physical layouts defined by Arrow:
 
 * **Primitive (fixed-size)**: a sequence of values each having the
   same byte or bit width
@@ -406,8 +406,8 @@ This layout is adapted from TU Munich's `UmbraDB`_.
 
 .. _variable-size-list-layout:
 
-Variable-size List Layouts
---------------------------
+Variable-size List Layout
+-------------------------
 
 List is a nested type which is semantically similar to variable-size
 binary. There are two list layout variations — "list" and "list-view" —
@@ -727,8 +727,8 @@ for the null struct but they are "hidden" by the struct array's validity
 bitmap. However, when treated independently, corresponding entries of the
 children array will be non-null.
 
-Union Layouts
--------------
+Union Layout
+------------
 
 A union is defined by an ordered sequence of types; each slot in the
 union can have a value chosen from these types. The types are named

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -512,10 +512,11 @@ in the sizes buffer instead of inferred. This allows offsets to be out of order.
 Elements of the child array do not have to be stored in the same order they
 logically appear in the list elements of the parent array.
 
-When a value is null, the corresponding size is expected to be 0. When the size
-is 0 because the value is null or because the value represents an empty list,
-the corresponding offset may have any value between 0 and the length of the
-child array (inclusive).
+Every list-view value, including null values, has to guarantee the following
+invariants: ::
+
+    0 <= offsets[i] <= length of the child array
+    0 <= offsets[i] + size[i] <= length of the child array
 
 A list-view type is specified like ``ListView<T>``, where ``T`` is any type
 (primitive or nested). In these examples we use 32-bit offsets and sizes where

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -518,8 +518,8 @@ the corresponding offset may have any value between 0 and the length of the
 child array (inclusive).
 
 A list-view type is specified like ``ListView<T>``, where ``T`` is any type
-(primitive or nested). In these examples we use 32-bit offsets where
-the 64-bit offset version would be denoted by ``LargeListView<T>``.
+(primitive or nested). In these examples we use 32-bit offsets and sizes where
+the 64-bit version would be denoted by ``LargeListView<T>``.
 
 **Example Layout: ``ListView<Int8>`` Array**
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -100,8 +100,8 @@ Arrays are defined by a few pieces of metadata and data:
 Nested arrays additionally have a sequence of one or more sets of
 these items, called the **child arrays**.
 
-Each logical data type has a well-defined physical layout. Here are
-the different physical layouts defined by Arrow:
+Each logical data type has one or more well-defined physical layouts. Here
+are the different physical layouts defined by Arrow:
 
 * **Primitive (fixed-size)**: a sequence of values each having the
   same byte or bit width
@@ -618,8 +618,8 @@ for the null struct but they are "hidden" by the struct array's validity
 bitmap. However, when treated independently, corresponding entries of the
 children array will be non-null.
 
-Union Layout
-------------
+Union Layouts
+-------------
 
 A union is defined by an ordered sequence of types; each slot in the
 union can have a value chosen from these types. The types are named

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -382,7 +382,7 @@ In both the long and short string cases, the first four bytes encode the
 length of the string and can be used to determine how the rest of the view
 should be interpreted.
 
-In the short string case the string's bytes are inlined- stored inside the
+In the short string case the string's bytes are inlined — stored inside the
 view itself, in the twelve bytes which follow the length.
 
 In the long string case, a buffer index indicates which data buffer
@@ -858,19 +858,19 @@ are held in the second child array.
 For the purposes of determining field names and schemas, these child arrays
 are prescribed the standard names of **run_ends** and **values** respectively.
 
-The values in the first child array represent the accumulated length of all runs 
+The values in the first child array represent the accumulated length of all runs
 from the first to the current one, i.e. the logical index where the
 current run ends. This allows relatively efficient random access from a logical
 index using binary search. The length of an individual run can be determined by
 subtracting two adjacent values. (Contrast this with run-length encoding, in
 which the lengths of the runs are represented directly, and in which random
-access is less efficient.) 
+access is less efficient.)
 
 .. note::
    Because the ``run_ends`` child array cannot have nulls, it's reasonable
    to consider why the ``run_ends`` are a child array instead of just a
    buffer, like the offsets for a :ref:`variable-size-list-layout`. This
-   layout was considered, but it was decided to use the child arrays. 
+   layout was considered, but it was decided to use the child arrays.
 
    Child arrays allow us to keep the "logical length" (the decoded length)
    associated with the parent array and the "physical length" (the number

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -527,7 +527,7 @@ We illustrate an example of ``ListView<Int8>`` with length 4 having values::
 
     [[12, -7, 25], null, [0, -127, 127, 50], []]
 
-will have the following representation: ::
+It may have the following representation: ::
 
     * Length: 4, Null count: 1
     * Validity bitmap buffer:

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -411,7 +411,8 @@ Variable-size List Layouts
 
 List is a nested type which is semantically similar to variable-size
 binary. There are two list layout variations — "list" and "list-view" —
-and each variation can use either 32-bit or 64-bit offsets.
+and each variation can be delimited by either 32-bit or 64-bit offsets
+integers.
 
 List Layout
 ~~~~~~~~~~~
@@ -452,7 +453,7 @@ will have the following representation: ::
       |------------|-------------|-------------|-------------|-------------|-----------------------|
       | 0          | 3           | 3           | 7           | 7           | unspecified (padding) |
 
-    * Values array (Int8array):
+    * Values array (Int8Array):
       * Length: 7,  Null count: 0
       * Validity bitmap buffer: Not required
       * Values buffer (int8)
@@ -501,16 +502,15 @@ will be represented as follows: ::
 ListView Layout
 ~~~~~~~~~~~~~~~
 
-The ListView layout is defined by three buffers instead of just two:
-a validity bitmap, an offsets buffer, and an additional sizes buffer.
-The sizes have the same bit width as the offsets and both 32-bit and 64-bit
-signed integer options are supported. Like in the List layout, the offsets
-reference the child array.
+The ListView layout is defined by three buffers: a validity bitmap, an offsets
+buffer, and an additional sizes buffer. Sizes and offsets have the identical bit
+width and both 32-bit and 64-bit signed integer options are supported.
 
-Rather then inferring list lengths from the offsets, the sizes buffer
-stores the length of each list in the array. This in turn allows offsets to be
-out of order. Elements of the child array do not have to be stored in the
-same order they logically appear in the list elements of the parent array.
+As in the List layout, the offsets encode the start position of each slot in the
+child array. In contrast to the List layout, list lengths are stored explicitly
+in the sizes buffer instead of inferred. This allows offsets to be out of order.
+Elements of the child array do not have to be stored in the same order they
+logically appear in the list elements of the parent array.
 
 When a value is null, the corresponding offset and size can have arbitrary
 values. When size is 0, the corresponding offset can have an arbitrary value.
@@ -521,7 +521,7 @@ A list-view type is specified like ``ListView<T>``, where ``T`` is any type
 (primitive or nested). In these examples we use 32-bit offsets where
 the 64-bit offset version would be denoted by ``LargeListView<T>``.
 
-**Example Layout: ``List<Int8>`` Array**
+**Example Layout: ``ListView<Int8>`` Array**
 
 We illustrate an example of ``ListView<Int8>`` with length 4 having values::
 
@@ -548,7 +548,7 @@ will have the following representation: ::
       |------------|-------------|-------------|-------------|-----------------------|
       | 3          | unspecified | 4           | 0           | unspecified (padding) |
 
-    * Values array (Int8array):
+    * Values array (Int8Array):
       * Length: 7,  Null count: 0
       * Validity bitmap buffer: Not required
       * Values buffer (int8)
@@ -586,7 +586,7 @@ It will have the following representation: ::
       |------------|-------------|-------------|-------------|-------------|-----------------------|
       | 3          | unspecified | 4           | 0           | 2           | unspecified (padding) |
 
-    * Values array (Int8array):
+    * Values array (Int8Array):
       * Length: 7,  Null count: 0
       * Validity bitmap buffer: Not required
       * Values buffer (int8)

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -108,7 +108,7 @@ are the different physical layouts defined by Arrow:
 * **Variable-size Binary**: a sequence of values each having a variable
   byte length. Two variants of this layout are supported using 32-bit
   and 64-bit length encoding.
-* **Views of Variable-size Binary**: a sequence of values each having a
+* **View of Variable-size Binary**: a sequence of values each having a
   variable byte length. In contrast to Variable-size Binary, the values
   of this layout are distributed across potentially multiple buffers
   instead of densely and sequentially packed in a single buffer.

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -512,10 +512,10 @@ in the sizes buffer instead of inferred. This allows offsets to be out of order.
 Elements of the child array do not have to be stored in the same order they
 logically appear in the list elements of the parent array.
 
-When a value is null, the corresponding offset and size can have arbitrary
-values. When size is 0, the corresponding offset can have an arbitrary value.
-If choosing a value is possible, we recommend setting offsets and sizes to 0 in
-these cases.
+When a value is null, the corresponding size is expected to be 0. When the size
+is 0 because the value is null or because the value represents an empty list,
+the corresponding offset may have any value between 0 and the length of the
+child array (inclusive).
 
 A list-view type is specified like ``ListView<T>``, where ``T`` is any type
 (primitive or nested). In these examples we use 32-bit offsets where
@@ -540,13 +540,13 @@ It may have the following representation: ::
 
       | Bytes 0-3  | Bytes 4-7   | Bytes 8-11  | Bytes 12-15 | Bytes 16-63           |
       |------------|-------------|-------------|-------------|-----------------------|
-      | 0          | unspecified | 3           | unspecified | unspecified (padding) |
+      | 0          | 7           | 3           | 0           | unspecified (padding) |
 
     * Sizes buffer (int32)
 
       | Bytes 0-3  | Bytes 4-7   | Bytes 8-11  | Bytes 12-15 | Bytes 16-63           |
       |------------|-------------|-------------|-------------|-----------------------|
-      | 3          | unspecified | 4           | 0           | unspecified (padding) |
+      | 3          | 0           | 4           | 0           | unspecified (padding) |
 
     * Values array (Int8Array):
       * Length: 7,  Null count: 0
@@ -565,7 +565,7 @@ having logical values::
 
     [[12, -7, 25], null, [0, -127, 127, 50], [], [50, 12]]
 
-It will have the following representation: ::
+It may have the following representation: ::
 
     * Length: 4, Null count: 1
     * Validity bitmap buffer:
@@ -578,13 +578,13 @@ It will have the following representation: ::
 
       | Bytes 0-3  | Bytes 4-7   | Bytes 8-11  | Bytes 12-15 | Bytes 16-19 | Bytes 20-63           |
       |------------|-------------|-------------|-------------|-------------|-----------------------|
-      | 4          | unspecified | 0           | unspecified | 3           | unspecified (padding) |
+      | 4          | 7           | 0           | 0           | 3           | unspecified (padding) |
 
     * Sizes buffer (int32)
 
       | Bytes 0-3  | Bytes 4-7   | Bytes 8-11  | Bytes 12-15 | Bytes 16-19 | Bytes 20-63           |
       |------------|-------------|-------------|-------------|-------------|-----------------------|
-      | 3          | unspecified | 4           | 0           | 2           | unspecified (padding) |
+      | 3          | 0           | 4           | 0           | 2           | unspecified (padding) |
 
     * Values array (Int8Array):
       * Length: 7,  Null count: 0

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1230,7 +1230,7 @@ addresses between libraries, it is recommended to set ``size`` to the actual
 memory size rather than the padded size.
 
 Variadic buffers
-^^^^^^^^^^^^^^^^
+----------------
 
 Some types such as Utf8View are represented using a variable number of buffers.
 For each such Field in the pre-ordered flattened logical schema, there will be

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -22,7 +22,8 @@
 /// Version 1.1 - Add Decimal256.
 /// Version 1.2 - Add Interval MONTH_DAY_NANO.
 /// Version 1.3 - Add Run-End Encoded.
-/// Version 1.4 - Add BinaryView, Utf8View, and variadicBufferCounts.
+/// Version 1.4 - Add BinaryView, Utf8View, variadicBufferCounts, ListView, and
+/// LargeListView.
 
 namespace org.apache.arrow.flatbuf;
 
@@ -95,6 +96,17 @@ table List {
 /// Same as List, but with 64-bit offsets, allowing to represent
 /// extremely large data values.
 table LargeList {
+}
+
+/// Represents the same logical types that List can, but contains offsets and
+/// sizes allowing for writes in any order and sharing of child values among
+/// list values.
+table ListView {
+}
+
+/// Same as ListVIew, but with 64-bit offsets and sizes, allowing to represent
+/// extremely large data values.
+table LargeListView {
 }
 
 table FixedSizeList {
@@ -451,6 +463,8 @@ union Type {
   RunEndEncoded,
   BinaryView,
   Utf8View,
+  ListView,
+  LargeListView,
 }
 
 /// ----------------------------------------------------------------------

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -104,7 +104,7 @@ table LargeList {
 table ListView {
 }
 
-/// Same as ListVIew, but with 64-bit offsets and sizes, allowing to represent
+/// Same as ListView, but with 64-bit offsets and sizes, allowing to represent
 /// extremely large data values.
 table LargeListView {
 }


### PR DESCRIPTION
### Rationale for this change

More details in the draft implementations of this spec:

 - C++: #35345
 - Go: #37468

### What changes are included in this PR?

 - Some unrelated fixes to the spec text (I can extract these to another PR if necessary)
 - Changes to the spec text
 - Additions to the Flatbuffers specifications of the Arrow format

### Are these changes tested?

N/A.

### Are there any user-facing changes?

Changes in documentation and backwards compatible additions to the format spec.

* Closes: #37876