### PR TITLE
GH-38417: [MATLAB] Implement a `TableTypeValidator` class that validates a MATLAB `cell` array contains only `table`s that share the same schema

### DIFF
--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -39,7 +39,7 @@ classdef TableValidator < arrow.array.internal.list.Validator
                 validators{ii} = arrow.array.internal.list.createValidator(T.(ii));
             end
 
-            obj.VariableValidators = validators{:};
+            obj.VariableValidators = [validators{:}];
         end
 
         function validateElement(obj, element)

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -66,7 +66,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
             for ii=1:numVars
                 var = element.(ii);
 
-                if ~istable(var) || ~iscolumn(var)
+                if ~istable(var) && ~iscolumn(var)
                     id = "arrow:array:list:NonTabularVariablesMustBeColumnar";
                     msg = "Table variables must be columnar";
                     error(id, msg);

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -46,8 +46,8 @@ classdef TableValidator < arrow.array.internal.list.Validator
             error("Not Implemented");
         end
 
-        function length = getElementLength(obj, element)
-            error("Not Implemented");
+        function length = getElementLength(~, element)
+            length = height(element);
         end
 
         function C = reshapeCellElements(~, C)

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -23,7 +23,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
     methods
         function obj = TableValidator(T)
             arguments
-                T table {}
+                T table
             end
             
             numVars = width(T);

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -50,8 +50,8 @@ classdef TableValidator < arrow.array.internal.list.Validator
             error("Not Implemented");
         end
 
-        function C = reshapeCellElements(obj, C)
-            error("Not Implemented");
+        function C = reshapeCellElements(~, C)
+            % NO-OP for cell array of tables
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -30,7 +30,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
 
             if (numVars == 0)
                 error("arrow:array:list:TableWithZeroVariables", ...
-                    "Require tables to have at least one variable.");
+                    "Expect tables to have at least one variable.");
             end
 
             obj@arrow.array.internal.list.ClassTypeValidator(table);
@@ -51,15 +51,16 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
             numVars = numel(obj.VariableNames);
             if width(element) ~= numVars
                 id = "arrow:array:list:NumVariablesMismatch";
-                fmt = "Expected all tables in the cell array to have %d variables";
-                msg = compose(fmt, numVars);
+                msg = "Expect all tables in the cell array to have " + ...
+                    string(numVars) + " variables.";
                 error(id, msg);
             end
 
             % Validate element has the expected variable names
             if ~all(obj.VariableNames == string(element.Properties.VariableNames))
                 id = "arrow:array:list:VariableNamesMismatch";
-                msg = "Expected table names to match";
+                msg = "Expect all tables in the cell array to have the " + ...
+                    "same variable names.";
                 error(id, msg);
             end
 
@@ -70,7 +71,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
                 % all non-tabular variables to be columnar or empty.
                 if ~istable(var) && (~iscolumn(var) || isempty(var))
                     id = "arrow:array:list:NonTabularVariablesMustBeColumnar";
-                    msg = "Table variables must be columnar";
+                    msg = "Expect all variables except for nested tables to be columnar.";
                     error(id, msg);
                 end
 

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -13,7 +13,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef TableValidator < arrow.array.internal.list.Validator
+classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
 
     properties (GetAccess=public, SetAccess=private)
         VariableNames string = string.empty(1, 0)
@@ -33,6 +33,7 @@ classdef TableValidator < arrow.array.internal.list.Validator
                     "Require tables to have at least one variable.");
             end
 
+            obj@arrow.array.internal.list.ClassTypeValidator(table);
             obj.VariableNames = string(T.Properties.VariableNames);
             validators = cell([1 numVars]);
             for ii = 1:numVars
@@ -43,7 +44,36 @@ classdef TableValidator < arrow.array.internal.list.Validator
         end
 
         function validateElement(obj, element)
