### PR TITLE
GH-37511: [C++] Implement file reads for Azure filesystem

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -48,6 +48,21 @@ bool AzureOptions::Equals(const AzureOptions& other) const {
           credentials_kind == other.credentials_kind);
 }
 
+Status AzureOptions::ConfigureAccountKeyCredentials(const std::string& account_name,
+                                                    const std::string& account_key) {
+  if (this->is_azurite) {
+    account_blob_url = "http://127.0.0.1:10000/" + account_name + "/";
+    account_dfs_url = "http://127.0.0.1:10000/" + account_name + "/";
+  } else {
+    account_dfs_url = "https://" + account_name + ".dfs.core.windows.net/";
+    account_blob_url = "https://" + account_name + ".blob.core.windows.net/";
+  }
+  storage_credentials_provider =
+      std::make_shared<Azure::Storage::StorageSharedKeyCredential>(account_name,
+                                                                   account_key);
+  credentials_kind = AzureCredentialsKind::StorageCredentials;
+  return Status::OK();
+}
 namespace {
 
 struct AzurePath {

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -439,8 +439,7 @@ Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
 
 Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
     const FileInfo& info) {
-  // return impl_->OpenInputFile(info, this);
-  return Status::NotImplemented("The Azure FileSystem is not fully implemented");
+  return impl_->OpenInputFile(info, this);
 }
 
 Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -26,6 +26,103 @@
 namespace arrow {
 namespace fs {
 
+struct AzurePath {
+  std::string full_path;
+  std::string container;
+  std::string path_to_file;
+  std::vector<std::string> path_to_file_parts;
+
+  static Result<AzurePath> FromString(const std::string& s) {
+    // https://synapsemladlsgen2.dfs.core.windows.net/synapsemlfs/testdir/testfile.txt
+    // container = synapsemlfs
+    // account_name = synapsemladlsgen2
+    // path_to_file = testdir/testfile.txt
+    // path_to_file_parts = [testdir, testfile.txt]
+
+    // Expected input here => s = synapsemlfs/testdir/testfile.txt,
+    // http://127.0.0.1/accountName/pathToBlob
+    auto src = internal::RemoveTrailingSlash(s);
+    if (arrow::internal::StartsWith(src, "https://127.0.0.1") || arrow::internal::StartsWith(src, "http://127.0.0.1")) {
+      RETURN_NOT_OK(FromLocalHostString(&src));
+    }
+    auto input_path = std::string(src.data());
+    if (internal::IsLikelyUri(input_path)) {
+      RETURN_NOT_OK(ExtractBlobPath(&input_path));
+      src = std::string_view(input_path);
+    }
+    src = internal::RemoveLeadingSlash(src);
+    auto first_sep = src.find_first_of(kSep);
+    if (first_sep == 0) {
+      return Status::IOError("Path cannot start with a separator ('", input_path, "')");
+    }
+    if (first_sep == std::string::npos) {
+      return AzurePath{std::string(src), std::string(src), "", {}};
+    }
+    AzurePath path;
+    path.full_path = std::string(src);
+    path.container = std::string(src.substr(0, first_sep));
+    path.path_to_file = std::string(src.substr(first_sep + 1));
+    path.path_to_file_parts = internal::SplitAbstractPath(path.path_to_file);
+    RETURN_NOT_OK(Validate(&path));
+    return path;
+  }
+
+  static Status FromLocalHostString(std::string_view* src) {
+    // src = http://127.0.0.1:10000/accountName/pathToBlob
+    Uri uri;
+    RETURN_NOT_OK(uri.Parse(src->data()));
+    *src = internal::RemoveLeadingSlash(uri.path());
+    if (src->empty()) {
+      return Status::IOError("Missing account name in Azure Blob Storage URI");
+    }
+    auto first_sep = src->find_first_of(kSep);
+    if (first_sep != std::string::npos) {
+      *src = src->substr(first_sep + 1);
+    } else {
+      *src = "";
+    }
+    return Status::OK();
+  }
+
+  // Removes scheme, host and port from the uri
+  static Status ExtractBlobPath(std::string* src) {
+    Uri uri;
+    RETURN_NOT_OK(uri.Parse(*src));
+    *src = uri.path();
+    return Status::OK();
+  }
+
+  static Status Validate(const AzurePath* path) {
+    auto status = internal::ValidateAbstractPathParts(path->path_to_file_parts);
+    if (!status.ok()) {
+      return Status::Invalid(status.message(), " in path ", path->full_path);
+    } else {
+      return status;
+    }
+  }
+
+  AzurePath parent() const {
+    DCHECK(has_parent());
+    auto parent = AzurePath{"", container, "", path_to_file_parts};
+    parent.path_to_file_parts.pop_back();
+    parent.path_to_file = internal::JoinAbstractPath(parent.path_to_file_parts);
+    if (parent.path_to_file.empty()) {
+      parent.full_path = parent.container;
+    } else {
+      parent.full_path = parent.container + kSep + parent.path_to_file;
+    }
+    return parent;
+  }
+
+  bool has_parent() const { return !path_to_file.empty(); }
+
+  bool empty() const { return container.empty() && path_to_file.empty(); }
+
+  bool operator==(const AzurePath& other) const {
+    return container == other.container && path_to_file == other.path_to_file;
+  }
+};
+
 // -----------------------------------------------------------------------
 // AzureOptions Implementation
 
@@ -36,6 +133,159 @@ bool AzureOptions::Equals(const AzureOptions& other) const {
           account_blob_url == other.account_blob_url &&
           credentials_kind == other.credentials_kind);
 }
+
+
+class ObjectInputFile final : public io::RandomAccessFile {
+ public:
+  ObjectInputFile(
+      std::shared_ptr<Azure::Storage::Files::DataLake::DataLakePathClient>& path_client,
+      std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeFileClient>& file_client,
+      const io::IOContext& io_context, const AzurePath& path, int64_t size = kNoSize)
+      : path_client_(std::move(path_client)),
+        file_client_(std::move(file_client)),
+        io_context_(io_context),
+        path_(path),
+        content_length_(size) {}
+
+  Status Init() {
+    if (content_length_ != kNoSize) {
+      DCHECK_GE(content_length_, 0);
+      return Status::OK();
+    }
+    try {
+      auto properties = path_client_->GetProperties();
+      if (properties.Value.IsDirectory) {
+        return ::arrow::fs::internal::NotAFile(path_.full_path);
+      }
+      content_length_ = properties.Value.FileSize;
+      metadata_ = GetObjectMetadata(properties.Value.Metadata);
+      return Status::OK();
+    } catch (const Azure::Storage::StorageException& exception) {
+      return ::arrow::fs::internal::PathNotFound(path_.full_path);
+    }
+  }
+
+  Status CheckClosed() const {
+    if (closed_) {
+      return Status::Invalid("Operation on closed stream");
+    }
+    return Status::OK();
+  }
+
+  Status CheckPosition(int64_t position, const char* action) const {
+    if (position < 0) {
+      return Status::Invalid("Cannot ", action, " from negative position");
+    }
+    if (position > content_length_) {
+      return Status::IOError("Cannot ", action, " past end of file");
+    }
+    return Status::OK();
+  }
+
+  // RandomAccessFile APIs
+
+  Result<std::shared_ptr<const KeyValueMetadata>> ReadMetadata() override {
+    return metadata_;
+  }
+
+  Future<std::shared_ptr<const KeyValueMetadata>> ReadMetadataAsync(
+      const io::IOContext& io_context) override {
+    return metadata_;
+  }
+
+  Status Close() override {
+    path_client_ = nullptr;
+    file_client_ = nullptr;
+    closed_ = true;
+    return Status::OK();
+  }
+
+  bool closed() const override { return closed_; }
+
+  Result<int64_t> Tell() const override {
+    RETURN_NOT_OK(CheckClosed());
+    return pos_;
+  }
+
+  Result<int64_t> GetSize() override {
+    RETURN_NOT_OK(CheckClosed());
+    return content_length_;
+  }
+
+  Status Seek(int64_t position) override {
+    RETURN_NOT_OK(CheckClosed());
+    RETURN_NOT_OK(CheckPosition(position, "seek"));
+
+    pos_ = position;
+    return Status::OK();
+  }
+
+  Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
+    RETURN_NOT_OK(CheckClosed());
+    RETURN_NOT_OK(CheckPosition(position, "read"));
+
+    nbytes = std::min(nbytes, content_length_ - position);
+    if (nbytes == 0) {
+      return 0;
+    }
+
+    // Read the desired range of bytes
+    Azure::Storage::Blobs::DownloadBlobToOptions download_options;
+    Azure::Core::Http::HttpRange range;
+    range.Offset = position;
+    range.Length = nbytes;
+    download_options.Range = Azure::Nullable<Azure::Core::Http::HttpRange>(range);
+    try {
+      auto result =
+          file_client_
+              ->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes, download_options)
+              .Value;
+      return result.ContentRange.Length.Value();
+    } catch (const Azure::Storage::StorageException& exception) {
+      return Status::IOError(exception.RawResponse->GetReasonPhrase());
+    }
+  }
+
+  Result<std::shared_ptr<Buffer>> ReadAt(int64_t position, int64_t nbytes) override {
+    RETURN_NOT_OK(CheckClosed());
+    RETURN_NOT_OK(CheckPosition(position, "read"));
+
+    // No need to allocate more than the remaining number of bytes
+    nbytes = std::min(nbytes, content_length_ - position);
+
+    ARROW_ASSIGN_OR_RAISE(auto buf, AllocateResizableBuffer(nbytes, io_context_.pool()));
+    if (nbytes > 0) {
+      ARROW_ASSIGN_OR_RAISE(int64_t bytes_read,
+                            ReadAt(position, nbytes, buf->mutable_data()));
+      DCHECK_LE(bytes_read, nbytes);
+      RETURN_NOT_OK(buf->Resize(bytes_read));
+    }
+    return std::move(buf);
+  }
+
+  Result<int64_t> Read(int64_t nbytes, void* out) override {
+    ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadAt(pos_, nbytes, out));
+    pos_ += bytes_read;
+    return bytes_read;
+  }
+
+  Result<std::shared_ptr<Buffer>> Read(int64_t nbytes) override {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, ReadAt(pos_, nbytes));
+    pos_ += buffer->size();
+    return std::move(buffer);
+  }
+
+ protected:
+  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakePathClient> path_client_;
+  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeFileClient> file_client_;
+  const io::IOContext io_context_;
+  AzurePath path_;
+
+  bool closed_ = false;
+  int64_t pos_ = 0;
+  int64_t content_length_ = kNoSize;
+  std::shared_ptr<const KeyValueMetadata> metadata_;
+};
 
 // -----------------------------------------------------------------------
 // AzureFilesystem Implementation

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -193,6 +193,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
       metadata_ = GetObjectMetadata(properties.Value.Metadata);
       return Status::OK();
     } catch (const Azure::Storage::StorageException& exception) {
+      // TODO: Only return path not found if Azure gave us path not found.
       return ::arrow::fs::internal::PathNotFound(path_.full_path);
     }
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -164,11 +164,10 @@ std::shared_ptr<const KeyValueMetadata> GetObjectMetadata(const ObjectResult& re
 class ObjectInputFile final : public io::RandomAccessFile {
  public:
   ObjectInputFile(std::shared_ptr<Azure::Storage::Blobs::BlobClient> blob_client,
-                  const io::IOContext& io_context, const AzurePath& path,
-                  int64_t size = kNoSize)
+                  const io::IOContext& io_context, AzurePath path, int64_t size = kNoSize)
       : blob_client_(std::move(blob_client)),
         io_context_(io_context),
-        path_(path),
+        path_(std::move(path)),
         content_length_(size) {}
 
   Status Init() {
@@ -342,7 +341,8 @@ class AzureFileSystem::Impl {
         service_client_->GetBlobContainerClient(path.container)
             .GetBlobClient(path.path_to_file));
 
-    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(), path);
+    auto ptr =
+        std::make_shared<ObjectInputFile>(blob_client, fs->io_context(), std::move(path));
     RETURN_NOT_OK(ptr->Init());
     return ptr;
   }
