### PR TITLE
GH-38138: [R] Add curl to suggests for use of `skip_if_offline()`

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -45,6 +45,7 @@ RoxygenNote: 7.2.3
 Config/testthat/edition: 3
 Suggests:
     blob,
+    curl,
     cli,
     DBI,
     dbplyr,


### PR DESCRIPTION
### Rationale for this change

testthat now requires the curl package for `skip_if_offline()`. Previously tests were skipped; how the tests fail (although the message is somewhat bizarre).

### What changes are included in this PR?

Include curl explicitly as an optional dependency so that our dependency install step picks it up.

### Are these changes tested?

Covered by existing tests

### Are there any user-facing changes?

No.
* Closes: #38138