### PR TITLE
GH-38039: [C++][Parquet] Fix segfault getting compression level for a Parquet column

### DIFF
--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -196,7 +196,12 @@ class PARQUET_EXPORT ColumnProperties {
 
   size_t max_statistics_size() const { return max_stats_size_; }
 
-  int compression_level() const { return codec_options_->compression_level; }
+  int compression_level() const {
+    if (!codec_options_) {
+      return ::arrow::util::kUseDefaultCompressionLevel;
+    }
+    return codec_options_->compression_level;
+  }
 
   const std::shared_ptr<CodecOptions>& codec_options() const { return codec_options_; }
 

--- a/cpp/src/parquet/properties_test.cc
+++ b/cpp/src/parquet/properties_test.cc
@@ -49,6 +49,13 @@ TEST(TestWriterProperties, Basics) {
   ASSERT_FALSE(props->page_checksum_enabled());
 }
 
+TEST(TestWriterProperties, DefaultCompression) {
+  std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
+
+  ASSERT_EQ(props->compression(ColumnPath::FromDotString("any")), Compression::UNCOMPRESSED);
+  ASSERT_EQ(props->compression_level(ColumnPath::FromDotString("any")), ::arrow::util::kUseDefaultCompressionLevel);
+}
+
 TEST(TestWriterProperties, AdvancedHandling) {
   WriterProperties::Builder builder;
   builder.compression("gzip", Compression::GZIP);

--- a/cpp/src/parquet/properties_test.cc
+++ b/cpp/src/parquet/properties_test.cc
@@ -52,8 +52,10 @@ TEST(TestWriterProperties, Basics) {
 TEST(TestWriterProperties, DefaultCompression) {
   std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
 
-  ASSERT_EQ(props->compression(ColumnPath::FromDotString("any")), Compression::UNCOMPRESSED);
-  ASSERT_EQ(props->compression_level(ColumnPath::FromDotString("any")), ::arrow::util::kUseDefaultCompressionLevel);
+  ASSERT_EQ(props->compression(ColumnPath::FromDotString("any")),
+            Compression::UNCOMPRESSED);
+  ASSERT_EQ(props->compression_level(ColumnPath::FromDotString("any")),
+            ::arrow::util::kUseDefaultCompressionLevel);
 }
 
 TEST(TestWriterProperties, AdvancedHandling) {


### PR DESCRIPTION
### Rationale for this change

After the changes in #35886, getting the compression level for a Parquet column segfaults if the compression level or other options weren't previously set

### What changes are included in this PR?

Adds a null check on the codec options of the column  properties before trying to access the compression level.

### Are these changes tested?

Yes, I added a unit test.

### Are there any user-facing changes?

This fixes a regression added after 13.0.0 so isn't a user-facing fix
* Closes: #38039