### PR TITLE
GH-38090: [C++][Emscripten] acero/swiss_join: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -405,7 +405,7 @@ void RowArray::DebugPrintToFile(const char* filename, bool print_sorted) const {
       return;
     }
     std::vector<char> buffer;
-    buffer.resize(sb.st_size);
+    buffer.resize(static_cast<size_t>(sb.st_size));
     std::vector<std::string> lines;
     FILE* fin;
 #if defined(_MSC_VER) && _MSC_VER >= 1400
@@ -538,7 +538,7 @@ void RowArrayMerge::CopyFixedLength(RowTableImpl* target, const RowTableImpl& so
   //
   if (!source_rows_permutation) {
     memcpy(target->mutable_data(1) + fixed_length * first_target_row_id, source.data(1),
-           fixed_length * num_source_rows);
+           static_cast<size_t>(fixed_length * num_source_rows));
   } else {
     // Row length must be a multiple of 64-bits due to enforced alignment.
     // Loop for each output row copying a fixed number of 64-bit words.
@@ -617,7 +617,8 @@ void RowArrayMerge::CopyNulls(RowTableImpl* target, const RowTableImpl& source,
   int num_bytes_per_row = target->metadata().null_masks_bytes_per_row;
   uint8_t* target_nulls = target->null_masks() + num_bytes_per_row * first_target_row_id;
   if (!source_rows_permutation) {
-    memcpy(target_nulls, source.null_masks(), num_bytes_per_row * num_source_rows);
+    memcpy(target_nulls, source.null_masks(),
+           static_cast<size_t>(num_bytes_per_row * num_source_rows));
   } else {
     for (int64_t i = 0; i < num_source_rows; ++i) {
       int64_t source_row_id = source_rows_permutation[i];
@@ -873,7 +874,7 @@ void SwissTableWithKeys::EqualCallback(int num_keys, const uint16_t* selection_m
     auto selection_to_use_buf =
         arrow::util::TempVectorHolder<uint16_t>(in->temp_stack, num_keys);
     ARROW_DCHECK(in->temp_group_ids);
-    in->temp_group_ids->resize(in->batch->length);
+    in->temp_group_ids->resize(static_cast<size_t>(in->batch->length));
 
     if (selection_maybe_null) {
       for (int i = 0; i < num_keys; ++i) {
@@ -1069,14 +1070,16 @@ uint8_t* SwissTableForJoin::local_has_match(int64_t thread_id) {
     return nullptr;
   }
 
-  ThreadLocalState& local_state = local_states_[thread_id];
+  ThreadLocalState& local_state = local_states_[static_cast<size_t>(thread_id)];
   if (local_state.has_match.empty() && num_rows_hash_table > 0) {
-    local_state.has_match.resize(bit_util::BytesForBits(num_rows_hash_table) +
-                                 sizeof(uint64_t));
-    memset(local_state.has_match.data(), 0, bit_util::BytesForBits(num_rows_hash_table));
+    local_state.has_match.resize(
+        static_cast<size_t>(bit_util::BytesForBits(num_rows_hash_table)) +
+        sizeof(uint64_t));
+    memset(local_state.has_match.data(), 0,
+           static_cast<size_t>(bit_util::BytesForBits(num_rows_hash_table)));
   }
 
-  return local_states_[thread_id].has_match.data();
+  return local_states_[static_cast<size_t>(thread_id)].has_match.data();
 }
 
 void SwissTableForJoin::UpdateHasMatchForKeys(int64_t thread_id, int num_ids,
@@ -1098,8 +1101,10 @@ void SwissTableForJoin::MergeHasMatch() {
     return;
   }
 
-  has_match_.resize(bit_util::BytesForBits(num_rows_hash_table) + sizeof(uint64_t));
-  memset(has_match_.data(), 0, bit_util::BytesForBits(num_rows_hash_table));
+  has_match_.resize(static_cast<size_t>(bit_util::BytesForBits(num_rows_hash_table)) +
+                    sizeof(uint64_t));
+  memset(has_match_.data(), 0,
+         static_cast<size_t>(bit_util::BytesForBits(num_rows_hash_table)));
 
   for (size_t tid = 0; tid < local_states_.size(); ++tid) {
     if (!local_states_[tid].has_match.empty()) {
@@ -1202,11 +1207,11 @@ Status SwissTableForJoinBuild::PushNextBatch(int64_t thread_id,
                                              const ExecBatch* payload_batch_maybe_null,
                                              arrow::util::TempVectorStack* temp_stack) {
   ARROW_DCHECK(thread_id < dop_);
-  ThreadState& locals = thread_states_[thread_id];
+  ThreadState& locals = thread_states_[static_cast<size_t>(thread_id)];
 
   // Compute hash
   //
-  locals.batch_hashes.resize(key_batch.length);
+  locals.batch_hashes.resize(static_cast<size_t>(key_batch.length));
   RETURN_NOT_OK(Hashing32::HashBatch(
       key_batch, locals.batch_hashes.data(), locals.temp_column_arrays, hardware_flags_,
       temp_stack, /*start_row=*/0, static_cast<int>(key_batch.length)));
@@ -1234,7 +1239,8 @@ Status SwissTableForJoinBuild::PushNextBatch(int64_t thread_id,
           // We want each partition to correspond to a range of block indices,
           // so we also partition on the highest bits of the hash.
           //
-          return locals.batch_hashes[i] >> (31 - log_num_prtns_) >> 1;
+          return locals.batch_hashes[static_cast<size_t>(i)] >> (31 - log_num_prtns_) >>
+                 1;
         },
         [&locals](int64_t i, int pos) {
           locals.batch_prtn_row_ids[pos] = static_cast<uint16_t>(i);
@@ -1255,7 +1261,7 @@ Status SwissTableForJoinBuild::PushNextBatch(int64_t thread_id,
   locals.temp_prtn_ids.resize(num_prtns_);
 
   RETURN_NOT_OK(prtn_locks_.ForEachPartition(
-      thread_id, locals.temp_prtn_ids.data(),
+      static_cast<size_t>(thread_id), locals.temp_prtn_ids.data(),
       /*is_prtn_empty_fn=*/
       [&](int prtn_id) {
         return locals.batch_prtn_ranges[prtn_id + 1] == locals.batch_prtn_ranges[prtn_id];
@@ -1275,7 +1281,7 @@ Status SwissTableForJoinBuild::ProcessPartition(int64_t thread_id,
                                                 arrow::util::TempVectorStack* temp_stack,
                                                 int prtn_id) {
   ARROW_DCHECK(thread_id < dop_);
-  ThreadState& locals = thread_states_[thread_id];
+  ThreadState& locals = thread_states_[static_cast<size_t>(thread_id)];
 
   int num_rows_new =
       locals.batch_prtn_ranges[prtn_id + 1] - locals.batch_prtn_ranges[prtn_id];
@@ -1370,14 +1376,16 @@ Status SwissTableForJoinBuild::PreparePrtnMerge() {
   //
   target_->no_duplicate_keys_ = no_duplicate_keys;
   if (!no_duplicate_keys) {
-    target_->row_offset_for_key_.resize(num_keys + 1);
+    target_->row_offset_for_key_.resize(static_cast<size_t>(num_keys + 1));
     int64_t num_rows = 0;
-    for (int i = 0; i < num_prtns_; ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(num_prtns_); ++i) {
       int64_t first_key = partition_keys_first_row_id_[i];
-      target_->row_offset_for_key_[first_key] = static_cast<uint32_t>(num_rows);
+      target_->row_offset_for_key_[static_cast<size_t>(first_key)] =
+          static_cast<uint32_t>(num_rows);
       num_rows += static_cast<int64_t>(prtn_states_[i].key_ids.size());
     }
-    target_->row_offset_for_key_[num_keys] = static_cast<uint32_t>(num_rows);
+    target_->row_offset_for_key_[static_cast<size_t>(num_keys)] =
+        static_cast<uint32_t>(num_rows);
   }
 
   return Status::OK();
@@ -1449,7 +1457,7 @@ void SwissTableForJoinBuild::PrtnMerge(int prtn_id) {
       for (size_t i = 0; i < prtn_state.key_ids.size(); ++i) {
         uint32_t key_id = prtn_state.key_ids[i];
         int64_t position = --counters[key_id];
-        source_payload_ids[position] = static_cast<int64_t>(i);
+        source_payload_ids[static_cast<size_t>(position)] = static_cast<int64_t>(i);
       }
       // Add base payload id to all of the counters.
       //
@@ -1764,7 +1772,8 @@ void JoinNullFilter::Filter(const ExecBatch& key_batch, int batch_start_row,
     // Filter out nulls for this column
     //
     if (!is_output_initialized) {
-      memset(inout_bit_vector, 0xff, bit_util::BytesForBits(num_batch_rows));
+      memset(inout_bit_vector, 0xff,
+             static_cast<size_t>(bit_util::BytesForBits(num_batch_rows)));
       is_output_initialized = true;
     }
     arrow::internal::BitmapAnd(inout_bit_vector, 0, non_null_buffer, offset,
@@ -1950,7 +1959,7 @@ Status JoinProbeProcessor::OnNextBatch(int64_t thread_id,
               static_cast<uint16_t>(minibatch_start);
         }
 
-        RETURN_NOT_OK(materialize_[thread_id]->AppendProbeOnly(
+        RETURN_NOT_OK(materialize_[static_cast<size_t>(thread_id)]->AppendProbeOnly(
             keypayload_batch, num_passing_ids, materialize_batch_ids_buf.mutable_data(),
             [&](ExecBatch batch) {
               return output_batch_fn_(thread_id, std::move(batch));
@@ -1990,7 +1999,7 @@ Status JoinProbeProcessor::OnNextBatch(int64_t thread_id,
         // Call materialize for resulting id tuples pointing to matching pairs
         // of rows.
         //
-        RETURN_NOT_OK(materialize_[thread_id]->Append(
+        RETURN_NOT_OK(materialize_[static_cast<size_t>(thread_id)]->Append(
             keypayload_batch, num_matches_next, materialize_batch_ids,
             materialize_key_ids, materialize_payload_ids, [&](ExecBatch batch) {
               return output_batch_fn_(thread_id, std::move(batch));
@@ -2016,7 +2025,7 @@ Status JoinProbeProcessor::OnNextBatch(int64_t thread_id,
               static_cast<uint16_t>(minibatch_start);
         }
 
-        RETURN_NOT_OK(materialize_[thread_id]->AppendProbeOnly(
+        RETURN_NOT_OK(materialize_[static_cast<size_t>(thread_id)]->AppendProbeOnly(
             keypayload_batch, num_passing_ids, materialize_batch_ids_buf.mutable_data(),
             [&](ExecBatch batch) {
               return output_batch_fn_(thread_id, std::move(batch));
@@ -2219,7 +2228,9 @@ class SwissJoin : public HashJoinImpl {
 
     ExecBatch input_batch;
     ARROW_ASSIGN_OR_RAISE(
-        input_batch, KeyPayloadFromInput(/*side=*/1, &build_side_batches_[batch_id]));
+        input_batch,
+        KeyPayloadFromInput(/*side=*/1,
+                            &build_side_batches_[static_cast<size_t>(batch_id)]));
 
     if (input_batch.length == 0) {
       return Status::OK();
@@ -2302,7 +2313,7 @@ class SwissJoin : public HashJoinImpl {
     }
     hash_table_ready_.store(true);
 
-    return build_finished_callback_(thread_id);
+    return build_finished_callback_(static_cast<size_t>(thread_id));
   }
 
   Status StartScanHashTable(int64_t thread_id) {

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -381,7 +381,8 @@ class SwissTableForJoin {
   }
   int64_t num_keys() const { return map_.keys()->num_rows(); }
   int64_t num_rows() const {
-    return no_duplicate_keys_ ? num_keys() : row_offset_for_key_[num_keys()];
+    return no_duplicate_keys_ ? num_keys()
+                              : row_offset_for_key_[static_cast<size_t>(num_keys())];
   }
 
   uint32_t payload_id_to_key_id(uint32_t payload_id) const;


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090