### PR TITLE
GH-38452: [C++][Benchmark] Adding benchmark for LZ4/Snappy Compression

### DIFF
--- a/cpp/src/arrow/util/compression_benchmark.cc
+++ b/cpp/src/arrow/util/compression_benchmark.cc
@@ -254,16 +254,12 @@ BENCHMARK_TEMPLATE(ReferenceCompression, Compression::LZ4_FRAME);
 BENCHMARK_TEMPLATE(ReferenceStreamingDecompression, Compression::LZ4_FRAME);
 BENCHMARK_TEMPLATE(ReferenceDecompression, Compression::LZ4_FRAME);
 
-BENCHMARK_TEMPLATE(ReferenceStreamingCompression, Compression::LZ4);
 BENCHMARK_TEMPLATE(ReferenceCompression, Compression::LZ4);
-BENCHMARK_TEMPLATE(ReferenceStreamingDecompression, Compression::LZ4);
 BENCHMARK_TEMPLATE(ReferenceDecompression, Compression::LZ4);
 #endif
 
 #ifdef ARROW_WITH_SNAPPY
-BENCHMARK_TEMPLATE(ReferenceStreamingCompression, Compression::SNAPPY);
 BENCHMARK_TEMPLATE(ReferenceCompression, Compression::SNAPPY);
-BENCHMARK_TEMPLATE(ReferenceStreamingDecompression, Compression::SNAPPY);
 BENCHMARK_TEMPLATE(ReferenceDecompression, Compression::SNAPPY);
 #endif
 

--- a/cpp/src/arrow/util/compression_benchmark.cc
+++ b/cpp/src/arrow/util/compression_benchmark.cc
@@ -253,6 +253,18 @@ BENCHMARK_TEMPLATE(ReferenceStreamingCompression, Compression::LZ4_FRAME);
 BENCHMARK_TEMPLATE(ReferenceCompression, Compression::LZ4_FRAME);
 BENCHMARK_TEMPLATE(ReferenceStreamingDecompression, Compression::LZ4_FRAME);
 BENCHMARK_TEMPLATE(ReferenceDecompression, Compression::LZ4_FRAME);
+
+BENCHMARK_TEMPLATE(ReferenceStreamingCompression, Compression::LZ4);
+BENCHMARK_TEMPLATE(ReferenceCompression, Compression::LZ4);
+BENCHMARK_TEMPLATE(ReferenceStreamingDecompression, Compression::LZ4);
+BENCHMARK_TEMPLATE(ReferenceDecompression, Compression::LZ4);
+#endif
+
+#ifdef ARROW_WITH_SNAPPY
+BENCHMARK_TEMPLATE(ReferenceStreamingCompression, Compression::SNAPPY);
+BENCHMARK_TEMPLATE(ReferenceCompression, Compression::SNAPPY);
+BENCHMARK_TEMPLATE(ReferenceStreamingDecompression, Compression::SNAPPY);
+BENCHMARK_TEMPLATE(ReferenceDecompression, Compression::SNAPPY);
 #endif
 
 #endif


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This patch add LZ4 (LZ4_RAW in Parquet standard) and Snappy compression/decompression benchmark.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add groups of benchmarks.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

no

### Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38452