### PR TITLE
GH-38420: [MATLAB] Implement a `DatetimeValidator` class that validates a MATLAB `cell` array contains only values of zoned or unzoned `datetime`s

### DIFF
--- a/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
@@ -30,6 +30,8 @@ classdef DatetimeValidator < arrow.array.internal.list.ClassTypeValidator
 
         function validateElement(obj, element)
             validateElement@arrow.array.internal.list.ClassTypeValidator(obj, element);
+            % hasTimeZone and obj.HasTimeZone must be equal because zoned
+            % and unzoned datetimes cannot be concatenated together.
             hasTimeZone = ~isempty(element.TimeZone);
             if obj.HasTimeZone && ~hasTimeZone
                 errorID = "arrow:array:list:ExpectedZonedDatetime";

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
@@ -16,7 +16,7 @@
 classdef DatetimeValidator < arrow.array.internal.list.ClassTypeValidator
 
     properties (GetAccess=public, SetAccess=private)
-        HasTimeZone (1, 1) logical = false
+        Zoned (1, 1) logical = false
     end
 
     methods
@@ -25,20 +25,20 @@ classdef DatetimeValidator < arrow.array.internal.list.ClassTypeValidator
                 date(:, :) datetime
             end
             obj@arrow.array.internal.list.ClassTypeValidator(date);
-            obj.HasTimeZone = ~isempty(date.TimeZone);
+            obj.Zoned = ~isempty(date.TimeZone);
         end
 
         function validateElement(obj, element)
             validateElement@arrow.array.internal.list.ClassTypeValidator(obj, element);
-            % hasTimeZone and obj.HasTimeZone must be equal because zoned
+            % zoned and obj.Zoned must be equal because zoned
             % and unzoned datetimes cannot be concatenated together.
-            hasTimeZone = ~isempty(element.TimeZone);
-            if obj.HasTimeZone && ~hasTimeZone
+            zoned = ~isempty(element.TimeZone);
+            if obj.Zoned && ~zoned
                 errorID = "arrow:array:list:ExpectedZonedDatetime";
                 msg = "Expected all datetime elements in the cell array to " + ...
                     "have a time zone but encountered a datetime array without a time zone";
                 error(errorID, msg);
-            elseif ~obj.HasTimeZone && hasTimeZone
+            elseif ~obj.Zoned && zoned
                 errorID = "arrow:array:list:ExpectedUnzonedDatetime";
                 msg = "Expected all datetime elements in the cell array to " + ...
                     "not have a time zone but encountered a datetime array with a time zone";

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
@@ -29,7 +29,7 @@ classdef DatetimeValidator < arrow.array.internal.list.ClassTypeValidator
         end
 
         function validateElement(obj, element)
-            validateElement@arrow.array.internal.list.ClassTypeValidator(element);
+            validateElement@arrow.array.internal.list.ClassTypeValidator(obj, element);
             hasTimeZone = ~isempty(element.TimeZone);
             if obj.HasTimeZone && ~hasTimeZone
                 errorID = "arrow:array:list:ExpectedZonedDatetime";

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/DatetimeValidator.m
@@ -1,0 +1,47 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef DatetimeValidator < arrow.array.internal.list.ClassTypeValidator
+
+    properties (GetAccess=public, SetAccess=private)
+        HasTimeZone (1, 1) logical = false
+    end
+
+    methods
+        function obj = DatetimeValidator(date)
+            arguments
+                date(:, :) datetime
+            end
+            obj@arrow.array.internal.list.ClassTypeValidator(date);
+            obj.HasTimeZone = ~isempty(date.TimeZone);
+        end
+
+        function validateElement(obj, element)
+            validateElement@arrow.array.internal.list.ClassTypeValidator(element);
+            hasTimeZone = ~isempty(element.TimeZone);
+            if obj.HasTimeZone && ~hasTimeZone
+                errorID = "arrow:array:list:ExpectedZonedDatetime";
+                msg = "Expected all datetime elements in the cell array to " + ...
+                    "have a time zone but encountered a datetime array without a time zone";
+                error(errorID, msg);
+            elseif ~obj.HasTimeZone && hasTimeZone
+                errorID = "arrow:array:list:ExpectedUnzonedDatetime";
+                msg = "Expected all datetime elements in the cell array to " + ...
+                    "not have a time zone but encountered a datetime array with a time zone";
+                error(errorID, msg);
+            end
+        end
+    end
+end

--- a/matlab/test/arrow/array/list/tDatetimeValidator.m
+++ b/matlab/test/arrow/array/list/tDatetimeValidator.m
@@ -98,6 +98,8 @@ classdef tDatetimeValidator < matlab.unittest.TestCase
             % datetimes to zoned.
             import arrow.array.internal.list.DatetimeValidator
 
