### PR TITLE
GH-37200: [Python] Converting empty table to batch should results in empty RecordBatch

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4020,16 +4020,19 @@ cdef class Table(_Tabular):
             c_max_chunksize = max_chunksize
             reader.get().set_chunksize(c_max_chunksize)
 
-        while True:
-            with nogil:
-                check_status(reader.get().ReadNext(&batch))
+        if self.num_rows == 0:
+            return record_batch([[]], schema=self.schema)
+        else:
+            while True:
+                with nogil:
+                    check_status(reader.get().ReadNext(&batch))
 
-            if batch.get() == NULL:
-                break
+                if batch.get() == NULL:
+                    break
 
-            result.append(pyarrow_wrap_batch(batch))
+                result.append(pyarrow_wrap_batch(batch))
 
-        return result
+            return result
 
     def to_reader(self, max_chunksize=None):
         """

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -928,6 +928,16 @@ def test_table_to_batches():
     assert table.equals(table_from_iter)
 
 
+def test_empty_table_to_batches():
+    # GH-37200
+    my_schema = pa.schema([pa.field('x', pa.int64())])
+    table = pa.table([[]], schema=my_schema)
+    batch = table.to_batches()
+    assert table.schema == batch.schema
+    assert isinstance(batch, pa.RecordBatch)
+    assert batch.num_rows == 0
+
+
 def test_table_basics():
     data = [
         pa.array(range(5), type='int64'),


### PR DESCRIPTION
### Rationale for this change

If we call `to_batches()` on a empty `pa.Table` we currently get an empty list. But we should in this case get an empty `RecordBatch`.

### What changes are included in this PR?

A check is added in `to_batches()` for empty tables. The change is only in the Python layer. I am not sure if we want this to be also dealt with on the C++ side.

### Are these changes tested?

Test is added in `test_table.py`

### Are there any user-facing changes?
There might be some changes for a user that is using the current `pa.Table.to_batches()` on an empty table that results in an empty list. With this change this should be changed to an empty `RecordBatch`.
* Closes: #37200