-            error("Not Implemented");
+            % Verify element is a table
+            validateElement@arrow.array.internal.list.ClassTypeValidator(obj, element);
+            
+            % Validate element has the expected number of variables
+            numVars = numel(obj.VariableNames);
+            if width(element) ~= numVars
+                id = "arrow:array:list:NumVariablesMismatch";
+                fmt = "Expected all tables in the cell array to have %d variables";
+                msg = compose(fmt, numVars);
+                error(id, msg);
+            end
+
+            % Validate element has the expected variable names
+            if ~all(obj.VariableNames == string(element.Properties.VariableNames))
+                id = "arrow:array:list:VariableNamesMismatch";
+                msg = "Expected table names to match";
+                error(id, msg);
+            end
+
+            for ii=1:numVars
+                var = element.(ii);
+
+                if ~istable(var) || ~iscolumn(var)
+                    id = "arrow:array:list:NonTabularVariablesMustBeColumnar";
+                    msg = "Table variables must be columnar";
+                    error(id, msg);
+                end
+
+                obj.VariableValidators(ii).validateElement(var);
+            end
         end
 
         function length = getElementLength(~, element)

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -30,7 +30,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
 
             if (numVars == 0)
                 error("arrow:array:list:TableWithZeroVariables", ...
-                    "Expect tables to have at least one variable.");
+                    "Expected table to have at least one variable.");
             end
 
             obj@arrow.array.internal.list.ClassTypeValidator(table);
@@ -51,7 +51,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
             numVars = numel(obj.VariableNames);
             if width(element) ~= numVars
                 id = "arrow:array:list:NumVariablesMismatch";
-                msg = "Expect all tables in the cell array to have " + ...
+                msg = "Expected all tables in the cell array to have " + ...
                     string(numVars) + " variables.";
                 error(id, msg);
             end
@@ -59,7 +59,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
             % Validate element has the expected variable names
             if ~all(obj.VariableNames == string(element.Properties.VariableNames))
                 id = "arrow:array:list:VariableNamesMismatch";
-                msg = "Expect all tables in the cell array to have the " + ...
+                msg = "Expected all tables in the cell array to have the " + ...
                     "same variable names.";
                 error(id, msg);
             end
@@ -71,7 +71,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
                 % all non-tabular variables to be columnar or empty.
                 if ~istable(var) && (~iscolumn(var) && ~isempty(var))
                     id = "arrow:array:list:NonTabularVariablesMustBeColumnar";
-                    msg = "Expect all variables except for nested tables to be columnar.";
+                    msg = "Expected all variables except for nested tables to be columnar.";
                     error(id, msg);
                 end
 

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -16,15 +16,42 @@
 classdef TableValidator < arrow.array.internal.list.Validator
 
     properties (GetAccess=public, SetAccess=private)
-        VariableNames
-        VariableValidators
+        VariableNames string = string.empty(1, 0)
+        VariableValidators arrow.array.internal.list.Validator = arrow.array.internal.list.Validator.empty(1, 0) 
     end
 
     methods
         function obj = TableValidator(T)
             arguments
-                T table
+                T table {}
             end
+            
+            numVars = width(T);
+
+            if (numVars == 0)
+                error("arrow:array:list:TableWithZeroVariables", ...
+                    "Require tables to have at least one variable.");
+            end
+
+            obj.VariableNames = string(T.Properties.VariableNames);
+            validators = cell([1 numVars]);
+            for ii = 1:numVars
+                validators{ii} = arrow.array.internal.list.createValidator(T.(ii));
+            end
+
+            obj.VariableValidators = validators{:};
+        end
+
+        function validateElement(obj, element)
+            error("Not Implemented");
+        end
+
+        function length = getElementLength(obj, element)
+            error("Not Implemented");
+        end
+
+        function C = reshapeCellElements(obj, C)
+            error("Not Implemented");
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -1,0 +1,30 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef TableValidator < arrow.array.internal.list.Validator
+
+    properties (GetAccess=public, SetAccess=private)
+        VariableNames
+        VariableValidators
+    end
+
+    methods
+        function obj = TableValidator(T)
+            arguments
+                T table
+            end
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -66,7 +66,9 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
             for ii=1:numVars
                 var = element.(ii);
 
