### PR TITLE
MINOR: [Docs][Python] Fix typo on pycapsule and ipc docs

### DIFF
--- a/docs/source/format/CDataInterface/PyCapsuleInterface.rst
+++ b/docs/source/format/CDataInterface/PyCapsuleInterface.rst
@@ -30,7 +30,7 @@ The :ref:`C data interface <c-data-interface>` and
 different implementations of Arrow. However, these interfaces don't specify how
 Python libraries should expose these structs to other libraries. Prior to this,
 many libraries simply provided export to PyArrow data structures, using the
-``_import_from_c`` and ``_export_from_c`` methods. However, this always required
+``_import_from_c`` and ``_export_to_c`` methods. However, this always required
 PyArrow to be installed. In addition, those APIs could cause memory leaks if
 handled improperly.
 

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -632,7 +632,7 @@ cdef class RecordBatchReader(_Weakrefable):
     Notes
     -----
     To import and export using the Arrow C stream interface, use the
-    ``_import_from_c`` and ``_export_from_c`` methods. However, keep in mind this
+    ``_import_from_c`` and ``_export_to_c`` methods. However, keep in mind this
     interface is intended for expert users.
 
     Examples


### PR DESCRIPTION
### Rationale for this change

`_export_from_c` was a typo and it should be `_export_to_c`.

### Are these changes tested?

No.

### Are there any user-facing changes?

Docs changes.