### PR TITLE
GH-38197: [R] Update actions that used setup-r@v1 to use setup-r@v2

### DIFF
--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -26,17 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-20.04, windows-latest]
+        os: [macOS-latest, ubuntu-20.04]
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
-      # TODO (ARROW-16376): Switch to v2 once we use UCRT
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          # temp workaround the fact that R 4.2 requires UCRT which isn't
-          # currently part of this build.
-          # remove after https://issues.apache.org/jira/browse/ARROW-16376
-          r-version: '4.1'
+      - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -47,15 +41,11 @@ jobs:
           pkgs <- installed.packages()[, "Package"]
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
-      - name: Remove system gfortran so that brew can install gcc successfully
-        run: rm -f /usr/local/bin/gfortran
-        if: {{ "${{ !contains(matrix.os, 'windows') }}" }}
       - name: Write the install script
         env:
           RUN_DEVDOCS: TRUE
           DEVDOCS_MACOS: {{ "${{contains(matrix.os, 'macOS')}}" }}
           DEVDOCS_UBUNTU: {{ "${{contains(matrix.os, 'ubuntu')}}" }}
-          DEVDOCS_WINDOWS: {{ "${{contains(matrix.os, 'windows')}}" }}
         run: |
           # This isn't actually rendering the docs, but will save arrow/r/vignettes/developers/script.sh
           # which can be sourced to install arrow.
@@ -65,21 +55,10 @@ jobs:
         env:
           LIBARROW_BINARY: FALSE
           ARROW_R_DEV: TRUE
-          DEVDOCS_WINDOWS: {{ "${{contains(matrix.os, 'windows')}}" }}
         run: |
-          if [ $DEVDOCS_WINDOWS == "true" ]; then
-            # Part of Path, including the path to R's bin, needs to be reformatted
-            # from Windows paths (C:\R\bin) to Unix paths (/c/r/bin)
-            echo export PATH=\"$(cygpath --path "$PATH")\" >> ~/.bash_profile
-            # This starts a special mingw64 Git Bash shell
-            $RTOOLS40_HOME/msys2_shell.cmd -here -mingw64 -no-start -defterm -full-path arrow/r/vignettes/developers/script.sh
-          else
-            bash arrow/r/vignettes/developers/script.sh
-          fi
+          bash arrow/r/vignettes/developers/script.sh
         shell: bash
       - name: Ensure that the Arrow package is loadable and we have the correct one
-        env:
-          DEVDOCS_WINDOWS: {{ "${{contains(matrix.os, 'windows')}}" }}
         run: |
           echo $LD_LIBRARY_PATH
           R --no-save <<EOF

--- a/dev/tasks/r/github.linux.rchk.yml
+++ b/dev/tasks/r/github.linux.rchk.yml
@@ -34,8 +34,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          GITHUB_PAT: "${{ github.token }}"
         with:
           working-directory: 'r'
           extra-packages: |

--- a/dev/tasks/r/github.linux.rchk.yml
+++ b/dev/tasks/r/github.linux.rchk.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          working-directory: 'r'
+          working-directory: 'arrow/r'
           extra-packages: |
             any::rcmdcheck
       - name: Build arrow package

--- a/dev/tasks/r/github.linux.rchk.yml
+++ b/dev/tasks/r/github.linux.rchk.yml
@@ -31,12 +31,15 @@ jobs:
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 
-      - uses: r-lib/actions/setup-r@v1
-      - uses: r-lib/actions/setup-pandoc@v1
-      - name: Install dependencies
-        run: |
-          install.packages("remotes")
-          remotes::install_deps("arrow/r", dependencies = TRUE)
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          GITHUB_PAT: "${{ github.token }}"
+        with:
+          working-directory: 'r'
+          extra-packages: |
+            any::rcmdcheck
         shell: Rscript {0}
       - name: Build arrow package
         run: |

--- a/dev/tasks/r/github.linux.rchk.yml
+++ b/dev/tasks/r/github.linux.rchk.yml
@@ -38,7 +38,6 @@ jobs:
           working-directory: 'r'
           extra-packages: |
             any::rcmdcheck
-        shell: Rscript {0}
       - name: Build arrow package
         run: |
           R CMD build --no-build-vignettes arrow/r

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1344,10 +1344,6 @@ tasks:
       env:
         CMAKE_BUILD_TYPE: MinSizeRel
 
-  test-r-devdocs:
-    ci: github
-    template: r/github.devdocs.yml
-
   test-r-depsource-bundled:
     ci: azure
     template: r/azure.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1344,6 +1344,10 @@ tasks:
       env:
         CMAKE_BUILD_TYPE: MinSizeRel
 
+  test-r-devdocs:
+    ci: github
+    template: r/github.devdocs.yml
+
   test-r-depsource-bundled:
     ci: azure
     template: r/azure.linux.yml


### PR DESCRIPTION
### Rationale for this change

CI jobs that used setup-r@v1 no longer run without error.

### What changes are included in this PR?

- Updated the rchk job to use the `setup-r@v2`
- Updated the devdocs job to use `setup-r@v2`. To make this work, we needed to remove the Windows build because it was installing an old version of R. It seems that the job has been running an outdated and unsable (for most users) for a very long time.

### Are these changes tested?

Will be covered by crossbow jobs submitted below.

### Are there any user-facing changes?

No.
* Closes: #38197