### PR TITLE
GH-38198: [Go] Fix AuthenticateBasicToken to be reliable behind proxies

### DIFF
--- a/go/arrow/flight/client.go
+++ b/go/arrow/flight/client.go
@@ -312,6 +312,11 @@ func (c *client) AuthenticateBasicToken(ctx context.Context, username, password 
 		return ctx, err
 	}
 
+	err = stream.CloseSend()
+	if err != nil {
+		return ctx, err
+	}
+
 	header, err := stream.Header()
 	if err != nil {
 		return ctx, err
@@ -319,11 +324,6 @@ func (c *client) AuthenticateBasicToken(ctx context.Context, username, password 
 
 	_, err = stream.Recv()
 	if err != nil && err != io.EOF {
-		return ctx, err
-	}
-
-	err = stream.CloseSend()
-	if err != nil {
 		return ctx, err
 	}
 


### PR DESCRIPTION
### Rationale for this change

Fixes a bug in the Go Flight client library that makes using AuthenticateBasicToken unreliable behind proxies.

### What changes are included in this PR?

Closes the sending side of the bi-directional stream for the Flight Handshake RPC call before trying to read the headers. This matches the C++ implementation.

<img width="609" alt="Screenshot 2023-10-11 at 6 18 40 PM" src="https://github.com/apache/arrow/assets/879445/05e23c6a-0ff8-41fc-825b-8add7fe938bc">


### Are these changes tested?

I've tested these changes against my service deployed behind CloudFlare and verified the error listed in the linked issue disappears.

### Are there any user-facing changes?

No
* Closes: #38198