-                if ~istable(var) && ~iscolumn(var)
+                % In order to concatenate tables together later, require
+                % all non-tabular variables to be columnar or empty.
+                if ~istable(var) && (~iscolumn(var) || isempty(var))
                     id = "arrow:array:list:NonTabularVariablesMustBeColumnar";
                     msg = "Table variables must be columnar";
                     error(id, msg);

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/TableValidator.m
@@ -69,7 +69,7 @@ classdef TableValidator < arrow.array.internal.list.ClassTypeValidator
 
                 % In order to concatenate tables together later, require
                 % all non-tabular variables to be columnar or empty.
-                if ~istable(var) && (~iscolumn(var) || isempty(var))
+                if ~istable(var) && (~iscolumn(var) && ~isempty(var))
                     id = "arrow:array:list:NonTabularVariablesMustBeColumnar";
                     msg = "Expect all variables except for nested tables to be columnar.";
                     error(id, msg);

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/Validator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/Validator.m
@@ -16,7 +16,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Validator
+classdef Validator < matlab.mixin.Heterogeneous
 
     methods (Abstract)
         tf = validateElement(obj, element)

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/createValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/createValidator.m
@@ -1,0 +1,42 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+function validator = createValidator(data)
+    import arrow.array.internal.list.ClassTypeValidator
+    import arrow.array.internal.list.DatetimeValidator
+    import arrow.array.internal.list.TableValidator
+
+    if isnumeric(data)
+        validator = ClassValidator(data);
+    elseif islogical(data)
+        validator = ClassValidator(data);
+    elseif isduration(data)
+        validator = ClassValidator(data);
+    elseif isstring(data)
+        validator = ClassValidator(data);
+    elseif iscell(data)
+        validator = ClassValidator(data);
+    elseif isdatetime(data)
+        validator = DatetimeValidator(data);
+    elseif istable(data)
+        validator = TableValidator(data);
+    else
+        errorID = "arrow:array:list:UnsupportedDataType";
+        msg = "Unable to create ListArray from " + class(data) + " values.";
+        error(errorID, msg);
+    end
+
+end
+

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/createValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/createValidator.m
@@ -19,15 +19,15 @@ function validator = createValidator(data)
     import arrow.array.internal.list.TableValidator
 
     if isnumeric(data)
-        validator = ClassValidator(data);
+        validator = ClassTypeValidator(data);
     elseif islogical(data)
-        validator = ClassValidator(data);
+        validator = ClassTypeValidator(data);
     elseif isduration(data)
-        validator = ClassValidator(data);
+        validator = ClassTypeValidator(data);
     elseif isstring(data)
-        validator = ClassValidator(data);
+        validator = ClassTypeValidator(data);
     elseif iscell(data)
-        validator = ClassValidator(data);
+        validator = ClassTypeValidator(data);
     elseif isdatetime(data)
         validator = DatetimeValidator(data);
     elseif istable(data)

--- a/matlab/src/matlab/+arrow/+array/+internal/+list/createValidator.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/+list/createValidator.m
@@ -34,7 +34,7 @@ function validator = createValidator(data)
         validator = TableValidator(data);
     else
         errorID = "arrow:array:list:UnsupportedDataType";
-        msg = "Unable to create ListArray from " + class(data) + " values.";
+        msg = "Unable to create a ListArray from a cell array containing " + class(data) + " values.";
         error(errorID, msg);
     end
 

