### PR TITLE
GH-38315: [Dev][CI] autotune needs additional permissions to push to PR branches

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -59,6 +59,8 @@ jobs:
     name: "Fix all the things"
     if: startsWith(github.event.comment.body, '@github-actions autotune')
     runs-on: ubuntu-latest
+    permissions: 
+      contents: write
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       - uses: r-lib/actions/pr-fetch@11a22a908006c25fe054c4ef0ac0436b1de3edbe # v2.6.4

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -63,6 +63,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0
       - uses: r-lib/actions/pr-fetch@11a22a908006c25fe054c4ef0ac0436b1de3edbe # v2.6.4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/r/R/dplyr-count.R
+++ b/r/R/dplyr-count.R
@@ -17,7 +17,9 @@
 
 # The following S3 methods are registered on load if dplyr is present
 
-count.arrow_dplyr_query <- function(x, ..., wt = NULL, sort = FALSE, name = NULL) {
+count.arrow_dplyr_query <- function(
+  
+  x, ..., wt = NULL, sort = FALSE, name = NULL) {
   if (!missing(...)) {
     out <- dplyr::group_by(x, ..., .add = TRUE)
   } else {

--- a/r/R/dplyr-count.R
+++ b/r/R/dplyr-count.R
@@ -17,9 +17,7 @@
 
 # The following S3 methods are registered on load if dplyr is present
 
-count.arrow_dplyr_query <- function(
-  
-  x, ..., wt = NULL, sort = FALSE, name = NULL) {
+count.arrow_dplyr_query <- function(x, ..., wt = NULL, sort = FALSE, name = NULL) {
   if (!missing(...)) {
     out <- dplyr::group_by(x, ..., .add = TRUE)
   } else {


### PR DESCRIPTION
### Rationale for this change

autotune is giving 403 errors as there aren't enough permissions on the default `GITHUB_TOKEN`

### What changes are included in this PR?

Add required permissions

### Are these changes tested?

I've pushed some dodgy formatting to this branch, so am intend to test it here

### Are there any user-facing changes?

Nope
* Closes: #38315