### PR TITLE
GH-36044: [Python][Docs] Added ParquetFileFragment to the API reference docs

### DIFF
--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -48,6 +48,7 @@ Classes
    ParquetFileFormat
    ParquetReadOptions
    ParquetFragmentScanOptions
+   ParquetFileFragment
    OrcFileFormat
    Partitioning
    PartitioningFactory


### PR DESCRIPTION
* Closes: #36044
