### PR TITLE
GH-38090: [C++][Emscripten] buffer: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -215,7 +215,7 @@ Result<std::shared_ptr<Buffer>> ConcatenateBuffers(
   for (const auto& buffer : buffers) {
     // Passing nullptr to std::memcpy is undefined behavior, so skip empty buffers
     if (buffer->size() != 0) {
-      std::memcpy(out_data, buffer->data(), buffer->size());
+      std::memcpy(out_data, buffer->data(), static_cast<size_t>(buffer->size()));
       out_data += buffer->size();
     }
   }


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090