### PR TITLE
GH-38200: [CI][Release][Go] Ensure removing all module caches

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -880,8 +880,6 @@ test_go() {
     go test ./...
   fi
   go install -buildvcs=false ./...
-  go clean -modcache
-
   if [ ${TEST_INTEGRATION_GO} -gt 0 ]; then
     pushd arrow/internal/cdata_integration
     case "$(uname)" in
@@ -898,7 +896,7 @@ test_go() {
     go build -buildvcs=false -tags cdata_integration,assert -buildmode=c-shared -o ${go_lib} .
     popd
   fi
-
+  go clean -modcache
   popd
 }
 
@@ -1204,7 +1202,7 @@ BUILD_JS=$((${TEST_JS} + ${TEST_INTEGRATION_JS}))
 BUILD_GO=$((${TEST_GO} + ${TEST_INTEGRATION_GO}))
 TEST_INTEGRATION=$((${TEST_INTEGRATION} + ${TEST_INTEGRATION_CPP} + ${TEST_INTEGRATION_JAVA} + ${TEST_INTEGRATION_JS} + ${TEST_INTEGRATION_GO}))
 
-# Execute tests in a conda enviroment
+# Execute tests in a conda environment
 : ${USE_CONDA:=0}
 
 # Build options for the C++ library


### PR DESCRIPTION
### Rationale for this change

Module caches don't have write permission by owner. So we can remove them by `rm -rf`.

### What changes are included in this PR?

Run `go clean -modcache` after all builds.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38200