### PR TITLE
GH-37328: [Python] Add a function to download and extract timezone database on Windows

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -82,7 +82,8 @@ tzdata on Windows
 While Arrow uses the OS-provided timezone database on Linux and macOS, it requires a
 user-provided database on Windows. To download and extract the text version of
 the IANA timezone database follow the instructions in the C++
-:ref:`download-timezone-database`.
+:ref:`download-timezone-database` or use pyarrow utility function
+`pyarrow.util.download_tzdata_on_windows()` that does the same.
 
 By default, the timezone database will be detected at ``%USERPROFILE%\Downloads\tzdata``.
 If the database has been downloaded in a different location, you will need to set

--- a/python/pyarrow/tests/test_util.py
+++ b/python/pyarrow/tests/test_util.py
@@ -222,6 +222,6 @@ def test_download_tzdata_on_windows():
     tzdata_zones_path = os.path.join(tzdata_path, "windowsZones.xml")
     assert os.path.exists(tzdata_path)
     assert os.path.exists(tzdata_zones_path)
-    # 31 files in tzdata + compressed tzdata.tar.gz + windowsZones.xml
-    assert len(os.listdir(tzdata_path)) == 33
+    # 30 files in tzdata (2023) + compressed tzdata.tar.gz + windowsZones.xml
+    assert len(os.listdir(tzdata_path)) == 32
     assert 'version' in os.listdir(tzdata_path)

--- a/python/pyarrow/tests/test_util.py
+++ b/python/pyarrow/tests/test_util.py
@@ -216,7 +216,6 @@ def test_signal_refcycle():
                     reason="Timezone database is already provided.")
 def test_download_tzdata_on_windows():
     tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
-    tzdata_zones_path = os.path.join(tzdata_path, "windowsZones.xml")
 
     # Download timezone database and remove data in case it already exists
     if (os.path.exists(tzdata_path)):
@@ -225,7 +224,6 @@ def test_download_tzdata_on_windows():
 
     # Inspect the folder
     assert os.path.exists(tzdata_path)
-    assert os.path.exists(tzdata_zones_path)
-    # 30 files in tzdata (2023) + compressed tzdata.tar.gz + windowsZones.xml
-    assert len(os.listdir(tzdata_path)) == 32
+    assert os.path.exists(os.path.join(tzdata_path, "windowsZones.xml"))
+    assert os.path.exists(os.path.join(tzdata_path, "europe"))
     assert 'version' in os.listdir(tzdata_path)

--- a/python/pyarrow/tests/test_util.py
+++ b/python/pyarrow/tests/test_util.py
@@ -18,6 +18,7 @@
 import gc
 import os
 import signal
+import shutil
 import sys
 import textwrap
 import weakref
@@ -214,12 +215,15 @@ def test_signal_refcycle():
 @pytest.mark.skipif(sys.platform != "win32",
                     reason="Timezone database is already provided.")
 def test_download_tzdata_on_windows():
-    # Download timezone database
+    tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
+    tzdata_zones_path = os.path.join(tzdata_path, "windowsZones.xml")
+
+    # Download timezone database and remove data in case it already exists
+    if (os.path.exists(tzdata_path)):
+        shutil.rmtree(tzdata_path)
     download_tzdata_on_windows()
 
     # Inspect the folder
-    tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
-    tzdata_zones_path = os.path.join(tzdata_path, "windowsZones.xml")
     assert os.path.exists(tzdata_path)
     assert os.path.exists(tzdata_zones_path)
     # 30 files in tzdata (2023) + compressed tzdata.tar.gz + windowsZones.xml

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -245,14 +245,14 @@ def download_tzdata_on_windows():
     os.makedirs(tzdata_path, exist_ok=True)
 
     from urllib.request import urlopen
