### PR TITLE
MINOR: [Docs][Python] Add more text around PyArrow build types

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -407,7 +407,7 @@ to the ``arrow/python`` folder and run ``git clean -Xfd .``.
 
 By default, PyArrow will be built in release mode even if Arrow C++ has been
 built in debug mode. To create a debug build of PyArrow, run
-``PYARROW_BUILD_TYPE=debug`` prior to running  ``python setup.py
+``export PYARROW_BUILD_TYPE=debug`` prior to running  ``python setup.py
 build_ext --inplace`` above. A ``relwithdebinfo`` build can be created
 similarly.
 

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -405,6 +405,12 @@ set the ``PYARROW_PARALLEL`` environment variable.
 If you wish to delete stale PyArrow build artifacts before rebuilding, navigate
 to the ``arrow/python`` folder and run ``git clean -Xfd .``.
 
+By default, PyArrow will be built in release mode even if Arrow C++ has been
+built in debug mode. To create a debug build of PyArrow, run
+``PYARROW_BUILD_TYPE=debug`` prior to running  ``python setup.py
+build_ext --inplace`` above. A ``relwithdebinfo`` build can be created
+similarly.
+
 Now you are ready to install test dependencies and run `Unit Testing`_, as
 described above.
 
@@ -434,6 +440,9 @@ Debugging
 
 Since pyarrow depends on the Arrow C++ libraries, debugging can
 frequently involve crossing between Python and C++ shared libraries.
+For the best experience, make sure you've built both Arrow C++
+(``-DCMAKE_BUILD_TYPE=Debug``) and PyArrow (``export PYARROW_BUILD_TYPE=debug``)
+in debug mode.
 
 Using gdb on Linux
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Rationale for this change

It's not very clear that PyArrow will get built in release mode even if the linked Arrow C++ is built in debug mode. I added some text to the docs to make it more clear. An example of a user running into this is https://github.com/apache/arrow/issues/38519.

### Are these changes tested?

No as they're just minor docs changes.

### Are there any user-facing changes?

This adds text to the Python docs.