### PR TITLE
GH-37983: [JS] create nullable Fields in Table constructor

### DIFF
--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -112,7 +112,7 @@ export class Table<T extends TypeMap = any> {
                 } else if (typeof x === 'object') {
                     const keys = Object.keys(x) as (keyof T)[];
                     const vecs = keys.map((k) => new Vector([x[k]]));
-                    const schema = new Schema(keys.map((k, i) => new Field(String(k), vecs[i].type)));
+                    const schema = new Schema(keys.map((k, i) => new Field(String(k), vecs[i].type, true)));
                     const [, batches] = distributeVectorsIntoRecordBatches(schema, vecs);
                     return batches.length === 0 ? [new RecordBatch(x)] : batches;
                 }


### PR DESCRIPTION
Previously, Tables constructed from vectors with null values would infer Schemas that did not permit null values. This resulted in downstream code making bad assumptions about the data. After this change, we always assume data can be nullable, and construct a Schema with nullable Fields.

### Are these changes tested?

I informally tested these changes for my use case, but have not tested them more extensively

### Are there any user-facing changes?

Yes: the `Table` constructor will now produce schemas with nullable `Fields` in situations in which it previously did not
* Closes: #37983