### PR TITLE
GH-37864: [Java] Remove unnecessary throws from OrcReader

### DIFF
--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcReader.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcReader.java
@@ -84,7 +84,7 @@ public class OrcReader implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     jniWrapper.close(nativeInstanceId);
   }
 }


### PR DESCRIPTION
### Rationale for this change
Make OrcReader more friendly to use with try-with-resources blocks and AutoCloseables by
removing an unnecessary throws modifier on close().

### What changes are included in this PR?
Removes an unused throws specifier on OrcReader#close().

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* Closes: #37864