### PR TITLE
GH-38090: [C++][Emscripten] io: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -70,7 +70,7 @@ class BufferedBase {
 
   void AppendToBuffer(const void* data, int64_t nbytes) {
     DCHECK_LE(buffer_pos_ + nbytes, buffer_size_);
-    std::memcpy(buffer_data_ + buffer_pos_, data, nbytes);
+    std::memcpy(buffer_data_ + buffer_pos_, data, static_cast<size_t>(nbytes));
     buffer_pos_ += nbytes;
   }
 
@@ -381,7 +381,7 @@ class BufferedInputStream::Impl : public BufferedBase {
     // 1. First consume pre-buffered data.
     int64_t pre_buffer_copy_bytes = std::min(nbytes, bytes_buffered_);
     if (pre_buffer_copy_bytes > 0) {
-      memcpy(out, buffer_data_ + buffer_pos_, pre_buffer_copy_bytes);
+      memcpy(out, buffer_data_ + buffer_pos_, static_cast<size_t>(pre_buffer_copy_bytes));
       ConsumeBuffer(pre_buffer_copy_bytes);
     }
     int64_t remaining_bytes = nbytes - pre_buffer_copy_bytes;
@@ -407,7 +407,7 @@ class BufferedInputStream::Impl : public BufferedBase {
       RETURN_NOT_OK(DoBuffer());
       int64_t bytes_copy_after_buffer = std::min(bytes_buffered_, remaining_bytes);
       memcpy(reinterpret_cast<uint8_t*>(out) + pre_buffer_copy_bytes,
-             buffer_data_ + buffer_pos_, bytes_copy_after_buffer);
+             buffer_data_ + buffer_pos_, static_cast<size_t>(bytes_copy_after_buffer));
       ConsumeBuffer(bytes_copy_after_buffer);
       return pre_buffer_copy_bytes + bytes_copy_after_buffer;
     }

--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -314,7 +314,8 @@ class CompressedInputStream::Impl {
     int64_t read_bytes = std::min(readable, nbytes);
 
     if (read_bytes > 0) {
-      memcpy(out, decompressed_->data() + decompressed_pos_, read_bytes);
+      memcpy(out, decompressed_->data() + decompressed_pos_,
+             static_cast<size_t>(read_bytes));
       decompressed_pos_ += read_bytes;
 
       if (decompressed_pos_ == decompressed_->size()) {

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -491,7 +491,8 @@ class MemoryMappedFile::MemoryMap
     if (map_len_ > 0) {
       void* result;
       auto data = region_->data();
-      RETURN_NOT_OK(::arrow::internal::MemoryMapRemap(data, map_len_, new_size,
+      RETURN_NOT_OK(::arrow::internal::MemoryMapRemap(data, static_cast<size_t>(map_len_),
+                                                      static_cast<const size_t>(new_size),
                                                       file_->fd(), &result));
       region_->Detach();  // avoid munmap() on destruction
       region_ = std::make_shared<Region>(shared_from_this(),

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -104,7 +104,7 @@ Status BufferOutputStream::Write(const void* data, int64_t nbytes) {
     if (ARROW_PREDICT_FALSE(position_ + nbytes >= capacity_)) {
       RETURN_NOT_OK(Reserve(nbytes));
     }
-    memcpy(mutable_data_ + position_, data, nbytes);
+    memcpy(mutable_data_ + position_, data, static_cast<size_t>(nbytes));
     position_ += nbytes;
   }
   return Status::OK();
@@ -188,11 +188,11 @@ class FixedSizeBufferWriter::FixedSizeBufferWriterImpl {
   Status Write(const void* data, int64_t nbytes) {
     RETURN_NOT_OK(internal::ValidateWriteRange(position_, nbytes, size_));
     if (nbytes > memcopy_threshold_ && memcopy_num_threads_ > 1) {
-      ::arrow::internal::parallel_memcopy(mutable_data_ + position_,
-                                          reinterpret_cast<const uint8_t*>(data), nbytes,
-                                          memcopy_blocksize_, memcopy_num_threads_);
+      ::arrow::internal::parallel_memcopy(
+          mutable_data_ + position_, reinterpret_cast<const uint8_t*>(data), nbytes,
+          static_cast<size_t>(memcopy_blocksize_), memcopy_num_threads_);
     } else {
-      memcpy(mutable_data_ + position_, data, nbytes);
+      memcpy(mutable_data_ + position_, data, static_cast<size_t>(nbytes));
     }
     position_ += nbytes;
     return Status::OK();
@@ -335,7 +335,7 @@ Result<int64_t> BufferReader::DoReadAt(int64_t position, int64_t nbytes, void* b
   ARROW_ASSIGN_OR_RAISE(nbytes, internal::ValidateReadRange(position, nbytes, size_));
   DCHECK_GE(nbytes, 0);
   if (nbytes) {
-    memcpy(buffer, data_ + position, nbytes);
+    memcpy(buffer, data_ + position, static_cast<size_t>(nbytes));
   }
   return nbytes;
 }

--- a/cpp/src/arrow/io/stdio.cc
+++ b/cpp/src/arrow/io/stdio.cc
@@ -39,7 +39,8 @@ Result<int64_t> StdoutStream::Tell() const { return pos_; }
 
 Status StdoutStream::Write(const void* data, int64_t nbytes) {
   pos_ += nbytes;
-  std::cout.write(reinterpret_cast<const char*>(data), nbytes);
+  std::cout.write(reinterpret_cast<const char*>(data),
+                  static_cast<std::streamsize>(nbytes));
   return Status::OK();
 }
 
@@ -57,7 +58,8 @@ Result<int64_t> StderrStream::Tell() const { return pos_; }
 
 Status StderrStream::Write(const void* data, int64_t nbytes) {
   pos_ += nbytes;
-  std::cerr.write(reinterpret_cast<const char*>(data), nbytes);
+  std::cerr.write(reinterpret_cast<const char*>(data),
+                  static_cast<std::streamsize>(nbytes));
   return Status::OK();
 }
 
@@ -74,7 +76,7 @@ bool StdinStream::closed() const { return false; }
 Result<int64_t> StdinStream::Tell() const { return pos_; }
 
 Result<int64_t> StdinStream::Read(int64_t nbytes, void* out) {
-  std::cin.read(reinterpret_cast<char*>(out), nbytes);
+  std::cin.read(reinterpret_cast<char*>(out), static_cast<std::streamsize>(nbytes));
   nbytes = std::cin.gcount();
   pos_ += nbytes;
   return nbytes;


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090