### PR TITLE
GH-38554: [Release][Website] post-03-website.sh doesn't quote current.date

### DIFF
--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -258,7 +258,7 @@ current:
   number: '${version}'
   pinned_number: '${pinned_version}'
   major_number: '${major_version}'
-  date: '${release_date_iso8601}'
+  date: ${release_date_iso8601}
   git-tag: '${git_tag_hash}'
   github-tag-link: 'https://github.com/apache/arrow/releases/tag/${git_tag}'
   release-notes: 'https://arrow.apache.org/release/${version}.html'


### PR DESCRIPTION
### Rationale for this change

We should not quote the value to process the value as a date value.

### What changes are included in this PR?

Remove needless quotation.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* Closes: #38554