### PR TITLE
GH-38286: [CI][R] Clean GitHub runner disk for ubuntu-r-only-r images

### DIFF
--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -27,6 +27,9 @@ jobs:
 {{ macros.github_set_env(env) }}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth|default(1))|indent }}
+    {{% if image in ["ubuntu-r-only-r"] }}
+      {{ macros.github_free_space()|indent }}
+    {{% endif %}}
       {{ macros.github_install_archery()|indent }}
 
       - name: Execute Docker Build

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -27,9 +27,9 @@ jobs:
 {{ macros.github_set_env(env) }}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth|default(1))|indent }}
-    {{% if image in ["ubuntu-r-only-r"] %}}
+    {% if image in ["ubuntu-r-only-r"] %}
       {{ macros.github_free_space()|indent }}
-    {{% endif %}}
+    {% endif %}
       {{ macros.github_install_archery()|indent }}
 
       - name: Execute Docker Build

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -27,7 +27,7 @@ jobs:
 {{ macros.github_set_env(env) }}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth|default(1))|indent }}
-    {{% if image in ["ubuntu-r-only-r"] }}
+    {{% if image in ["ubuntu-r-only-r"] %}}
       {{ macros.github_free_space()|indent }}
     {{% endif %}}
       {{ macros.github_install_archery()|indent }}


### PR DESCRIPTION
### Rationale for this change
Fix CI failures for job that is getting out of space.

### What changes are included in this PR?

Using our free disk space script to add space for the ubuntu-r-only-r images.

### Are these changes tested?

On CI

### Are there any user-facing changes?
No
* Closes: #38286