### PR TITLE
GH-38576: [Java] Change JDBC driver to optionally preserve cookies and auth tokens when getting streams

### DIFF
--- a/docs/source/java/flight_sql_jdbc_driver.rst
+++ b/docs/source/java/flight_sql_jdbc_driver.rst
@@ -141,6 +141,17 @@ case-sensitive. The supported parameters are:
      - true
      - When TLS is enabled, whether to use the system certificate store
 
+   * - retainCookies
+     - true
+     - Whether to use cookies from the initial connection in subsequent
+       internal connections when retrieving streams from separate endpoints.
+
+   * - retainAuth
+     - true
+     - Whether to use bearer tokens obtained from the initial connection
+       in subsequent internal connections used for retrieving streams
+       from separate endpoints.
+
 Note that URI values must be URI-encoded if they contain characters such
 as !, @, $, etc.
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientIncomingAuthHeaderMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientIncomingAuthHeaderMiddleware.java
@@ -34,7 +34,7 @@ public class ClientIncomingAuthHeaderMiddleware implements FlightClientMiddlewar
    */
   public static class Factory implements FlightClientMiddleware.Factory {
     private final ClientHeaderHandler headerHandler;
-    private CredentialCallOption credentialCallOption;
+    private CredentialCallOption credentialCallOption = null;
 
     /**
      * Construct a factory with the given header handler.

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
@@ -109,6 +109,8 @@ public final class ArrowFlightConnection extends AvaticaConnection {
           .withDisableCertificateVerification(config.getDisableCertificateVerification())
           .withToken(config.getToken())
           .withCallOptions(config.toCallOption())
+          .withRetainCookies(config.retainCookies())
+          .withRetainAuth(config.retainAuth())
           .build();
     } catch (final SQLException e) {
       try {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
@@ -144,6 +144,22 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
   }
 
   /**
+   * Indicates if sub-connections created for stream retrieval
+   * should reuse cookies from the main connection.
+   */
+  public boolean retainCookies() {
+    return ArrowFlightConnectionProperty.RETAIN_COOKIES.getBoolean(properties);
+  }
+
+  /**
+   * Indicates if sub-connections created for stream retrieval
+   * should reuse bearer tokens created from the main connection.
+   */
+  public boolean retainAuth() {
+    return ArrowFlightConnectionProperty.RETAIN_AUTH.getBoolean(properties);
+  }
+
+  /**
    * Gets the {@link CallOption}s from this {@link ConnectionConfig}.
    *
    * @return the call options.
@@ -191,7 +207,9 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
     CLIENT_CERTIFICATE("clientCertificate", null, Type.STRING, false),
     CLIENT_KEY("clientKey", null, Type.STRING, false),
     THREAD_POOL_SIZE("threadPoolSize", 1, Type.NUMBER, false),
-    TOKEN("token", null, Type.STRING, false);
+    TOKEN("token", null, Type.STRING, false),
+    RETAIN_COOKIES("retainCookies", true, Type.BOOLEAN, false),
+    RETAIN_AUTH("retainAuth", true, Type.BOOLEAN, false);
 
     private final String camelName;
     private final Object defaultValue;

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionMutualTlsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionMutualTlsTest.java
@@ -140,17 +140,21 @@ public class ConnectionMutualTlsTest {
     final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
             userTest, passTest);
 
-    assertThrows(SQLException.class, () -> new ArrowFlightSqlClientHandler.Builder()
-            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-            .withUsername(credentials.getUserName())
-            .withPassword(credentials.getPassword())
-            .withTlsRootCertificates(tlsRootCertsPath)
-            .withClientCertificate(badClientMTlsCertPath)
-            .withClientKey(clientMTlsKeyPath)
-            .withBufferAllocator(allocator)
-            .withEncryption(true)
-            .build());
+    assertThrows(SQLException.class, () -> {
+      try (ArrowFlightSqlClientHandler handler = new ArrowFlightSqlClientHandler.Builder()
+          .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+          .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+          .withUsername(credentials.getUserName())
+          .withPassword(credentials.getPassword())
+          .withTlsRootCertificates(tlsRootCertsPath)
+          .withClientCertificate(badClientMTlsCertPath)
+          .withClientKey(clientMTlsKeyPath)
+          .withBufferAllocator(allocator)
+          .withEncryption(true)
+          .build()) {
+        Assert.fail();
+      }
+    });
   }
 
   /**
@@ -162,17 +166,21 @@ public class ConnectionMutualTlsTest {
     final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
             userTest, passTest);
 
-    assertThrows(SQLException.class, () -> new ArrowFlightSqlClientHandler.Builder()
-                         .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                         .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-                         .withUsername(credentials.getUserName())
-                         .withPassword(credentials.getPassword())
-                         .withTlsRootCertificates(tlsRootCertsPath)
-                         .withClientCertificate(clientMTlsCertPath)
-                         .withClientKey(badClientMTlsKeyPath)
-                         .withBufferAllocator(allocator)
-                         .withEncryption(true)
-                         .build());
+    assertThrows(SQLException.class, () -> {
+      try (ArrowFlightSqlClientHandler handler = new ArrowFlightSqlClientHandler.Builder()
+          .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+          .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+          .withUsername(credentials.getUserName())
+          .withPassword(credentials.getPassword())
+          .withTlsRootCertificates(tlsRootCertsPath)
+          .withClientCertificate(clientMTlsCertPath)
+          .withClientKey(badClientMTlsKeyPath)
+          .withBufferAllocator(allocator)
+          .withEncryption(true)
+          .build()) {
+        Assert.fail();
+      }
+    });
   }
 
   /**
@@ -222,7 +230,7 @@ public class ConnectionMutualTlsTest {
     final ArrowFlightJdbcDataSource dataSource =
         ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 
@@ -245,7 +253,7 @@ public class ConnectionMutualTlsTest {
 
     final ArrowFlightJdbcDataSource dataSource = ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -20,6 +20,7 @@ package org.apache.arrow.driver.jdbc;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.URISyntaxException;
 import java.sql.Connection;
@@ -100,7 +101,7 @@ public class ConnectionTest {
     try (Connection connection = DriverManager.getConnection(
         "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" +
             FLIGHT_SERVER_TEST_RULE.getPort(), properties)) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 
@@ -122,11 +123,13 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.TOKEN.camelName(), "token");
     properties.put("useEncryption", false);
 
-    SQLException e = assertThrows(SQLException.class, () ->
-            DriverManager.getConnection(
-                    "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" +
-                            FLIGHT_SERVER_TEST_RULE.getPort(),
-                    properties));
+    SQLException e = assertThrows(SQLException.class, () -> {
+      try (Connection conn = DriverManager.getConnection(
+          "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" + FLIGHT_SERVER_TEST_RULE.getPort(),
+          properties)) {
+        Assert.fail();
+      }
+    });
     assertTrue(e.getMessage().contains("UNAUTHENTICATED"));
   }
 
@@ -145,7 +148,9 @@ public class ConnectionTest {
     properties.put("password", passTest);
     final String invalidUrl = "jdbc:arrow-flight-sql://";
 
-    DriverManager.getConnection(invalidUrl, properties);
+    try (Connection conn = DriverManager.getConnection(invalidUrl, properties)) {
+      Assert.fail("Expected SQLException.");
+    }
   }
 
   /**
@@ -192,7 +197,9 @@ public class ConnectionTest {
     final String invalidUrl = "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() +
         ":" + 65537;
 
-    DriverManager.getConnection(invalidUrl, properties);
+    try (Connection conn = DriverManager.getConnection(invalidUrl, properties)) {
+      fail("Expected SQLException");
+    }
   }
 
   /**
@@ -207,6 +214,7 @@ public class ConnectionTest {
              new ArrowFlightSqlClientHandler.Builder()
                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
                  .withBufferAllocator(allocator)
+                 .withEncryption(false)
                  .build()) {
       assertNotNull(client);
     }
@@ -229,7 +237,7 @@ public class ConnectionTest {
         false);
     try (Connection connection = DriverManager
         .getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 
@@ -272,14 +280,14 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=false",
             FLIGHT_SERVER_TEST_RULE.getPort(),
             userTest,
-            passTest));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            passTest))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -302,13 +310,13 @@ public class ConnectionTest {
         passTest);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "false");
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -330,13 +338,13 @@ public class ConnectionTest {
         passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -351,14 +359,14 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=0",
             FLIGHT_SERVER_TEST_RULE.getPort(),
             userTest,
-            passTest));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            passTest))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -381,13 +389,13 @@ public class ConnectionTest {
         passTest);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "0");
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -410,13 +418,13 @@ public class ConnectionTest {
         passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), 0);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -431,15 +439,15 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&threadPoolSize=1&useEncryption=%s",
             FLIGHT_SERVER_TEST_RULE.getPort(),
             userTest,
             passTest,
-            false));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            false))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -463,13 +471,13 @@ public class ConnectionTest {
     properties.setProperty(ArrowFlightConnectionProperty.THREAD_POOL_SIZE.camelName(), "1");
     properties.put("useEncryption", false);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -493,13 +501,13 @@ public class ConnectionTest {
     properties.put(ArrowFlightConnectionProperty.THREAD_POOL_SIZE.camelName(), 1);
     properties.put("useEncryption", false);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -514,15 +522,15 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=%s",
             FLIGHT_SERVER_TEST_RULE.getPort(),
             userTest,
             passTest,
-            false));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            false))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -545,13 +553,13 @@ public class ConnectionTest {
         passTest);
     properties.put("useEncryption", false);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -574,12 +582,12 @@ public class ConnectionTest {
         passTest);
     properties.put("useEncryption", false);
 
-    Connection connection = DriverManager.getConnection(
+    try (Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -161,6 +161,7 @@ public class ConnectionTest {
              new ArrowFlightSqlClientHandler.Builder()
                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
                  .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+                 .withEncryption(false)
                  .withUsername(userTest)
                  .withPassword(passTest)
                  .withBufferAllocator(allocator)

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsRootCertsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsRootCertsTest.java
@@ -118,12 +118,16 @@ public class ConnectionTlsRootCertsTest {
    */
   @Test
   public void testGetEncryptedClientWithNoCertificateOnKeyStore() {
-    assertThrows(SQLException.class, () -> new ArrowFlightSqlClientHandler.Builder()
-            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-            .withTlsRootCertificates(badTlsRootCertsPath)
-            .withBufferAllocator(allocator)
-            .withEncryption(true)
-            .build());
+    assertThrows(SQLException.class, () -> {
+      try (ArrowFlightSqlClientHandler handler = new ArrowFlightSqlClientHandler.Builder()
+          .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+          .withTlsRootCertificates(badTlsRootCertsPath)
+          .withBufferAllocator(allocator)
+          .withEncryption(true)
+          .build()) {
+        Assert.fail();
+      }
+    });
   }
 
   /**
@@ -167,7 +171,7 @@ public class ConnectionTlsRootCertsTest {
     final ArrowFlightJdbcDataSource dataSource =
         ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 
@@ -188,7 +192,7 @@ public class ConnectionTlsRootCertsTest {
 
     final ArrowFlightJdbcDataSource dataSource = ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 
@@ -203,7 +207,7 @@ public class ConnectionTlsRootCertsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
                 "&useEncryption=true&%s=%s",
@@ -211,9 +215,9 @@ public class ConnectionTlsRootCertsTest {
             userTest,
             passTest,
             ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
-            URLEncoder.encode(tlsRootCertsPath, "UTF-8")));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            URLEncoder.encode(tlsRootCertsPath, "UTF-8")))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -235,13 +239,13 @@ public class ConnectionTlsRootCertsTest {
     properties.setProperty(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "true");
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -263,13 +267,13 @@ public class ConnectionTlsRootCertsTest {
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), true);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -284,7 +288,7 @@ public class ConnectionTlsRootCertsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
                 "&useEncryption=1&useSystemTrustStore=0&%s=%s",
@@ -292,9 +296,9 @@ public class ConnectionTlsRootCertsTest {
             userTest,
             passTest,
             ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
-            URLEncoder.encode(tlsRootCertsPath, "UTF-8")));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            URLEncoder.encode(tlsRootCertsPath, "UTF-8")))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -316,11 +320,11 @@ public class ConnectionTlsRootCertsTest {
     properties.setProperty(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "1");
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -342,11 +346,11 @@ public class ConnectionTlsRootCertsTest {
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), 1);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format("jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
@@ -127,6 +127,7 @@ public class ConnectionTlsTest {
              new ArrowFlightSqlClientHandler.Builder()
                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
                  .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+                 .withSystemTrustStore(false)
                  .withUsername(credentials.getUserName())
                  .withPassword(credentials.getPassword())
                  .withTrustStorePath(trustStorePath)
@@ -153,6 +154,7 @@ public class ConnectionTlsTest {
                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
                  .withTrustStorePath(noCertificateKeyStorePath)
                  .withTrustStorePassword(noCertificateKeyStorePassword)
+                 .withSystemTrustStore(false)
                  .withBufferAllocator(allocator)
                  .withEncryption(true)
                  .build()) {
@@ -170,6 +172,7 @@ public class ConnectionTlsTest {
     try (ArrowFlightSqlClientHandler client =
              new ArrowFlightSqlClientHandler.Builder()
                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+                 .withSystemTrustStore(false)
                  .withTrustStorePath(trustStorePath)
                  .withTrustStorePassword(trustStorePass)
                  .withBufferAllocator(allocator)
@@ -192,6 +195,7 @@ public class ConnectionTlsTest {
     try (ArrowFlightSqlClientHandler ignored =
              new ArrowFlightSqlClientHandler.Builder()
                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+                 .withSystemTrustStore(false)
                  .withTrustStorePath(trustStorePath)
                  .withTrustStorePassword(keyStoreBadPassword)
                  .withBufferAllocator(allocator)

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
@@ -229,7 +229,7 @@ public class ConnectionTlsTest {
     final ArrowFlightJdbcDataSource dataSource =
         ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 
@@ -280,7 +280,7 @@ public class ConnectionTlsTest {
 
     final ArrowFlightJdbcDataSource dataSource = ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
-      assert connection.isValid(300);
+      Assert.assertTrue(connection.isValid(300));
     }
   }
 
@@ -295,7 +295,7 @@ public class ConnectionTlsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
                 "&useEncryption=true&useSystemTrustStore=false&%s=%s&%s=%s",
@@ -305,9 +305,9 @@ public class ConnectionTlsTest {
             ArrowFlightConnectionProperty.TRUST_STORE.camelName(),
             URLEncoder.encode(trustStorePath, "UTF-8"),
             ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(),
-            URLEncoder.encode(trustStorePass, "UTF-8")));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            URLEncoder.encode(trustStorePass, "UTF-8")))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -331,13 +331,13 @@ public class ConnectionTlsTest {
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "true");
     properties.setProperty(ArrowFlightConnectionProperty.USE_SYSTEM_TRUST_STORE.camelName(), "false");
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -361,13 +361,13 @@ public class ConnectionTlsTest {
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -382,7 +382,7 @@ public class ConnectionTlsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format(
             "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
                 "&useEncryption=1&useSystemTrustStore=0&%s=%s&%s=%s",
@@ -392,9 +392,9 @@ public class ConnectionTlsTest {
             ArrowFlightConnectionProperty.TRUST_STORE.camelName(),
             URLEncoder.encode(trustStorePath, "UTF-8"),
             ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(),
-            URLEncoder.encode(trustStorePass, "UTF-8")));
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+            URLEncoder.encode(trustStorePass, "UTF-8")))) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -418,11 +418,11 @@ public class ConnectionTlsTest {
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "1");
     properties.setProperty(ArrowFlightConnectionProperty.USE_SYSTEM_TRUST_STORE.camelName(), "0");
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 
   /**
@@ -446,11 +446,11 @@ public class ConnectionTlsTest {
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
 
-    final Connection connection = DriverManager.getConnection(
+    try (final Connection connection = DriverManager.getConnection(
         String.format("jdbc:arrow-flight-sql://localhost:%s",
             FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties);
-    Assert.assertTrue(connection.isValid(0));
-    connection.close();
+        properties)) {
+      Assert.assertTrue(connection.isValid(0));
+    }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/FlightServerTestRule.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/FlightServerTestRule.java
@@ -55,6 +55,9 @@ import org.slf4j.LoggerFactory;
  * and interact with it.
  */
 public class FlightServerTestRule implements TestRule, AutoCloseable {
+  public static final String DEFAULT_USER = "flight-test-user";
+  public static final String DEFAULT_PASSWORD = "flight-test-password";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(FlightServerTestRule.class);
 
   private final Properties properties;
@@ -92,7 +95,7 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
   public static FlightServerTestRule createStandardTestRule(final FlightSqlProducer producer) {
     UserPasswordAuthentication authentication =
         new UserPasswordAuthentication.Builder()
-            .user("flight-test-user", "flight-test-password")
+            .user(DEFAULT_USER, DEFAULT_PASSWORD)
             .build();
 
     return new Builder()

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
@@ -237,16 +237,17 @@ public class ResultSetTest {
    */
   @Test
   public void testShouldCloseStatementWhenIsCloseOnCompletionWithMaxRowsLimit() throws Exception {
-    Statement statement = connection.createStatement();
-    ResultSet resultSet = statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD);
+    try (Statement statement = connection.createStatement();
+         ResultSet resultSet = statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
 
-    final long maxRowsLimit = 3;
-    statement.setLargeMaxRows(maxRowsLimit);
-    statement.closeOnCompletion();
+      final long maxRowsLimit = 3;
+      statement.setLargeMaxRows(maxRowsLimit);
+      statement.closeOnCompletion();
 
-    resultSetNextUntilDone(resultSet);
+      resultSetNextUntilDone(resultSet);
 
-    collector.checkThat(statement.isClosed(), is(true));
+      collector.checkThat(statement.isClosed(), is(true));
+    }
   }
 
   /**

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.driver.jdbc.client;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.arrow.driver.jdbc.FlightServerTestRule;
+import org.apache.arrow.driver.jdbc.utils.CoreMockedSqlProducers;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Test the behavior of ArrowFlightSqlClientHandler.Builder
+ */
+public class ArrowFlightSqlClientHandlerBuilderTest {
+  @ClassRule
+  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE = FlightServerTestRule
+      .createStandardTestRule(CoreMockedSqlProducers.getLegacyProducer());
+
+  private static BufferAllocator allocator;
+
+  @BeforeClass
+  public static void setup() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testRetainCookiesOnAuthOff() throws Exception {
+    // Arrange
+    final ArrowFlightSqlClientHandler.Builder rootBuilder = new ArrowFlightSqlClientHandler.Builder()
+        .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+        .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+        .withBufferAllocator(allocator)
+        .withUsername(FlightServerTestRule.DEFAULT_USER)
+        .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
+        .withEncryption(false)
+        .withRetainCookies(true)
+        .withRetainAuth(false);
+
+    try (ArrowFlightSqlClientHandler rootHandler = rootBuilder.build()) {
+      // Act
+      final ArrowFlightSqlClientHandler.Builder testBuilder = new ArrowFlightSqlClientHandler.Builder(rootBuilder);
+
+      // Assert
+      assertSame(rootBuilder.cookieFactory, testBuilder.cookieFactory);
+      assertNotSame(rootBuilder.authFactory, testBuilder.authFactory);
+    }
+  }
+
+  @Test
+  public void testRetainCookiesOffAuthOff() throws Exception {
+    // Arrange
+    final ArrowFlightSqlClientHandler.Builder rootBuilder = new ArrowFlightSqlClientHandler.Builder()
+        .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+        .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+        .withBufferAllocator(allocator)
+        .withUsername(FlightServerTestRule.DEFAULT_USER)
+        .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
+        .withEncryption(false)
+        .withRetainCookies(false)
+        .withRetainAuth(false);
+
+    try (ArrowFlightSqlClientHandler rootHandler = rootBuilder.build()) {
+      // Act
+      final ArrowFlightSqlClientHandler.Builder testBuilder = new ArrowFlightSqlClientHandler.Builder(rootBuilder);
+
+      // Assert
+      assertNotSame(rootBuilder.cookieFactory, testBuilder.cookieFactory);
+      assertNotSame(rootBuilder.authFactory, testBuilder.authFactory);
+    }
+  }
+
+  @Test
+  public void testRetainCookiesOnAuthOn() throws Exception {
+    // Arrange
+    final ArrowFlightSqlClientHandler.Builder rootBuilder = new ArrowFlightSqlClientHandler.Builder()
+        .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+        .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+        .withBufferAllocator(allocator)
+        .withUsername(FlightServerTestRule.DEFAULT_USER)
+        .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
+        .withEncryption(false)
+        .withRetainCookies(true)
+        .withRetainAuth(true);
+
+    try (ArrowFlightSqlClientHandler rootHandler = rootBuilder.build()) {
+      // Act
+      final ArrowFlightSqlClientHandler.Builder testBuilder = new ArrowFlightSqlClientHandler.Builder(rootBuilder);
+
+      // Assert
+      assertSame(rootBuilder.cookieFactory, testBuilder.cookieFactory);
+      assertSame(rootBuilder.authFactory, testBuilder.authFactory);
+    }
+  }
+
+  @Test
+  public void testDefaults() {
+    final ArrowFlightSqlClientHandler.Builder builder = new ArrowFlightSqlClientHandler.Builder();
+
+    // Validate all non-mandatory fields against defaults in ArrowFlightConnectionProperty.
+    assertNull(builder.username);
+    assertNull(builder.password);
+    assertTrue(builder.useEncryption);
+    assertFalse(builder.disableCertificateVerification);
+    assertNull(builder.trustStorePath);
+    assertNull(builder.trustStorePassword);
+    assertTrue(builder.useSystemTrustStore);
+    assertNull(builder.token);
+    assertTrue(builder.retainAuth);
+    assertTrue(builder.retainCookies);
+    assertNull(builder.tlsRootCertificatesPath);
+    assertNull(builder.clientCertificatePath);
+    assertNull(builder.clientKeyPath);
+  }
+}


### PR DESCRIPTION
### Rationale for this change
This change restores the original behavior of transmitting existing cookies and auth tokens when getting separate
streams returned by getFlightInfo after adding support for multiple endpoints.

These properties are now optional though.

### What changes are included in this PR?
- Change the JDBC driver to add new properties "retainCookies" and "retainAuth"
- These properties allow internally spawned connections for getting streams to use the cookies and bearer tokens from the original connection.
- Add tests for validating defaults from ArrowFlightSqlClient.Builder

### Are these changes tested?
Unit tests have been added.

### Are there any user-facing changes?
Yes. There are now properties and they are documented.
* Closes: #38576