### PR TITLE
GH-36099: [C++] Add Utf8View and BinaryView to the c ABI

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -53,7 +53,6 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 
-using internal::Zip;
 
 using internal::SmallVector;
 using internal::StaticVector;
@@ -595,8 +594,9 @@ struct ArrayExporter {
     if (need_variadic_buffer_sizes) {
       auto variadic_buffers = util::span(data->buffers).subspan(2);
       export_.variadic_buffer_sizes_.resize(variadic_buffers.size());
-      for (auto [size, buf] : Zip(export_.variadic_buffer_sizes_, variadic_buffers)) {
-        size = buf->size();
+      size_t i = 0;
+      for (const auto& buf : variadic_buffers) {
+        export_.variadic_buffer_sizes_[i++] = buf->size();
       }
       export_.buffers_.back() = export_.variadic_buffer_sizes_.data();
     }
@@ -1896,7 +1896,8 @@ struct ArrayImporter {
   std::shared_ptr<Buffer> zero_size_buffer_;
 
   std::shared_ptr<MemoryManager> memory_mgr_;
-  DeviceAllocationType device_type_{};
+  DeviceAllocationType device_type_{DeviceAllocationType::kCPU};
+;
 };
 
 }  // namespace

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -41,6 +42,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/range.h"
 #include "arrow/util/small_vector.h"
 #include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"
@@ -50,6 +52,8 @@ namespace arrow {
 
 using internal::checked_cast;
 using internal::checked_pointer_cast;
+
+using internal::Zip;
 
 using internal::SmallVector;
 using internal::StaticVector;
@@ -260,7 +264,7 @@ struct SchemaExporter {
       // Dictionary type: parent struct describes index type,
       // child dictionary struct describes value type.
       RETURN_NOT_OK(VisitTypeInline(*dict_type.index_type(), this));
-      dict_exporter_.reset(new SchemaExporter());
+      dict_exporter_ = std::make_unique<SchemaExporter>();
       RETURN_NOT_OK(dict_exporter_->ExportType(*dict_type.value_type()));
     } else {
       RETURN_NOT_OK(VisitTypeInline(type, this));
@@ -357,9 +361,13 @@ struct SchemaExporter {
 
   Status Visit(const LargeBinaryType& type) { return SetFormat("Z"); }
 
+  Status Visit(const BinaryViewType& type) { return SetFormat("vz"); }
+
   Status Visit(const StringType& type) { return SetFormat("u"); }
 
   Status Visit(const LargeStringType& type) { return SetFormat("U"); }
+
+  Status Visit(const StringViewType& type) { return SetFormat("vu"); }
 
   Status Visit(const Date32Type& type) { return SetFormat("tdD"); }
 
@@ -521,13 +529,14 @@ namespace {
 
 struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> {
   // The buffers are owned by the ArrayData member
-  StaticVector<const void*, 3> buffers_;
+  SmallVector<const void*, 3> buffers_;
   struct ArrowArray dictionary_;
   SmallVector<struct ArrowArray, 1> children_;
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 
   std::shared_ptr<ArrayData> data_;
   std::shared_ptr<Device::SyncEvent> sync_;
+  std::vector<int64_t> variadic_buffer_sizes_;
 
   ExportedArrayPrivateData() = default;
   ARROW_DEFAULT_MOVE_AND_ASSIGN(ExportedArrayPrivateData);
@@ -570,15 +579,31 @@ struct ArrayExporter {
       --n_buffers;
       ++buffers_begin;
     }
+
+    bool need_variadic_buffer_sizes =
+        data->type->id() == Type::BINARY_VIEW || data->type->id() == Type::STRING_VIEW;
+    if (need_variadic_buffer_sizes) {
+      ++n_buffers;
+    }
+
     export_.buffers_.resize(n_buffers);
     std::transform(buffers_begin, data->buffers.end(), export_.buffers_.begin(),
                    [](const std::shared_ptr<Buffer>& buffer) -> const void* {
                      return buffer ? buffer->data() : nullptr;
                    });
 
+    if (need_variadic_buffer_sizes) {
+      auto variadic_buffers = util::span(data->buffers).subspan(2);
+      export_.variadic_buffer_sizes_.resize(variadic_buffers.size());
+      for (auto [size, buf] : Zip(export_.variadic_buffer_sizes_, variadic_buffers)) {
+        size = buf->size();
+      }
+      export_.buffers_.back() = export_.variadic_buffer_sizes_.data();
+    }
+
     // Export dictionary
     if (data->dictionary != nullptr) {
-      dict_exporter_.reset(new ArrayExporter());
+      dict_exporter_ = std::make_unique<ArrayExporter>();
       RETURN_NOT_OK(dict_exporter_->Export(data->dictionary));
     }
 
@@ -795,7 +820,7 @@ Status InvalidFormatString(std::string_view v) {
 
 class FormatStringParser {
  public:
-  FormatStringParser() {}
+  FormatStringParser() = default;
 
   explicit FormatStringParser(std::string_view v) : view_(v), index_(0) {}
 
@@ -941,8 +966,6 @@ Result<DecodedMetadata> DecodeMetadata(const char* metadata) {
 }
 
 struct SchemaImporter {
-  SchemaImporter() : c_struct_(nullptr), guard_(nullptr) {}
-
   Status Import(struct ArrowSchema* src) {
     if (ArrowSchemaIsReleased(src)) {
       return Status::Invalid("Cannot import released ArrowSchema");
@@ -1068,6 +1091,8 @@ struct SchemaImporter {
         return ProcessPrimitive(binary());
       case 'Z':
         return ProcessPrimitive(large_binary());
+      case 'v':
+        return ProcessBinaryView();
       case 'w':
         return ProcessFixedSizeBinary();
       case 'd':
@@ -1076,6 +1101,17 @@ struct SchemaImporter {
         return ProcessTemporal();
       case '+':
         return ProcessNested();
+    }
+    return f_parser_.Invalid();
+  }
+
+  Status ProcessBinaryView() {
+    RETURN_NOT_OK(f_parser_.CheckHasNext());
+    switch (f_parser_.Next()) {
+      case 'z':
+        return ProcessPrimitive(binary_view());
+      case 'u':
+        return ProcessPrimitive(utf8_view());
     }
     return f_parser_.Invalid();
   }
@@ -1360,8 +1396,8 @@ struct SchemaImporter {
     return Status::OK();
   }
 
-  struct ArrowSchema* c_struct_;
-  SchemaExportGuard guard_;
+  struct ArrowSchema* c_struct_{nullptr};
+  SchemaExportGuard guard_{nullptr};
   FormatStringParser f_parser_;
   int64_t recursion_level_;
   std::vector<SchemaImporter> child_importers_;
@@ -1429,7 +1465,7 @@ class ImportedBuffer : public Buffer {
                  std::shared_ptr<ImportedArrayData> import)
       : Buffer(data, size, mm, nullptr, device_type), import_(std::move(import)) {}
 
-  ~ImportedBuffer() override {}
+  ~ImportedBuffer() override = default;
 
   std::shared_ptr<Device::SyncEvent> device_sync_event() override {
     return import_->device_sync_;
@@ -1441,9 +1477,7 @@ class ImportedBuffer : public Buffer {
 
 struct ArrayImporter {
   explicit ArrayImporter(const std::shared_ptr<DataType>& type)
-      : type_(type),
-        zero_size_buffer_(std::make_shared<Buffer>(kZeroSizeArea, 0)),
-        device_type_(DeviceAllocationType::kCPU) {}
+      : type_(type), zero_size_buffer_(std::make_shared<Buffer>(kZeroSizeArea, 0)) {}
 
   Status Import(struct ArrowDeviceArray* src, const DeviceMemoryMapper& mapper) {
     ARROW_ASSIGN_OR_RAISE(memory_mgr_, mapper(src->device_type, src->device_id));
@@ -1591,6 +1625,10 @@ struct ArrayImporter {
 
   Status Visit(const LargeBinaryType& type) { return ImportStringLike(type); }
 
+  Status Visit(const StringViewType& type) { return ImportBinaryView(type); }
+
+  Status Visit(const BinaryViewType& type) { return ImportBinaryView(type); }
+
   Status Visit(const ListType& type) { return ImportListLike(type); }
 
   Status Visit(const LargeListType& type) { return ImportListLike(type); }
@@ -1670,6 +1708,28 @@ struct ArrayImporter {
       DCHECK_EQ(type.bit_width(), 1);
       RETURN_NOT_OK(ImportBitsBuffer(1));
     }
+    return Status::OK();
+  }
+
+  Status ImportBinaryView(const BinaryViewType&) {
+    RETURN_NOT_OK(CheckNoChildren());
+    if (c_struct_->n_buffers < 3) {
+      return Status::Invalid("Expected at least 3 buffers for imported type ",
+                             type_->ToString(), ", ArrowArray struct has ",
+                             c_struct_->n_buffers);
+    }
+    RETURN_NOT_OK(AllocateArrayData());
+    RETURN_NOT_OK(ImportNullBitmap());
+    RETURN_NOT_OK(ImportFixedSizeBuffer(1, BinaryViewType::kSize));
+
+    // The last C data buffer stores buffer sizes, and shouldn't be imported
+    auto* buffer_sizes =
+        static_cast<const int64_t*>(c_struct_->buffers[c_struct_->n_buffers - 1]);
+
+    for (int32_t buffer_id = 2; buffer_id < c_struct_->n_buffers - 1; ++buffer_id) {
+      RETURN_NOT_OK(ImportBuffer(buffer_id, buffer_sizes[buffer_id - 2]));
+    }
+    data_->buffers.pop_back();
     return Status::OK();
   }
 
@@ -1836,7 +1896,7 @@ struct ArrayImporter {
   std::shared_ptr<Buffer> zero_size_buffer_;
 
   std::shared_ptr<MemoryManager> memory_mgr_;
-  DeviceAllocationType device_type_;
+  DeviceAllocationType device_type_{};
 };
 
 }  // namespace
@@ -2042,7 +2102,7 @@ class ArrayStreamBatchReader : public RecordBatchReader {
     DCHECK(!ArrowArrayStreamIsReleased(&stream_));
   }
 
-  ~ArrayStreamBatchReader() {
+  ~ArrayStreamBatchReader() override {
     if (!ArrowArrayStreamIsReleased(&stream_)) {
       ArrowArrayStreamRelease(&stream_);
     }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -53,7 +53,6 @@ namespace arrow {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 
-
 using internal::SmallVector;
 using internal::StaticVector;
 
@@ -1897,7 +1896,6 @@ struct ArrayImporter {
 
   std::shared_ptr<MemoryManager> memory_mgr_;
   DeviceAllocationType device_type_{DeviceAllocationType::kCPU};
-;
 };
 
 }  // namespace

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -42,7 +42,7 @@ logging.basicConfig(level=logging.INFO)
 BOOL = ArrowBool()
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--debug", type=BOOL, is_flag=True, default=False,
               help="Increase logging with debugging output.")
 @click.option("--pdb", type=BOOL, is_flag=True, default=False,

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1858,9 +1858,7 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('Go')
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('Rust')
-        .skip_format(SKIP_C_SCHEMA, 'C++')
-        .skip_format(SKIP_C_ARRAY, 'C++'),
+        .skip_tester('Rust'),
 
         generate_extension_case()
         .skip_tester('C#')

--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -140,9 +140,13 @@ strings:
 +-----------------+---------------------------------------------------+------------+
 | ``Z``           | large binary                                      |            |
 +-----------------+---------------------------------------------------+------------+
+| ``vz``          | binary view                                       |            |
++-----------------+---------------------------------------------------+------------+
 | ``u``           | utf-8 string                                      |            |
 +-----------------+---------------------------------------------------+------------+
 | ``U``           | large utf-8 string                                |            |
++-----------------+---------------------------------------------------+------------+
+| ``vu``          | utf-8 view                                        |            |
 +-----------------+---------------------------------------------------+------------+
 | ``d:19,10``     | decimal128 [precision 19, scale 10]               |            |
 +-----------------+---------------------------------------------------+------------+
@@ -547,6 +551,14 @@ parameterized extension types).
 
 The ``ArrowArray`` structure exported from an extension array simply points
 to the storage data of the extension array.
+
+Binary view arrays
+------------------
+
+For binary or utf-8 view arrays, an extra buffer is appended which stores
+the lengths of each variadic data buffer as ``int64_t``. This buffer is
+necessary since these buffer lengths are not trivially extractable from
+other data in an array of binary or utf-8 view type.
 
 .. _c-data-interface-semantics:
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Utf8View and BinaryView should be added to the c ABI spec and to the c++ library's importer/exporter.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, minimally

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

View arrays will be importable/exportable through the c ABI in c++

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36099