+            % validator will expect all elements to be zoned datetimes
+            % because the input datetime is zoned.
             validator = DatetimeValidator(datetime(2023, 10, 31, TimeZone="UTC"));
             errorID = "arrow:array:list:ExpectedZonedDatetime";
             fcn = @() validator.validateElement(datetime(2023, 11, 1));
@@ -111,6 +113,8 @@ classdef tDatetimeValidator < matlab.unittest.TestCase
             % datetimes to be unzoned.
             import arrow.array.internal.list.DatetimeValidator
 
+            % validator will expect all elements to be unzoned datetimes
+            % because the input datetime is not zoned.
             validator = DatetimeValidator(datetime(2023, 10, 31));
             errorID = "arrow:array:list:ExpectedUnzonedDatetime";
             fcn = @() validator.validateElement(datetime(2023, 11, 1, TimeZone="America/New_York"));

--- a/matlab/test/arrow/array/list/tDatetimeValidator.m
+++ b/matlab/test/arrow/array/list/tDatetimeValidator.m
@@ -1,5 +1,5 @@
 %TDATETIMEVALIDATOR Unit tests for
-%arrow.array.internal.list.DatetimeValditor
+%arrow.array.internal.list.DatetimeValidator
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
@@ -43,36 +43,36 @@ classdef tDatetimeValidator < matlab.unittest.TestCase
             testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
         end
 
-        function HasTimeZoneGetter(testCase)
-            % Verify the HasTimeZone getter returns the expected scalar
+        function ZonedGetter(testCase)
+            % Verify the Zoned getter returns the expected scalar
             % logical.
 
             import arrow.array.internal.list.DatetimeValidator
             validator = DatetimeValidator(datetime(2023, 10, 31));
-            testCase.verifyEqual(validator.HasTimeZone, false);
+            testCase.verifyEqual(validator.Zoned, false);
 
             validator = DatetimeValidator(datetime(2023, 10, 31, TimeZone="UTC"));
-            testCase.verifyEqual(validator.HasTimeZone, true);
+            testCase.verifyEqual(validator.Zoned, true);
         end
 
-        function HasTimeZoneNoSetter(testCase)
-            % Verify HasTimeZone property is not settable.
+        function ZonedNoSetter(testCase)
+            % Verify Zoned property is not settable.
             import arrow.array.internal.list.DatetimeValidator
 
             validator = DatetimeValidator(datetime(2023, 10, 31));
-            fcn = @() setfield(validator, "HasTimeZone", true);
+            fcn = @() setfield(validator, "Zoned", true);
             testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
 
              validator = DatetimeValidator(datetime(2023, 10, 31, TimeZone="UTC"));
-            fcn = @() setfield(validator, "HasTimeZone", false);
+            fcn = @() setfield(validator, "Zoned", false);
             testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
         end
 
         function ValidateElementNoThrow(testCase) %#ok<MANU>
             % Verify validateElement does not throw an exception if:
             %  1. the input element is a datetime
-            %  2. its TimeZone property is '' (only if HasTimeZone = false)
-            %  3. its TimeZone property is not empty (ony if HasTimeZone = true).
+            %  2. its TimeZone property is '' (only if Zoned = false)
+            %  3. its TimeZone property is not empty (ony if Zoned = true).
 
             import arrow.array.internal.list.DatetimeValidator
 

--- a/matlab/test/arrow/array/list/tDatetimeValidator.m
+++ b/matlab/test/arrow/array/list/tDatetimeValidator.m
@@ -71,8 +71,8 @@ classdef tDatetimeValidator < matlab.unittest.TestCase
         function ValidateElementNoThrow(testCase) %#ok<MANU>
             % Verify validateElement does not throw an exception if:
             %  1. the input element is a datetime
-            %  2. its TimeZone property is '' (only if Zoned = false)
-            %  3. its TimeZone property is not empty (ony if Zoned = true).
+            %  2. its TimeZone property is '' and Zoned = false
+            %  3. its TimeZone property is not empty and Zoned = true
 
             import arrow.array.internal.list.DatetimeValidator
 
@@ -135,7 +135,6 @@ classdef tDatetimeValidator < matlab.unittest.TestCase
             testCase.verifyError(fcn, errorID);
             fcn = @() validator.validateElement(seconds(1));
             testCase.verifyError(fcn, errorID);
-
         end
 
         function GetElementLength(testCase)

