### PR TITLE
MINOR: [R] Fix the error of ignoring stdout in `on_rosetta()`

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -244,7 +244,7 @@ on_macos_10_13_or_lower <- function() {
 on_rosetta <- function() {
   # make sure to suppress warnings and ignore the stdout + stderr so that this is silent
   identical(tolower(Sys.info()[["sysname"]]), "darwin") &&
-    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)), "1")
+    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)), "1")
 }
 
 option_use_threads <- function() {


### PR DESCRIPTION
### Rationale for this change

A follow on to #38052 which introduced a small bug

### What changes are included in this PR?

Don't ignore the stdout which is the mechanism to tell if under emulation.

### Are these changes tested?

I tested these locally:

On an M2 with emulation:

```
> identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)), "1")
[1] FALSE
> system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)
character(0)
> system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)
[1] "1"
> identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)), "1")
[1] TRUE
```

On an M2 without emulation:

```
> identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)), "1")
[1] FALSE
> system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)
character(0)
> system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)
[1] "0"
> identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)), "1")
[1] FALSE
```

On an x86 (note the warning message suppression is what #38052 resolved):

```
>  identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)), "1")
[1] FALSE
> system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE, ignore.stdout = TRUE)
character(0)
attr(,"status")
[1] 1
Warning message:
In system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE,  :
  running command 'sysctl -n sysctl.proc_translated >/dev/null 2>/dev/null' had status 1
> system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)
character(0)
attr(,"status")
[1] 1
Warning message:
In system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE) :
  running command 'sysctl -n sysctl.proc_translated 2>/dev/null' had status 1
> identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)), "1")
[1] FALSE
```

### Are there any user-facing changes?

No / the functionality is restored