### PR TITLE
GH-38090: [C++][Emscripten] util: Suppress shorten-64-to-32 warnings

### DIFF
--- a/cpp/src/arrow/util/align_util.cc
+++ b/cpp/src/arrow/util/align_util.cc
@@ -158,7 +158,8 @@ Result<std::shared_ptr<Buffer>> EnsureAlignment(std::shared_ptr<Buffer> buffer,
     ARROW_ASSIGN_OR_RAISE(
         auto new_buffer,
         AllocateBuffer(buffer->size(), minimum_desired_alignment, memory_pool));
-    std::memcpy(new_buffer->mutable_data(), buffer->data(), buffer->size());
+    std::memcpy(new_buffer->mutable_data(), buffer->data(),
+                static_cast<size_t>(buffer->size()));
     return std::move(new_buffer);
   } else {
     return std::move(buffer);

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -308,9 +308,9 @@ template <size_t N>
 static int64_t FillInArray(const std::array<uint64_t, N>& value_array,
                            uint32_t* result_array) {
   const auto value_array_le = bit_util::little_endian::Make(value_array);
-  int64_t next_index = 0;
+  size_t next_index = 0;
   // 1st loop to find out 1st non-negative value in input
-  int64_t i = N - 1;
+  size_t i = N - 1;
   for (; i >= 0; i--) {
     if (value_array_le[i] != 0) {
       if (value_array_le[i] <= std::numeric_limits<uint32_t>::max()) {
@@ -321,7 +321,7 @@ static int64_t FillInArray(const std::array<uint64_t, N>& value_array,
     }
   }
   // 2nd loop to fill in the rest of the array.
-  for (int64_t j = i; j >= 0; j--) {
+  for (auto j = i; j >= 0; j--) {
     result_array[next_index++] = static_cast<uint32_t>(value_array_le[j] >> 32);
     result_array[next_index++] = static_cast<uint32_t>(value_array_le[j]);
   }

--- a/cpp/src/arrow/util/bit_run_reader.h
+++ b/cpp/src/arrow/util/bit_run_reader.h
@@ -141,7 +141,7 @@ class ARROW_EXPORT BitRunReader {
     if (ARROW_PREDICT_TRUE(bits_remaining >= 64)) {
       std::memcpy(&word_, bitmap_, 8);
     } else {
-      int64_t bytes_to_load = bit_util::BytesForBits(bits_remaining);
+      auto bytes_to_load = static_cast<size_t>(bit_util::BytesForBits(bits_remaining));
       auto word_ptr = reinterpret_cast<uint8_t*>(&word_);
       std::memcpy(word_ptr, bitmap_, bytes_to_load);
       // Ensure stoppage at last bit in bitmap by reversing the next higher
@@ -304,12 +304,13 @@ class BaseSetBitRunReader {
     if (Reverse) {
       // Read in the most significant bytes of the word
       bitmap_ -= num_bytes;
-      memcpy(reinterpret_cast<char*>(&word) + 8 - num_bytes, bitmap_, num_bytes);
+      memcpy(reinterpret_cast<char*>(&word) + 8 - num_bytes, bitmap_,
+             static_cast<size_t>(num_bytes));
       // XXX MostSignificantBitmask
       return (bit_util::ToLittleEndian(word) << bit_offset) &
              ~bit_util::LeastSignificantBitMask(64 - num_bits);
     } else {
-      memcpy(&word, bitmap_, num_bytes);
+      memcpy(&word, bitmap_, static_cast<size_t>(num_bytes));
       bitmap_ += num_bytes;
       return (bit_util::ToLittleEndian(word) >> bit_offset) &
              bit_util::LeastSignificantBitMask(num_bits);

--- a/cpp/src/arrow/util/bit_util.cc
+++ b/cpp/src/arrow/util/bit_util.cc
@@ -105,7 +105,7 @@ void SetBitmapImpl(uint8_t* data, int64_t offset, int64_t length) {
 
   // set values per byte
   DCHECK_EQ(offset % 8, 0);
-  std::memset(data + offset / 8, set_byte, length / 8);
+  std::memset(data + offset / 8, set_byte, static_cast<size_t>(length / 8));
   offset += bit_util::RoundDown(length, 8);
   length -= bit_util::RoundDown(length, 8);
 

--- a/cpp/src/arrow/util/bitmap.cc
+++ b/cpp/src/arrow/util/bitmap.cc
@@ -31,9 +31,9 @@ namespace arrow {
 namespace internal {
 
 std::string Bitmap::ToString() const {
-  std::string out(length_ + ((length_ - 1) / 8), ' ');
+  std::string out(static_cast<size_t>(length_ + ((length_ - 1) / 8)), ' ');
   for (int64_t i = 0; i < length_; ++i) {
-    out[i + (i / 8)] = GetBit(i) ? '1' : '0';
+    out[static_cast<size_t>(i + (i / 8))] = GetBit(i) ? '1' : '0';
   }
   return out;
 }

--- a/cpp/src/arrow/util/bitmap.h
+++ b/cpp/src/arrow/util/bitmap.h
@@ -198,7 +198,7 @@ class ARROW_EXPORT Bitmap : public util::ToStringOstreamable<Bitmap>,
     }
     assert(*std::min_element(offsets, offsets + N) == 0);
 
-    int64_t whole_word_count = bit_length / kBitWidth;
+    auto whole_word_count = static_cast<size_t>(bit_length / kBitWidth);
     assert(whole_word_count >= 1);
 
     if (min_offset == max_offset) {
@@ -206,7 +206,7 @@ class ARROW_EXPORT Bitmap : public util::ToStringOstreamable<Bitmap>,
       assert(
           std::all_of(offsets, offsets + N, [](int64_t offset) { return offset == 0; }));
 
-      for (int64_t word_i = 0; word_i < whole_word_count; ++word_i) {
+      for (size_t word_i = 0; word_i < whole_word_count; ++word_i) {
         for (size_t i = 0; i < N; ++i) {
           visited_words[i] = words[i][word_i];
         }
@@ -218,7 +218,7 @@ class ARROW_EXPORT Bitmap : public util::ToStringOstreamable<Bitmap>,
 
       // word_i such that words[i][word_i] and words[i][word_i + 1] are lie entirely
       // within the bitmap for all i
-      for (int64_t word_i = 0; word_i < whole_word_count - 1; ++word_i) {
+      for (size_t word_i = 0; word_i < whole_word_count - 1; ++word_i) {
         for (size_t i = 0; i < N; ++i) {
           if (offsets[i] == 0) {
             visited_words[i] = words[i][word_i];

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -271,8 +271,8 @@ bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right
                   int64_t right_offset, int64_t length) {
   if (left_offset % 8 == 0 && right_offset % 8 == 0) {
     // byte aligned, can use memcmp
-    bool bytes_equal =
-        std::memcmp(left + left_offset / 8, right + right_offset / 8, length / 8) == 0;
+    bool bytes_equal = std::memcmp(left + left_offset / 8, right + right_offset / 8,
+                                   static_cast<size_t>(length / 8)) == 0;
     if (!bytes_equal) {
       return false;
     }

--- a/cpp/src/arrow/util/bitmap_reader.h
+++ b/cpp/src/arrow/util/bitmap_reader.h
@@ -130,7 +130,7 @@ class BitmapUInt64Reader {
 
   uint64_t LoadPartialWord(int8_t bit_offset, int64_t num_bits) {
     uint64_t word = 0;
-    const int64_t num_bytes = bit_util::BytesForBits(num_bits);
+    const auto num_bytes = static_cast<size_t>(bit_util::BytesForBits(num_bits));
     memcpy(&word, bitmap_, num_bytes);
     bitmap_ += num_bytes;
     return (bit_util::ToLittleEndian(word) >> bit_offset) &

--- a/cpp/src/arrow/util/bitmap_writer.h
+++ b/cpp/src/arrow/util/bitmap_writer.h
@@ -135,7 +135,8 @@ class FirstTimeBitmapWriter {
       number_of_bits -= bits_to_carry;
     }
     word = bit_util::ToLittleEndian(word);
-    int64_t bytes_for_word = ::arrow::bit_util::BytesForBits(number_of_bits);
+    auto bytes_for_word =
+        static_cast<size_t>(::arrow::bit_util::BytesForBits(number_of_bits));
     std::memcpy(append_position, &word, bytes_for_word);
     // At this point, the previous current_byte_ has been written to bitmap_.
     // The new current_byte_ is either the last relevant byte in 'word'

--- a/cpp/src/arrow/util/byte_stream_split.h
+++ b/cpp/src/arrow/util/byte_stream_split.h
@@ -597,9 +597,9 @@ void ByteStreamSplitDecodeScalar(const uint8_t* data, int64_t num_values, int64_
   constexpr size_t kNumStreams = sizeof(T);
   auto output_buffer_raw = reinterpret_cast<uint8_t*>(out);
 
-  for (int64_t i = 0; i < num_values; ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(num_values); ++i) {
     for (size_t b = 0; b < kNumStreams; ++b) {
-      const size_t byte_index = b * stride + i;
+      const size_t byte_index = b * static_cast<size_t>(stride) + i;
       output_buffer_raw[i * kNumStreams + b] = data[byte_index];
     }
   }

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -236,7 +236,8 @@ bool FutureImpl::TryAddCallback(const std::function<Callback()>& callback_factor
 
 Future<> AllComplete(const std::vector<Future<>>& futures) {
   struct State {
-    explicit State(int64_t n_futures) : mutex(), n_remaining(n_futures) {}
+    explicit State(int64_t n_futures)
+        : mutex(), n_remaining(static_cast<size_t>(n_futures)) {}
 
     std::mutex mutex;
     std::atomic<size_t> n_remaining;

--- a/cpp/src/arrow/util/int_util.cc
+++ b/cpp/src/arrow/util/int_util.cc
@@ -396,7 +396,7 @@ void DowncastInts(const int64_t* source, int32_t* dest, int64_t length) {
 }
 
 void DowncastInts(const int64_t* source, int64_t* dest, int64_t length) {
-  memcpy(dest, source, length * sizeof(int64_t));
+  memcpy(dest, source, static_cast<size_t>(length) * sizeof(int64_t));
 }
 
 void DowncastUInts(const uint64_t* source, uint8_t* dest, int64_t length) {
@@ -412,7 +412,7 @@ void DowncastUInts(const uint64_t* source, uint32_t* dest, int64_t length) {
 }
 
 void DowncastUInts(const uint64_t* source, uint64_t* dest, int64_t length) {
-  memcpy(dest, source, length * sizeof(int64_t));
+  memcpy(dest, source, static_cast<size_t>(length) * sizeof(int64_t));
 }
 
 void UpcastInts(const int32_t* source, int64_t* dest, int64_t length) {

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -79,7 +79,7 @@ void KeyValueMetadata::ToUnorderedMap(
     std::unordered_map<std::string, std::string>* out) const {
   DCHECK_NE(out, nullptr);
   const int64_t n = size();
-  out->reserve(n);
+  out->reserve(static_cast<size_t>(n));
   for (int64_t i = 0; i < n; ++i) {
     out->insert(std::make_pair(key(i), value(i)));
   }
@@ -100,26 +100,26 @@ Result<std::string> KeyValueMetadata::Get(const std::string& key) const {
 }
 
 Status KeyValueMetadata::Delete(int64_t index) {
-  keys_.erase(keys_.begin() + index);
-  values_.erase(values_.begin() + index);
+  keys_.erase(keys_.begin() + static_cast<ptrdiff_t>(index));
+  values_.erase(values_.begin() + static_cast<ptrdiff_t>(index));
   return Status::OK();
 }
 
 Status KeyValueMetadata::DeleteMany(std::vector<int64_t> indices) {
   std::sort(indices.begin(), indices.end());
-  const int64_t size = static_cast<int64_t>(keys_.size());
-  indices.push_back(size);
+  const auto size = keys_.size();
+  indices.push_back(static_cast<int64_t>(size));
 
-  int64_t shift = 0;
-  for (int64_t i = 0; i < static_cast<int64_t>(indices.size() - 1); ++i) {
+  size_t shift = 0;
+  for (size_t i = 0; i < indices.size() - 1; ++i) {
     ++shift;
-    const auto start = indices[i] + 1;
-    const auto stop = indices[i + 1];
+    const auto start = static_cast<size_t>(indices[i]) + 1;
+    const auto stop = static_cast<size_t>(indices[i + 1]);
     DCHECK_GE(start, 0);
     DCHECK_LE(start, size);
     DCHECK_GE(stop, 0);
     DCHECK_LE(stop, size);
-    for (int64_t index = start; index < stop; ++index) {
+    for (size_t index = start; index < stop; ++index) {
       keys_[index - shift] = std::move(keys_[index]);
       values_[index - shift] = std::move(values_[index]);
     }
@@ -168,22 +168,22 @@ int64_t KeyValueMetadata::size() const {
 const std::string& KeyValueMetadata::key(int64_t i) const {
   DCHECK_GE(i, 0);
   DCHECK_LT(static_cast<size_t>(i), keys_.size());
-  return keys_[i];
+  return keys_[static_cast<size_t>(i)];
 }
 
 const std::string& KeyValueMetadata::value(int64_t i) const {
   DCHECK_GE(i, 0);
   DCHECK_LT(static_cast<size_t>(i), values_.size());
-  return values_[i];
+  return values_[static_cast<size_t>(i)];
 }
 
 std::vector<std::pair<std::string, std::string>> KeyValueMetadata::sorted_pairs() const {
   std::vector<std::pair<std::string, std::string>> pairs;
-  pairs.reserve(size());
+  pairs.reserve(static_cast<size_t>(size()));
 
   auto indices = internal::ArgSort(keys_);
   for (const auto i : indices) {
-    pairs.emplace_back(keys_[i], values_[i]);
+    pairs.emplace_back(keys_[static_cast<size_t>(i)], values_[static_cast<size_t>(i)]);
   }
   return pairs;
 }
@@ -240,9 +240,9 @@ bool KeyValueMetadata::Equals(const KeyValueMetadata& other) const {
   auto indices = internal::ArgSort(keys_);
   auto other_indices = internal::ArgSort(other.keys_);
 
-  for (int64_t i = 0; i < size(); ++i) {
-    auto j = indices[i];
-    auto k = other_indices[i];
+  for (size_t i = 0; i < static_cast<size_t>(size()); ++i) {
+    auto j = static_cast<size_t>(indices[i]);
+    auto k = static_cast<size_t>(other_indices[i]);
     if (keys_[j] != other.keys_[k] || values_[j] != other.values_[k]) {
       return false;
     }
@@ -254,7 +254,7 @@ std::string KeyValueMetadata::ToString() const {
   std::stringstream buffer;
 
   buffer << "\n-- metadata --";
-  for (int64_t i = 0; i < size(); ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(size()); ++i) {
     buffer << "\n" << keys_[i] << ": " << values_[i];
   }
 

--- a/cpp/src/arrow/util/memory.cc
+++ b/cpp/src/arrow/util/memory.cc
@@ -62,8 +62,8 @@ void parallel_memcopy(uint8_t* dst, const uint8_t* src, int64_t nbytes,
     futures.push_back(*pool->Submit(wrap_memcpy, dst + prefix + i * chunk_size,
                                     left + i * chunk_size, chunk_size));
   }
-  memcpy(dst, src, prefix);
-  memcpy(dst + prefix + num_threads * chunk_size, right, suffix);
+  memcpy(dst, src, static_cast<size_t>(prefix));
+  memcpy(dst + prefix + num_threads * chunk_size, right, static_cast<size_t>(suffix));
 
   for (auto& fut : futures) {
     ARROW_CHECK_OK(fut.status());

--- a/cpp/src/arrow/util/sort.h
+++ b/cpp/src/arrow/util/sort.h
@@ -31,8 +31,9 @@ template <typename T, typename Cmp = std::less<T>>
 std::vector<int64_t> ArgSort(const std::vector<T>& values, Cmp&& cmp = {}) {
   std::vector<int64_t> indices(values.size());
   std::iota(indices.begin(), indices.end(), 0);
-  std::sort(indices.begin(), indices.end(),
-            [&](int64_t i, int64_t j) -> bool { return cmp(values[i], values[j]); });
+  std::sort(indices.begin(), indices.end(), [&](int64_t i, int64_t j) -> bool {
+    return cmp(values[static_cast<size_t>(i)], values[static_cast<size_t>(j)]);
+  });
   return indices;
 }
 
@@ -54,21 +55,22 @@ size_t Permute(const std::vector<int64_t>& indices, std::vector<T>* values) {
     // position in which an element belongs WRT sort
     auto sort_into = static_cast<int64_t>(cycle_start - sorted.begin());
 
-    if (indices[sort_into] == sort_into) {
+    if (indices[static_cast<size_t>(sort_into)] == sort_into) {
       // trivial cycle
-      sorted[sort_into] = true;
+      sorted[static_cast<size_t>(sort_into)] = true;
       continue;
     }
 
     // resolve this cycle
     const auto end = sort_into;
-    for (int64_t take_from = indices[sort_into]; take_from != end;
-         take_from = indices[sort_into]) {
-      std::swap(values->at(sort_into), values->at(take_from));
-      sorted[sort_into] = true;
+    for (int64_t take_from = indices[static_cast<size_t>(sort_into)]; take_from != end;
+         take_from = indices[static_cast<size_t>(sort_into)]) {
+      std::swap(values->at(static_cast<size_t>(sort_into)),
+                values->at(static_cast<size_t>(take_from)));
+      sorted[static_cast<size_t>(sort_into)] = true;
       sort_into = take_from;
     }
-    sorted[sort_into] = true;
+    sorted[static_cast<size_t>(sort_into)] = true;
   }
 
   return cycle_count;

--- a/cpp/src/arrow/util/spaced.h
+++ b/cpp/src/arrow/util/spaced.h
@@ -46,7 +46,8 @@ inline int SpacedCompress(const T* src, int num_values, const uint8_t* valid_bit
     if (run.length == 0) {
       break;
     }
-    std::memcpy(output + num_valid_values, src + run.position, run.length * sizeof(T));
+    std::memcpy(output + num_valid_values, src + run.position,
+                static_cast<size_t>(run.length) * sizeof(T));
     num_valid_values += static_cast<int32_t>(run.length);
   }
 
@@ -85,7 +86,8 @@ inline int SpacedExpand(T* buffer, int num_values, int null_count,
     }
     idx_decode -= static_cast<int32_t>(run.length);
     assert(idx_decode >= 0);
-    std::memmove(buffer + run.position, buffer + idx_decode, run.length * sizeof(T));
+    std::memmove(buffer + run.position, buffer + idx_decode,
+                 static_cast<size_t>(run.length) * sizeof(T));
   }
 
   // Otherwise caller gave an incorrect null_count


### PR DESCRIPTION
### Rationale for this change

We need explicit cast to use `int64_t` for `size_t` on Emscripten.

### What changes are included in this PR?

Explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38090