### PR TITLE
GH-38090: [C++][Emscripten] testing: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/testing/builder.h
+++ b/cpp/src/arrow/testing/builder.h
@@ -150,7 +150,7 @@ template <class T, class Builder>
 Status MakeArray(const std::vector<uint8_t>& valid_bytes, const std::vector<T>& values,
                  int64_t size, Builder* builder, std::shared_ptr<Array>* out) {
   // Append the first 1000
-  for (int64_t i = 0; i < size; ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(size); ++i) {
     if (valid_bytes[i] > 0) {
       RETURN_NOT_OK(builder->Append(values[i]));
     } else {

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -688,8 +688,9 @@ void AssertZeroPadded(const Array& array) {
     if (buffer) {
       const int64_t padding = buffer->capacity() - buffer->size();
       if (padding > 0) {
-        std::vector<uint8_t> zeros(padding);
-        ASSERT_EQ(0, memcmp(buffer->data() + buffer->size(), zeros.data(), padding));
+        std::vector<uint8_t> zeros(static_cast<size_t>(padding));
+        ASSERT_EQ(0, memcmp(buffer->data() + buffer->size(), zeros.data(),
+                            static_cast<size_t>(padding)));
       }
     }
   }
@@ -1199,7 +1200,8 @@ std::shared_ptr<ArrayData> UnalignBuffers(const ArrayData& array) {
     }
     EXPECT_OK_AND_ASSIGN(std::shared_ptr<Buffer> padded,
                          AllocateBuffer(buffer->size() + 1, default_memory_pool()));
-    memcpy(padded->mutable_data() + 1, buffer->data(), buffer->size());
+    memcpy(padded->mutable_data() + 1, buffer->data(),
+           static_cast<size_t>(buffer->size()));
     std::shared_ptr<Buffer> unaligned = SliceBuffer(padded, 1);
     new_buffers.push_back(std::move(unaligned));
   }

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -140,7 +140,7 @@ std::shared_ptr<Buffer> RandomArrayGenerator::NullBitmap(int64_t size,
 
   GenOpt null_gen(seed(), 0, 1, null_probability);
   std::shared_ptr<Buffer> bitmap = *AllocateEmptyBitmap(size, alignment, memory_pool);
-  null_gen.GenerateBitmap(bitmap->mutable_data(), size, nullptr);
+  null_gen.GenerateBitmap(bitmap->mutable_data(), static_cast<size_t>(size), nullptr);
 
   return bitmap;
 }
@@ -167,10 +167,12 @@ std::shared_ptr<Array> RandomArrayGenerator::Boolean(int64_t size,
 
   int64_t null_count = 0;
   buffers[0] = *AllocateEmptyBitmap(size, alignment, memory_pool);
-  null_gen.GenerateBitmap(buffers[0]->mutable_data(), size, &null_count);
+  null_gen.GenerateBitmap(buffers[0]->mutable_data(), static_cast<size_t>(size),
+                          &null_count);
 
   buffers[1] = *AllocateEmptyBitmap(size, alignment, memory_pool);
-  value_gen.GenerateBitmap(buffers[1]->mutable_data(), size, nullptr);
+  value_gen.GenerateBitmap(buffers[1]->mutable_data(), static_cast<size_t>(size),
+                           nullptr);
 
   auto array_data = ArrayData::Make(arrow::boolean(), size, buffers, null_count);
   return std::make_shared<BooleanArray>(array_data);
@@ -191,12 +193,13 @@ static std::shared_ptr<NumericArray<ArrowType>> GenerateNumericArray(
 
   int64_t null_count = 0;
   buffers[0] = *AllocateEmptyBitmap(size, alignment, memory_pool);
-  options.GenerateBitmap(buffers[0]->mutable_data(), size, &null_count);
+  options.GenerateBitmap(buffers[0]->mutable_data(), static_cast<size_t>(size),
+                         &null_count);
 
   buffers[1] = *AllocateBuffer(sizeof(CType) * size, alignment, memory_pool);
-  options.GenerateData(buffers[1]->mutable_data(), size);
+  options.GenerateData(buffers[1]->mutable_data(), static_cast<size_t>(size));
   if (std::is_same<ArrowType, Date64Type>::value) {
-    GenerateFullDayMillisNoNan(buffers[1]->mutable_data(), size);
+    GenerateFullDayMillisNoNan(buffers[1]->mutable_data(), static_cast<size_t>(size));
   }
 
   auto array_data = ArrayData::Make(type, size, buffers, null_count);
@@ -391,7 +394,7 @@ static std::shared_ptr<Array> GenerateBinaryArray(RandomArrayGenerator* gen, int
 
   for (int64_t i = 0; i < size; ++i) {
     if (lengths->IsValid(i)) {
-      options.GenerateData(str_buffer.data(), lengths->Value(i));
+      options.GenerateData(str_buffer.data(), static_cast<size_t>(lengths->Value(i)));
       ABORT_NOT_OK(builder.Append(str_buffer.data(), lengths->Value(i)));
     } else {
       ABORT_NOT_OK(builder.AppendNull());
@@ -476,8 +479,10 @@ std::shared_ptr<Array> RandomArrayGenerator::FixedSizeBinary(int64_t size,
   int64_t null_count = 0;
   auto null_bitmap = *AllocateEmptyBitmap(size, alignment, memory_pool);
   auto data_buffer = *AllocateBuffer(size * byte_width, alignment, memory_pool);
-  options.GenerateBitmap(null_bitmap->mutable_data(), size, &null_count);
-  options.GenerateData(data_buffer->mutable_data(), size * byte_width);
+  options.GenerateBitmap(null_bitmap->mutable_data(), static_cast<size_t>(size),
+                         &null_count);
+  options.GenerateData(data_buffer->mutable_data(),
+                       static_cast<size_t>(size * byte_width));
 
   auto type = fixed_size_binary(byte_width);
   return std::make_shared<FixedSizeBinaryArray>(type, size, std::move(data_buffer),
@@ -502,7 +507,7 @@ std::shared_ptr<Array> GenerateOffsets(SeedType seed, int64_t size,
 
   buffers[0] = *AllocateEmptyBitmap(size, alignment, memory_pool);
   uint8_t* null_bitmap = buffers[0]->mutable_data();
-  options.GenerateBitmap(null_bitmap, size, &null_count);
+  options.GenerateBitmap(null_bitmap, static_cast<size_t>(size), &null_count);
   // Make sure the first and last entry are non-null
   for (const int64_t offset : std::vector<int64_t>{0, size - 1}) {
     if (!arrow::bit_util::GetBit(null_bitmap, offset)) {
@@ -515,7 +520,7 @@ std::shared_ptr<Array> GenerateOffsets(SeedType seed, int64_t size,
                                alignment, memory_pool);
   auto data =
       reinterpret_cast<typename OffsetArrayType::value_type*>(buffers[1]->mutable_data());
-  options.GenerateTypedData(data, size);
+  options.GenerateTypedData(data, static_cast<size_t>(size));
   // Ensure offsets are in increasing order
   std::sort(data, data + size);
   // Ensure first and last offsets are as required
@@ -1083,7 +1088,7 @@ void rand_day_millis(int64_t N, std::vector<DayTimeIntervalType::DayMilliseconds
   arrow::random::pcg32_fast gen(random_seed);
   std::uniform_int_distribution<int32_t> d(std::numeric_limits<int32_t>::min(),
                                            std::numeric_limits<int32_t>::max());
-  out->resize(N, {});
+  out->resize(static_cast<size_t>(N), {});
   std::generate(out->begin(), out->end(), [&d, &gen] {
     DayTimeIntervalType::DayMilliseconds tmp;
     tmp.days = d(gen);
@@ -1098,7 +1103,7 @@ void rand_month_day_nanos(int64_t N,
   arrow::random::pcg32_fast gen(random_seed);
   std::uniform_int_distribution<int64_t> d(std::numeric_limits<int64_t>::min(),
                                            std::numeric_limits<int64_t>::max());
-  out->resize(N, {});
+  out->resize(static_cast<size_t>(N), {});
   std::generate(out->begin(), out->end(), [&d, &gen] {
     MonthDayNanoIntervalType::MonthDayNanos tmp;
     tmp.months = static_cast<int32_t>(d(gen));

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -68,7 +68,7 @@ void random_is_valid(int64_t n, double pct_null, std::vector<bool>* is_valid,
                      int random_seed) {
   pcg32_fast gen(random_seed);
   ::arrow::random::uniform_real_distribution<double> d(0.0, 1.0);
-  is_valid->resize(n, false);
+  is_valid->resize(static_cast<size_t>(n), false);
   std::generate(is_valid->begin(), is_valid->end(),
                 [&d, &gen, &pct_null] { return d(gen) > pct_null; });
 }


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090