### PR TITLE
GH-37907: [R] Setting rosetta variable is missing

### DIFF
--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -79,7 +79,8 @@ install_arrow <- function(nightly = FALSE,
     # On the M1, we can't use the usual autobrew, which pulls Intel dependencies
     apple_m1 <- grepl("arm-apple|aarch64.*darwin", R.Version()$platform)
     # On Rosetta, we have to build without JEMALLOC, so we also can't autobrew
-    if (on_rosetta()) {
+    rosetta <- on_rosetta()
+    if (rosetta) {
       Sys.setenv(ARROW_JEMALLOC = "OFF")
     }
     if (apple_m1 || rosetta) {


### PR DESCRIPTION
### Rationale for this change

Adding missing bit of code back into `install_arrow()` whereby some refactoring had accidentally missed one reference to a variable.

### What changes are included in this PR?

Assign variable so can be used multiple times

### Are these changes tested?

No

### Are there any user-facing changes?

No

* Closes: #37907