### PR TITLE
GH-36994: [Java] Use JDK 21 in CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -68,12 +68,12 @@ jobs:
           maven: 3.6.2
           image: debian-java
         - jdk: 17
-          title: AMD64 Ubuntu 22.04 Java JDK 17 Maven 3.9.3
-          maven: 3.9.3
+          title: AMD64 Ubuntu 22.04 Java JDK 17 Maven 3.9.4
+          maven: 3.9.4
           image: eclipse-java
-        - jdk: 20
-          title: AMD64 Ubuntu 22.04 Java JDK 20 Maven 3.9.3
-          maven: 3.9.3
+        - jdk: 21
+          title: AMD64 Ubuntu 22.04 Java JDK 21 Maven 3.9.4
+          maven: 3.9.4
           image: eclipse-java
     env:
       JDK: ${{ matrix.jdk }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 11, 17, 20]
+        jdk: [8, 11, 17, 21]
         include:
         - jdk: 8
           title: AMD64 Debian 9 Java JDK 8 Maven 3.5.4

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -565,11 +565,7 @@ maybe_setup_nodejs() {
 test_package_java() {
   show_header "Build and test Java libraries"
 
-  # Build and test Java (Requires newer Maven -- I used 3.3.9)
-  # Pin OpenJDK 17 since OpenJDK 20 is incompatible with our versions
-  # of things like Mockito, and we also can't update Mockito due to
-  # not supporting Java 8 anymore
-  maybe_setup_conda maven openjdk=17.0.3 || exit 1
+  maybe_setup_conda maven openjdk || exit 1
 
   pushd java
   if [ ${TEST_JAVA} -gt 0 ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1698,8 +1698,8 @@ services:
     #   docker-compose build eclipse-java
     #   docker-compose run eclipse-java
     # Parameters:
-    #   MAVEN: 3.9.3
-    #   JDK: 17, 20
+    #   MAVEN: 3.9.4
+    #   JDK: 17, 21
     image: ${ARCH}/maven:${MAVEN}-eclipse-temurin-${JDK}
     shm_size: *shm-size
     volumes: *java-volumes

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -30,7 +30,7 @@ Java Compatibility
 ==================
 
 Java modules are compatible with JDK 8 and above.
-Currently, JDK 8, 11, 17, and 18 are tested in CI.
+Currently, JDK 8, 11, 17, and 21 are tested in CI.
 
 When using Java 9 or later, some JDK internals must be exposed by
 adding ``--add-opens=java.base/java.nio=ALL-UNNAMED`` to the ``java`` command:

--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -107,14 +107,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.core.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.inline.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -68,14 +68,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.core.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>4.11.0</version>
+            <version>${mockito.inline.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -52,4 +52,17 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>pin-mockito-jdk8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <mockito.core.version>4.11.0</mockito.core.version>
+                <mockito.inline.version>4.11.0</mockito.inline.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,8 +44,10 @@
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
-    <error_prone_core.version>2.16</error_prone_core.version>
+    <error_prone_core.version>2.22.0</error_prone_core.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <mockito.core.version>5.5.0</mockito.core.version>
+    <mockito.inline.version>5.2.0</mockito.inline.version>
   </properties>
 
   <scm>

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -112,13 +112,14 @@ public class DictionaryEncoder {
    * @param valueCount dictionary vector valueCount.
    * @return index type.
    */
+  @SuppressWarnings("ComparisonOutOfRange")
   public static ArrowType.Int getIndexType(int valueCount) {
     Preconditions.checkArgument(valueCount >= 0);
     if (valueCount <= Byte.MAX_VALUE) {
       return new ArrowType.Int(8, true);
     } else if (valueCount <= Character.MAX_VALUE) {
       return new ArrowType.Int(16, true);
-    } else if (valueCount <= Integer.MAX_VALUE) {
+    } else if (valueCount <= Integer.MAX_VALUE) { //this comparison will always evaluate to true
       return new ArrowType.Int(32, true);
     } else {
       return new ArrowType.Int(64, true);


### PR DESCRIPTION
### Rationale for this change

Verify JDK 21 in CI in time for the Arrow v14 release.

### What changes are included in this PR?

* Bump latest Java version from 20 -> 21 in CI

### Are these changes tested?

Yes, via CI.

### Are there any user-facing changes?

No.
* Closes: #36994