### PR TITLE
GH-38210: [C++][FlightRPC] Add missing app_metadata arguments

### DIFF
--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -215,7 +215,7 @@ class MiddlewareServer : public FlightServerBase {
       // Return a fake location - the test doesn't read it
       ARROW_ASSIGN_OR_RAISE(auto location, Location::ForGrpcTcp("localhost", 10010));
       std::vector<FlightEndpoint> endpoints{
-          FlightEndpoint{{"foo"}, {location}, std::nullopt}};
+          FlightEndpoint{{"foo"}, {location}, std::nullopt, ""}};
       ARROW_ASSIGN_OR_RAISE(
           auto info, FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false));
       *result = std::make_unique<FlightInfo>(info);
@@ -296,13 +296,13 @@ class OrderedServer : public FlightServerBase {
     auto schema = BuildSchema();
     std::vector<FlightEndpoint> endpoints;
     if (ordered) {
-      endpoints.push_back(FlightEndpoint{{"1"}, {}, std::nullopt});
-      endpoints.push_back(FlightEndpoint{{"2"}, {}, std::nullopt});
-      endpoints.push_back(FlightEndpoint{{"3"}, {}, std::nullopt});
+      endpoints.push_back(FlightEndpoint{{"1"}, {}, std::nullopt, ""});
+      endpoints.push_back(FlightEndpoint{{"2"}, {}, std::nullopt, ""});
+      endpoints.push_back(FlightEndpoint{{"3"}, {}, std::nullopt, ""});
     } else {
-      endpoints.push_back(FlightEndpoint{{"1"}, {}, std::nullopt});
-      endpoints.push_back(FlightEndpoint{{"3"}, {}, std::nullopt});
-      endpoints.push_back(FlightEndpoint{{"2"}, {}, std::nullopt});
+      endpoints.push_back(FlightEndpoint{{"1"}, {}, std::nullopt, ""});
+      endpoints.push_back(FlightEndpoint{{"3"}, {}, std::nullopt, ""});
+      endpoints.push_back(FlightEndpoint{{"2"}, {}, std::nullopt, ""});
     }
     ARROW_ASSIGN_OR_RAISE(
         auto info, FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, ordered));
@@ -557,7 +557,7 @@ class ExpirationTimeServer : public FlightServerBase {
   void AddEndpoint(std::vector<FlightEndpoint>& endpoints, std::string ticket,
                    std::optional<Timestamp> expiration_time) {
     endpoints.push_back(FlightEndpoint{
-        {std::to_string(statuses_.size()) + ": " + ticket}, {}, expiration_time});
+        {std::to_string(statuses_.size()) + ": " + ticket}, {}, expiration_time, ""});
     statuses_.emplace_back(expiration_time);
   }
 
@@ -754,7 +754,7 @@ class PollFlightInfoServer : public FlightServerBase {
                         std::unique_ptr<PollInfo>* result) override {
     auto schema = arrow::schema({arrow::field("number", arrow::uint32(), false)});
     std::vector<FlightEndpoint> endpoints = {
-        FlightEndpoint{{"long-running query"}, {}, std::nullopt}};
+        FlightEndpoint{{"long-running query"}, {}, std::nullopt, ""}};
     ARROW_ASSIGN_OR_RAISE(
         auto info, FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false));
     if (descriptor == FlightDescriptor::Command("poll")) {
@@ -983,7 +983,7 @@ class FlightSqlScenarioServer : public sql::FlightSqlServerBase {
       schema = GetQueryWithTransactionSchema().get();
     }
     ARROW_ASSIGN_OR_RAISE(auto handle, sql::CreateStatementQueryTicket(ticket));
-    std::vector<FlightEndpoint> endpoints{FlightEndpoint{{handle}, {}, std::nullopt}};
+    std::vector<FlightEndpoint> endpoints{FlightEndpoint{{handle}, {}, std::nullopt, ""}};
     ARROW_ASSIGN_OR_RAISE(
         auto result, FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false));
     return std::make_unique<FlightInfo>(result);
@@ -1008,7 +1008,7 @@ class FlightSqlScenarioServer : public sql::FlightSqlServerBase {
       schema = GetQueryWithTransactionSchema().get();
     }
     ARROW_ASSIGN_OR_RAISE(auto handle, sql::CreateStatementQueryTicket(ticket));
-    std::vector<FlightEndpoint> endpoints{FlightEndpoint{{handle}, {}, std::nullopt}};
+    std::vector<FlightEndpoint> endpoints{FlightEndpoint{{handle}, {}, std::nullopt, ""}};
     ARROW_ASSIGN_OR_RAISE(
         auto result, FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false));
     return std::make_unique<FlightInfo>(result);
@@ -1452,7 +1452,7 @@ class FlightSqlScenarioServer : public sql::FlightSqlServerBase {
   arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoForCommand(
       const FlightDescriptor& descriptor, const std::shared_ptr<Schema>& schema) {
     std::vector<FlightEndpoint> endpoints{
-        FlightEndpoint{{descriptor.cmd}, {}, std::nullopt}};
+        FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, ""}};
     ARROW_ASSIGN_OR_RAISE(auto result,
                           FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false))
 

