### PR TITLE
MINOR: [GLib][Docs] Specify downloaded archive name explicitly

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -67,7 +67,8 @@ GLib (replace the version number in the following commands with the
 one you use):
 
 ```console
-$ wget 'https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-12.0.0/apache-arrow-12.0.0.tar.gz'
+$ wget 'https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-12.0.0/apache-arrow-12.0.0.tar.gz' \
+    --output-document apache-arrow-12.0.0.tar.gz
 $ tar xf apache-arrow-12.0.0.tar.gz
 $ cd apache-arrow-12.0.0
 ```


### PR DESCRIPTION
### Rationale for this change

Unable to extract on the [arrow/c_glib/README.md](https://github.com/apache/arrow/blob/848725f31b2633a35a0389e4ffb96e1c14bc8e26/c_glib/README.md?plain=1#L70-L71) because the downloaded file name is `closer.lua?action=download&filename=arrow%2Farrow-12.0.0%2Fapache-arrow-12.0.0.tar.gz` not `apache-arrow-12.0.0.tar.gz`.

### What changes are included in this PR?

Specify the downloaded file name explicitly.