### PR TITLE
GH-38049: [R] Prevent `on_rosetta()` from warning

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -183,7 +183,7 @@ configure_tzdb <- function() {
   # Just to be extra safe, let's wrap this in a try();
   # we don't want a failed startup message to prevent the package from loading
   try({
-        # On MacOS only, Check if we are running in under emulation, and warn this will not work
+    # On MacOS only, Check if we are running in under emulation, and warn this will not work
     if (on_rosetta()) {
       packageStartupMessage(
         paste(
@@ -242,8 +242,9 @@ on_macos_10_13_or_lower <- function() {
 }
 
 on_rosetta <- function() {
+  # make sure to suppress warnings and ignore the stdout + stderr so that this is silent
   identical(tolower(Sys.info()[["sysname"]]), "darwin") &&
-    identical(system("sysctl -n sysctl.proc_translated", intern = TRUE), "1")
+    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)), "1")
 }
 
 option_use_threads <- function() {

--- a/r/tests/testthat/test-arrow-pacakge.R
+++ b/r/tests/testthat/test-arrow-pacakge.R
@@ -16,5 +16,6 @@
 # under the License.
 
 test_that("on_rosetta() does not warn", {
-    expect_warning(on_rosetta(), NA)
+  # There is no warning
+  expect_warning(on_rosetta(), NA)
 })

--- a/r/tests/testthat/test-arrow-pacakge.R
+++ b/r/tests/testthat/test-arrow-pacakge.R
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+test_that("on_rosetta() does not warn", {
+    expect_warning(on_rosetta(), NA)
+})


### PR DESCRIPTION
### Rationale for this change

Stop extraneous warnings.

### What changes are included in this PR?

Prevent warning when detecting translation, but on x86

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, there will be fewer extraneous warnings.
* Closes: #38049