### PR TITLE
GH-38090: [C++][Emscripten] dataset: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -148,7 +148,7 @@ inline RecordBatchGenerator MakeChunkedBatchGenerator(RecordBatchGenerator gen,
           return ::arrow::MakeVectorGenerator<std::shared_ptr<RecordBatch>>({batch});
         }
         std::vector<std::shared_ptr<RecordBatch>> slices;
-        slices.reserve(rows / batch_size + (rows % batch_size != 0));
+        slices.reserve(static_cast<size_t>(rows / batch_size + (rows % batch_size != 0)));
         for (int64_t i = 0; i < rows; i += batch_size) {
           slices.push_back(batch->Slice(i, batch_size));
         }

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -102,7 +102,7 @@ bool KeyValuePartitioning::Equals(const Partitioning& other) const {
   if (dictionaries_.size() != other_dictionaries.size()) {
     return false;
   }
-  int64_t idx = 0;
+  size_t idx = 0;
   for (const auto& array : dictionaries_) {
     const auto& other_array = other_dictionaries[idx++];
     bool match = (array == nullptr && other_array == nullptr) ||


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090