### PR TITLE
GH-38059: [Python][CI] Upgrade CUDA to 11.2.2

### DIFF
--- a/.env
+++ b/.env
@@ -54,7 +54,7 @@ UBUNTU=20.04
 
 # Default versions for various dependencies
 CLANG_TOOLS=14
-CUDA=11.0.3
+CUDA=11.2.2
 DASK=latest
 DOTNET=7.0
 GCC_VERSION=""

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -322,9 +322,8 @@ Status CudaDevice::Stream::WaitEvent(const Device::SyncEvent& event) {
   }
 
   ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
-  // we are currently building with CUDA toolkit 11.0.3 which doesn't have enum
-  // values for the flags yet. The "flags" param *must* be 0 for now.
-  CU_RETURN_NOT_OK("cuStreamWaitEvent", cuStreamWaitEvent(value(), cu_event, 0));
+  CU_RETURN_NOT_OK("cuStreamWaitEvent",
+                   cuStreamWaitEvent(value(), cu_event, CU_EVENT_WAIT_DEFAULT));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -322,8 +322,9 @@ Status CudaDevice::Stream::WaitEvent(const Device::SyncEvent& event) {
   }
 
   ContextSaver set_temporary(reinterpret_cast<CUcontext>(context_.get()->handle()));
-  CU_RETURN_NOT_OK("cuStreamWaitEvent",
-                   cuStreamWaitEvent(value(), cu_event, CU_EVENT_WAIT_DEFAULT));
+  // we are currently building with CUDA toolkit 11.0.3 which doesn't have enum
+  // values for the flags yet. The "flags" param *must* be 0 for now.
+  CU_RETURN_NOT_OK("cuStreamWaitEvent", cuStreamWaitEvent(value(), cu_event, 0));
   return Status::OK();
 }
 


### PR DESCRIPTION
### Rationale for this change

Numba v0.58 requires cuda-toolkit >= v11.2

### What changes are included in this PR?

* Upgrade CUDA from 11.0.3 -> 11.2.2

### Are these changes tested?

Will test in CI

### Are there any user-facing changes?

Yes
* Closes: #38059