### PR TITLE
GH-38090: [C++][Emscripten] chunked_array: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -172,7 +172,7 @@ Result<std::shared_ptr<Scalar>> ChunkedArray::GetScalar(int64_t index) const {
     return Status::IndexError("index with value of ", index,
                               " is out-of-bounds for chunked array of length ", length_);
   }
-  return chunks_[loc.chunk_index]->GetScalar(loc.index_in_chunk);
+  return chunks_[static_cast<size_t>(loc.chunk_index)]->GetScalar(loc.index_in_chunk);
 }
 
 std::shared_ptr<ChunkedArray> ChunkedArray::Slice(int64_t offset, int64_t length) const {


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090