### PR TITLE
MINOR: [R] Fix spelling of delimiter

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -22,8 +22,8 @@
 #' `readr::read_delim()`, and `col_select` was inspired by `vroom::vroom()`.
 #'
 #' `read_csv_arrow()` and `read_tsv_arrow()` are wrappers around
-#' `read_delim_arrow()` that specify a delimeter. `read_csv2_arrow()` uses `;` for
-#' the delimeter and `,` for the decimal point.
+#' `read_delim_arrow()` that specify a delimiter. `read_csv2_arrow()` uses `;` for
+#' the delimiter and `,` for the decimal point.
 #'
 #' Note that not all `readr` options are currently implemented here. Please file
 #' an issue if you encounter one that `arrow` should support.

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -174,8 +174,8 @@ Arrow C++ options have been mapped to argument names that follow those of
 }
 \details{
 \code{read_csv_arrow()} and \code{read_tsv_arrow()} are wrappers around
-\code{read_delim_arrow()} that specify a delimeter. \code{read_csv2_arrow()} uses \verb{;} for
-the delimeter and \verb{,} for the decimal point.
+\code{read_delim_arrow()} that specify a delimiter. \code{read_csv2_arrow()} uses \verb{;} for
+the delimiter and \verb{,} for the decimal point.
 
 Note that not all \code{readr} options are currently implemented here. Please file
 an issue if you encounter one that \code{arrow} should support.


### PR DESCRIPTION
### Rationale for this change

Fix typo in docs introduced in #38232

### What changes are included in this PR?

Change spelling of "delimeter" to "delimiter"

### Are these changes tested?

No
### Are there any user-facing changes?

Just docs