### PR TITLE
GH-25659: [Java] Add DefaultVectorComparators for Large types

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.vector.BaseFixedWidthVector;
-import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
@@ -50,6 +49,7 @@ import org.apache.arrow.vector.UInt2Vector;
 import org.apache.arrow.vector.UInt4Vector;
 import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VariableWidthVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
 
 /**
@@ -112,7 +112,7 @@ public class DefaultVectorComparators {
       } else if (vector instanceof TimeStampVector) {
         return (VectorValueComparator<T>) new TimeStampComparator();
       }
-    } else if (vector instanceof BaseVariableWidthVector) {
+    } else if (vector instanceof VariableWidthVector) {
       return (VectorValueComparator<T>) new VariableWidthComparator();
     } else if (vector instanceof BaseRepeatedValueVector) {
       VectorValueComparator<?> innerComparator =
@@ -675,14 +675,14 @@ public class DefaultVectorComparators {
   }
 
   /**
-   * Default comparator for {@link org.apache.arrow.vector.BaseVariableWidthVector}.
+   * Default comparator for {@link org.apache.arrow.vector.VariableWidthVector}.
    * The comparison is in lexicographic order, with null comes first.
    */
-  public static class VariableWidthComparator extends VectorValueComparator<BaseVariableWidthVector> {
+  public static class VariableWidthComparator extends VectorValueComparator<VariableWidthVector> {
 
-    private ArrowBufPointer reusablePointer1 = new ArrowBufPointer();
+    private final ArrowBufPointer reusablePointer1 = new ArrowBufPointer();
 
-    private ArrowBufPointer reusablePointer2 = new ArrowBufPointer();
+    private final ArrowBufPointer reusablePointer2 = new ArrowBufPointer();
 
     @Override
     public int compare(int index1, int index2) {
@@ -699,7 +699,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<BaseVariableWidthVector> createNew() {
+    public VectorValueComparator<VariableWidthVector> createNew() {
       return new VariableWidthComparator();
     }
   }
@@ -743,7 +743,7 @@ public class DefaultVectorComparators {
     @Override
     public VectorValueComparator<BaseRepeatedValueVector> createNew() {
       VectorValueComparator<T> newInnerComparator = innerComparator.createNew();
-      return new RepeatedValueComparator(newInnerComparator);
+      return new RepeatedValueComparator<>(newInnerComparator);
     }
 
     @Override

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
@@ -35,6 +35,8 @@ import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TimeMicroVector;
 import org.apache.arrow.vector.TimeMilliVector;
@@ -47,6 +49,9 @@ import org.apache.arrow.vector.UInt1Vector;
 import org.apache.arrow.vector.UInt2Vector;
 import org.apache.arrow.vector.UInt4Vector;
 import org.apache.arrow.vector.UInt8Vector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
 import org.apache.arrow.vector.types.TimeUnit;
@@ -910,5 +915,26 @@ public class TestDefaultVectorComparator {
       comparator.attachVectors(vec, vec2);
       assertTrue(comparator.checkNullsOnCompare());
     }
+  }
+
+  @Test
+  public void testVariableWidthDefaultComparators() {
+    try (VarCharVector vec = new VarCharVector("test", allocator)) {
+      verifyVariableWidthComparatorReturned(vec);
+    }
+    try (VarBinaryVector vec = new VarBinaryVector("test", allocator)) {
+      verifyVariableWidthComparatorReturned(vec);
+    }
+    try (LargeVarCharVector vec = new LargeVarCharVector("test", allocator)) {
+      verifyVariableWidthComparatorReturned(vec);
+    }
+    try (LargeVarBinaryVector vec = new LargeVarBinaryVector("test", allocator)) {
+      verifyVariableWidthComparatorReturned(vec);
+    }
+  }
+
+  private static <V extends ValueVector> void verifyVariableWidthComparatorReturned(V vec) {
+    VectorValueComparator<V> comparator = DefaultVectorComparators.createDefaultComparator(vec);
+    assertEquals(DefaultVectorComparators.VariableWidthComparator.class, comparator.getClass());
   }
 }


### PR DESCRIPTION
### Rationale for this change
Support additional vector types in DefaultVectorComparators to make arrow-algorithm easier to use.

### What changes are included in this PR?
Add DefaultVectorComparators for large vector types (LargeVarCharVector and LargeVarBinaryVector).

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* Closes: #25659