### PR TITLE
MINOR: Update dev docs link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,4 @@ integrations in other projects, we'd be happy to have you involved:
 [2]: https://github.com/apache/arrow/tree/main/format
 [3]: https://github.com/apache/arrow/issues
 [4]: https://github.com/apache/arrow
-[5]: https://arrow.apache.org/docs/dev/developers/contributing.html
+[5]: https://arrow.apache.org/docs/dev/developers/index.html


### PR DESCRIPTION
### Rationale for this change

Broken link on the [arrow/README.md](https://github.com/apache/arrow/blob/main/README.md?plain=1#L102) after the landing page for the dev docs has been changed in https://github.com/apache/arrow/pull/36591.
### What changes are included in this PR?

Update the link.