### PR TITLE
GH-37735: [C++][FreeBSD] Suppress a shorten-64-to-32 warning

### DIFF
--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -94,7 +94,8 @@ class CerrLog {
   void PrintBackTrace() {
 #ifdef ARROW_WITH_BACKTRACE
     void* buffer[255];
-    const int calls = backtrace(buffer, static_cast<int>(sizeof(buffer) / sizeof(void*)));
+    const auto calls =
+        backtrace(buffer, static_cast<int>(sizeof(buffer) / sizeof(void*)));
     backtrace_symbols_fd(buffer, calls, 1);
 #endif
   }


### PR DESCRIPTION
### Rationale for this change

It's caused by `backtrace()` and `backtrace_symbols_fd()` signatures are different on Linux and FreeBSD (`int` vs `size_t`).

Linux:

```c
extern int backtrace (void **__array, int __size) __nonnull ((1));
extern void backtrace_symbols_fd (void *const *__array, int __size, int __fd)
     __THROW __nonnull ((1));
```

FreeBSD:

```c
size_t backtrace(void **, size_t);
int backtrace_symbols_fd(void *const *, size_t, int);
```

### What changes are included in this PR?

Use `auto` to ignore the difference.

### Are these changes tested?

Yes on FreeBSD 12.

### Are there any user-facing changes?

No.
* Closes: #37735