### PR TITLE
GH-38391: [PYTHON] Explicitly declare MACOSX_DEPLOYMENT_TARGET in setup.py to avoid spurious build failure on some macOS systems (incl. GitHub Actions runners)

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -21,6 +21,7 @@ import contextlib
 import os
 import os.path
 from os.path import join as pjoin
+import platform
 import re
 import shlex
 import sys
@@ -291,6 +292,13 @@ class build_ext(_build_ext):
 
             cmake_options.append(
                 f'-DCMAKE_BUILD_TYPE={self.build_type.lower()}')
+
+            if sys.platform == 'darwin':
+                mac_ver = platform.mac_ver()[0]
+                if not mac_ver >= '13.0':
+                    raise RuntimeError('Not supported on macOS older than 13.0')
+                cmake_options.append(
+                    f'-DMACOSX_DEPLOYMENT_TARGET={mac_ver}')
 
             extra_cmake_args = shlex.split(self.extra_cmake_args)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -297,8 +297,7 @@ class build_ext(_build_ext):
                 mac_ver = platform.mac_ver()[0]
                 if not mac_ver >= '13.0':
                     raise RuntimeError('Not supported on macOS older than 13.0')
-                cmake_options.append(
-                    f'-DMACOSX_DEPLOYMENT_TARGET={mac_ver}')
+                os.environ['MACOSX_DEPLOYMENT_TARGET'] = mac_ver
 
             extra_cmake_args = shlex.split(self.extra_cmake_args)
 


### PR DESCRIPTION
**Note:** this is mostly a dupe of #38392, which got closed by mistake when I renamed the branch to something more sensible than `patch-1`. I've also added (out-of-repo) testing.

---

### Rationale for this change

Explained in detail in the issue: #38391 

### What changes are included in this PR?

Adds a check to fail fast for macOS prior to 13, and then adds an explicit `MACOSX_DEPLOYMENT_TARGET` for the actual version.

Without this, the `MACOSX_DEPLOYMENT_TARGET` is inferred from the version that the Python distribution was originally built against –which can be (such as on GitHub Actions runners) as old as Mac OS X 10.9– rather than the system itself.

### Are these changes tested?

Yes, but not in the PR, as this is a change to the `python/setup.py`. I have tested this both locally and on the GitHub Actions runner that precipitated the issue. I will also add to this PR an example in the minimal issue reproduction repo (linked in 38391) against this fork to demonstrate that it fixes the issue. 

### Are there any user-facing changes?

No. It does not introduce any new flags or user-facing change in behavior.
* Closes: #38391