### PR TITLE
GH-38017: [Go][FlightSQL] Increment types handled by internal converter

### DIFF
--- a/go/arrow/flight/flightsql/driver/utils.go
+++ b/go/arrow/flight/flightsql/driver/utils.go
@@ -60,24 +60,92 @@ func (g grpcCredentials) RequireTransportSecurity() bool {
 func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
 	switch c := arr.(type) {
 	case *array.Boolean:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return c.Value(idx), nil
 	case *array.Float16:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return float64(c.Value(idx).Float32()), nil
 	case *array.Float32:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return float64(c.Value(idx)), nil
 	case *array.Float64:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return c.Value(idx), nil
+	case *array.Decimal128:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
+		dt, ok := arr.DataType().(*arrow.Decimal128Type)
+		if !ok {
+			return nil, fmt.Errorf("datatype %T not matching decimal128", arr.DataType())
+		}
+
+		return c.Value(idx).ToFloat64(dt.Scale), nil
+	case *array.Decimal256:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
+		dt, ok := arr.DataType().(*arrow.Decimal256Type)
+		if !ok {
+			return nil, fmt.Errorf("datatype %T not matching decimal256", arr.DataType())
+		}
+
+		return c.Value(idx).ToFloat64(dt.Scale), nil
 	case *array.Int8:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return int64(c.Value(idx)), nil
 	case *array.Int16:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return int64(c.Value(idx)), nil
 	case *array.Int32:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return int64(c.Value(idx)), nil
 	case *array.Int64:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
+		return c.Value(idx), nil
+	case *array.Binary:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return c.Value(idx), nil
 	case *array.String:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		return c.Value(idx), nil
 	case *array.Time32:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		dt, ok := arr.DataType().(*arrow.Time32Type)
 		if !ok {
 			return nil, fmt.Errorf("datatype %T not matching time32", arr.DataType())
@@ -85,6 +153,10 @@ func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
 		v := c.Value(idx)
 		return v.ToTime(dt.TimeUnit()), nil
 	case *array.Time64:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		dt, ok := arr.DataType().(*arrow.Time64Type)
 		if !ok {
 			return nil, fmt.Errorf("datatype %T not matching time64", arr.DataType())
@@ -92,12 +164,31 @@ func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
 		v := c.Value(idx)
 		return v.ToTime(dt.TimeUnit()), nil
 	case *array.Timestamp:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
 		dt, ok := arr.DataType().(*arrow.TimestampType)
 		if !ok {
 			return nil, fmt.Errorf("datatype %T not matching timestamp", arr.DataType())
 		}
 		v := c.Value(idx)
 		return v.ToTime(dt.TimeUnit()), nil
+	case *array.Date64:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
+		return c.Value(idx).ToTime(), nil
+	case *array.DayTimeInterval:
+		if c.IsNull(idx) {
+			return nil, nil
+		}
+
+		durationDays := time.Duration(c.Value(idx).Days*24) * time.Hour
+		duration := time.Duration(c.Value(idx).Milliseconds) * time.Millisecond
+
+		return durationDays + duration, nil
 	}
 
 	return nil, fmt.Errorf("type %T: %w", arr, ErrNotSupported)

--- a/go/arrow/flight/flightsql/driver/utils.go
+++ b/go/arrow/flight/flightsql/driver/utils.go
@@ -58,133 +58,52 @@ func (g grpcCredentials) RequireTransportSecurity() bool {
 
 // *** Type conversions ***
 func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
+	if arr.IsNull(idx) {
+		return nil, nil
+	}
+
 	switch c := arr.(type) {
 	case *array.Boolean:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
 		return c.Value(idx), nil
 	case *array.Float16:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		return float64(c.Value(idx).Float32()), nil
+		return c.Value(idx), nil
 	case *array.Float32:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		return float64(c.Value(idx)), nil
+		return c.Value(idx), nil
 	case *array.Float64:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
 		return c.Value(idx), nil
 	case *array.Decimal128:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		dt, ok := arr.DataType().(*arrow.Decimal128Type)
-		if !ok {
-			return nil, fmt.Errorf("datatype %T not matching decimal128", arr.DataType())
-		}
-
-		return c.Value(idx).ToFloat64(dt.Scale), nil
+		v := arr.DataType().(*arrow.Decimal128Type)
+		return c.Value(idx).ToFloat64(v.Scale), nil
 	case *array.Decimal256:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		dt, ok := arr.DataType().(*arrow.Decimal256Type)
-		if !ok {
-			return nil, fmt.Errorf("datatype %T not matching decimal256", arr.DataType())
-		}
-
-		return c.Value(idx).ToFloat64(dt.Scale), nil
+		v := arr.DataType().(*arrow.Decimal256Type)
+		return c.Value(idx).ToFloat64(v.Scale), nil
 	case *array.Int8:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		return int64(c.Value(idx)), nil
+		return c.Value(idx), nil
 	case *array.Int16:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		return int64(c.Value(idx)), nil
+		return c.Value(idx), nil
 	case *array.Int32:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		return int64(c.Value(idx)), nil
+		return c.Value(idx), nil
 	case *array.Int64:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
 		return c.Value(idx), nil
 	case *array.Binary:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
 		return c.Value(idx), nil
 	case *array.String:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
 		return c.Value(idx), nil
 	case *array.Time32:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		dt, ok := arr.DataType().(*arrow.Time32Type)
-		if !ok {
-			return nil, fmt.Errorf("datatype %T not matching time32", arr.DataType())
-		}
+		d32 := arr.DataType().(*arrow.Time32Type)
 		v := c.Value(idx)
-		return v.ToTime(dt.TimeUnit()), nil
+		return v.ToTime(d32.TimeUnit()), nil
 	case *array.Time64:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		dt, ok := arr.DataType().(*arrow.Time64Type)
-		if !ok {
-			return nil, fmt.Errorf("datatype %T not matching time64", arr.DataType())
-		}
+		d64 := arr.DataType().(*arrow.Time64Type)
 		v := c.Value(idx)
-		return v.ToTime(dt.TimeUnit()), nil
+		return v.ToTime(d64.TimeUnit()), nil
 	case *array.Timestamp:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
-		dt, ok := arr.DataType().(*arrow.TimestampType)
-		if !ok {
-			return nil, fmt.Errorf("datatype %T not matching timestamp", arr.DataType())
-		}
+		ts := arr.DataType().(*arrow.TimestampType)
 		v := c.Value(idx)
-		return v.ToTime(dt.TimeUnit()), nil
+		return v.ToTime(ts.TimeUnit()), nil
 	case *array.Date64:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
 		return c.Value(idx).ToTime(), nil
 	case *array.DayTimeInterval:
-		if c.IsNull(idx) {
-			return nil, nil
-		}
-
 		durationDays := time.Duration(c.Value(idx).Days*24) * time.Hour
 		duration := time.Duration(c.Value(idx).Milliseconds) * time.Millisecond
 

--- a/go/arrow/flight/flightsql/driver/utils_test.go
+++ b/go/arrow/flight/flightsql/driver/utils_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/arrow/go/v14/arrow/decimal256"
 	"github.com/apache/arrow/go/v14/arrow/float16"
 	"github.com/apache/arrow/go/v14/arrow/memory"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_fromArrowType(t *testing.T) {
@@ -51,14 +52,10 @@ func Test_fromArrowType(t *testing.T) {
 		{Name: "f17-dti", Type: arrow.FixedWidthTypes.DayTimeInterval},
 	}
 
-	pool := memory.NewGoAllocator()
-
 	schema := arrow.NewSchema(fields, nil)
-
+	pool := memory.NewGoAllocator()
 	b := array.NewRecordBuilder(pool, schema)
 	defer b.Release()
-
-	testTime := time.Now()
 
 	b.Field(0).(*array.BooleanBuilder).Append(true)
 	b.Field(1).(*array.Float16Builder).Append(float16.New(1))
@@ -74,26 +71,23 @@ func Test_fromArrowType(t *testing.T) {
 	b.Field(11).(*array.StringBuilder).Append("a")
 
 	t32, err := arrow.Time32FromString("12:30:00", arrow.Second)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	b.Field(12).(*array.Time32Builder).Append(t32)
 
 	t64, err := arrow.Time64FromString("12:00:00", arrow.Microsecond)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	b.Field(13).(*array.Time64Builder).Append(t64)
 
 	ts, err := arrow.TimestampFromString("1970-01-01T12:00:00", arrow.Nanosecond)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+
 	fmt.Println(ts.ToTime(arrow.Nanosecond))
 
 	b.Field(14).(*array.TimestampBuilder).Append(ts)
+
+	testTime := time.Now()
 	b.Field(15).(*array.Date64Builder).Append(arrow.Date64FromTime(testTime))
 	b.Field(16).(*array.DayTimeIntervalBuilder).Append(arrow.DayTimeInterval{Days: 1, Milliseconds: 1000})
 
@@ -112,21 +106,21 @@ func Test_fromArrowType(t *testing.T) {
 		})
 	}
 
-	tf(t, 0, true)
-	tf(t, 1, float64(1))
-	tf(t, 2, float64(1))
-	tf(t, 3, float64(1))
-	tf(t, 4, float64(1))
-	tf(t, 5, float64(1))
-	tf(t, 6, int64(1))
-	tf(t, 7, int64(1))
-	tf(t, 8, int64(1))
-	tf(t, 9, int64(1))
-	tf(t, 10, []byte("a"))
-	tf(t, 11, "a")
-	tf(t, 12, time.Date(1970, 1, 1, 12, 30, 0, 0, time.UTC))
-	tf(t, 13, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))
-	tf(t, 14, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))
-	tf(t, 15, testTime.In(time.UTC).Truncate(24*time.Hour))
-	tf(t, 16, time.Duration(24*time.Hour+time.Second))
+	tf(t, 0, true)                                           // "f1-bool"
+	tf(t, 1, float16.New(1))                                 // "f2-f16"
+	tf(t, 2, float32(1))                                     // "f3-f32"
+	tf(t, 3, float64(1))                                     // "f4-f64"
+	tf(t, 4, float64(1))                                     // "f5-d128"
+	tf(t, 5, float64(1))                                     // "f6-d256"
+	tf(t, 6, int8(1))                                        // "f7-i8"
+	tf(t, 7, int16(1))                                       // "f8-i16"
+	tf(t, 8, int32(1))                                       // "f9-i32"
+	tf(t, 9, int64(1))                                       // "f10-i64"
+	tf(t, 10, []byte("a"))                                   // "f11-binary"
+	tf(t, 11, "a")                                           // "f12-string"
+	tf(t, 12, time.Date(1970, 1, 1, 12, 30, 0, 0, time.UTC)) // "f13-t32s"
+	tf(t, 13, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))  // "f14-t64us"
+	tf(t, 14, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))  // "f15-ts_us"
+	tf(t, 15, testTime.In(time.UTC).Truncate(24*time.Hour))  // "f16-d64"
+	tf(t, 16, time.Duration(24*time.Hour+time.Second))       // "f17-dti"
 }

