### PR TITLE
GH-38332: [CI][Release] Resolve symlinks in RAT lint

### DIFF
--- a/cpp/cmake_modules/snappy.diff
+++ b/cpp/cmake_modules/snappy.diff
@@ -1,3 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# https://github.com/google/snappy/pull/172
+
 diff --git a/snappy.cc b/snappy.cc
 index d414718..5b0d0d6 100644
 --- a/snappy.cc

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -65,7 +65,9 @@ rm -rf ${tag}
   git archive ${release_hash} --prefix ${tag}/) | \
   tar xf -
 
-# Resolve all hard and symbolic links
+# Resolve all hard and symbolic links.
+# If we change this, we must change Source.archive in
+# dev/archery/archery/utils/source.py too.
 rm -rf ${tag}.tmp
 mv ${tag} ${tag}.tmp
 cp -R -L ${tag}.tmp ${tag}

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -66,7 +66,7 @@ rm -rf ${tag}
   tar xf -
 
 # Resolve all hard and symbolic links.
-# If we change this, we must change Source.archive in
+# If we change this, we must change ArrowSources.archive in
 # dev/archery/archery/utils/source.py too.
 rm -rf ${tag}.tmp
 mv ${tag} ${tag}.tmp

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -22,9 +22,6 @@ cpp/build-support/cpplint.py
 cpp/build-support/lint_exclusions.txt
 cpp/build-support/iwyu/*
 cpp/cmake_modules/FindPythonLibsNew.cmake
-cpp/cmake_modules/SnappyCMakeLists.txt
-cpp/cmake_modules/SnappyConfig.h
-cpp/cmake_modules/snappy.diff
 cpp/examples/parquet/parquet-arrow/cmake_modules/FindArrow.cmake
 cpp/src/parquet/.parquetcppversion
 cpp/src/generated/parquet_constants.cpp
@@ -89,8 +86,6 @@ js/yarn.lock
 js/.eslintignore
 python/cmake_modules
 python/cmake_modules/FindPythonLibsNew.cmake
-python/cmake_modules/SnappyCMakeLists.txt
-python/cmake_modules/SnappyConfig.h
 python/MANIFEST.in
 python/manylinux1/.dockerignore
 python/pyarrow/includes/__init__.pxd


### PR DESCRIPTION
### Rationale for this change

Our release script (`dev/release/02-source.sh`) resolves symlinks in source archive but our lint script (`dev/archery/archery/utils/source.py`) doesn't resolve symlinks. So we may detect RAT problem by our CI.

### What changes are included in this PR?

Resolve symlinks in our lint script too.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38332