### PR TITLE
GH-38330: [C++][Azure] Use properties for input stream metadata

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -186,7 +186,7 @@ std::shared_ptr<const KeyValueMetadata> PropertiesToMetadata(
   }
   metadata->Append("Content-Type", properties.HttpHeaders.ContentType);
   metadata->Append("Content-Encoding", properties.HttpHeaders.ContentEncoding);
-  metadata->Append("Content-Language", properties.HttpHeaders.ContentEncoding);
+  metadata->Append("Content-Language", properties.HttpHeaders.ContentLanguage);
   const auto& content_hash = properties.HttpHeaders.ContentHash.Value;
   metadata->Append("Content-Hash", HexEncode(content_hash.data(), content_hash.size()));
   metadata->Append("Content-Disposition", properties.HttpHeaders.ContentDisposition);


### PR DESCRIPTION
### Rationale for this change

We use user defined metadata for input stream metadata for now. But we should use properties returned from Azure like other remove filesystem implementations such as S3 and GCS.

### What changes are included in this PR?

Convert `Azure::Storage::Blobs::Models::BlobProperties` to `KeyValueMetadata`. The following values aren't supported yet:

* `BlobProperties::ObjectReplicationSourceProperties`
* `BlobProperties::Metadata`

If they need, we will add support for them as a follow-up task.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #38330