--- a/go/arrow/flight/flightsql/driver/utils_test.go
+++ b/go/arrow/flight/flightsql/driver/utils_test.go
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package driver
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow/go/v14/arrow"
+	"github.com/apache/arrow/go/v14/arrow/array"
+	"github.com/apache/arrow/go/v14/arrow/decimal128"
+	"github.com/apache/arrow/go/v14/arrow/decimal256"
+	"github.com/apache/arrow/go/v14/arrow/float16"
+	"github.com/apache/arrow/go/v14/arrow/memory"
+)
+
+func Test_fromArrowType(t *testing.T) {
+	fields := []arrow.Field{
+		{Name: "f1-bool", Type: arrow.FixedWidthTypes.Boolean},
+		{Name: "f2-f16", Type: arrow.FixedWidthTypes.Float16},
+		{Name: "f3-f32", Type: arrow.PrimitiveTypes.Float32},
+		{Name: "f4-f64", Type: arrow.PrimitiveTypes.Float64},
+		{Name: "f5-d128", Type: &arrow.Decimal128Type{}},
+		{Name: "f6-d256", Type: &arrow.Decimal256Type{}},
+		{Name: "f7-i8", Type: arrow.PrimitiveTypes.Int8},
+		{Name: "f8-i16", Type: arrow.PrimitiveTypes.Int16},
+		{Name: "f9-i32", Type: arrow.PrimitiveTypes.Int32},
+		{Name: "f10-i64", Type: arrow.PrimitiveTypes.Int64},
+		{Name: "f11-binary", Type: arrow.BinaryTypes.Binary},
+		{Name: "f12-string", Type: arrow.BinaryTypes.String},
+		{Name: "f13-t32s", Type: arrow.FixedWidthTypes.Time32s},
+		{Name: "f14-t64us", Type: arrow.FixedWidthTypes.Time64us},
+		{Name: "f15-ts_us", Type: arrow.FixedWidthTypes.Timestamp_ns},
+		{Name: "f16-d64", Type: arrow.FixedWidthTypes.Date64},
+		{Name: "f17-dti", Type: arrow.FixedWidthTypes.DayTimeInterval},
+	}
+
+	pool := memory.NewGoAllocator()
+
+	schema := arrow.NewSchema(fields, nil)
+
+	b := array.NewRecordBuilder(pool, schema)
+	defer b.Release()
+
+	testTime := time.Now()
+
+	b.Field(0).(*array.BooleanBuilder).Append(true)
+	b.Field(1).(*array.Float16Builder).Append(float16.New(1))
+	b.Field(2).(*array.Float32Builder).Append(1)
+	b.Field(3).(*array.Float64Builder).Append(1)
+	b.Field(4).(*array.Decimal128Builder).Append(decimal128.FromBigInt(big.NewInt(1)))
+	b.Field(5).(*array.Decimal256Builder).Append(decimal256.FromBigInt(big.NewInt(1)))
+	b.Field(6).(*array.Int8Builder).Append(1)
+	b.Field(7).(*array.Int16Builder).Append(1)
+	b.Field(8).(*array.Int32Builder).Append(1)
+	b.Field(9).(*array.Int64Builder).Append(1)
+	b.Field(10).(*array.BinaryBuilder).Append([]byte("a"))
+	b.Field(11).(*array.StringBuilder).Append("a")
+
+	t32, err := arrow.Time32FromString("12:30:00", arrow.Second)
+	if err != nil {
+		t.Error(err)
+	}
+
+	b.Field(12).(*array.Time32Builder).Append(t32)
+
+	t64, err := arrow.Time64FromString("12:00:00", arrow.Microsecond)
+	if err != nil {
+		t.Error(err)
+	}
+
+	b.Field(13).(*array.Time64Builder).Append(t64)
+
+	ts, err := arrow.TimestampFromString("1970-01-01T12:00:00", arrow.Nanosecond)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println(ts.ToTime(arrow.Nanosecond))
+
+	b.Field(14).(*array.TimestampBuilder).Append(ts)
+	b.Field(15).(*array.Date64Builder).Append(arrow.Date64FromTime(testTime))
+	b.Field(16).(*array.DayTimeIntervalBuilder).Append(arrow.DayTimeInterval{Days: 1, Milliseconds: 1000})
+
+	rec := b.NewRecord()
+	defer rec.Release()
+
+	tf := func(t *testing.T, idx int, want any) {
+		t.Run(fmt.Sprintf("fromArrowType %v %s", fields[idx].Type, fields[idx].Name), func(t *testing.T) {
+			v, err := fromArrowType(rec.Column(idx), 0)
+			if err != nil {
+				t.Fatalf("err when converting from arrow: %s", err)
+			}
+			if !reflect.DeepEqual(v, want) {
+				t.Fatalf("test failed, wanted %T %v got %T %v", want, want, v, v)
+			}
+		})
+	}
+
+	tf(t, 0, true)
+	tf(t, 1, float64(1))
+	tf(t, 2, float64(1))
+	tf(t, 3, float64(1))
+	tf(t, 4, float64(1))
+	tf(t, 5, float64(1))
+	tf(t, 6, int64(1))
+	tf(t, 7, int64(1))
+	tf(t, 8, int64(1))
+	tf(t, 9, int64(1))
+	tf(t, 10, []byte("a"))
+	tf(t, 11, "a")
+	tf(t, 12, time.Date(1970, 1, 1, 12, 30, 0, 0, time.UTC))
+	tf(t, 13, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))
+	tf(t, 14, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))
+	tf(t, 15, testTime.In(time.UTC).Truncate(24*time.Hour))
+	tf(t, 16, time.Duration(24*time.Hour+time.Second))
+}


### PR DESCRIPTION
### Rationale for this change
This PR targets flightsql.Driver, that complies with sql.Driver interface, from the stdlib. <br>

The driver has a resultset iterator: the type [Rows](https://github.com/apache/arrow/blob/7d834d65c37c17d1c19bfb497eadb983893c9ea0/go/arrow/flight/flightsql/driver/driver.go#L39). <br>

The method [Rows.Next()](https://github.com/apache/arrow/blob/7d834d65c37c17d1c19bfb497eadb983893c9ea0/go/arrow/flight/flightsql/driver/driver.go#L81), which populates the next row of data, lacks handling/treatment of some common types, as described in the [issue](https://github.com/apache/arrow/issues/38017). <br>


### What changes are included in this PR?
This PR includes the missing common basic data types for Rows.Next() method. <br>

### Are these changes tested?
The driver is already tested, but I also included unitary tests that cover not only the new types, but all the implemented types. <br>


### Are there any user-facing changes?
All the contracts and signatures, and the current types were preserved. <br>

Closes #38017 

* Closes: #38017