--- a/matlab/test/arrow/array/list/tDatetimeValidator.m
+++ b/matlab/test/arrow/array/list/tDatetimeValidator.m
@@ -1,0 +1,91 @@
+%TDATETIMEVALIDATOR Unit tests for
+%arrow.array.internal.list.DatetimeValditor
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tDatetimeValidator < matlab.unittest.TestCase
+
+    methods (Test)
+        function Smoke(testCase)
+            import arrow.array.internal.list.DatetimeValidator
+            validator = DatetimeValidator(datetime(2023, 10, 31));
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.DatetimeValidator");
+        end
+
+        function ClassNameGetter(testCase)
+            % Verify the ClassName getter returns the expected scalar
+            % string.
+            import arrow.array.internal.list.DatetimeValidator
+
+            validator = DatetimeValidator(datetime(2023, 10, 31));
+            testCase.verifyEqual(validator.ClassName, "datetime");
+        end
+
+        function ClassNameNoSetter(testCase)
+            % Verify ClassName property is not settable.
+            import arrow.array.internal.list.DatetimeValidator
+
+            validator = DatetimeValidator(datetime(2023, 10, 31));
+            fcn = @() setfield(validator, "ClassName", "duration");
+            testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
+        end
+
+        function HasTimeZoneGetter(testCase)
+            % Verify the HasTimeZone getter returns the expected scalar
+            % logical.
+
+            import arrow.array.internal.list.DatetimeValidator
+            validator = DatetimeValidator(datetime(2023, 10, 31));
+            testCase.verifyEqual(validator.HasTimeZone, false);
+
+            validator = DatetimeValidator(datetime(2023, 10, 31, TimeZone="UTC"));
+            testCase.verifyEqual(validator.HasTimeZone, true);
+        end
+
+        function HasTimeZoneNoSetter(testCase)
+            % Verify HasTimeZone property is not settable.
+            import arrow.array.internal.list.DatetimeValidator
+
+            validator = DatetimeValidator(datetime(2023, 10, 31));
+            fcn = @() setfield(validator, "HasTimeZone", true);
+            testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
+
+             validator = DatetimeValidator(datetime(2023, 10, 31, TimeZone="UTC"));
+            fcn = @() setfield(validator, "HasTimeZone", false);
+            testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
+        end
+
+        function validateElementNoThrow(testCase) %#ok<MANU>
+            import arrow.array.internal.list.DatetimeValidator
+
+            validator = DatetimeValidator(datetime(2023, 10, 31));
+            validator.validateElement(datetime(2023, 11, 1));
+            validator.validateElement(datetime(2023, 11, 1) + days(0:2));
+            validator.validateElement(datetime(2023, 11, 1) + days(0:2)');
+            validator.validateElement(datetime.empty(0, 1));
+
+            validator = DatetimeValidator(datetime(2023, 10, 31, TimeZone="UTC"));
+            validator.validateElement(datetime(2023, 11, 1,  TimeZone="UTC"));
+            validator.validateElement(datetime(2023, 11, 1,  TimeZone="America/New_York") + days(0:2));
+            validator.validateElement(datetime(2023, 11, 1,  TimeZone="Pacific/Fiji") + days(0:2)');
+            emptyDatetime = datetime.empty(0, 1);
+            emptyDatetime.TimeZone = "Asia/Dubai";
+            validator.validateElement(emptyDatetime);
+        end
+
+    end
+
+end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

This is a followup to #38419.

Adding this `DatetimeTypeValidator` class is a step towards implementing the `arrow.array.ListArray.fromMATLAB()` method for creating `ListArray`s whose `ValueType`s is a timestamp array from a MATLAB `cell` array.

This validator will ensure the cell array contain only `datetime`s or unzoned `datetime`s. This is a requirement when creating a `List` of `Timestamp`s because two MATLAB `datetime`s can only be concatenated together if they are either both zoned or both unzoned:

```matlab
>> d1 = datetime(2023, 10, 31, TimeZone="America/New_York");
>> d2 =datetime(2023, 11, 1);
>> [d1; d2]
Error using datetime/vertcat
Unable to concatenate a datetime array that has a time zone with one that does not have a time
zone.
```

### What changes are included in this PR?

Added a new MATLAB class called `arrow.array.internal.list.DatetimeValidator`, which inherits from `arrow.array.internal.list.ClassTypeValidator`.

 This new class defines one property called `HasTimeZone`, which is a scalar `logical` indicating if the validator expects all `datetime`s to be zoned or not. 

Additionally, `DatetimeValidator` overrides the `validateElement` method. It first call's `ClassTypeValidator`'s implementation of `validateElement` to verify the input element is a `datetime`. If so, it then confirms that the input `datetime`'s TimeZone property is empty or nonempty, based on the validator's `HasTimeZone`  property value.

### Are these changes tested?

Yes, I added a new test class called `tDatetimeValidator.m`.

### Are there any user-facing changes?

No.

### Future Directions

1. #38417 
2. #38354 
* Closes: #38420