### PR TITLE
GH-38090: [C++][Emscripten] array: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -72,7 +72,7 @@ class BaseBinaryArray : public FlatArray {
     i += data_->offset;
     const offset_type pos = raw_value_offsets_[i];
     return std::string_view(reinterpret_cast<const char*>(raw_data_ + pos),
-                            raw_value_offsets_[i + 1] - pos);
+                            static_cast<size_t>(raw_value_offsets_[i + 1] - pos));
   }
 
   std::optional<std::string_view> operator[](int64_t i) const {

--- a/cpp/src/arrow/array/array_run_end.cc
+++ b/cpp/src/arrow/array/array_run_end.cc
@@ -110,7 +110,7 @@ Result<std::shared_ptr<Array>> MakeLogicalRunEnds(const RunEndEncodedArray& self
     }
     auto* new_run_end_values = new_run_ends_data->GetMutableValues<RunEndCType>(1);
     memcpy(new_run_end_values, run_end_values,
-           (physical_length - 1) * sizeof(RunEndCType));
+           static_cast<size_t>(physical_length - 1) * sizeof(RunEndCType));
     new_run_end_values[physical_length - 1] = static_cast<RunEndCType>(self.length());
     return MakeArray(std::move(new_run_ends_data));
   }

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -52,7 +52,8 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
     ARROW_RETURN_NOT_OK(CommitPendingData());
     if (ARROW_PREDICT_TRUE(length > 0)) {
       ARROW_RETURN_NOT_OK(Reserve(length));
-      memset(data_->mutable_data() + length_ * int_size_, 0, int_size_ * length);
+      memset(data_->mutable_data() + length_ * int_size_, 0,
+             static_cast<size_t>(int_size_ * length));
       UnsafeSetNull(length);
     }
     return Status::OK();