--- a/matlab/test/arrow/array/list/tCreateValidator.m
+++ b/matlab/test/arrow/array/list/tCreateValidator.m
@@ -1,0 +1,110 @@
+%TCREATEVALIDATOR Unit tests for arrow.array.internal.list.createValidator.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tCreateValidator < matlab.unittest.TestCase
+
+    properties (TestParameter)
+        NumericTypes
+    end
+
+    methods (TestParameterDefinition, Static)
+        function NumericTypes = initializeNumericTypes()
+            NumericTypes = {"uint8", ...
+                            "uint16", ...
+                            "uint32", ...
+                            "uint64", ...
+                            "int8", ...
+                            "int16", ...
+                            "int32", ...
+                            "int64", ...
+                            "single", ...
+                            "double"};
+        end
+    end
+
+    methods (Test)
+        function TestNumericTypes(testCase, NumericTypes)
+            import arrow.array.internal.list.createValidator
+            data = cast(1, NumericTypes);
+            validator = createValidator(data);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.ClassTypeValidator");
+            testCase.verifyEqual(validator.ClassName, NumericTypes);
+        end
+
+        function TestLogical(testCase)
+            import arrow.array.internal.list.createValidator
+            data = true;
+            validator = createValidator(data);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.ClassTypeValidator");
+            testCase.verifyEqual(validator.ClassName, "logical");
+        end
+
+        function TestDuration(testCase)
+            import arrow.array.internal.list.createValidator
+            data = seconds(1);
+            validator = createValidator(data);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.ClassTypeValidator");
+            testCase.verifyEqual(validator.ClassName, "duration");
+        end
+
+        function TestString(testCase)
+            import arrow.array.internal.list.createValidator
+            data = "Hello World";
+            validator = createValidator(data);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.ClassTypeValidator");
+            testCase.verifyEqual(validator.ClassName, "string");
+        end
+
+        function TestCell(testCase)
+            import arrow.array.internal.list.createValidator
+            data = {"Hello World"};
+            validator = createValidator(data);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.ClassTypeValidator");
+            testCase.verifyEqual(validator.ClassName, "cell");
+        end
+
+        function TestDatetime(testCase)
+            import arrow.array.internal.list.createValidator
+            data = datetime(2023, 10, 31);
+            validator = createValidator(data);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.DatetimeValidator");
+            testCase.verifyEqual(validator.ClassName, "datetime");
+            testCase.verifyEqual(validator.Zoned, false);
+        end
+
+        function TestTable(testCase)
+            import arrow.array.internal.list.createValidator
+            data = table(1, "A", VariableNames=["Number", "Letter"]);
+            validator = createValidator(data);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.TableValidator");
+            testCase.verifyEqual(validator.VariableNames, ["Number", "Letter"]);
+            testCase.verifyEqual(numel(validator.VariableValidators), 2);
+            testCase.verifyInstanceOf(validator.VariableValidators(1), "arrow.array.internal.list.ClassTypeValidator");
+            testCase.verifyEqual(validator.VariableValidators(1).ClassName, "double");
+            testCase.verifyInstanceOf(validator.VariableValidators(2), "arrow.array.internal.list.ClassTypeValidator");
+            testCase.verifyEqual(validator.VariableValidators(2).ClassName, "string");
+
+        end
+    
+        function UnsupportedDataTypeError(testCase)
+            import arrow.array.internal.list.createValidator
+            data = calyears(1);
+            fcn = @() createValidator(data);
+            testCase.verifyError(fcn, "arrow:array:list:UnsupportedDataType");
+        end
+    end
+end

--- a/matlab/test/arrow/array/list/tCreateValidator.m
+++ b/matlab/test/arrow/array/list/tCreateValidator.m
@@ -38,6 +38,8 @@ classdef tCreateValidator < matlab.unittest.TestCase
 
     methods (Test)
         function TestNumericTypes(testCase, NumericTypes)
+            % Verify createValidator returns a ClassTypeValidator with the
+            % expected ClassName value when given a numeric array as input.
             import arrow.array.internal.list.createValidator
             data = cast(1, NumericTypes);
             validator = createValidator(data);
@@ -46,6 +48,9 @@ classdef tCreateValidator < matlab.unittest.TestCase
         end
 
         function TestLogical(testCase)
+            % Verify createValidator returns a ClassTypeValidator whose
+            % ClassName property is set to "logical" when given a logical
+            % array as input.
             import arrow.array.internal.list.createValidator
             data = true;
             validator = createValidator(data);
@@ -54,6 +59,9 @@ classdef tCreateValidator < matlab.unittest.TestCase
         end
 
         function TestDuration(testCase)
