### PR TITLE
GH-37993: [CI] Fix conda-integration build

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -29,9 +29,11 @@ ARG go=1.19.13
 # Install Archery and integration dependencies
 COPY ci/conda_env_archery.txt /arrow/ci/
 
+# Pin Python until pythonnet is made compatible with 3.12
+# (https://github.com/pythonnet/pythonnet/pull/2249)
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_archery.txt \
-        "python>=3.7" \
+        "python < 3.12" \
         numpy \
         compilers \
         maven=${maven} \


### PR DESCRIPTION
### Rationale for this change

The conda-integration build has recently started failing:
https://github.com/apache/arrow/actions/runs/6393852866/job/17353952453

Apparently this is because conda-forge is now providing Python 3.12 by default, and pythonnet [does not support it yet](https://github.com/pythonnet/pythonnet/pull/2249).

### What changes are included in this PR?

Avoid using Python 3.12 for Archery in conda-integration build.

### Are these changes tested?

Yes, by construction.

### Are there any user-facing changes?

No.
* Closes: #37993