### PR TITLE
GH-38395: [Go] fix rounding errors in decimal256 string functions

### DIFF
--- a/go/arrow/decimal128/decimal128.go
+++ b/go/arrow/decimal128/decimal128.go
@@ -518,7 +518,11 @@ func (n Num) FitsInPrecision(prec int32) bool {
 
 func (n Num) ToString(scale int32) string {
 	f := (&big.Float{}).SetInt(n.BigInt())
-	f.Quo(f, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt()))
+	if scale < 0 {
+		f.SetPrec(128).Mul(f, (&big.Float{}).SetInt(scaleMultipliers[-scale].BigInt()))
+	} else {
+		f.SetPrec(128).Quo(f, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt()))
+	}
 	return f.Text('f', int(scale))
 }
 

--- a/go/arrow/decimal128/decimal128.go
+++ b/go/arrow/decimal128/decimal128.go
@@ -275,12 +275,11 @@ func FromString(v string, prec, scale int32) (n Num, err error) {
 		n = FromBigInt(val)
 		n, _ = n.Div(scaleMultipliers[-scale])
 	} else {
-
 		// Since we're going to truncate this to get an integer, we need to round
 		// the value instead because of edge cases so that we match how other implementations
 		// (e.g. C++) handles Decimal values. So if we're negative we'll subtract 0.5 and if
 		// we're positive we'll add 0.5.
-		p := (&big.Float{}).SetFloat64(float64PowersOfTen[scale+38])
+		p := (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt())
 		out.Mul(out, p).SetPrec(precInBits)
 		if out.Signbit() {
 			out.Sub(out, pt5)

--- a/go/arrow/decimal128/decimal128_test.go
+++ b/go/arrow/decimal128/decimal128_test.go
@@ -659,6 +659,7 @@ func TestFromString(t *testing.T) {
 		{"1e-37", 1, 37},
 		{"2112.33", 211233, 2},
 		{"-2112.33", -211233, 2},
+		{"12E2", 12, -2},
 	}
 
 	for _, tt := range tests {

--- a/go/arrow/decimal128/decimal128_test.go
+++ b/go/arrow/decimal128/decimal128_test.go
@@ -682,3 +682,19 @@ func TestInvalidNonNegScaleFromString(t *testing.T) {
 		})
 	}
 }
+
+func TestBitLen(t *testing.T) {
+	n := decimal128.GetScaleMultiplier(38)
+	b := n.BigInt()
+	b.Mul(b, big.NewInt(25))
+	assert.Greater(t, b.BitLen(), 128)
+
+	assert.Panics(t, func() {
+		decimal128.FromBigInt(b)
+	})
+
+	_, err := decimal128.FromString(b.String(), decimal128.MaxPrecision, 0)
+	assert.ErrorContains(t, err, "bitlen too large for decimal128")
+	_, err = decimal128.FromString(b.String(), decimal128.MaxPrecision, -1)
+	assert.ErrorContains(t, err, "bitlen too large for decimal128")
+}

--- a/go/arrow/decimal256/decimal256.go
+++ b/go/arrow/decimal256/decimal256.go
@@ -154,7 +154,7 @@ func FromString(v string, prec, scale int32) (n Num, err error) {
 		return
 	}
 
-	out.Mul(out, big.NewFloat(math.Pow10(int(scale)))).SetPrec(precInBits)
+	out.Mul(out, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt())).SetPrec(precInBits)
 	// Since we're going to truncate this to get an integer, we need to round
 	// the value instead because of edge cases so that we match how other implementations
 	// (e.g. C++) handles Decimal values. So if we're negative we'll subtract 0.5 and if
@@ -506,7 +506,7 @@ func (n Num) FitsInPrecision(prec int32) bool {
 
 func (n Num) ToString(scale int32) string {
 	f := (&big.Float{}).SetInt(n.BigInt())
-	f.Quo(f, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt()))
+	f.SetPrec(256).Quo(f, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt()))
 	return f.Text('f', int(scale))
 }
 

--- a/go/arrow/decimal256/decimal256.go
+++ b/go/arrow/decimal256/decimal256.go
@@ -154,23 +154,34 @@ func FromString(v string, prec, scale int32) (n Num, err error) {
 		return
 	}
 
