### PR TITLE
GH-36994: [Java][CI] Enable support for JDK21

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 11, 17, 20]
+        jdk: [8, 11, 17, 21]
         include:
         - jdk: 8
           title: AMD64 Debian 9 Java JDK 8 Maven 3.5.4
@@ -71,10 +71,10 @@ jobs:
           title: AMD64 Ubuntu 22.04 Java JDK 17 Maven 3.9.3
           maven: 3.9.3
           image: eclipse-java
-        - jdk: 20
-          title: AMD64 Ubuntu 22.04 Java JDK 20 Maven 3.9.3
-          maven: 3.9.3
-          image: eclipse-java
+        - jdk: 21
+          title: AMD64 Ubuntu 22.04 Java JDK 21 Maven 3.9.4
+          maven: 3.9.4
+          image: amazon-java
     env:
       JDK: ${{ matrix.jdk }}
       MAVEN: ${{ matrix.maven }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,7 @@ x-hierarchy:
   - debian-java
   - debian-js
   - eclipse-java
+  - amazon-java
   - fedora-cpp:
     - fedora-python
   - python-sdist
@@ -1701,6 +1702,18 @@ services:
     #   MAVEN: 3.9.3
     #   JDK: 17, 20
     image: ${ARCH}/maven:${MAVEN}-eclipse-temurin-${JDK}
+    shm_size: *shm-size
+    volumes: *java-volumes
+    command: *java-command
+
+  amazon-java:
+    # Usage:
+    #   docker-compose build amazon-java
+    #   docker-compose run amazon-java
+    # Parameters:
+    #   MAVEN: 3.9.4
+    #   JDK: 21
+    image: ${ARCH}/maven:${MAVEN}-amazoncorretto-${JDK}
     shm_size: *shm-size
     volumes: *java-volumes
     command: *java-command

--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -107,14 +107,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.core.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.inline.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -68,14 +68,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.core.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.inline.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -52,4 +52,17 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>pin-mockito-jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <mockito.core.version>4.11.0</mockito.core.version>
+                <mockito.inline.version>4.11.0</mockito.inline.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,8 +44,10 @@
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
-    <error_prone_core.version>2.16</error_prone_core.version>
+    <error_prone_core.version>2.22.0</error_prone_core.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <mockito.core.version>5.5.0</mockito.core.version>
+    <mockito.inline.version>5.2.0</mockito.inline.version>
   </properties>
 
   <scm>

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -112,13 +112,14 @@ public class DictionaryEncoder {
    * @param valueCount dictionary vector valueCount.
    * @return index type.
    */
+  @SuppressWarnings("ComparisonOutOfRange")
   public static ArrowType.Int getIndexType(int valueCount) {
     Preconditions.checkArgument(valueCount >= 0);
     if (valueCount <= Byte.MAX_VALUE) {
       return new ArrowType.Int(8, true);
     } else if (valueCount <= Character.MAX_VALUE) {
       return new ArrowType.Int(16, true);
-    } else if (valueCount <= Integer.MAX_VALUE) {
+    } else if (valueCount <= Integer.MAX_VALUE) { //this comparison to Integer.MAX_VALUE will always evaluate to true
       return new ArrowType.Int(32, true);
     } else {
       return new ArrowType.Int(64, true);


### PR DESCRIPTION
### Rationale for this change

Enable support for last Java JDK 21 version 

### What changes are included in this PR?

To be able to build Arrow Java using JDK21

### Are these changes tested?

For initial testing, Amazon Corretto was used, but at the end Temurin JDK21 docker image should be used.

### Are there any user-facing changes?

No

Closes: https://github.com/apache/arrow/issues/37914
* Closes: #37914
* Closes: #36994