### PR TITLE
GH-38490: [C++][Compute] Support ChunkedArray sorting for dictionary type

### DIFF
--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -78,6 +78,13 @@ int64_t DictionaryArray::GetValueIndex(int64_t i) const {
   }
 }
 
+ViewType DictionaryArray::GetView(int64_t i) const {
+  const auto index = GetValueIndex(i);
+  GetViewVisitor visitor(index, *this);
+  ARROW_CHECK_OK(dictionary()->type()->Accept(&visitor));
+  return visitor.view();
+}
+
 DictionaryArray::DictionaryArray(const std::shared_ptr<ArrayData>& data)
     : dict_type_(checked_cast<const DictionaryType*>(data->type.get())) {
   ARROW_CHECK_EQ(data->type->id(), Type::DICTIONARY);

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -113,14 +113,8 @@ class ARROW_EXPORT DictionaryArray : public Array {
   int64_t GetValueIndex(int64_t i) const;
 
   std::string_view GetView(int64_t i) const {
-    // Ensure the dictionary and indices are not null
-    assert(dictionary() != nullptr && indices() != nullptr);
-
     // Obtain the index at position i
     const auto index = GetValueIndex(i);
-
-    // Ensure the index is within bounds
-    assert(index < dictionary()->length());
 
     // Assuming the dictionary is a StringArray
     return std::string_view(

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -23,6 +23,7 @@
 #include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
 #include "arrow/result.h"
+#include "arrow/scalar.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
@@ -110,6 +111,23 @@ class ARROW_EXPORT DictionaryArray : public Array {
   /// for use in performance-sensitive code. Does not validate whether the
   /// value is null or out-of-bounds.
   int64_t GetValueIndex(int64_t i) const;
+
+  std::string_view GetView(int64_t i) const {
+    // Ensure the dictionary and indices are not null
+    assert(dictionary() != nullptr && indices() != nullptr);
+
+    // Obtain the index at position i
+    const auto index = GetValueIndex(i);
+
+    // Ensure the index is within bounds
+    assert(index < dictionary()->length());
+
+    // Assuming the dictionary is a StringArray
+    return std::string_view(
+        reinterpret_cast<const char*>(
+            dictionary()->GetScalar(index).ValueOrDie()->ToString().data()),
+        dictionary()->GetScalar(index).ValueOrDie()->ToString().size());
+  }
 
   const DictionaryType* dict_type() const { return dict_type_; }
 

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -112,15 +112,12 @@ class ARROW_EXPORT DictionaryArray : public Array {
   /// value is null or out-of-bounds.
   int64_t GetValueIndex(int64_t i) const;
 
-  std::string_view GetView(int64_t i) const {
+  std::string GetView(int64_t i) const {
     // Obtain the index at position i
     const auto index = GetValueIndex(i);
 
-    // Assuming the dictionary is a StringArray
-    return std::string_view(
-        reinterpret_cast<const char*>(
-            dictionary()->GetScalar(index).ValueOrDie()->ToString().data()),
-        dictionary()->GetScalar(index).ValueOrDie()->ToString().size());
+    // Assuming the dictionary is a String
+    return dictionary()->GetScalar(index).ValueOrDie()->ToString();
   }
 
   const DictionaryType* dict_type() const { return dict_type_; }

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -22,6 +22,7 @@
 
 #include "arrow/array.h"
 #include "arrow/array/array_base.h"
+#include "arrow/array/array_primitive.h"
 #include "arrow/array/data.h"
 #include "arrow/result.h"
 #include "arrow/scalar.h"
@@ -59,7 +60,6 @@ using ViewType = std::variant<std::string_view, int32_t>;
 class ARROW_EXPORT DictionaryArray : public Array {
  public:
   using TypeClass = DictionaryType;
-//  using ViewType = std::variant<std::string_view, int32_t>;
 
   explicit DictionaryArray(const std::shared_ptr<ArrayData>& data);
 
@@ -145,21 +145,12 @@ class GetViewVisitor : public TypeVisitor {
     return Status::OK();
   }
 
-//  Status Visit(const Int32Type& type) override {
-//    const auto& dict =
-//        internal::checked_cast<const Int32Type&>(*dict_array_.dictionary());
-//    view_ = dict.GetView(index_);
-//    return Status::OK();
-//  }
-
-//    Status Visit(const Int32Type& type) {
-//      const auto& dict =
-//          internal::checked_cast<const Int32Array&>(*dict_array_.dictionary());
-//      view_ = dict.GetView(index_);
-//      return Status::OK();
-//    }
-
-  // Add more types as needed...
+  Status Visit(const Int32Type& type) override {
+    const auto& array =
+        internal::checked_cast<const Int32Array&>(*dict_array_.dictionary());
+    view_ = array.GetView(index_);
+    return Status::OK();
+  }
 
   ViewType view() const { return view_; }
 
@@ -168,13 +159,6 @@ class GetViewVisitor : public TypeVisitor {
   const DictionaryArray& dict_array_;
   ViewType view_;
 };
-
-// ViewType DictionaryArray::GetView(int64_t i) const {
-//   const auto index = GetValueIndex(i);
-//   GetViewVisitor visitor(index, *this);
-//   ARROW_CHECK_OK(dictionary()->type()->Accept(&visitor));
-//   return visitor.view();
-// }
 
 /// \brief Helper class for incremental dictionary unification
 class ARROW_EXPORT DictionaryUnifier {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -187,6 +187,14 @@ struct GetOutputType<Decimal256Type> {
   using T = Decimal256;
 };
 
+template <>
+struct GetViewType<DictionaryType> {
+  using T = std::string_view;
+  using PhysicalType = std::string_view;
+
+  static T LogicalValue(PhysicalType value) { return value; }
+};
+
 // ----------------------------------------------------------------------
 // enable_if helpers for C types
 

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -165,65 +165,6 @@ struct GetViewType<Decimal256Type> {
   static T LogicalValue(T value) { return value; }
 };
 
-// template <>
-// struct GetViewType<DictionaryType> {
-//   using T = std::string_view;
-//   using PhysicalType = std::string_view;
-//
-//   static T LogicalValue(PhysicalType value) { return value; }
-// };
-
-// template <>
-// struct GetViewType<DictionaryType> {
-//   using T = std::variant<std::string_view, uint32_t, int32_t>;
-//   using PhysicalType = T;
-//   using ViewType = T;
-//   ViewType view;
-//
-//   Status Visit(const arrow::StringType& type) {
-//     // 여기에 StringType에 대한 실제 논리적 값을 설정하는 로직을 구현합니다.
-//     view = std::string_view();  // 예시를 위한 코드
-//     return Status::OK();
-//   }
-//
-//   Status Visit(const arrow::UInt32Type& type) {
-//     // 여기에 UInt32Type에 대한 실제 논리적 값을 설정하는 로직을 구현합니다.
-//     view = static_cast<uint32_t>(0);  // 예시를 위한 코드
-//     return Status::OK();
-//   }
-//
-//   Status Visit(const arrow::Int32Type& type) {
-//     // 여기에 Int32Type에 대한 실제 논리적 값을 설정하는 로직을 구현합니다.
-//     view = static_cast<int32_t>(0);  // 예시를 위한 코드
-//     return Status::OK();
-//   }
-//
-//   Status Visit(const DataType& type) {
-//     return Status::TypeError("View not supported for type ", type.ToString());
-//   }
-//
-//   static Result<ViewType> MakeViewType(const std::shared_ptr<DictionaryType>& dict) {
-//     GetViewType<DictionaryType> getter;
-//     // dict의 value_type에 따라 적절한 Visit 메소드를 호출합니다.
-//     ARROW_RETURN_NOT_OK(VisitTypeInline(*dict->value_type(), &getter));
-//     // view가 설정되었는지 확인합니다.
-//     //    DCHECK(getter.view);
-//     return getter.view;
-//   }
-//
-//   // 이전의 LogicalValue 함수는 삭제하거나 수정합니다.
-//   // GetViewType 구조체 내부
-//
-//   // ...
-//
-//   static T LogicalValue(PhysicalType value) {
-//     GetViewType<DictionaryType> getter;
-//     getter.view = value;
-//     // Assuming dict_type is the dictionary type
-//     return getter.MakeViewType(getter.view);
-//   }
-// };
-
 template <>
 struct GetViewType<DictionaryType> {
   using T = std::variant<std::string_view, int32_t>;
@@ -243,11 +184,6 @@ struct GetViewType<DictionaryType> {
     return Status::OK();
   }
 
-  //  Status Visit(const arrow::Int32Type& type) {
-  //    view = int32_t();
-  //    return Status::OK();
-  //  }
-
   Status Visit(const DataType& type) {
     return Status::TypeError("View not supported for type ", type.ToString());
   }
@@ -255,59 +191,9 @@ struct GetViewType<DictionaryType> {
   static T LogicalValue(PhysicalType value) {
     GetViewType<DictionaryType> getter;
     getter.view = value;
-    // Assuming dict_type is the dictionary type
     return getter.view;
   }
 };
-
-// template <>
-// struct GetViewType<DictionaryType> {
-//   using T = DataType;
-//   using PhysicalType = T;
-//
-//
-//   Status Visit(const DataType& type) {
-//     return Status::TypeError("GetViewType not supported for type ", type.ToString());
-//   }
-//
-//   template <typename T>
-//   Status Visit(const T& type) {
-//     view = type.dictionary()->type();
-//     return Status::OK();
-//   }
-//
-//   static T LogicalValue(PhysicalType value) {
-//
-//
-//   }
-// };
-
-// template <>
-// struct GetViewType<DictionaryType> : public TypeVisitor {
-//   using T = std::variant<std::string_view, uint64_t>;
-//   using PhysicalType = std::variant<std::string, uint64_t>;
-//
-//   T view;
-//   PhysicalType value;
-//
-//   arrow::Status Visit(const StringType& type) override {
-//     view = std::get<std::string>(value);
-//     return Status::OK();
-//   }
-//
-//   arrow::Status Visit(const UInt64Type& type) override {
-//     view = std::get<uint64_t>(value);
-//     return Status::OK();
-//   }
-//
-//   static T LogicalValue(PhysicalType value) {
-//     GetViewType<DictionaryType> visitor;
-//     visitor.value = std::move(value);
-//     // Assuming dict_type is the dictionary type
-//     dict_type->dictionary()->type()->Accept(&visitor);
-//     return visitor.view;
-//   }
-// };
 
 template <typename Type, typename Enable = void>
 struct GetOutputType;

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <unordered_map>
 #include <unordered_set>
 
 #include "arrow/compute/function.h"

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -67,7 +67,6 @@ class ChunkedArraySorter : public TypeVisitor {
   Status Visit(const TYPE& type) override { return SortInternal<TYPE>(); }
 
   VISIT_SORTABLE_PHYSICAL_TYPES(VISIT)
-  VISIT(DictionaryType)
 
 #undef VISIT
 
@@ -120,13 +119,8 @@ class ChunkedArraySorter : public TypeVisitor {
       };
       auto merge_non_nulls = [&](uint64_t* range_begin, uint64_t* range_middle,
                                  uint64_t* range_end, uint64_t* temp_indices) {
-        if (is_dictionary(*physical_type_)) {
-          MergeNonNulls<DictionaryType>(range_begin, range_middle, range_end, arrays,
-                                        temp_indices);
-        } else {
-          MergeNonNulls<ArrayType>(range_begin, range_middle, range_end, arrays,
-                                   temp_indices);
-        }
+        MergeNonNulls<ArrayType>(range_begin, range_middle, range_end, arrays,
+                                 temp_indices);
       };
 
       MergeImpl merge_impl{null_placement_, std::move(merge_nulls),
@@ -238,67 +232,6 @@ class ChunkedArraySorter : public TypeVisitor {
   ExecContext* ctx_;
   NullPartitionResult* output_;
 };
-
-template <>
-void ChunkedArraySorter::MergeNonNulls<DictionaryType>(
-    uint64_t* range_begin, uint64_t* range_middle, uint64_t* range_end,
-    const std::vector<const Array*>& arrays, uint64_t* temp_indices) {
-  const ChunkedArrayResolver left_resolver(arrays);
-  const ChunkedArrayResolver right_resolver(arrays);
-
-  // concatenate all dictionary arrays to calculate rank
-  ArrayVector dicts_array;
-  for (const auto& array : arrays) {
-    const auto& dicts = checked_cast<const DictionaryArray&>(*array);
-    dicts_array.push_back(dicts.dictionary());
-  }
-  auto concat_dict = Concatenate(dicts_array).ValueOrDie();
-  auto ranks = RanksWithNulls(concat_dict).ValueOrDie();
-
-  // build unified rank map using dicts and rank array
-  std::unordered_map<std::string, int64_t> unified_rank_map;
-  for (int i = 0; i < concat_dict->length(); i++) {
-    auto dict = concat_dict->GetScalar(i).ValueOrDie();
-    auto rank = ranks->GetScalar(i).ValueOrDie();
-    unified_rank_map[dict->ToString()] =
-        static_cast<const arrow::Int64Scalar&>(*rank).value;
-  }
-
-  if (order_ == SortOrder::Ascending) {
-    std::merge(range_begin, range_middle, range_middle, range_end, temp_indices,
-               [&](uint64_t left, uint64_t right) {
-                 const auto chunk_left = left_resolver.Resolve<DictionaryArray>(left);
-                 const auto chunk_right = right_resolver.Resolve<DictionaryArray>(right);
-
-                 auto value_left = chunk_left.array->GetView(chunk_left.index);
-                 auto value_right = chunk_right.array->GetView(chunk_right.index);
-
-                 // get rank from unified_rank_map
-                 auto rank_left = unified_rank_map[value_left];
-                 auto rank_right = unified_rank_map[value_right];
-
-                 return rank_left < rank_right;
-               });
-  } else {
-    std::merge(range_begin, range_middle, range_middle, range_end, temp_indices,
-               [&](uint64_t left, uint64_t right) {
-                 const auto chunk_left = left_resolver.Resolve<DictionaryArray>(left);
-                 const auto chunk_right = right_resolver.Resolve<DictionaryArray>(right);
-
-                 auto value_left = chunk_left.array->GetView(chunk_left.index);
-                 auto value_right = chunk_right.array->GetView(chunk_right.index);
-
-                 // get rank from unified_rank_map
-                 auto rank_left = unified_rank_map[value_left];
-                 auto rank_right = unified_rank_map[value_right];
-
-                 return rank_right < rank_left;
-               });
-  }
-
-  // Copy back temp area into main buffer
-  std::copy(temp_indices, temp_indices + (range_end - range_begin), range_begin);
-}
 
 // ----------------------------------------------------------------------
 // Record batch sorting implementation(s)

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -268,16 +268,12 @@ void ChunkedArraySorter::MergeNonNulls<DictionaryType>(
     const auto chunk_left = left_resolver.Resolve<DictionaryArray>(left);
     const auto chunk_right = right_resolver.Resolve<DictionaryArray>(right);
 
-    auto left_index = chunk_left.array->GetValueIndex(chunk_left.index);
-    auto right_index = chunk_right.array->GetValueIndex(chunk_right.index);
-
-    auto value_left = chunk_left.array->dictionary()->GetScalar(left_index).ValueOrDie();
-    auto value_right =
-        chunk_right.array->dictionary()->GetScalar(right_index).ValueOrDie();
+    auto value_left = chunk_left.array->GetView(chunk_left.index);
+    auto value_right = chunk_right.array->GetView(chunk_right.index);
 
     // get rank from unified_rank_map
-    auto rank_left = unified_rank_map[value_left->ToString()];
-    auto rank_right = unified_rank_map[value_right->ToString()];
+    auto rank_left = unified_rank_map[value_left];
+    auto rank_right = unified_rank_map[value_right];
 
     return rank_left < rank_right;
   };

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -50,7 +50,8 @@ namespace internal {
   VISIT(LargeBinaryType)                     \
   VISIT(FixedSizeBinaryType)                 \
   VISIT(Decimal128Type)                      \
-  VISIT(Decimal256Type)
+  VISIT(Decimal256Type)                      \
+  VISIT(DictionaryType)
 
 // NOTE: std::partition is usually faster than std::stable_partition.
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1128,9 +1128,9 @@ TYPED_TEST(TestChunkedArraySortIndicesForDictionary, Basics) {
   AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtStart,
                     "[0, 4, 2, 7, 5, 6, 3, 1]");
   AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtEnd,
-                    "[1, 3, 6, 5, 7, 2, 0, 4]");
+                    "[1, 3, 6, 5, 2, 7, 0, 4]");
   AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtStart,
-                    "[0, 4, 1, 3, 6, 5, 7, 2]");
+                    "[0, 4, 1, 3, 6, 5, 2, 7]");
 }
 
 // Base class for testing against random chunked array.

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1105,6 +1105,34 @@ TYPED_TEST(TestChunkedArraySortIndicesForDecimal, Basics) {
                     "[2, 5, 3, 0, 1, 4]");
 }
 
+// Tests for string types
+template <typename ArrayType>
+class TestChunkedArraySortIndicesForString : public TestChunkedArraySortIndices {
+ protected:
+  std::shared_ptr<DataType> GetType() {
+    return utf8();
+  }
+};
+
+TYPED_TEST_SUITE(TestChunkedArraySortIndicesForString, StringArrowTypes);
+
+TYPED_TEST(TestChunkedArraySortIndicesForString, Basics) {
+  auto type = this->GetType();
+  auto chunked_array = ChunkedArrayFromJSON(type, {
+                                                      R"([null, "e", "a"])",
+                                                      R"(["d", null, "b"])",
+                                                      R"(["c", "a"])",
+                                                  });
+  AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtEnd,
+                    "[2, 7, 5, 6, 3, 1, 0, 4]");
+  AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtStart,
+                    "[0, 4, 2, 7, 5, 6, 3, 1]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtEnd,
+                    "[1, 3, 6, 5, 2, 7, 0, 4]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtStart,
+                    "[0, 4, 1, 3, 6, 5, 2, 7]");
+}
+
 // Tests for dictionary types
 template <typename ArrayType>
 class TestChunkedArraySortIndicesForDictionary : public TestChunkedArraySortIndices {

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1105,6 +1105,34 @@ TYPED_TEST(TestChunkedArraySortIndicesForDecimal, Basics) {
                     "[2, 5, 3, 0, 1, 4]");
 }
 
+// Tests for dictionary types
+template <typename ArrayType>
+class TestChunkedArraySortIndicesForDictionary : public TestChunkedArraySortIndices {
+ protected:
+  std::shared_ptr<DataType> GetType() {
+    return dictionary(int8(), utf8(), /*ordered=*/false);
+  }
+};
+
+TYPED_TEST_SUITE(TestChunkedArraySortIndicesForDictionary, DictionaryArrowTypes);
+
+TYPED_TEST(TestChunkedArraySortIndicesForDictionary, Basics) {
+  auto type = this->GetType();
+  auto chunked_array = ChunkedArrayFromJSON(type, {
+                                                      R"([null, "e", "a"])",
+                                                      R"(["d", null, "b"])",
+                                                      R"(["c", "a"])",
+                                                  });
+  AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtEnd,
+                    "[2, 7, 5, 6, 3, 1, 0, 4]");
+  AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtStart,
+                    "[0, 4, 2, 7, 5, 6, 3, 1]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtEnd,
+                    "[1, 3, 6, 5, 7, 2, 0, 4]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtStart,
+                    "[0, 4, 1, 3, 6, 5, 7, 2]");
+}
+
 // Base class for testing against random chunked array.
 template <typename Type>
 class TestChunkedArrayRandomBase : public ::testing::Test {

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1109,9 +1109,7 @@ TYPED_TEST(TestChunkedArraySortIndicesForDecimal, Basics) {
 template <typename ArrayType>
 class TestChunkedArraySortIndicesForString : public TestChunkedArraySortIndices {
  protected:
-  std::shared_ptr<DataType> GetType() {
-    return utf8();
-  }
+  std::shared_ptr<DataType> GetType() { return utf8(); }
 };
 
 TYPED_TEST_SUITE(TestChunkedArraySortIndicesForString, StringArrowTypes);
@@ -1150,6 +1148,34 @@ TYPED_TEST(TestChunkedArraySortIndicesForDictionary, Basics) {
                                                       R"([null, "e", "a"])",
                                                       R"(["d", null, "b"])",
                                                       R"(["c", "a"])",
+                                                  });
+  AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtEnd,
+                    "[2, 7, 5, 6, 3, 1, 0, 4]");
+  AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtStart,
+                    "[0, 4, 2, 7, 5, 6, 3, 1]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtEnd,
+                    "[1, 3, 6, 5, 2, 7, 0, 4]");
+  AssertSortIndices(chunked_array, SortOrder::Descending, NullPlacement::AtStart,
+                    "[0, 4, 1, 3, 6, 5, 2, 7]");
+}
+
+template <typename ArrayType>
+class TestChunkedArraySortIndicesForDictionaryNumber
+    : public TestChunkedArraySortIndices {
+ protected:
+  std::shared_ptr<DataType> GetType() {
+    return dictionary(int8(), int32(), /*ordered=*/false);
+  }
+};
+
+TYPED_TEST_SUITE(TestChunkedArraySortIndicesForDictionaryNumber, DictionaryArrowTypes);
+
+TYPED_TEST(TestChunkedArraySortIndicesForDictionaryNumber, Basics) {
+  auto type = this->GetType();
+  auto chunked_array = ChunkedArrayFromJSON(type, {
+                                                      R"([null, 5, 1])",
+                                                      R"([4, null, 2])",
+                                                      R"([3, 1])",
                                                   });
   AssertSortIndices(chunked_array, SortOrder::Ascending, NullPlacement::AtEnd,
                     "[2, 7, 5, 6, 3, 1, 0, 4]");

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -191,6 +191,8 @@ using ListArrowTypes = ::testing::Types<ListType, LargeListType>;
 
 using UnionArrowTypes = ::testing::Types<SparseUnionType, DenseUnionType>;
 
+using DictionaryArrowTypes = ::testing::Types<DictionaryType>;
+
 class Array;
 class ChunkedArray;
 class RecordBatch;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Support `ChunkedArray` sorting for `DictionaryType`.

By referencing the sorting algorithm for `DictionaryType` for `Array`, modifications were made to **unify** dictionaries stored within among ChunkedArrays, **compute** rankings, and **perform** a merge sort based on the calculated rankings.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

* Updated `ChunkedArraySorter` to support `DictionaryType`.
* Added unit test

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38490