### PR TITLE
GH-38378: [C++][Parquet] Don't initialize OpenSSL explicitly with OpenSSL 1.1

### DIFF
--- a/cpp/src/parquet/encryption/openssl_internal.cc
+++ b/cpp/src/parquet/encryption/openssl_internal.cc
@@ -24,11 +24,14 @@
 namespace parquet::encryption::openssl {
 
 void EnsureInitialized() {
+// OpenSSL 1.1 doesn't provide OPENSSL_INIT_ENGINE_ALL_BUILTIN.
+#ifdef OPENSSL_INIT_ENGINE_ALL_BUILTIN
   // Initialize ciphers and random engines
   if (!OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN | OPENSSL_INIT_ADD_ALL_CIPHERS,
                            NULL)) {
     throw ParquetException("OpenSSL initialization failed");
   }
+#endif
 }
 
 }  // namespace parquet::encryption::openssl


### PR DESCRIPTION
### Rationale for this change

This explicit initialization is for Valgrind and OpenSSL 1.1 will be unsupported eventually. So we can disable this explicit initialization for OpenSSL 1.1. 

### What changes are included in this PR?

Disable the explicit initialization with OpenSSL 1.1.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38378