### PR TITLE
GH-38364: [Python] Initialize S3 on first use

### DIFF
--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -271,24 +271,6 @@ cdef class S3FileSystem(FileSystem):
                  retry_strategy: S3RetryStrategy = AwsStandardS3RetryStrategy(max_attempts=3)):
         ensure_s3_initialized()
 
-        self._initialize_s3(access_key=access_key, secret_key=secret_key, session_token=session_token,
-                            anonymous=anonymous, region=region, request_timeout=request_timeout,
-                            connect_timeout=connect_timeout, scheme=scheme, endpoint_override=endpoint_override,
-                            background_writes=background_writes, default_metadata=default_metadata,
-                            role_arn=role_arn, session_name=session_name, external_id=external_id,
-                            load_frequency=load_frequency, proxy_options=proxy_options,
-                            allow_bucket_creation=allow_bucket_creation, allow_bucket_deletion=allow_bucket_deletion,
-                            retry_strategy=retry_strategy)
-
-    def _initialize_s3(self, *, access_key=None, secret_key=None, session_token=None,
-                       bint anonymous=False, region=None, request_timeout=None,
-                       connect_timeout=None, scheme=None, endpoint_override=None,
-                       bint background_writes=True, default_metadata=None,
-                       role_arn=None, session_name=None, external_id=None,
-                       load_frequency=900, proxy_options=None,
-                       allow_bucket_creation=False, allow_bucket_deletion=False,
-                       retry_strategy: S3RetryStrategy = AwsStandardS3RetryStrategy(max_attempts=3)):
-
         cdef:
             optional[CS3Options] options
             shared_ptr[CS3FileSystem] wrapped

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -37,9 +37,6 @@ cpdef enum S3LogLevel:
     Debug = <int8_t> CS3LogLevel_Debug
     Trace = <int8_t> CS3LogLevel_Trace
 
-# Prevent registration of multiple `atexit` handlers
-_initialized = False
-
 
 def initialize_s3(S3LogLevel log_level=S3LogLevel.Fatal, int num_event_loop_threads=1):
     """
@@ -66,17 +63,18 @@ def ensure_s3_initialized():
     """
     Initialize S3 (with default options) if not already initialized
     """
-    global _initialized
-
-    if not _initialized:
-        check_status(CEnsureS3Initialized())
-        import atexit
-        atexit.register(finalize_s3)
-        _initialized = True
+    check_status(CEnsureS3Initialized())
 
 
 def finalize_s3():
     check_status(CFinalizeS3())
+
+
+def ensure_s3_finalized():
+    """
+    Finalize S3 if already initialized
+    """
+    check_status(CEnsureS3Finalized())
 
 
 def resolve_s3_region(bucket):

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -58,6 +58,10 @@ try:
 except ImportError:
     _not_imported.append("S3FileSystem")
 else:
+    # GH-38364: we don't initialize S3 eagerly as that could lead
+    # to crashes at shutdown even when S3 isn't used.
+    # Instead, S3 is initialized lazily using `ensure_s3_initialized`
+    # in assorted places.
     import atexit
     atexit.register(ensure_s3_finalized)
 

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -54,9 +54,12 @@ try:
     from pyarrow._s3fs import (  # noqa
         AwsDefaultS3RetryStrategy, AwsStandardS3RetryStrategy,
         S3FileSystem, S3LogLevel, S3RetryStrategy, ensure_s3_initialized,
-        finalize_s3, initialize_s3, resolve_s3_region)
+        finalize_s3, ensure_s3_finalized, initialize_s3, resolve_s3_region)
 except ImportError:
     _not_imported.append("S3FileSystem")
+else:
+    import atexit
+    atexit.register(ensure_s3_finalized)
 
 
 def __getattr__(name):

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -57,10 +57,6 @@ try:
         finalize_s3, initialize_s3, resolve_s3_region)
 except ImportError:
     _not_imported.append("S3FileSystem")
-else:
-    ensure_s3_initialized()
-    import atexit
-    atexit.register(finalize_s3)
 
 
 def __getattr__(name):

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -211,6 +211,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         const CS3GlobalOptions& options)
     cdef CStatus CEnsureS3Initialized "arrow::fs::EnsureS3Initialized"()
     cdef CStatus CFinalizeS3 "arrow::fs::FinalizeS3"()
+    cdef CStatus CEnsureS3Finalized "arrow::fs::EnsureS3Finalized"()
 
     cdef CResult[c_string] ResolveS3BucketRegion(const c_string& bucket)
 


### PR DESCRIPTION
### Rationale for this change

In accordance to https://github.com/apache/arrow/issues/38364, we believe that for various reasons (shortening import time, preventing unnecessary resource consumption and potential bugs with S3 library) it is appropriate to avoid initialization of S3 resources at import time and move that step to occur at first-use.

### What changes are included in this PR?

- Remove calls to `ensure_s3_initialized()` that were up until now executed during `import pyarrow.fs`;
- Move `ensure_s3_intialized()` calls to `python/pyarrow/_s3fs.pyx` module;
- Add global flag to mark whether S3 has been previously initialized and `atexit` handlers registered.

### Are these changes tested?

Yes, existing S3 tests check whether it has been initialized, otherwise failing with a C++ exception.

### Are there any user-facing changes?

No, the behavior is now slightly different with S3 initialization not happening immediately after `pyarrow.fs` is imported, but no changes are expected from a user perspective relying on the public API alone.

**This PR contains a "Critical Fix".**
A bug in aws-sdk-cpp reported in https://github.com/aws/aws-sdk-cpp/issues/2681 causes segmentation faults under specific circumstances when Python processes shutdown, specifically observed with Dask+GPUs (so far we were unable to pinpoint the exact correlation of Dask+GPUs+S3). While this definitely doesn't seem to affect all users and is not directly sourced in Arrow, it may affect use cases that are completely independent of S3 to operate, which is particularly problematic in CI where all tests pass successfully but the process crashes at shutdown.
* Closes: #38364