### PR TITLE
GH-37803: [Python][CI] Pin setuptools_scm to fix release verification scripts

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -666,7 +666,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv "cython<3" numpy setuptools_scm setuptools || exit 1
+  maybe_setup_virtualenv "cython<3" numpy "setuptools_scm<8.0.0" setuptools || exit 1
   maybe_setup_conda --file ci/conda_env_python.txt || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then


### PR DESCRIPTION
Follow-up on https://github.com/apache/arrow/pull/37819, which missed one place to add a pin for the release verification scripts
* Closes: #37803