### PR TITLE
GH-37999: [CI][Archery] Install python3-dev on ARM jobs to have access to Python.h

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -108,6 +108,7 @@ jobs:
           restore-keys: ${{ matrix.image }}-
       - name: Setup Python
         run: |
+          sudo apt update
           sudo apt install -y --no-install-recommends python3 python3-dev python3-pip
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -108,7 +108,7 @@ jobs:
           restore-keys: ${{ matrix.image }}-
       - name: Setup Python
         run: |
-          sudo apt install -y --no-install-recommends python3 python3-pip
+          sudo apt install -y --no-install-recommends python3 python3-dev python3-pip
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]
       - name: Execute Docker Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,6 +79,7 @@ jobs:
           submodules: recursive
       - name: Setup Python
         run: |
+          sudo apt update
           sudo apt install -y --no-install-recommends python3 python3-dev python3-pip
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,7 @@ jobs:
           submodules: recursive
       - name: Setup Python
         run: |
-          sudo apt install -y --no-install-recommends python3 python3-pip
+          sudo apt install -y --no-install-recommends python3 python3-dev python3-pip
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]
       - name: Execute Docker Build


### PR DESCRIPTION
### Rationale for this change
Currently CI on ARM is failing due to ruamel.yaml requiring Python.h

### What changes are included in this PR?

Install python3-dev

### Are these changes tested?

Yes, CI
### Are there any user-facing changes?

No
* Closes: #37999