@@ -76,7 +77,8 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
     ARROW_RETURN_NOT_OK(CommitPendingData());
     if (ARROW_PREDICT_TRUE(length > 0)) {
       ARROW_RETURN_NOT_OK(Reserve(length));
-      memset(data_->mutable_data() + length_ * int_size_, 0, int_size_ * length);
+      memset(data_->mutable_data() + length_ * int_size_, 0,
+             static_cast<size_t>(int_size_ * length));
       UnsafeSetNotNull(length);
     }
     return Status::OK();

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -189,7 +189,7 @@ class BaseBinaryBuilder
   /// \return Status
   Status AppendValues(const std::vector<std::string>& values,
                       const uint8_t* valid_bytes = NULLPTR) {
-    std::size_t total_length = std::accumulate(
+    auto total_length = std::accumulate(
         values.begin(), values.end(), 0ULL,
         [](uint64_t sum, const std::string& str) { return sum + str.size(); });
     ARROW_RETURN_NOT_OK(Reserve(values.size()));
@@ -380,7 +380,8 @@ class BaseBinaryBuilder
   std::string_view GetView(int64_t i) const {
     offset_type value_length;
     const uint8_t* value_data = GetValue(i, &value_length);
-    return std::string_view(reinterpret_cast<const char*>(value_data), value_length);
+    return std::string_view(reinterpret_cast<const char*>(value_data),
+                            static_cast<size_t>(value_length));
   }
 
   // Cannot make this a static attribute because of linking issues

--- a/cpp/src/arrow/array/builder_primitive.cc
+++ b/cpp/src/arrow/array/builder_primitive.cc
@@ -119,7 +119,7 @@ Status BooleanBuilder::AppendValues(const std::vector<bool>& values,
   const int64_t length = static_cast<int64_t>(values.size());
   RETURN_NOT_OK(Reserve(length));
   DCHECK_EQ(length, static_cast<int64_t>(is_valid.size()));
-  int64_t i = 0;
+  size_t i = 0;
   data_builder_.UnsafeAppend<false>(length,
                                     [&values, &i]() -> bool { return values[i++]; });
   ArrayBuilder::UnsafeAppendToBitmap(is_valid);
@@ -129,7 +129,7 @@ Status BooleanBuilder::AppendValues(const std::vector<bool>& values,
 Status BooleanBuilder::AppendValues(const std::vector<bool>& values) {
   const int64_t length = static_cast<int64_t>(values.size());
   RETURN_NOT_OK(Reserve(length));
-  int64_t i = 0;
+  size_t i = 0;
   data_builder_.UnsafeAppend<false>(length,
                                     [&values, &i]() -> bool { return values[i++]; });
   ArrayBuilder::UnsafeSetNotNull(length);

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -546,7 +546,8 @@ bool ArraySpan::IsNullDenseUnion(int64_t i) const {
   auto* union_type = checked_cast<const DenseUnionType*>(this->type);
   const auto* types = reinterpret_cast<const int8_t*>(this->buffers[1].data);
   const auto* offsets = reinterpret_cast<const int32_t*>(this->buffers[2].data);
-  const int64_t child_id = union_type->child_ids()[types[this->offset + i]];
+  const auto child_id =
+      static_cast<size_t>(union_type->child_ids()[types[this->offset + i]]);
   const int64_t child_offset = offsets[this->offset + i];
   return this->child_data[child_id].IsNull(child_offset);
 }

--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -77,8 +77,9 @@ struct DictionaryTraits<BooleanType> {
 
     // Will iterate up to 3 times.
     for (int64_t i = start_offset; i < memo_table.size(); i++) {
-      RETURN_NOT_OK(i == null_index ? builder.AppendNull()
-                                    : builder.Append(bool_values[i]));
+      RETURN_NOT_OK(i == null_index
+                        ? builder.AppendNull()
+                        : builder.Append(bool_values[static_cast<size_t>(i)]));
     }
 
     std::shared_ptr<ArrayData> out;

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -229,7 +229,7 @@ class QuadraticSpaceMyersDiff {
     DCHECK_LT(index, StorageOffset(edit_count + 1));
     auto insertions_minus_deletions =
         2 * (index - StorageOffset(edit_count)) - edit_count;
-    auto maximal_base = endpoint_base_[index];
+    auto maximal_base = endpoint_base_[static_cast<size_t>(index)];
     auto maximal_target = std::min(
         target_begin_ + ((maximal_base - base_begin_) + insertions_minus_deletions),
         target_end_);
@@ -240,8 +240,9 @@ class QuadraticSpaceMyersDiff {
     ++edit_count_;
     // base_begin_ is used as a dummy value here since Iterator may not be default
     // constructible. The newly allocated range is completely overwritten below.
-    endpoint_base_.resize(StorageOffset(edit_count_ + 1), base_begin_);
-    insert_.resize(StorageOffset(edit_count_ + 1), false);
+    endpoint_base_.resize(static_cast<size_t>(StorageOffset(edit_count_ + 1)),
+                          base_begin_);
+    insert_.resize(static_cast<size_t>(StorageOffset(edit_count_ + 1)), false);
 
     auto previous_offset = StorageOffset(edit_count_ - 1);
     auto current_offset = StorageOffset(edit_count_);
@@ -249,7 +250,8 @@ class QuadraticSpaceMyersDiff {
     // try deleting from base first
     for (int64_t i = 0, i_out = 0; i < edit_count_; ++i, ++i_out) {
       auto previous_endpoint = GetEditPoint(edit_count_ - 1, i + previous_offset);
-      endpoint_base_[i_out + current_offset] = DeleteOne(previous_endpoint).base;
+      endpoint_base_[static_cast<size_t>(i_out + current_offset)] =
+          DeleteOne(previous_endpoint).base;
     }
 
     // check if inserting from target could do better
@@ -263,8 +265,9 @@ class QuadraticSpaceMyersDiff {
 
       if (endpoint_after_insertion.base - endpoint_after_deletion.base >= 0) {
         // insertion was more efficient; keep it and mark the insertion in insert_
-        insert_[i_out + current_offset] = true;
-        endpoint_base_[i_out + current_offset] = endpoint_after_insertion.base;
+        insert_[static_cast<size_t>(i_out + current_offset)] = true;
+        endpoint_base_[static_cast<size_t>(i_out + current_offset)] =
+            endpoint_after_insertion.base;
       }
     }
 
@@ -293,7 +296,7 @@ class QuadraticSpaceMyersDiff {
     auto endpoint = GetEditPoint(edit_count_, finish_index_);
 
     for (int64_t i = edit_count_; i > 0; --i) {
-      bool insert = insert_[index];
+      bool insert = insert_[static_cast<size_t>(index)];
       bit_util::SetBitTo(insert_buf->mutable_data(), i, insert);
 
       auto insertions_minus_deletions =
@@ -307,8 +310,8 @@ class QuadraticSpaceMyersDiff {
 
       // endpoint of previous edit
       auto previous = GetEditPoint(i - 1, index);
-      run_length[i] = endpoint.base - previous.base - !insert;
-      DCHECK_GE(run_length[i], 0);
+      run_length[static_cast<size_t>(i)] = endpoint.base - previous.base - !insert;
+      DCHECK_GE(run_length[static_cast<size_t>(i)], 0);
 
       endpoint = previous;
     }

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -465,7 +465,7 @@ class NullArrayFactory {
     ARROW_ASSIGN_OR_RAISE(int64_t buffer_length,
                           GetBufferLength(type_, length_).Finish());
     ARROW_ASSIGN_OR_RAISE(buffer_, AllocateBuffer(buffer_length, pool_));
-    std::memset(buffer_->mutable_data(), 0, buffer_->size());
+    std::memset(buffer_->mutable_data(), 0, static_cast<size_t>(buffer_->size()));
     return Status::OK();
   }
 
@@ -528,7 +528,8 @@ class NullArrayFactory {
     // buffer_ is zeroed, but 0 may not be a valid type code
     if (type.type_codes()[0] != 0) {
       ARROW_ASSIGN_OR_RAISE(out_->buffers[1], AllocateBuffer(length_, pool_));
-      std::memset(out_->buffers[1]->mutable_data(), type.type_codes()[0], length_);
+      std::memset(out_->buffers[1]->mutable_data(), type.type_codes()[0],
+                  static_cast<size_t>(length_));
     }
 
     // For sparse unions, we now create children with the same length as the
@@ -662,7 +663,7 @@ class RepeatedArrayFactory {
 
     auto value = checked_cast<const ScalarType&>(scalar_).value;
 
-    ArrayVector values(length_, value);
+    ArrayVector values(static_cast<size_t>(length_), value);
     ARROW_ASSIGN_OR_RAISE(auto value_array, Concatenate(values, pool_));
 
     std::shared_ptr<Buffer> offsets_buffer;
@@ -677,7 +678,7 @@ class RepeatedArrayFactory {
   Status Visit(const FixedSizeListType& type) {
     auto value = checked_cast<const FixedSizeListScalar&>(scalar_).value;
 
-    ArrayVector values(length_, value);
+    ArrayVector values(static_cast<size_t>(length_), value);
     ARROW_ASSIGN_OR_RAISE(auto value_array, Concatenate(values, pool_));
 
     out_ = std::make_shared<FixedSizeListArray>(scalar_.type, length_, value_array);
@@ -688,8 +689,8 @@ class RepeatedArrayFactory {
     auto map_scalar = checked_cast<const MapScalar&>(scalar_);
     auto struct_array = checked_cast<const StructArray*>(map_scalar.value.get());
 
-    ArrayVector keys(length_, struct_array->field(0));
-    ArrayVector values(length_, struct_array->field(1));
+    ArrayVector keys(static_cast<size_t>(length_), struct_array->field(0));
+    ArrayVector values(static_cast<size_t>(length_), struct_array->field(1));
 
     ARROW_ASSIGN_OR_RAISE(auto key_array, Concatenate(keys, pool_));
     ARROW_ASSIGN_OR_RAISE(auto value_array, Concatenate(values, pool_));
@@ -778,7 +779,8 @@ class RepeatedArrayFactory {
     // Create an offsets buffer with all offsets equal to 0
     ARROW_ASSIGN_OR_RAISE(auto offsets_buffer,
                           AllocateBuffer(length_ * sizeof(int32_t), pool_));
-    memset(offsets_buffer->mutable_data(), 0, offsets_buffer->size());
+    memset(offsets_buffer->mutable_data(), 0,
+           static_cast<size_t>(offsets_buffer->size()));
 
     ARROW_ASSIGN_OR_RAISE(auto type_codes_buffer, CreateUnionTypeCodes(scalar_type_code));
 
@@ -823,7 +825,7 @@ class RepeatedArrayFactory {
     return builder.Finish(out);
   }
 
-  Status CreateBufferOf(const void* data, size_t data_length,
+  Status CreateBufferOf(const void* data, int64_t data_length,
                         std::shared_ptr<Buffer>* out) {
     BufferBuilder builder(pool_);
     RETURN_NOT_OK(builder.Resize(length_ * data_length));
@@ -833,7 +835,7 @@ class RepeatedArrayFactory {
     return builder.Finish(out);
   }
 
-  Status FinishFixedWidth(const void* data, size_t data_length) {
+  Status FinishFixedWidth(const void* data, int64_t data_length) {
     std::shared_ptr<Buffer> buffer;
     RETURN_NOT_OK(CreateBufferOf(data, data_length, &buffer));
     out_ = MakeArray(


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090