### PR TITLE
GH-35328: [Go][FlightSQL] Fix flaky test for FlightSql driver

### DIFF
--- a/go/arrow/flight/flightsql/driver/driver_test.go
+++ b/go/arrow/flight/flightsql/driver/driver_test.go
@@ -812,6 +812,17 @@ func (s *MockServer) DoPutPreparedStatementQuery(ctx context.Context, qry flight
 		return fmt.Errorf("parameter schema: %w", arrow.ErrInvalid)
 	}
 
+	// GH-35328: it's rare, but this function can complete execution and return
+	// closing the reader *after* the schema is written but *before* the parameter batch
+	// is written (race condition based on goroutine scheduling). In that situation,
+	// the client call to Write the parameter record batch will return an io.EOF because
+	// this end of the connection will have closed before it attempted to send the batch.
+	// This created a flaky test situation that was difficult to reproduce (1-4 failures
+	// in 5000 runs). We can avoid this flakiness by simply *explicitly* draining the
+	// record batch messages from the reader before returning.
+	for r.Next() {
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fixing a flaky test that is *very* difficult to reproduce.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Adding an explicit call to drain the remaining batches from the parameter batch reader in the `DoPutPreparedStatementQuery` of the `MockServer` in the tests. This ensures that the gRPC connection doesn't close on us in between the client writing the schema message and writing the record batch message producing an `io.EOF` error. This is an extremely rare occurence based on goroutine scheduling due to the client and mockserver both running in the same process for the tests, in local testing i was only able to get it to happen 1 - 4 times per 5000 runs of the test.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

* Closes: #35328