### PR TITLE
MINOR: [C++] Fix a maybe-uninitialized warning

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -1259,7 +1259,7 @@ std::shared_ptr<ScalarFunction> MakeUnaryRoundFunction(std::string name,
   RoundKernelGenerator<Op, RoundKernel, OptionsType> kernel_generator;
   for (const auto& tys : {NumericTypes(), {decimal128(1, 0), decimal256(1, 0)}}) {
     for (const auto& ty : tys) {
-      ArrayKernelExec exec;
+      ArrayKernelExec exec = nullptr;
       KernelInit init;
       DCHECK_OK(VisitTypeInline(*ty, &kernel_generator, &exec, &init));
       DCHECK_OK(func->AddKernel(
@@ -1280,7 +1280,7 @@ std::shared_ptr<ScalarFunction> MakeBinaryRoundFunction(const std::string& name,
   RoundKernelGenerator<Op, RoundBinaryKernel, OptionsType> kernel_generator;
   for (const auto& tys : {NumericTypes(), {decimal128(1, 0), decimal256(1, 0)}}) {
     for (const auto& ty : tys) {
-      ArrayKernelExec exec;
+      ArrayKernelExec exec = nullptr;
       KernelInit init;
       DCHECK_OK(VisitTypeInline(*ty, &kernel_generator, &exec, &init));
       DCHECK_OK(func->AddKernel(


### PR DESCRIPTION
Some compilers generate a maybe-uninitialized warning when compiling scalar_round.cc
```
/home/jinshang/arrow/cpp/src/arrow/util/logging.h: In function 'void arrow::compute::internal::RegisterScalarRoundArithmetic(arrow::compute::FunctionRegistry*)':
/home/jinshang/arrow/cpp/src/arrow/util/logging.h:59:34: warning: 'exec' may be used uninitialized [-Wmaybe-uninitialized]
   59 | #define ARROW_IGNORE_EXPR(expr) ((void)(expr))
      |                                  ^
/home/jinshang/arrow/cpp/src/arrow/compute/kernels/scalar_round.cc:1262:23: note: 'exec' was declared here
 1262 |       ArrayKernelExec exec;
      |                       ^~~~
/home/jinshang/arrow/cpp/src/arrow/util/logging.h:59:34: warning: 'exec' may be used uninitialized [-Wmaybe-uninitialized]
   59 | #define ARROW_IGNORE_EXPR(expr) ((void)(expr))
      |                                  ^
/home/jinshang/arrow/cpp/src/arrow/compute/kernels/scalar_round.cc:1283:23: note: 'exec' was declared here
 1283 |       ArrayKernelExec exec;
      |                       ^~~~
```