### PR TITLE
GH-38228: [R] Fence examples that need dataset with `examplesIf`

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -412,7 +412,7 @@ CsvTableReader$create <- function(file,
 #'      - column names are read (unless `column_names` is set);
 #'      - `skip_rows_after_names` is applied (if non-zero).
 #'
-#' @examples
+#' @examplesIf arrow_with_dataset()
 #' tf <- tempfile()
 #' on.exit(unlink(tf))
 #' writeLines("my file has a non-data header\nx\n1\n2", tf)
@@ -672,7 +672,7 @@ readr_to_csv_read_options <- function(skip = 0, col_names = TRUE) {
 #'    and LF (`0x0a`) characters?
 #' @param ignore_empty_lines Logical: should empty lines be ignored (default) or
 #'    generate a row of missing values (if `FALSE`)?
-#' @examples
+#' @examplesIf arrow_with_dataset()
 #' tf <- tempfile()
 #' on.exit(unlink(tf))
 #' writeLines("x\n1\n\n2", tf)
@@ -780,7 +780,7 @@ TimestampParser$create <- function(format = NULL) {
 #'    (c) a list of [TimestampParser] objects.
 #' @param decimal_point Character to use for decimal point in floating point numbers.
 #'
-#' @examples
+#' @examplesIf arrow_with_dataset()
 #' tf <- tempfile()
 #' on.exit(unlink(tf))
 #' writeLines("x\n1\nNULL\n2\nNA", tf)

--- a/r/man/arrow-package.Rd
+++ b/r/man/arrow-package.Rd
@@ -29,6 +29,7 @@ Authors:
   \item Jonathan Keane \email{jkeane@gmail.com}
   \item Dragoș Moldovan-Grünfeld \email{dragos.mold@gmail.com}
   \item Jeroen Ooms \email{jeroen@berkeley.edu}
+  \item Jacob Wujciak-Jens \email{jacob@wujciak.de}
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
 }
 

--- a/r/man/csv_convert_options.Rd
+++ b/r/man/csv_convert_options.Rd
@@ -64,9 +64,11 @@ starting from the beginning of this vector. Possible values are
 CSV Convert Options
 }
 \examples{
+\dontshow{if (arrow_with_dataset()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 tf <- tempfile()
 on.exit(unlink(tf))
 writeLines("x\n1\nNULL\n2\nNA", tf)
 read_csv_arrow(tf, convert_options = csv_convert_options(null_values = c("", "NA", "NULL")))
 open_csv_dataset(tf, convert_options = csv_convert_options(null_values = c("", "NA", "NULL")))
+\dontshow{\}) # examplesIf}
 }

--- a/r/man/csv_parse_options.Rd
+++ b/r/man/csv_parse_options.Rd
@@ -38,9 +38,11 @@ generate a row of missing values (if \code{FALSE})?}
 CSV Parsing Options
 }
 \examples{
+\dontshow{if (arrow_with_dataset()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 tf <- tempfile()
 on.exit(unlink(tf))
 writeLines("x\n1\n\n2", tf)
 read_csv_arrow(tf, parse_options = csv_parse_options(ignore_empty_lines = FALSE))
 open_csv_dataset(tf, parse_options = csv_parse_options(ignore_empty_lines = FALSE))
+\dontshow{\}) # examplesIf}
 }

--- a/r/man/csv_read_options.Rd
+++ b/r/man/csv_read_options.Rd
@@ -43,9 +43,11 @@ The order of application is as follows:
 CSV Reading Options
 }
 \examples{
+\dontshow{if (arrow_with_dataset()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 tf <- tempfile()
 on.exit(unlink(tf))
 writeLines("my file has a non-data header\nx\n1\n2", tf)
 read_csv_arrow(tf, read_options = csv_read_options(skip_rows = 1))
 open_csv_dataset(tf, read_options = csv_read_options(skip_rows = 1))
+\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
### Rationale for this change

The minimal nightly build are failing with examples that won't run without the dataset feature

### What changes are included in this PR?

- Added `examplesIf` where needed
- Redocumented

### Are these changes tested?

Yes, by all R CMD check jobs

### Are there any user-facing changes?

No
* Closes: #38228