@@ -362,8 +362,8 @@ class AzureFileSystem::Impl {
         service_client_->GetBlobContainerClient(path.container)
             .GetBlobClient(path.path_to_file));
 
-    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(), path,
-                                                 info.size());
+    auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(),
+                                                 std::move(path), info.size());
     RETURN_NOT_OK(ptr->Init());
     return ptr;
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -50,7 +50,7 @@ bool AzureOptions::Equals(const AzureOptions& other) const {
 
 Status AzureOptions::ConfigureAccountKeyCredentials(const std::string& account_name,
                                                     const std::string& account_key) {
-  if (this->is_azurite) {
+  if (this->backend == AzureBackend::Azurite) {
     account_blob_url = "http://127.0.0.1:10000/" + account_name + "/";
     account_dfs_url = "http://127.0.0.1:10000/" + account_name + "/";
   } else {

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -253,8 +253,8 @@ class ObjectInputFile final : public io::RandomAccessFile {
     }
 
     // Read the desired range of bytes
-    Azure::Core::Http::HttpRange range{.Offset = position, .Length = nbytes};
-    Azure::Storage::Blobs::DownloadBlobToOptions download_options{.Range = range};
+    Azure::Core::Http::HttpRange range{position, nbytes};
+    Azure::Storage::Blobs::DownloadBlobToOptions download_options{range};
     try {
       return blob_client_
           ->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes, download_options)

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -20,7 +20,6 @@
 #include <azure/identity/default_azure_credential.hpp>
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/blobs/blob_client.hpp>
-#include <azure/storage/files/datalake.hpp>
 
 #include "arrow/buffer.h"
 #include "arrow/filesystem/path_util.h"

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -418,8 +418,8 @@ Status AzureFileSystem::CopyFile(const std::string& src, const std::string& dest
 }
 
 Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
-    const std::string& s) {
-  return impl_->OpenInputFile(s, this);
+    const std::string& path) {
+  return impl_->OpenInputFile(path, this);
 }
 
 Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
@@ -428,8 +428,8 @@ Result<std::shared_ptr<io::InputStream>> AzureFileSystem::OpenInputStream(
 }
 
 Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
-    const std::string& s) {
-  return impl_->OpenInputFile(s, this);
+    const std::string& path) {
+  return impl_->OpenInputFile(path, this);
 }
 
 Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -345,8 +345,8 @@ class AzureFileSystem::Impl {
     RETURN_NOT_OK(ValidateFilePath(path));
 
     auto blob_client = std::make_shared<Azure::Storage::Blobs::BlobClient>(
-        std::move(service_client_->GetBlobContainerClient(path.container)
-                      .GetBlobClient(path.path_to_file)));
+        service_client_->GetBlobContainerClient(path.container)
+            .GetBlobClient(path.path_to_file));
 
     auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(), path);
     RETURN_NOT_OK(ptr->Init());
@@ -366,8 +366,8 @@ class AzureFileSystem::Impl {
     RETURN_NOT_OK(ValidateFilePath(path));
 
     auto blob_client = std::make_shared<Azure::Storage::Blobs::BlobClient>(
-        std::move(service_client_->GetBlobContainerClient(path.container)
-                      .GetBlobClient(path.path_to_file)));
+        service_client_->GetBlobContainerClient(path.container)
+            .GetBlobClient(path.path_to_file));
 
     auto ptr = std::make_shared<ObjectInputFile>(blob_client, fs->io_context(), path,
                                                  info.size());

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -83,7 +83,7 @@ struct AzurePath {
     src = internal::RemoveLeadingSlash(src);
     auto first_sep = src.find_first_of(internal::kSep);
     if (first_sep == 0) {
-      return Status::Invalid("Path cannot start with a separator ('", input_path, "')");
+      return Status::Invalid("Path cannot start with a separator ('", s, "')");
     }
     if (first_sep == std::string::npos) {
       return AzurePath{std::string(src), std::string(src), "", {}};

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -81,6 +81,10 @@ struct AzurePath {
     // Expected input here => s = synapsemlfs/testdir/testfile.txt,
     // http://127.0.0.1/accountName/pathToBlob
     auto src = internal::RemoveTrailingSlash(s);
+    if (internal::IsLikelyUri(s)) {
+      return Status::Invalid(
+          "Expected a Azure object path of the form 'container/key...', got a URI: '", s, "'");
+    }
     if (arrow::internal::StartsWith(src, "https://127.0.0.1") ||
         arrow::internal::StartsWith(src, "http://127.0.0.1")) {
       RETURN_NOT_OK(FromLocalHostString(&src));

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -340,6 +340,7 @@ class AzureFileSystem::Impl {
 
   Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const std::string& s,
                                                          AzureFileSystem* fs) {
+    ARROW_RETURN_NOT_OK(internal::AssertNoTrailingSlash(s));
     ARROW_ASSIGN_OR_RAISE(auto path, AzurePath::FromString(s));
     RETURN_NOT_OK(ValidateFilePath(path));
     auto blob_client = std::make_shared<Azure::Storage::Blobs::BlobClient>(
@@ -353,6 +354,7 @@ class AzureFileSystem::Impl {
 
   Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const FileInfo& info,
                                                          AzureFileSystem* fs) {
+    ARROW_RETURN_NOT_OK(internal::AssertNoTrailingSlash(info.path()));
     if (info.type() == FileType::NotFound) {
       return ::arrow::fs::internal::PathNotFound(info.path());
     }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -254,7 +254,8 @@ class ObjectInputFile final : public io::RandomAccessFile {
 
     // Read the desired range of bytes
     Azure::Core::Http::HttpRange range{position, nbytes};
-    Azure::Storage::Blobs::DownloadBlobToOptions download_options{range};
+    Azure::Storage::Blobs::DownloadBlobToOptions download_options;
+    download_options.Range = range;
     try {
       return blob_client_
           ->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes, download_options)

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -78,9 +78,7 @@ struct AzurePath {
           "Expected an Azure object path of the form 'container/path...', got a URI: '",
           s, "'");
     }
-    auto src = internal::RemoveTrailingSlash(s);
-    auto input_path = std::string(src.data());
-    src = internal::RemoveLeadingSlash(src);
+    const auto src = internal::RemoveTrailingSlash(s);
     auto first_sep = src.find_first_of(internal::kSep);
     if (first_sep == 0) {
       return Status::Invalid("Path cannot start with a separator ('", s, "')");

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -79,6 +79,9 @@ struct ARROW_EXPORT AzureOptions {
 
   AzureOptions();
 
+  Status ConfigureAccountKeyCredentials(const std::string& account_name,
+                                        const std::string& account_key);
+
   bool Equals(const AzureOptions& other) const;
 };
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -34,24 +34,23 @@
 #include <boost/process.hpp>
 
 #include "arrow/filesystem/azurefs.h"
-#include "arrow/util/io_util.h"
-#include "arrow/util/key_value_metadata.h"
-
-#include <gmock/gmock-matchers.h>
-#include <gmock/gmock-more-matchers.h>
-#include <gtest/gtest.h>
 
 #include <random>
 #include <string>
 
-#include "arrow/testing/gtest_util.h"
-#include "arrow/testing/util.h"
-
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock-more-matchers.h>
+#include <gtest/gtest.h>
 #include <azure/identity/client_secret_credential.hpp>
 #include <azure/identity/default_azure_credential.hpp>
 #include <azure/identity/managed_identity_credential.hpp>
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/common/storage_credential.hpp>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/util.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/key_value_metadata.h"
 
 namespace arrow {
 using internal::TemporaryDir;

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -314,6 +314,8 @@ TEST_F(TestAzureFileSystem, OpenInputStreamReadMetadata) {
 
   std::shared_ptr<const KeyValueMetadata> actual;
   ASSERT_OK_AND_ASSIGN(actual, stream->ReadMetadata());
+  // TODO(GH-38330): This is asserting that the user defined metadata is returned but this is 
+  // probably not the correct behaviour.
   ASSERT_OK_AND_EQ("value0", actual->Get("key0"));
 }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -270,15 +270,9 @@ TEST_F(TestAzureFileSystem, OpenInputFileMixedReadVsReadAt) {
   const auto path = PreexistingContainerPath() + path_to_file;
 
   // TODO: Switch to using Azure filesystem to write once its implemented. 
-  auto file_client = gen2_client_->GetFileSystemClient("container").GetFileClient(path);
-  int64_t total_size = 0;
-  for (auto const& line : lines) {
-    auto bufferStream = Azure::Core::IO::MemoryBodyStream(
-        reinterpret_cast<const uint8_t*>(line.data()), line.size());
-    file_client.Append(bufferStream, 0);
-    total_size += line.size();
-  }
-  file_client.Flush(total_size);
+  auto file_client = gen2_client_->GetFileSystemClient(PreexistingContainerName()).GetFileClient(path_to_file);
+  std::string all_lines = std::accumulate(lines.begin(), lines.end(), std::string(""));
+  file_client.UploadFrom(reinterpret_cast<const uint8_t*>(all_lines.data()), kLineWidth * kLineCount);
 
   std::shared_ptr<io::RandomAccessFile> file;
   ASSERT_OK_AND_ASSIGN(file, fs_->OpenInputFile(path));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -300,6 +300,10 @@ TEST_F(TestAzureFileSystem, OpenInputStreamUri) {
   ASSERT_RAISES(Invalid, fs_->OpenInputStream("abfss://" + PreexistingObjectPath()));
 }
 
+TEST_F(TestAzureFileSystem, OpenInputStreamTrailingSlash) {
+  ASSERT_RAISES(IOError, fs_->OpenInputStream(PreexistingObjectPath() + '/'));
+}
+
 TEST_F(TestAzureFileSystem, OpenInputStreamReadMetadata) {
   const std::string object_name = "OpenInputStreamMetadataTest/simple.txt";
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -254,11 +254,8 @@ TEST_F(TestAzureFileSystem, OpenInputStreamInfo) {
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream, fs_->OpenInputStream(info));
 
-  std::array<char, 1024> buffer{};
-  std::int64_t size;
-  ASSERT_OK_AND_ASSIGN(size, stream->Read(buffer.size(), buffer.data()));
-
-  EXPECT_EQ(std::string(buffer.data(), size), kLoremIpsum);
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
+  EXPECT_EQ(buffer->ToString(), kLoremIpsum);
 }
 
 TEST_F(TestAzureFileSystem, OpenInputStreamEmpty) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -378,38 +378,38 @@ TEST_F(TestAzureFileSystem, OpenInputFileIoContext) {
   EXPECT_EQ(fs_->io_context().external_id(), file->io_context().external_id());
 }
 
-// TODO: Implement this once GetFileInfo is implemented.
-// TEST_F(TestAzureFileSystem, OpenInputFileInfo) {
-//   arrow::fs::FileInfo info;
-//   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingObjectPath()));
+TEST_F(TestAzureFileSystem, OpenInputFileInfo) {
+  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // fs->GetFileInfo(PreexistingObjectPath()));
+  arrow::fs::FileInfo info(PreexistingObjectPath(), FileType::File);
 
-//   std::shared_ptr<io::RandomAccessFile> file;
-//   ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(info));
+  std::shared_ptr<io::RandomAccessFile> file;
+  ASSERT_OK_AND_ASSIGN(file, fs_->OpenInputFile(info));
 
-//   std::array<char, 1024> buffer{};
-//   std::int64_t size;
-//   auto constexpr kStart = 16;
-//   ASSERT_OK_AND_ASSIGN(size, file->ReadAt(kStart, buffer.size(), buffer.data()));
+  std::array<char, 1024> buffer{};
+  std::int64_t size;
+  auto constexpr kStart = 16;
+  ASSERT_OK_AND_ASSIGN(size, file->ReadAt(kStart, buffer.size(), buffer.data()));
 
-//   auto const expected = std::string(kLoremIpsum).substr(kStart);
-//   EXPECT_EQ(std::string(buffer.data(), size), expected);
-// }
+  auto const expected = std::string(kLoremIpsum).substr(kStart);
+  EXPECT_EQ(std::string(buffer.data(), size), expected);
+}
 
 TEST_F(TestAzureFileSystem, OpenInputFileNotFound) {
   ASSERT_RAISES(IOError, fs_->OpenInputFile(NotFoundObjectPath()));
 }
 
-// TODO: Implement this once GetFileInfo is implemented.
-// TEST_F(GcsIntegrationTest, OpenInputFileInfoInvalid) {
-//   auto fs = GcsFileSystem::Make(TestGcsOptions());
+TEST_F(TestAzureFileSystem, OpenInputFileInfoInvalid) {
+  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // fs->GetFileInfo(PreexistingContainerPath()));
+  arrow::fs::FileInfo info(PreexistingContainerPath(), FileType::File);
+  ASSERT_RAISES(IOError, fs_->OpenInputFile(info));
 
-//   arrow::fs::FileInfo info;
-//   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingContainerPath()));
-//   ASSERT_RAISES(IOError, fs->OpenInputFile(info));
-
-//   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(NotFoundObjectPath()));
-//   ASSERT_RAISES(IOError, fs->OpenInputFile(info));
-// }
+  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // fs->GetFileInfo(NotFoundObjectPath()));
+  arrow::fs::FileInfo info2(NotFoundObjectPath(), FileType::NotFound);
+  ASSERT_RAISES(IOError, fs_->OpenInputFile(info2));
+}
 
 TEST_F(TestAzureFileSystem, OpenInputFileClosed) {
   ASSERT_OK_AND_ASSIGN(auto stream, fs_->OpenInputFile(PreexistingObjectPath()));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -155,240 +155,240 @@ TEST(AzureFileSystem, OptionsCompare) {
 }
 
 
-class TestAzureFileSystem : public ::testing::Test {
- public:
-  std::shared_ptr<FileSystem> fs_;
-  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient> gen2_client_;
-  AzureOptions options_;
+// class TestAzureFileSystem : public ::testing::Test {
+//  public:
+//   std::shared_ptr<FileSystem> fs_;
+//   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient> gen2_client_;
+//   AzureOptions options_;
 
-  void MakeFileSystem() {
-    const std::string& account_name = GetAzuriteEnv()->account_name();
-    const std::string& account_key = GetAzuriteEnv()->account_key();
-    options_.is_azurite = true;
-    options_.ConfigureAccountKeyCredentials(account_name, account_key);
-    gen2_client_ =
-        std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
-            options_.account_dfs_url, options_.storage_credentials_provider);
-    ASSERT_OK_AND_ASSIGN(fs_, AzureBlobFileSystem::Make(options_));
-  }
+//   void MakeFileSystem() {
+//     const std::string& account_name = GetAzuriteEnv()->account_name();
+//     const std::string& account_key = GetAzuriteEnv()->account_key();
+//     options_.is_azurite = true;
+//     options_.ConfigureAccountKeyCredentials(account_name, account_key);
+//     gen2_client_ =
+//         std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
+//             options_.account_dfs_url, options_.storage_credentials_provider);
+//     ASSERT_OK_AND_ASSIGN(fs_, AzureBlobFileSystem::Make(options_));
+//   }
 
-  void SetUp() override {
-    ASSERT_THAT(GetAzuriteEnv(), NotNull());
-    ASSERT_OK(GetAzuriteEnv()->status());
+//   void SetUp() override {
+//     ASSERT_THAT(GetAzuriteEnv(), NotNull());
+//     ASSERT_OK(GetAzuriteEnv()->status());
 
-    MakeFileSystem();
-    auto file_system_client = gen2_client_->GetFileSystemClient("container");
-    file_system_client.CreateIfNotExists();
-    file_system_client = gen2_client_->GetFileSystemClient("empty-container");
-    file_system_client.CreateIfNotExists();
-    auto file_client =
-        std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
-            options_.account_blob_url + "container/somefile",
-            options_.storage_credentials_provider);
-    std::string s = "some data";
-    file_client->UploadFrom(
-        const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(s.data())), s.size());
-  }
+//     MakeFileSystem();
+//     auto file_system_client = gen2_client_->GetFileSystemClient("container");
+//     file_system_client.CreateIfNotExists();
+//     file_system_client = gen2_client_->GetFileSystemClient("empty-container");
+//     file_system_client.CreateIfNotExists();
+//     auto file_client =
+//         std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
+//             options_.account_blob_url + "container/somefile",
+//             options_.storage_credentials_provider);
+//     std::string s = "some data";
+//     file_client->UploadFrom(
+//         const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(s.data())), s.size());
+//   }
 
-  void TearDown() override {
-    auto containers = gen2_client_->ListFileSystems();
-    for (auto container : containers.FileSystems) {
-      auto file_system_client = gen2_client_->GetFileSystemClient(container.Name);
-      file_system_client.DeleteIfExists();
-    }
-  }
+//   void TearDown() override {
+//     auto containers = gen2_client_->ListFileSystems();
+//     for (auto container : containers.FileSystems) {
+//       auto file_system_client = gen2_client_->GetFileSystemClient(container.Name);
+//       file_system_client.DeleteIfExists();
+//     }
+//   }
 
-  void AssertObjectContents(
-      Azure::Storage::Files::DataLake::DataLakeServiceClient* client,
-      const std::string& container, const std::string& path_to_file,
-      const std::string& expected) {
-    auto path_client =
-        std::make_shared<Azure::Storage::Files::DataLake::DataLakePathClient>(
-            client->GetUrl() + container + "/" + path_to_file,
-            options_.storage_credentials_provider);
-    auto size = path_client->GetProperties().Value.FileSize;
-    if (size == 0) {
-      ASSERT_EQ(expected, "");
-      return;
-    }
-    auto buf = AllocateBuffer(size, fs_->io_context().pool());
-    Azure::Storage::Blobs::DownloadBlobToOptions download_options;
-    Azure::Core::Http::HttpRange range;
-    range.Offset = 0;
-    range.Length = size;
-    download_options.Range = Azure::Nullable<Azure::Core::Http::HttpRange>(range);
-    auto file_client =
-        std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
-            client->GetUrl() + container + "/" + path_to_file,
-            options_.storage_credentials_provider);
-    auto result = file_client
-                      ->DownloadTo(reinterpret_cast<uint8_t*>(buf->get()->mutable_data()),
-                                   size, download_options)
-                      .Value;
-    auto buf_data = std::move(buf->get());
-    auto expected_data = std::make_shared<Buffer>(
-        reinterpret_cast<const uint8_t*>(expected.data()), expected.size());
-    AssertBufferEqual(*buf_data, *expected_data);
-  }
-};
+//   void AssertObjectContents(
+//       Azure::Storage::Files::DataLake::DataLakeServiceClient* client,
+//       const std::string& container, const std::string& path_to_file,
+//       const std::string& expected) {
+//     auto path_client =
+//         std::make_shared<Azure::Storage::Files::DataLake::DataLakePathClient>(
+//             client->GetUrl() + container + "/" + path_to_file,
+//             options_.storage_credentials_provider);
+//     auto size = path_client->GetProperties().Value.FileSize;
+//     if (size == 0) {
+//       ASSERT_EQ(expected, "");
+//       return;
+//     }
+//     auto buf = AllocateBuffer(size, fs_->io_context().pool());
+//     Azure::Storage::Blobs::DownloadBlobToOptions download_options;
+//     Azure::Core::Http::HttpRange range;
+//     range.Offset = 0;
+//     range.Length = size;
+//     download_options.Range = Azure::Nullable<Azure::Core::Http::HttpRange>(range);
+//     auto file_client =
+//         std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
+//             client->GetUrl() + container + "/" + path_to_file,
+//             options_.storage_credentials_provider);
+//     auto result = file_client
+//                       ->DownloadTo(reinterpret_cast<uint8_t*>(buf->get()->mutable_data()),
+//                                    size, download_options)
+//                       .Value;
+//     auto buf_data = std::move(buf->get());
+//     auto expected_data = std::make_shared<Buffer>(
+//         reinterpret_cast<const uint8_t*>(expected.data()), expected.size());
+//     AssertBufferEqual(*buf_data, *expected_data);
+//   }
+// };
 
-TEST_F(TestAzureFileSystem, FromAccountKey) {
-  auto options = AzureOptions::FromAccountKey(GetAzuriteEnv()->account_name(),
-                                              GetAzuriteEnv()->account_key())
-                     .ValueOrDie();
-  ASSERT_EQ(options.credentials_kind,
-            arrow::fs::AzureCredentialsKind::StorageCredentials);
-  ASSERT_NE(options.storage_credentials_provider, nullptr);
-}
+// TEST_F(TestAzureFileSystem, FromAccountKey) {
+//   auto options = AzureOptions::FromAccountKey(GetAzuriteEnv()->account_name(),
+//                                               GetAzuriteEnv()->account_key())
+//                      .ValueOrDie();
+//   ASSERT_EQ(options.credentials_kind,
+//             arrow::fs::AzureCredentialsKind::StorageCredentials);
+//   ASSERT_NE(options.storage_credentials_provider, nullptr);
+// }
 
-TEST_F(GcsIntegrationTest, OpenInputFileMixedReadVsReadAt) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+// TEST_F(GcsIntegrationTest, OpenInputFileMixedReadVsReadAt) {
+//   auto fs = GcsFileSystem::Make(TestGcsOptions());
 
-  // Create a file large enough to make the random access tests non-trivial.
-  auto constexpr kLineWidth = 100;
-  auto constexpr kLineCount = 4096;
-  std::vector<std::string> lines(kLineCount);
-  int lineno = 0;
-  std::generate_n(lines.begin(), lines.size(),
-                  [&] { return RandomLine(++lineno, kLineWidth); });
+//   // Create a file large enough to make the random access tests non-trivial.
+//   auto constexpr kLineWidth = 100;
+//   auto constexpr kLineCount = 4096;
+//   std::vector<std::string> lines(kLineCount);
+//   int lineno = 0;
+//   std::generate_n(lines.begin(), lines.size(),
+//                   [&] { return RandomLine(++lineno, kLineWidth); });
 
-  const auto path =
-      PreexistingBucketPath() + "OpenInputFileMixedReadVsReadAt/object-name";
-  std::shared_ptr<io::OutputStream> output;
-  ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
-  for (auto const& line : lines) {
-    ASSERT_OK(output->Write(line.data(), line.size()));
-  }
-  ASSERT_OK(output->Close());
+//   const auto path =
+//       PreexistingBucketPath() + "OpenInputFileMixedReadVsReadAt/object-name";
+//   std::shared_ptr<io::OutputStream> output;
+//   ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
+//   for (auto const& line : lines) {
+//     ASSERT_OK(output->Write(line.data(), line.size()));
+//   }
+//   ASSERT_OK(output->Close());
 
-  std::shared_ptr<io::RandomAccessFile> file;
-  ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(path));
-  for (int i = 0; i != 32; ++i) {
-    SCOPED_TRACE("Iteration " + std::to_string(i));
-    // Verify sequential reads work as expected.
-    std::array<char, kLineWidth> buffer{};
-    std::int64_t size;
-    {
-      ASSERT_OK_AND_ASSIGN(auto actual, file->Read(kLineWidth));
-      EXPECT_EQ(lines[2 * i], actual->ToString());
-    }
-    {
-      ASSERT_OK_AND_ASSIGN(size, file->Read(buffer.size(), buffer.data()));
-      EXPECT_EQ(size, kLineWidth);
-      auto actual = std::string{buffer.begin(), buffer.end()};
-      EXPECT_EQ(lines[2 * i + 1], actual);
-    }
+//   std::shared_ptr<io::RandomAccessFile> file;
+//   ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(path));
+//   for (int i = 0; i != 32; ++i) {
+//     SCOPED_TRACE("Iteration " + std::to_string(i));
+//     // Verify sequential reads work as expected.
+//     std::array<char, kLineWidth> buffer{};
+//     std::int64_t size;
+//     {
+//       ASSERT_OK_AND_ASSIGN(auto actual, file->Read(kLineWidth));
+//       EXPECT_EQ(lines[2 * i], actual->ToString());
+//     }
+//     {
+//       ASSERT_OK_AND_ASSIGN(size, file->Read(buffer.size(), buffer.data()));
+//       EXPECT_EQ(size, kLineWidth);
+//       auto actual = std::string{buffer.begin(), buffer.end()};
+//       EXPECT_EQ(lines[2 * i + 1], actual);
+//     }
 
-    // Verify random reads interleave too.
-    auto const index = RandomIndex(kLineCount);
-    auto const position = index * kLineWidth;
-    ASSERT_OK_AND_ASSIGN(size, file->ReadAt(position, buffer.size(), buffer.data()));
-    EXPECT_EQ(size, kLineWidth);
-    auto actual = std::string{buffer.begin(), buffer.end()};
-    EXPECT_EQ(lines[index], actual);
+//     // Verify random reads interleave too.
+//     auto const index = RandomIndex(kLineCount);
+//     auto const position = index * kLineWidth;
+//     ASSERT_OK_AND_ASSIGN(size, file->ReadAt(position, buffer.size(), buffer.data()));
+//     EXPECT_EQ(size, kLineWidth);
+//     auto actual = std::string{buffer.begin(), buffer.end()};
+//     EXPECT_EQ(lines[index], actual);
 
-    // Verify random reads using buffers work.
-    ASSERT_OK_AND_ASSIGN(auto b, file->ReadAt(position, kLineWidth));
-    EXPECT_EQ(lines[index], b->ToString());
-  }
-}
+//     // Verify random reads using buffers work.
+//     ASSERT_OK_AND_ASSIGN(auto b, file->ReadAt(position, kLineWidth));
+//     EXPECT_EQ(lines[index], b->ToString());
+//   }
+// }
 
-TEST_F(GcsIntegrationTest, OpenInputFileRandomSeek) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+// TEST_F(GcsIntegrationTest, OpenInputFileRandomSeek) {
+//   auto fs = GcsFileSystem::Make(TestGcsOptions());
 
-  // Create a file large enough to make the random access tests non-trivial.
-  auto constexpr kLineWidth = 100;
-  auto constexpr kLineCount = 4096;
-  std::vector<std::string> lines(kLineCount);
-  int lineno = 0;
-  std::generate_n(lines.begin(), lines.size(),
-                  [&] { return RandomLine(++lineno, kLineWidth); });
+//   // Create a file large enough to make the random access tests non-trivial.
+//   auto constexpr kLineWidth = 100;
+//   auto constexpr kLineCount = 4096;
+//   std::vector<std::string> lines(kLineCount);
+//   int lineno = 0;
+//   std::generate_n(lines.begin(), lines.size(),
+//                   [&] { return RandomLine(++lineno, kLineWidth); });
 
-  const auto path = PreexistingBucketPath() + "OpenInputFileRandomSeek/object-name";
-  std::shared_ptr<io::OutputStream> output;
-  ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
-  for (auto const& line : lines) {
-    ASSERT_OK(output->Write(line.data(), line.size()));
-  }
-  ASSERT_OK(output->Close());
+//   const auto path = PreexistingBucketPath() + "OpenInputFileRandomSeek/object-name";
+//   std::shared_ptr<io::OutputStream> output;
+//   ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
+//   for (auto const& line : lines) {
+//     ASSERT_OK(output->Write(line.data(), line.size()));
+//   }
+//   ASSERT_OK(output->Close());
 
-  std::shared_ptr<io::RandomAccessFile> file;
-  ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(path));
-  for (int i = 0; i != 32; ++i) {
-    SCOPED_TRACE("Iteration " + std::to_string(i));
-    // Verify sequential reads work as expected.
-    auto const index = RandomIndex(kLineCount);
-    auto const position = index * kLineWidth;
-    ASSERT_OK(file->Seek(position));
-    ASSERT_OK_AND_ASSIGN(auto actual, file->Read(kLineWidth));
-    EXPECT_EQ(lines[index], actual->ToString());
-  }
-}
+//   std::shared_ptr<io::RandomAccessFile> file;
+//   ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(path));
+//   for (int i = 0; i != 32; ++i) {
+//     SCOPED_TRACE("Iteration " + std::to_string(i));
+//     // Verify sequential reads work as expected.
+//     auto const index = RandomIndex(kLineCount);
+//     auto const position = index * kLineWidth;
+//     ASSERT_OK(file->Seek(position));
+//     ASSERT_OK_AND_ASSIGN(auto actual, file->Read(kLineWidth));
+//     EXPECT_EQ(lines[index], actual->ToString());
+//   }
+// }
 
-TEST_F(GcsIntegrationTest, OpenInputFileIoContext) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+// TEST_F(GcsIntegrationTest, OpenInputFileIoContext) {
+//   auto fs = GcsFileSystem::Make(TestGcsOptions());
 
-  // Create a test file.
-  const auto path = PreexistingBucketPath() + "OpenInputFileIoContext/object-name";
-  std::shared_ptr<io::OutputStream> output;
-  ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
-  const std::string contents = "The quick brown fox jumps over the lazy dog";
-  ASSERT_OK(output->Write(contents.data(), contents.size()));
-  ASSERT_OK(output->Close());
+//   // Create a test file.
+//   const auto path = PreexistingBucketPath() + "OpenInputFileIoContext/object-name";
+//   std::shared_ptr<io::OutputStream> output;
+//   ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
+//   const std::string contents = "The quick brown fox jumps over the lazy dog";
+//   ASSERT_OK(output->Write(contents.data(), contents.size()));
+//   ASSERT_OK(output->Close());
 
-  std::shared_ptr<io::RandomAccessFile> file;
-  ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(path));
-  EXPECT_EQ(fs->io_context().external_id(), file->io_context().external_id());
-}
+//   std::shared_ptr<io::RandomAccessFile> file;
+//   ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(path));
+//   EXPECT_EQ(fs->io_context().external_id(), file->io_context().external_id());
+// }
 
-TEST_F(GcsIntegrationTest, OpenInputFileInfo) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+// TEST_F(GcsIntegrationTest, OpenInputFileInfo) {
+//   auto fs = GcsFileSystem::Make(TestGcsOptions());
 
-  arrow::fs::FileInfo info;
-  ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingObjectPath()));
+//   arrow::fs::FileInfo info;
+//   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingObjectPath()));
 
