### PR TITLE
GH-14936: [Java] Remove netty dependency from arrow-vector

### DIFF
--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -62,10 +62,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.flatbuffers</groupId>
       <artifactId>flatbuffers-java</artifactId>
       <version>${dep.fbs.version}</version>
@@ -73,6 +69,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections</artifactId>
+      <version>11.1.0</version>
     </dependency>
   </dependencies>
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinalImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinalImpl.java
@@ -25,14 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
-import org.apache.arrow.util.Preconditions;
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
 
 /**
  * An implementation of map that supports constant time look-up by a generic key or an ordinal.
@@ -133,9 +129,7 @@ public class MapWithOrdinalImpl<K, V> implements MapWithOrdinal<K, V> {
 
     @Override
     public Collection<V> values() {
-      return StreamSupport.stream(secondary.entries().spliterator(), false)
-          .map((IntObjectMap.PrimitiveEntry<V> t) -> Preconditions.checkNotNull(t).value())
-          .collect(Collectors.toList());
+      return secondary.values();
     }
 
     @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/MultiMapWithOrdinal.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/MultiMapWithOrdinal.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import io.netty.util.collection.IntObjectHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 
 /**
  * An implementation of a multimap that supports constant time look-up by a generic key or an ordinal.

--- a/java/vector/src/test/java/org/apache/arrow/vector/util/TestMapWithOrdinal.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/util/TestMapWithOrdinal.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.util;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestMapWithOrdinal {
+
+  private MapWithOrdinal<String, String> map;
+
+  @Before
+  public void setUp() {
+    map = new MapWithOrdinalImpl<>();
+  }
+
+  @Test
+  public void testGetByOrdinal() {
+    map.put("key0", "val0", true);
+    assertEquals("val0", map.getByOrdinal(0));
+
+    map.put("key1", "val1", true);
+    assertEquals("val1", map.getByOrdinal(1));
+    assertEquals("val0", map.getByOrdinal(0));
+  }
+
+  @Test
+  public void testGetByKey() {
+    map.put("key0", "val0", true);
+    assertEquals("val0", map.get("key0"));
+
+    map.put("key1", "val1", true);
+    assertEquals("val1", map.get("key1"));
+    assertEquals("val0", map.get("key0"));
+  }
+
+  @Test
+  public void testInvalidOrdinal() {
+    map.put("key0", "val0", true);
+    assertNull(map.getByOrdinal(1));
+
+    map.removeAll("key0");
+    assertNull(map.getByOrdinal(0));
+  }
+
+  @Test
+  public void testInvalidKey() {
+    MapWithOrdinalImpl<String, String> map = new MapWithOrdinalImpl<>();
+    map.put("key0", "val0", true);
+    assertNull(map.get("fake_key"));
+
+    map.removeAll("key0");
+    assertNull(map.get("key0"));
+  }
+
+  @Test
+  public void testValues() {
+    map.put("key0", "val0", true);
+    map.put("key1", "val1", true);
+
+    Collection<String> values = map.values();
+    assertTrue(values.contains("val0"));
+    assertTrue(values.contains("val1"));
+
+    map.put("key1", "new_val1", true);
+    values = map.values();
+    assertTrue(values.contains("val0"));
+    assertTrue(values.contains("new_val1"));
+    assertFalse(values.contains("val1"));
+
+    map.removeAll("key0");
+    assertTrue(values.contains("new_val1"));
+    assertFalse(values.contains("val0"));
+  }
+}


### PR DESCRIPTION
### Rationale for this change
This removes Netty from core Arrow modules that do not have net code (aside from tests).

### What changes are included in this PR?
* Change use of IntObjectHashMap to come from Eclipse instead of Netty-common to remove the dependency on Netty from arrow-vector.
* Add test cases for MapWithOrdinal.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.

* Closes: #14936