### PR TITLE
GH-38057: [Python][CI] Fix flaky hypothesis tests

### DIFF
--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2020,6 +2020,7 @@ def test_array_pickle_dictionary(pickle_module):
         assert array.equals(result)
 
 
+@h.settings(suppress_health_check=(h.HealthCheck.too_slow,))
 @h.given(
     past.arrays(
         past.all_types,

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -1184,6 +1184,7 @@ def test_is_boolean_value():
     assert pa.types.is_boolean_value(np.bool_(False))
 
 
+@h.settings(suppress_health_check=(h.HealthCheck.too_slow,))
 @h.given(
     past.all_types |
     past.all_fields |


### PR DESCRIPTION
### Rationale for this change

Some hypothesis tests are consistently flaky due to taking too long to generate examples. "Too long" is ~2 seconds so let's just suppress the warnings. It is suppressed only for a small number of tests.

### What changes are included in this PR?

* Suppress hypothesis warnings for test data generation being too slow (> 2 seconds).

### Are these changes tested?

Will test the hypothesis CI job here.

### Are there any user-facing changes?

No
* Closes: #38057