### PR TITLE
GH-38418: [MATLAB]  Add method for extracting one row of an `arrow.tabular.Table` as a string

### DIFF
--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -202,5 +202,5 @@ namespace arrow::matlab::error {
     static const char* INDEX_OUT_OF_RANGE = "arrow:index:OutOfRange";
     static const char* BUFFER_VIEW_OR_COPY_FAILED = "arrow:buffer:ViewOrCopyFailed";
     static const char* ARRAY_PRETTY_PRINT_FAILED = "arrow:array:PrettyPrintFailed";
-    static const char* TABULAR_PRINT_ROW_FAILED = "arrow:tabular:PrintRowFailed";
+    static const char* TABULAR_GET_STRING_AS_ROW_FAILED = "arrow:tabular:PrintRowFailed";
 }

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -202,4 +202,5 @@ namespace arrow::matlab::error {
     static const char* INDEX_OUT_OF_RANGE = "arrow:index:OutOfRange";
     static const char* BUFFER_VIEW_OR_COPY_FAILED = "arrow:buffer:ViewOrCopyFailed";
     static const char* ARRAY_PRETTY_PRINT_FAILED = "arrow:array:PrettyPrintFailed";
+    static const char* TABULAR_PRINT_ROW_FAILED = "arrow:tabular:PrintRowFailed";
 }

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -202,5 +202,5 @@ namespace arrow::matlab::error {
     static const char* INDEX_OUT_OF_RANGE = "arrow:index:OutOfRange";
     static const char* BUFFER_VIEW_OR_COPY_FAILED = "arrow:buffer:ViewOrCopyFailed";
     static const char* ARRAY_PRETTY_PRINT_FAILED = "arrow:array:PrettyPrintFailed";
-    static const char* TABULAR_GET_STRING_AS_ROW_FAILED = "arrow:tabular:GetRowAsStringFailed";
+    static const char* TABULAR_GET_ROW_AS_STRING_FAILED = "arrow:tabular:GetRowAsStringFailed";
 }

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -202,5 +202,5 @@ namespace arrow::matlab::error {
     static const char* INDEX_OUT_OF_RANGE = "arrow:index:OutOfRange";
     static const char* BUFFER_VIEW_OR_COPY_FAILED = "arrow:buffer:ViewOrCopyFailed";
     static const char* ARRAY_PRETTY_PRINT_FAILED = "arrow:array:PrettyPrintFailed";
-    static const char* TABULAR_GET_STRING_AS_ROW_FAILED = "arrow:tabular:PrintRowFailed";
+    static const char* TABULAR_GET_STRING_AS_ROW_FAILED = "arrow:tabular:GetRowAsStringFailed";
 }

