### PR TITLE
GH-37413:  [Java] ZSTD compression issue 

### DIFF
--- a/java/compression/src/main/java/org/apache/arrow/compression/ZstdCompressionCodec.java
+++ b/java/compression/src/main/java/org/apache/arrow/compression/ZstdCompressionCodec.java
@@ -47,7 +47,7 @@ public class ZstdCompressionCodec extends AbstractCompressionCodec {
     long dstSize = CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH + maxSize;
     ArrowBuf compressedBuffer = allocator.buffer(dstSize);
     long bytesWritten = Zstd.compressUnsafe(
-                          compressedBuffer.memoryAddress() + CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH, maxSize,
+                          compressedBuffer.memoryAddress() + CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH, dstSize,
                           /*src*/uncompressedBuffer.memoryAddress(), /*srcSize=*/uncompressedBuffer.writerIndex(),
                           /*level=*/this.compressionLevel);
     if (Zstd.isError(bytesWritten)) {

--- a/java/compression/src/main/java/org/apache/arrow/compression/ZstdCompressionCodec.java
+++ b/java/compression/src/main/java/org/apache/arrow/compression/ZstdCompressionCodec.java
@@ -47,7 +47,7 @@ public class ZstdCompressionCodec extends AbstractCompressionCodec {
     long dstSize = CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH + maxSize;
     ArrowBuf compressedBuffer = allocator.buffer(dstSize);
     long bytesWritten = Zstd.compressUnsafe(
-                          compressedBuffer.memoryAddress() + CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH, dstSize,
+                          compressedBuffer.memoryAddress() + CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH, maxSize,
                           /*src*/uncompressedBuffer.memoryAddress(), /*srcSize=*/uncompressedBuffer.writerIndex(),
                           /*level=*/this.compressionLevel);
     if (Zstd.isError(bytesWritten)) {

--- a/java/compression/src/test/java/org/apache/arrow/compression/TestArrowReaderWriterWithCompression.java
+++ b/java/compression/src/test/java/org/apache/arrow/compression/TestArrowReaderWriterWithCompression.java
@@ -86,4 +86,47 @@ public class TestArrowReaderWriterWithCompression {
     }
   }
 
+  @Test
+  public void testArrowFileZstdOverflowRoundTrip() throws Exception {
+    // Prepare sample data
+    final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+    List<Field> fields = new ArrayList<>();
+    fields.add(new Field("col", FieldType.notNullable(new ArrowType.Utf8()), new ArrayList<>()));
+    VectorSchemaRoot root = VectorSchemaRoot.create(new Schema(fields), allocator);
+    final int rowCount = 1;
+    GenerateSampleData.generateRandomTestData(root.getVector(0), rowCount);
+    root.setRowCount(rowCount);
+
+    // Write an in-memory compressed arrow file
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (final ArrowFileWriter writer =
+        new ArrowFileWriter(root, null, Channels.newChannel(out), new HashMap<>(),
+            IpcOption.DEFAULT, CommonsCompressionFactory.INSTANCE, CompressionUtil.CodecType.ZSTD, Optional.of(7))) {
+      writer.start();
+      writer.writeBatch();
+      writer.end();
+    }
+
+    // Read the in-memory compressed arrow file with CommonsCompressionFactory provided
+    try (ArrowFileReader reader =
+        new ArrowFileReader(new ByteArrayReadableSeekableByteChannel(out.toByteArray()),
+            allocator, CommonsCompressionFactory.INSTANCE)) {
+      Assert.assertEquals(1, reader.getRecordBlocks().size());
+      Assert.assertTrue(reader.loadNextBatch());
+      Assert.assertTrue(root.equals(reader.getVectorSchemaRoot()));
+      Assert.assertFalse(reader.loadNextBatch());
+    }
+
+    // Read the in-memory compressed arrow file without CompressionFactory provided
+    try (ArrowFileReader reader =
+        new ArrowFileReader(new ByteArrayReadableSeekableByteChannel(out.toByteArray()),
+            allocator, NoCompressionCodec.Factory.INSTANCE)) {
+      Assert.assertEquals(1, reader.getRecordBlocks().size());
+
+      Exception exception = Assert.assertThrows(IllegalArgumentException.class, () -> reader.loadNextBatch());
+      String expectedMessage = "Please add arrow-compression module to use CommonsCompressionFactory for ZSTD";
+      Assert.assertEquals(expectedMessage, exception.getMessage());
+    }
+  }
+
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector;
 
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
+import java.util.Random;
 
 /**
  * Helper class to generate test data for Nullable fixed and variable
@@ -91,6 +92,13 @@ public class GenerateSampleData {
       writeUInt4Data((UInt4Vector) vector, valueCount);
     } else if (vector instanceof UInt8Vector) {
       writeUInt8Data((UInt8Vector) vector, valueCount);
+    }
+  }
+
+  /** Populates <code>vector</code> with <code>valueCount</code> random values. */
+  public static void generateRandomTestData(final ValueVector vector, final int valueCount) {
+    if (vector instanceof IntVector) {
+      writeRandomIntData((IntVector) vector, valueCount);
     }
   }
 
@@ -390,6 +398,14 @@ public class GenerateSampleData {
       } else {
         vector.setSafe(i, odd);
       }
+    }
+    vector.setValueCount(valueCount);
+  }
+
+  private static void writeRandomIntData(IntVector vector, int valueCount) {
+    Random random = new Random();
+    for (int i = 0; i < valueCount; i++) {
+      vector.setSafe(i, random.nextInt());
     }
     vector.setValueCount(valueCount);
   }


### PR DESCRIPTION
### Rationale for this change

This PR fixes https://github.com/apache/arrow-java/issues/169

### What changes are included in this PR?

A minor change for a function parameter which fixes the available space in the destination buffer.

### Are these changes tested?

No

### Are there any user-facing changes?

No

* Closes: apache/arrow-java#169
* GitHub Issue: #169