### PR TITLE
GH-38335: [C++] Implement `GetFileInfo` for a single file in Azure filesystem

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -502,8 +502,8 @@ if(ARROW_FILESYSTEM)
        filesystem/util_internal.cc)
 
   if(ARROW_AZURE)
-    list(APPEND ARROW_SRCS filesystem/azurefs.cc)
-    set_source_files_properties(filesystem/azurefs.cc
+    list(APPEND ARROW_SRCS filesystem/azurefs.cc filesystem/azurefs_internal.cc)
+    set_source_files_properties(filesystem/azurefs.cc filesystem/azurefs_internal.cc
                                 PROPERTIES SKIP_PRECOMPILE_HEADERS ON
                                            SKIP_UNITY_BUILD_INCLUSION ON)
   endif()

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -459,7 +459,7 @@ class AzureFileSystem::Impl {
   io::IOContext io_context_;
   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
       datalake_service_client_;
-  std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
+  std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
   AzureOptions options_;
   internal::HierarchicalNamespaceDetector hierarchical_namespace_;
 
@@ -467,7 +467,7 @@ class AzureFileSystem::Impl {
       : io_context_(io_context), options_(std::move(options)) {}
 
   Status Init() {
-    blob_service_client_ = std::make_shared<Azure::Storage::Blobs::BlobServiceClient>(
+    blob_service_client_ = std::make_unique<Azure::Storage::Blobs::BlobServiceClient>(
         options_.account_blob_url, options_.storage_credentials_provider);
     datalake_service_client_ =
         std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -77,10 +77,12 @@ class HierachicalNamespaceDetecter {
           .GetAccessControlList();
       is_hierachical_namespace_enabled_ = true;
     } catch (const Azure::Storage::StorageException& exception) {
-      if (exception.StatusCode == Azure::Core::Http::HttpStatusCode::BadRequest) {
-        // The container exists, but the access control list (ACL) endpoint responded
-        // bad request because this storage account does not support hierarchical
-        // namespace.
+      if (exception.StatusCode == Azure::Core::Http::HttpStatusCode::BadRequest ||
+          exception.StatusCode == Azure::Core::Http::HttpStatusCode::Conflict) {
+        // GetAccessControlList will fail on storage accounts without hierarchical
+        // namespace enabled. If soft delete blobs is enabled it returns Conflict, 
+        // otherwise it returns BadRequest.
+        // On Azureite it returns NotFound.
         is_hierachical_namespace_enabled_ = false;
       } else {
         // Something else failed so we can't tell if the storage account has hierachical

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -530,7 +530,7 @@ class AzureFileSystem::Impl {
       return info;
     } catch (const Azure::Storage::StorageException& exception) {
       if (exception.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound) {
-        ARROW_ASSIGN_OR_RAISE(bool hierarchical_namespace_enabled,
+        ARROW_ASSIGN_OR_RAISE(auto hierarchical_namespace_enabled,
                               hierarchical_namespace_.Enabled(path.container));
         if (hierarchical_namespace_enabled) {
           // If the hierarchical namespace is enabled, then the storage account will have

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -467,6 +467,7 @@ class AzureFileSystem::Impl {
     datalake_service_client_ =
         std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
             options_.account_dfs_url, options_.storage_credentials_provider);
+    RETURN_NOT_OK(hierarchical_namespace_.Init(datalake_service_client_));
     return Status::OK();
   }
 
@@ -522,10 +523,8 @@ class AzureFileSystem::Impl {
       return info;
     } catch (const Azure::Storage::StorageException& exception) {
       if (ContainerOrBlobNotFound(exception)) {
-        ARROW_ASSIGN_OR_RAISE(
-            bool hierarchical_namespace_enabled,
-            hierarchical_namespace_.Enabled(
-                datalake_service_client_->GetFileSystemClient(path.container)));
+        ARROW_ASSIGN_OR_RAISE(bool hierarchical_namespace_enabled,
+                              hierarchical_namespace_.Enabled(path.container));
         if (hierarchical_namespace_enabled) {
           // If the hierarchical namespace is enabled, then the storage account will have
           // explicit directories. Neither a file nor a directory was found.

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -529,6 +529,9 @@ class AzureFileSystem::Impl {
       auto info = FileInfo(path.full_path, FileType::File);
       if (properties.Value.IsDirectory) {
         info.set_type(FileType::Directory);
+      } else if (internal::HasTrailingSlash(path.path_to_file)) {
+        info.set_type(FileType::NotFound);
+        return info;
       } else {
         info.set_type(FileType::File);
         info.set_size(properties.Value.FileSize);

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -320,7 +320,10 @@ class ObjectInputFile final : public io::RandomAccessFile {
         return PathNotFound(path_);
       }
       return internal::ErrorToStatus(
-          "When fetching properties for '" + blob_client_->GetUrl() + "': ", exception);
+          "GetProperties failed for '" + blob_client_->GetUrl() +
+              "' with an unexpected Azure error. Can not initialise an ObjectInputFile "
+              "without knowing the file size. ",
+          exception);
     }
   }
 
@@ -397,9 +400,11 @@ class ObjectInputFile final : public io::RandomAccessFile {
           ->DownloadTo(reinterpret_cast<uint8_t*>(out), nbytes, download_options)
           .Value.ContentRange.Length.Value();
     } catch (const Azure::Storage::StorageException& exception) {
-      return internal::ErrorToStatus("When reading from '" + blob_client_->GetUrl() +
+      return internal::ErrorToStatus("DownloadTo from '" + blob_client_->GetUrl() +
                                          "' at position " + std::to_string(position) +
-                                         " for " + std::to_string(nbytes) + " bytes: ",
+                                         " for " + std::to_string(nbytes) +
+                                         " bytes failed with an Azure error. ReadAt "
+                                         "failed to read the required byte range.",
                                      exception);
     }
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -456,7 +456,7 @@ class AzureFileSystem::Impl {
       datalake_service_client_;
   std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
   AzureOptions options_;
-  internal::HierachicalNamespaceDetecter hierarchical_namespace_;
+  internal::HierarchicalNamespaceDetector hierarchical_namespace_;
 
   explicit Impl(AzureOptions options, io::IOContext io_context)
       : io_context_(io_context), options_(std::move(options)) {}

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -542,8 +542,6 @@ class AzureFileSystem::Impl {
                                           // but not path_to_file.
       // path must refer to the root of the Azure storage account. This is a directory,
       // and there isn't any extra metadata to fetch.
-      // TODO: Confirm if we need to check that the storage account exists. I think there
-      // would have been an earlier failure.
       return FileInfo(path.full_path, FileType::Directory);
     }
     if (path.path_to_file.empty()) {

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -453,7 +453,7 @@ class ObjectInputFile final : public io::RandomAccessFile {
 class AzureFileSystem::Impl {
  public:
   io::IOContext io_context_;
-  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
+  std::unique_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
       datalake_service_client_;
   std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
   AzureOptions options_;
@@ -466,9 +466,9 @@ class AzureFileSystem::Impl {
     blob_service_client_ = std::make_unique<Azure::Storage::Blobs::BlobServiceClient>(
         options_.account_blob_url, options_.storage_credentials_provider);
     datalake_service_client_ =
-        std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
+        std::make_unique<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
             options_.account_dfs_url, options_.storage_credentials_provider);
-    RETURN_NOT_OK(hierarchical_namespace_.Init(datalake_service_client_));
+    RETURN_NOT_OK(hierarchical_namespace_.Init(datalake_service_client_.get()));
     return Status::OK();
   }
 
@@ -559,7 +559,7 @@ class AzureFileSystem::Impl {
           } else {
             info.set_type(FileType::NotFound);
           }
-            return info;
+          return info;
         } catch (const Azure::Storage::StorageException& exception) {
           return internal::ExceptionToStatus(
               "ListBlobs for '" + prefix +

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -1,0 +1,67 @@
+#include "arrow/filesystem/azurefs_internal.h"
+
+#include <azure/storage/files/datalake.hpp>
+
+#include "arrow/result.h"
+
+namespace arrow {
+namespace fs {
+namespace internal {
+
+Status ErrorToStatus(const std::string& prefix,
+                     const Azure::Storage::StorageException& exception) {
+  return Status::IOError(prefix, " Azure Error: ", exception.what());
+}
+
+Result<bool> HierachicalNamespaceDetecter::Enabled(
+    Azure::Storage::Files::DataLake::DataLakeFileSystemClient filesystem_client) {
+  if (is_hierachical_namespace_enabled_.has_value()) {
+    return is_hierachical_namespace_enabled_.value();
+  }
+
+  // This approach is inspired by hadoop-azure
+  // https://github.com/apache/hadoop/blob/7c6af6a5f626d18d68b656d085cc23e4c1f7a1ef/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java#L356.
+  // Unfortunately `blob_service_client->GetAccountInfo()` requires significantly
+  // elevated permissions.
+  // https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties?tabs=azure-ad#authorization
+  auto directory_client = filesystem_client.GetDirectoryClient("/");
+  try {
+    directory_client.GetAccessControlList();
+    is_hierachical_namespace_enabled_ = true;
+  } catch (const Azure::Storage::StorageException& exception) {
+    // GetAccessControlList will fail on storage accounts without hierarchical
+    // namespace enabled.
+
+    if (exception.StatusCode == Azure::Core::Http::HttpStatusCode::BadRequest ||
+        exception.StatusCode == Azure::Core::Http::HttpStatusCode::Conflict) {
+      // Flat namespace storage accounts with soft delete enabled return
+      // Conflict - This endpoint does not support BlobStorageEvents or SoftDelete
+      // otherwise it returns: BadRequest - This operation is only supported on a
+      // hierarchical namespace account.
+      is_hierachical_namespace_enabled_ = false;
+    } else if (exception.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound) {
+      // Azurite returns NotFound.
+      try {
+        // Ensure sure that the directory exists by checking its properties. If it
+        // doesn't then the GetAccessControlList check was invalid and we can't tell
+        // if the storage account has hierachical namespace.
+        filesystem_client.GetProperties();
+        is_hierachical_namespace_enabled_ = false;
+      } catch (const Azure::Storage::StorageException& exception) {
+        return ErrorToStatus(
+            "When getting properties '" + filesystem_client.GetUrl() + "': ", exception);
+      }
+    } else {
+      // Unexpected error so we can't tell if the storage account has hierachical
+      // namespace.
+      return ErrorToStatus(
+          "When getting access control list '" + directory_client.GetUrl() + "': ",
+          exception);
+    }
+  }
+  return is_hierachical_namespace_enabled_.value();
+}
+
+}  // namespace internal
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 #include "arrow/filesystem/azurefs_internal.h"
 
 #include <azure/storage/files/datalake.hpp>

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -13,19 +13,19 @@ Status ErrorToStatus(const std::string& prefix,
   return Status::IOError(prefix, " Azure Error: ", exception.what());
 }
 
-Status HierachicalNamespaceDetecter::Init(
+Status HierarchicalNamespaceDetector::Init(
     std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
         datalake_service_client) {
   datalake_service_client_ = datalake_service_client;
   return Status::OK();
 };
 
-Result<bool> HierachicalNamespaceDetecter::Enabled(const std::string& container_name) {
+Result<bool> HierarchicalNamespaceDetector::Enabled(const std::string& container_name) {
   // Hierarchical namespace can't easily be changed after the storage account is created
   // and its common across all containers in the storage account. Do nothing until we've
   // checked for a cached result.
-  if (is_hierachical_namespace_enabled_.has_value()) {
-    return is_hierachical_namespace_enabled_.value();
+  if (is_hierarchical_namespace_enabled_.has_value()) {
+    return is_hierarchical_namespace_enabled_.value();
   }
 
   // This approach is inspired by hadoop-azure
@@ -37,7 +37,7 @@ Result<bool> HierachicalNamespaceDetecter::Enabled(const std::string& container_
   auto directory_client = filesystem_client.GetDirectoryClient("/");
   try {
     directory_client.GetAccessControlList();
-    is_hierachical_namespace_enabled_ = true;
+    is_hierarchical_namespace_enabled_ = true;
   } catch (const Azure::Storage::StorageException& exception) {
     // GetAccessControlList will fail on storage accounts without hierarchical
     // namespace enabled.
@@ -48,7 +48,7 @@ Result<bool> HierachicalNamespaceDetecter::Enabled(const std::string& container_
       // Conflict - This endpoint does not support BlobStorageEvents or SoftDelete
       // otherwise it returns: BadRequest - This operation is only supported on a
       // hierarchical namespace account.
-      is_hierachical_namespace_enabled_ = false;
+      is_hierarchical_namespace_enabled_ = false;
     } else if (exception.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound) {
       // Azurite returns NotFound.
       try {
@@ -56,7 +56,7 @@ Result<bool> HierachicalNamespaceDetecter::Enabled(const std::string& container_
         // doesn't then the GetAccessControlList check was invalid and we can't tell
         // if the storage account has hierachical namespace.
         filesystem_client.GetProperties();
-        is_hierachical_namespace_enabled_ = false;
+        is_hierarchical_namespace_enabled_ = false;
       } catch (const Azure::Storage::StorageException& exception) {
         return ErrorToStatus(
             "When getting properties '" + filesystem_client.GetUrl() + "': ", exception);
@@ -69,7 +69,7 @@ Result<bool> HierachicalNamespaceDetecter::Enabled(const std::string& container_
           exception);
     }
   }
-  return is_hierachical_namespace_enabled_.value();
+  return is_hierarchical_namespace_enabled_.value();
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -29,8 +29,7 @@ Status ExceptionToStatus(const std::string& prefix,
 }
 
 Status HierarchicalNamespaceDetector::Init(
-    std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
-        datalake_service_client) {
+    Azure::Storage::Files::DataLake::DataLakeServiceClient* datalake_service_client) {
   datalake_service_client_ = datalake_service_client;
   return Status::OK();
 }

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -69,20 +69,19 @@ Result<bool> HierarchicalNamespaceDetector::Enabled(const std::string& container
     } else if (exception.StatusCode == Azure::Core::Http::HttpStatusCode::NotFound) {
       // Azurite returns NotFound.
       try {
-        // Ensure sure that the directory exists by checking its properties. If it
-        // doesn't then the GetAccessControlList check was invalid and we can't tell
-        // if the storage account has hierachical namespace.
         filesystem_client.GetProperties();
         is_hierarchical_namespace_enabled_ = false;
       } catch (const Azure::Storage::StorageException& exception) {
-        return ErrorToStatus(
-            "When getting properties '" + filesystem_client.GetUrl() + "': ", exception);
+        return ErrorToStatus("Failed to confirm '" + filesystem_client.GetUrl() +
+                                 "' is an accessible container. Therefore the "
+                                 "hierarchical namespace check was invalid.",
+                             exception);
       }
     } else {
-      // Unexpected error so we can't tell if the storage account has hierachical
-      // namespace.
       return ErrorToStatus(
-          "When getting access control list '" + directory_client.GetUrl() + "': ",
+          "GetAccessControlList for '" + directory_client.GetUrl() +
+              "' failed with an unexpected Azure error, while checking "
+              "whether the storage account has hierarchical namespace enabled.",
           exception);
     }
   }

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -35,7 +35,7 @@ Status HierarchicalNamespaceDetector::Init(
         datalake_service_client) {
   datalake_service_client_ = datalake_service_client;
   return Status::OK();
-};
+}
 
 Result<bool> HierarchicalNamespaceDetector::Enabled(const std::string& container_name) {
   // Hierarchical namespace can't easily be changed after the storage account is created

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -30,13 +30,12 @@ Status ExceptionToStatus(const std::string& prefix,
 
 class HierarchicalNamespaceDetector {
  public:
-  Status Init(std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
-                  datalake_service_client);
+  Status Init(
+      Azure::Storage::Files::DataLake::DataLakeServiceClient* datalake_service_client);
   Result<bool> Enabled(const std::string& container_name);
 
  private:
-  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
-      datalake_service_client_;
+  Azure::Storage::Files::DataLake::DataLakeServiceClient* datalake_service_client_;
   std::optional<bool> enabled_;
 };
 

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -23,12 +23,10 @@
 
 #include "arrow/result.h"
 
-namespace arrow {
-namespace fs {
-namespace internal {
+namespace arrow::fs::internal {
 
-Status ErrorToStatus(const std::string& prefix,
-                     const Azure::Storage::StorageException& exception);
+Status ExceptionToStatus(const std::string& prefix,
+                         const Azure::Storage::StorageException& exception);
 
 class HierarchicalNamespaceDetector {
  public:
@@ -39,9 +37,7 @@ class HierarchicalNamespaceDetector {
  private:
   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
       datalake_service_client_;
-  std::optional<bool> is_hierarchical_namespace_enabled_;
+  std::optional<bool> enabled_;
 };
 
-}  // namespace internal
-}  // namespace fs
-}  // namespace arrow
+}  // namespace arrow::fs::internal

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -1,0 +1,26 @@
+
+#include <azure/storage/files/datalake.hpp>
+
+#include "arrow/result.h"
+
+namespace arrow {
+namespace fs {
+namespace internal {
+
+Status ErrorToStatus(const std::string& prefix,
+                                  const Azure::Storage::StorageException& exception);
+
+class HierachicalNamespaceDetecter {
+ public:
+  //  TODO: Switch back to holding a reference to the datalake service client. That way we
+  //  can avoid instantiating a filesystem client if the result is cached.
+  Result<bool> Enabled(
+      Azure::Storage::Files::DataLake::DataLakeFileSystemClient filesystem_client);
+
+ private:
+  std::optional<bool> is_hierachical_namespace_enabled_;
+};
+
+}  // namespace internal
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -8,16 +8,17 @@ namespace fs {
 namespace internal {
 
 Status ErrorToStatus(const std::string& prefix,
-                                  const Azure::Storage::StorageException& exception);
+                     const Azure::Storage::StorageException& exception);
 
 class HierachicalNamespaceDetecter {
  public:
-  //  TODO: Switch back to holding a reference to the datalake service client. That way we
-  //  can avoid instantiating a filesystem client if the result is cached.
-  Result<bool> Enabled(
-      Azure::Storage::Files::DataLake::DataLakeFileSystemClient filesystem_client);
+  Status Init(std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
+                  datalake_service_client);
+  Result<bool> Enabled(const std::string& container_name);
 
  private:
+  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
+      datalake_service_client_;
   std::optional<bool> is_hierachical_namespace_enabled_;
 };
 

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -1,3 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
 
 #include <azure/storage/files/datalake.hpp>
 

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <azure/storage/files/datalake.hpp>
 
 #include "arrow/result.h"

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -10,7 +10,7 @@ namespace internal {
 Status ErrorToStatus(const std::string& prefix,
                      const Azure::Storage::StorageException& exception);
 
-class HierachicalNamespaceDetecter {
+class HierarchicalNamespaceDetector {
  public:
   Status Init(std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
                   datalake_service_client);
@@ -19,7 +19,7 @@ class HierachicalNamespaceDetecter {
  private:
   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
       datalake_service_client_;
-  std::optional<bool> is_hierachical_namespace_enabled_;
+  std::optional<bool> is_hierarchical_namespace_enabled_;
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -485,7 +485,7 @@ std::shared_ptr<const KeyValueMetadata> NormalizerKeyValueMetadata(
         value = "2023-10-31T08:15:20Z";
       }
     } else if (key == "ETag") {
-      if (internal::StartsWith(value, "\"") && internal::EndsWith(value, "\"")) {
+      if (arrow::internal::StartsWith(value, "\"") && arrow::internal::EndsWith(value, "\"")) {
         // Valid value
         value = "\"ETagValue\"";
       }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -33,8 +33,8 @@
 // cpp/cmake_modules/ThirdpartyToolchain.cmake for details.
 #include <boost/process.hpp>
 
-#include "arrow/filesystem/azurefs.h"
 #include "arrow/filesystem/azurefs.cc"
+#include "arrow/filesystem/azurefs.h"
 
 #include <random>
 #include <string>
@@ -146,7 +146,8 @@ class TestAzureFileSystem : public ::testing::Test {
  public:
   std::shared_ptr<FileSystem> fs_;
   std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
-  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient> datalake_service_client_;
+  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
+      datalake_service_client_;
   AzureOptions options_;
   std::mt19937_64 generator_;
   std::string container_name_;
@@ -254,12 +255,22 @@ class TestAzureHNSFileSystem : public TestAzureFileSystem {
 
 TEST_F(TestAzureFlatFileSystem, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
-  EXPECT_FALSE(hierarchical_namespace.Enabled(PreexistingContainerName()));
+  ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(TestAzureHNSFileSystem, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
-  EXPECT_TRUE(hierarchical_namespace.Enabled(PreexistingContainerName()));
+  ASSERT_OK_AND_EQ(true, hierarchical_namespace.Enabled(PreexistingContainerName()));
+}
+
+TEST_F(TestAzureFileSystem, DetectHierarchicalNamespace) {
+  auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
+  ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
+}
+
+TEST_F(TestAzureFileSystem, DetectHierarchicalNamespaceFailsWithMissingContainer) {
+  auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
+  ASSERT_NOT_OK(hierarchical_namespace.Enabled("non-existent-container"));
 }
 
 TEST_F(TestAzureFileSystem, GetFileInfoAccount) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -33,8 +33,8 @@
 // cpp/cmake_modules/ThirdpartyToolchain.cmake for details.
 #include <boost/process.hpp>
 
-#include "arrow/filesystem/azurefs.cc"
 #include "arrow/filesystem/azurefs.h"
+#include "arrow/filesystem/azurefs_internal.h"
 
 #include <random>
 #include <string>
@@ -254,28 +254,28 @@ class TestAzureHNSFileSystem : public TestAzureFileSystem {
 };
 
 TEST_F(TestAzureFlatFileSystem, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
   ASSERT_OK_AND_EQ(
       false, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
                  PreexistingContainerName())));
 }
 
 TEST_F(TestAzureHNSFileSystem, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
   ASSERT_OK_AND_EQ(
       true, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
                 PreexistingContainerName())));
 }
 
 TEST_F(TestAzureFileSystem, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
   ASSERT_OK_AND_EQ(
       false, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
                  PreexistingContainerName())));
 }
 
 TEST_F(TestAzureFileSystem, DetectHierarchicalNamespaceFailsWithMissingContainer) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
   ASSERT_NOT_OK(hierarchical_namespace.Enabled(
       datalake_service_client_->GetFileSystemClient("non-existent-container")));
 }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -146,7 +146,7 @@ TEST(AzureFileSystem, OptionsCompare) {
 class AzureFileSystemTest : public ::testing::Test {
  public:
   std::shared_ptr<FileSystem> fs_;
-  std::shared_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
+  std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
       datalake_service_client_;
   AzureOptions options_;
@@ -167,7 +167,7 @@ class AzureFileSystemTest : public ::testing::Test {
       GTEST_SKIP() << options.status().message();
     }
     container_name_ = RandomChars(32);
-    blob_service_client_ = std::make_shared<Azure::Storage::Blobs::BlobServiceClient>(
+    blob_service_client_ = std::make_unique<Azure::Storage::Blobs::BlobServiceClient>(
         options_.account_blob_url, options_.storage_credentials_provider);
     datalake_service_client_ =
         std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -229,6 +229,15 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 };
 
+class TestAzureFlatFileSystem : public TestAzureFileSystem {
+  AzureOptions MakeOptions() override {
+    AzureOptions options;
+    ARROW_EXPECT_OK(options.ConfigureAccountKeyCredentials(
+        std::getenv("AZURE_FLAT_ACCOUNT_NAME"), std::getenv("AZURE_FLAT_ACCOUNT_KEY")));
+    return options;
+  }
+};
+
 class TestAzureHNSFileSystem : public TestAzureFileSystem {
  public:
   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
@@ -264,7 +273,7 @@ TEST_F(TestAzureFileSystem, GetFileInfoContainer) {
   ASSERT_RAISES(Invalid, fs_->GetFileInfo("abfs://" + PreexistingContainerName()));
 }
 
-TEST_F(TestAzureFileSystem, GetFileInfoObjectWithNestedStructure) {
+TEST_F(TestAzureFlatFileSystem, GetFileInfoObjectWithNestedStructure) {
   // Adds detailed tests to handle cases of different edge cases
   // with directory naming conventions (e.g. with and without slashes).
   constexpr auto kObjectName = "test-object-dir/some_other_dir/another_dir/foo";

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -227,6 +227,13 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 };
 
+TEST_F(TestAzureFileSystem, GetFileInfoAccount) {
+  arrow::fs::AssertFileInfo(fs_.get(), "", FileType::Directory);
+
+  // URI
+  ASSERT_RAISES(Invalid, fs_->GetFileInfo("abfs://"));
+}
+
 TEST_F(TestAzureFileSystem, GetFileInfoContainer) {
   arrow::fs::AssertFileInfo(fs_.get(), PreexistingContainerName(), FileType::Directory);
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -147,7 +147,7 @@ class AzureFileSystemTest : public ::testing::Test {
  public:
   std::shared_ptr<FileSystem> fs_;
   std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> blob_service_client_;
-  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
+  std::unique_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
       datalake_service_client_;
   AzureOptions options_;
   std::mt19937_64 generator_;
@@ -170,7 +170,7 @@ class AzureFileSystemTest : public ::testing::Test {
     blob_service_client_ = std::make_unique<Azure::Storage::Blobs::BlobServiceClient>(
         options_.account_blob_url, options_.storage_credentials_provider);
     datalake_service_client_ =
-        std::make_shared<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
+        std::make_unique<Azure::Storage::Files::DataLake::DataLakeServiceClient>(
             options_.account_dfs_url, options_.storage_credentials_provider);
     ASSERT_OK_AND_ASSIGN(fs_, AzureFileSystem::Make(options_));
     auto container_client = blob_service_client_->GetBlobContainerClient(container_name_);
@@ -284,25 +284,25 @@ class AzureHierarchicalNamespaceFileSystemTest : public AzureFileSystemTest {
 
 TEST_F(AzureFlatNamespaceFileSystemTest, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
-  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_.get()));
   ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(AzureHierarchicalNamespaceFileSystemTest, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
-  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_.get()));
   ASSERT_OK_AND_EQ(true, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(AzuriteFileSystemTest, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
-  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_.get()));
   ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(AzuriteFileSystemTest, DetectHierarchicalNamespaceFailsWithMissingContainer) {
   auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
-  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_.get()));
   ASSERT_NOT_OK(hierarchical_namespace.Enabled("non-existent-container"));
 }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -255,29 +255,26 @@ class TestAzureHNSFileSystem : public TestAzureFileSystem {
 
 TEST_F(TestAzureFlatFileSystem, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
-  ASSERT_OK_AND_EQ(
-      false, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
-                 PreexistingContainerName())));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(TestAzureHNSFileSystem, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
-  ASSERT_OK_AND_EQ(
-      true, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
-                PreexistingContainerName())));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_OK_AND_EQ(true, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(TestAzureFileSystem, DetectHierarchicalNamespace) {
   auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
-  ASSERT_OK_AND_EQ(
-      false, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
-                 PreexistingContainerName())));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(TestAzureFileSystem, DetectHierarchicalNamespaceFailsWithMissingContainer) {
   auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
-  ASSERT_NOT_OK(hierarchical_namespace.Enabled(
-      datalake_service_client_->GetFileSystemClient("non-existent-container")));
+  ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
+  ASSERT_NOT_OK(hierarchical_namespace.Enabled("non-existent-container"));
 }
 
 TEST_F(TestAzureFileSystem, GetFileInfoAccount) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -254,23 +254,30 @@ class TestAzureHNSFileSystem : public TestAzureFileSystem {
 };
 
 TEST_F(TestAzureFlatFileSystem, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
-  ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
+  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  ASSERT_OK_AND_EQ(
+      false, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
+                 PreexistingContainerName())));
 }
 
 TEST_F(TestAzureHNSFileSystem, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
-  ASSERT_OK_AND_EQ(true, hierarchical_namespace.Enabled(PreexistingContainerName()));
+  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  ASSERT_OK_AND_EQ(
+      true, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
+                PreexistingContainerName())));
 }
 
 TEST_F(TestAzureFileSystem, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
-  ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
+  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  ASSERT_OK_AND_EQ(
+      false, hierarchical_namespace.Enabled(datalake_service_client_->GetFileSystemClient(
+                 PreexistingContainerName())));
 }
 
 TEST_F(TestAzureFileSystem, DetectHierarchicalNamespaceFailsWithMissingContainer) {
-  auto hierarchical_namespace = HierachicalNamespaceDetecter(datalake_service_client_);
-  ASSERT_NOT_OK(hierarchical_namespace.Enabled("non-existent-container"));
+  auto hierarchical_namespace = HierachicalNamespaceDetecter();
+  ASSERT_NOT_OK(hierarchical_namespace.Enabled(
+      datalake_service_client_->GetFileSystemClient("non-existent-container")));
 }
 
 TEST_F(TestAzureFileSystem, GetFileInfoAccount) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -379,15 +379,9 @@ TEST_F(TestAzureHNSFileSystem, GetFileInfoObjectWithNestedStructure) {
 
   AssertFileInfo(fs_.get(), PreexistingContainerPath() + "test-empty-object-dir",
                  FileType::Directory);
-
-  // TODO: Add an assert that it did not use ListBlobs to detect directories.
 }
 
-// TODO: Add ADLS Gen2 directory tests.
-
-// TODO: Check I haven't accidentally changed the purpose of this test. The name seems a
-// bit strange.
-TEST_F(TestAzureFileSystem, GetFileInfoObjectNoExplicitObject) {
+TEST_F(TestAzureFileSystem, GetFileInfoObject) {
   auto object_properties =
       blob_service_client_->GetBlobContainerClient(PreexistingContainerName())
           .GetBlobClient(PreexistingObjectName())
@@ -403,7 +397,7 @@ TEST_F(TestAzureFileSystem, GetFileInfoObjectNoExplicitObject) {
   ASSERT_RAISES(Invalid, fs_->GetFileInfo("abfs://" + PreexistingObjectName()));
 }
 
-TEST_F(TestAzureHNSFileSystem, GetFileInfoObjectNoExplicitObject) {
+TEST_F(TestAzureHNSFileSystem, GetFileInfoObject) {
   auto object_properties =
       blob_service_client_->GetBlobContainerClient(PreexistingContainerName())
           .GetBlobClient(PreexistingObjectName())

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -435,9 +435,7 @@ TEST_F(TestAzureFileSystem, OpenInputStreamStringBuffers) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputStreamInfo) {
-  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
-  // fs->GetFileInfo(PreexistingObjectPath()));
-  arrow::fs::FileInfo info(PreexistingObjectPath(), FileType::File);
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(PreexistingObjectPath()));
 
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream, fs_->OpenInputStream(info));
@@ -465,14 +463,10 @@ TEST_F(TestAzureFileSystem, OpenInputStreamNotFound) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputStreamInfoInvalid) {
-  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
-  // fs->GetFileInfo(PreexistingContainerPath()));
-  arrow::fs::FileInfo info(PreexistingContainerPath(), FileType::Directory);
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(PreexistingContainerPath()));
   ASSERT_RAISES(IOError, fs_->OpenInputStream(info));
 
-  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
-  // fs->GetFileInfo(NotFoundObjectPath()));
-  arrow::fs::FileInfo info2(PreexistingContainerPath(), FileType::NotFound);
+  ASSERT_OK_AND_ASSIGN(auto info2, fs_->GetFileInfo(NotFoundObjectPath()));
   ASSERT_RAISES(IOError, fs_->OpenInputStream(info2));
 }
 
@@ -649,9 +643,7 @@ TEST_F(TestAzureFileSystem, OpenInputFileIoContext) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputFileInfo) {
-  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
-  // fs->GetFileInfo(PreexistingObjectPath()));
-  arrow::fs::FileInfo info(PreexistingObjectPath(), FileType::File);
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(PreexistingObjectPath()));
 
   std::shared_ptr<io::RandomAccessFile> file;
   ASSERT_OK_AND_ASSIGN(file, fs_->OpenInputFile(info));
@@ -670,14 +662,10 @@ TEST_F(TestAzureFileSystem, OpenInputFileNotFound) {
 }
 
 TEST_F(TestAzureFileSystem, OpenInputFileInfoInvalid) {
-  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
-  // fs->GetFileInfo(PreexistingContainerPath()));
-  arrow::fs::FileInfo info(PreexistingContainerPath(), FileType::File);
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(PreexistingContainerPath()));
   ASSERT_RAISES(IOError, fs_->OpenInputFile(info));
 
-  // TODO(GH-38335): When implemented use ASSERT_OK_AND_ASSIGN(info,
-  // fs->GetFileInfo(NotFoundObjectPath()));
-  arrow::fs::FileInfo info2(NotFoundObjectPath(), FileType::NotFound);
+  ASSERT_OK_AND_ASSIGN(auto info2, fs_->GetFileInfo(NotFoundObjectPath()));
   ASSERT_RAISES(IOError, fs_->OpenInputFile(info2));
 }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -184,11 +184,11 @@ class AzureFileSystemTest : public ::testing::Test {
 
   void TearDown() override {
     if (!suite_skipped_) {
-    auto containers = blob_service_client_->ListBlobContainers();
-    for (auto container : containers.BlobContainers) {
-      auto container_client =
-          blob_service_client_->GetBlobContainerClient(container.Name);
-      container_client.DeleteIfExists();
+      auto containers = blob_service_client_->ListBlobContainers();
+      for (auto container : containers.BlobContainers) {
+        auto container_client =
+            blob_service_client_->GetBlobContainerClient(container.Name);
+        container_client.DeleteIfExists();
       }
     }
   }
@@ -257,7 +257,7 @@ class AzureFlatNamespaceFileSystemTest : public AzureFileSystemTest {
       char* account_key = std::getenv("AZURE_FLAT_NAMESPACE_ACCOUNT_KEY");
       EXPECT_THAT(account_key, NotNull());
       ARROW_EXPECT_OK(options.ConfigureAccountKeyCredentials(account_name, account_key));
-    return options;
+      return options;
     }
     return Status::Cancelled(
         "Connection details not provided for a real flat namespace "
@@ -272,7 +272,7 @@ class AzureHierarchicalNamespaceFileSystemTest : public AzureFileSystemTest {
       char* account_key = std::getenv("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_KEY");
       EXPECT_THAT(account_key, NotNull());
       ARROW_EXPECT_OK(options.ConfigureAccountKeyCredentials(account_name, account_key));
-    return options;
+      return options;
     }
     return Status::Cancelled(
         "Connection details not provided for a real hierachical namespace "
@@ -281,25 +281,25 @@ class AzureHierarchicalNamespaceFileSystemTest : public AzureFileSystemTest {
 };
 
 TEST_F(AzureFlatNamespaceFileSystemTest, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
   ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
   ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(AzureHierarchicalNamespaceFileSystemTest, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
   ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
   ASSERT_OK_AND_EQ(true, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(AzuriteFileSystemTest, DetectHierarchicalNamespace) {
-  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
   ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
   ASSERT_OK_AND_EQ(false, hierarchical_namespace.Enabled(PreexistingContainerName()));
 }
 
 TEST_F(AzuriteFileSystemTest, DetectHierarchicalNamespaceFailsWithMissingContainer) {
-  auto hierarchical_namespace = internal::HierachicalNamespaceDetecter();
+  auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
   ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_));
   ASSERT_NOT_OK(hierarchical_namespace.Enabled("non-existent-container"));
 }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -255,8 +255,8 @@ class AzuriteFileSystemTest : public AzureFileSystemTest {
 class AzureFlatNamespaceFileSystemTest : public AzureFileSystemTest {
   Result<AzureOptions> MakeOptions() override {
     AzureOptions options;
-    if (char* account_name = std::getenv("AZURE_FLAT_NAMESPACE_ACCOUNT_NAME")) {
-      char* account_key = std::getenv("AZURE_FLAT_NAMESPACE_ACCOUNT_KEY");
+    if (const auto account_name = std::getenv("AZURE_FLAT_NAMESPACE_ACCOUNT_NAME")) {
+      const auto account_key = std::getenv("AZURE_FLAT_NAMESPACE_ACCOUNT_KEY");
       EXPECT_THAT(account_key, NotNull());
       ARROW_EXPECT_OK(options.ConfigureAccountKeyCredentials(account_name, account_key));
       return options;
@@ -270,8 +270,8 @@ class AzureFlatNamespaceFileSystemTest : public AzureFileSystemTest {
 class AzureHierarchicalNamespaceFileSystemTest : public AzureFileSystemTest {
   Result<AzureOptions> MakeOptions() override {
     AzureOptions options;
-    if (char* account_name = std::getenv("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_NAME")) {
-      char* account_key = std::getenv("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_KEY");
+    if (const auto account_name = std::getenv("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_NAME")) {
+      const auto account_key = std::getenv("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_KEY");
       EXPECT_THAT(account_key, NotNull());
       ARROW_EXPECT_OK(options.ConfigureAccountKeyCredentials(account_name, account_key));
       return options;
@@ -307,16 +307,16 @@ TEST_F(AzuriteFileSystemTest, DetectHierarchicalNamespaceFailsWithMissingContain
 }
 
 TEST_F(AzuriteFileSystemTest, GetFileInfoAccount) {
-  arrow::fs::AssertFileInfo(fs_.get(), "", FileType::Directory);
+  AssertFileInfo(fs_.get(), "", FileType::Directory);
 
   // URI
   ASSERT_RAISES(Invalid, fs_->GetFileInfo("abfs://"));
 }
 
 TEST_F(AzuriteFileSystemTest, GetFileInfoContainer) {
-  arrow::fs::AssertFileInfo(fs_.get(), PreexistingContainerName(), FileType::Directory);
+  AssertFileInfo(fs_.get(), PreexistingContainerName(), FileType::Directory);
 
-  arrow::fs::AssertFileInfo(fs_.get(), "non-existent-container", FileType::NotFound);
+  AssertFileInfo(fs_.get(), "non-existent-container", FileType::NotFound);
 
   // URI
   ASSERT_RAISES(Invalid, fs_->GetFileInfo("abfs://" + PreexistingContainerName()));
@@ -382,7 +382,7 @@ void AzureFileSystemTest::RunGetFileInfoObjectTest() {
           .GetProperties()
           .Value;
 
-  arrow::fs::AssertFileInfo(
+  AssertFileInfo(
       fs_.get(), PreexistingObjectPath(), FileType::File,
       std::chrono::system_clock::time_point(object_properties.LastModified),
       static_cast<int64_t>(object_properties.BlobSize));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -485,7 +485,8 @@ std::shared_ptr<const KeyValueMetadata> NormalizerKeyValueMetadata(
         value = "2023-10-31T08:15:20Z";
       }
     } else if (key == "ETag") {
-      if (arrow::internal::StartsWith(value, "\"") && arrow::internal::EndsWith(value, "\"")) {
+      if (arrow::internal::StartsWith(value, "\"") &&
+          arrow::internal::EndsWith(value, "\"")) {
         // Valid value
         value = "\"ETagValue\"";
       }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -323,6 +323,10 @@ TEST_F(TestAzureHNSFileSystem, GetFileInfoObjectWithNestedStructure) {
       .GetBlockBlobClient(std::string(kObjectName) + "0")
       .UploadFrom(reinterpret_cast<const uint8_t*>(kLoremIpsum), strlen(kLoremIpsum));
 
+  datalake_service_client_->GetFileSystemClient(PreexistingContainerName())
+      .GetDirectoryClient("test-empty-object-dir")
+      .Create();
+
   AssertFileInfo(fs_.get(), PreexistingContainerPath() + kObjectName, FileType::File);
   AssertFileInfo(fs_.get(), PreexistingContainerPath() + kObjectName + "/",
                  FileType::NotFound);
@@ -340,6 +344,11 @@ TEST_F(TestAzureHNSFileSystem, GetFileInfoObjectWithNestedStructure) {
                  FileType::NotFound);
   AssertFileInfo(fs_.get(), PreexistingContainerPath() + "test-object-dir/some_other_di",
                  FileType::NotFound);
+
+  AssertFileInfo(fs_.get(), PreexistingContainerPath() + "test-empty-object-dir",
+                 FileType::Directory);
+
+  // TODO: Add an assert that it did not use ListBlobs to detect directories.
 }
 
 // TODO: Add ADLS Gen2 directory tests.

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -157,7 +157,6 @@ class AzureFileSystemTest : public ::testing::Test {
   AzureFileSystemTest() : generator_(std::random_device()()) {}
 
   virtual Result<AzureOptions> MakeOptions() = 0;
-  virtual void Skip(){};
 
   void SetUp() override {
     auto options = MakeOptions();

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -197,19 +197,9 @@ Status AssertNoTrailingSlash(std::string_view key) {
   return Status::OK();
 }
 
-bool HasTrailingSlash(std::string_view key) {
-  if (key.back() != '/') {
-    return false;
-  }
-  return true;
-}
+bool HasTrailingSlash(std::string_view key) { return key.back() == '/'; }
 
-bool HasLeadingSlash(std::string_view key) {
-  if (key.front() != '/') {
-    return false;
-  }
-  return true;
-}
+bool HasLeadingSlash(std::string_view key) { return key.front() == '/'; }
 
 Result<std::string> MakeAbstractPathRelative(const std::string& base,
                                              const std::string& path) {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -191,10 +191,17 @@ std::string_view RemoveLeadingSlash(std::string_view key) {
 }
 
 Status AssertNoTrailingSlash(std::string_view key) {
-  if (key.back() == '/') {
+  if (HasTrailingSlash(key)) {
     return NotAFile(key);
   }
   return Status::OK();
+}
+
+bool HasTrailingSlash(std::string_view key) {
+  if (key.back() != '/') {
+    return false;
+  }
+  return true;
 }
 
 bool HasLeadingSlash(std::string_view key) {

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -95,6 +95,9 @@ ARROW_EXPORT
 Status AssertNoTrailingSlash(std::string_view s);
 
 ARROW_EXPORT
+bool HasTrailingSlash(std::string_view s);
+
+ARROW_EXPORT
 bool HasLeadingSlash(std::string_view s);
 
 ARROW_EXPORT


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
`GetFileInfo` is an important part of an Arrow filesystem implementation. 

### What changes are included in this PR?
- Start `azurefs_internal` similar to GCS and S3 filesystems. 
- Implement `HierarchicalNamespaceDetector`. 
  - This does not use the obvious and simple implementation. It uses a more complicated option inspired by `hadoop-azure` that avoids requiring the significantly elevated permissions needed for `blob_service_client->GetAccountInfo()`.
  - This can't be detected an initialisation time of the filesystem because it requires a `container_name`.  Its packed into its only class so that the result can be cached. 
- Implement `GetFileInfo` for single paths. 
  - Supports hierarchical or flat namespace accounts and takes advantage of hierarchical namespace where possible to avoid unnecessary extra calls to blob storage. The performance difference is actually noticeable just from running the `GetFileInfoObjectWithNestedStructure` test against real flat and hierarchical accounts.  Its about 3 seconds with hierarchical namespace or 5 seconds with a flat namespace.
- Update tests with TODO(GH-38335) to now use this implementation of `GetFileInfo` to replace the temporary direct Azure SDK usage.
- Rename the main test fixture and introduce new ones for connecting to real blob storage. If details of real blob storage is not provided then the real blob storage tests will be skipped. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. There are new Azurite based tests for everything that can be tested with Azurite. 

There are also some tests that are designed to test against a real blob storage account. This is because [Azurite cannot emulate a hierarchical namespace account](https://github.com/Azure/Azurite/issues/553). Additionally some of the behaviour used to detect a hierarchical namespace account is different on Azurite compared to a real flat namespace account. These tests will be automatically skipped unless environment variables are provided with details for connecting to the relevant real storage accounts. 

Initially I based the tests on the GCS filesystem but I added a few extras where I thought it was appropriate. 

### Are there any user-facing changes?
Yes. `GetFileInfo` is now supported on the Azure filesystem. 

* Closes: #38335