--- a/matlab/src/cpp/arrow/matlab/tabular/get_row_as_string.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/get_row_as_string.h
@@ -55,8 +55,12 @@ namespace arrow::matlab::tabular {
                 auto slice = column->Slice(row_index, 1);
                 ARROW_RETURN_NOT_OK(arrow::PrettyPrint(*slice, opts, &ss));
             } else if (type_id == arrow::Type::type::STRUCT) {
+                // Use <Struct> as a placeholder since we don't have a good
+                // way to display StructArray elements horiztonally on screen.
                 ss << "<Struct>";
             } else if (type_id == arrow::Type::type::LIST) {
+                // Use <List> as a placeholder since we don't have a good
+                // way to display ListArray elements horiztonally on screen.
                 ss << "<List>";
             } else {
                 return arrow::Status::NotImplemented("Datatype " + column->type()->ToString() + "is not currently supported for display.");

--- a/matlab/src/cpp/arrow/matlab/tabular/get_row_as_string.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/get_row_as_string.h
@@ -36,7 +36,7 @@ namespace arrow::matlab::tabular {
     }
 
     template <typename TabularType>
-    arrow::Result<std::string> print_row(const std::shared_ptr<TabularType>& tabular_object, const int64_t matlab_row_index) {
+    arrow::Result<std::string> get_row_as_string(const std::shared_ptr<TabularType>& tabular_object, const int64_t matlab_row_index) {
         std::stringstream ss;
         const int64_t row_index = matlab_row_index - 1;
         if (row_index >= tabular_object->num_rows() || row_index < 0) {

--- a/matlab/src/cpp/arrow/matlab/tabular/print_row.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/print_row.h
@@ -59,7 +59,7 @@ namespace arrow::matlab::tabular {
             } else if (type_id == arrow::Type::type::LIST) {
                 ss << "<List>";
             } else {
-                return arrow::Status::NotImplemented("Invalid Datatype: " + column->type()->ToString());
+                return arrow::Status::NotImplemented("Datatype " + column->type()->ToString() + "is not currently supported for display.");
             }
 
             if (i + 1 < num_columns) {

--- a/matlab/src/cpp/arrow/matlab/tabular/print_row.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/print_row.h
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/result.h"
+#include "arrow/type_fwd.h"
+#include "arrow/scalar.h"
+
+#include <sstream>
+
+namespace arrow::matlab::tabular {
+
+    namespace {
+        arrow::Result<std::string> scalar_to_string(const std::shared_ptr<arrow::Scalar>& scalar) {
+            using ID = arrow::Type::type;
+
+            const auto type_id = scalar->type->id();
+            if (arrow::is_primitive(type_id) || arrow::is_string(type_id)) {
+                return scalar->ToString();
+            } else if (type_id == ID::STRUCT) {
+                return "<Struct>";
+            } else if (type_id == ID::LIST) {
+                return "<List>";
+            } else {
+                return arrow::Status::NotImplemented("Unsupported DataType: " + scalar->type->ToString());
+            }
+        }
+    }  // namespace
+
+    template <typename TabularType>
+    arrow::Result<std::string> print_row(const std::shared_ptr<TabularType>& tabular_object, const int64_t matlab_row_index) {
+        std::stringstream ss;
+        const int64_t row_index = matlab_row_index - 1;
+        
+        if (row_index >= tabular_object->num_rows() || row_index < 0) {
+            ss << "Invalid Row Index: " << matlab_row_index;
+            return arrow::Status::Invalid(ss.str());
+        }
+
+        const auto num_columns = tabular_object->num_columns();
+        const auto& columns = tabular_object->columns();
+
+        for (int32_t i = 0; i < num_columns; ++i) {
+            const auto& column = columns[i];
+            ARROW_ASSIGN_OR_RAISE(auto scalar, column->GetScalar(row_index));
+            ARROW_ASSIGN_OR_RAISE(auto str, scalar_to_string(scalar));
+            ss << str;
+            if (i + 1 < num_columns) {
+                ss << " | ";
+            }
+        }
+        return ss.str();
+    }
+}

--- a/matlab/src/cpp/arrow/matlab/tabular/print_row.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/print_row.h
@@ -68,6 +68,8 @@ namespace arrow::matlab::tabular {
             }
 
             if (i + 1 < num_columns) {
+                // Only add the delimiter if there is at least 
+                // one more element to print. 
                 ss << " | ";
             }
         }

--- a/matlab/src/cpp/arrow/matlab/tabular/print_row.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/print_row.h
@@ -63,6 +63,8 @@ namespace arrow::matlab::tabular {
                 ss << "<Struct>";
             } else if (type_id == arrow::Type::type::LIST) {
                 ss << "<List>";
+            } else {
+                return arrow::Status::NotImplemented("Invalid Datatype: " + column->type()->ToString());
             }
 
             if (i + 1 < num_columns) {

--- a/matlab/src/cpp/arrow/matlab/tabular/print_row.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/print_row.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 #include "arrow/result.h"
 #include "arrow/type_fwd.h"
 #include "arrow/scalar.h"
@@ -26,14 +28,16 @@
 
 namespace arrow::matlab::tabular {
 
-    arrow::PrettyPrintOptions make_pretty_print_options() {
-        auto opts = arrow::PrettyPrintOptions::Defaults();
-        opts.skip_new_lines = true;
-        opts.array_delimiters.open = "";
-        opts.array_delimiters.close = "";
-        opts.chunked_array_delimiters.open = "";
-        opts.chunked_array_delimiters.close = "";
-        return opts;
+    namespace {
+        arrow::PrettyPrintOptions make_pretty_print_options() {
+            auto opts = arrow::PrettyPrintOptions::Defaults();
+            opts.skip_new_lines = true;
+            opts.array_delimiters.open = "";
+            opts.array_delimiters.close = "";
+            opts.chunked_array_delimiters.open = "";
+            opts.chunked_array_delimiters.close = "";
+            return opts;
+        }
     }
 
     template <typename TabularType>

--- a/matlab/src/cpp/arrow/matlab/tabular/print_row.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/print_row.h
@@ -17,11 +17,6 @@
 
 #pragma once
 
-#include "arrow/result.h"
-#include "arrow/type_fwd.h"
-#include "arrow/scalar.h"
-#include "arrow/type_traits.h"
-#include "arrow/util/formatting.h"
 #include "arrow/pretty_print.h"
 
 #include <sstream>

--- a/matlab/src/cpp/arrow/matlab/tabular/print_row.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/print_row.h
@@ -18,46 +18,49 @@
 #include "arrow/result.h"
 #include "arrow/type_fwd.h"
 #include "arrow/scalar.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/formatting.h"
+#include "arrow/pretty_print.h"
 
 #include <sstream>
 
 namespace arrow::matlab::tabular {
 
-    namespace {
-        arrow::Result<std::string> scalar_to_string(const std::shared_ptr<arrow::Scalar>& scalar) {
-            using ID = arrow::Type::type;
-
-            const auto type_id = scalar->type->id();
-            if (arrow::is_primitive(type_id) || arrow::is_string(type_id)) {
-                return scalar->ToString();
-            } else if (type_id == ID::STRUCT) {
-                return "<Struct>";
-            } else if (type_id == ID::LIST) {
-                return "<List>";
-            } else {
-                return arrow::Status::NotImplemented("Unsupported DataType: " + scalar->type->ToString());
-            }
-        }
-    }  // namespace
+    arrow::PrettyPrintOptions make_pretty_print_options() {
+        auto opts = arrow::PrettyPrintOptions::Defaults();
+        opts.skip_new_lines = true;
+        opts.array_delimiters.open = "";
+        opts.array_delimiters.close = "";
+        opts.chunked_array_delimiters.open = "";
+        opts.chunked_array_delimiters.close = "";
+        return opts;
+    }
 
     template <typename TabularType>
     arrow::Result<std::string> print_row(const std::shared_ptr<TabularType>& tabular_object, const int64_t matlab_row_index) {
         std::stringstream ss;
         const int64_t row_index = matlab_row_index - 1;
-        
         if (row_index >= tabular_object->num_rows() || row_index < 0) {
             ss << "Invalid Row Index: " << matlab_row_index;
             return arrow::Status::Invalid(ss.str());
         }
 
+        const auto opts = make_pretty_print_options();
         const auto num_columns = tabular_object->num_columns();
         const auto& columns = tabular_object->columns();
 
         for (int32_t i = 0; i < num_columns; ++i) {
             const auto& column = columns[i];
-            ARROW_ASSIGN_OR_RAISE(auto scalar, column->GetScalar(row_index));
-            ARROW_ASSIGN_OR_RAISE(auto str, scalar_to_string(scalar));
-            ss << str;
+            const auto type_id = column->type()->id();
+            if (arrow::is_primitive(type_id) || arrow::is_string(type_id)) {
+                auto slice = column->Slice(row_index, 1);
+                ARROW_RETURN_NOT_OK(arrow::PrettyPrint(*slice, opts, &ss));
+            } else if (type_id == arrow::Type::type::STRUCT) {
+                ss << "<Struct>";
+            } else if (type_id == arrow::Type::type::LIST) {
+                ss << "<List>";
+            }
+
             if (i + 1 < num_columns) {
                 ss << " | ";
             }

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -23,6 +23,7 @@
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
+#include "arrow/matlab/tabular/print_row.h"
 #include "arrow/type.h"
 #include "arrow/util/utf8.h"
 
@@ -58,6 +59,7 @@ namespace arrow::matlab::tabular::proxy {
         REGISTER_METHOD(RecordBatch, getColumnByIndex);
         REGISTER_METHOD(RecordBatch, getColumnByName);
         REGISTER_METHOD(RecordBatch, getSchema);
+        REGISTER_METHOD(RecordBatch, getRowString);
     }
 
     std::shared_ptr<arrow::RecordBatch> RecordBatch::unwrap() {
@@ -216,6 +218,22 @@ namespace arrow::matlab::tabular::proxy {
         const auto schema_proxy_id_mda = factory.createScalar(schema_proxy_id);
 
         context.outputs[0] = schema_proxy_id_mda;
+    }
+
+    void RecordBatch::getRowString(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        using namespace libmexclass::proxy;
+        mda::ArrayFactory factory;
+
+        mda::StructArray args = context.inputs[0];
+        const mda::TypedArray<int64_t> index_mda = args[0]["Index"];
+        const auto matlab_row_index = int64_t(index_mda[0]);
+
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::print_row(record_batch, matlab_row_index), 
+                                            context, error::TABULAR_PRINT_ROW_FAILED);
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
+                                            context, error::UNICODE_CONVERSION_ERROR_ID);
+        context.outputs[0] = factory.createScalar(row_str_utf16);
     }
 
 }

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -23,7 +23,7 @@
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
-#include "arrow/matlab/tabular/print_row.h"
+#include "arrow/matlab/tabular/get_row_as_string.h"
 #include "arrow/type.h"
 #include "arrow/util/utf8.h"
 
@@ -229,7 +229,7 @@ namespace arrow::matlab::tabular::proxy {
         const mda::TypedArray<int64_t> index_mda = args[0]["Index"];
         const auto matlab_row_index = int64_t(index_mda[0]);
 
-        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::print_row(record_batch, matlab_row_index), 
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::get_row_as_string(record_batch, matlab_row_index), 
                                             context, error::TABULAR_PRINT_ROW_FAILED);
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
                                             context, error::UNICODE_CONVERSION_ERROR_ID);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -230,7 +230,7 @@ namespace arrow::matlab::tabular::proxy {
         const auto matlab_row_index = int64_t(index_mda[0]);
 
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::get_row_as_string(record_batch, matlab_row_index), 
-                                            context, error::TABULAR_GET_STRING_AS_ROW_FAILED);
+                                            context, error::TABULAR_GET_ROW_AS_STRING_FAILED);
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
                                             context, error::UNICODE_CONVERSION_ERROR_ID);
         context.outputs[0] = factory.createScalar(row_str_utf16);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -220,7 +220,7 @@ namespace arrow::matlab::tabular::proxy {
         context.outputs[0] = schema_proxy_id_mda;
     }
 
-    void RecordBatch::getRowString(libmexclass::proxy::method::Context& context) {
+    void RecordBatch::getRowAsString(libmexclass::proxy::method::Context& context) {
         namespace mda = ::matlab::data;
         using namespace libmexclass::proxy;
         mda::ArrayFactory factory;

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -59,7 +59,7 @@ namespace arrow::matlab::tabular::proxy {
         REGISTER_METHOD(RecordBatch, getColumnByIndex);
         REGISTER_METHOD(RecordBatch, getColumnByName);
         REGISTER_METHOD(RecordBatch, getSchema);
-        REGISTER_METHOD(RecordBatch, getRowString);
+        REGISTER_METHOD(RecordBatch, getRowAsString);
     }
 
     std::shared_ptr<arrow::RecordBatch> RecordBatch::unwrap() {

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.cc
@@ -230,7 +230,7 @@ namespace arrow::matlab::tabular::proxy {
         const auto matlab_row_index = int64_t(index_mda[0]);
 
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::get_row_as_string(record_batch, matlab_row_index), 
-                                            context, error::TABULAR_PRINT_ROW_FAILED);
+                                            context, error::TABULAR_GET_STRING_AS_ROW_FAILED);
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
                                             context, error::UNICODE_CONVERSION_ERROR_ID);
         context.outputs[0] = factory.createScalar(row_str_utf16);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
@@ -41,7 +41,7 @@ namespace arrow::matlab::tabular::proxy {
             void getColumnByIndex(libmexclass::proxy::method::Context& context);
             void getColumnByName(libmexclass::proxy::method::Context& context);
             void getSchema(libmexclass::proxy::method::Context& context);
-            void getRowString(libmexclass::proxy::method::Context& context);
+            void getRowAsString(libmexclass::proxy::method::Context& context);
 
             std::shared_ptr<arrow::RecordBatch> record_batch;
     };

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/record_batch.h
@@ -41,6 +41,7 @@ namespace arrow::matlab::tabular::proxy {
             void getColumnByIndex(libmexclass::proxy::method::Context& context);
             void getColumnByName(libmexclass::proxy::method::Context& context);
             void getSchema(libmexclass::proxy::method::Context& context);
+            void getRowString(libmexclass::proxy::method::Context& context);
 
             std::shared_ptr<arrow::RecordBatch> record_batch;
     };

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -225,7 +225,7 @@ namespace arrow::matlab::tabular::proxy {
         const auto matlab_row_index = int64_t(index_mda[0]);
 
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::get_row_as_string(table, matlab_row_index), 
-                                            context, error::TABULAR_GET_STRING_AS_ROW_FAILED);
+                                            context, error::TABULAR_GET_ROW_AS_STRING_FAILED);
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
                                             context, error::UNICODE_CONVERSION_ERROR_ID);
         context.outputs[0] = factory.createScalar(row_str_utf16);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -59,7 +59,7 @@ namespace arrow::matlab::tabular::proxy {
         REGISTER_METHOD(Table, getSchema);
         REGISTER_METHOD(Table, getColumnByIndex);
         REGISTER_METHOD(Table, getColumnByName);
-        REGISTER_METHOD(Table, getRowString);
+        REGISTER_METHOD(Table, getRowAsString);
     }
 
     std::shared_ptr<arrow::Table> Table::unwrap() {
@@ -215,7 +215,7 @@ namespace arrow::matlab::tabular::proxy {
         context.outputs[0] = chunked_array_proxy_id_mda;
     }
 
-    void Table::getRowString(libmexclass::proxy::method::Context& context) {
+    void Table::getRowAsString(libmexclass::proxy::method::Context& context) {
         namespace mda = ::matlab::data;
         using namespace libmexclass::proxy;
         mda::ArrayFactory factory;

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -24,6 +24,8 @@
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/tabular/proxy/table.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
+#include "arrow/matlab/tabular/print_row.h"
+
 #include "arrow/type.h"
 #include "arrow/util/utf8.h"
 
@@ -57,6 +59,7 @@ namespace arrow::matlab::tabular::proxy {
         REGISTER_METHOD(Table, getSchema);
         REGISTER_METHOD(Table, getColumnByIndex);
         REGISTER_METHOD(Table, getColumnByName);
+        REGISTER_METHOD(Table, getRowString);
     }
 
     std::shared_ptr<arrow::Table> Table::unwrap() {
@@ -210,6 +213,22 @@ namespace arrow::matlab::tabular::proxy {
         const auto chunked_array_proxy_id_mda = factory.createScalar(chunked_array_proxy_id);
 
         context.outputs[0] = chunked_array_proxy_id_mda;
+    }
+
+    void Table::getRowString(libmexclass::proxy::method::Context& context) {
+        namespace mda = ::matlab::data;
+        using namespace libmexclass::proxy;
+        mda::ArrayFactory factory;
+
+        mda::StructArray args = context.inputs[0];
+        const mda::TypedArray<int64_t> index_mda = args[0]["Index"];
+        const auto matlab_row_index = int64_t(index_mda[0]);
+
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::print_row(table, matlab_row_index), 
+                                            context, error::TABULAR_PRINT_ROW_FAILED);
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
+                                            context, error::UNICODE_CONVERSION_ERROR_ID);
+        context.outputs[0] = factory.createScalar(row_str_utf16);
     }
 
 }

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -225,7 +225,7 @@ namespace arrow::matlab::tabular::proxy {
         const auto matlab_row_index = int64_t(index_mda[0]);
 
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::get_row_as_string(table, matlab_row_index), 
-                                            context, error::TABULAR_PRINT_ROW_FAILED);
+                                            context, error::TABULAR_GET_STRING_AS_ROW_FAILED);
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
                                             context, error::UNICODE_CONVERSION_ERROR_ID);
         context.outputs[0] = factory.createScalar(row_str_utf16);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -24,7 +24,7 @@
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/tabular/proxy/table.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
-#include "arrow/matlab/tabular/print_row.h"
+#include "arrow/matlab/tabular/get_row_as_string.h"
 
 #include "arrow/type.h"
 #include "arrow/util/utf8.h"
@@ -224,7 +224,7 @@ namespace arrow::matlab::tabular::proxy {
         const mda::TypedArray<int64_t> index_mda = args[0]["Index"];
         const auto matlab_row_index = int64_t(index_mda[0]);
 
-        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::print_row(table, matlab_row_index), 
+        MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf8, arrow::matlab::tabular::get_row_as_string(table, matlab_row_index), 
                                             context, error::TABULAR_PRINT_ROW_FAILED);
         MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(auto row_str_utf16, arrow::util::UTF8StringToUTF16(row_str_utf8),
                                             context, error::UNICODE_CONVERSION_ERROR_ID);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.h
@@ -41,6 +41,7 @@ namespace arrow::matlab::tabular::proxy {
             void getSchema(libmexclass::proxy::method::Context& context);
             void getColumnByIndex(libmexclass::proxy::method::Context& context);
             void getColumnByName(libmexclass::proxy::method::Context& context);
+            void getRowString(libmexclass::proxy::method::Context& context);
 
             std::shared_ptr<arrow::Table> table;
     };

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.h
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.h
@@ -41,7 +41,7 @@ namespace arrow::matlab::tabular::proxy {
             void getSchema(libmexclass::proxy::method::Context& context);
             void getColumnByIndex(libmexclass::proxy::method::Context& context);
             void getColumnByName(libmexclass::proxy::method::Context& context);
-            void getRowString(libmexclass::proxy::method::Context& context);
+            void getRowAsString(libmexclass::proxy::method::Context& context);
 
             std::shared_ptr<arrow::Table> table;
     };

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
@@ -101,6 +101,7 @@ function classes = getArrayClassNames()
 
     % Return the class names as a string array
     classes = string({metaClass.Name});
+    classes = sort(classes);
 end
 
 function dict = getNumericArrayToMatlabDictionary()

--- a/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
+++ b/matlab/src/matlab/+arrow/+internal/+test/+tabular/createAllSupportedArrayTypes.m
@@ -24,8 +24,8 @@ function [arrowArrays, matlabData] = createAllSupportedArrayTypes(opts)
     end
 
     % Seed the random number generator to ensure
-    % reproducible results in tests.
-    rng(1);
+    % reproducible results in tests across MATLAB sessions.
+    rng(1, "twister");
 
     import arrow.type.ID
     import arrow.array.*

--- a/matlab/test/arrow/tabular/tTabularInternal.m
+++ b/matlab/test/arrow/tabular/tTabularInternal.m
@@ -93,16 +93,16 @@ classdef tTabularInternal < matlab.unittest.TestCase
             testCase.verifyEqual(actualString, expectedString);
         end
 
-        function PrintRowFailed(testCase, TabularObjectWithThreeRows)
+        function GetRowAsStringFailed(testCase, TabularObjectWithThreeRows)
             % Verify getRowAsString throws an error with the ID
-            % arrow:tabular:PrintRowFailed if provided invalid index
+            % arrow:tabular:GetRowAsStringFailed if provided invalid index
             % values.
             proxy = TabularObjectWithThreeRows.Proxy;
             fcn = @() proxy.getRowAsString(struct(Index=int64(0)));
-            testCase.verifyError(fcn, "arrow:tabular:PrintRowFailed");
+            testCase.verifyError(fcn, "arrow:tabular:GetRowAsStringFailed");
 
             fcn = @() proxy.getRowAsString(struct(Index=int64(4)));
-            testCase.verifyError(fcn, "arrow:tabular:PrintRowFailed");
+            testCase.verifyError(fcn, "arrow:tabular:GetRowAsStringFailed");
         end
 
     end

--- a/matlab/test/arrow/tabular/tTabularInternal.m
+++ b/matlab/test/arrow/tabular/tTabularInternal.m
@@ -1,4 +1,4 @@
-%TTABULARINTERNAL Unit tests for internal tabular functionality.
+%TTABULARINTERNAL Unit tests for internal functionality of tabular types.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
@@ -53,6 +53,9 @@ classdef tTabularInternal < matlab.unittest.TestCase
 
     methods (Test)
         function RowWithAllTypes(testCase, TabularObjectWithAllTypes)
+            % Verify getRowString successfully returns the expected string
+            % when called on a Table/RecordBatch that contains all
+            % supported array types.
             proxy = TabularObjectWithAllTypes.Proxy;
             columnStrs = ["false", "2024-02-23", "2023-08-24", "78", "38", ...
                           "24", "48", "89", "102", "<List>", """107""", "<Struct>", ...
@@ -63,7 +66,9 @@ classdef tTabularInternal < matlab.unittest.TestCase
             testCase.verifyEqual(actualString, expectedString);
         end
 
-        function RowWithOneField(testCase, TabularObjectWithOneColumn)
+        function RowWithOneColumn(testCase, TabularObjectWithOneColumn)
+            % Verify getRowString successfully returns the expected string
+            % when called on a Table/RecordBatch with one column.
             proxy = TabularObjectWithOneColumn.Proxy;
             expectedString = "1";
             actualString = proxy.getRowString(struct(Index=int64(1)));
@@ -71,6 +76,8 @@ classdef tTabularInternal < matlab.unittest.TestCase
         end
 
         function RowIndex(testCase, TabularObjectWithThreeRows)
+            % Verify getRowString returns the expected string when provided
+            % for each row index value supplied.
             proxy = TabularObjectWithThreeRows.Proxy;
 
             actualString = proxy.getRowString(struct(Index=int64(1)));
@@ -86,7 +93,10 @@ classdef tTabularInternal < matlab.unittest.TestCase
             testCase.verifyEqual(actualString, expectedString);
         end
 
-        function TabularPrettyPrintRowFailed(testCase, TabularObjectWithThreeRows)
+        function PrintRowFailed(testCase, TabularObjectWithThreeRows)
+            % Verify getRowString throws an error with the ID
+            % arrow:tabular:PrintRowFailed if provided invalid index
+            % values.
             proxy = TabularObjectWithThreeRows.Proxy;
             fcn = @() proxy.getRowString(struct(Index=int64(0)));
             testCase.verifyError(fcn, "arrow:tabular:PrintRowFailed");

--- a/matlab/test/arrow/tabular/tTabularInternal.m
+++ b/matlab/test/arrow/tabular/tTabularInternal.m
@@ -53,7 +53,7 @@ classdef tTabularInternal < matlab.unittest.TestCase
 
     methods (Test)
         function RowWithAllTypes(testCase, TabularObjectWithAllTypes)
-            % Verify getRowString successfully returns the expected string
+            % Verify getRowAsString successfully returns the expected string
             % when called on a Table/RecordBatch that contains all
             % supported array types.
             proxy = TabularObjectWithAllTypes.Proxy;
@@ -62,46 +62,46 @@ classdef tTabularInternal < matlab.unittest.TestCase
                           "00:03:44", "00:00:07.000000", "2024-02-10 00:00:00.000000", ...
                           "107", "143", "36", "51"];
             expectedString = strjoin(columnStrs, " | ");
-            actualString = proxy.getRowString(struct(Index=int64(1)));
+            actualString = proxy.getRowAsString(struct(Index=int64(1)));
             testCase.verifyEqual(actualString, expectedString);
         end
 
         function RowWithOneColumn(testCase, TabularObjectWithOneColumn)
-            % Verify getRowString successfully returns the expected string
+            % Verify getRowAsString successfully returns the expected string
             % when called on a Table/RecordBatch with one column.
             proxy = TabularObjectWithOneColumn.Proxy;
             expectedString = "1";
-            actualString = proxy.getRowString(struct(Index=int64(1)));
+            actualString = proxy.getRowAsString(struct(Index=int64(1)));
             testCase.verifyEqual(actualString, expectedString);
         end
 
         function RowIndex(testCase, TabularObjectWithThreeRows)
-            % Verify getRowString returns the expected string when provided
+            % Verify getRowAsString returns the expected string when provided
             % for each row index value supplied.
             proxy = TabularObjectWithThreeRows.Proxy;
 
-            actualString = proxy.getRowString(struct(Index=int64(1)));
+            actualString = proxy.getRowAsString(struct(Index=int64(1)));
             expectedString = "1 | ""A""";
             testCase.verifyEqual(actualString, expectedString);
 
-            actualString = proxy.getRowString(struct(Index=int64(2)));
+            actualString = proxy.getRowAsString(struct(Index=int64(2)));
             expectedString = "2 | ""B""";
             testCase.verifyEqual(actualString, expectedString);
 
-            actualString = proxy.getRowString(struct(Index=int64(3)));
+            actualString = proxy.getRowAsString(struct(Index=int64(3)));
             expectedString = "3 | ""C""";
             testCase.verifyEqual(actualString, expectedString);
         end
 
         function PrintRowFailed(testCase, TabularObjectWithThreeRows)
-            % Verify getRowString throws an error with the ID
+            % Verify getRowAsString throws an error with the ID
             % arrow:tabular:PrintRowFailed if provided invalid index
             % values.
             proxy = TabularObjectWithThreeRows.Proxy;
-            fcn = @() proxy.getRowString(struct(Index=int64(0)));
+            fcn = @() proxy.getRowAsString(struct(Index=int64(0)));
             testCase.verifyError(fcn, "arrow:tabular:PrintRowFailed");
 
-            fcn = @() proxy.getRowString(struct(Index=int64(4)));
+            fcn = @() proxy.getRowAsString(struct(Index=int64(4)));
             testCase.verifyError(fcn, "arrow:tabular:PrintRowFailed");
         end
 

--- a/matlab/test/arrow/tabular/tTabularInternal.m
+++ b/matlab/test/arrow/tabular/tTabularInternal.m
@@ -76,8 +76,8 @@ classdef tTabularInternal < matlab.unittest.TestCase
         end
 
         function RowIndex(testCase, TabularObjectWithThreeRows)
-            % Verify getRowAsString returns the expected string when provided
-            % for each row index value supplied.
+            % Verify getRowAsString returns the expected string for 
+            % the provided row index.
             proxy = TabularObjectWithThreeRows.Proxy;
 
             actualString = proxy.getRowAsString(struct(Index=int64(1)));

--- a/matlab/test/arrow/tabular/tTabularInternal.m
+++ b/matlab/test/arrow/tabular/tTabularInternal.m
@@ -28,15 +28,26 @@ classdef tTabularInternal < matlab.unittest.TestCase
     methods (TestParameterDefinition, Static)
         function TabularObjectWithAllTypes = initializeTabularObjectWithAllTypes()
             arrays = arrow.internal.test.tabular.createAllSupportedArrayTypes(NumRows=1);
-            TabularObjectWithAllTypes = {arrow.tabular.Table.fromArrays(arrays{:})};
+            arrowTable = arrow.tabular.Table.fromArrays(arrays{:});
+            arrowRecordBatch = arrow.tabular.Table.fromArrays(arrays{:});
+            TabularObjectWithAllTypes = struct(Table=arrowTable, ...
+                RecordBatch=arrowRecordBatch);
         end
 
         function TabularObjectWithOneColumn = initializeTabularObjectWithOneColumn()
-            TabularObjectWithOneColumn = {arrow.table(table((1:3)'))};
+            t = table((1:3)');
+            arrowTable = arrow.table(t);
+            arrowRecordBatch = arrow.recordBatch(t);
+            TabularObjectWithOneColumn = struct(Table=arrowTable, ...
+                RecordBatch=arrowRecordBatch);
         end
 
         function TabularObjectWithThreeRows = initializeTabularObjectWithThreeRows()
-            TabularObjectWithThreeRows = {arrow.table(table((1:3)', ["A"; "B"; "C"]))};
+            t = table((1:3)', ["A"; "B"; "C"]);
+            arrowTable = arrow.table(t);
+            arrowRecordBatch = arrow.recordBatch(t);
+            TabularObjectWithThreeRows = struct(Table=arrowTable, ...
+                RecordBatch=arrowRecordBatch);
         end
     end
 

--- a/matlab/test/arrow/tabular/tTabularInternal.m
+++ b/matlab/test/arrow/tabular/tTabularInternal.m
@@ -1,0 +1,89 @@
+%TTABULARINTERNAL Unit tests for internal tabular functionality.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tTabularInternal < matlab.unittest.TestCase
+
+    properties(TestParameter)
+        TabularObjectWithAllTypes
+
+        TabularObjectWithOneColumn
+
+        TabularObjectWithThreeRows
+    end
+
+    methods (TestParameterDefinition, Static)
+        function TabularObjectWithAllTypes = initializeTabularObjectWithAllTypes()
+            arrays = arrow.internal.test.tabular.createAllSupportedArrayTypes(NumRows=1);
+            TabularObjectWithAllTypes = {arrow.tabular.Table.fromArrays(arrays{:})};
+        end
+
+        function TabularObjectWithOneColumn = initializeTabularObjectWithOneColumn()
+            TabularObjectWithOneColumn = {arrow.table(table((1:3)'))};
+        end
+
+        function TabularObjectWithThreeRows = initializeTabularObjectWithThreeRows()
+            TabularObjectWithThreeRows = {arrow.table(table((1:3)', ["A"; "B"; "C"]))};
+        end
+    end
+
+    methods (Test)
+        function RowWithAllTypes(testCase, TabularObjectWithAllTypes)
+            proxy = TabularObjectWithAllTypes.Proxy;
+            columnStrs = ["false", "2024-02-23", "2023-08-24", "78", "38", ...
+                          "24", "48", "89", "102", "<List>", """107""", "<Struct>", ...
+                          "00:03:44", "00:00:07.000000", "2024-02-10 00:00:00.000000", ...
+                          "107", "143", "36", "51"];
+            expectedString = strjoin(columnStrs, " | ");
+            actualString = proxy.getRowString(struct(Index=int64(1)));
+            testCase.verifyEqual(actualString, expectedString);
+        end
+
+        function RowWithOneField(testCase, TabularObjectWithOneColumn)
+            proxy = TabularObjectWithOneColumn.Proxy;
+            expectedString = "1";
+            actualString = proxy.getRowString(struct(Index=int64(1)));
+            testCase.verifyEqual(actualString, expectedString);
+        end
+
+        function RowIndex(testCase, TabularObjectWithThreeRows)
+            proxy = TabularObjectWithThreeRows.Proxy;
+
+            actualString = proxy.getRowString(struct(Index=int64(1)));
+            expectedString = "1 | ""A""";
+            testCase.verifyEqual(actualString, expectedString);
+
+            actualString = proxy.getRowString(struct(Index=int64(2)));
+            expectedString = "2 | ""B""";
+            testCase.verifyEqual(actualString, expectedString);
+
+            actualString = proxy.getRowString(struct(Index=int64(3)));
+            expectedString = "3 | ""C""";
+            testCase.verifyEqual(actualString, expectedString);
+        end
+
+        function TabularPrettyPrintRowFailed(testCase, TabularObjectWithThreeRows)
+            proxy = TabularObjectWithThreeRows.Proxy;
+            fcn = @() proxy.getRowString(struct(Index=int64(0)));
+            testCase.verifyError(fcn, "arrow:tabular:PrintRowFailed");
+
+            fcn = @() proxy.getRowString(struct(Index=int64(4)));
+            testCase.verifyError(fcn, "arrow:tabular:PrintRowFailed");
+        end
+
+    end
+
+end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

We would like to modify the display of the `arrow.tabular.Table` and `arrow.tabular.RecordBatch` classes to be more "MATLAB-like". In order to do this, we need to add a method to their respective C++ Proxy classes that  returns a single row of the Table/RecordBatch as a MATLAB `string` array.

### What changes are included in this PR?

Added  new function template:
```cpp 
template <typename TabularLike>
arrow::matlab::tabular::print_row(const std::shared_ptr<TabularLike>& tabularObject, const int64_t row_index) 
```
This function template returns a string representation of the specified row in `tabbularObject`. 

Added a new proxy method called `getRowString` to both the `Table` and `RecordBatch` C++ proxy classes. These methods invoke `print_row` to return a string representation of one row in the `Table`/`RecordBatch`.  Neither MATLAB class `arrow.tabular.Table` nor `arrow.tabular.RecordBatch` expose these methods directly because they will only be used internally for display. 

Below is an example Output of `getRowString()`:

```matlab
>> matlabTable = table([1; 2; 3], ["ABC"; "DE"; "FGH"], datetime(2023, 10, 25) + days(0:2)');
>> arrowTable = arrow.table(matlabTable);
>> rowOneAsString = arrowTable.Proxy.getRowString(struct(Index=int64(1)))

rowOneAsString = 

    "1 | "ABC" | 2023-10-25 00:00:00.000000"
```


### Are these changes tested?

Yes, added a new test class called `tTabularInternal.m`. Because `getRowString()` is not a method on the MATLAB classes `arrow.tabular.Table` and `arrow.tabular.RecordBatch`, this test class calls `getRowString()` on their `Proxy` properties, which are public but hidden.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
6. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38418