### PR TITLE
GH-35785: [C++] Support null type non-key columns for join operation

### DIFF
--- a/cpp/src/arrow/acero/hash_join_node.cc
+++ b/cpp/src/arrow/acero/hash_join_node.cc
@@ -53,6 +53,9 @@ bool HashJoinSchema::IsTypeSupported(const DataType& type) {
   if (id == Type::EXTENSION) {
     return IsTypeSupported(*checked_cast<const ExtensionType&>(type).storage_type());
   }
+  if (id == Type::NA) {
+    return true;
+  }
   return is_fixed_width(id) || is_binary_like(id) || is_large_binary_like(id);
 }
 

--- a/cpp/src/arrow/acero/hash_join_node.h
+++ b/cpp/src/arrow/acero/hash_join_node.h
@@ -75,7 +75,7 @@ class ARROW_ACERO_EXPORT HashJoinSchema {
   SchemaProjectionMaps<HashJoinProjection> proj_maps[2];
 
  private:
-  static bool IsTypeSupported(const DataType& type);
+  static bool IsTypeSupported(const DataType& type, bool is_key);
 
   Status CollectFilterColumns(std::vector<FieldRef>& left_filter,
                               std::vector<FieldRef>& right_filter,

--- a/cpp/src/arrow/acero/hash_join_node_test.cc
+++ b/cpp/src/arrow/acero/hash_join_node_test.cc
@@ -282,9 +282,7 @@ struct RandomDataTypeConstraints {
     }
   }
 
-  void withoutNullColumn() {
-    data_type_enabled_mask = ~kNull;
-  }
+  void withoutNullColumn() { data_type_enabled_mask = ~kNull; }
 
   // Data type mask constants
   static constexpr int64_t kInt1 = 1;

--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -274,8 +274,8 @@ void RowEncoder::Init(const std::vector<TypeHolder>& column_types, ExecContext* 
     }
 
     if (type.id() == Type::NA) {
-        encoders_[i] = std::make_shared<NullKeyEncoder>();
-        continue;
+      encoders_[i] = std::make_shared<NullKeyEncoder>();
+      continue;
     }
 
     if (type.id() == Type::BOOL) {

--- a/cpp/src/arrow/compute/kernels/row_encoder.cc
+++ b/cpp/src/arrow/compute/kernels/row_encoder.cc
@@ -272,6 +272,12 @@ void RowEncoder::Init(const std::vector<TypeHolder>& column_types, ExecContext* 
       extension_types_[i] = arrow::internal::checked_pointer_cast<ExtensionType>(
           column_types[i].GetSharedPtr());
     }
+
+    if (type.id() == Type::NA) {
+        encoders_[i] = std::make_shared<NullKeyEncoder>();
+        continue;
+    }
+
     if (type.id() == Type::BOOL) {
       encoders_[i] = std::make_shared<BooleanKeyEncoder>();
       continue;

--- a/cpp/src/arrow/compute/light_array.cc
+++ b/cpp/src/arrow/compute/light_array.cc
@@ -502,7 +502,7 @@ Status ExecBatchBuilder::AppendSelected(const std::shared_ptr<ArrayData>& source
   KeyColumnMetadata column_metadata =
       ColumnMetadataFromDataType(source->type).ValueOrDie();
 
-  if (column_metadata.is_fixed_length) {
+  if (column_metadata.is_fixed_length && column_metadata.fixed_length > 0) {
     // Fixed length column
     //
     uint32_t fixed_length = column_metadata.fixed_length;
@@ -571,7 +571,7 @@ Status ExecBatchBuilder::AppendSelected(const std::shared_ptr<ArrayData>& source
         }
       }
     }
-  } else {
+  } else if (column_metadata.fixed_length > 0) {
     // Varying length column
     //
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Supports join on null types for non-key columns.

* Issue raised: #35785

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

* Separated the check of supported types for key and non-key columns during join execution
* Updated the logic associated with Null types for non-key columns.
* Modified the random tests for Hash Join (TEST(HashJoin, Random)) to allow the creation of Null as non-key column values.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

For users utilizing the Join operation

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35785