+            % Verify createValidator returns a ClassTypeValidator whose
+            % ClassName property is set to "duration" when given a duration
+            % array as input.
             import arrow.array.internal.list.createValidator
             data = seconds(1);
             validator = createValidator(data);
@@ -62,6 +70,9 @@ classdef tCreateValidator < matlab.unittest.TestCase
         end
 
         function TestString(testCase)
+            % Verify createValidator returns a ClassTypeValidator whose
+            % ClassName property is set to "string" when given a string
+            % array as input.
             import arrow.array.internal.list.createValidator
             data = "Hello World";
             validator = createValidator(data);
@@ -70,6 +81,9 @@ classdef tCreateValidator < matlab.unittest.TestCase
         end
 
         function TestCell(testCase)
+            % Verify createValidator returns a ClassTypeValidator whose
+            % ClassName property is set to "cell" when given a cell
+            % array as input.
             import arrow.array.internal.list.createValidator
             data = {"Hello World"};
             validator = createValidator(data);
@@ -78,6 +92,8 @@ classdef tCreateValidator < matlab.unittest.TestCase
         end
 
         function TestDatetime(testCase)
+            % Verify createValidator returns a DatetimeValidator when given
+            % a datetime array as input.
             import arrow.array.internal.list.createValidator
             data = datetime(2023, 10, 31);
             validator = createValidator(data);
@@ -87,6 +103,8 @@ classdef tCreateValidator < matlab.unittest.TestCase
         end
 
         function TestTable(testCase)
+            % Verify createValidator returns a TableValidator when given
+            % a table as input.
             import arrow.array.internal.list.createValidator
             data = table(1, "A", VariableNames=["Number", "Letter"]);
             validator = createValidator(data);
@@ -101,6 +119,9 @@ classdef tCreateValidator < matlab.unittest.TestCase
         end
     
         function UnsupportedDataTypeError(testCase)
+            % Verify createValidator throws an exception whose identifier
+            % is "arrow:array:list:UnsupportedDataType" when given an
+            % unsupported datatype as input.
             import arrow.array.internal.list.createValidator
             data = calyears(1);
             fcn = @() createValidator(data);

--- a/matlab/test/arrow/array/list/tTableValidator.m
+++ b/matlab/test/arrow/array/list/tTableValidator.m
@@ -167,10 +167,11 @@ classdef tTableValidator < matlab.unittest.TestCase
 
             % validator expects all table variables that are not tables
             % themselves to be columnar or empty
