### PR TITLE
GH-37952: [C++] Make unique->shared explicit to fix build failure on at least one compiler

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -462,7 +462,9 @@ Result<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
   std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
   RETURN_NOT_OK(parquet::arrow::FileReader::Make(
       options->pool, std::move(reader), std::move(arrow_properties), &arrow_reader));
-  return arrow_reader;
+
+  std::shared_ptr<parquet::arrow::FileReader> file_reader_shared(arrow_reader.release());
+  return file_reader_shared;
 }
 
 Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReaderAsync(

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -462,9 +462,7 @@ Result<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
   std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
   RETURN_NOT_OK(parquet::arrow::FileReader::Make(
       options->pool, std::move(reader), std::move(arrow_properties), &arrow_reader));
-
-  std::shared_ptr<parquet::arrow::FileReader> file_reader_shared(arrow_reader.release());
-  return file_reader_shared;
+  return std::move(arrow_reader);
 }
 
 Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReaderAsync(


### PR DESCRIPTION

### Rationale for this change

The [test-r-rstudio-r-base-4.1-opensuse153](https://github.com/ursacomputing/crossbow/runs/17162402631) nightly has been failing with a compile error for many days.

### What changes are included in this PR?

Made the unique->shared conversion explicit.

### Are these changes tested?

Yes (by existing tests)

### Are there any user-facing changes?

No.
* Closes: #37952