### PR TITLE
GH-38090: [C++][Emscripten] compute/kernel: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -54,7 +54,7 @@ Result<std::shared_ptr<ResizableBuffer>> KernelContext::AllocateBitmap(int64_t n
                         AllocateResizableBuffer(nbytes, exec_ctx_->memory_pool()));
   // Since bitmaps are typically written bit by bit, we could leak uninitialized bits.
   // Make sure all memory is initialized (this also appeases Valgrind).
-  std::memset(result->mutable_data(), 0, result->size());
+  std::memset(result->mutable_data(), 0, static_cast<size_t>(result->size()));
   return result;
 }
 

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -396,7 +396,7 @@ class ARROW_EXPORT KernelSignature {
   bool is_varargs_;
 
   // For caching the hash code after it's computed the first time
-  mutable uint64_t hash_code_;
+  mutable size_t hash_code_;
 };
 
 /// \brief A function may contain multiple variants of a kernel for a given


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090