### PR TITLE
GH-38090: [C++][Emscripten] ipc: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -913,7 +913,7 @@ class MessageDecoder::MessageDecoderImpl {
       auto data = chunk->data();
       auto data_size = chunk->size();
       auto copy_size = std::min(required_size, data_size);
-      memcpy(static_cast<uint8_t*>(out) + offset, data, copy_size);
+      memcpy(static_cast<uint8_t*>(out) + offset, data, static_cast<size_t>(copy_size));
       n_used_chunks++;
       offset += copy_size;
       required_size -= copy_size;

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -464,7 +464,7 @@ static KeyValueOffset AppendKeyValue(FBB& fbb, const std::string& key,
 
 static void AppendKeyValueMetadata(FBB& fbb, const KeyValueMetadata& metadata,
                                    std::vector<KeyValueOffset>* key_values) {
-  key_values->reserve(metadata.size());
+  key_values->reserve(static_cast<size_t>(metadata.size()));
   for (int i = 0; i < metadata.size(); ++i) {
     key_values->push_back(AppendKeyValue(fbb, metadata.key(i), metadata.value(i)));
   }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -2166,7 +2166,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCSFIndex(
     const flatbuf::SparseTensor* sparse_tensor, const std::vector<int64_t>& shape,
     io::RandomAccessFile* file) {
   auto* sparse_index = sparse_tensor->sparseIndex_as_SparseTensorIndexCSF();
-  const auto ndim = static_cast<int64_t>(shape.size());
+  const auto ndim = shape.size();
   auto* indptr_buffers = sparse_index->indptrBuffers();
   auto* indices_buffers = sparse_index->indicesBuffers();
   std::vector<std::shared_ptr<Buffer>> indptr_data(ndim - 1);
@@ -2374,14 +2374,14 @@ Result<std::shared_ptr<SparseTensor>> ReadSparseTensorPayload(const IpcPayload& 
           &indices_size, &indptr_type, &indices_type));
       ARROW_CHECK_EQ(indptr_type, indices_type);
 
-      const int64_t ndim = shape.size();
+      const auto ndim = shape.size();
       std::vector<std::shared_ptr<Buffer>> indptr_data(ndim - 1);
       std::vector<std::shared_ptr<Buffer>> indices_data(ndim);
 
-      for (int64_t i = 0; i < ndim - 1; ++i) {
+      for (size_t i = 0; i < ndim - 1; ++i) {
         indptr_data[i] = payload.body_buffers[i];
       }
-      for (int64_t i = 0; i < ndim; ++i) {
+      for (size_t i = 0; i < ndim; ++i) {
         indices_data[i] = payload.body_buffers[i + ndim - 1];
       }
 

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -324,8 +324,8 @@ Status MakeRandomStringArray(int64_t length, bool include_nulls, MemoryPool* poo
                                            "efg", "456!@#!@#", "12312"};
   StringBuilder builder(pool);
   const size_t values_len = values.size();
-  for (int64_t i = 0; i < length; ++i) {
-    int64_t values_index = i % values_len;
+  for (size_t i = 0; i < static_cast<size_t>(length); ++i) {
+    auto values_index = i % values_len;
     if (include_nulls && values_index == 0) {
       RETURN_NOT_OK(builder.AppendNull());
     } else {
@@ -529,7 +529,7 @@ Status MakeStruct(std::shared_ptr<RecordBatch>* out) {
 
   // construct individual nullable/non-nullable struct arrays
   std::shared_ptr<Array> no_nulls(new StructArray(type, list_batch->num_rows(), columns));
-  std::vector<uint8_t> null_bytes(list_batch->num_rows(), 1);
+  std::vector<uint8_t> null_bytes(static_cast<size_t>(list_batch->num_rows()), 1);
   null_bytes[0] = 0;
   ARROW_ASSIGN_OR_RAISE(auto null_bitmap, internal::BytesToBits(null_bytes));
   std::shared_ptr<Array> with_nulls(
@@ -1120,8 +1120,8 @@ Status MakeRandomTensor(const std::shared_ptr<DataType>& type,
   }
 
   const int64_t element_size = element_type.bit_width() / CHAR_BIT;
-  const int64_t len =
-      std::accumulate(shape.begin(), shape.end(), int64_t(1), std::multiplies<int64_t>());
+  const auto len = static_cast<size_t>(std::accumulate(
+      shape.begin(), shape.end(), int64_t(1), std::multiplies<int64_t>()));
 
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> buf, AllocateBuffer(element_size * len));
 


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090