### PR TITLE
GH-38090: [C++][Emscripten] acero/tpch_node: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/acero/tpch_node.cc
+++ b/cpp/src/arrow/acero/tpch_node.cc
@@ -307,7 +307,7 @@ Status TpchPseudotext::EnsureInitialized(random::pcg32_fast& rng) {
       generated_offset_ += memcpy_size;
       last_one = generated_offset_ == kTextBytes;
     }
-    std::memcpy(out + offset, temp_buff, memcpy_size);
+    std::memcpy(out + offset, temp_buff, static_cast<size_t>(memcpy_size));
     if (last_one) done_.store(true);
   }
   return Status::OK();
@@ -646,7 +646,8 @@ class PartAndPartSupplierGenerator {
       random::pcg64_fast seed_rng(seed);
       for (ThreadLocalData& tld : thread_local_data_) {
         constexpr int kMaxNumDistinctStrings = 5;
-        tld.string_indices.resize(kMaxNumDistinctStrings * batch_size_);
+        tld.string_indices.resize(
+            static_cast<size_t>(kMaxNumDistinctStrings * batch_size_));
         tld.rng.seed(kSeedDist(seed_rng));
       }
       part_rows_to_generate_ = static_cast<int64_t>(scale_factor_ * 200000);
@@ -880,9 +881,9 @@ class PartAndPartSupplierGenerator {
                             AllocateBuffer((tld.part_to_generate + 1) * sizeof(int32_t)));
       int32_t* offsets = reinterpret_cast<int32_t*>(offset_buff->mutable_data());
       offsets[0] = 0;
-      for (int64_t irow = 0; irow < tld.part_to_generate; irow++) {
+      for (size_t irow = 0; irow < static_cast<size_t>(tld.part_to_generate); irow++) {
         size_t string_length = 0;
-        for (int ipart = 0; ipart < 5; ipart++) {
+        for (size_t ipart = 0; ipart < 5; ipart++) {
           uint8_t name_part_index = static_cast<uint8_t>(dist(tld.rng));
           tld.string_indices[irow * 5 + ipart] = name_part_index;
           string_length += std::strlen(NameParts[name_part_index]);
@@ -894,9 +895,9 @@ class PartAndPartSupplierGenerator {
       ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> string_buffer,
                             AllocateBuffer(offsets[tld.part_to_generate] + 1));
       char* strings = reinterpret_cast<char*>(string_buffer->mutable_data());
-      for (int64_t irow = 0; irow < tld.part_to_generate; irow++) {
+      for (size_t irow = 0; irow < static_cast<size_t>(tld.part_to_generate); irow++) {
         char* row = strings + offsets[irow];
-        for (int ipart = 0; ipart < 5; ipart++) {
+        for (size_t ipart = 0; ipart < 5; ipart++) {
           uint8_t name_part_index = tld.string_indices[irow * 5 + ipart];
           const char* part = NameParts[name_part_index];
           size_t length = std::strlen(part);
@@ -976,9 +977,9 @@ class PartAndPartSupplierGenerator {
                             AllocateBuffer((tld.part_to_generate + 1) * sizeof(int32_t)));
       int32_t* offsets = reinterpret_cast<int32_t*>(offset_buff->mutable_data());
       offsets[0] = 0;
-      for (int64_t irow = 0; irow < tld.part_to_generate; irow++) {
+      for (size_t irow = 0; irow < static_cast<size_t>(tld.part_to_generate); irow++) {
         size_t string_length = 0;
-        for (int ipart = 0; ipart < 3; ipart++) {
+        for (size_t ipart = 0; ipart < 3; ipart++) {
           uint8_t name_part_index = static_cast<uint8_t>(dists[ipart](tld.rng));
           tld.string_indices[irow * 3 + ipart] = name_part_index;
           string_length += std::strlen(types[ipart][name_part_index]);
@@ -988,9 +989,9 @@ class PartAndPartSupplierGenerator {
       ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> string_buffer,
                             AllocateBuffer(offsets[tld.part_to_generate]));
       char* strings = reinterpret_cast<char*>(string_buffer->mutable_data());
-      for (int64_t irow = 0; irow < tld.part_to_generate; irow++) {
+      for (size_t irow = 0; irow < static_cast<size_t>(tld.part_to_generate); irow++) {
         char* row = strings + offsets[irow];
-        for (int ipart = 0; ipart < 3; ipart++) {
+        for (size_t ipart = 0; ipart < 3; ipart++) {
           uint8_t name_part_index = tld.string_indices[irow * 3 + ipart];
           const char* part = types[ipart][name_part_index];
           size_t length = std::strlen(part);
@@ -1069,7 +1070,8 @@ class PartAndPartSupplierGenerator {
     if (tld.part[PART::P_COMMENT].kind() == Datum::NONE) {
       ARROW_ASSIGN_OR_RAISE(
           tld.part[PART::P_COMMENT],
-          g_text.GenerateComments(tld.part_to_generate, 5, 22, tld.rng));
+          g_text.GenerateComments(static_cast<size_t>(tld.part_to_generate), 5, 22,
+                                  tld.rng));
     }
     return Status::OK();
   }
@@ -1085,7 +1087,7 @@ class PartAndPartSupplierGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     tld.generated_partsupp.reset();
     int64_t num_batches = PartsuppBatchesToGenerate(thread_index);
-    tld.partsupp.resize(num_batches);
+    tld.partsupp.resize(static_cast<size_t>(num_batches));
     for (std::vector<Datum>& batch : tld.partsupp) {
       batch.resize(PARTSUPP::kNumCols);
       std::fill(batch.begin(), batch.end(), Datum());
@@ -1145,8 +1147,8 @@ class PartAndPartSupplierGenerator {
             ipart++;
           }
         }
-        RETURN_NOT_OK(
-            SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_PARTKEY, next_run));
+        RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_PARTKEY,
+                                            static_cast<size_t>(next_run)));
         irow += next_run;
       }
     }
@@ -1190,8 +1192,8 @@ class PartAndPartSupplierGenerator {
             ipart++;
           }
         }
-        RETURN_NOT_OK(
-            SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_SUPPKEY, next_run));
+        RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_SUPPKEY,
+                                            static_cast<size_t>(next_run)));
         irow += next_run;
       }
     }
@@ -1203,17 +1205,19 @@ class PartAndPartSupplierGenerator {
     if (!tld.generated_partsupp[PARTSUPP::PS_AVAILQTY]) {
       tld.generated_partsupp[PARTSUPP::PS_AVAILQTY] = true;
       std::uniform_int_distribution<int32_t> dist(1, 9999);
-      int64_t ps_to_generate = kPartSuppRowsPerPart * tld.part_to_generate;
-      int64_t ibatch = 0;
-      for (int64_t irow = 0; irow < ps_to_generate; ibatch++) {
+      auto ps_to_generate =
+          static_cast<size_t>(kPartSuppRowsPerPart * tld.part_to_generate);
+      size_t ibatch = 0;
+      for (size_t irow = 0; irow < ps_to_generate; ibatch++) {
         RETURN_NOT_OK(AllocatePartSuppBatch(thread_index, ibatch, PARTSUPP::PS_AVAILQTY));
         int32_t* ps_availqty =
             reinterpret_cast<int32_t*>(tld.partsupp[ibatch][PARTSUPP::PS_AVAILQTY]
                                            .array()
                                            ->buffers[1]
                                            ->mutable_data());
-        int64_t next_run = std::min(batch_size_, ps_to_generate - irow);
-        for (int64_t irun = 0; irun < next_run; irun++) ps_availqty[irun] = dist(tld.rng);
+        size_t next_run =
+            std::min(static_cast<size_t>(batch_size_), ps_to_generate - irow);
+        for (size_t irun = 0; irun < next_run; irun++) ps_availqty[irun] = dist(tld.rng);
 
         RETURN_NOT_OK(
             SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_AVAILQTY, next_run));
@@ -1229,7 +1233,7 @@ class PartAndPartSupplierGenerator {
       tld.generated_partsupp[PARTSUPP::PS_SUPPLYCOST] = true;
       std::uniform_int_distribution<int64_t> dist(100, 100000);
       int64_t ps_to_generate = kPartSuppRowsPerPart * tld.part_to_generate;
-      int64_t ibatch = 0;
+      size_t ibatch = 0;
       for (int64_t irow = 0; irow < ps_to_generate; ibatch++) {
         RETURN_NOT_OK(
             AllocatePartSuppBatch(thread_index, ibatch, PARTSUPP::PS_SUPPLYCOST));
@@ -1238,8 +1242,8 @@ class PartAndPartSupplierGenerator {
                                               .array()
                                               ->buffers[1]
                                               ->mutable_data());
-        int64_t next_run = std::min(batch_size_, ps_to_generate - irow);
-        for (int64_t irun = 0; irun < next_run; irun++)
+        auto next_run = static_cast<size_t>(std::min(batch_size_, ps_to_generate - irow));
+        for (size_t irun = 0; irun < next_run; irun++)
           ps_supplycost[irun] = {dist(tld.rng)};
 
         RETURN_NOT_OK(SetPartSuppColumnSize(thread_index, ibatch, PARTSUPP::PS_SUPPLYCOST,
@@ -1257,7 +1261,7 @@ class PartAndPartSupplierGenerator {
       int64_t irow = 0;
       int64_t ps_to_generate = kPartSuppRowsPerPart * tld.part_to_generate;
       for (size_t ibatch = 0; ibatch < tld.partsupp.size(); ibatch++) {
-        int64_t num_rows = std::min(batch_size_, ps_to_generate - irow);
+        auto num_rows = static_cast<size_t>(std::min(batch_size_, ps_to_generate - irow));
         ARROW_ASSIGN_OR_RAISE(tld.partsupp[ibatch][PARTSUPP::PS_COMMENT],
                               g_text.GenerateComments(num_rows, 49, 198, tld.rng));
         irow += num_rows;
@@ -1306,7 +1310,7 @@ class OrdersAndLineItemGenerator {
       thread_local_data_.resize(num_threads);
       random::pcg64_fast seed_rng(seed);
       for (ThreadLocalData& tld : thread_local_data_) {
-        tld.items_per_order.resize(batch_size_);
+        tld.items_per_order.resize(static_cast<size_t>(batch_size_));
         tld.rng.seed(kSeedDist(seed_rng));
       }
       orders_rows_to_generate_ = static_cast<int64_t>(scale_factor_ * 150000 * 10);
@@ -1348,7 +1352,7 @@ class OrdersAndLineItemGenerator {
         orders_batches_generated_.fetch_add(1);
         tld.first_batch_offset = 0;
         RETURN_NOT_OK(GenerateRowCounts(thread_index));
-        lineitem_batches_generated_.fetch_add(static_cast<int64_t>(tld.lineitem.size()));
+        lineitem_batches_generated_.fetch_add(tld.lineitem.size());
         ARROW_DCHECK(orders_rows_generated_ <= orders_rows_to_generate_);
       }
     }
@@ -1416,8 +1420,7 @@ class OrdersAndLineItemGenerator {
       orders_rows_generated_ += tld.orders_to_generate;
       orders_batches_generated_.fetch_add(1);
       RETURN_NOT_OK(GenerateRowCounts(thread_index));
-      lineitem_batches_generated_.fetch_add(
-          static_cast<int64_t>(tld.lineitem.size() - from_queue));
+      lineitem_batches_generated_.fetch_add(tld.lineitem.size() - from_queue);
       ARROW_DCHECK(orders_rows_generated_ <= orders_rows_to_generate_);
     }
     tld.orders.resize(ORDERS::kNumCols);
@@ -1611,7 +1614,7 @@ class OrdersAndLineItemGenerator {
       char* o_orderstatus = reinterpret_cast<char*>(
           tld.orders[ORDERS::O_ORDERSTATUS].array()->buffers[1]->mutable_data());
 
-      size_t batch_offset = tld.first_batch_offset;
+      auto batch_offset = static_cast<size_t>(tld.first_batch_offset);
       size_t ibatch = 0;
       size_t iorder = 0;
       int32_t iline = 0;
@@ -1656,7 +1659,7 @@ class OrdersAndLineItemGenerator {
       RETURN_NOT_OK(L_DISCOUNT(thread_index));
       RETURN_NOT_OK(AllocateOrdersBatch(thread_index, ORDERS::O_TOTALPRICE));
 
-      size_t batch_offset = tld.first_batch_offset;
+      auto batch_offset = static_cast<size_t>(tld.first_batch_offset);
       size_t ibatch = 0;
       size_t iorder = 0;
       int32_t iline = 0;
@@ -1752,7 +1755,8 @@ class OrdersAndLineItemGenerator {
       RETURN_NOT_OK(AllocateOrdersBatch(thread_index, ORDERS::O_SHIPPRIORITY));
       int32_t* o_shippriority = reinterpret_cast<int32_t*>(
           tld.orders[ORDERS::O_SHIPPRIORITY].array()->buffers[1]->mutable_data());
-      std::memset(o_shippriority, 0, tld.orders_to_generate * sizeof(int32_t));
+      std::memset(o_shippriority, 0,
+                  static_cast<size_t>(tld.orders_to_generate) * sizeof(int32_t));
     }
     return Status::OK();
   }
@@ -1762,7 +1766,8 @@ class OrdersAndLineItemGenerator {
     if (tld.orders[ORDERS::O_COMMENT].kind() == Datum::NONE) {
       ARROW_ASSIGN_OR_RAISE(
           tld.orders[ORDERS::O_COMMENT],
-          g_text.GenerateComments(tld.orders_to_generate, 19, 78, tld.rng));
+          g_text.GenerateComments(static_cast<size_t>(tld.orders_to_generate), 19, 78,
+                                  tld.rng));
     }
     return Status::OK();
   }
@@ -1777,9 +1782,9 @@ class OrdersAndLineItemGenerator {
       tld.items_per_order.push_back(length);
       tld.lineitem_to_generate += length;
     }
-    int64_t num_batches =
+    auto num_batches = static_cast<size_t>(
         (tld.first_batch_offset + tld.lineitem_to_generate + batch_size_ - 1) /
-        batch_size_;
+        batch_size_);
     tld.lineitem.resize(num_batches);
     for (std::vector<Datum>& batch : tld.lineitem) {
       batch.resize(LINEITEM::kNumCols);
@@ -1800,7 +1805,7 @@ class OrdersAndLineItemGenerator {
       tld.lineitem[ibatch][column] = std::move(ad);
       out_batch_offset = 0;
     }
-    if (ibatch == 0) out_batch_offset = tld.first_batch_offset;
+    if (ibatch == 0) out_batch_offset = static_cast<size_t>(tld.first_batch_offset);
 
     return Status::OK();
   }
@@ -2357,11 +2362,12 @@ class OrdersAndLineItemGenerator {
         // bump the length
         size_t batch_offset = 0;
         if (tld.lineitem[ibatch][LINEITEM::L_COMMENT].kind() == Datum::NONE) {
-          ARROW_ASSIGN_OR_RAISE(tld.lineitem[ibatch][LINEITEM::L_COMMENT],
-                                g_text.GenerateComments(batch_size_, 10, 43, tld.rng));
+          ARROW_ASSIGN_OR_RAISE(
+              tld.lineitem[ibatch][LINEITEM::L_COMMENT],
+              g_text.GenerateComments(static_cast<size_t>(batch_size_), 10, 43, tld.rng));
           batch_offset = 0;
         }
-        if (irow == 0) batch_offset = tld.first_batch_offset;
+        if (irow == 0) batch_offset = static_cast<size_t>(tld.first_batch_offset);
 
         int64_t remaining_in_batch = static_cast<int64_t>(batch_size_ - batch_offset);
         int64_t next_run = std::min(tld.lineitem_to_generate - irow, remaining_in_batch);
@@ -2627,7 +2633,8 @@ class SupplierGenerator : public TpchTableGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (tld.batch[SUPPLIER::S_COMMENT].kind() == Datum::NONE) {
       ARROW_ASSIGN_OR_RAISE(tld.batch[SUPPLIER::S_COMMENT],
-                            g_text.GenerateComments(tld.to_generate, 25, 100, tld.rng));
+                            g_text.GenerateComments(static_cast<size_t>(tld.to_generate),
+                                                    25, 100, tld.rng));
       ModifyComments(thread_index, "Recommends", good_rows_);
       ModifyComments(thread_index, "Complaints", bad_rows_);
     }
@@ -3039,7 +3046,8 @@ class CustomerGenerator : public TpchTableGenerator {
     ThreadLocalData& tld = thread_local_data_[thread_index];
     if (tld.batch[CUSTOMER::C_COMMENT].kind() == Datum::NONE) {
       ARROW_ASSIGN_OR_RAISE(tld.batch[CUSTOMER::C_COMMENT],
-                            g_text.GenerateComments(tld.to_generate, 29, 116, tld.rng));
+                            g_text.GenerateComments(static_cast<size_t>(tld.to_generate),
+                                                    29, 116, tld.rng));
     }
     return Status::OK();
   }


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090