### PR TITLE
GH-32483: [Docs][Python] Clarify you need to use conda-forge for installing nightly conda package

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -717,6 +717,9 @@ Install the development version of PyArrow from `arrow-nightlies
 
     conda install -c arrow-nightlies pyarrow
 
+Note that this requires to use the ``conda-forge`` channel for all other
+packages (``conda config --add channels conda-forge``).
+
 Install the development version from an `alternative PyPI
 <https://gemfury.com/arrow-nightlies>`_ index:
 

--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -56,8 +56,8 @@ need to install the `Visual C++ Redistributable for Visual Studio 2015
 .. warning::
    On Linux, you will need pip >= 19.0 to detect the prebuilt binary packages.
 
-Installing from source
-----------------------
+Installing nightly packages or from source
+------------------------------------------
 
 See :ref:`python-development`.
 


### PR DESCRIPTION
### Rationale for this change

Our nightly packages don't work with the defaults channel from Anaconda.

* Closes: #32483