### PR TITLE
GH-37950: [R] tests fail on R < 4.0 due to test calling data.frame() without specifying stringsAsFactors=FALSE

### DIFF
--- a/r/tests/testthat/test-schema.R
+++ b/r/tests/testthat/test-schema.R
@@ -300,7 +300,11 @@ test_that("schema extraction", {
   expect_equal(schema(example_data), tbl$schema)
   expect_equal(schema(tbl), tbl$schema)
 
-  expect_equal(schema(data.frame(a = 1, a = "x", check.names = FALSE)), schema(a = double(), a = string()))
+  expect_equal(
+    schema(data.frame(a = 1, a = "x", check.names = FALSE, stringsAsFactors = FALSE)),
+    schema(a = double(), a = string())
+  )
+
   expect_equal(schema(data.frame()), schema())
 
   ds <- InMemoryDataset$create(example_data)


### PR DESCRIPTION
### Rationale for this change

Tests failing on R < 4.0 builds due to the default value of the the `data.frame()` parameter `stringsAsFactors` between older and newer versions of R

### What changes are included in this PR?

Update a test using `data.frame()` to manually specify the value of `stringsAsFactors` as `FALSE`.

### Are these changes tested?

No

### Are there any user-facing changes?

No
* Closes: #37950