### PR TITLE
GH-38090: [C++][Emscripten] compute: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -393,7 +393,7 @@ struct ARROW_EXPORT ExecSpan {
   /// \brief Return the value at the i-th index
   template <typename index_type>
   inline const ExecValue& operator[](index_type i) const {
-    return values[i];
+    return values[static_cast<size_t>(i)];
   }
 
   /// \brief A convenience for the number of values / arguments.

--- a/cpp/src/arrow/compute/key_hash.cc
+++ b/cpp/src/arrow/compute/key_hash.cc
@@ -142,7 +142,7 @@ void Hashing32::HashFixedLenImp(uint32_t num_rows, uint64_t length, const uint8_
     uint32_t acc1, acc2, acc3, acc4;
     ProcessFullStripes(num_stripes, key, &acc1, &acc2, &acc3, &acc4);
     memcpy(last_stripe_copy, key + (num_stripes - 1) * kStripeSize,
-           length - (num_stripes - 1) * kStripeSize);
+           static_cast<size_t>(length - (num_stripes - 1) * kStripeSize));
     ProcessLastStripe(mask1, mask2, mask3, mask4,
                       reinterpret_cast<const uint8_t*>(last_stripe_copy), &acc1, &acc2,
                       &acc3, &acc4);
@@ -214,7 +214,7 @@ void Hashing32::HashVarLenImp(uint32_t num_rows, const T* offsets,
     ProcessFullStripes(num_stripes, key, &acc1, &acc2, &acc3, &acc4);
     if (length > 0) {
       memcpy(last_stripe_copy, key + (num_stripes - 1) * kStripeSize,
-             length - (num_stripes - 1) * kStripeSize);
+             static_cast<size_t>(length - (num_stripes - 1) * kStripeSize));
     }
     if (num_stripes > 0) {
       ProcessLastStripe(mask1, mask2, mask3, mask4,
@@ -611,7 +611,7 @@ void Hashing64::HashFixedLenImp(uint32_t num_rows, uint64_t length, const uint8_
     uint64_t acc1, acc2, acc3, acc4;
     ProcessFullStripes(num_stripes, key, &acc1, &acc2, &acc3, &acc4);
     memcpy(last_stripe_copy, key + (num_stripes - 1) * kStripeSize,
-           length - (num_stripes - 1) * kStripeSize);
+           static_cast<size_t>(length - (num_stripes - 1) * kStripeSize));
     ProcessLastStripe(mask1, mask2, mask3, mask4,
                       reinterpret_cast<const uint8_t*>(last_stripe_copy), &acc1, &acc2,
                       &acc3, &acc4);
@@ -682,7 +682,7 @@ void Hashing64::HashVarLenImp(uint32_t num_rows, const T* offsets,
     ProcessFullStripes(num_stripes, key, &acc1, &acc2, &acc3, &acc4);
     if (length > 0) {
       memcpy(last_stripe_copy, key + (num_stripes - 1) * kStripeSize,
-             length - (num_stripes - 1) * kStripeSize);
+             static_cast<size_t>(length - (num_stripes - 1) * kStripeSize));
     }
     if (num_stripes > 0) {
       ProcessLastStripe(mask1, mask2, mask3, mask4,

--- a/cpp/src/arrow/compute/key_map.cc
+++ b/cpp/src/arrow/compute/key_map.cc
@@ -664,7 +664,7 @@ Status SwissTable::grow_double() {
   // Allocate new buffers
   ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> blocks_new,
                         AllocateBuffer(block_size_total_after, pool_));
-  memset(blocks_new->mutable_data(), 0, block_size_total_after);
+  memset(blocks_new->mutable_data(), 0, static_cast<size_t>(block_size_total_after));
   ARROW_ASSIGN_OR_RAISE(std::unique_ptr<Buffer> hashes_new_buffer,
                         AllocateBuffer(hashes_size_total_after, pool_));
   auto hashes_new = reinterpret_cast<uint32_t*>(hashes_new_buffer->mutable_data());
@@ -787,7 +787,7 @@ Status SwissTable::init(int64_t hardware_flags, MemoryPool* pool, int log_blocks
   ARROW_ASSIGN_OR_RAISE(blocks_, AllocateBuffer(slot_bytes, pool_));
 
   // Make sure group ids are initially set to zero for all slots.
-  memset(blocks_->mutable_data(), 0, slot_bytes);
+  memset(blocks_->mutable_data(), 0, static_cast<size_t>(slot_bytes));
 
   // Initialize all status bytes to represent an empty slot.
   uint8_t* blocks_ptr = blocks_->mutable_data();

--- a/cpp/src/arrow/compute/light_array.cc
+++ b/cpp/src/arrow/compute/light_array.cc
@@ -251,7 +251,8 @@ Status ResizableArrayData::ResizeFixedLengthBuffers(int num_rows_new) {
         AllocateResizableBuffer(
             bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes, pool_));
     memset(mutable_data(kValidityBuffer), 0,
-           bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes);
+           static_cast<size_t>(bit_util::BytesForBits(num_rows_allocated_new) +
+                               kNumPaddingBytes));
     if (column_metadata.is_fixed_length) {
       if (column_metadata.fixed_length == 0) {
         ARROW_ASSIGN_OR_RAISE(
@@ -260,7 +261,8 @@ Status ResizableArrayData::ResizeFixedLengthBuffers(int num_rows_new) {
                 bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes,
                 pool_));
         memset(mutable_data(kFixedLengthBuffer), 0,
-               bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes);
+               static_cast<size_t>(bit_util::BytesForBits(num_rows_allocated_new) +
+                                   kNumPaddingBytes));
       } else {
         ARROW_ASSIGN_OR_RAISE(
             buffers_[kFixedLengthBuffer],
@@ -284,10 +286,10 @@ Status ResizableArrayData::ResizeFixedLengthBuffers(int num_rows_new) {
     ARROW_DCHECK(buffers_[kValidityBuffer] != NULLPTR &&
                  buffers_[kVariableLengthBuffer] != NULLPTR);
 
-    int64_t bytes_for_bits_before =
-        bit_util::BytesForBits(num_rows_allocated_) + kNumPaddingBytes;
-    int64_t bytes_for_bits_after =
-        bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes;
+    auto bytes_for_bits_before = static_cast<size_t>(
+        bit_util::BytesForBits(num_rows_allocated_) + kNumPaddingBytes);
+    auto bytes_for_bits_after = static_cast<size_t>(
+        bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes);
 
     RETURN_NOT_OK(buffers_[kValidityBuffer]->Resize(
         bit_util::BytesForBits(num_rows_allocated_new) + kNumPaddingBytes));
@@ -653,11 +655,11 @@ Status ExecBatchBuilder::AppendNulls(const std::shared_ptr<DataType>& type,
       int64_t offset_begin = num_rows_before / 8 + 1;
       int64_t offset_end = bit_util::BytesForBits(num_rows_after);
       if (offset_end > offset_begin) {
-        memset(dst + offset_begin, 0, offset_end - offset_begin);
+        memset(dst + offset_begin, 0, static_cast<size_t>(offset_end - offset_begin));
       }
     } else {
       memset(dst + num_rows_before * static_cast<int64_t>(column_metadata.fixed_length),
-             0, static_cast<int64_t>(column_metadata.fixed_length) * num_rows_to_append);
+             0, static_cast<size_t>(column_metadata.fixed_length * num_rows_to_append));
     }
   } else {
     uint32_t* dst = reinterpret_cast<uint32_t*>(target.mutable_data(1));
@@ -671,8 +673,8 @@ Status ExecBatchBuilder::AppendNulls(const std::shared_ptr<DataType>& type,
   //
   uint8_t* dst = target.mutable_data(0);
   dst[num_rows_before / 8] &= static_cast<uint8_t>((1 << (num_rows_before % 8)) - 1);
-  int64_t offset_begin = num_rows_before / 8 + 1;
-  int64_t offset_end = bit_util::BytesForBits(num_rows_after);
+  auto offset_begin = static_cast<size_t>(num_rows_before / 8 + 1);
+  auto offset_end = static_cast<size_t>(bit_util::BytesForBits(num_rows_after));
   if (offset_end > offset_begin) {
     memset(dst + offset_begin, 0, offset_end - offset_begin);
   }

--- a/cpp/src/arrow/compute/util.h
+++ b/cpp/src/arrow/compute/util.h
@@ -92,7 +92,7 @@ class ARROW_EXPORT TempVectorStack {
     buffer_size_ = PaddedAllocationSize(size) + kPadding + 2 * sizeof(uint64_t);
     ARROW_ASSIGN_OR_RAISE(auto buffer, AllocateResizableBuffer(size, pool));
     // Ensure later operations don't accidentally read uninitialized memory.
-    std::memset(buffer->mutable_data(), 0xFF, size);
+    std::memset(buffer->mutable_data(), 0xFF, static_cast<size_t>(size));
     buffer_ = std::move(buffer);
     return Status::OK();
   }


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090