### PR TITLE
GH-38071: [C++][CI] Fix Overlap column chunk ranges for pre-buffer

### DIFF
--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -174,8 +174,9 @@ struct ReadRangeCache::Impl {
 
   // Add the given ranges to the cache, coalescing them where possible
   virtual Status Cache(std::vector<ReadRange> ranges) {
-    ranges = internal::CoalesceReadRanges(std::move(ranges), options.hole_size_limit,
-                                          options.range_size_limit);
+    ARROW_ASSIGN_OR_RAISE(
+        ranges, internal::CoalesceReadRanges(std::move(ranges), options.hole_size_limit,
+                                             options.range_size_limit));
     std::vector<RangeCacheEntry> new_entries = MakeCacheEntries(ranges);
     // Add new entries, themselves ordered by offset
     if (entries.size() > 0) {

--- a/cpp/src/arrow/io/util_internal.h
+++ b/cpp/src/arrow/io/util_internal.h
@@ -45,9 +45,9 @@ ARROW_EXPORT Status ValidateWriteRange(int64_t offset, int64_t size, int64_t fil
 ARROW_EXPORT Status ValidateRange(int64_t offset, int64_t size);
 
 ARROW_EXPORT
-std::vector<ReadRange> CoalesceReadRanges(std::vector<ReadRange> ranges,
-                                          int64_t hole_size_limit,
-                                          int64_t range_size_limit);
+Result<std::vector<ReadRange>> CoalesceReadRanges(std::vector<ReadRange> ranges,
+                                                  int64_t hole_size_limit,
+                                                  int64_t range_size_limit);
 
 ARROW_EXPORT
 ::arrow::internal::ThreadPool* GetIOThreadPool();

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -139,8 +139,10 @@ const RowGroupMetaData* RowGroupReader::metadata() const { return contents_->met
 ::arrow::io::ReadRange ComputeColumnChunkRange(FileMetaData* file_metadata,
                                                int64_t source_size, int row_group_index,
                                                int column_index) {
-  auto row_group_metadata = file_metadata->RowGroup(row_group_index);
-  auto column_metadata = row_group_metadata->ColumnChunk(column_index);
+  std::unique_ptr<RowGroupMetaData> row_group_metadata =
+      file_metadata->RowGroup(row_group_index);
+  std::unique_ptr<ColumnChunkMetaData> column_metadata =
+      row_group_metadata->ColumnChunk(column_index);
 
   int64_t col_start = column_metadata->data_page_offset();
   if (column_metadata->has_dictionary_page() &&
@@ -365,6 +367,20 @@ class SerializedFile : public ParquetFileReader::Contents {
             ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col));
       }
     }
+#ifndef NDEBUG
+    if (!ranges.empty()) {
+      auto copied_ranges = ranges;
+      std::sort(copied_ranges.begin(), copied_ranges.end(),
+                [](const ::arrow::io::ReadRange& a, const ::arrow::io::ReadRange& b) {
+                  return a.offset < b.offset;
+                });
+      for (size_t i = 1; i < copied_ranges.size(); ++i) {
+        if (ranges[i].offset < ranges[i - 1].offset + ranges[i - 1].length) {
+          throw ParquetException("Overlapping column chunk ranges for prebuffer");
+        }
+      }
+    }
+#endif
     PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
   }
 

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -367,21 +367,6 @@ class SerializedFile : public ParquetFileReader::Contents {
             ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col));
       }
     }
-#ifndef NDEBUG
-    if (!ranges.empty()) {
-      auto copied_ranges = ranges;
-      std::sort(copied_ranges.begin(), copied_ranges.end(),
-                [](const ::arrow::io::ReadRange& a, const ::arrow::io::ReadRange& b) {
-                  return a.offset < b.offset;
-                });
-      for (size_t i = 1; i < copied_ranges.size(); ++i) {
-        if (copied_ranges[i].offset <
-            copied_ranges[i - 1].offset + copied_ranges[i - 1].length) {
-          throw ParquetException("Overlapping column chunk ranges for pre-buffer");
-        }
-      }
-    }
-#endif
     PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
   }
 

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -375,8 +375,9 @@ class SerializedFile : public ParquetFileReader::Contents {
                   return a.offset < b.offset;
                 });
       for (size_t i = 1; i < copied_ranges.size(); ++i) {
-        if (ranges[i].offset < ranges[i - 1].offset + ranges[i - 1].length) {
-          throw ParquetException("Overlapping column chunk ranges for prebuffer");
+        if (copied_ranges[i].offset <
+            copied_ranges[i - 1].offset + copied_ranges[i - 1].length) {
+          throw ParquetException("Overlapping column chunk ranges for pre-buffer");
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The C++ Parquet Arrow fuzz will generate bad Parquet file with bad row-range, this patch change the `CoalesceReadRanges` to return `Result<>`.

### What changes are included in this PR?

Just a checking, change `CoalesceReadRanges` to return `Result<>`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No.

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38071