-             inputTable = table([1 2 3 4], "B", datetime(2023, 10, 31, TimeZone="UTC"), ...
+            nonColumnar = [1 2 3 4];
+            inputTable = table(nonColumnar, "B", datetime(2023, 10, 31, TimeZone="UTC"), ...
                 VariableNames=["Number", "Letter", "Date"]);
-             fcn = @() validator.validateElement(inputTable);
-             testCase.verifyError(fcn, "arrow:array:list:NonTabularVariablesMustBeColumnar");
+            fcn = @() validator.validateElement(inputTable);
+            testCase.verifyError(fcn, "arrow:array:list:NonTabularVariablesMustBeColumnar");
         end
 
         function ValidateElementErrorFromSecondVariable(testCase)
@@ -188,10 +189,11 @@ classdef tTableValidator < matlab.unittest.TestCase
 
             % validator expects all table variables that are not tables
             % themselves to be columnar or empty
-             inputTable = table(2, ["A" "B"], datetime(2023, 10, 31, TimeZone="UTC"), ...
+            nonColumnar = ["A" "B"];
+            inputTable = table(2, nonColumnar, datetime(2023, 10, 31, TimeZone="UTC"), ...
                 VariableNames=["Number", "Letter", "Date"]);
-             fcn = @() validator.validateElement(inputTable);
-             testCase.verifyError(fcn, "arrow:array:list:NonTabularVariablesMustBeColumnar");
+            fcn = @() validator.validateElement(inputTable);
+            testCase.verifyError(fcn, "arrow:array:list:NonTabularVariablesMustBeColumnar");
         end
 
         function ValidateElementErrorFromThirdVariable(testCase)
@@ -215,10 +217,10 @@ classdef tTableValidator < matlab.unittest.TestCase
 
             % validator expects all table variables that are not tables
             % themselves to be columnar or empty
-             inputTable = table(2, "B", datetime(2023, 10, 31, TimeZone="UTC") + days(0:4), ...
-                VariableNames=["Number", "Letter", "Date"]);
-             fcn = @() validator.validateElement(inputTable);
-             testCase.verifyError(fcn, "arrow:array:list:NonTabularVariablesMustBeColumnar");
+            nonColumnar = datetime(2023, 10, 31, TimeZone="UTC") + days(0:4);
+            inputTable = table(2, "B", nonColumnar, VariableNames=["Number", "Letter", "Date"]);
+            fcn = @() validator.validateElement(inputTable);
+            testCase.verifyError(fcn, "arrow:array:list:NonTabularVariablesMustBeColumnar");
         end
 
         function validateElementNoThrow(testCase)
@@ -235,6 +237,7 @@ classdef tTableValidator < matlab.unittest.TestCase
             inputTable = repmat(inputTable, [10 1]);
             validator.validateElement(inputTable);
 
+            % Create a 0x3 table
             inputTable = inputTable(1:0, :);
             validator.validateElement(inputTable);
         end

--- a/matlab/test/arrow/array/list/tTableValidator.m
+++ b/matlab/test/arrow/array/list/tTableValidator.m
@@ -1,0 +1,88 @@
+%TTABLEVALIDATOR Unit tests for arrow.array.internal.list.TableValidator
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tTableValidator < matlab.unittest.TestCase
+    
+    properties (Constant)
+        BaseTable = table(1, "A", datetime(2023, 11, 1, TimeZone="UTC"), ...
+                VariableNames=["Number", "Letter", "Date"]);
+    end
+
+    methods(Test)
+        function Smoke(testCase)
+            import arrow.array.internal.list.TableValidator
+            validator = TableValidator(testCase.BaseTable);
+            testCase.verifyInstanceOf(validator, "arrow.array.internal.list.TableValidator");
+        end
+
+        function TableWithZeroVariablesError(testCase)
+            import arrow.array.internal.list.TableValidator
+            fcn = @() TableValidator(table);
+            testCase.verifyError(fcn, "arrow:array:list:TableWithZeroVariables");
+        end
+
+        function VariableNamesGetter(testCase)
+            import arrow.array.internal.list.TableValidator
+            validator = TableValidator(testCase.BaseTable);
+            testCase.verifyEqual(validator.VariableNames, ["Number", "Letter", "Date"]);
+        end
+
+        function VariableNamesNoSetter(testCase)
+            import arrow.array.internal.list.TableValidator
+            validator = TableValidator(testCase.BaseTable);
+            fcn = @() setfield(validator, "VariableNames", ["A", "B", "C"]);
+            testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
+        end
+
+        function VariableValidatorsGetter(testCase)
+            import arrow.array.internal.list.TableValidator
+            import arrow.array.internal.list.DatetimeValidator
+            import arrow.array.internal.list.ClassTypeValidator
+
+            validator = TableValidator(testCase.BaseTable);
+
+            numberVariableValidator = ClassTypeValidator(1);
+            letterVariableValidator = ClassTypeValidator("A");
+            datetimeVariableValidator = DatetimeValidator(datetime(2023, 10, 31, TimeZone="UTC"));
+            expectedValidators = [numberVariableValidator letterVariableValidator datetimeVariableValidator];
+            testCase.verifyEqual(validator.VariableValidators, expectedValidators);
+        end
+
+        function VariableValidatorsNoSetter(testCase)
+            import arrow.array.internal.list.TableValidator
+            import arrow.array.internal.list.ClassTypeValidator
+
+            validator = TableValidator(testCase.BaseTable);
+            numberVariableValidator = ClassTypeValidator(1);
+            fcn = @() setfield(validator, "VariableValidators", numberVariableValidator);
+            testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
+        end
+
+        function ClassNameGetter(testCase)
+            import arrow.array.internal.list.TableValidator
+            validator = TableValidator(testCase.BaseTable);
+            testCase.verifyEqual(validator.ClassName, "table");
+        end
+
+        function ClassNameNoSetter(testCase)
+            import arrow.array.internal.list.TableValidator
+            validator = TableValidator(testCase.BaseTable);
+            fcn = @() setfield(validator, "ClassName", "string");
+            testCase.verifyError(fcn, "MATLAB:class:SetProhibited");
+        end
+    end
+end

--- a/matlab/test/arrow/array/list/tTableValidator.m
+++ b/matlab/test/arrow/array/list/tTableValidator.m
@@ -250,5 +250,34 @@ classdef tTableValidator < matlab.unittest.TestCase
             inputTable = table([1; 2], seconds([3;4]), table(["C"; "D"], [false; false]));
             validator.validateElement(inputTable);
         end
+
+        function GetElementLength(testCase)
+            % Verify GetElementLength returns the the number of rows as the
+            % length of the element.
+            import arrow.array.internal.list.TableValidator
+            
+            validator = TableValidator(testCase.BaseTable);
+            
+            length = validator.getElementLength(testCase.BaseTable);
+            testCase.verifyEqual(length, 1);
+
+            length = validator.getElementLength(repmat(testCase.BaseTable, [12 1]));
+            testCase.verifyEqual(length, 12);
+
+            length = validator.getElementLength(testCase.BaseTable(1:0, :));
+            testCase.verifyEqual(length, 0);
+        end
+
+        function ReshapeCellElements(testCase)
+            % Verify reshapeCellElements is a no-op. It should return the
+            % original cell array unchanged.
+            import arrow.array.internal.list.TableValidator
+
+            validator = TableValidator(testCase.BaseTable);
+            
+            COriginal = {testCase.BaseTable, repmat(testCase.BaseTable, [10 1]), testCase.BaseTable(1:0, :)};
+            CActual = validator.reshapeCellElements(COriginal);
+            testCase.verifyEqual(COriginal, CActual);
+        end
     end
 end


### PR DESCRIPTION
### Rationale for this change

This is a followup to #38533.

Adding this `TableValidator` class is a step towards implementing the `arrow.array.ListArray.fromMATLAB` method for creating `ListArray`s whose `ValueType` is a `StructArray`.


This validator will ensure all `table`s in a `cell` array have the same schema when attempting to make a `ListArray` of `Struct`s. This is a requirement to ensure the `table`s in the `cell` array are vertcat'ble. For example, two `table`s with different `VariableNames` cannot be concatenated together:

```matlab
>> t1 = table(1, 2, VariableNames=["A", "B"]);
>> t2 = table(3, 4, VariableNames=["C", "D"]);
>> vertcat(t1, t2)
Error using tabular/vertcat
All tables being vertically concatenated must have the same variable names.
```

### What changes are included in this PR?

Modified `arrow.array.internal.list.Validator` to inherit from `matlab.mixin.Heterogeneous`. Doing so enables creating an array whose elements are different subclasses of `arrow.array.internal.list.Validator`.

Added a new MATLAB class `arrow.array.internal.list.TableValidator`, which inherits from `arrow.array.internal.list.Validator`. This class has two properties: `VariableNames` and `VariableValidators`. 

`VariableNames` is a `string` array containing the expected variable names of all `table`s.

`VariableValidators` is an array of `arrow.array.internal.list.Validator`, in which each element represents one variable in a `table`. This array is used to validate `table` variables have the expected type and configuration. 

`TableValidator`'s `validateElement` method uses both its `VariableNames` and `VariableValidator` properties to validate the input argument provided is a `table` with the expected schema. If not, it throws an error.

Lastly, I  added a gateway function called `arrow.array.internal.list.createValidator`, which creates the appropriate `Validator` subclass based on the input. If no such `Validator` exists, an error is thrown.

### Are these changes tested?

Yes. Added two new test classes: `tTableValidator.m` and `tCreateValidator.m`.

### Are there any user-facing changes?

No.

### Future Directions: 

1. #38354
* Closes: #38417