### PR TITLE
GH-38084: [R] Do not memory map when explicitly checking for file removal

### DIFF
--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -22,6 +22,7 @@
 #'
 #' @inheritParams read_feather
 #' @param props [ParquetArrowReaderProperties]
+#' @param mmap Use TRUE to use memory mapping where possible
 #' @param ... Additional arguments passed to `ParquetFileReader$create()`
 #'
 #' @return A `tibble` if `as_data_frame` is `TRUE` (the default), or an
@@ -43,14 +44,15 @@ read_parquet <- function(file,
                          # Assembling `props` yourself is something you do with
                          # ParquetFileReader but not here.
                          props = ParquetArrowReaderProperties$create(),
+                         mmap = TRUE,
                          ...) {
   if (!inherits(file, "RandomAccessFile")) {
     # Compression is handled inside the parquet file format, so we don't need
     # to detect from the file extension and wrap in a CompressedInputStream
-    file <- make_readable_file(file)
+    file <- make_readable_file(file, mmap = mmap)
     on.exit(file$close())
   }
-  reader <- ParquetFileReader$create(file, props = props, ...)
+  reader <- ParquetFileReader$create(file, props = props, mmap = mmap, ...)
 
   col_select <- enquo(col_select)
   if (!quo_is_null(col_select)) {

--- a/r/man/read_parquet.Rd
+++ b/r/man/read_parquet.Rd
@@ -9,6 +9,7 @@ read_parquet(
   col_select = NULL,
   as_data_frame = TRUE,
   props = ParquetArrowReaderProperties$create(),
+  mmap = TRUE,
   ...
 )
 }
@@ -28,6 +29,8 @@ of columns, as used in \code{dplyr::select()}.}
 an Arrow \link{Table}?}
 
 \item{props}{\link{ParquetArrowReaderProperties}}
+
+\item{mmap}{Use TRUE to use memory mapping where possible}
 
 \item{...}{Additional arguments passed to \code{ParquetFileReader$create()}}
 }

--- a/r/tests/testthat/test-read-record-batch.R
+++ b/r/tests/testthat/test-read-record-batch.R
@@ -38,7 +38,7 @@ test_that("RecordBatchFileWriter / RecordBatchFileReader roundtrips", {
   writer$close()
   stream$close()
 
-  expect_equal(read_feather(tf, as_data_frame = FALSE), tab)
+  expect_equal(read_feather(tf, as_data_frame = FALSE, mmap = FALSE), tab)
   # Make sure connections are closed
   expect_error(file.remove(tf), NA)
   skip_on_os("windows") # This should pass, we've closed the stream


### PR DESCRIPTION
### Rationale for this change

We have failing CI on Windows because removing files that have memory mapped sections is not allowed.

### What changes are included in this PR?

Pass `mmap = FALSE` when we explicitly check for removal. I think the other cases are OK because `unlink()` fails silently (which is maybe why we haven't seen mass CI failures because of this issue before).

### Are these changes tested?

The changes are covered by existing tests.

### Are there any user-facing changes?

No.

* Closes: #38084