### PR TITLE
GH-38449: [Release][Go][macOS] Use local test data if possible

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -962,7 +962,7 @@ ensure_source_directory() {
   # Ensure that the testing repositories are prepared
   if [ ! -d ${ARROW_SOURCE_DIR}/testing/data ]; then
     if [ -d ${SOURCE_DIR}/../../testing/data ]; then
-      cp -a ${SOURCE_DIR}/../../testing/ ${ARROW_SOURCE_DIR}/
+      cp -a ${SOURCE_DIR}/../../testing ${ARROW_SOURCE_DIR}/
     else
       git clone \
         https://github.com/apache/arrow-testing.git \
@@ -972,7 +972,7 @@ ensure_source_directory() {
   if [ ! -d ${ARROW_SOURCE_DIR}/cpp/submodules/parquet-testing/data ]; then
     if [ -d ${SOURCE_DIR}/../../cpp/submodules/parquet-testing/data ]; then
       cp -a \
-         ${SOURCE_DIR}/../../cpp/submodules/parquet-testing/ \
+         ${SOURCE_DIR}/../../cpp/submodules/parquet-testing \
          ${ARROW_SOURCE_DIR}/cpp/submodules/
     else
       git clone \


### PR DESCRIPTION
### Rationale for this change

On macOS, "cp -a source/ destination/" copies "source/*" to "destination/" (such as "source/a" is copied to "destination/a") not "source/" to "destination/" (such as "source/a" is copied to "destination/source/a").

### What changes are included in this PR?

We need to remove the trailing "/" from "source/" to copy "source/" itself to "destination/source/".

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38449