### PR TITLE
GH-38026: [Python] Use provided field types in StructArray.from_arrays

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4244,6 +4244,9 @@ cdef class StructArray(Array):
 
         for arr in arrays:
             c_array = pyarrow_unwrap_array(arr)
+            # The following is asserting an invariant, but shouldn't
+            # occur. Use of asarray above when constructing arrays
+            # should guarantee that we always get a non-null result.
             if c_array == nullptr:
                 raise TypeError(f"Expected Array, got {arr.__class__}")
             c_arrays.push_back(c_array)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4242,7 +4242,6 @@ cdef class StructArray(Array):
                 # Arrow Arrays. Coerce the data type of anything else,
                 # since that other stuff doesn't have a certain type
                 # we can verify.
-                print(ary, field)
                 if isinstance(ary, (Array, ChunkedArray)):
                     if ary.type != field.type:
                         raise ValueError(f"Field {field.name} is expected to have type {field.type}, but provided data is {ary.type}")

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4244,7 +4244,8 @@ cdef class StructArray(Array):
                 # we can verify.
                 if isinstance(ary, (Array, ChunkedArray)):
                     if ary.type != field.type:
-                        raise ValueError(f"Field {field.name} is expected to have type {field.type}, but provided data is {ary.type}")
+                        raise ValueError(
+                            f"Field {field.name} is expected to have type {field.type}, but provided data is {ary.type}")
                     type_enforced_arrays.append(ary)
                 else:
                     type_enforced_arrays.append(asarray(ary, field.type))

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -772,6 +772,14 @@ def test_struct_from_arrays():
     with pytest.raises(ValueError, match="Failed to parse string"):
         pa.StructArray.from_arrays([a, b, c], fields=[fa, fb2, fc])
 
+    # Too few fields
+    with pytest.raises(ValueError, match="Must pass same number of arrays as fields"):
+        pa.StructArray.from_arrays([a, b, c], names=None, fields=[fa, fb])
+
+    # Too many fields
+    with pytest.raises(ValueError, match="Mismatching number of fields and child arrays"):
+        pa.StructArray.from_arrays([a, b], names=None, fields=[fa, fb, fc])
+
     arrays = [a, b, c]
     fields = [fa, fb, fc]
     # With mask

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -769,7 +769,10 @@ def test_struct_from_arrays():
 
     # Inconsistent fields
     fa2 = pa.field("a", pa.int32())
-    with pytest.raises(ValueError, match="expected to have type int32, but provided data is int64"):
+    with pytest.raises(
+            ValueError,
+            match="expected to have type int32, but provided data is int64",
+    ):
         pa.StructArray.from_arrays([a, b, c], fields=[fa2, fb, fc])
 
     # Too few fields

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -768,9 +768,9 @@ def test_struct_from_arrays():
     assert arr.to_pylist() == []
 
     # Inconsistent fields
-    fa2 = pa.field("a", pa.int32())
-    with pytest.raises(ValueError, match="int64 vs int32"):
-        pa.StructArray.from_arrays([a, b, c], fields=[fa2, fb, fc])
+    fb2 = pa.field("b", pa.int32())
+    with pytest.raises(ValueError, match="Failed to parse string"):
+        pa.StructArray.from_arrays([a, b, c], fields=[fa, fb2, fc])
 
     arrays = [a, b, c]
     fields = [fa, fb, fc]
@@ -798,6 +798,16 @@ def test_struct_from_arrays():
     arr = pa.StructArray.from_arrays([], [], mask=mask)
     assert arr.is_null() == mask
     assert arr.to_pylist() == [None, {}, {}]
+
+    # Fixed length lists https://github.com/apache/arrow/issues/38026
+    fa2 = pa.field("x", pa.list_(pa.int32(), 2))
+    arr = pa.StructArray.from_arrays([[[1, 2], [3, 4]]], fields=[fa2])
+    assert arr.to_pylist() == [{'x': [1, 2]}, {'x': [3, 4]}]
+
+    # Large Strings https://github.com/apache/arrow/issues/38026
+    fa3 = pa.field("y", pa.large_string())
+    arr = pa.StructArray.from_arrays([["foo", "bar"]], fields=[fa3])
+    assert arr.to_pylist() == [{'y': "foo"}, {'y': "bar"}]
 
 
 def test_struct_array_from_chunked():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -768,16 +768,16 @@ def test_struct_from_arrays():
     assert arr.to_pylist() == []
 
     # Inconsistent fields
-    fb2 = pa.field("b", pa.int32())
-    with pytest.raises(ValueError, match="Failed to parse string"):
-        pa.StructArray.from_arrays([a, b, c], fields=[fa, fb2, fc])
+    fa2 = pa.field("a", pa.int32())
+    with pytest.raises(ValueError, match="expected to have type int32, but provided data is int64"):
+        pa.StructArray.from_arrays([a, b, c], fields=[fa2, fb, fc])
 
     # Too few fields
     with pytest.raises(ValueError, match="Must pass same number of arrays as fields"):
         pa.StructArray.from_arrays([a, b, c], names=None, fields=[fa, fb])
 
     # Too many fields
-    with pytest.raises(ValueError, match="Mismatching number of fields and child arrays"):
+    with pytest.raises(ValueError, match="Must pass same number of arrays as fields"):
         pa.StructArray.from_arrays([a, b], names=None, fields=[fa, fb, fc])
 
     arrays = [a, b, c]


### PR DESCRIPTION
### Rationale for this change

Previously, pyarrow.StructArray.from_arrays would fail on certain types of input. When it receives a non-pyarrow data array, it would first infer the type of the input data, and _then_ apply the user-input type from the constructor, which can fail when casting.

Instead, proactively use the field type information provided.

### What changes are included in this PR?

Changes to StructArray.from_arrays to use field type info, and a bit more test coverage for that case.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes: Since StructArray.from_arrays uses `asarray` under the hood, it will now cast the inputs to match the Struct fields provided, if inputs are PyArrow arrays already. This seems like an improvement, to me, but it is a change in behavior. 
* Closes: #38026