-  std::shared_ptr<io::RandomAccessFile> file;
-  ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(info));
+//   std::shared_ptr<io::RandomAccessFile> file;
+//   ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(info));
 
-  std::array<char, 1024> buffer{};
-  std::int64_t size;
-  auto constexpr kStart = 16;
-  ASSERT_OK_AND_ASSIGN(size, file->ReadAt(kStart, buffer.size(), buffer.data()));
+//   std::array<char, 1024> buffer{};
+//   std::int64_t size;
+//   auto constexpr kStart = 16;
+//   ASSERT_OK_AND_ASSIGN(size, file->ReadAt(kStart, buffer.size(), buffer.data()));
 
-  auto const expected = std::string(kLoremIpsum).substr(kStart);
-  EXPECT_EQ(std::string(buffer.data(), size), expected);
-}
+//   auto const expected = std::string(kLoremIpsum).substr(kStart);
+//   EXPECT_EQ(std::string(buffer.data(), size), expected);
+// }
 
-TEST_F(GcsIntegrationTest, OpenInputFileNotFound) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+// TEST_F(GcsIntegrationTest, OpenInputFileNotFound) {
+//   auto fs = GcsFileSystem::Make(TestGcsOptions());
 
-  ASSERT_RAISES(IOError, fs->OpenInputFile(NotFoundObjectPath()));
-}
+//   ASSERT_RAISES(IOError, fs->OpenInputFile(NotFoundObjectPath()));
+// }
 
