### PR TITLE
GH-37650: [Python] Check filter inputs in FilterMetaFunction

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -998,8 +998,7 @@ class FilterMetaFunction : public MetaFunction {
   Result<Datum> ExecuteImpl(const std::vector<Datum>& args,
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
-    if ((args[1].kind() != Datum::ARRAY) &&
-        (args[1].kind() != Datum::CHUNKED_ARRAY)) {
+    if (args[1].kind() != Datum::ARRAY && args[1].kind() != Datum::CHUNKED_ARRAY) {
         return Status::NotImplemented("Filter should be array-like");
     }
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -942,7 +942,7 @@ Result<std::shared_ptr<Table>> FilterTable(const Table& table, const Datum& filt
       inputs.back() = filter.chunked_array()->chunks();
       break;
     default:
-      return Status::NotImplemented("Filter should be array-like");
+      return Status::TypeError("Filter should be array-like");
   }
 
   // Rechunk inputs to allow consistent iteration over their respective chunks
@@ -999,7 +999,7 @@ class FilterMetaFunction : public MetaFunction {
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
     if (args[1].kind() != Datum::ARRAY && args[1].kind() != Datum::CHUNKED_ARRAY) {
-        return Status::NotImplemented("Filter should be array-like");
+        return Status::TypeError("Filter should be array-like");
     }
 
     const auto& filter_type = *args[1].type();

--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -999,7 +999,7 @@ class FilterMetaFunction : public MetaFunction {
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
     if (args[1].kind() != Datum::ARRAY && args[1].kind() != Datum::CHUNKED_ARRAY) {
-        return Status::TypeError("Filter should be array-like");
+      return Status::TypeError("Filter should be array-like");
     }
 
     const auto& filter_type = *args[1].type();

--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -998,7 +998,8 @@ class FilterMetaFunction : public MetaFunction {
   Result<Datum> ExecuteImpl(const std::vector<Datum>& args,
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
-    if ((args[1].kind() != Datum::ARRAY) and (args[1].kind() != Datum::CHUNKED_ARRAY)) {
+    if ((args[1].kind() != Datum::ARRAY) &&
+        (args[1].kind() != Datum::CHUNKED_ARRAY)) {
         return Status::NotImplemented("Filter should be array-like");
     }
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -998,6 +998,10 @@ class FilterMetaFunction : public MetaFunction {
   Result<Datum> ExecuteImpl(const std::vector<Datum>& args,
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
+    if ((args[1].kind() != Datum::ARRAY) and (args[1].kind() != Datum::CHUNKED_ARRAY)) {
+        return Status::NotImplemented("Filter should be array-like");
+    }
+
     const auto& filter_type = *args[1].type();
     const bool filter_is_plain_bool = filter_type.id() == Type::BOOL;
     const bool filter_is_ree_bool =

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1359,6 +1359,9 @@ def test_filter_table():
         result = table.filter(mask, null_selection_behavior="emit_null")
         assert result.equals(expected_null)
 
+    with pytest.raises(NotImplementedError):
+        result = table.filter(table)
+
 
 def test_filter_errors():
     arr = pa.chunked_array([["a", None], ["c", "d", "e"]])

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1359,9 +1359,6 @@ def test_filter_table():
         result = table.filter(mask, null_selection_behavior="emit_null")
         assert result.equals(expected_null)
 
-    with pytest.raises(NotImplementedError):
-        result = table.filter(table)
-
 
 def test_filter_errors():
     arr = pa.chunked_array([["a", None], ["c", "d", "e"]])
@@ -1380,6 +1377,9 @@ def test_filter_errors():
         with pytest.raises(pa.ArrowInvalid,
                            match="must all be the same length"):
             obj.filter(mask)
+
+    with pytest.raises(TypeError):
+        result = table.filter(table)
 
 
 def test_filter_null_type():

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1378,8 +1378,10 @@ def test_filter_errors():
                            match="must all be the same length"):
             obj.filter(mask)
 
-    with pytest.raises(TypeError):
-        result = table.filter(table)
+    scalar = pa.scalar(True)
+    for filt in [batch, table, scalar]:
+        with pytest.raises(TypeError):
+            table.filter(filt)
 
 
 def test_filter_null_type():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2302,9 +2302,6 @@ def test_table_filter_expression():
         "colVals": ["a", "b", "f", "B", "A"]
     })
 
-    with pytest.raises(NotImplementedError):
-        result = t1.filter(t2)
-
 
 @pytest.mark.acero
 def test_table_join_many_columns():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2302,6 +2302,9 @@ def test_table_filter_expression():
         "colVals": ["a", "b", "f", "B", "A"]
     })
 
+    with pytest.raises(NotImplementedError):
+        result = t1.filter(t2)
+
 
 @pytest.mark.acero
 def test_table_join_many_columns():


### PR DESCRIPTION
### Rationale for this change
Prevent a segfault upon passing a non-(chunked_)array object into `Table.filter`. See #37650.

### What changes are included in this PR?
1. Check filter Datum kind to make sure that it is an array or a chunked array
2. test that attempting to filter a table with another table raises a not implemented error

### Are these changes tested?
In PyArrow, yes

### Are there any user-facing changes?
Raises an error if a non-array or non-chunked_array object is passed into `Table.filter`

* Closes: #37650