### PR TITLE
GH-38090: [C++][Emscripten] compute/kernels/row_encoder: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -116,7 +116,7 @@ Result<std::shared_ptr<ArrayData>> BooleanKeyEncoder::Decode(uint8_t** encoded_b
   ARROW_ASSIGN_OR_RAISE(auto key_buf, AllocateBitmap(length, pool));
 
   uint8_t* raw_output = key_buf->mutable_data();
-  memset(raw_output, 0, bit_util::BytesForBits(length));
+  memset(raw_output, 0, static_cast<size_t>(bit_util::BytesForBits(length)));
   for (int32_t i = 0; i < length; ++i) {
     auto& encoded_ptr = encoded_bytes[i];
     bit_util::SetBitTo(raw_output, i, encoded_ptr[0] != 0);
@@ -326,8 +326,8 @@ Status RowEncoder::EncodeAndAppend(const ExecSpan& batch) {
     offsets_[0] = 0;
   }
   size_t length_before = offsets_.size() - 1;
-  offsets_.resize(length_before + batch.length + 1);
-  for (int64_t i = 0; i < batch.length; ++i) {
+  offsets_.resize(length_before + static_cast<size_t>(batch.length) + 1);
+  for (size_t i = 0; i < static_cast<size_t>(batch.length); ++i) {
     offsets_[length_before + 1 + i] = 0;
   }
 
@@ -336,14 +336,14 @@ Status RowEncoder::EncodeAndAppend(const ExecSpan& batch) {
   }
 
   int32_t total_length = offsets_[length_before];
-  for (int64_t i = 0; i < batch.length; ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(batch.length); ++i) {
     total_length += offsets_[length_before + 1 + i];
     offsets_[length_before + 1 + i] = total_length;
   }
 
   bytes_.resize(total_length);
-  std::vector<uint8_t*> buf_ptrs(batch.length);
-  for (int64_t i = 0; i < batch.length; ++i) {
+  std::vector<uint8_t*> buf_ptrs(static_cast<size_t>(batch.length));
+  for (size_t i = 0; i < static_cast<size_t>(batch.length); ++i) {
     buf_ptrs[i] = bytes_.data() + offsets_[length_before + i];
   }
 
@@ -357,10 +357,11 @@ Status RowEncoder::EncodeAndAppend(const ExecSpan& batch) {
 Result<ExecBatch> RowEncoder::Decode(int64_t num_rows, const int32_t* row_ids) {
   ExecBatch out({}, num_rows);
 
-  std::vector<uint8_t*> buf_ptrs(num_rows);
-  for (int64_t i = 0; i < num_rows; ++i) {
-    buf_ptrs[i] = (row_ids[i] == kRowIdForNulls()) ? encoded_nulls_.data()
-                                                   : bytes_.data() + offsets_[row_ids[i]];
+  std::vector<uint8_t*> buf_ptrs(static_cast<size_t>(num_rows));
+  for (size_t i = 0; i < static_cast<size_t>(num_rows); ++i) {
+    buf_ptrs[i] = (row_ids[i] == kRowIdForNulls())
+                      ? encoded_nulls_.data()
+                      : bytes_.data() + offsets_[static_cast<size_t>(row_ids[i])];
   }
 
   out.values.resize(encoders_.size());

--- a/cpp/src/arrow/compute/kernels/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/kernels/row_encoder_internal.h
@@ -168,7 +168,7 @@ struct VarLengthKeyEncoder : KeyEncoder {
           *encoded_ptr++ = kValidByte;
           util::SafeStore(encoded_ptr, static_cast<Offset>(bytes.size()));
           encoded_ptr += sizeof(Offset);
-          memcpy(encoded_ptr, bytes.data(), bytes.size());
+          memcpy(encoded_ptr, bytes.data(), static_cast<size_t>(bytes.size()));
           encoded_ptr += bytes.size();
         }
       } else {
@@ -215,7 +215,8 @@ struct VarLengthKeyEncoder : KeyEncoder {
       auto key_length = util::SafeLoadAs<Offset>(encoded_bytes[i]);
       encoded_bytes[i] += sizeof(Offset);
 
-      memcpy(raw_keys + current_offset, encoded_bytes[i], key_length);
+      memcpy(raw_keys + current_offset, encoded_bytes[i],
+             static_cast<size_t>(key_length));
       encoded_bytes[i] += key_length;
 
       current_offset += key_length;


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090