### PR TITLE
MINOR: [CI][Dev] Fix crossbow badge url

### DIFF
--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -284,7 +284,7 @@ class CommentReport(Report):
         'github': _markdown_badge.format(
             title='Github Actions',
             badge=(
-                'https://github.com/{repo}/workflows/Crossbow/'
+                'https://github.com/{repo}/actions/workflows/crossbow.yml/'
                 'badge.svg?branch={branch}'
             ),
         ),


### PR DESCRIPTION
Github has changed the badge url so all crossbow badges where showing up as grey.