### PR TITLE
GH-37917: [Parquet] Add OpenAsync for FileSource

### DIFF
--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -90,7 +90,7 @@ Future<std::shared_ptr<io::RandomAccessFile>> FileSource::OpenAsync() const {
     return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(std::make_shared<io::BufferReader>(buffer_));
   }
 
-  // TODO(GH-37917): custom_open_ should not block
+  // TODO(GH-37962): custom_open_ should not block
   return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(custom_open_());
 }
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -81,6 +81,18 @@ Result<std::shared_ptr<io::RandomAccessFile>> FileSource::Open() const {
   return custom_open_();
 }
 
+Future<std::shared_ptr<io::RandomAccessFile>> FileSource::OpenAsync() const {
+  if (filesystem_) {
+    return filesystem_->OpenInputFileAsync(file_info_);
+  }
+  
+  if (buffer_) {
+    return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(std::make_shared<io::BufferReader>(buffer_));
+  }
+
+  return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(custom_open_());
+}
+
 int64_t FileSource::Size() const {
   if (filesystem_) {
     return file_info_.size();

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -85,9 +85,10 @@ Future<std::shared_ptr<io::RandomAccessFile>> FileSource::OpenAsync() const {
   if (filesystem_) {
     return filesystem_->OpenInputFileAsync(file_info_);
   }
-  
+
   if (buffer_) {
-    return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(std::make_shared<io::BufferReader>(buffer_));
+    return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(
+        std::make_shared<io::BufferReader>(buffer_));
   }
 
   // TODO(GH-37962): custom_open_ should not block

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -90,6 +90,7 @@ Future<std::shared_ptr<io::RandomAccessFile>> FileSource::OpenAsync() const {
     return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(std::make_shared<io::BufferReader>(buffer_));
   }
 
+  // TODO(GH-37917): custom_open_ should not block
   return Future<std::shared_ptr<io::RandomAccessFile>>::MakeFinished(custom_open_());
 }
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -115,6 +115,7 @@ class ARROW_DS_EXPORT FileSource : public util::EqualityComparable<FileSource> {
 
   /// \brief Get a RandomAccessFile which views this file source
   Result<std::shared_ptr<io::RandomAccessFile>> Open() const;
+  Future<std::shared_ptr<io::RandomAccessFile>> OpenAsync() const;
 
   /// \brief Get the size (in bytes) of the file or buffer
   /// If the file is compressed this should be the compressed (on-disk) size.

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -483,17 +483,17 @@ Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
   // TODO(ARROW-12259): workaround since we have Future<(move-only type)>
 
   auto path = source.path();
-  auto reader_fut = input_fut.Then(
-    [=](const std::shared_ptr<arrow::io::RandomAccessFile>&) mutable
-      -> Result<std::unique_ptr<parquet::ParquetFileReader>> {
+  auto reader_fut =
+      input_fut.Then([=](const std::shared_ptr<arrow::io::RandomAccessFile>&) mutable
+                     -> Result<std::unique_ptr<parquet::ParquetFileReader>> {
         ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::io::RandomAccessFile> input,
                               input_fut.MoveResult());
-        auto rfut = parquet::ParquetFileReader::OpenAsync(std::move(input), std::move(properties), metadata);
-        ARROW_ASSIGN_OR_RAISE(auto reader,
-                              rfut.MoveResult());
+        auto rfut = parquet::ParquetFileReader::OpenAsync(
+            std::move(input), std::move(properties), metadata);
+        ARROW_ASSIGN_OR_RAISE(auto reader, rfut.MoveResult());
         return reader;
       });
-    
+
   auto self = checked_pointer_cast<const ParquetFileFormat>(shared_from_this());
   return reader_fut.Then(
       [=](const std::unique_ptr<parquet::ParquetFileReader>&) mutable

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -482,31 +482,33 @@ Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
 
   auto self = checked_pointer_cast<const ParquetFileFormat>(shared_from_this());
 
-  return source.OpenAsync().Then([=](const std::shared_ptr<io::RandomAccessFile>& input) mutable {
-    return parquet::ParquetFileReader::OpenAsync(input, std::move(properties), metadata)
-        .Then(
-            [=](const std::unique_ptr<parquet::ParquetFileReader>& reader) mutable
-            -> Result<std::shared_ptr<parquet::arrow::FileReader>> {
-              auto arrow_properties = MakeArrowReaderProperties(
-                  *self, *reader->metadata(), *options, *parquet_scan_options);
-
-              std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-              RETURN_NOT_OK(parquet::arrow::FileReader::Make(
-                  options->pool,
-                  // TODO(ARROW-12259): workaround since we have Future<(move-only type)>
-                  // It *wouldn't* be safe to const_cast reader except that here we know
-                  // there are no other waiters on the reader.
-                  std::move(
-                      const_cast<std::unique_ptr<parquet::ParquetFileReader>&>(reader)),
-                  std::move(arrow_properties), &arrow_reader));
-
-              return std::move(arrow_reader);
-            },
-            [path = source.path()](const Status& status)
+  return source.OpenAsync().Then(
+      [=](const std::shared_ptr<io::RandomAccessFile>& input) mutable {
+        return parquet::ParquetFileReader::OpenAsync(input, std::move(properties),
+                                                     metadata)
+            .Then(
+                [=](const std::unique_ptr<parquet::ParquetFileReader>& reader) mutable
                 -> Result<std::shared_ptr<parquet::arrow::FileReader>> {
-              return WrapSourceError(status, path);
-            });
-  });
+                  auto arrow_properties = MakeArrowReaderProperties(
+                      *self, *reader->metadata(), *options, *parquet_scan_options);
+
+                  std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+                  RETURN_NOT_OK(parquet::arrow::FileReader::Make(
+                      options->pool,
+                      // TODO(ARROW-12259): workaround since we have Future<(move-only
+                      // type)> It *wouldn't* be safe to const_cast reader except that
+                      // here we know there are no other waiters on the reader.
+                      std::move(const_cast<std::unique_ptr<parquet::ParquetFileReader>&>(
+                          reader)),
+                      std::move(arrow_properties), &arrow_reader));
+
+                  return std::move(arrow_reader);
+                },
+                [path = source.path()](const Status& status)
+                    -> Result<std::shared_ptr<parquet::arrow::FileReader>> {
+                  return WrapSourceError(status, path);
+                });
+      });
 }
 
 struct SlicingGenerator {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Improves performance of file reads with an expensive Open operation.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37917