### PR TITLE
GH-38310: [MATLAB] Create the test guideline document for MATLAB interface to arrow

### DIFF
--- a/matlab/doc/guideline_for_writing_tests_for_MATLAB_interface_for_apache_arrow.md
+++ b/matlab/doc/guideline_for_writing_tests_for_MATLAB_interface_for_apache_arrow.md
@@ -1,0 +1,69 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Guideline for Writing Tests for MATLAB Interface for Apache Arrow
+
+## Overview  
+
+This document is aimed at providing guidelines on testing when people contribute to the [`mathworks/arrow`](https://github.com/mathworks/arrow) repository.  
+
+## Test File Location and Organization  
+
+All tests for MATLAB interface are put under `matlab/test`. To help easily locate related tests for each source file, test organization follows the following two rules:  
+
+- Test directory maps source directory. For example,  
+
+    | Test Directory            | Corresponding Source Directory     |  
+    |---------------------------|------------------------------------|  
+    | test/**arrow/array/**     | src/matlab/**+arrow/+array/**      |  
+    | test/**arrow/internal/**  | src/matlab/**+arrow/+internal/**   |  
+    | test/**arrow/io/**        | src/matlab/**+arrow/+io/**         |  
+    | test/**arrow/tabular/**   | src/matlab/**+arrow/+tabular/**    |  
+    | test/**arrow/type/**      | src/matlab/**+arrow/+type/**       |  
+- One test for one source file. For example `test/arrow/array/tArray.m` is the test file for `src/matlab/+arrow/+array/Array.m`.
+## When tests are run  
+
+When pushing changes to the [`mathworks/arrow`](https://github.com/mathworks/arrow) repository, GitHub Actions is used to automatically trigger tests under `matlab/test` to run. Currently, all tests under `matlab/test` are configured to run. In the future when there are a lot of tests, we might consider doing source to test mapping and only triggering related tests to run.  
+
+## How to Write Tests  
+
+## How to Run Tests Locally on Your Own Machine  
+
+### Prerequisites  
+
+The tests are written by using MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html). The run the tests, the following software must be installed on your machine:  
+
+1. [MATLAB](https://www.mathworks.com/products/get-matlab.html)
+2. [MATLAB Interface to Apache Arrow](https://github.com/mathworks/arrow/tree/main/matlab)  
+
+### Run tests in MATLAB  
+
+To run the MATLAB tests, start MATLAB and then cd to the test directory where test files of interest reside.  Call the runtests command to run your tests:  
+
+```matlab
+>> runtests(testFileName) % For example runtests("tArray.m")
+```
+
+To learn more about `runtests`, please check [the document of `runtests`](https://www.mathworks.com/help/matlab/ref/runtests.html#btzwrop-tests).  
+
+
+
+## Test Case Design  
+
+## Code Coverage

--- a/matlab/doc/guideline_for_writing_tests_for_MATLAB_interface_for_apache_arrow.md
+++ b/matlab/doc/guideline_for_writing_tests_for_MATLAB_interface_for_apache_arrow.md
@@ -21,49 +21,77 @@
 
 ## Overview  
 
-This document is aimed at providing guidelines on testing when people contribute to the [`mathworks/arrow`](https://github.com/mathworks/arrow) repository.  
+This document is aimed at providing guidelines on testing of the `matlab` directory in the [`apache/arrow`](https://github.com/apache/arrow) repository.  
+
+## General Guideline  
+
+When designing any test case, please try to design it at the MATLAB interface level such that the tests are testing real use cases. Tests for MATLAB interface should use the MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html).
+
+If the source code cannot be covered by any test at the MATLAB interface level, consider adding c++ unit tests by using GoogleTest framework.
+
+## Code Coverage Goals  
+
+When making change to the `matlab` directory in the [`apache/arrow`](https://github.com/apache/arrow) repository, please try to add tests to cover all changed lines, conditions and decisions. It is understandable that some code cannot be hit due to defensive purpose or other reasons. When reviewer reviews code change, they'll check the code coverage for the changed code.  
+
+### How to Check Code Coverage  
+
+The Name-Value input argument [`ReportCoverageFor`](https://www.mathworks.com/help/matlab/ref/runtests.html#mw_764c9db7-6823-439f-a77d-7fd25a03d20e) to `runtests` is used to generate code coverage report.  
+
+
+```matlab  
+>> addpath( <your local arrow/matlab> )
+>> runtests(testFilePath/testFolderPath, 'ReportCoverageFor', sourceFilePath/sourceFolderPath, 'IncludeSubfolders', true/false);  
+
+% Example
+>> runtests('C:\TryCodeCoverage\arrow\matlab\test', 'ReportCoverageFor', 'C:\TryCodeCoverage\arrow\matlab\src\matlab\', 'IncludeSubfolders', true);
+```
+
+It might happen that caching or shadowing issue causes zero coverage because the test ends up executing some other source file. To avoid such problem, please first set a breakpoint in your source file and run the tests. This step is to make sure that your source file is executed by the tests. After this step, the command `runtests(___, "ReportCoverageFor", ___)` will work well.
 
 ## Test File Location and Organization  
 
 All tests for MATLAB interface are put under `matlab/test`. To help easily locate related tests for each source file, test organization follows the following two rules:  
 
-- Test directory maps source directory. For example,  
+- Test directory maps source directory. For example, the test directory `test/arrow/array/` contains all tests for the source directory `src/matlab/+arrow/+array/`.  
+- One test for one source file. For example, `test/arrow/array/tArray.m` is the test file for `src/matlab/+arrow/+array/Array.m`.  
 
-    | Test Directory            | Corresponding Source Directory     |  
-    |---------------------------|------------------------------------|  
-    | test/**arrow/array/**     | src/matlab/**+arrow/+array/**      |  
-    | test/**arrow/internal/**  | src/matlab/**+arrow/+internal/**   |  
-    | test/**arrow/io/**        | src/matlab/**+arrow/+io/**         |  
-    | test/**arrow/tabular/**   | src/matlab/**+arrow/+tabular/**    |  
-    | test/**arrow/type/**      | src/matlab/**+arrow/+type/**       |  
-- One test for one source file. For example `test/arrow/array/tArray.m` is the test file for `src/matlab/+arrow/+array/Array.m`.
 ## When tests are run  
 
-When pushing changes to the [`mathworks/arrow`](https://github.com/mathworks/arrow) repository, GitHub Actions is used to automatically trigger tests under `matlab/test` to run. Currently, all tests under `matlab/test` are configured to run. In the future when there are a lot of tests, we might consider doing source to test mapping and only triggering related tests to run.  
+When pushing changes to the `matlab` directory, GitHub Actions is used to automatically trigger tests under `matlab/test` to run. Currently, all tests under `matlab/test` are configured to run. In the future when the run time of running tests becomes a concern, we will consider doing source to test mapping and only triggering related tests to run.  
 
 ## How to Write Tests  
+
+Tests for MATLAB interface should use the MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html). Here is a simple example.  
+
+```matlab
+classdef tArray < matlab.unittest.TestCase
+    methods(Test)
+        function InferNullsTrue(testCase)
+            matlabArray = [1 2 NaN 3];
+            arrowArray = arrow.array(matlabArray, InferNulls=true);
+            testCase.verifyEqual(arrowArray.Valid, [true; true; false; true]);
+        end
+    end
+end
+```
+
+More test examples can be found in the directory `matlab/test`.  
 
 ## How to Run Tests Locally on Your Own Machine  
 
 ### Prerequisites  
 
-The tests are written by using MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html). The run the tests, the following software must be installed on your machine:  
+The tests are written by using MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html). To run the tests on your machine, the following software must be installed on your machine:  
 
 1. [MATLAB](https://www.mathworks.com/products/get-matlab.html)
 2. [MATLAB Interface to Apache Arrow](https://github.com/mathworks/arrow/tree/main/matlab)  
 
 ### Run tests in MATLAB  
 
-To run the MATLAB tests, start MATLAB and then cd to the test directory where test files of interest reside.  Call the runtests command to run your tests:  
+To run the MATLAB tests, start MATLAB and then cd to the test directory where test files of interest reside.  Call the `runtests` command to run your tests:  
 
 ```matlab
 >> runtests(testFileName) % For example runtests("tArray.m")
 ```
 
-To learn more about `runtests`, please check [the document of `runtests`](https://www.mathworks.com/help/matlab/ref/runtests.html#btzwrop-tests).  
-
-
-
-## Test Case Design  
-
-## Code Coverage
+To learn more about `runtests`, please check [the document of `runtests`](https://www.mathworks.com/help/matlab/ref/runtests.html).  

--- a/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
+++ b/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
@@ -17,7 +17,7 @@
   under the License.
 -->
 
-# Guideline for Writing Tests for MATLAB Interface for Apache Arrow
+# Testing Guidelines for the MATLAB Interface to Apache Arrow  
 
 ## Overview  
 

--- a/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
+++ b/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
@@ -34,6 +34,8 @@ MATLAB interface has its own tests to ensure its quality. To run those tests loc
 
 When adding new tests, it is recommended to, at a minimum, ensure that real-world workflows work as expected.  
 
+If the change cannot be covered by any use case at the MATLAB interface level, please consider test it at the C++ level. One approach for testing C++ code is to create a Proxy instance manually in MATLAB and call the Proxy's method from a MATLAB test case. Examples can be found in `matlab/test/arrow/tabular/tTabularInternal.m`.
+
 ### MATLAB Class-Based Unit Testing Framework  
 
 All tests for the MATLAB interface should use the [MATLAB Class-Based Unit Testing Framework](https://www.mathworks.com/help/matlab/class-based-unit-tests.html) (i.e. they should use [`matlab.unittest.TestCase`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html)).  

--- a/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
+++ b/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
@@ -21,77 +21,120 @@
 
 ## Overview  
 
-This document is aimed at providing guidelines on testing of the `matlab` directory in the [`apache/arrow`](https://github.com/apache/arrow) repository.  
+The goal of this document is to provide helpful guidelines for testing functionality within the [`matlab` directory](https://github.com/apache/arrow/tree/main/matlab) of the [`apache/arrow`](https://github.com/apache/arrow) repository.  
 
-## General Guideline  
+## Prerequisites  
 
-When designing any test case, please try to design it at the MATLAB interface level such that the tests are testing real use cases. Tests for MATLAB interface should use the MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html).
+MATLAB interface has its own tests to ensure its quality. To run those tests locally on your machine, the following software must be installed on your machine:  
 
-If the source code cannot be covered by any test at the MATLAB interface level, consider adding c++ unit tests by using GoogleTest framework.
+1. [MATLAB](https://www.mathworks.com/products/get-matlab.html)
+2. [MATLAB Interface to Apache Arrow](https://github.com/mathworks/arrow/tree/main/matlab)
+
+## General Guidelines  
+
+When adding new tests, it is recommended to, at a minimum, ensure that real-world workflows work as expected.  
+
+### MATLAB Class-Based Unit Testing Framework  
+
+All tests for the MATLAB interface should use the [MATLAB Class-Based Unit Testing Framework](https://www.mathworks.com/help/matlab/class-based-unit-tests.html) (i.e. they should use [`matlab.unittest.TestCase`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html)).  
 
 ## Code Coverage Goals  
 
-When making change to the `matlab` directory in the [`apache/arrow`](https://github.com/apache/arrow) repository, please try to add tests to cover all changed lines, conditions and decisions. It is understandable that some code cannot be hit due to defensive purpose or other reasons. When reviewer reviews code change, they'll check the code coverage for the changed code.  
+When making changes to the MATLAB interface, please do your best to add tests to cover all changed lines, conditions, and decisions.  
+
+Before making a pull request, please check the code coverage for any changed code. If possible, it can be helpful to explicitly comment on the code coverage in your pull request description.  
+
+Although we strive for high code coverage, it is understood that some code cannot be reasonably tested (e.g. an "un-reachable" branch in a `switch` condition on an enumeration value).
 
 ### How to Check Code Coverage  
 
-The Name-Value input argument [`ReportCoverageFor`](https://www.mathworks.com/help/matlab/ref/runtests.html#mw_764c9db7-6823-439f-a77d-7fd25a03d20e) to `runtests` is used to generate code coverage report.  
-
+To generate a MATLAB code coverage report, the [`ReportCoverageFor`](https://www.mathworks.com/help/matlab/ref/runtests.html#mw_764c9db7-6823-439f-a77d-7fd25a03d20e) name-value pair argument can be supplied to the [`runtests`](https://www.mathworks.com/help/matlab/ref/runtests.html) command. Before generating the code coverage report, remember to add your source file directory to path. Here are the commands.
 
 ```matlab  
->> addpath( <your local arrow/matlab> )
+>> addpath( genpath(<your local arrow/matlab>) ) % Include subdirectories
 >> runtests(testFilePath/testFolderPath, 'ReportCoverageFor', sourceFilePath/sourceFolderPath, 'IncludeSubfolders', true/false);  
+```
 
-% Example
+Below is an example of running all tests under `matlab/test` and getting the MATLAB code coverage report for all files under `matlab/src/matlab`.
+
+```matlab  
+>> addpath(genpath("C:\TryCodeCoverage\arrow\matlab"))
 >> runtests('C:\TryCodeCoverage\arrow\matlab\test', 'ReportCoverageFor', 'C:\TryCodeCoverage\arrow\matlab\src\matlab\', 'IncludeSubfolders', true);
 ```
 
-It might happen that caching or shadowing issue causes zero coverage because the test ends up executing some other source file. To avoid such problem, please first set a breakpoint in your source file and run the tests. This step is to make sure that your source file is executed by the tests. After this step, the command `runtests(___, "ReportCoverageFor", ___)` will work well.
+## Test Organization  
 
-## Test File Location and Organization  
+All tests for the MATLAB interface are located under the `matlab/test` directory.  
 
-All tests for MATLAB interface are put under `matlab/test`. To help easily locate related tests for each source file, test organization follows the following two rules:  
+To make it easy to find the test files which correspond to specific source files, the MATLAB interface tests are organized using the following rules:  
 
-- Test directory maps source directory. For example, the test directory `test/arrow/array/` contains all tests for the source directory `src/matlab/+arrow/+array/`.  
-- One test for one source file. For example, `test/arrow/array/tArray.m` is the test file for `src/matlab/+arrow/+array/Array.m`.  
+- Source and test directories follow an (approximately) "parallel" structure. For example, the test directory [`test/arrow/array`](https://github.com/apache/arrow/tree/main/matlab/test/arrow/array) contains tests for the source directory [`src/matlab/+arrow/+array`](https://github.com/apache/arrow/tree/main/matlab/src/matlab/%2Barrow/%2Barray).  
+- One test file maps to one source file. For example, [`test/arrow/array/tArray.m`](https://github.com/apache/arrow/blob/main/matlab/test/arrow/array/tArray.m) is the test file for [`src/matlab/+arrow/+array/Array.m`](https://github.com/apache/arrow/blob/main/matlab/src/matlab/%2Barrow/%2Barray/Array.m).  
+- **Note**: In certain scenarios, it can make sense to diverge from these rules. For example, if a particular class is very complex and contains a lot of divergent functionality (which we generally try to avoid), we might choose to split the testing into several "focused" test files (e.g. one for testing the class display, one for testing the properties, and one for testing the methods).  
 
-## When tests are run  
+## Continuous Integration (CI) Workflows  
 
-When pushing changes to the `matlab` directory, GitHub Actions is used to automatically trigger tests under `matlab/test` to run. Currently, all tests under `matlab/test` are configured to run. In the future when the run time of running tests becomes a concern, we will consider doing source to test mapping and only triggering related tests to run.  
+The Apache Arrow project uses [GitHub Actions](https://github.com/features/actions) as its primary [Continuous Integration (CI)](https://en.wikipedia.org/wiki/Continuous_integration) platform.  
 
-## How to Write Tests  
+Creating a pull request that changes code in the MATLAB interface will automatically trigger [MATLAB CI Workflows](https://github.com/apache/arrow/actions/workflows/matlab.yml) to be run. These CI workflows will run all tests located under the `matlab/test` directory.  
+
+Reviewers will generally expect the MATLAB CI Workflows to be passing successfully before they will consider merging a pull request.  
+
+If you are having trouble understanding CI failures, you can always ask a reviewer or another community member for help.  
+
+## Writing Tests  
 
 Tests for MATLAB interface should use the MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html). Here is a simple example.  
 
 ```matlab
-classdef tArray < matlab.unittest.TestCase
+classdef tStringArray < matlab.unittest.TestCase
     methods(Test)
-        function InferNullsTrue(testCase)
-            matlabArray = [1 2 NaN 3];
-            arrowArray = arrow.array(matlabArray, InferNulls=true);
-            testCase.verifyEqual(arrowArray.Valid, [true; true; false; true]);
+        function TestBasicStringArray(testCase)
+            % Verify that an `arrow.array.StringArray` can be created from
+            % a basic MATLAB `string` array using the `arrow.array` gateway
+            % construction function.
+
+            % Create a basic MATLAB array.
+            matlabArray = ["A" ,"B", "C"];
+            % Create an `arrow.array.StringArray` from the MATLAB `string`
+            % array by using the `arrow.array` gateway construction function.
+            arrowArray = arrow.array(matlabArray);
+            % Verify the class of `arrowArray` is `arrow.array.StringArray`.
+            testCase.verifyEqual(string(class(arrowArray)), "arrow.array.StringArray");
+            % Verify the value of `arrowArray`
+            testCase.verifyEqual(arrowArray.toMATLAB,["A";"B";"C"]);
         end
     end
 end
 ```
 
-More test examples can be found in the directory `matlab/test`.  
+More test examples can be found in the `matlab/test` directory.  
 
-## How to Run Tests Locally on Your Own Machine  
+### Testing Best Practices  
 
-### Prerequisites  
+- Use descriptive names for your test cases.
+- Focus on testing one software "behavior" in each test case.
+- Test with both "expected" and "unexpected" inputs.
+- Add a comment at the beginning of each test case which describes what the test case is verifying.
+- Treat test code like any other code (i.e. use clear variable names, write helper functions, make use of abstraction, etc.)
+- Follow existing patterns when adding new test cases to an existing test class.
 
-The tests are written by using MATLAB testing framework [`matlab.unittest.TestCase class`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html). To run the tests on your machine, the following software must be installed on your machine:  
-
-1. [MATLAB](https://www.mathworks.com/products/get-matlab.html)
-2. [MATLAB Interface to Apache Arrow](https://github.com/mathworks/arrow/tree/main/matlab)  
-
-### Run tests in MATLAB  
+## Running Tests Locally   
 
 To run the MATLAB tests, start MATLAB and then cd to the test directory where test files of interest reside.  Call the `runtests` command to run your tests:  
 
 ```matlab
+% To run a single test file
 >> runtests(testFileName) % For example runtests("tArray.m")
+
+% To run tests under a test directory
+>> runtests(testFolderName, IncludeSubfolders=true) % For example runtests('matlab\test',IncludeSubfolders=true)
 ```
 
-To learn more about `runtests`, please check [the document of `runtests`](https://www.mathworks.com/help/matlab/ref/runtests.html).  
+To learn more about `runtests`, please check [the documentation of `runtests`](https://www.mathworks.com/help/matlab/ref/runtests.html).  
+
+## Tips  
+
+### Generate MATLAB Code Coverage Report  
+
+It might happen that caching or other issue causes zero coverage because the test ends up executing some other source file. To avoid such problem, please first set a breakpoint in your source file and run the tests. This step is to make sure that your source file is executed by the tests. After this step, the command `runtests(___, "ReportCoverageFor", ___)` will work well.

--- a/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
+++ b/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md
@@ -42,11 +42,13 @@ To run the MATLAB interface tests on a local machine, start MATLAB and then `cd`
 >> runtests(testFolderName, IncludeSubfolders = true) % For example: runtests('matlab\test', IncludeSubfolders = true)
 ```
 
-To learn more about `runtests`, please check [the documentation of `runtests`](https://www.mathworks.com/help/matlab/ref/runtests.html).  
+To learn more about `runtests`, please check [the documentation](https://www.mathworks.com/help/matlab/ref/runtests.html).  
 
 ## Writing Tests  
 
-All tests for the MATLAB interface should use the [MATLAB Class-Based Unit Testing Framework](https://www.mathworks.com/help/matlab/class-based-unit-tests.html) (i.e. they should use [`matlab.unittest.TestCase`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html)). Here is a simple example.  
+All tests for the MATLAB interface should use the [MATLAB Class-Based Unit Testing Framework](https://www.mathworks.com/help/matlab/class-based-unit-tests.html) (i.e. they should use [`matlab.unittest.TestCase`](https://www.mathworks.com/help/matlab/ref/matlab.unittest.testcase-class.html)).  
+
+Included below is a simple example of a MATLAB test:  
 
 ```matlab
 classdef tStringArray < matlab.unittest.TestCase
@@ -139,4 +141,4 @@ Below is an example of running all tests under `matlab/test` and getting the MAT
 
 ### Debugging Code Coverage Results  
 
-If the `runtests` command with `RepoCoverageFor` reports confusing or incorrect code coverage results, this could be due to caching or other issues. As a workaround, you can try setting a breakpoint in your source file, and then run the tests. This step can be used to verify that your source file is being executed by the tests.  
+If the `runtests` command with `RepoCoverageFor` reports confusing or incorrect code coverage results, this could be due to caching or other issues. As a workaround, you can try setting a breakpoint in your source file, and then re-run the tests. This step can be used to verify that your source file is being executed by the tests.  


### PR DESCRIPTION
### Rationale for this change

This document is aimed at coaching people on how to write and run tests for the MATLAB interface. This document is helpful to reproduce and address test failures in GitHub Actions CI, and is also helpful to maintain the good quality of MATLAB interface.

### What changes are included in this PR?

Created a markdown page under arrow/matlab/doc.

### Are these changes tested?

No test needed.

### Are there any user-facing changes?

No software change.
* Closes: #38310