### PR TITLE
GH-35260: [C++][Python][R] Allow users to adjust S3 log level by environment variable

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -2969,11 +2969,20 @@ AwsInstance* GetAwsInstance() {
   return instance.get();
 }
 
+Result<bool> EnsureAwsInstanceInitialized() {
+  S3LogLevel log_level = GetS3LogLevelFromEnvOrDefault();
+  auto options = S3GlobalOptions{log_level};
+
+  return GetAwsInstance()->EnsureInitialized(options);
+}
+
 Result<bool> EnsureAwsInstanceInitialized(const S3GlobalOptions& options) {
   return GetAwsInstance()->EnsureInitialized(options);
 }
 
 }  // namespace
+
+Status InitializeS3() { return InitializeS3(S3GlobalOptions{S3LogLevel::Fatal}); }
 
 Status InitializeS3(const S3GlobalOptions& options) {
   ARROW_ASSIGN_OR_RAISE(bool successfully_initialized,
@@ -2986,9 +2995,7 @@ Status InitializeS3(const S3GlobalOptions& options) {
   return Status::OK();
 }
 
-Status EnsureS3Initialized() {
-  return EnsureAwsInstanceInitialized({S3LogLevel::Fatal}).status();
-}
+Status EnsureS3Initialized() { return EnsureAwsInstanceInitialized().status(); }
 
 Status FinalizeS3() {
   GetAwsInstance()->Finalize();
@@ -3014,6 +3021,36 @@ Result<std::string> ResolveS3BucketRegion(const std::string& bucket) {
 
   ARROW_ASSIGN_OR_RAISE(auto resolver, RegionResolver::DefaultInstance());
   return resolver->ResolveRegion(bucket);
+}
+
+S3LogLevel GetS3LogLevelFromEnvOrDefault() {
+  auto result = arrow::internal::GetEnvVar("ARROW_S3_LOG_LEVEL");
+
+  if (!result.ok()) {
+    return S3LogLevel::Fatal;
+  }
+
+  // Extract, trim, and downcase the value of the enivronment variable
+  auto value =
+      arrow::internal::AsciiToLower(arrow::internal::TrimString(result.ValueUnsafe()));
+
+  if (value == "fatal") {
+    return S3LogLevel::Fatal;
+  } else if (value == "error") {
+    return S3LogLevel::Error;
+  } else if (value == "warn") {
+    return S3LogLevel::Warn;
+  } else if (value == "info") {
+    return S3LogLevel::Info;
+  } else if (value == "debug") {
+    return S3LogLevel::Debug;
+  } else if (value == "trace") {
+    return S3LogLevel::Trace;
+  } else if (value == "off") {
+    return S3LogLevel::Off;
+  }
+
+  return S3LogLevel::Fatal;
 }
 
 }  // namespace fs

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -2994,7 +2994,7 @@ Status InitializeS3(const S3GlobalOptions& options) {
   return Status::OK();
 }
 
-Status EnsureS3Initialized() { return EnsureAwsInstanceInitialized().status(); }
+Status EnsureS3Initialized() { return EnsureAwsInstanceInitialized(S3GlobalOptions::Defaults()).status(); }
 
 Status FinalizeS3() {
   GetAwsInstance()->Finalize();

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -2986,7 +2986,9 @@ Status InitializeS3(const S3GlobalOptions& options) {
   return Status::OK();
 }
 
-Status EnsureS3Initialized() { return EnsureAwsInstanceInitialized(S3GlobalOptions::Defaults()).status(); }
+Status EnsureS3Initialized() {
+  return EnsureAwsInstanceInitialized(S3GlobalOptions::Defaults()).status();
+}
 
 Status FinalizeS3() {
   GetAwsInstance()->Finalize();

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -2969,19 +2969,11 @@ AwsInstance* GetAwsInstance() {
   return instance.get();
 }
 
-Result<bool> EnsureAwsInstanceInitialized() {
-  auto options = S3GlobalOptions::Defaults();
-
-  return GetAwsInstance()->EnsureInitialized(options);
-}
-
 Result<bool> EnsureAwsInstanceInitialized(const S3GlobalOptions& options) {
   return GetAwsInstance()->EnsureInitialized(options);
 }
 
 }  // namespace
-
-Status InitializeS3() { return InitializeS3(S3GlobalOptions::Defaults()); }
 
 Status InitializeS3(const S3GlobalOptions& options) {
   ARROW_ASSIGN_OR_RAISE(bool successfully_initialized,

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -3002,7 +3002,7 @@ bool IsS3Initialized() { return GetAwsInstance()->IsInitialized(); }
 bool IsS3Finalized() { return GetAwsInstance()->IsFinalized(); }
 
 S3GlobalOptions S3GlobalOptions::Defaults() {
-  S3LogLevel log_level = S3LogLevel::Fatal;
+  auto log_level = S3LogLevel::Fatal;
 
   auto result = arrow::internal::GetEnvVar("ARROW_S3_LOG_LEVEL");
 

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -392,6 +392,7 @@ Result<std::string> ResolveS3BucketRegion(const std::string& bucket);
 /// Tries to get a valid log level name from the environment variable
 /// ARROW_S3_LOG_LEVEL and returns a matching value of S3LogLevel. If it fails
 /// returns S3LogLevel::Fatal.
+ARROW_EXPORT
 S3LogLevel GetS3LogLevelFromEnvOrDefault();
 
 }  // namespace fs

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -348,7 +348,7 @@ Status InitializeS3();
 /// It is required to call this function at least once before using S3FileSystem.
 ///
 /// Once this function is called you MUST call FinalizeS3 before the end of the
-/// application in order to avoid a segmentation fault at shutdown.ARROW_EXPORT
+/// application in order to avoid a segmentation fault at shutdown.
 ARROW_EXPORT
 Status InitializeS3(const S3GlobalOptions& options);
 

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -340,15 +340,6 @@ struct ARROW_EXPORT S3GlobalOptions {
   static S3GlobalOptions Defaults();
 };
 
-/// \brief Initialize the S3 APIs with default options.
-///
-/// It is required to call this function at least once before using S3FileSystem.
-///
-/// Once this function is called you MUST call FinalizeS3 before the end of the
-/// application in order to avoid a segmentation fault at shutdown.
-ARROW_EXPORT
-Status InitializeS3();
-
 /// \brief Initialize the S3 APIs with the specified set of options.
 ///
 /// It is required to call this function at least once before using S3FileSystem.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -334,12 +334,21 @@ struct ARROW_EXPORT S3GlobalOptions {
   int num_event_loop_threads = 1;
 };
 
-/// \brief Initialize the S3 APIs.
+/// \brief Initialize the S3 APIs with default options.
 ///
 /// It is required to call this function at least once before using S3FileSystem.
 ///
 /// Once this function is called you MUST call FinalizeS3 before the end of the
 /// application in order to avoid a segmentation fault at shutdown.
+ARROW_EXPORT
+Status InitializeS3();
+
+/// \brief Initialize the S3 APIs with the specified set of options.
+///
+/// It is required to call this function at least once before using S3FileSystem.
+///
+/// Once this function is called you MUST call FinalizeS3 before the end of the
+/// application in order to avoid a segmentation fault at shutdown.ARROW_EXPORT
 ARROW_EXPORT
 Status InitializeS3(const S3GlobalOptions& options);
 
@@ -377,6 +386,13 @@ Status EnsureS3Finalized();
 
 ARROW_EXPORT
 Result<std::string> ResolveS3BucketRegion(const std::string& bucket);
+
+/// \brief Try to extract the S3LogLevel from environment variable
+///
+/// Tries to get a valid log level name from the environment variable
+/// ARROW_S3_LOG_LEVEL and returns a matching value of S3LogLevel. If it fails
+/// returns S3LogLevel::Fatal.
+S3LogLevel GetS3LogLevelFromEnvOrDefault();
 
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -332,6 +332,12 @@ struct ARROW_EXPORT S3GlobalOptions {
   ///
   /// For more details see Aws::Crt::Io::EventLoopGroup
   int num_event_loop_threads = 1;
+
+  /// \brief Initialize with default options
+  ///
+  /// For log_level, this method first tries to extract a suitable value from the
+  /// environment variable ARROW_S3_LOG_LEVEL.
+  static S3GlobalOptions Defaults();
 };
 
 /// \brief Initialize the S3 APIs with default options.
@@ -386,14 +392,6 @@ Status EnsureS3Finalized();
 
 ARROW_EXPORT
 Result<std::string> ResolveS3BucketRegion(const std::string& bucket);
-
-/// \brief Try to extract the S3LogLevel from environment variable
-///
-/// Tries to get a valid log level name from the environment variable
-/// ARROW_S3_LOG_LEVEL and returns a matching value of S3LogLevel. If it fails
-/// returns S3LogLevel::Fatal.
-ARROW_EXPORT
-S3LogLevel GetS3LogLevelFromEnvOrDefault();
 
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1381,7 +1381,7 @@ class TestS3FSGeneric : public S3TestMixin, public GenericFileSystemTest {
 GENERIC_FS_TEST_FUNCTIONS(TestS3FSGeneric);
 
 ////////////////////////////////////////////////////////////////////////////
-// S3GlobalOptionsDefaults tests
+// S3GlobalOptions::Defaults tests
 
 class S3GlobalOptionsDefaults : public ::testing::Test {};
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1383,9 +1383,7 @@ GENERIC_FS_TEST_FUNCTIONS(TestS3FSGeneric);
 ////////////////////////////////////////////////////////////////////////////
 // S3GlobalOptions::Defaults tests
 
-class S3GlobalOptionsDefaults : public ::testing::Test {};
-
-TEST_F(S3GlobalOptionsDefaults, S3GlobalOptionsDefaultsLogLevel) {
+TEST(S3GlobalOptions, DefaultsLogLevel) {
   // Verify we get the default value of Fatal
   ASSERT_EQ(S3LogLevel::Fatal, arrow::fs::S3GlobalOptions::Defaults().log_level);
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1380,5 +1380,33 @@ class TestS3FSGeneric : public S3TestMixin, public GenericFileSystemTest {
 
 GENERIC_FS_TEST_FUNCTIONS(TestS3FSGeneric);
 
+////////////////////////////////////////////////////////////////////////////
+// GetS3LogLevelFromEnvOrDefault tests
+
+class GetS3LogLevelFromEnvOrDefault : public ::testing::Test {};
+
+TEST_F(GetS3LogLevelFromEnvOrDefault, GetS3LogLevelFromEnvOrDefaultBehavior) {
+  // Verify we get the default value of Fatal
+  ASSERT_EQ(S3LogLevel::Fatal, arrow::fs::GetS3LogLevelFromEnvOrDefault());
+
+  // Verify we get the value specified by env var and not the default
+  {
+    EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "Error");
+    ASSERT_EQ(arrow::fs::GetS3LogLevelFromEnvOrDefault(), S3LogLevel::Error);
+  }
+
+  // Verify we trim and case-insensitively compare the environment variable's value
+  {
+    EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", " eRrOr ");
+    ASSERT_EQ(arrow::fs::GetS3LogLevelFromEnvOrDefault(), S3LogLevel::Error);
+  }
+
+  // Verify we get the default value of Fatal if our env var is invalid
+  {
+    EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "invalid");
+    ASSERT_EQ(arrow::fs::GetS3LogLevelFromEnvOrDefault(), S3LogLevel::Fatal);
+  }
+}
+
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1381,30 +1381,30 @@ class TestS3FSGeneric : public S3TestMixin, public GenericFileSystemTest {
 GENERIC_FS_TEST_FUNCTIONS(TestS3FSGeneric);
 
 ////////////////////////////////////////////////////////////////////////////
-// GetS3LogLevelFromEnvOrDefault tests
+// S3GlobalOptionsDefaults tests
 
-class GetS3LogLevelFromEnvOrDefault : public ::testing::Test {};
+class S3GlobalOptionsDefaults : public ::testing::Test {};
 
-TEST_F(GetS3LogLevelFromEnvOrDefault, GetS3LogLevelFromEnvOrDefaultBehavior) {
+TEST_F(S3GlobalOptionsDefaults, S3GlobalOptionsDefaultsLogLevel) {
   // Verify we get the default value of Fatal
-  ASSERT_EQ(S3LogLevel::Fatal, arrow::fs::GetS3LogLevelFromEnvOrDefault());
+  ASSERT_EQ(S3LogLevel::Fatal, arrow::fs::S3GlobalOptions::Defaults().log_level);
 
   // Verify we get the value specified by env var and not the default
   {
     EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "Error");
-    ASSERT_EQ(S3LogLevel::Error, arrow::fs::GetS3LogLevelFromEnvOrDefault());
+    ASSERT_EQ(S3LogLevel::Error, arrow::fs::S3GlobalOptions::Defaults().log_level);
   }
 
   // Verify we trim and case-insensitively compare the environment variable's value
   {
     EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", " eRrOr ");
-    ASSERT_EQ(arrow::fs::GetS3LogLevelFromEnvOrDefault(), S3LogLevel::Error);
+    ASSERT_EQ(S3LogLevel::Error, arrow::fs::S3GlobalOptions::Defaults().log_level);
   }
 
   // Verify we get the default value of Fatal if our env var is invalid
   {
     EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "invalid");
-    ASSERT_EQ(arrow::fs::GetS3LogLevelFromEnvOrDefault(), S3LogLevel::Fatal);
+    ASSERT_EQ(S3LogLevel::Fatal, arrow::fs::S3GlobalOptions::Defaults().log_level);
   }
 }
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1389,7 +1389,7 @@ TEST(S3GlobalOptions, DefaultsLogLevel) {
 
   // Verify we get the value specified by env var and not the default
   {
-    EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "Error");
+    EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "ERROR");
     ASSERT_EQ(S3LogLevel::Error, arrow::fs::S3GlobalOptions::Defaults().log_level);
   }
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -1392,7 +1392,7 @@ TEST_F(GetS3LogLevelFromEnvOrDefault, GetS3LogLevelFromEnvOrDefaultBehavior) {
   // Verify we get the value specified by env var and not the default
   {
     EnvVarGuard log_level_guard("ARROW_S3_LOG_LEVEL", "Error");
-    ASSERT_EQ(arrow::fs::GetS3LogLevelFromEnvOrDefault(), S3LogLevel::Error);
+    ASSERT_EQ(S3LogLevel::Error, arrow::fs::GetS3LogLevelFromEnvOrDefault());
   }
 
   // Verify we trim and case-insensitively compare the environment variable's value

--- a/docs/source/cpp/api/filesystem.rst
+++ b/docs/source/cpp/api/filesystem.rst
@@ -66,8 +66,6 @@ S3 filesystem
 .. doxygenclass:: arrow::fs::S3FileSystem
    :members:
 
-.. doxygenfunction:: arrow::fs::InitializeS3()
-
 .. doxygenfunction:: arrow::fs::InitializeS3(const S3GlobalOptions& options)
 
 Hadoop filesystem

--- a/docs/source/cpp/api/filesystem.rst
+++ b/docs/source/cpp/api/filesystem.rst
@@ -66,6 +66,10 @@ S3 filesystem
 .. doxygenclass:: arrow::fs::S3FileSystem
    :members:
 
+.. doxygenfunction:: arrow::fs::InitializeS3()
+
+.. doxygenfunction:: arrow::fs::InitializeS3(const S3GlobalOptions& options)
+
 Hadoop filesystem
 -----------------
 

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -85,6 +85,28 @@ that changing their value later will have an effect.
    ``libhdfs.dylib`` on macOS, ``libhdfs.so`` on other platforms).
    Alternatively, one can set :envvar:`HADOOP_HOME`.
 
+.. envvar:: ARROW_S3_LOG_LEVEL
+
+   Controls the verbosity of logging produced by S3 calls. Defaults to Fatal
+   which only produces output in the case of fatal errors. Debug is recommended
+   when you're trying to troubleshoot issues.
+
+   Possible values include:
+
+   - ``Fatal`` (the default)
+   - ``Error``
+   - ``Warn``
+   - ``Info``
+   - ``Debug``
+   - ``Trace``
+   - ``Off``
+
+   .. seealso::
+
+      `Logging - AWS SDK For C++
+      <https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/logging.html>`__
+
+
 .. envvar:: ARROW_TRACING_BACKEND
 
    The backend where to export `OpenTelemetry <https://opentelemetry.io/>`_-based

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -87,19 +87,19 @@ that changing their value later will have an effect.
 
 .. envvar:: ARROW_S3_LOG_LEVEL
 
-   Controls the verbosity of logging produced by S3 calls. Defaults to ``Fatal``
-   which only produces output in the case of fatal errors. ``Debug`` is recommended
+   Controls the verbosity of logging produced by S3 calls. Defaults to ``FATAL``
+   which only produces output in the case of fatal errors. ``DEBUG`` is recommended
    when you're trying to troubleshoot issues.
 
    Possible values include:
 
-   - ``Fatal`` (the default)
-   - ``Error``
-   - ``Warn``
-   - ``Info``
-   - ``Debug``
-   - ``Trace``
-   - ``Off``
+   - ``FATAL`` (the default)
+   - ``ERROR``
+   - ``WARN``
+   - ``INFO``
+   - ``DEBUG``
+   - ``TRACE``
+   - ``OFF``
 
    .. seealso::
 

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -87,7 +87,7 @@ that changing their value later will have an effect.
 
 .. envvar:: ARROW_S3_LOG_LEVEL
 
-   Controls the verbosity of logging produced by S3 calls. Defaults to Fatal
+   Controls the verbosity of logging produced by S3 calls. Defaults to ``Fatal``
    which only produces output in the case of fatal errors. Debug is recommended
    when you're trying to troubleshoot issues.
 

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -88,7 +88,7 @@ that changing their value later will have an effect.
 .. envvar:: ARROW_S3_LOG_LEVEL
 
    Controls the verbosity of logging produced by S3 calls. Defaults to ``Fatal``
-   which only produces output in the case of fatal errors. Debug is recommended
+   which only produces output in the case of fatal errors. ``Debug`` is recommended
    when you're trying to troubleshoot issues.
 
    Possible values include:

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -213,8 +213,8 @@ Troubleshooting
 When using :class:`S3FileSystem`, output is only produced for fatal errors or
 when printing return values. For troubleshooting, the log level can be set using
 the environment variable ``ARROW_S3_LOG_LEVEL``. The log level must be set prior
-to running any code that interacts with S3. Possible values include 'Fatal' (the
-default), 'Error', 'Warn', 'Info', 'Debug' (recommended), 'Trace', and 'Off'.
+to running any code that interacts with S3. Possible values include ``Fatal`` (the
+default), ``Error``, ``Warn``, ``Info``, ``Debug`` (recommended), ``Trace``, and ``Off``.
 
 .. _filesystem-gcs:
 

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -207,6 +207,14 @@ Here are a couple examples in code::
 
    :func:`pyarrow.fs.resolve_s3_region` for resolving region from a bucket name.
 
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+When using :class:`S3FileSystem`, output is only produced for fatal errors or
+when printing return values. For troubleshooting, the log level can be set using
+the environment variable ``ARROW_S3_LOG_LEVEL``. The log level must be set prior
+to running any code that interacts with S3. Possible values include 'Fatal' (the
+default), 'Error', 'Warn', 'Info', 'Debug' (recommended), 'Trace', and 'Off'.
 
 .. _filesystem-gcs:
 

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -213,8 +213,8 @@ Troubleshooting
 When using :class:`S3FileSystem`, output is only produced for fatal errors or
 when printing return values. For troubleshooting, the log level can be set using
 the environment variable ``ARROW_S3_LOG_LEVEL``. The log level must be set prior
-to running any code that interacts with S3. Possible values include ``Fatal`` (the
-default), ``Error``, ``Warn``, ``Info``, ``Debug`` (recommended), ``Trace``, and ``Off``.
+to running any code that interacts with S3. Possible values include ``FATAL`` (the
+default), ``ERROR``, ``WARN``, ``INFO``, ``DEBUG`` (recommended), ``TRACE``, and ``OFF``.
 
 .. _filesystem-gcs:
 

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -242,10 +242,10 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' On S3FileSystem, output is only produced for fatal errors or when printing
 #' return values. For troubleshooting, the log level can be set using the
 #' environment variable `ARROW_S3_LOG_LEVEL` (e.g.,
-#' `Sys.setenv("ARROW_S3_LOG_LEVEL"="Debug")`). The log level must be set prior
-#' to running any code that interacts with S3. Possible values include 'Fatal'
-#' (the default), 'Error', 'Warn', 'Info', 'Debug' (recommended), 'Trace', and
-#' 'Off'.
+#' `Sys.setenv("ARROW_S3_LOG_LEVEL"="DEBUG")`). The log level must be set prior
+#' to running any code that interacts with S3. Possible values include 'FATAL'
+#' (the default), 'ERROR', 'WARN', 'INFO', 'DEBUG' (recommended), 'TRACE', and
+#' 'OFF'.
 #'
 #' @usage NULL
 #' @format NULL
@@ -486,7 +486,7 @@ default_s3_options <- list(
 #' @examplesIf FALSE
 #' # Turn on debug logging. The following line of code should be run in a fresh
 #' # R session prior to any calls to `s3_bucket()` (or other S3 functions)
-#' Sys.setenv("ARROW_S3_LOG_LEVEL", "Debug")
+#' Sys.setenv("ARROW_S3_LOG_LEVEL", "DEBUG")
 #' bucket <- s3_bucket("voltrondata-labs-datasets")
 #'
 #' @export

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -239,6 +239,14 @@ FileSelector$create <- function(base_dir, allow_not_found = FALSE, recursive = F
 #' and no resource tags. To have more control over how buckets are created,
 #' use a different API to create them.
 #'
+#' On S3FileSystem, output is only produced for fatal errors or when printing
+#' return values. For troubleshooting, the log level can be set using the
+#' environment variable `ARROW_S3_LOG_LEVEL` (e.g.,
+#' `Sys.setenv("ARROW_S3_LOG_LEVEL"="Debug")`). The log level must be set prior
+#' to running any code that interacts with S3. Possible values include 'Fatal'
+#' (the default), 'Error', 'Warn', 'Info', 'Debug' (recommended), 'Trace', and
+#' 'Off'.
+#'
 #' @usage NULL
 #' @format NULL
 #' @docType class
@@ -462,11 +470,25 @@ default_s3_options <- list(
 #'
 #' @param bucket string S3 bucket name or path
 #' @param ... Additional connection options, passed to `S3FileSystem$create()`
+#'
+#' @details By default, \code{\link{s3_bucket}} and other
+#' \code{\link{S3FileSystem}} functions only produce output for fatal errors
+#' or when printing their return values. When troubleshooting problems, it may
+#' be useful to increase the log level. See the Notes section in
+#' \code{\link{S3FileSystem}} for more information or see Examples below.
+#'
 #' @return A `SubTreeFileSystem` containing an `S3FileSystem` and the bucket's
 #' relative path. Note that this function's success does not guarantee that you
 #' are authorized to access the bucket's contents.
 #' @examplesIf FALSE
 #' bucket <- s3_bucket("voltrondata-labs-datasets")
+#'
+#' @examplesIf FALSE
+#' # Turn on debug logging. The following line of code should be run in a fresh
+#' # session prior to any calls to s3_bucket (or other S3 functions)
+#' Sys.setenv("ARROW_S3_LOG_LEVEL", "Debug")
+#' bucket <- s3_bucket("voltrondata-labs-datasets")
+#'
 #' @export
 s3_bucket <- function(bucket, ...) {
   assert_that(is.string(bucket))

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -485,7 +485,7 @@ default_s3_options <- list(
 #'
 #' @examplesIf FALSE
 #' # Turn on debug logging. The following line of code should be run in a fresh
-#' # session prior to any calls to s3_bucket (or other S3 functions)
+#' # R session prior to any calls to `s3_bucket()` (or other S3 functions)
 #' Sys.setenv("ARROW_S3_LOG_LEVEL", "Debug")
 #' bucket <- s3_bucket("voltrondata-labs-datasets")
 #'

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -153,9 +153,9 @@ use a different API to create them.
 On S3FileSystem, output is only produced for fatal errors or when printing
 return values. For troubleshooting, the log level can be set using the
 environment variable \code{ARROW_S3_LOG_LEVEL} (e.g.,
-\code{Sys.setenv("ARROW_S3_LOG_LEVEL"="Debug")}). The log level must be set prior
-to running any code that interacts with S3. Possible values include 'Fatal'
-(the default), 'Error', 'Warn', 'Info', 'Debug' (recommended), 'Trace', and
-'Off'.
+\code{Sys.setenv("ARROW_S3_LOG_LEVEL"="DEBUG")}). The log level must be set prior
+to running any code that interacts with S3. Possible values include 'FATAL'
+(the default), 'ERROR', 'WARN', 'INFO', 'DEBUG' (recommended), 'TRACE', and
+'OFF'.
 }
 

--- a/r/man/FileSystem.Rd
+++ b/r/man/FileSystem.Rd
@@ -149,5 +149,13 @@ it does not pass any non-default settings. In AWS S3, the bucket and all
 objects will be not publicly visible, and will have no bucket policies
 and no resource tags. To have more control over how buckets are created,
 use a different API to create them.
+
+On S3FileSystem, output is only produced for fatal errors or when printing
+return values. For troubleshooting, the log level can be set using the
+environment variable \code{ARROW_S3_LOG_LEVEL} (e.g.,
+\code{Sys.setenv("ARROW_S3_LOG_LEVEL"="Debug")}). The log level must be set prior
+to running any code that interacts with S3. Possible values include 'Fatal'
+(the default), 'Error', 'Warn', 'Info', 'Debug' (recommended), 'Trace', and
+'Off'.
 }
 

--- a/r/man/s3_bucket.Rd
+++ b/r/man/s3_bucket.Rd
@@ -34,8 +34,8 @@ bucket <- s3_bucket("voltrondata-labs-datasets")
 \dontshow{\}) # examplesIf}
 \dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Turn on debug logging. The following line of code should be run in a fresh
-# session prior to any calls to s3_bucket (or other S3 functions)
-Sys.setenv("ARROW_S3_LOG_LEVEL", "Debug")
+# R session prior to any calls to `s3_bucket()` (or other S3 functions)
+Sys.setenv("ARROW_S3_LOG_LEVEL", "DEBUG")
 bucket <- s3_bucket("voltrondata-labs-datasets")
 \dontshow{\}) # examplesIf}
 }

--- a/r/man/s3_bucket.Rd
+++ b/r/man/s3_bucket.Rd
@@ -21,8 +21,21 @@ are authorized to access the bucket's contents.
 that automatically detects the bucket's AWS region and holding onto the its
 relative path.
 }
+\details{
+By default, \code{\link{s3_bucket}} and other
+\code{\link{S3FileSystem}} functions only produce output for fatal errors
+or when printing their return values. When troubleshooting problems, it may
+be useful to increase the log level. See the Notes section in
+\code{\link{S3FileSystem}} for more information or see Examples below.
+}
 \examples{
 \dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+bucket <- s3_bucket("voltrondata-labs-datasets")
+\dontshow{\}) # examplesIf}
+\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+# Turn on debug logging. The following line of code should be run in a fresh
+# session prior to any calls to s3_bucket (or other S3 functions)
+Sys.setenv("ARROW_S3_LOG_LEVEL", "Debug")
 bucket <- s3_bucket("voltrondata-labs-datasets")
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
### Rationale for this change

It's useful when troubleshooting issues with Arrow's S3 filesystem implementation to raise the log level. Currently, this can only be done in C++ and Python, but not from R. In addition, the log level can only be set during S3 initialization and not directly so the user has to introduce explicit S3 initialization code to turn on logging and must make sure this code is called before S3 initialization.

While discussing exposing control of log level to R, we realized that allowing the log level to be controlled by environment variable may be more intuitive and useful and would just be a good addition for C++, Python, and R. 

### What changes are included in this PR?

- A new environment variable `AWS_S3_LOG_LEVEL` with documentation for controlling S3 log level
- Updated documentation for C++, Python, and R
- A new `InitializeS3()` as a quality-of-life thing for C++ users. Feel free to ask me to remove this.

No changes are needed directly for Python and R because these implementation uses the internal implicit initializer `EnsureS3Initialized` rather than the explicit form, `InitializeS3`. And it's the behavior of the `EnsureS3Initialized` routine that's changed here.

### Are these changes tested?

Yes. I added a unit test for the new `GetS3LogLevelFromEnvOrDefault` and tested from Python and R manually. I didn't add a test to make sure the underlying `AwsInstance` gets set up correctly because it looked like it would require a refactor and didn't seem worth it.

### Are there any user-facing changes?

Yes. A new way to turn on logging for S3 and matching docs in C++, Python, and R.

* Closes: #35260