### PR TITLE
GH-38382: [R] Explicitly clean up `arrow_duck_connection()` on exit

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -89,7 +89,7 @@ arrow_duck_connection <- function() {
     # but if we don't explicitly run dbDisconnect() the user gets a warning
     # that they may not expect (since they did not open a duckdb connection).
     # This bit of code will run when the package namespace is cleaned up (i.e.,
-    # at exit). This is more reliable than ..onUnload() or .onDetatch(), which
+    # at exit). This is more reliable than .onUnload() or .onDetatch(), which
     # don't necessarily run on exit.
     reg.finalizer(arrow_duck_finalizer, function(...) {
       con <- getOption("arrow_duck_con")

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -277,8 +277,9 @@ test_that("to_duckdb passing a connection", {
   table_four <- ds %>%
     select(int, lgl, dbl) %>%
     to_duckdb(con = con_separate, auto_disconnect = FALSE)
-  # dbplyr 2.2.0 renames this internal attribute to lazy_query
-  table_four_name <- table_four$ops$x %||% table_four$lazy_query$x
+  # dbplyr 2.2.0 renames this internal attribute to lazy_query;
+  # lazy_table$... is now deprecated
+  table_four_name <- unclass(unclass(table_four)$lazy_query$x)$table
 
   result <- DBI::dbGetQuery(
     con_separate,

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -277,9 +277,14 @@ test_that("to_duckdb passing a connection", {
   table_four <- ds %>%
     select(int, lgl, dbl) %>%
     to_duckdb(con = con_separate, auto_disconnect = FALSE)
-  # dbplyr 2.2.0 renames this internal attribute to lazy_query;
-  # lazy_table$... is now deprecated
-  table_four_name <- unclass(unclass(table_four)$lazy_query$x)$table
+
+  # dbplyr 2.4.0 renames this internal attribute to lazy_query;
+  # and reserves $... for internal use
+  if (packageVersion("dbplyr") < "2.4.0") {
+    table_four_name <- table_four$ops$x
+  } else {
+    table_four_name <- unclass(unclass(table_four)$lazy_query$x)$table
+  }
 
   result <- DBI::dbGetQuery(
     con_separate,

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -278,10 +278,10 @@ test_that("to_duckdb passing a connection", {
     select(int, lgl, dbl) %>%
     to_duckdb(con = con_separate, auto_disconnect = FALSE)
 
-  # dbplyr 2.4.0 renames this internal attribute to lazy_query;
-  # and reserves $... for internal use
+  # dbplyr 2.3.0 renamed this internal attribute to lazy_query;
+  # and 2.4.0 reserved $... for internal use + changed the identifier class
   if (packageVersion("dbplyr") < "2.4.0") {
-    table_four_name <- table_four$ops$x
+    table_four_name <- unclass(table_four)$lazy_query$x
   } else {
     table_four_name <- unclass(unclass(table_four)$lazy_query$x)$table
   }


### PR DESCRIPTION

### Rationale for this change

We get lots of warning messages about unclosed connections when running tests + users get them on exit when they weren't expecting them.

### What changes are included in this PR?

A finalizer was added on exit to close the global arrow_duck_con that we cache in the global options.

### Are these changes tested?

Yes, the finalizer will run in every test that runs `to_duckb()` with the default connection.

### Are there any user-facing changes?

No.
* Closes: #38382