### PR TITLE
GH-38282: [C++] Implement ReplaceString with the right type signature

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -2063,7 +2063,13 @@ struct RegexSubstringReplacer {
         regex_find_("(" + options_.pattern + ")", MakeRE2Options<Type>()),
         regex_replacement_(options_.pattern, MakeRE2Options<Type>()) {}
 
-  Status ReplaceString(re2::StringPiece s, TypedBufferBuilder<uint8_t>* builder) const {
+  Status ReplaceString(std::string_view s, TypedBufferBuilder<uint8_t>* builder) const {
+    re2::StringPiece piece(s.data(), s.length());
+    return ReplaceStringImpl(piece, builder);
+  }
+
+  Status ReplaceStringImpl(re2::StringPiece s,
+                           TypedBufferBuilder<uint8_t>* builder) const {
     re2::StringPiece replacement(options_.replacement);
 
     // If s is empty, then it's essentially global


### PR DESCRIPTION
### Rationale for this change

The type signature of `ReplaceString` should be identical when arrow is compiled with or without `ARROW_WITH_RE2`.

### What changes are included in this PR?

The right signature + delegating to the implementation that takes `re2::StringPiece`. The conversion should be a no-op when compiled and optimized.

### Are these changes tested?

By existing tests and CI checks.

* Closes: #38282