-TEST_F(GcsIntegrationTest, OpenInputFileInfoInvalid) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+// TEST_F(GcsIntegrationTest, OpenInputFileInfoInvalid) {
+//   auto fs = GcsFileSystem::Make(TestGcsOptions());
 
-  arrow::fs::FileInfo info;
-  ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingBucketPath()));
-  ASSERT_RAISES(IOError, fs->OpenInputFile(info));
+//   arrow::fs::FileInfo info;
+//   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingBucketPath()));
+//   ASSERT_RAISES(IOError, fs->OpenInputFile(info));
 
-  ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(NotFoundObjectPath()));
-  ASSERT_RAISES(IOError, fs->OpenInputFile(info));
-}
+//   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(NotFoundObjectPath()));
+//   ASSERT_RAISES(IOError, fs->OpenInputFile(info));
+// }
 
-TEST_F(GcsIntegrationTest, OpenInputFileClosed) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+// TEST_F(GcsIntegrationTest, OpenInputFileClosed) {
+//   auto fs = GcsFileSystem::Make(TestGcsOptions());
 
-  ASSERT_OK_AND_ASSIGN(auto stream, fs->OpenInputFile(PreexistingObjectPath()));
-  ASSERT_OK(stream->Close());
-  std::array<char, 16> buffer{};
-  ASSERT_RAISES(Invalid, stream->Tell());
-  ASSERT_RAISES(Invalid, stream->Read(buffer.size(), buffer.data()));
-  ASSERT_RAISES(Invalid, stream->Read(buffer.size()));
-  ASSERT_RAISES(Invalid, stream->ReadAt(1, buffer.size(), buffer.data()));
-  ASSERT_RAISES(Invalid, stream->ReadAt(1, 1));
-  ASSERT_RAISES(Invalid, stream->Seek(2));
-}
+//   ASSERT_OK_AND_ASSIGN(auto stream, fs->OpenInputFile(PreexistingObjectPath()));
+//   ASSERT_OK(stream->Close());
+//   std::array<char, 16> buffer{};
+//   ASSERT_RAISES(Invalid, stream->Tell());
+//   ASSERT_RAISES(Invalid, stream->Read(buffer.size(), buffer.data()));
+//   ASSERT_RAISES(Invalid, stream->Read(buffer.size()));
+//   ASSERT_RAISES(Invalid, stream->ReadAt(1, buffer.size(), buffer.data()));
+//   ASSERT_RAISES(Invalid, stream->ReadAt(1, 1));
+//   ASSERT_RAISES(Invalid, stream->Seek(2));
+// }
 
 }  // namespace
 }  // namespace fs

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -50,6 +50,7 @@
 #include <azure/identity/managed_identity_credential.hpp>
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/common/storage_credential.hpp>
+#include <azure/storage/files/datalake.hpp>
 
 namespace arrow {
 using internal::TemporaryDir;
@@ -154,83 +155,82 @@ TEST(AzureFileSystem, OptionsCompare) {
   EXPECT_TRUE(options.Equals(options));
 }
 
+class TestAzureFileSystem : public ::testing::Test {
+ public:
+  std::shared_ptr<FileSystem> fs_;
+  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient> gen2_client_;
+  AzureOptions options_;
 
-// class TestAzureFileSystem : public ::testing::Test {
-//  public:
-//   std::shared_ptr<FileSystem> fs_;
-//   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient> gen2_client_;
-//   AzureOptions options_;
+  void MakeFileSystem() {
+    const std::string& account_name = GetAzuriteEnv()->account_name();
+    const std::string& account_key = GetAzuriteEnv()->account_key();
+    options_.backend = AzureBackend::Azurite;
+    ASSERT_OK(options_.ConfigureAccountKeyCredentials(account_name, account_key));
+    gen2_client_ =
+        std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
+            options_.account_dfs_url, options_.storage_credentials_provider);
+    ASSERT_OK_AND_ASSIGN(fs_, AzureFileSystem::Make(options_));
+  }
 
-//   void MakeFileSystem() {
-//     const std::string& account_name = GetAzuriteEnv()->account_name();
-//     const std::string& account_key = GetAzuriteEnv()->account_key();
-//     options_.is_azurite = true;
-//     options_.ConfigureAccountKeyCredentials(account_name, account_key);
-//     gen2_client_ =
-//         std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
-//             options_.account_dfs_url, options_.storage_credentials_provider);
-//     ASSERT_OK_AND_ASSIGN(fs_, AzureBlobFileSystem::Make(options_));
-//   }
+  void SetUp() override {
+    ASSERT_THAT(GetAzuriteEnv(), NotNull());
+    ASSERT_OK(GetAzuriteEnv()->status());
 
-//   void SetUp() override {
-//     ASSERT_THAT(GetAzuriteEnv(), NotNull());
-//     ASSERT_OK(GetAzuriteEnv()->status());
+    MakeFileSystem();
+    auto file_system_client = gen2_client_->GetFileSystemClient("container");
+    file_system_client.CreateIfNotExists();
+    file_system_client = gen2_client_->GetFileSystemClient("empty-container");
+    file_system_client.CreateIfNotExists();
+    auto file_client =
+        std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
+            options_.account_blob_url + "container/somefile",
+            options_.storage_credentials_provider);
+    std::string s = "some data";
+    file_client->UploadFrom(
+        const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(s.data())), s.size());
+  }
 