--- a/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration_server.cc
@@ -89,7 +89,7 @@ class FlightIntegrationTestServer : public FlightServerBase {
 
       ARROW_ASSIGN_OR_RAISE(auto server_location,
                             Location::ForGrpcTcp("127.0.0.1", port()));
-      FlightEndpoint endpoint1({{request.path[0]}, {server_location}, std::nullopt});
+      FlightEndpoint endpoint1({{request.path[0]}, {server_location}, std::nullopt, ""});
 
       FlightInfo::Data flight_data;
       RETURN_NOT_OK(internal::SchemaToString(*flight.schema, &flight_data.schema));

--- a/cpp/src/arrow/flight/sql/example/acero_server.cc
+++ b/cpp/src/arrow/flight/sql/example/acero_server.cc
@@ -166,7 +166,7 @@ class AceroFlightSqlServer : public FlightSqlServerBase {
       const std::string& plan, const FlightDescriptor& descriptor, const Schema& schema) {
     ARROW_ASSIGN_OR_RAISE(auto ticket, CreateStatementQueryTicket(plan));
     std::vector<FlightEndpoint> endpoints{FlightEndpoint{
-        Ticket{std::move(ticket)}, /*locations=*/{}, /*expiration_time=*/std::nullopt}};
+        Ticket{std::move(ticket)}, /*locations=*/{}, /*expiration_time=*/std::nullopt, ""}};
     ARROW_ASSIGN_OR_RAISE(
         auto info,
         FlightInfo::Make(schema, descriptor, std::move(endpoints),

--- a/cpp/src/arrow/flight/sql/example/acero_server.cc
+++ b/cpp/src/arrow/flight/sql/example/acero_server.cc
@@ -165,8 +165,9 @@ class AceroFlightSqlServer : public FlightSqlServerBase {
   arrow::Result<std::unique_ptr<FlightInfo>> MakeFlightInfo(
       const std::string& plan, const FlightDescriptor& descriptor, const Schema& schema) {
     ARROW_ASSIGN_OR_RAISE(auto ticket, CreateStatementQueryTicket(plan));
-    std::vector<FlightEndpoint> endpoints{FlightEndpoint{
-        Ticket{std::move(ticket)}, /*locations=*/{}, /*expiration_time=*/std::nullopt, ""}};
+    std::vector<FlightEndpoint> endpoints{
+        FlightEndpoint{Ticket{std::move(ticket)}, /*locations=*/{},
+                       /*expiration_time=*/std::nullopt, ""}};
     ARROW_ASSIGN_OR_RAISE(
         auto info,
         FlightInfo::Make(schema, descriptor, std::move(endpoints),

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -126,8 +126,7 @@ arrow::Result<std::unique_ptr<FlightDataStream>> DoGetSQLiteQuery(
 arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoForCommand(
     const FlightDescriptor& descriptor, const std::shared_ptr<Schema>& schema) {
   std::vector<FlightEndpoint> endpoints{
-      FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, ""}
-  };
+      FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, ""}};
   ARROW_ASSIGN_OR_RAISE(auto result,
                         FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false))
 

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -126,7 +126,8 @@ arrow::Result<std::unique_ptr<FlightDataStream>> DoGetSQLiteQuery(
 arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoForCommand(
     const FlightDescriptor& descriptor, const std::shared_ptr<Schema>& schema) {
   std::vector<FlightEndpoint> endpoints{
-      FlightEndpoint{{descriptor.cmd}, {}, std::nullopt}};
+      FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, ""}
+  };
   ARROW_ASSIGN_OR_RAISE(auto result,
                         FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false))
 
@@ -305,7 +306,7 @@ class SQLiteFlightSqlServer::Impl {
     ARROW_ASSIGN_OR_RAISE(auto ticket,
                           EncodeTransactionQuery(query, command.transaction_id));
     std::vector<FlightEndpoint> endpoints{
-        FlightEndpoint{std::move(ticket), {}, std::nullopt}};
+        FlightEndpoint{std::move(ticket), {}, std::nullopt, ""}};
     // TODO: Set true only when "ORDER BY" is used in a main "SELECT"
     // in the given query.
     const bool ordered = false;
@@ -389,7 +390,7 @@ class SQLiteFlightSqlServer::Impl {
       const ServerCallContext& context, const GetTables& command,
       const FlightDescriptor& descriptor) {
     std::vector<FlightEndpoint> endpoints{
-        FlightEndpoint{{descriptor.cmd}, {}, std::nullopt}};
+        FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, ""}};
 
     bool include_schema = command.include_schema;
     ARROW_LOG(INFO) << "GetTables include_schema=" << include_schema;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

I have fixed the error occurring when using the "DARROW_FLIGHT_SQL=ON" option on a Mac with ARM Architecture CPU.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

It seems that implicit values are not recognized in this environment (Mac ARM), so I have added values explicitly.

### Are these changes tested?

yes (build and run unit test)

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38210