### PR TITLE
GH-38201: [CI][Packaging] Pin zlib 1.2.13 when using thrift on conan

### DIFF
--- a/ci/conan/all/conanfile.py
+++ b/ci/conan/all/conanfile.py
@@ -358,6 +358,7 @@ class ArrowConan(ConanFile):
 
     def requirements(self):
         if self._with_thrift():
+            self.requires("zlib/1.2.13")
             self.requires("thrift/0.17.0")
         if self._with_protobuf():
             self.requires("protobuf/3.21.4")


### PR DESCRIPTION
### Rationale for this change
There is a conflict between the required Zlib version when using both thrift and GRPC.

### What changes are included in this PR?

Pinning zlib when using thrifht.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* Closes: #38201