### PR TITLE
MINOR: [Python] Deduplicate `ensure_s3_initialized()` call

### DIFF
--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -269,8 +269,6 @@ cdef class S3FileSystem(FileSystem):
                  load_frequency=900, proxy_options=None,
                  allow_bucket_creation=False, allow_bucket_deletion=False,
                  retry_strategy: S3RetryStrategy = AwsStandardS3RetryStrategy(max_attempts=3)):
-        ensure_s3_initialized()
-
         cdef:
             optional[CS3Options] options
             shared_ptr[CS3FileSystem] wrapped


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/38375 introduced duplicate calls to `ensure_s3_initialized()`.

### What changes are included in this PR?

Deduplicates call to `ensure_s3_initialized()`.

### Are these changes tested?

Yes, covered by existing S3 tests.

### Are there any user-facing changes?

No.