### PR TITLE
GH-37072: [C++] MakeArrayOfNulls should respect Field::nullable

### DIFF
--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -475,9 +475,7 @@ TEST_P(TestRunEndEncodedArray, Validate) {
   BitmapFromVector<bool>({true, false}, &null_bitmap);
   has_null_buffer->data()->buffers[0] = null_bitmap;
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid,
-      ::testing::HasSubstr(
-          std::string("Invalid: Run end encoded array should not have a null bitmap.")),
+      Invalid, ::testing::HasSubstr(std::string("should not have a null bitmap")),
       has_null_buffer->Validate());
 
   auto too_many_children = MakeArray(good_array->data()->Copy());
@@ -503,7 +501,7 @@ TEST_P(TestRunEndEncodedArray, Validate) {
       values_nullptr->Validate());
 
   auto run_ends_string = MakeArray(good_array->data()->Copy());
-  run_ends_string->data()->child_data[0] = values->data();
+  run_ends_string->data()->child_data[0] = MakeEmptyArray(utf8()).ValueOrDie()->data();
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       Invalid,
       ::testing::HasSubstr(
@@ -529,10 +527,9 @@ TEST_P(TestRunEndEncodedArray, Validate) {
     malformed_array->data()->buffers.emplace_back(NULLPTR);
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid,
-        ::testing::HasSubstr(
-            std::string(
-                "Invalid: Run ends array invalid: Expected 2 buffers in array of type ") +
-            run_end_type->ToString() + ", got 3"),
+        ::testing::HasSubstr(std::string("Invalid: Run ends array invalid: Invalid: "
+                                         "Expected 2 buffers in array of type ") +
+                             run_end_type->ToString() + ", got 3"),
         run_ends_malformed->Validate());
   }
 
