### PR TITLE
GH-38363: [Release][CI] Omit tests for main/maintenance branches on RC branch

### DIFF
--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -54,12 +54,12 @@ class PostBumpVersionsTest < Test::Unit::TestCase
     end
     env = env.merge(additional_env)
     case bump_type
-    when :minor_on_main, :patch_on_main
+    when :minor, :patch
       previous_version_components = @previous_version.split(".")
       case bump_type
-      when :minor_on_main
+      when :minor
         previous_version_components[1].succ!
-      when :patch_on_main
+      when :patch
         previous_version_components[2].succ!
       end
       sh(env,
@@ -323,8 +323,9 @@ class PostBumpVersionsTest < Test::Unit::TestCase
                  "Output:\n#{stdout}")
   end
 
-  data(:bump_type, [nil, :minor_on_main, :patch_on_main])
+  data(:bump_type, [nil, :minor, :patch])
   def test_deb_package_names
+    omit_on_release_branch unless bump_type.nil?
     current_commit = git_current_commit
     stdout = bump_versions("DEB_PACKAGE_NAMES")
     changes = parse_patch(git("log", "-p", "#{current_commit}.."))


### PR DESCRIPTION
### Rationale for this change

Tests of deb package names for the following patterns are only for main/maintenance branches:

* `dev/release/post-11-bump-versions.sh 14.1.0 15.0.0` (minor release -> major release)
* `dev/release/post-11-bump-versions.sh 14.0.1 15.0.0` (patch release -> major release)

### What changes are included in this PR?

Omit these patterns.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38363