### PR TITLE
GH-38090: [C++][Emscripten] c: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -986,8 +986,8 @@ struct SchemaImporter {
 
   Status DoImport() {
     // First import children (required for reconstituting parent type)
-    child_importers_.resize(c_struct_->n_children);
-    for (int64_t i = 0; i < c_struct_->n_children; ++i) {
+    child_importers_.resize(static_cast<size_t>(c_struct_->n_children));
+    for (size_t i = 0; i < static_cast<size_t>(c_struct_->n_children); ++i) {
       DCHECK_NE(c_struct_->children[i], nullptr);
       RETURN_NOT_OK(child_importers_[i].ImportChild(this, c_struct_->children[i]));
     }
@@ -1301,7 +1301,7 @@ struct SchemaImporter {
   }
 
   Result<std::shared_ptr<Field>> MakeChildField(int64_t child_id) {
-    const auto& child = child_importers_[child_id];
+    const auto& child = child_importers_[static_cast<size_t>(child_id)];
     if (child.c_struct_->name == nullptr) {
       return Status::Invalid("Expected non-null name in imported array child");
     }
@@ -1310,7 +1310,7 @@ struct SchemaImporter {
 
   Result<std::vector<std::shared_ptr<Field>>> MakeChildFields() {
     std::vector<std::shared_ptr<Field>> fields(child_importers_.size());
-    for (int64_t i = 0; i < static_cast<int64_t>(child_importers_.size()); ++i) {
+    for (size_t i = 0; i < child_importers_.size(); ++i) {
       ARROW_ASSIGN_OR_RAISE(fields[i], MakeChildField(i));
     }
     return fields;
@@ -1511,7 +1511,7 @@ struct ArrayImporter {
                              type_->ToString());
     }
     child_importers_.reserve(fields.size());
-    for (int64_t i = 0; i < c_struct_->n_children; ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(c_struct_->n_children); ++i) {
       DCHECK_NE(c_struct_->children[i], nullptr);
       child_importers_.emplace_back(fields[i]->type());
       RETURN_NOT_OK(child_importers_.back().ImportChild(this, c_struct_->children[i]));


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090