### PR TITLE
GH-38226: [R] Remove R 3.5 from test-r-versions

### DIFF
--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -30,8 +30,6 @@ jobs:
         r_version:
           # We test devel, release, and oldrel in regular CI.
           # This is for older versions
-          # glue depends on R >= 3.4, and vctrs depends on glue
-          - "3.5"
           - "3.6"
           - "4.0"
           - "4.1"


### PR DESCRIPTION

### Rationale for this change

The test-r-versions job is failing because not all of our dependencies support R 3.5. We follow the tidyverse support policy where possible, which means we only support R 3.6 and above. Thus, we can drop the test for R 3.5.

### What changes are included in this PR?

R 3.5 was removed from the test matrix for test-r-versions

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #38226