### PR TITLE
GH-38090: [C++][Emscripten] compute/kernels/scalar: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -52,7 +52,8 @@ struct CastPrimitive<OutType, InType, enable_if_t<std::is_same<OutType, InType>:
   // memcpy output
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
     using T = typename InType::c_type;
-    std::memcpy(out->GetValues<T>(1), arr.GetValues<T>(1), arr.length * sizeof(T));
+    std::memcpy(out->GetValues<T>(1), arr.GetValues<T>(1),
+                static_cast<size_t>(arr.length) * sizeof(T));
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -247,7 +247,7 @@ Status CastBinaryToBinaryOffsets<int32_t, int64_t>(KernelContext* ctx,
       output->buffers[1],
       ctx->Allocate((output->length + output->offset + 1) * sizeof(output_offset_type)));
   memset(output->buffers[1]->mutable_data(), 0,
-         output->offset * sizeof(output_offset_type));
+         static_cast<size_t>(output->offset) * sizeof(output_offset_type));
   ::arrow::internal::CastInts(input.GetValues<input_offset_type>(1),
                               output->GetMutableValues<output_offset_type>(1),
                               output->length + 1);
@@ -275,7 +275,7 @@ Status CastBinaryToBinaryOffsets<int64_t, int32_t>(KernelContext* ctx,
                           ctx->Allocate((output->length + output->offset + 1) *
                                         sizeof(output_offset_type)));
     memset(output->buffers[1]->mutable_data(), 0,
-           output->offset * sizeof(output_offset_type));
+           static_cast<size_t>(output->offset) * sizeof(output_offset_type));
     ::arrow::internal::CastInts(input_offsets,
                                 output->GetMutableValues<output_offset_type>(1),
                                 output->length + 1);

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -660,7 +660,7 @@ struct BinaryScalarMinMax {
               bit_util::GetBit(array.buffers[0].data, array.offset + row)) {
             const auto offsets = array.GetValues<offset_type>(1);
             const auto data = array.GetValues<uint8_t>(2, /*absolute_offset=*/0);
-            const int64_t length = offsets[row + 1] - offsets[row];
+            const auto length = static_cast<size_t>(offsets[row + 1] - offsets[row]);
             visit_value(
                 string_view(reinterpret_cast<const char*>(data + offsets[row]), length));
           } else if (!options.skip_nulls) {

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -47,14 +47,14 @@ struct SetLookupState : public SetLookupStateBase {
     this->null_matching_behavior = options.GetNullMatchingBehavior();
     if (options.value_set.is_array()) {
       const ArrayData& value_set = *options.value_set.array();
-      memo_index_to_value_index.reserve(value_set.length);
+      memo_index_to_value_index.reserve(static_cast<size_t>(value_set.length));
       lookup_table =
           MemoTable(memory_pool,
                     ::arrow::internal::HashTable<char>::kLoadFactor * value_set.length);
       RETURN_NOT_OK(AddArrayValueSet(options, *options.value_set.array()));
     } else if (options.value_set.kind() == Datum::CHUNKED_ARRAY) {
       const ChunkedArray& value_set = *options.value_set.chunked_array();
-      memo_index_to_value_index.reserve(value_set.length());
+      memo_index_to_value_index.reserve(static_cast<size_t>(value_set.length()));
       lookup_table =
           MemoTable(memory_pool,
                     ::arrow::internal::HashTable<char>::kLoadFactor * value_set.length());
@@ -290,7 +290,8 @@ struct IndexInVisitor {
 
       // Set all values to 0, which will be unmasked only if null is in the value_set
       // and null_matching_behavior is equal to MATCH
-      std::memset(out->GetValues<int32_t>(1), 0x00, out->length * sizeof(int32_t));
+      std::memset(out->GetValues<int32_t>(1), 0x00,
+                  static_cast<size_t>(out->length) * sizeof(int32_t));
     }
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -364,7 +364,7 @@ struct StringSplitExec {
       // we will record the parts in reverse order
       parts.clear();
       if (max_splits > -1) {
-        parts.reserve(max_splits + 1);
+        parts.reserve(static_cast<size_t>(max_splits + 1));
       }
       while (max_splits != 0) {
         const uint8_t *separator_begin, *separator_end;

--- a/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
@@ -558,12 +558,12 @@ struct Utf8NormalizeBase {
     ARROW_ASSIGN_OR_RAISE(const auto n_codepoints, DecomposeIntoScratch(v));
     // Encode normalized codepoints directly into the output
     int64_t n_bytes = 0;
-    for (int64_t i = 0; i < n_codepoints; ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(n_codepoints); ++i) {
       n_bytes += ::arrow::util::UTF8EncodedLength(codepoints_[i]);
     }
     RETURN_NOT_OK(data_builder->Reserve(n_bytes));
     uint8_t* out = data_builder->mutable_data() + data_builder->length();
-    for (int64_t i = 0; i < n_codepoints; ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(n_codepoints); ++i) {
       out = ::arrow::util::UTF8Encode(out, codepoints_[i]);
     }
     DCHECK_EQ(out - data_builder->mutable_data(), data_builder->length() + n_bytes);


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090