### PR TITLE
GH-38090: [C++][Emscripten] arrow: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -169,8 +169,9 @@ struct ScalarHashImpl {
       // We can't visit values without unboxing the whole array, so only hash
       // the null bitmap for now. Only hash the null bitmap if the null count
       // is not 0 to ensure hash consistency.
-      hash_ = internal::ComputeBitmapHash(validity, /*seed=*/hash_,
-                                          /*bits_offset=*/offset, /*num_bits=*/length);
+      hash_ = static_cast<size_t>(internal::ComputeBitmapHash(validity, /*seed=*/hash_,
+                                                              /*bits_offset=*/offset,
+                                                              /*num_bits=*/length));
     }
 
     // Hash the relevant child arrays for each type taking offset and length
@@ -791,7 +792,7 @@ struct MakeNullImpl {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> value,
                           AllocateBuffer(type.byte_width()));
     // Avoid exposing past memory contents
-    memset(value->mutable_data(), 0, value->size());
+    memset(value->mutable_data(), 0, static_cast<size_t>(value->size()));
     out_ = std::make_shared<FixedSizeBinaryScalar>(std::move(value), type_,
                                                    /*is_valid=*/false);
     return Status::OK();

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1057,7 +1057,8 @@ std::string NullType::ToString() const { return name(); }
 // FieldPath
 
 size_t FieldPath::hash() const {
-  return internal::ComputeStringHash<0>(indices().data(), indices().size() * sizeof(int));
+  return static_cast<size_t>(
+      internal::ComputeStringHash<0>(indices().data(), indices().size() * sizeof(int)));
 }
 
 std::string FieldPath::ToString() const {
@@ -1423,7 +1424,7 @@ void FieldRef::Flatten(std::vector<FieldRef> children) {
       if (n_indices == 0) {
         return;
       } else if (n_indices > 0) {
-        std::vector<int> indices(n_indices);
+        std::vector<int> indices(static_cast<size_t>(n_indices));
         auto out_indices = indices.begin();
         for (const auto& child : flattened_children) {
           for (int index : *child.field_path()) {

--- a/cpp/src/arrow/visit_data_inline.h
+++ b/cpp/src/arrow/visit_data_inline.h
@@ -104,7 +104,8 @@ struct ArraySpanInlineVisitor<T, enable_if_base_binary<T>> {
         arr.buffers[0].data, arr.offset, arr.length,
         [&](int64_t i) {
           ARROW_UNUSED(i);
-          auto value = std::string_view(data + cur_offset, *offsets - cur_offset);
+          auto value = std::string_view(data + cur_offset,
+                                        static_cast<size_t>(*offsets - cur_offset));
           cur_offset = *offsets++;
           return valid_func(value);
         },
@@ -137,7 +138,7 @@ struct ArraySpanInlineVisitor<T, enable_if_base_binary<T>> {
         arr.buffers[0].data, arr.offset, arr.length,
         [&](int64_t i) {
           auto value = std::string_view(reinterpret_cast<const char*>(data + offsets[i]),
-                                        offsets[i + 1] - offsets[i]);
+                                        static_cast<size_t>(offsets[i + 1] - offsets[i]));
           valid_func(value);
         },
         std::forward<NullFunc>(null_func));


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090