### PR TITLE
GH-38090: [C++][Emscripten] acero/hash_join: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/acero/hash_join.cc
+++ b/cpp/src/arrow/acero/hash_join.cc
@@ -462,11 +462,11 @@ class HashJoinBasicImpl : public HashJoinImpl {
                          std::vector<const uint8_t*>* nn_bit_vectors,
                          std::vector<int64_t>* nn_offsets,
                          std::vector<uint8_t>* nn_bit_vector_all_nulls) {
-    int num_cols = static_cast<int>(batch.values.size());
+    auto num_cols = batch.values.size();
     nn_bit_vectors->resize(num_cols);
     nn_offsets->resize(num_cols);
     nn_bit_vector_all_nulls->clear();
-    for (int64_t i = 0; i < num_cols; ++i) {
+    for (size_t i = 0; i < num_cols; ++i) {
       const uint8_t* nn = nullptr;
       int64_t offset = 0;
       if (batch[i].is_array()) {
@@ -478,9 +478,10 @@ class HashJoinBasicImpl : public HashJoinImpl {
         ARROW_DCHECK(batch[i].is_scalar());
         if (!batch[i].scalar_as<arrow::internal::PrimitiveScalarBase>().is_valid) {
           if (nn_bit_vector_all_nulls->empty()) {
-            nn_bit_vector_all_nulls->resize(bit_util::BytesForBits(batch.length));
+            nn_bit_vector_all_nulls->resize(
+                static_cast<size_t>(bit_util::BytesForBits(batch.length)));
             memset(nn_bit_vector_all_nulls->data(), 0,
-                   bit_util::BytesForBits(batch.length));
+                   static_cast<size_t>(bit_util::BytesForBits(batch.length)));
           }
           nn = nn_bit_vector_all_nulls->data();
         }
@@ -704,8 +705,10 @@ class HashJoinBasicImpl : public HashJoinImpl {
     }
     if (!hash_table_empty_) {
       int32_t num_rows = hash_table_keys_.num_rows();
-      local_state->has_match.resize(bit_util::BytesForBits(num_rows));
-      memset(local_state->has_match.data(), 0, bit_util::BytesForBits(num_rows));
+      local_state->has_match.resize(
+          static_cast<size_t>(bit_util::BytesForBits(num_rows)));
+      memset(local_state->has_match.data(), 0,
+             static_cast<size_t>(bit_util::BytesForBits(num_rows)));
     }
     local_state->is_has_match_initialized = true;
   }
@@ -716,8 +719,8 @@ class HashJoinBasicImpl : public HashJoinImpl {
     }
 
     int32_t num_rows = hash_table_keys_.num_rows();
-    has_match_.resize(bit_util::BytesForBits(num_rows));
-    memset(has_match_.data(), 0, bit_util::BytesForBits(num_rows));
+    has_match_.resize(static_cast<size_t>(bit_util::BytesForBits(num_rows)));
+    memset(has_match_.data(), 0, static_cast<size_t>(bit_util::BytesForBits(num_rows)));
 
     for (size_t tid = 0; tid < local_states_.size(); ++tid) {
       if (!local_states_[tid].is_initialized) {

--- a/cpp/src/arrow/acero/hash_join_dict.cc
+++ b/cpp/src/arrow/acero/hash_join_dict.cc
@@ -107,7 +107,7 @@ static Result<std::shared_ptr<ArrayData>> ConvertImp(
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> to_nn_buf,
                         AllocateBitmap(batch_length, ctx->memory_pool()));
   uint8_t* to_nn = to_nn_buf->mutable_data();
-  memset(to_nn, 0xff, bit_util::BytesForBits(batch_length));
+  memset(to_nn, 0xff, static_cast<size_t>(bit_util::BytesForBits(batch_length)));
 
   if (!is_scalar) {
     const ArrayData& arr = *input.array();
@@ -143,11 +143,11 @@ static Result<std::shared_ptr<ArrayData>> ConvertImp(
         to[i] = to_value;
       }
 
-      memset(to_nn, 0xff, bit_util::BytesForBits(batch_length));
+      memset(to_nn, 0xff, static_cast<size_t>(bit_util::BytesForBits(batch_length)));
       return ArrayData::Make(to_type, batch_length,
                              {std::move(to_nn_buf), std::move(to_buf)});
     } else {
-      memset(to_nn, 0, bit_util::BytesForBits(batch_length));
+      memset(to_nn, 0, static_cast<size_t>(bit_util::BytesForBits(batch_length)));
       return ArrayData::Make(to_type, batch_length,
                              {std::move(to_nn_buf), std::move(to_buf)});
     }
@@ -249,7 +249,7 @@ Status HashJoinDictBuild::Init(ExecContext* ctx, std::shared_ptr<Array> dictiona
                         AllocateBuffer(length * sizeof(int32_t), ctx->memory_pool()));
   uint8_t* non_nulls = non_nulls_buf->mutable_data();
   int32_t* ids = reinterpret_cast<int32_t*>(ids_buf->mutable_data());
-  memset(non_nulls, 0xff, bit_util::BytesForBits(length));
+  memset(non_nulls, 0xff, static_cast<size_t>(bit_util::BytesForBits(length)));
 
   int32_t num_entries = 0;
   for (int64_t i = 0; i < length; ++i) {
@@ -310,7 +310,7 @@ Result<std::shared_ptr<ArrayData>> HashJoinDictBuild::RemapInputValues(
       AllocateBuffer(batch_length * sizeof(int32_t), ctx->memory_pool()));
   uint8_t* non_nulls = non_nulls_buf->mutable_data();
   int32_t* ids = reinterpret_cast<int32_t*>(ids_buf->mutable_data());
-  memset(non_nulls, 0xff, bit_util::BytesForBits(batch_length));
+  memset(non_nulls, 0xff, static_cast<size_t>(bit_util::BytesForBits(batch_length)));
 
   // Populate output buffers (for scalar only the first entry is populated)
   //
@@ -334,7 +334,7 @@ Result<std::shared_ptr<ArrayData>> HashJoinDictBuild::RemapInputValues(
   //
   if (is_scalar) {
     if (!bit_util::GetBit(non_nulls, 0)) {
-      memset(non_nulls, 0, bit_util::BytesForBits(batch_length));
+      memset(non_nulls, 0, static_cast<size_t>(bit_util::BytesForBits(batch_length)));
     }
     for (int64_t i = 1; i < batch_length; ++i) {
       ids[i] = ids[0];

--- a/cpp/src/arrow/acero/hash_join_node.cc
+++ b/cpp/src/arrow/acero/hash_join_node.cc
@@ -554,9 +554,9 @@ struct BloomFilterPushdownContext {
     ExecBatch& batch = *batch_ptr;
     if (eval_.num_expected_bloom_filters_ == 0 || batch.length == 0) return Status::OK();
 
-    int64_t bit_vector_bytes = bit_util::BytesForBits(batch.length);
+    auto bit_vector_bytes = static_cast<size_t>(bit_util::BytesForBits(batch.length));
     std::vector<uint8_t> selected(bit_vector_bytes);
-    std::vector<uint32_t> hashes(batch.length);
+    std::vector<uint32_t> hashes(static_cast<size_t>(batch.length));
     std::vector<uint8_t> bv(bit_vector_bytes);
 
     ARROW_ASSIGN_OR_RAISE(arrow::util::TempVectorStack * stack,
@@ -961,8 +961,9 @@ class HashJoinNode : public ExecNode, public TracedNode {
 
     task_group_probe_ = ctx->RegisterTaskGroup(
         [this](size_t thread_index, int64_t task_id) -> Status {
-          return impl_->ProbeSingleBatch(thread_index,
-                                         std::move(queued_batches_to_probe_[task_id]));
+          return impl_->ProbeSingleBatch(
+              thread_index,
+              std::move(queued_batches_to_probe_[static_cast<size_t>(task_id)]));
         },
         [this](size_t thread_index) -> Status {
           return OnQueuedBatchesProbed(thread_index);
@@ -1070,7 +1071,8 @@ void BloomFilterPushdownContext::Init(
 
   eval_.task_id_ = register_task_group_callback(
       [this](size_t thread_index, int64_t task_id) {
-        return FilterSingleBatch(thread_index, &eval_.batches_[task_id]);
+        return FilterSingleBatch(thread_index,
+                                 &eval_.batches_[static_cast<size_t>(task_id)]);
       },
       [this](size_t thread_index) {
         return eval_.on_finished_(thread_index, std::move(eval_.batches_));
@@ -1111,7 +1113,7 @@ Status BloomFilterPushdownContext::PushBloomFilter(size_t thread_index) {
 
 Status BloomFilterPushdownContext::BuildBloomFilter_exec_task(size_t thread_index,
                                                               int64_t task_id) {
-  const ExecBatch& input_batch = build_.batches_[task_id];
+  const ExecBatch& input_batch = build_.batches_[static_cast<size_t>(task_id)];
   SchemaProjectionMap key_to_in =
       schema_mgr_->proj_maps[1].map(HashJoinProjection::KEY, HashJoinProjection::INPUT);
   std::vector<Datum> key_columns(key_to_in.num_cols);


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090