### PR TITLE
GH-38255: [Format] Add Flight SQL Command for Bulk Ingestion

### DIFF
--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1822,7 +1822,7 @@ message CommandStatementIngest {
   // Use a temporary table.
   optional bool temporary = 5;
   // Perform the ingestion as part of this transaction (if unset, the query is auto-committed).
-  optional bool transaction_id = 6;
+  optional bytes transaction_id = 6;
 
   // Future extensions to the parameters of CommandStatementIngest should be added here, at a lower index than the generic 'options' parameter.
 

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1823,6 +1823,9 @@ message CommandStatementIngest {
   optional bool temporary = 5;
   // Perform the ingestion as part of this transaction (if unset, the query is auto-committed).
   optional bool transaction_id = 6;
+
+  // Future extensions to the parameters of CommandStatementIngest should be added here, at a lower index than the generic 'options' parameter.
+
   // Backend-specific options.
   map<string, string> options = 1000;
 }

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -817,6 +817,17 @@ enum SqlInfo {
    * - true: if invoking user-defined or vendor functions using the stored procedure escape syntax is supported.
    */
   SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED = 576;
+
+  /*
+   * Retrieves a boolean value indicating whether transactions are supported for bulk ingestion. If not, invoking
+   * the method commit in the context of a bulk ingestion is a noop, and the isolation level is
+   * `arrow.flight.protocol.sql.SqlTransactionIsolationLevel.TRANSACTION_NONE`.
+   *
+   * Returns:
+   * - false: if bulk ingestion transactions are unsupported;
+   * - true: if bulk ingestion transactions are supported.
+   */
+   INGEST_TRANSACTIONS_SUPPORTED = 577;
 }
 
 // The level of support for Flight SQL transaction RPCs.
@@ -1776,6 +1787,44 @@ message CommandPreparedStatementUpdate {
 
   // Opaque handle for the prepared statement on the server.
   bytes prepared_statement_handle = 1;
+}
+
+  /*
+   * Represents a bulk ingestion request. Used in the command member of FlightDescriptor
+   * for the the RPC call DoPut to cause the server load the contents of the stream's
+   * FlightData into the target destination.
+   */
+message CommandStatementIngest {
+  option (experimental) = true;
+
+  // Describes the behavior for loading bulk data.
+  enum IngestMode {
+    // Ingestion behavior unspecified.
+    INGEST_MODE_UNSPECIFIED = 0;
+    // Create the target table. Fail if the target table already exists.
+    INGEST_MODE_CREATE = 1;
+    // Append to an existing target table. Fail if the target table does not exist.
+    INGEST_MODE_APPEND = 2;
+    // Drop the target table if it exists. Then follow INGEST_MODE_CREATE behavior.
+    INGEST_MODE_REPLACE = 3;
+    // Create the target table if it does not exist. Then follow INGEST_MODE_APPEND behavior.
+    INGEST_MODE_CREATE_APPEND = 4;
+  }
+
+  // The ingestion behavior.
+  IngestMode mode = 1;
+  // The table to load data into.
+  string target_table = 2;
+  // The db_schema of the target_table to load data into. If unset, ... (TODO)
+  optional string target_schema = 3;
+  // The catalog of the target_table to load data into. If unset, ... (TODO)
+  optional string target_catalog = 4;
+  // Use a temporary table for target_table.
+  optional bool temporary = 5;
+  // Perform the ingestion as part of this transaction (if unset, the query is auto-committed).
+  optional bool transaction_id = 6;
+  // Backend-specific options.
+  map<string, string> options = 1000;
 }
 
 /*

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1815,9 +1815,9 @@ message CommandStatementIngest {
   IngestMode mode = 1;
   // The table to load data into.
   string target_table = 2;
-  // The db_schema of the target_table to load data into. If unset, ... (TODO)
+  // The db_schema of the target_table to load data into. If unset, a backend-specific default may be used.
   optional string target_schema = 3;
-  // The catalog of the target_table to load data into. If unset, ... (TODO)
+  // The catalog of the target_table to load data into. If unset, a backend-specific default may be used.
   optional string target_catalog = 4;
   // Use a temporary table for target_table.
   optional bool temporary = 5;

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1814,12 +1814,12 @@ message CommandStatementIngest {
   // The ingestion behavior.
   IngestMode mode = 1;
   // The table to load data into.
-  string target_table = 2;
-  // The db_schema of the target_table to load data into. If unset, a backend-specific default may be used.
-  optional string target_schema = 3;
-  // The catalog of the target_table to load data into. If unset, a backend-specific default may be used.
-  optional string target_catalog = 4;
-  // Use a temporary table for target_table.
+  string table = 2;
+  // The db_schema of the destination table to load data into. If unset, a backend-specific default may be used.
+  optional string schema = 3;
+  // The catalog of the destination table to load data into. If unset, a backend-specific default may be used.
+  optional string catalog = 4;
+  // Use a temporary table.
   optional bool temporary = 5;
   // Perform the ingestion as part of this transaction (if unset, the query is auto-committed).
   optional bool transaction_id = 6;


### PR DESCRIPTION
### Rationale for this change
It was suggested in the discussion around [supporting generic ingest](https://github.com/apache/arrow-adbc/issues/1107) for the Flight SQL ADBC driver that an "Ingest" command would be a helpful addition to the Flight SQL specification. This command would enable a Flight SQL client to provide a FlightData stream to the server without needing to know its SQL syntax, and have that stream loaded into a target table by whichever means the server deems appropriate.

### What changes are included in this PR?
- Add `CommandStatementIngest` message type to Flight SQL proto definition
- Add `INGEST_TRANSACTIONS_SUPPORTED` option for `SqlInfo`

### Are these changes tested?
Yes, see implementation PRs:
- Go: #38385
- 2nd impl TBD...

### Are there any user-facing changes?
Yes, a new command is added to the Flight SQL spec.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38255