### PR TITLE
GH-38209: [Docs] Reduce width of header items and keep header height default (small) on smaller screens

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -21,10 +21,16 @@
 /* Customizing with theme CSS variables */
 
 :root {
-  /* Change header hight to make the logo a bit larger */
-  --pst-header-height: 6rem;
   /* Make headings more bold */
   --pst-font-weight-heading: 600;
+}
+
+/* Change header hight to make the logo a bit larger */
+/* only on wider screens */
+@media only screen and (min-width: 950px){
+  :root {
+    --pst-header-height: 6rem;
+  }
 }
 
 /* Contibuting landing page overview cards */

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -27,7 +27,7 @@
 
 /* Change header hight to make the logo a bit larger */
 /* only on wider screens */
-@media only screen and (min-width: 950px){
+@media only screen and (min-width: 1170px){
   :root {
     --pst-header-height: 6rem;
   }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -296,7 +296,7 @@ html_theme_options = {
       "image_dark": "_static/arrow-dark.png",
     },
     "header_links_before_dropdown": 2,
-    "header_dropdown_text": "Language implementations",
+    "header_dropdown_text": "Implementations",
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "icon_links": [
         {

--- a/docs/source/format/index.rst
+++ b/docs/source/format/index.rst
@@ -17,8 +17,8 @@
 
 .. _format:
 
-Specifications and Protocols
-============================
+Specifications
+==============
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,7 @@ target environment.**
    :padding: 2 2 0 0
    :class-container: sd-text-center
 
-   .. grid-item-card:: Specifications and Protocols
+   .. grid-item-card:: Specifications
       :class-card: contrib-card
       :shadow: none
 
@@ -57,7 +57,7 @@ target environment.**
          :color: primary
          :expand:
 
-         To the Specifications and Protocols
+         To the Specifications
 
    .. grid-item-card:: Development
       :class-card: contrib-card


### PR DESCRIPTION
### Rationale for this change

The Sphinx theme we have been using (PyData Sphinx Theme) has been pinned to an older version for a while now and with the https://github.com/apache/arrow/pull/36591 we have updated the code and are now using version 0.14.0 for the dev docs.

This PR fixes bugs we have encountered after the PR updating the theme has been merged.

### What changes are included in this PR?

- Have default header size for smaller screens and keep it increased for bigger screens.

* Closes: #38209