### PR TITLE
GH-35770: [Go][Documentation] Update TimestampType zero value as seconds in comment

### DIFF
--- a/go/arrow/datatype_fixedwidth.go
+++ b/go/arrow/datatype_fixedwidth.go
@@ -347,7 +347,7 @@ type TemporalWithUnit interface {
 }
 
 // TimestampType is encoded as a 64-bit signed integer since the UNIX epoch (2017-01-01T00:00:00Z).
-// The zero-value is a nanosecond and time zone neutral. Time zone neutral can be
+// The zero-value is a second and time zone neutral. Time zone neutral can be
 // considered UTC without having "UTC" as a time zone.
 type TimestampType struct {
 	Unit     TimeUnit


### PR DESCRIPTION
### Rationale for this change

To clear the confusion around the zero value of `TimestampType`

### What changes are included in this PR?

Just a comment change `nanosecond -> second`

### Are these changes tested?

No need to test

### Are there any user-facing changes?

No

Closes: https://github.com/apache/arrow/issues/35770
* Closes: #35770