### PR TITLE
MINOR: [R][Documentation] Add default descriptions in CsvParseOptions$create() docs

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -404,10 +404,10 @@ CsvTableReader$create <- function(file,
 #'
 #' - `delimiter` Field delimiting character (default `","`)
 #' - `quoting` Logical: are strings quoted? (default `TRUE`)
-#' - `quote_char` Quoting character, if `quoting` is `TRUE`
+#' - `quote_char` Quoting character, if `quoting` is `TRUE` (default `'"'`)
 #' - `double_quote` Logical: are quotes inside values double-quoted? (default `TRUE`)
 #' - `escaping` Logical: whether escaping is used (default `FALSE`)
-#' - `escape_char` Escaping character, if `escaping` is `TRUE`
+#' - `escape_char` Escaping character, if `escaping` is `TRUE` (default `"\\"`)
 #' - `newlines_in_values` Logical: are values allowed to contain CR (`0x0d`)
 #'    and LF (`0x0a`) characters? (default `FALSE`)
 #' - `ignore_empty_lines` Logical: should empty lines be ignored (default) or

--- a/r/man/CsvReadOptions.Rd
+++ b/r/man/CsvReadOptions.Rd
@@ -52,10 +52,10 @@ The order of application is as follows:
 \itemize{
 \item \code{delimiter} Field delimiting character (default \code{","})
 \item \code{quoting} Logical: are strings quoted? (default \code{TRUE})
-\item \code{quote_char} Quoting character, if \code{quoting} is \code{TRUE}
+\item \code{quote_char} Quoting character, if \code{quoting} is \code{TRUE} (default \code{'"'})
 \item \code{double_quote} Logical: are quotes inside values double-quoted? (default \code{TRUE})
 \item \code{escaping} Logical: whether escaping is used (default \code{FALSE})
-\item \code{escape_char} Escaping character, if \code{escaping} is \code{TRUE}
+\item \code{escape_char} Escaping character, if \code{escaping} is \code{TRUE} (default \code{"\\\\"})
 \item \code{newlines_in_values} Logical: are values allowed to contain CR (\code{0x0d})
 and LF (\code{0x0a}) characters? (default \code{FALSE})
 \item \code{ignore_empty_lines} Logical: should empty lines be ignored (default) or


### PR DESCRIPTION
### Rationale for this change

Add more function documentation for folks who want to manually change `quote_char` or `escape_char` options in `CsvParseOptions$create()`, as I did in #37908.

I had to go through the source code to arrow/r/R/csv.R - [line 587](https://github.com/apache/arrow/blob/7dc9f69a8a77345d0ec7920af9224ef96d7f5f78/r/R/csv.R#L587) to find the default argument, which was a pain.

### What changes are included in this PR?

Documentation changes

### Are these changes tested?

No - not changing underlying code. Maintainers might need to rebuild package to include these changes in man/ folder

### Are there any user-facing changes?

Yes, on documentation of methods.