### PR TITLE
GH-38079: [R] Allow override of version used to download libarrow static library

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -88,8 +88,9 @@ thirdparty_dependency_dir <- Sys.getenv("ARROW_THIRDPARTY_DEPENDENCY_DIR", "tool
 
 
 download_binary <- function(lib) {
+  binary_version <- Sys.getenv("LIBARROW_BINARY_VERSION", VERSION)
   libfile <- tempfile()
-  binary_url <- paste0(arrow_repo, "bin/", lib, "/arrow-", VERSION, ".zip")
+  binary_url <- paste0(arrow_repo, "bin/", lib, "/arrow-", binary_version, ".zip")
   if (try_download(binary_url, libfile)) {
     if (!quietly) {
       cat(sprintf("*** Successfully retrieved C++ binaries (%s)\n", lib))
@@ -98,7 +99,7 @@ download_binary <- function(lib) {
     if (!quietly) {
       cat(sprintf(
         "*** Downloading libarrow binary failed for version %s (%s)\n    at %s\n",
-        VERSION, lib, binary_url
+        binary_version, lib, binary_url
       ))
     }
     libfile <- NULL

--- a/r/tools/winlibs.R
+++ b/r/tools/winlibs.R
@@ -30,9 +30,10 @@ if (!file.exists(sprintf("windows/arrow-%s/include/arrow/api.h", VERSION))) {
     # Download static arrow from the apache artifactory
     quietly <- !identical(tolower(Sys.getenv("ARROW_R_DEV")), "true")
     get_file <- function(template, version) {
+      binary_version <- Sys.getenv("LIBARROW_BINARY_VERSION", version)
       try(
         suppressWarnings(
-          download.file(sprintf(template, version), "lib.zip", quiet = quietly)
+          download.file(sprintf(template, binary_version), "lib.zip", quiet = quietly)
         ),
         silent = quietly
       )


### PR DESCRIPTION
### Rationale for this change

Doing a bundled build of libarrow is time-consuming and makes casual contribution difficult. Downloading a recent nightly static library is sufficient in most cases; however, there is no route to override the version used to do this download.

### What changes are included in this PR?

Adds an environment variable `LIBARROW_BINARY_VERSION` that can be used to override the `VERSION` for the purposes of downloading the binary.

### Are these changes tested?

Not yet! Working on the best way to do this.

### Are there any user-facing changes?

No (this is currently just a developer-facing tool).

* Closes: #38079