### PR TITLE
GH-38090: [C++][Emscripten] integration: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/integration/json_internal.cc
+++ b/cpp/src/arrow/integration/json_internal.cc
@@ -1587,7 +1587,7 @@ class ArrayReader {
 
     data_->null_count = 0;
     for (int64_t i = 0; i < length; ++i) {
-      if (is_valid_[i]) {
+      if (is_valid_[static_cast<size_t>(i)]) {
         bit_util::SetBit(bitmap, i);
       } else {
         ++data_->null_count;


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090