### PR TITLE
GH-38447: [CI][Release] Don't use "|| {exit,continue}"

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -153,17 +153,17 @@ verify_dir_artifact_signatures() {
   # verify the signature and the checksums of each artifact
   find $1 -name '*.asc' | while read sigfile; do
     artifact=${sigfile/.asc/}
-    gpg --verify $sigfile $artifact || exit 1
+    gpg --verify $sigfile $artifact
 
     # go into the directory because the checksum files contain only the
     # basename of the artifact
     pushd $(dirname $artifact)
     base_artifact=$(basename $artifact)
     if [ -f $base_artifact.sha256 ]; then
-      ${sha256_verify} $base_artifact.sha256 || exit 1
+      ${sha256_verify} $base_artifact.sha256
     fi
     if [ -f $base_artifact.sha512 ]; then
-      ${sha512_verify} $base_artifact.sha512 || exit 1
+      ${sha512_verify} $base_artifact.sha512
     fi
     popd
   done
@@ -171,7 +171,7 @@ verify_dir_artifact_signatures() {
 
 test_binary() {
   show_header "Testing binary artifacts"
-  maybe_setup_conda || exit 1
+  maybe_setup_conda
 
   local download_dir=binaries
   mkdir -p ${download_dir}
@@ -565,7 +565,7 @@ maybe_setup_nodejs() {
 test_package_java() {
   show_header "Build and test Java libraries"
 
-  maybe_setup_conda maven openjdk || exit 1
+  maybe_setup_conda maven openjdk
 
   pushd java
   if [ ${TEST_JAVA} -gt 0 ]; then
@@ -579,7 +579,7 @@ test_and_install_cpp() {
   show_header "Build, install and test C++ libraries"
 
   # Build and test C++
-  maybe_setup_virtualenv numpy || exit 1
+  maybe_setup_virtualenv numpy
   maybe_setup_conda \
     --file ci/conda_env_unix.txt \
     --file ci/conda_env_cpp.txt \
@@ -587,7 +587,7 @@ test_and_install_cpp() {
     ncurses \
     numpy \
     sqlite \
-    compilers || exit 1
+    compilers
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     DEFAULT_DEPENDENCY_SOURCE="CONDA"
@@ -671,8 +671,8 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv "cython>=0.29.31" numpy "setuptools_scm<8.0.0" setuptools || exit 1
-  maybe_setup_conda --file ci/conda_env_python.txt || exit 1
+  maybe_setup_virtualenv "cython>=0.29.31" numpy "setuptools_scm<8.0.0" setuptools
+  maybe_setup_conda --file ci/conda_env_python.txt
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     CMAKE_PREFIX_PATH="${CONDA_BACKUP_CMAKE_PREFIX_PATH}:${CMAKE_PREFIX_PATH}"
@@ -746,8 +746,8 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
-  maybe_setup_conda glib gobject-introspection meson ninja ruby || exit 1
-  maybe_setup_virtualenv meson || exit 1
+  maybe_setup_conda glib gobject-introspection meson ninja ruby
+  maybe_setup_virtualenv meson
 
   # Install bundler if doesn't exist
   if ! bundle --version; then
@@ -781,8 +781,8 @@ test_ruby() {
   show_header "Build and test Ruby libraries"
 
   # required dependencies are installed by test_glib
-  maybe_setup_conda || exit 1
-  maybe_setup_virtualenv || exit 1
+  maybe_setup_conda
+  maybe_setup_virtualenv
 
   which ruby
   which bundle
@@ -844,8 +844,8 @@ test_csharp() {
 test_js() {
   show_header "Build and test JavaScript libraries"
 
-  maybe_setup_nodejs || exit 1
-  maybe_setup_conda nodejs=18 || exit 1
+  maybe_setup_nodejs
+  maybe_setup_conda nodejs=18
 
   if ! command -v yarn &> /dev/null; then
     npm install yarn
@@ -867,8 +867,8 @@ test_js() {
 test_go() {
   show_header "Build and test Go libraries"
 
-  maybe_setup_go || exit 1
-  maybe_setup_conda compilers go=1.19 || exit 1
+  maybe_setup_go
+  maybe_setup_conda compilers go=1.19
 
   pushd go
   go get -v ./...
@@ -900,8 +900,8 @@ test_go() {
 test_integration() {
   show_header "Build and execute integration tests"
 
-  maybe_setup_conda || exit 1
-  maybe_setup_virtualenv || exit 1
+  maybe_setup_conda
+  maybe_setup_virtualenv
 
   pip install -e dev/archery[integration]
 
@@ -1067,8 +1067,10 @@ test_linux_wheels() {
     local pyver=${python/m}
     for platform in ${platform_tags}; do
       show_header "Testing Python ${pyver} wheel for platform ${platform}"
-      CONDA_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_conda || exit 1
-      VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv || continue
+      CONDA_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_conda
+      if ! VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv; then
+        continue
+      fi
       pip install pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-${platform}.whl
       INSTALL_PYARROW=OFF ARROW_GCS=${check_gcs} ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done
@@ -1100,8 +1102,10 @@ test_macos_wheels() {
         check_s3=OFF
       fi
 
-      CONDA_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_conda || exit 1
-      VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv || continue
+      CONDA_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_conda
+      if ! VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv; then
+        continue
+      fi
 
       pip install pyarrow-${VERSION}-cp${pyver/.}-cp${python/.}-${platform}.whl
       INSTALL_PYARROW=OFF ARROW_FLIGHT=${check_flight} ARROW_GCS=${check_gcs} ARROW_S3=${check_s3} \
@@ -1112,7 +1116,7 @@ test_macos_wheels() {
 
 test_wheels() {
   show_header "Downloading Python wheels"
-  maybe_setup_conda python || exit 1
+  maybe_setup_conda python
 
   local wheels_dir=
   if [ "${SOURCE_KIND}" = "local" ]; then
@@ -1151,7 +1155,7 @@ test_wheels() {
 
 test_jars() {
   show_header "Testing Java JNI jars"
-  maybe_setup_conda maven python || exit 1
+  maybe_setup_conda maven python
 
   local download_dir=${ARROW_TMPDIR}/jars
   mkdir -p ${download_dir}


### PR DESCRIPTION
### Rationale for this change

If we use "|| {exit,continue}", "set -x" doesn't work.

With "|| exit" ("false" in "a()" doesn't stop the shell execution):

```console
$ cat /tmp/with-or-exit.sh
set -e

a()
{
    false
    echo "a: failed after"
}
a || exit 1
echo "top level"
false
echo "failed after"
$ bash /tmp/with-or-exit.sh
a: failed after
top level
```

Without "|| exit" ("false" in "a()" stops the shell execution):

```console
$ cat /tmp/without-or-exit.sh
set -e

a()
{
    false
    echo "a: failed after"
}
a
echo "top level"
false
echo "failed after"
$ bash /tmp/without-or-exit.sh
```
### What changes are included in this PR?

* Remove needless `|| exit`
* Use `if` instead of `|| continue`

### Are these changes tested?

No.
* Closes: #38447