### PR TITLE
GH-38556: [C++] Add missing explicit size_t cast for i386

### DIFF
--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -568,7 +568,7 @@ std::shared_ptr<ArrayData> ArraySpan::ToArrayData() const {
 util::span<const std::shared_ptr<Buffer>> ArraySpan::GetVariadicBuffers() const {
   DCHECK(HasVariadicBuffers());
   return {buffers[2].data_as<std::shared_ptr<Buffer>>(),
-          buffers[2].size / sizeof(std::shared_ptr<Buffer>)};
+          static_cast<size_t>(buffers[2].size) / sizeof(std::shared_ptr<Buffer>)};
 }
 
 bool ArraySpan::HasVariadicBuffers() const {


### PR DESCRIPTION
### Rationale for this change

We need explicit cast for `int64_t` to `size_t` conversion for i386 environment.

This was introduced by GH-37792.

### What changes are included in this PR?

Add explicit cast.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38556