### PR TITLE
GH-37971: [CI][Java] Don't use cache for nightly upload

### DIFF
--- a/.github/workflows/java_nightly.yml
+++ b/.github/workflows/java_nightly.yml
@@ -73,12 +73,6 @@ jobs:
           fi
           echo $PREFIX
           archery crossbow download-artifacts -f java-jars -t binaries  $PREFIX
-      - name: Cache Repo
-        uses: actions/cache@v3
-        with:
-          path: repo
-          key: java-nightly-${{ github.run_id }}
-          restore-keys: java-nightly
       - name: Sync from Remote
         uses: ./arrow/.github/actions/sync-nightlies
         with:


### PR DESCRIPTION
### Rationale for this change

It's too large (8.6 GB) and it's always re-created because it uses github.run_id for key. It expires other caches soon.

### What changes are included in this PR?

Remove actions/cache.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* Closes: #37971