### PR TITLE
GH-38211: [MATLAB] Add support for creating an empty arrow.tabular.RecordBatch by calling arrow.recordBatch with no input arguments

### DIFF
--- a/matlab/src/matlab/+arrow/recordBatch.m
+++ b/matlab/src/matlab/+arrow/recordBatch.m
@@ -16,7 +16,7 @@
 % permissions and limitations under the License.
 function rb = recordBatch(T)
     arguments
-        T table= table.empty(0, 0)
+        matlabTable {istable} = table.empty(0, 0)
     end
 
     arrowArrays = arrow.tabular.internal.decompose(T);

--- a/matlab/src/matlab/+arrow/recordBatch.m
+++ b/matlab/src/matlab/+arrow/recordBatch.m
@@ -16,7 +16,7 @@
 % permissions and limitations under the License.
 function rb = recordBatch(T)
     arguments
-        T table
+        T table= table.empty(0, 0)
     end
 
     arrowArrays = arrow.tabular.internal.decompose(T);

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -494,9 +494,13 @@ classdef tRecordBatch < matlab.unittest.TestCase
             % Call isequal with more than two arguments
             testCase.verifyFalse(isequal(rb1, rb2, rb3, rb4));
         end
-
-
-    end
+        % Verify that passing in no arguments to arrow.recordBatch returns an empty RecordBatch
+        function testArrowRecordBatchNoArgs()
+            expected = arrow.tabular.RecordBatch.empty();
+            actual = arrow.recordBatch();
+            assertEqual(expected, actual);
+        end
+end
 
     methods
         function verifyRecordBatch(tc, recordBatch, expectedColumnNames, expectedArrayClasses, expectedTable)

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -494,12 +494,22 @@ classdef tRecordBatch < matlab.unittest.TestCase
             % Call isequal with more than two arguments
             testCase.verifyFalse(isequal(rb1, rb2, rb3, rb4));
         end
-        % Verify that passing in no arguments to arrow.recordBatch returns an empty RecordBatch
-        function testArrowRecordBatchNoArgs()
-            expected = arrow.tabular.RecordBatch.empty();
-            actual = arrow.recordBatch();
-            assertEqual(expected, actual);
-        end
+       function testArrowRecordBatchNoArgs()
+    % Call arrow.recordBatch with no arguments
+    actual = arrow.recordBatch();
+    
+    % Create an empty expected RecordBatch
+    schema = arrow.schema();
+    expected = arrow.tabular.RecordBatch(schema, {});
+    
+    % Use isequal to check if the actual and expected are equal
+    if isequal(expected, actual)
+        disp('Test passed: arrow.recordBatch() with no arguments returns an empty RecordBatch.');
+    else
+        error('Test failed: arrow.recordBatch() did not return an empty RecordBatch.');
+    end
+end
+
 end
 
     methods


### PR DESCRIPTION
* Closes: #38211