@@ -543,8 +540,9 @@ TEST_P(TestRunEndEncodedArray, Validate) {
     malformed_array->data()->buffers.emplace_back(NULLPTR);
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid,
-        ::testing::HasSubstr("Invalid: Values array invalid: Expected 2 buffers in array "
-                             "of type int32, got 3"),
+        ::testing::HasSubstr(
+            "Invalid: Values array invalid: Invalid: Expected 2 buffers in array "
+            "of type int32, got 3"),
         values_malformed->Validate());
   }
 

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -387,7 +387,7 @@ class NullArrayFactory {
   // - buffers = []
   // - child_data = [nullptr] * type.num_fields()
   // - dictionary = nullptr
-  bool presizing_zero_buffer_;
+  const bool presizing_zero_buffer_;
 
   NullArrayFactory(const std::shared_ptr<DataType>& type, bool nullable, int64_t length)
       : presizing_zero_buffer_{true},
@@ -534,8 +534,8 @@ class NullArrayFactory {
     for (auto [field, id] : Zip(type.fields(), type.type_codes())) {
       if (field->nullable()) return id;
     }
-    return Status::Invalid("Cannot produce an array of null ", type,
-                           " because no child field is nullable");
+    return Status::TypeError("Cannot produce an array of null ", type,
+                             " because no child field is nullable");
   }
 
   Status Visit(const UnionType& type) {
@@ -576,6 +576,7 @@ class NullArrayFactory {
     }
 
     if (type.mode() == UnionMode::DENSE) {
+      // offsets
       out_->buffers.push_back(*zero_buffer_);
     }
 
@@ -613,8 +614,8 @@ class NullArrayFactory {
 
     out_->buffers = {nullptr};
     if (!type.field(1)->nullable()) {
-      return Status::Invalid("Cannot produce an array of null ", type,
-                             " because the values field is not nullable");
+      return Status::TypeError("Cannot produce an array of null ", type,
+                               " because the values field is not nullable");
     }
 
     std::shared_ptr<Array> run_ends, values;

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -476,7 +476,11 @@ class NullArrayFactory {
   }
 
   Status Visit(const BinaryViewType&) {
-    out_->buffers.resize(2, *zero_buffer_);
+    if (presizing_zero_buffer_) {
+      ZeroBufferMustBeAtLeast(sizeof(BinaryViewType::c_type) * length_);
+      return Status::OK();
+    }
+    out_->buffers = {GetValidityBitmap(), *zero_buffer_};
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -581,15 +581,15 @@ struct ValidateArrayImpl {
 
     if (HasValidityBitmap(data.type->id()) && data.buffers[0]) {
       // Do not call GetNullCount() as it would also set the `null_count` member
-      return null_count = data.length -
-                          CountSetBits(data.buffers[0]->data(), data.offset, data.length);
+      null_count =
+          data.length - CountSetBits(data.buffers[0]->data(), data.offset, data.length);
+    } else if (data.type->storage_id() == Type::NA) {
+      null_count = data.length;
+    } else {
+      null_count = 0;
     }
 
-    if (data.type->storage_id() == Type::NA) {
-      return null_count = data.length;
-    }
-
-    return null_count = 0;
+    return null_count;
   }
 
   Status ValidateFixedWidthBuffers() {

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -293,7 +293,7 @@ struct ValidateArrayImpl {
   Status Visit(const StructType& type) {
     for (int i = 0; i < type.num_fields(); ++i) {
       // Validate child first, to catch nonsensical length / offset etc.
-      RETURN_NOT_OK(RecurseIntoField(0, "Struct child array #", i));
+      RETURN_NOT_OK(RecurseIntoField(i, "Struct child array #", i));
 
       const auto& field_data = *data.child_data[i];
       if (field_data.length < data.length + data.offset) {
@@ -440,7 +440,7 @@ struct ValidateArrayImpl {
   Status RecurseIntoField(int field_index, const FieldDescription&... description) {
     const auto& related_data = *data.child_data[field_index];
 
-    if (!data.type->storage_type_ref().field(field_index)->nullable()) {
+    if (!data.type->storage_type()->field(field_index)->nullable()) {
       if (related_data.null_count != 0 && related_data.null_count != kUnknownNullCount) {
         return Status::Invalid(description...,
                                " invalid: was non-nullable but had null count ",

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -759,14 +759,9 @@ struct ValidateArrayImpl {
 
   template <typename ListViewType>
   Status ValidateListView(const ListViewType& type) {
-    const ArrayData& values = *data.child_data[0];
-    const Status child_valid = RecurseInto(values);
-    if (!child_valid.ok()) {
-      return Status::Invalid("List-view child array is invalid: ",
-                             child_valid.ToString());
-    }
+    RETURN_NOT_OK(RecurseIntoField(0, "List-view child array"));
     // For list-views, sizes are validated together with offsets.
-    return ValidateOffsetsAndSizes(type, /*offset_limit=*/values.length);
+    return ValidateOffsetsAndSizes(type, /*offset_limit=*/data.child_data[0]->length);
   }
 
   template <typename RunEndCType>

--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -43,10 +43,7 @@ class ARROW_EXPORT ExtensionType : public DataType {
   static constexpr const char* type_name() { return "extension"; }
 
   /// \brief The type of array used to represent this extension type's data
-  const std::shared_ptr<DataType>& storage_type() const { return storage_type_; }
-
-  /// \brief Return a reference to the storage type
-  const DataType& storage_type_ref() const override { return *storage_type_; }
+  std::shared_ptr<DataType> storage_type() const override { return storage_type_; }
 
   /// \brief Return the type category of the storage type
   Type::type storage_id() const override { return storage_type_->id(); }

--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -45,6 +45,9 @@ class ARROW_EXPORT ExtensionType : public DataType {
   /// \brief The type of array used to represent this extension type's data
   const std::shared_ptr<DataType>& storage_type() const { return storage_type_; }
 
+  /// \brief Return a reference to the storage type
+  const DataType& storage_type_ref() const override { return *storage_type_; }
+
   /// \brief Return the type category of the storage type
   Type::type storage_id() const override { return storage_type_->id(); }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -886,7 +886,7 @@ std::string Field::ToString(bool show_metadata) const {
 
 void PrintTo(const Field& field, std::ostream* os) { *os << field.ToString(); }
 
-DataType::~DataType() {}
+DataType::~DataType() = default;
 
 bool DataType::Equals(const DataType& other, bool check_metadata) const {
   return TypeEquals(*this, other, check_metadata);

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -186,6 +186,9 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
   /// \brief Return a reference to the storage type
   virtual const DataType& storage_type_ref() const { return *this; }
 
+  /// \brief Return the storage type
+  virtual std::shared_ptr<DataType> storage_type() const { return GetSharedPtr(); }
+
   /// \brief Returns the type's fixed byte width, if any. Returns -1
   /// for non-fixed-width types, and should only be used for
   /// subclasses of FixedWidthType

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -183,6 +183,9 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
   /// \brief Return the type category of the storage type
   virtual Type::type storage_id() const { return id_; }
 
+  /// \brief Return a reference to the storage type
+  virtual const DataType& storage_type_ref() const { return *this; }
+
   /// \brief Returns the type's fixed byte width, if any. Returns -1
   /// for non-fixed-width types, and should only be used for
   /// subclasses of FixedWidthType

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -183,9 +183,6 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
   /// \brief Return the type category of the storage type
   virtual Type::type storage_id() const { return id_; }
 
-  /// \brief Return a reference to the storage type
-  virtual const DataType& storage_type_ref() const { return *this; }
-
   /// \brief Return the storage type
   virtual std::shared_ptr<DataType> storage_type() const { return GetSharedPtr(); }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

MakeArrayOfNulls didn't examine Field::nullable, so it could produce nested arrays whose children were null even if the schema said they couldn't have nulls. Additionally validation didn't look at Field::nullable so these malformed arrays don't fail tests.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, mostly by fixtures already in place.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

### Behavior

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**This PR includes breaking changes to public APIs.**

The `Field::nullable` flag is now enforce in array validation, so now (for example) an array with nulls which corresponds to a non nullable field will fail validation.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37072