### PR TITLE
GH-38323: [CI][Python] Use system gdb on test-conda-python

### DIFF
--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -25,7 +25,6 @@ COPY ci/conda_env_python.txt \
      /arrow/ci/
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
-        gdb \
         python=${python} \
         nomkl && \
     mamba clean --all

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -23,8 +23,11 @@ FROM ${repo}:${arch}-conda-cpp
 ARG python=3.8
 COPY ci/conda_env_python.txt \
      /arrow/ci/
+# If the Python version being tested is the same as the Python used by the system gdb,
+# we need to install the conda-forge gdb instead.
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
+        $([ "$python" == "3.10" ] && echo "gdb") \
         python=${python} \
         nomkl && \
     mamba clean --all

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -24,10 +24,10 @@ ARG python=3.8
 COPY ci/conda_env_python.txt \
      /arrow/ci/
 # If the Python version being tested is the same as the Python used by the system gdb,
-# we need to install the conda-forge gdb instead.
+# we need to install the conda-forge gdb instead (GH-38323).
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
-        $([ "$python" == "3.10" ] && echo "gdb") \
+        $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb") \
         python=${python} \
         nomkl && \
     mamba clean --all


### PR DESCRIPTION
### Rationale for this change

gdb on conda-forge frequently conflicts with the newest Python version (example for Python 3.12: https://github.com/conda-forge/gdb-feedstock/issues/66)

### What changes are included in this PR?

Use the system-provided gdb instead of trying to install it from conda-forge.

This works because the Python interpreter used for gdb is entirely independent from the Python interpreter under test, and gdb itself can debug any binary, regardless of binutils version.

However, there is a complication: if the system Python version and the conda-forge Python version are the same, then for some reason `pyarrow/tests/test_gdb.py` would fail with the system gdb. In that case we still install the conda-forge gdb.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* Closes: #38323