### PR TITLE
GH-37767: [C++][CMake] Don't touch .git/index

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -747,7 +747,7 @@ if(NOT ARROW_GIT_ID)
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 if(NOT ARROW_GIT_DESCRIPTION)
-  execute_process(COMMAND "git" "describe" "--tags" "--dirty"
+  execute_process(COMMAND "git" "describe" "--tags"
                   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                   ERROR_QUIET
                   OUTPUT_VARIABLE ARROW_GIT_DESCRIPTION


### PR DESCRIPTION
### Rationale for this change

We run "git describe --tag --dirty" implicitly in
cpp/cmake_modules/DefineOptions.cmake. If we use "--dirty", .git/index's owner may be changed. Because "git describe" touches .git/index for "--dirty".

We can avoid changing .git/index's owner by not using "--dirty".

### What changes are included in this PR?

Remove "--dirty".

### Are these changes tested?

Yes. I used "strace git describe ...".

### Are there any user-facing changes?

No.
* Closes: #37767