-	out.Mul(out, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt())).SetPrec(precInBits)
-	// Since we're going to truncate this to get an integer, we need to round
-	// the value instead because of edge cases so that we match how other implementations
-	// (e.g. C++) handles Decimal values. So if we're negative we'll subtract 0.5 and if
-	// we're positive we'll add 0.5.
-	if out.Signbit() {
-		out.Sub(out, pt5)
-	} else {
-		out.Add(out, pt5)
-	}
+	if scale < 0 {
+		var tmp big.Int
+		val, _ := out.Int(&tmp)
+		if val.BitLen() > 255 {
+			return Num{}, errors.New("bitlen too large for decimal256")
+		}
+		n = FromBigInt(val)
 
-	var tmp big.Int
-	val, _ := out.Int(&tmp)
-	if val.BitLen() > 255 {
-		return Num{}, errors.New("bitlen too large for decimal256")
+		n, _ = n.Div(scaleMultipliers[-scale])
+	} else {
+		out.Mul(out, (&big.Float{}).SetFloat64(float64PowersOfTen[scale+76])).SetPrec(precInBits)
+		// Since we're going to truncate this to get an integer, we need to round
+		// the value instead because of edge cases so that we match how other implementations
+		// (e.g. C++) handles Decimal values. So if we're negative we'll subtract 0.5 and if
+		// we're positive we'll add 0.5.
+		if out.Signbit() {
+			out.Sub(out, pt5)
+		} else {
+			out.Add(out, pt5)
+		}
+
+		var tmp big.Int
+		val, _ := out.Int(&tmp)
+		if val.BitLen() > 255 {
+			return Num{}, errors.New("bitlen too large for decimal256")
+		}
+		n = FromBigInt(val)
 	}
-	n = FromBigInt(val)
 	if !n.FitsInPrecision(prec) {
 		err = fmt.Errorf("value %v doesn't fit in precision %d", n, prec)
 	}

--- a/go/arrow/decimal256/decimal256.go
+++ b/go/arrow/decimal256/decimal256.go
@@ -164,7 +164,7 @@ func FromString(v string, prec, scale int32) (n Num, err error) {
 
 		n, _ = n.Div(scaleMultipliers[-scale])
 	} else {
-		out.Mul(out, (&big.Float{}).SetFloat64(float64PowersOfTen[scale+76])).SetPrec(precInBits)
+		out.Mul(out, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt())).SetPrec(precInBits)
 		// Since we're going to truncate this to get an integer, we need to round
 		// the value instead because of edge cases so that we match how other implementations
 		// (e.g. C++) handles Decimal values. So if we're negative we'll subtract 0.5 and if

--- a/go/arrow/decimal256/decimal256.go
+++ b/go/arrow/decimal256/decimal256.go
@@ -517,7 +517,11 @@ func (n Num) FitsInPrecision(prec int32) bool {
 
 func (n Num) ToString(scale int32) string {
 	f := (&big.Float{}).SetInt(n.BigInt())
-	f.SetPrec(256).Quo(f, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt()))
+	if scale < 0 {
+		f.SetPrec(256).Mul(f, (&big.Float{}).SetInt(scaleMultipliers[-scale].BigInt()))
+	} else {
+		f.SetPrec(256).Quo(f, (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt()))
+	}
 	return f.Text('f', int(scale))
 }
 

--- a/go/arrow/decimal256/decimal256_test.go
+++ b/go/arrow/decimal256/decimal256_test.go
@@ -586,11 +586,8 @@ func TestToString(t *testing.T) {
 	dec := decimal256.FromBigInt(integer)
 
 	expected := "0." + decStr
-	actual := dec.ToString(76)
-
-	if expected != actual {
-		t.Errorf("expected: %s, actual: %s\n", expected, actual)
-	}
+	assert.Equal(t, expected, dec.ToString(76))
+	assert.Equal(t, decStr+"0000", dec.ToString(-4))
 }
 
 // Test issues from GH-38395

--- a/go/arrow/decimal256/decimal256_test.go
+++ b/go/arrow/decimal256/decimal256_test.go
@@ -586,7 +586,7 @@ func TestToString(t *testing.T) {
 	dec := decimal256.FromBigInt(integer)
 
 	expected := "0." + decStr
-	assert.Equal(t, expected, dec.ToString(76))
+	assert.Equal(t, expected, dec.ToString(int32(len(decStr))))
 	assert.Equal(t, decStr+"0000", dec.ToString(-4))
 }
 
@@ -604,4 +604,20 @@ func TestHexFromString(t *testing.T) {
 		expectedCoeff, _ := (&big.Int{}).SetString(strings.Replace(decStr, ".", "", -1), 10)
 		t.Errorf("expected(hex): %X, actual(hex): %X\n", expectedCoeff.Bytes(), actualCoeff.Bytes())
 	}
+}
+
+func TestBitLen(t *testing.T) {
+	n := decimal256.GetScaleMultiplier(76)
+	b := n.BigInt()
+	b.Mul(b, big.NewInt(25))
+	assert.Greater(t, b.BitLen(), 255)
+
+	assert.Panics(t, func() {
+		decimal256.FromBigInt(b)
+	})
+
+	_, err := decimal256.FromString(b.String(), decimal256.MaxPrecision, 0)
+	assert.ErrorContains(t, err, "bitlen too large for decimal256")
+	_, err = decimal256.FromString(b.String(), decimal256.MaxPrecision, -1)
+	assert.ErrorContains(t, err, "bitlen too large for decimal256")
 }

--- a/go/arrow/decimal256/decimal256_test.go
+++ b/go/arrow/decimal256/decimal256_test.go
@@ -564,6 +564,7 @@ func TestFromString(t *testing.T) {
 		{"1e-37", 1, 37},
 		{"2112.33", 211233, 2},
 		{"-2112.33", -211233, 2},
+		{"12E2", 12, -2},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Slight modifications to the `ToString` and `FromString` methods of decimal 256 to ensure proper accurate and proper conversion given precision and scale.

### Are these changes tested?
Yes

* Closes: #38395