### PR TITLE
GH-38227: [R] Fix non-unicode character errors in nightly builds

### DIFF
--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update -y && \
         libxml2-dev \
         libgit2-dev \
         libssl-dev \
+        # R CMD CHECK --as-cran needs pdflatex to build the package manual
+        texlive-latex-base \
         # Need locales so we can set UTF-8
         locales \
         # Need Python to check py-to-r bridge
@@ -56,10 +58,6 @@ RUN apt-get update -y && \
     locale-gen en_US.UTF-8 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# Install TinyTex:
-# R CMD CHECK --as-cran needs pdflatex to build the package manual
-RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
 
 ARG gcc_version=""
 RUN if [ "${gcc_version}" != "" ]; then \

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -57,7 +57,8 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install TinyTex
+# Install TinyTex:
+# R CMD CHECK --as-cran needs pdflatex to build the package manual
 RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
 
 ARG gcc_version=""

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -47,8 +47,6 @@ RUN apt-get update -y && \
         libxml2-dev \
         libgit2-dev \
         libssl-dev \
-        # R CMD CHECK --as-cran needs pdflatex to build the package manual
-        texlive-latex-base \
         # Need locales so we can set UTF-8
         locales \
         # Need Python to check py-to-r bridge
@@ -58,6 +56,9 @@ RUN apt-get update -y && \
     locale-gen en_US.UTF-8 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Install TinyTex
+RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
 
 ARG gcc_version=""
 RUN if [ "${gcc_version}" != "" ]; then \

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+
 ARG gcc_version=""
 RUN if [ "${gcc_version}" != "" ]; then \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-
 ARG gcc_version=""
 RUN if [ "${gcc_version}" != "" ]; then \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \

--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -22,8 +22,8 @@
 #' `readr::read_delim()`, and `col_select` was inspired by `vroom::vroom()`.
 #'
 #' `read_csv_arrow()` and `read_tsv_arrow()` are wrappers around
-#' `read_delim_arrow()` that specify a delimiter. `read_csv2_arrow()` uses `;`⁠ for
-#' the delimiter and `,` for the decimal point.
+#' `read_delim_arrow()` that specify a delimeter. `read_csv2_arrow()` uses `;` for
+#' the delimeter and `.` for the decimal point.
 #'
 #' Note that not all `readr` options are currently implemented here. Please file
 #' an issue if you encounter one that `arrow` should support.

--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -23,7 +23,7 @@
 #'
 #' `read_csv_arrow()` and `read_tsv_arrow()` are wrappers around
 #' `read_delim_arrow()` that specify a delimeter. `read_csv2_arrow()` uses `;` for
-#' the delimeter and `.` for the decimal point.
+#' the delimeter and `,` for the decimal point.
 #'
 #' Note that not all `readr` options are currently implemented here. Please file
 #' an issue if you encounter one that `arrow` should support.

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -175,7 +175,7 @@ Arrow C++ options have been mapped to argument names that follow those of
 \details{
 \code{read_csv_arrow()} and \code{read_tsv_arrow()} are wrappers around
 \code{read_delim_arrow()} that specify a delimeter. \code{read_csv2_arrow()} uses \verb{;} for
-the delimeter and \code{.} for the decimal point.
+the delimeter and \verb{,} for the decimal point.
 
 Note that not all \code{readr} options are currently implemented here. Please file
 an issue if you encounter one that \code{arrow} should support.

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -174,8 +174,8 @@ Arrow C++ options have been mapped to argument names that follow those of
 }
 \details{
 \code{read_csv_arrow()} and \code{read_tsv_arrow()} are wrappers around
-\code{read_delim_arrow()} that specify a delimiter. \code{read_csv2_arrow()} uses \verb{;}⁠ for
-the delimiter and \verb{,} for the decimal point.
+\code{read_delim_arrow()} that specify a delimeter. \code{read_csv2_arrow()} uses \verb{;} for
+the delimeter and \code{.} for the decimal point.
 
 Note that not all \code{readr} options are currently implemented here. Please file
 an issue if you encounter one that \code{arrow} should support.


### PR DESCRIPTION

### Rationale for this change

We have several nightly builds failing with errors building the manual as a result of unicode characters. The unicode characters aren't new, so I'm not sure why this happened now.

### What changes are included in this PR?

Install a distribution of latex that supports unicode characters (maybe)?

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #38227