### PR TITLE
MINOR: [R] Bump versions file for navigating between docs versions

### DIFF
--- a/r/pkgdown/assets/versions.html
+++ b/r/pkgdown/assets/versions.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
-<body><p><a href="../dev/r/">12.0.1.9000 (dev)</a></p>
-<p><a href="../r/">12.0.1.1 (release)</a></p>
+<body><p><a href="../dev/r/">13.0.0.9000 (dev)</a></p>
+<p><a href="../r/">13.0.0.1 (release)</a></p>
+<p><a href="../12.0/r/">12.0.1.1</a></p>
 <p><a href="../11.0/r/">11.0.0.3</a></p>
 <p><a href="../10.0/r/">10.0.1</a></p>
 <p><a href="../9.0/r/">9.0.0</a></p>

--- a/r/pkgdown/assets/versions.json
+++ b/r/pkgdown/assets/versions.json
@@ -4,7 +4,7 @@
         "version": "dev/"
     },
     {
-        "name": "13.0.0 (release)",
+        "name": "13.0.0.1 (release)",
         "version": ""
     },
     {


### PR DESCRIPTION
### Rationale for this change

Versions files needed bumping with the 13.0.01 release

### What changes are included in this PR?

Increasing version numbers

### Are these changes tested?

No

### Are there any user-facing changes?

No