### PR TITLE
GH-36388: [C++][Array] Add Overflow check for string Repeat

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -729,6 +729,16 @@ TEST_F(TestArray, TestMakeArrayFromScalarNegative) {
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(err_msg), array_result);
 }
 
+TEST_F(TestArray, TestMakeArrayFromScalarEmptyString) {
+  auto scalar = std::make_shared<StringScalar>("");
+
+  int64_t length = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
+  auto array_result = MakeArrayFromScalar(*scalar, length);
+
+  std::string err_msg = "length exceeds the maximum value of offset_type";
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(err_msg), array_result);
+}
+
 TEST_F(TestArray, TestMakeArrayFromDictionaryScalar) {
   auto dictionary = ArrayFromJSON(utf8(), R"(["foo", "bar", "baz"])");
   auto type = std::make_shared<DictionaryType>(int8(), utf8());

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -693,9 +693,7 @@ TEST_F(TestArray, TestMakeArrayFromScalarOverflow) {
   auto array_result = MakeArrayFromScalar(*scalar, length);
 
   std::string err_msg = "offset overflow in repeated array construction";
-  ASSERT_FALSE(array_result.ok());
-  ASSERT_EQ(array_result.status().code(), StatusCode::Invalid);
-  ASSERT_EQ(array_result.status().message().substr(0, err_msg.length()), err_msg);
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(err_msg), array_result);
 }
 
 TEST_F(TestArray, TestMakeArrayFromDictionaryScalar) {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -685,6 +685,19 @@ TEST_F(TestArray, TestMakeArrayFromScalarSliced) {
   }
 }
 
+TEST_F(TestArray, TestMakeArrayFromScalarOverflow) {
+  auto scalar = std::make_shared<StringScalar>("aa");
+
+  // Use a length that will cause an overflow when multiplied by the size of the string
+  int64_t length = static_cast<int64_t>(std::numeric_limits<int64_t>::max()) / 2 + 1;
+  auto array_result = MakeArrayFromScalar(*scalar, length);
+
+  std::string err_msg = "offset overflow in repeated array construction";
+  ASSERT_FALSE(array_result.ok());
+  ASSERT_EQ(array_result.status().code(), StatusCode::Invalid);
+  ASSERT_EQ(array_result.status().message().substr(0, err_msg.length()), err_msg);
+}
+
 TEST_F(TestArray, TestMakeArrayFromDictionaryScalar) {
   auto dictionary = ArrayFromJSON(utf8(), R"(["foo", "bar", "baz"])");
   auto type = std::make_shared<DictionaryType>(int8(), utf8());

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -673,8 +673,19 @@ class RepeatedArrayFactory {
     std::shared_ptr<Buffer> values_buffer, offsets_buffer;
     auto size = static_cast<typename T::offset_type>(value->size());
 
-    int64_t total_size;
-    if (MultiplyWithOverflow(size, length_, &total_size)) {
+    typename T::offset_type length_casted;
+    if (length_ < 0) {
+      return Status::Invalid("length cannot be negative: " + std::to_string(length_));
+    } else if (length_ > std::numeric_limits<typename T::offset_type>::max()) {
+      return Status::Invalid(
+          "length exceeds the maximum value of offset_type: " + std::to_string(length_) +
+          " is greater than " +
+          std::to_string(std::numeric_limits<typename T::offset_type>::max()));
+    }
+    length_casted = static_cast<typename T::offset_type>(length_);
+
+    typename T::offset_type total_size;
+    if (MultiplyWithOverflow(size, length_casted, &total_size)) {
       return Status::Invalid("offset overflow in repeated array construction");
     }
 

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -674,12 +674,10 @@ class RepeatedArrayFactory {
     auto size = static_cast<typename T::offset_type>(value->size());
 
     typename T::offset_type length_casted;
-    if (length_ < 0) {
-      return Status::Invalid("length cannot be negative: " + std::to_string(length_));
-    } else if (length_ > std::numeric_limits<typename T::offset_type>::max()) {
+    if (length_ > std::numeric_limits<typename T::offset_type>::max()) {
       return Status::Invalid(
-          "length exceeds the maximum value of offset_type: " + std::to_string(length_) +
-          " is greater than " +
+          "length exceeds the maximum value of offset_type: ", std::to_string(length_),
+          " is greater than ",
           std::to_string(std::numeric_limits<typename T::offset_type>::max()));
     }
     length_casted = static_cast<typename T::offset_type>(length_);
@@ -907,6 +905,10 @@ Result<std::shared_ptr<Array>> MakeArrayOfNull(const std::shared_ptr<DataType>& 
 
 Result<std::shared_ptr<Array>> MakeArrayFromScalar(const Scalar& scalar, int64_t length,
                                                    MemoryPool* pool) {
+  if (length < 0) {
+    return Status::Invalid("length cannot be negative: ", std::to_string(length));
+  }
+
   // Null union scalars still have a type code associated
   if (!scalar.is_valid && !is_union(scalar.type->id())) {
     return MakeArrayOfNull(scalar.type, length, pool);

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -673,12 +673,6 @@ class RepeatedArrayFactory {
     std::shared_ptr<Buffer> values_buffer, offsets_buffer;
     auto size = static_cast<typename T::offset_type>(value->size());
 
-    typename T::offset_type total_size;
-    if (MultiplyWithOverflow(size, static_cast<typename T::offset_type>(length_),
-                             &total_size)) {
-      return Status::Invalid("offset overflow in repeated array construction");
-    }
-
     RETURN_NOT_OK(CreateOffsetsBuffer(size, &offsets_buffer));
     RETURN_NOT_OK(CreateBufferOf(value->data(), value->size(), &values_buffer));
 
@@ -854,6 +848,12 @@ class RepeatedArrayFactory {
 
   template <typename OffsetType>
   Status CreateOffsetsBuffer(OffsetType value_length, std::shared_ptr<Buffer>* out) {
+    OffsetType total_size;
+    if (MultiplyWithOverflow(value_length, static_cast<OffsetType>(length_),
+                             &total_size)) {
+      return Status::Invalid("offset overflow in repeated array construction");
+    }
+
     if (length_ > std::numeric_limits<OffsetType>::max()) {
       return Status::Invalid(
           "length exceeds the maximum value of offset_type: ", std::to_string(length_),


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

As mentioned in the issue, the `Repeat` function does not currently check for overflow when multiplying the repeat count by the string size.


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

* Added check logic for overflow.
* Added unit test for overflow scenarios.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #36388