### PR TITLE
GH-38477: [Go] Fixing decimal 128 rounding issue

### DIFF
--- a/go/arrow/decimal128/decimal128.go
+++ b/go/arrow/decimal128/decimal128.go
@@ -261,7 +261,7 @@ func FromString(v string, prec, scale int32) (n Num, err error) {
 	var precInBits = uint(math.Round(float64(prec+scale+1)/math.Log10(2))) + 1
 
 	var out *big.Float
-	out, _, err = big.ParseFloat(v, 10, 127, big.ToNearestEven)
+	out, _, err = big.ParseFloat(v, 10, 128, big.ToNearestEven)
 	if err != nil {
 		return
 	}

--- a/go/arrow/decimal128/decimal128.go
+++ b/go/arrow/decimal128/decimal128.go
@@ -280,7 +280,7 @@ func FromString(v string, prec, scale int32) (n Num, err error) {
 		// (e.g. C++) handles Decimal values. So if we're negative we'll subtract 0.5 and if
 		// we're positive we'll add 0.5.
 		p := (&big.Float{}).SetInt(scaleMultipliers[scale].BigInt())
-		out.Mul(out, p).SetPrec(precInBits)
+		out.SetPrec(precInBits).Mul(out, p)
 		if out.Signbit() {
 			out.Sub(out, pt5)
 		} else {

--- a/go/arrow/decimal128/decimal128_test.go
+++ b/go/arrow/decimal128/decimal128_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/arrow/go/v14/arrow/decimal128"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFromU64(t *testing.T) {
@@ -697,4 +698,12 @@ func TestBitLen(t *testing.T) {
 	assert.ErrorContains(t, err, "bitlen too large for decimal128")
 	_, err = decimal128.FromString(b.String(), decimal128.MaxPrecision, -1)
 	assert.ErrorContains(t, err, "bitlen too large for decimal128")
+}
+
+func TestFromStringDecimal128b(t *testing.T) {
+	const decStr = "766710016439641.74508380782495962772837"
+
+	num, err := decimal128.FromString(decStr, 38, 23)
+	require.NoError(t, err)
+	assert.Equal(t, decStr, num.ToString(23))
 }

--- a/go/arrow/decimal128/decimal128_test.go
+++ b/go/arrow/decimal128/decimal128_test.go
@@ -701,9 +701,9 @@ func TestBitLen(t *testing.T) {
 }
 
 func TestFromStringDecimal128b(t *testing.T) {
-	const decStr = "766710016439641.74508380782495962772837"
+	const decStr = "9323406071781562130.6457232358109488923"
 
-	num, err := decimal128.FromString(decStr, 38, 23)
+	num, err := decimal128.FromString(decStr, 38, 19)
 	require.NoError(t, err)
-	assert.Equal(t, decStr, num.ToString(23))
+	assert.Equal(t, decStr, num.ToString(19))
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fixing an off-by-one rounding issue with decimal128 by ensuring proper precision handling.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


### Are these changes tested?
The test case which reproduced the rounding issue has been added as a unit test.

* Closes: #38477