-    with (urlopen('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response,
-          open(tzdata_compressed, 'wb') as f):
-        f.write(response.read())
+    with urlopen('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response:
+        with open(tzdata_compressed, 'wb') as f:
+            f.write(response.read())
 
     assert os.path.exists(tzdata_compressed)
 
     tarfile.open(tzdata_compressed).extractall(tzdata_path)
 
-    with (urlopen('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml') as response_zones,   # noqa
-          open(os.path.join(tzdata_path, "windowsZones.xml"), 'wb') as f):
-        f.write(response_zones.read())
+    with urlopen('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml') as response_zones:   # noqa
+        with open(os.path.join(tzdata_path, "windowsZones.xml"), 'wb') as f:
+            f.write(response_zones.read())

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -233,7 +233,7 @@ def _break_traceback_cycle_from_frame(frame):
 def download_tzdata_on_windows():
     """
     Download and extract latest IANA timezone database into the
-    location expected by Arrow which is %USERPROFILE%\Downloads\tzdata.
+    location expected by Arrow which is %USERPROFILE%\\Downloads\tzdata.
     """
     if sys.platform != 'win32':
         raise TypeError(f"Timezone database is already provided by {sys.platform}")
@@ -245,14 +245,14 @@ def download_tzdata_on_windows():
     os.makedirs(tzdata_path, exist_ok=True)
 
     from urllib.request import urlopen
-    with urlopen('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response:
-        with open(tzdata_compressed, 'wb') as f:
-            f.write(response.read())
+    with (urlopen('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response,
+          open(tzdata_compressed, 'wb') as f):
+        f.write(response.read())
 
     assert os.path.exists(tzdata_compressed)
 
     tarfile.open(tzdata_compressed).extractall(tzdata_path)
 
-    with (urlopen('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml') as response_zones,
-        open(os.path.join(tzdata_path, "windowsZones.xml"), 'wb') as f):
+    with (urlopen('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml') as response_zones,   # noqa
+          open(os.path.join(tzdata_path, "windowsZones.xml"), 'wb') as f):
         f.write(response_zones.read())

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -232,8 +232,8 @@ def _break_traceback_cycle_from_frame(frame):
 
 def download_tzdata_on_windows():
     """
-    Download and extract 2021e IANA timezone database into
-    the expected location in the Downloads directory.
+    Download and extract latest IANA timezone database into the
+    location expected by Arrow which is %USERPROFILE%\Downloads\tzdata.
     """
     if sys.platform != 'win32':
         raise TypeError(f"Timezone database is already provided by {sys.platform}")

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -247,6 +247,10 @@ def download_tzdata_on_windows():
     if response.status_code == 200:
         with open(tzdata_compressed, 'wb') as f:
             f.write(response.raw.read())
+    else:
+        raise TypeError(f"Timezone database not available")
+
+    assert os.path.exists(tzdata_compressed)
 
     tarfile.open(tzdata_compressed).extractall(tzdata_path)
 

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -241,8 +241,9 @@ def download_tzdata_on_windows():
     tzdata_compressed = os.path.join(tzdata_path, "tzdata.tar.gz")
     os.makedirs(tzdata_path, exist_ok=True)
 
-    response = requests.get('https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz',
-                            stream=True)
+    response = requests.get(
+        'https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz',
+        stream=True)
 
     if response.status_code == 200:
         with open(tzdata_compressed, 'wb') as f:

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -239,10 +239,10 @@ def download_tzdata_on_windows():
 
     tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
     tzdata_compressed = os.path.join(tzdata_path, "tzdata.tar.gz")
-    os.makedirs(tzdata_path)
+    os.makedirs(tzdata_path, exist_ok=True)
 
-    response = requests.get(
-        'https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz')
+    response = requests.get('https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz',
+                            stream=True)
 
     if response.status_code == 200:
         with open(tzdata_compressed, 'wb') as f:
@@ -254,8 +254,8 @@ def download_tzdata_on_windows():
 
     tarfile.open(tzdata_compressed).extractall(tzdata_path)
 
-    response_zones = requests.get(
-        'https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml')   # noqa
+    response_zones = requests.get('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml',   # noqa
+                                  stream=True)
 
     if response_zones.status_code == 200:
         with open(os.path.join(tzdata_path, "windowsZones.xml"), "wb") as f:

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -233,7 +233,7 @@ def _break_traceback_cycle_from_frame(frame):
 def download_tzdata_on_windows():
     """
     Download and extract 2021e IANA timezone database into
-    the expected location %USERPROFILE%\Downloads\tzdata.
+    the expected location in the Downloads directory.
     """
     if sys.platform != 'win32':
         raise TypeError(f"Timezone database is already provided by {sys.platform}")

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -231,6 +231,10 @@ def _break_traceback_cycle_from_frame(frame):
 
 
 def download_tzdata_on_windows():
+    """
+    Download and extract 2021e IANA timezone database into
+    the expected location %USERPROFILE%\Downloads\tzdata.
+    """
     if sys.platform != 'win32':
         raise TypeError(f"Timezone database is already provided by {sys.platform}")
 

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -248,7 +248,7 @@ def download_tzdata_on_windows():
         with open(tzdata_compressed, 'wb') as f:
             f.write(response.raw.read())
     else:
-        raise TypeError(f"Timezone database not available")
+        raise TypeError("Timezone database not available")
 
     assert os.path.exists(tzdata_compressed)
 

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -231,7 +231,7 @@ def _break_traceback_cycle_from_frame(frame):
 
 
 def download_tzdata_on_windows():
-    """
+    r"""
     Download and extract latest IANA timezone database into the
     location expected by Arrow which is %USERPROFILE%\Downloads\tzdata.
     """

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -233,7 +233,7 @@ def _break_traceback_cycle_from_frame(frame):
 def download_tzdata_on_windows():
     """
     Download and extract latest IANA timezone database into the
-    location expected by Arrow which is %USERPROFILE%\\Downloads\tzdata.
+    location expected by Arrow which is %USERPROFILE%\Downloads\tzdata.
     """
     if sys.platform != 'win32':
         raise TypeError(f"Timezone database is already provided by {sys.platform}")


### PR DESCRIPTION
### Rationale for this change

There is a section in the [Arrow C++ documentation with the instructions](https://arrow.apache.org/docs/dev/cpp/build_system.html#runtime-dependencies) on how to download and extract text version of the IANA timezone database and on Windows. We should provide a function in PyArrow that a user would call to download and extract the timezone database from Python.

### What changes are included in this PR?

Function `download_tzdata_on_windows()` added to python/pyarrow/util.py that downloads and extracts timezone database to a standard location in `%USERPROFILE%\Downloads\tzdata` on Widnows.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* Closes: #37328