### PR TITLE
MINOR: [R] Avoid stray output from expr when checking for 10.13

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -264,7 +264,7 @@ set_pkg_vars () {
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
 
-  if [ "$UNAME" = "Darwin" ] && [ $(sw_vers -productVersion) = "10.13" ]; then
+  if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13'; then
     # avoid C++17 availability warnings on macOS < 11
     PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
   fi

--- a/r/configure
+++ b/r/configure
@@ -264,6 +264,8 @@ set_pkg_vars () {
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
 
+  # 'expr :' always outputs the number of matched characters, to avoid noise in the log we 
+  # redirect the output to /dev/null
   if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then
     # avoid C++17 availability warnings on macOS < 11
     PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"

--- a/r/configure
+++ b/r/configure
@@ -264,7 +264,7 @@ set_pkg_vars () {
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
 
-  if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13'; then
+  if [ "$UNAME" = "Darwin" ] && [ $(sw_vers -productVersion) = "10.13" ]; then
     # avoid C++17 availability warnings on macOS < 11
     PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
   fi

--- a/r/configure
+++ b/r/configure
@@ -264,8 +264,9 @@ set_pkg_vars () {
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
 
-  # 'expr :' always outputs the number of matched characters, to avoid noise in the log we 
-  # redirect the output to /dev/null
+  # We use expr because the product version returns more than just 10.13 and we want to 
+  # match the substring. However, expr always outputs the number of matched characters
+  # to stdout, to avoid noise in the log we redirect the output to /dev/null
   if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then
     # avoid C++17 availability warnings on macOS < 11
     PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"

--- a/r/configure
+++ b/r/configure
@@ -264,7 +264,7 @@ set_pkg_vars () {
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
 
-  if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13'; then
+  if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then
     # avoid C++17 availability warnings on macOS < 11
     PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
   fi


### PR DESCRIPTION
### Rationale for this change

`expr` was printing the number of matching chars which showed up as noise in the log (which we want to avoid as much as possible to avoid any false positive checks)
See https://github.com/apache/arrow/pull/38236#issuecomment-1761679457 for @jonkeane's investigation.

### What changes are included in this PR?

Replace use of expr with test.

### Are these changes tested?
Crossbow