### PR TITLE
GH-38071: [C++] Revert to non-lazy CacheOptions::Defaults for default in Parquet reader

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2362,6 +2362,13 @@ TEST(TestArrowReadWrite, NoneCoalescedReads) {
   TestGetRecordBatchReader(arrow_properties);
 }
 
+TEST(TestArrowReadWrite, LazyCoalescedReads) {
+  ArrowReaderProperties arrow_properties = default_arrow_reader_properties();
+  arrow_properties.set_pre_buffer(true);
+  arrow_properties.set_cache_options(::arrow::io::CacheOptions::LazyDefaults());
+  TestGetRecordBatchReader(arrow_properties);
+}
+
 // Use coalesced reads, and explicitly wait for I/O to complete.
 TEST(TestArrowReadWrite, WaitCoalescedReads) {
   ArrowReaderProperties properties = default_arrow_reader_properties();

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -837,7 +837,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
         read_dict_indices_(),
         batch_size_(kArrowDefaultBatchSize),
         pre_buffer_(true),
-        cache_options_(::arrow::io::CacheOptions::LazyDefaults()),
+        cache_options_(::arrow::io::CacheOptions::Defaults()),
         coerce_int96_timestamp_unit_(::arrow::TimeUnit::NANO) {}
 
   /// \brief Set whether to use the IO thread pool to parse columns in parallel.


### PR DESCRIPTION
To see if this fixes the fuzzing error
* Closes: #38071