-//     MakeFileSystem();
-//     auto file_system_client = gen2_client_->GetFileSystemClient("container");
-//     file_system_client.CreateIfNotExists();
-//     file_system_client = gen2_client_->GetFileSystemClient("empty-container");
-//     file_system_client.CreateIfNotExists();
-//     auto file_client =
-//         std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
-//             options_.account_blob_url + "container/somefile",
-//             options_.storage_credentials_provider);
-//     std::string s = "some data";
-//     file_client->UploadFrom(
-//         const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(s.data())), s.size());
-//   }
+  void TearDown() override {
+    auto containers = gen2_client_->ListFileSystems();
+    for (auto container : containers.FileSystems) {
+      auto file_system_client = gen2_client_->GetFileSystemClient(container.Name);
+      file_system_client.DeleteIfExists();
+    }
+  }
 
-//   void TearDown() override {
-//     auto containers = gen2_client_->ListFileSystems();
-//     for (auto container : containers.FileSystems) {
-//       auto file_system_client = gen2_client_->GetFileSystemClient(container.Name);
-//       file_system_client.DeleteIfExists();
-//     }
-//   }
-
-//   void AssertObjectContents(
-//       Azure::Storage::Files::DataLake::DataLakeServiceClient* client,
-//       const std::string& container, const std::string& path_to_file,
-//       const std::string& expected) {
-//     auto path_client =
-//         std::make_shared<Azure::Storage::Files::DataLake::DataLakePathClient>(
-//             client->GetUrl() + container + "/" + path_to_file,
-//             options_.storage_credentials_provider);
-//     auto size = path_client->GetProperties().Value.FileSize;
-//     if (size == 0) {
-//       ASSERT_EQ(expected, "");
-//       return;
-//     }
-//     auto buf = AllocateBuffer(size, fs_->io_context().pool());
-//     Azure::Storage::Blobs::DownloadBlobToOptions download_options;
-//     Azure::Core::Http::HttpRange range;
-//     range.Offset = 0;
-//     range.Length = size;
-//     download_options.Range = Azure::Nullable<Azure::Core::Http::HttpRange>(range);
-//     auto file_client =
-//         std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
-//             client->GetUrl() + container + "/" + path_to_file,
-//             options_.storage_credentials_provider);
-//     auto result = file_client
-//                       ->DownloadTo(reinterpret_cast<uint8_t*>(buf->get()->mutable_data()),
-//                                    size, download_options)
-//                       .Value;
-//     auto buf_data = std::move(buf->get());
-//     auto expected_data = std::make_shared<Buffer>(
-//         reinterpret_cast<const uint8_t*>(expected.data()), expected.size());
-//     AssertBufferEqual(*buf_data, *expected_data);
-//   }
-// };
+  void AssertObjectContents(
+      Azure::Storage::Files::DataLake::DataLakeServiceClient* client,
+      const std::string& container, const std::string& path_to_file,
+      const std::string& expected) {
+    auto path_client =
+        std::make_shared<Azure::Storage::Files::DataLake::DataLakePathClient>(
+            client->GetUrl() + container + "/" + path_to_file,
+            options_.storage_credentials_provider);
+    auto size = path_client->GetProperties().Value.FileSize;
+    if (size == 0) {
+      ASSERT_EQ(expected, "");
+      return;
+    }
+    auto buf = AllocateBuffer(size, fs_->io_context().pool());
+    Azure::Storage::Blobs::DownloadBlobToOptions download_options;
+    Azure::Core::Http::HttpRange range;
+    range.Offset = 0;
+    range.Length = size;
+    download_options.Range = Azure::Nullable<Azure::Core::Http::HttpRange>(range);
+    auto file_client =
+        std::make_shared<Azure::Storage::Files::DataLake::DataLakeFileClient>(
+            client->GetUrl() + container + "/" + path_to_file,
+            options_.storage_credentials_provider);
+    auto result = file_client
+                      ->DownloadTo(reinterpret_cast<uint8_t*>(buf->get()->mutable_data()),
+                                   size, download_options)
+                      .Value;
+    auto buf_data = std::move(buf->get());
+    auto expected_data = std::make_shared<Buffer>(
+        reinterpret_cast<const uint8_t*>(expected.data()), expected.size());
+    AssertBufferEqual(*buf_data, *expected_data);
+  }
+};
 
 // TEST_F(TestAzureFileSystem, FromAccountKey) {
 //   auto options = AzureOptions::FromAccountKey(GetAzuriteEnv()->account_name(),

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -124,33 +124,6 @@ AzuriteEnv* GetAzuriteEnv() {
 
 // Placeholder tests
 // TODO: GH-18014 Remove once a proper test is added
-TEST(AzureFileSystem, UploadThenDownload) {
-  const std::string container_name = "sample-container";
-  const std::string blob_name = "sample-blob.txt";
-  const std::string blob_content = "Hello Azure!";
-
-  const std::string& account_name = GetAzuriteEnv()->account_name();
-  const std::string& account_key = GetAzuriteEnv()->account_key();
-
-  auto credential = std::make_shared<Azure::Storage::StorageSharedKeyCredential>(
-      account_name, account_key);
-
-  auto service_client = Azure::Storage::Blobs::BlobServiceClient(
-      std::string("http://127.0.0.1:10000/") + account_name, credential);
-  auto container_client = service_client.GetBlobContainerClient(container_name);
-  container_client.CreateIfNotExists();
-  auto blob_client_ = container_client.GetBlockBlobClient(blob_name);
-
-  std::vector<uint8_t> buffer(blob_content.begin(), blob_content.end());
-  blob_client_.UploadFrom(buffer.data(), buffer.size());
-
-  std::vector<uint8_t> downloaded_content(blob_content.size());
-  blob_client_.DownloadTo(downloaded_content.data(), downloaded_content.size());
-
-  EXPECT_EQ(std::string(downloaded_content.begin(), downloaded_content.end()),
-            blob_content);
-}
-
 TEST(AzureFileSystem, InitializeCredentials) {
   auto default_credential = std::make_shared<Azure::Identity::DefaultAzureCredential>();
   auto managed_identity_credential =

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -228,11 +228,8 @@ TEST_F(TestAzureFileSystem, OpenInputStreamString) {
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream, fs_->OpenInputStream(PreexistingObjectPath()));
 
-  std::array<char, 1024> buffer{};
-  std::int64_t size;
-  ASSERT_OK_AND_ASSIGN(size, stream->Read(buffer.size(), buffer.data()));
-
-  EXPECT_EQ(std::string(buffer.data(), size), kLoremIpsum);
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
+  EXPECT_EQ(buffer->ToString(), kLoremIpsum);
 }
 
 TEST_F(TestAzureFileSystem, OpenInputStreamStringBuffers) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -215,7 +215,7 @@ class TestAzureFileSystem : public ::testing::Test {
 
   void UploadLines(const std::vector<std::string>& lines, const char* path_to_file,
                    int total_size) {
-    // TODO: Switch to using Azure filesystem to write once its implemented.
+    // TODO(GH-38333): Switch to using Azure filesystem to write once its implemented.
     auto blob_client = service_client_->GetBlobContainerClient(PreexistingContainerName())
                            .GetBlockBlobClient(path_to_file);
     std::string all_lines = std::accumulate(lines.begin(), lines.end(), std::string(""));
@@ -247,7 +247,7 @@ TEST_F(TestAzureFileSystem, OpenInputStreamStringBuffers) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputStreamInfo) {
-  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
   // fs->GetFileInfo(PreexistingObjectPath()));
   arrow::fs::FileInfo info(PreexistingObjectPath(), FileType::File);
 
@@ -277,12 +277,12 @@ TEST_F(TestAzureFileSystem, OpenInputStreamNotFound) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputStreamInfoInvalid) {
-  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
   // fs->GetFileInfo(PreexistingBucketPath()));
   arrow::fs::FileInfo info(PreexistingContainerPath(), FileType::Directory);
   ASSERT_RAISES(IOError, fs_->OpenInputStream(info));
 
-  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
   // fs->GetFileInfo(NotFoundObjectPath()));
   arrow::fs::FileInfo info2(PreexistingContainerPath(), FileType::NotFound);
   ASSERT_RAISES(IOError, fs_->OpenInputStream(info2));
@@ -308,8 +308,8 @@ TEST_F(TestAzureFileSystem, OpenInputStreamReadMetadata) {
 
   std::shared_ptr<const KeyValueMetadata> actual;
   ASSERT_OK_AND_ASSIGN(actual, stream->ReadMetadata());
-  // TODO(GH-38330): This is asserting that the user defined metadata is returned but this is 
-  // probably not the correct behaviour.
+  // TODO(GH-38330): This is asserting that the user defined metadata is returned but this
+  // is probably not the correct behaviour.
   ASSERT_OK_AND_EQ("value0", actual->Get("key0"));
 }
 
@@ -413,7 +413,7 @@ TEST_F(TestAzureFileSystem, OpenInputFileIoContext) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputFileInfo) {
-  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
   // fs->GetFileInfo(PreexistingObjectPath()));
   arrow::fs::FileInfo info(PreexistingObjectPath(), FileType::File);
 
@@ -434,12 +434,12 @@ TEST_F(TestAzureFileSystem, OpenInputFileNotFound) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputFileInfoInvalid) {
-  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
   // fs->GetFileInfo(PreexistingContainerPath()));
   arrow::fs::FileInfo info(PreexistingContainerPath(), FileType::File);
   ASSERT_RAISES(IOError, fs_->OpenInputFile(info));
 
-  // TODO: When implemented use ASSERT_OK_AND_ASSIGN(info,
+  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
   // fs->GetFileInfo(NotFoundObjectPath()));
   arrow::fs::FileInfo info2(NotFoundObjectPath(), FileType::NotFound);
   ASSERT_RAISES(IOError, fs_->OpenInputFile(info2));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -52,7 +52,6 @@
 #include <azure/identity/managed_identity_credential.hpp>
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/common/storage_credential.hpp>
-#include <azure/storage/files/datalake.hpp>
 
 namespace arrow {
 using internal::TemporaryDir;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
We want a C++ implementation of an Azure filesystem. Reading files is the first step. 

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Adds an implementation of `io::RandomAccessFile` for Azure blob storage (with or without hierarchical namespace (HNS) a.k.a datalake gen 2). This is largely copied from https://github.com/apache/arrow/pull/12914. Using this `io::RandomAccessFile` implementation we implement the input file and stream methods of the `AzureFileSystem`. 

I've made a few changes to the implementation from https://github.com/apache/arrow/pull/12914. The biggest one is removing use of the Azure SDK datalake APIs. These APIs cannot be tested with `azurite`, they are only beneficial for listing operations on HNS enabled accounts and detecting a HNS enabled account is quite difficult (unless you use significantly elevated Azure permissions). Adding 2 different code paths for normal blob storage and datalake gen 2 seems like a bad idea to me except in cases where there is a performance advantage. I also made a few other tweaks to some of the error handling and to make things more consistent with the S3 or GCS filesystems. 

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. The tests are all based on the tests from the GCS filesystem with minimal chantges. I remember reading a review comment on https://github.com/apache/arrow/pull/12914 which recommended this approach. 
There are a few places where the GCS tests relied on file writes or file info methods so I've replaced those with direct calls to the Azure blob client and left TODO comments saying to switch them to use the AzureFilesystem when the relevant methods are implemented. 

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes. File reads using the Azure filesystem are now supported. 

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #37511