### PR TITLE
GH-38090: [C++][Emscripten] compute/kernels/internal: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/compute/kernels/chunked_internal.h
+++ b/cpp/src/arrow/compute/kernels/chunked_internal.h
@@ -71,7 +71,8 @@ struct ChunkedArrayResolver : protected ::arrow::internal::ChunkResolver {
   template <typename ArrayType>
   ResolvedChunk<ArrayType> Resolve(int64_t index) const {
     const auto loc = ::arrow::internal::ChunkResolver::Resolve(index);
-    return {checked_cast<const ArrayType*>(chunks_[loc.chunk_index]), loc.index_in_chunk};
+    return {checked_cast<const ArrayType*>(chunks_[static_cast<size_t>(loc.chunk_index)]),
+            loc.index_in_chunk};
   }
 
  protected:

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -279,7 +279,8 @@ struct ArrayIterator<Type, enable_if_base_binary<Type>> {
 
   std::string_view operator()() {
     offset_type next_offset = offsets[++position];
-    auto result = std::string_view(data + cur_offset, next_offset - cur_offset);
+    auto result = std::string_view(data + cur_offset,
+                                   static_cast<size_t>(next_offset - cur_offset));
     cur_offset = next_offset;
     return result;
   }
@@ -324,7 +325,7 @@ struct OutputArrayWriter<Type, enable_if_c_number_or_decimal<Type>> {
   void WriteNull() { *values++ = T{}; }
 
   void WriteAllNull(int64_t length) {
-    std::memset(static_cast<void*>(values), 0, sizeof(T) * length);
+    std::memset(static_cast<void*>(values), 0, sizeof(T) * static_cast<size_t>(length));
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/copy_data_internal.h
+++ b/cpp/src/arrow/compute/kernels/copy_data_internal.h
@@ -51,15 +51,15 @@ template <>
 struct CopyDataUtils<FixedSizeBinaryType> {
   static void CopyData(const DataType& ty, const Scalar& in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
-    const int32_t width = ty.byte_width();
+    const auto width = static_cast<size_t>(ty.byte_width());
     uint8_t* begin = out + (width * out_offset);
     const auto& scalar = checked_cast<const arrow::internal::PrimitiveScalarBase&>(in);
     // Null scalar may have null value buffer
     if (!scalar.is_valid) {
-      std::memset(begin, 0x00, width * length);
+      std::memset(begin, 0x00, width * static_cast<const size_t>(length));
     } else {
       const std::string_view buffer = scalar.view();
-      DCHECK_GE(buffer.size(), static_cast<size_t>(width));
+      DCHECK_GE(buffer.size(), width);
       for (int i = 0; i < length; i++) {
         std::memcpy(begin, buffer.data(), width);
         begin += width;
@@ -69,9 +69,9 @@ struct CopyDataUtils<FixedSizeBinaryType> {
 
   static void CopyData(const DataType& ty, const uint8_t* in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
-    const int32_t width = ty.byte_width();
+    const auto width = ty.byte_width();
     uint8_t* begin = out + (width * out_offset);
-    std::memcpy(begin, in + in_offset * width, length * width);
+    std::memcpy(begin, in + in_offset * width, static_cast<size_t>(length) * width);
   }
 
   static void CopyData(const DataType& ty, const ArraySpan& in, const int64_t in_offset,
@@ -97,7 +97,7 @@ struct CopyDataUtils<
   static void CopyData(const DataType&, const uint8_t* in, const int64_t in_offset,
                        uint8_t* out, const int64_t out_offset, const int64_t length) {
     std::memcpy(out + out_offset * sizeof(CType), in + in_offset * sizeof(CType),
-                length * sizeof(CType));
+                static_cast<size_t>(length) * sizeof(CType));
   }
 
   static void CopyData(const DataType&, const ArraySpan& in, const int64_t in_offset,

--- a/cpp/src/arrow/compute/kernels/ree_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.h
@@ -265,7 +265,7 @@ class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
       const offset_type offset0 = input_offsets_[read_offset];
       const offset_type offset1 = input_offsets_[read_offset + 1];
       *out = std::string_view(reinterpret_cast<const char*>(input_values_ + offset0),
-                              offset1 - offset0);
+                              static_cast<size_t>(offset1 - offset0));
     }
     return valid;
   }

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -119,7 +119,7 @@ ARROW_NOINLINE int64_t CopyNonNullValues(const ArraySpan& data, T* out) {
     const T* values = data.GetValues<T>(1);
     arrow::internal::VisitSetBitRunsVoid(
         data.buffers[0].data, data.offset, data.length, [&](int64_t pos, int64_t len) {
-          memcpy(out + index, values + pos, len * sizeof(T));
+          memcpy(out + index, values + pos, static_cast<size_t>(len) * sizeof(T));
           index += len;
         });
   }


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090