### PR TITLE
GH-38430: [R] Add test + fix corner cases after nixlibs.R refactor

### DIFF
--- a/ci/docker/linux-r.dockerfile
+++ b/ci/docker/linux-r.dockerfile
@@ -36,9 +36,6 @@ ENV R_PRUNE_DEPS=${r_prune_deps}
 ARG r_custom_ccache=false
 ENV R_CUSTOM_CCACHE=${r_custom_ccache}
 
-ARG r_libarrow_binary=FALSE
-ENV LIBARROW_BINARY=${r_libarrow_binary}
-
 ARG tz="UTC"
 ENV TZ=${tz}
 

--- a/ci/docker/linux-r.dockerfile
+++ b/ci/docker/linux-r.dockerfile
@@ -36,6 +36,9 @@ ENV R_PRUNE_DEPS=${r_prune_deps}
 ARG r_custom_ccache=false
 ENV R_CUSTOM_CCACHE=${r_custom_ccache}
 
+ARG r_libarrow_binary=FALSE
+ENV LIBARROW_BINARY=${r_libarrow_binary}
+
 ARG tz="UTC"
 ENV TZ=${tz}
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -57,7 +57,6 @@ find_latest_nightly <- function(description_version,
       description_version_major <- as.integer(description_version[1, 1])
       matching_major <- major_versions == description_version_major
       if (!any(matching_major)) {
-        warning("just for the stack trace")
         lg(
           "No nightly binaries were found for version %s: falling back to libarrow build from source",
           description_version

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -49,11 +49,7 @@ find_latest_nightly <- function(description_version,
       urls <- readLines(list_uri)
       versions <- grep("Version:\\s*.*?", urls, value = TRUE)
       versions <- sort(package_version(sub("Version:\\s*", "\\1", versions)))
-      major_versions <- vapply(
-        versions,
-        function(x) as.integer(x[[c(1, 1)]]),
-        integer(1)
-      )
+      major_versions <- versions$major
 
       description_version_major <- as.integer(description_version[1, 1])
       matching_major <- major_versions == description_version_major
@@ -67,7 +63,7 @@ find_latest_nightly <- function(description_version,
       }
 
       versions <- versions[matching_major]
-      versions[[length(versions)]]
+      max(versions)
     },
     silent = hush
   )

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -883,6 +883,8 @@ build_ok <- !env_is("LIBARROW_BUILD", "false")
 #  https://arrow.apache.org/docs/developers/cpp/building.html#offline-builds)
 download_ok <- !test_mode && !env_is("TEST_OFFLINE_BUILD", "true")
 
+download_libarrow_ok <- download_ok && !env_is("LIBARROW_DOWNLOAD", "false")
+
 # This "tools/thirdparty_dependencies" path, within the tar file, might exist if
 # create_package_with_all_dependencies() was run, or if someone has created it
 # manually before running make build.
@@ -920,7 +922,7 @@ if (!test_mode && !file.exists(api_h)) {
       lg("File not found: %s ($ARROW_DOWNLOADED_BINARIES)", bin_zip)
       bin_file <- NULL
     }
-  } else if (download_ok) {
+  } else if (download_libarrow_ok) {
     binary_flavor <- identify_binary()
     if (!is.null(binary_flavor)) {
       # The env vars say we can, and we've determined a lib that should work

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -155,3 +155,67 @@ test_that("check_allowlist", {
   expect_true(check_allowlist("redhat", tempfile())) # remote allowlist doesn't exist, so we fall back to the default list, which contains redhat
   expect_false(check_allowlist("debian", tempfile()))
 })
+
+test_that("find_latest_nightly()", {
+  tf <- tempfile()
+  tf_uri <- paste0("file://", tf)
+  on.exit(unlink(tf))
+
+  writeLines(
+    c(
+      "Version: 13.0.0.100000333",
+      "Version: 13.0.0.100000334",
+      "Version: 13.0.0.100000335",
+      "Version: 14.0.0.100000001"
+    ),
+    tf
+  )
+
+  expect_output(
+    expect_identical(
+      find_latest_nightly(package_version("13.0.1.9000"), list_uri = tf_uri),
+      package_version("13.0.0.100000335")
+    ),
+    "Found latest nightly"
+  )
+
+  expect_output(
+    expect_identical(
+      find_latest_nightly(package_version("14.0.0.9000"), list_uri = tf_uri),
+      package_version("14.0.0.100000001")
+    ),
+    "Found latest nightly"
+  )
+
+  expect_output(
+    expect_identical(
+      find_latest_nightly(package_version("15.0.0.9000"), list_uri = tf_uri),
+      package_version("15.0.0.9000")
+    ),
+    "No nightly binaries were found for version"
+  )
+
+  # Check empty input
+  writeLines(character(), tf)
+  expect_output(
+    expect_identical(
+      find_latest_nightly(package_version("15.0.0.9000"), list_uri = tf_uri),
+      package_version("15.0.0.9000")
+    ),
+    "No nightly binaries were found for version"
+  )
+
+  # Check input that will throw an error
+  expect_output(
+    expect_identical(
+      suppressWarnings(
+        find_latest_nightly(
+          package_version("15.0.0.9000"),
+          list_uri = "this is not a URI"
+        )
+      ),
+      package_version("15.0.0.9000")
+    ),
+    "Failed to find latest nightly"
+  )
+})

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -211,7 +211,8 @@ test_that("find_latest_nightly()", {
       suppressWarnings(
         find_latest_nightly(
           package_version("15.0.0.9000"),
-          list_uri = "this is not a URI"
+          list_uri = "this is not a URI",
+          hush = TRUE
         )
       ),
       package_version("15.0.0.9000")

--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -283,6 +283,7 @@ the bundled build script.  All boolean variables are case-insensitive.
 | --- | --- | :-: |
 | `LIBARROW_BUILD` | Allow building from source | `true` |
 | `LIBARROW_BINARY` | Try to install `libarrow` binary instead of building from source | (unset) |
+| `LIBARROW_DOWNLOAD` | Set to `false` to explicitly forbid fetching a `libarrow` binary | (unset) |
 | `LIBARROW_MINIMAL` | Build with minimal features enabled | (unset) |
 | `NOT_CRAN` | Set `LIBARROW_BINARY=true` and `LIBARROW_MINIMAL=false` | `false` |
 | `ARROW_R_DEV` | More verbose messaging and regenerates some code | `false` |


### PR DESCRIPTION

### Rationale for this change

A few rough edges exist after https://github.com/apache/arrow/pull/38236 including:

- When zero or 1 nightly with the matching major version exist, detection of the latest nightly might fail
- At least one CI job is pulling nightlies instead of using the version from the current commit

### What changes are included in this PR?

- Clean up `find_latest_nightly()` + add test
- Ensure all CI jobs are not using `find_latest_nightly()`

### Are these changes tested?

Yes (test added)

### Are there any user-facing changes?

No
* Closes: #38430