### PR TITLE
GH-38558: [C++] Add support for null sort option per sort key

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -571,6 +571,7 @@ GARROW_AVAILABLE_IN_3_0
 GArrowSortKey *
 garrow_sort_key_new(const gchar *target,
                     GArrowSortOrder order,
+                    GArrowNullPlacement null_placement,
                     GError **error);
 
 GARROW_AVAILABLE_IN_3_0

--- a/c_glib/test/test-rank-options.rb
+++ b/c_glib/test/test-rank-options.rb
@@ -29,27 +29,21 @@ class TestRankOptions < Test::Unit::TestCase
 
   def test_sort_keys
     sort_keys = [
-      Arrow::SortKey.new("column1", :ascending),
-      Arrow::SortKey.new("column2", :descending),
+      Arrow::SortKey.new("column1", :ascending, :at_end),
+      Arrow::SortKey.new("column2", :descending, :at_end),
     ]
     @options.sort_keys = sort_keys
     assert_equal(sort_keys, @options.sort_keys)
   end
 
   def test_add_sort_key
-    @options.add_sort_key(Arrow::SortKey.new("column1", :ascending))
-    @options.add_sort_key(Arrow::SortKey.new("column2", :descending))
+    @options.add_sort_key(Arrow::SortKey.new("column1", :ascending, :at_end))
+    @options.add_sort_key(Arrow::SortKey.new("column2", :descending, :at_start))
     assert_equal([
-                   Arrow::SortKey.new("column1", :ascending),
-                   Arrow::SortKey.new("column2", :descending),
+                   Arrow::SortKey.new("column1", :ascending, :at_end),
+                   Arrow::SortKey.new("column2", :descending, :at_start),
                  ],
                  @options.sort_keys)
-  end
-
-  def test_null_placement
-    assert_equal(Arrow::NullPlacement::AT_END, @options.null_placement)
-    @options.null_placement = :at_start
-    assert_equal(Arrow::NullPlacement::AT_START, @options.null_placement)
   end
 
   def test_tiebreaker

--- a/c_glib/test/test-sort-indices.rb
+++ b/c_glib/test/test-sort-indices.rb
@@ -41,8 +41,8 @@ class TestSortIndices < Test::Unit::TestCase
     }
     record_batch = build_record_batch(columns)
     sort_keys = [
-      Arrow::SortKey.new("column1", :ascending),
-      Arrow::SortKey.new("column2", :descending),
+      Arrow::SortKey.new("column1", :ascending, :at_end),
+      Arrow::SortKey.new("column2", :descending, :at_end),
     ]
     options = Arrow::SortOptions.new(sort_keys)
     assert_equal(build_uint64_array([4, 1, 0, 5, 3, 2]),
@@ -61,8 +61,8 @@ class TestSortIndices < Test::Unit::TestCase
     }
     table = build_table(columns)
     options = Arrow::SortOptions.new
-    options.add_sort_key(Arrow::SortKey.new("column1", :ascending))
-    options.add_sort_key(Arrow::SortKey.new("column2", :descending))
+    options.add_sort_key(Arrow::SortKey.new("column1", :ascending, :at_end))
+    options.add_sort_key(Arrow::SortKey.new("column2", :descending, :at_end))
     assert_equal(build_uint64_array([4, 1, 0, 5, 3, 2]),
                  table.sort_indices(options))
   end

--- a/c_glib/test/test-sort-options.rb
+++ b/c_glib/test/test-sort-options.rb
@@ -20,8 +20,8 @@ class TestSortOptions < Test::Unit::TestCase
 
   def test_new
     sort_keys = [
-      Arrow::SortKey.new("column1", :ascending),
-      Arrow::SortKey.new("column2", :descending),
+      Arrow::SortKey.new("column1", :ascending, :at_end),
+      Arrow::SortKey.new("column2", :descending, :at_end),
     ]
     options = Arrow::SortOptions.new(sort_keys)
     assert_equal(sort_keys, options.sort_keys)
@@ -29,20 +29,20 @@ class TestSortOptions < Test::Unit::TestCase
 
   def test_add_sort_key
     options = Arrow::SortOptions.new
-    options.add_sort_key(Arrow::SortKey.new("column1", :ascending))
-    options.add_sort_key(Arrow::SortKey.new("column2", :descending))
+    options.add_sort_key(Arrow::SortKey.new("column1", :ascending, :at_end))
+    options.add_sort_key(Arrow::SortKey.new("column2", :descending, :at_end))
     assert_equal([
-                   Arrow::SortKey.new("column1", :ascending),
-                   Arrow::SortKey.new("column2", :descending),
+                   Arrow::SortKey.new("column1", :ascending, :at_end),
+                   Arrow::SortKey.new("column2", :descending, :at_end),
                  ],
                  options.sort_keys)
   end
 
   def test_set_sort_keys
-    options = Arrow::SortOptions.new([Arrow::SortKey.new("column3", :ascending)])
+    options = Arrow::SortOptions.new([Arrow::SortKey.new("column3", :ascending, :at_end)])
     sort_keys = [
-      Arrow::SortKey.new("column1", :ascending),
-      Arrow::SortKey.new("column2", :descending),
+      Arrow::SortKey.new("column1", :ascending, :at_end),
+      Arrow::SortKey.new("column2", :descending, :at_end),
     ]
     options.sort_keys = sort_keys
     assert_equal(sort_keys, options.sort_keys)
@@ -50,8 +50,8 @@ class TestSortOptions < Test::Unit::TestCase
 
   def test_equal
     sort_keys = [
-      Arrow::SortKey.new("column1", :ascending),
-      Arrow::SortKey.new("column2", :descending),
+      Arrow::SortKey.new("column1", :ascending, :at_start),
+      Arrow::SortKey.new("column2", :descending, :at_end),
     ]
     assert_equal(Arrow::SortOptions.new(sort_keys),
                  Arrow::SortOptions.new(sort_keys))

--- a/cpp/src/arrow/acero/order_by_node.cc
+++ b/cpp/src/arrow/acero/order_by_node.cc
@@ -115,7 +115,7 @@ class OrderByNode : public ExecNode, public TracedNode {
     ARROW_ASSIGN_OR_RAISE(
         auto table,
         Table::FromRecordBatches(output_schema_, std::move(accumulation_queue_)));
-    SortOptions sort_options(ordering_.sort_keys(), ordering_.null_placement());
+    SortOptions sort_options(ordering_.sort_keys());
     ExecContext* ctx = plan_->query_context()->exec_context();
     ARROW_ASSIGN_OR_RAISE(auto indices, SortIndices(table, sort_options, ctx));
     ARROW_ASSIGN_OR_RAISE(Datum sorted,

--- a/cpp/src/arrow/acero/order_by_node_test.cc
+++ b/cpp/src/arrow/acero/order_by_node_test.cc
@@ -77,10 +77,10 @@ void CheckOrderByInvalid(OrderByNodeOptions options, const std::string& message)
 }
 
 TEST(OrderByNode, Basic) {
-  CheckOrderBy(OrderByNodeOptions({{SortKey("up")}}));
-  CheckOrderBy(OrderByNodeOptions({{SortKey("down", SortOrder::Descending)}}));
-  CheckOrderBy(
-      OrderByNodeOptions({{SortKey("up"), SortKey("down", SortOrder::Descending)}}));
+  CheckOrderBy(OrderByNodeOptions(Ordering{{SortKey("up")}}));
+  CheckOrderBy(OrderByNodeOptions(Ordering({SortKey("down", SortOrder::Descending)})));
+  CheckOrderBy(OrderByNodeOptions(
+      Ordering({SortKey("up"), SortKey("down", SortOrder::Descending)})));
 }
 
 TEST(OrderByNode, Large) {
@@ -95,7 +95,7 @@ TEST(OrderByNode, Large) {
                                      ->Table(ExecPlan::kMaxBatchSize, kSmallNumBatches);
   Declaration plan = Declaration::Sequence({
       {"table_source", TableSourceNodeOptions(input)},
-      {"order_by", OrderByNodeOptions({{SortKey("up", SortOrder::Descending)}})},
+      {"order_by", OrderByNodeOptions(Ordering({SortKey("up", SortOrder::Descending)}))},
       {"jitter", JitterNodeOptions(kSeed, kJitterMod)},
   });
   ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema batches_and_schema,

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -515,7 +515,7 @@ TEST(ExecPlan, ToString) {
   });
   ASSERT_OK_AND_ASSIGN(std::string plan_str, DeclarationToString(declaration));
   EXPECT_EQ(plan_str, R"a(ExecPlan with 6 nodes:
-custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
+custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC AtEnd]}}
   :FilterNode{filter=(sum(multiply(i32, 2)) > 10)}
     :GroupByNode{keys=["bool"], aggregates=[
     	hash_sum(multiply(i32, 2)),

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -105,6 +105,7 @@ class ARROW_EXPORT ArraySortOptions : public FunctionOptions {
 
 class ARROW_EXPORT SortOptions : public FunctionOptions {
  public:
+  /// DEPRECATED(null_placement has been removed, please use SortKey.null_placement)
   explicit SortOptions(std::vector<SortKey> sort_keys = {});
   explicit SortOptions(const Ordering& ordering);
   static constexpr char const kTypeName[] = "SortOptions";
@@ -173,6 +174,7 @@ class ARROW_EXPORT RankOptions : public FunctionOptions {
     Dense
   };
 
+  /// DEPRECATED(null_placement has been removed, please use SortKey.null_placement)
   explicit RankOptions(std::vector<SortKey> sort_keys = {},
                        Tiebreaker tiebreaker = RankOptions::First);
   /// Convenience constructor for array inputs

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -105,8 +105,7 @@ class ARROW_EXPORT ArraySortOptions : public FunctionOptions {
 
 class ARROW_EXPORT SortOptions : public FunctionOptions {
  public:
-  explicit SortOptions(std::vector<SortKey> sort_keys = {},
-                       NullPlacement null_placement = NullPlacement::AtEnd);
+  explicit SortOptions(std::vector<SortKey> sort_keys = {});
   explicit SortOptions(const Ordering& ordering);
   static constexpr char const kTypeName[] = "SortOptions";
   static SortOptions Defaults() { return SortOptions(); }
@@ -115,13 +114,11 @@ class ARROW_EXPORT SortOptions : public FunctionOptions {
   /// Note: Both classes contain the exact same information.  However,
   /// sort_options should only be used in a "function options" context while Ordering
   /// is used more generally.
-  Ordering AsOrdering() && { return Ordering(std::move(sort_keys), null_placement); }
-  Ordering AsOrdering() const& { return Ordering(sort_keys, null_placement); }
+  Ordering AsOrdering() && { return Ordering(std::move(sort_keys)); }
+  Ordering AsOrdering() const& { return Ordering(sort_keys); }
 
   /// Column key(s) to order by and how to order by these sort keys.
   std::vector<SortKey> sort_keys;
-  /// Whether nulls and NaNs are placed at the start or at the end
-  NullPlacement null_placement;
 };
 
 /// \brief SelectK options
@@ -177,21 +174,18 @@ class ARROW_EXPORT RankOptions : public FunctionOptions {
   };
 
   explicit RankOptions(std::vector<SortKey> sort_keys = {},
-                       NullPlacement null_placement = NullPlacement::AtEnd,
                        Tiebreaker tiebreaker = RankOptions::First);
   /// Convenience constructor for array inputs
   explicit RankOptions(SortOrder order,
                        NullPlacement null_placement = NullPlacement::AtEnd,
                        Tiebreaker tiebreaker = RankOptions::First)
-      : RankOptions({SortKey("", order)}, null_placement, tiebreaker) {}
+      : RankOptions({SortKey("", order, null_placement)}, tiebreaker) {}
 
   static constexpr char const kTypeName[] = "RankOptions";
   static RankOptions Defaults() { return RankOptions(); }
 
   /// Column key(s) to order by and how to order by these sort keys.
   std::vector<SortKey> sort_keys;
-  /// Whether nulls and NaNs are placed at the start or at the end
-  NullPlacement null_placement;
   /// Tiebreaker for dealing with equal values in ranks
   Tiebreaker tiebreaker;
 };

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -1400,7 +1400,7 @@ TEST(Ordering, IsSuborderOf) {
   Ordering a{{SortKey{3}, SortKey{1}, SortKey{7}}};
   Ordering b{{SortKey{3}, SortKey{1}}};
   Ordering c{{SortKey{1}, SortKey{7}}};
-  Ordering d{{SortKey{1}, SortKey{7}}, NullPlacement::AtEnd};
+  Ordering d{{SortKey{1}, SortKey{7, NullPlacement::AtStart}}};
   Ordering imp = Ordering::Implicit();
   Ordering unordered = Ordering::Unordered();
 

--- a/cpp/src/arrow/compute/kernels/select_k_test.cc
+++ b/cpp/src/arrow/compute/kernels/select_k_test.cc
@@ -88,24 +88,27 @@ class TestSelectKBase : public ::testing::Test {
 
  protected:
   template <SortOrder order>
-  void AssertSelectKArray(const std::shared_ptr<Array> values, int k) {
+  void AssertSelectKArray(const std::shared_ptr<Array> values, int k,
+                          bool check_indices = false) {
     std::shared_ptr<Array> select_k;
     ASSERT_OK_AND_ASSIGN(select_k, SelectK<order>(Datum(*values), k));
     ASSERT_EQ(select_k->data()->null_count, 0);
     ValidateOutput(*select_k);
-    ValidateSelectK(Datum(*values), *select_k, order);
+    ValidateSelectK(Datum(*values), *select_k, order, check_indices);
   }
 
-  void AssertTopKArray(const std::shared_ptr<Array> values, int n) {
-    AssertSelectKArray<SortOrder::Descending>(values, n);
+  void AssertTopKArray(const std::shared_ptr<Array> values, int n,
+                       bool check_indices = false) {
+    AssertSelectKArray<SortOrder::Descending>(values, n, check_indices);
   }
-  void AssertBottomKArray(const std::shared_ptr<Array> values, int n) {
-    AssertSelectKArray<SortOrder::Ascending>(values, n);
+  void AssertBottomKArray(const std::shared_ptr<Array> values, int n,
+                          bool check_indices = false) {
+    AssertSelectKArray<SortOrder::Ascending>(values, n, check_indices);
   }
 
-  void AssertSelectKJson(const std::string& values, int n) {
-    AssertTopKArray(ArrayFromJSON(type_singleton(), values), n);
-    AssertBottomKArray(ArrayFromJSON(type_singleton(), values), n);
+  void AssertSelectKJson(const std::string& values, int n, bool check_indices = false) {
+    AssertTopKArray(ArrayFromJSON(type_singleton(), values), n, check_indices);
+    AssertBottomKArray(ArrayFromJSON(type_singleton(), values), n, check_indices);
   }
 
   virtual std::shared_ptr<DataType> type_singleton() = 0;
@@ -162,9 +165,11 @@ TYPED_TEST(TestSelectKForReal, Real) {
   this->AssertSelectKJson("[null, 2, NaN, 3, 1]", 1);
   this->AssertSelectKJson("[null, 2, NaN, 3, 1]", 2);
   this->AssertSelectKJson("[null, 2, NaN, 3, 1]", 3);
-  this->AssertSelectKJson("[null, 2, NaN, 3, 1]", 4);
+  // The result will contain nan. By default, the comparison of NaN is not equal, so
+  // indices are used for comparison.
+  this->AssertSelectKJson("[null, 2, NaN, 3, 1]", 4, true);
   this->AssertSelectKJson("[NaN, 2, null, 3, 1]", 3);
-  this->AssertSelectKJson("[NaN, 2, null, 3, 1]", 4);
+  this->AssertSelectKJson("[NaN, 2, null, 3, 1]", 4, true);
   this->AssertSelectKJson("[100, 4, 2, 7, 8, 3, NaN, 3, 1]", 4);
 }
 
@@ -234,6 +239,78 @@ TYPED_TEST(TestSelectKRandom, RandomValues) {
   }
 }
 
+class TestSelectKWithArray : public ::testing::Test {
+ public:
+  void Check(const std::shared_ptr<DataType>& type, const std::string& array_json,
+             const SelectKOptions& options, const std::string& expected_array) {
+    std::shared_ptr<Array> actual;
+    ASSERT_OK(this->DoSelectK(type, array_json, options, &actual));
+    ASSERT_ARRAYS_EQUAL(*ArrayFromJSON(type, expected_array), *actual);
+  }
+
+  void CheckIndices(const std::shared_ptr<DataType>& type, const std::string& array_json,
+                    const SelectKOptions& options, const std::string& expected_json) {
+    auto array = ArrayFromJSON(type, array_json);
+    auto expected = ArrayFromJSON(uint64(), expected_json);
+    auto indices = SelectKUnstable(Datum(*array), options);
+    ASSERT_OK(indices);
+    auto actual = indices.MoveValueUnsafe();
+    ValidateOutput(*actual);
+    AssertArraysEqual(*expected, *actual, /*verbose=*/true);
+  }
+
+  Status DoSelectK(const std::shared_ptr<DataType>& type, const std::string& array_json,
+                   const SelectKOptions& options, std::shared_ptr<Array>* out) {
+    auto array = ArrayFromJSON(type, array_json);
+    ARROW_ASSIGN_OR_RAISE(auto indices, SelectKUnstable(Datum(*array), options));
+
+    ValidateOutput(*indices);
+    ARROW_ASSIGN_OR_RAISE(
+        auto select_k, Take(Datum(array), Datum(indices), TakeOptions::NoBoundsCheck()));
+    *out = select_k.make_array();
+    return Status::OK();
+  }
+};
+
+TEST_F(TestSelectKWithArray, PartialSelectKNull) {
+  auto array_input = R"([null, 30, 20, 10, null])";
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending)};
+  auto options = SelectKOptions(3, sort_keys);
+  auto expected = R"([10, 20, 30])";
+  Check(uint8(), array_input, options, expected);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  expected = R"([null, null, 10])";
+  Check(uint8(), array_input, options, expected);
+}
+
+TEST_F(TestSelectKWithArray, FullSelectKNull) {
+  auto array_input = R"([null, 30, 20, 10, null])";
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending)};
+  auto options = SelectKOptions(10, sort_keys);
+  auto expected = R"([10, 20, 30, null, null])";
+  Check(uint8(), array_input, options, expected);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  expected = R"([null, null, 10, 20, 30])";
+  Check(uint8(), array_input, options, expected);
+}
+
+TEST_F(TestSelectKWithArray, PartialSelectKNullNaN) {
+  auto array_input = R"([null, 30, NaN, 20, 10, null])";
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending)};
+  auto options = SelectKOptions(4, sort_keys);
+  CheckIndices(float64(), array_input, options, "[1, 3, 4, 2]");
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  CheckIndices(float64(), array_input, options, "[0, 5, 2, 1]");
+}
+
+TEST_F(TestSelectKWithArray, FullSelectKNullNaN) {
+  auto array_input = R"([null, 30, NaN, 20, 10, null])";
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending)};
+  auto options = SelectKOptions(10, sort_keys);
+  CheckIndices(float64(), array_input, options, "[1, 3, 4, 2, 0, 5]");
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  CheckIndices(float64(), array_input, options, "[0, 5, 2, 1, 3, 4]");
+}
 // Test basic cases for chunked array
 
 template <typename ArrowType>
@@ -263,6 +340,35 @@ struct TestSelectKWithChunkedArray : public ::testing::Test {
   void AssertBottomK(const std::shared_ptr<ChunkedArray>& chunked_array, int64_t k) {
     AssertSelectK<SortOrder::Ascending>(chunked_array, k);
   }
+
+  void Check(const std::shared_ptr<ChunkedArray>& chunked_array,
+             const SelectKOptions& options,
+             const std::shared_ptr<ChunkedArray>& expected_array) {
+    std::shared_ptr<ChunkedArray> actual;
+    ASSERT_OK(this->DoSelectK(chunked_array, options, &actual));
+    AssertChunkedEqual(*expected_array, *actual);
+  }
+
+  void CheckIndices(const std::shared_ptr<ChunkedArray>& chunked_array,
+                    const SelectKOptions& options, const std::string& expected_json) {
+    auto expected = ArrayFromJSON(uint64(), expected_json);
+    auto indices = SelectKUnstable(Datum(*chunked_array), options);
+    ASSERT_OK(indices);
+    auto actual = indices.MoveValueUnsafe();
+    ValidateOutput(*actual);
+    AssertArraysEqual(*expected, *actual, /*verbose=*/true);
+  }
+
+  Status DoSelectK(const std::shared_ptr<ChunkedArray>& chunked_array,
+                   const SelectKOptions& options, std::shared_ptr<ChunkedArray>* out) {
+    ARROW_ASSIGN_OR_RAISE(auto indices, SelectKUnstable(Datum(*chunked_array), options));
+
+    ValidateOutput(*indices);
+    ARROW_ASSIGN_OR_RAISE(auto select_k, Take(Datum(chunked_array), Datum(indices),
+                                              TakeOptions::NoBoundsCheck()));
+    *out = select_k.chunked_array();
+    return Status::OK();
+  }
 };
 
 TYPED_TEST_SUITE(TestSelectKWithChunkedArray, SelectKableTypes);
@@ -281,6 +387,59 @@ TYPED_TEST(TestSelectKWithChunkedArray, RandomValuesWithSlices) {
       this->AssertBottomK(chunked_array, k);
     }
   }
+}
+
+TYPED_TEST(TestSelectKWithChunkedArray, PartialSelectKNull) {
+  auto chunked_array = ChunkedArrayFromJSON(uint8(), {
+                                                         "[null, 1]",
+                                                         "[3, null, 2]",
+                                                         "[1]",
+                                                     });
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending)};
+  auto options = SelectKOptions(3, sort_keys);
+  auto expected = ChunkedArrayFromJSON(uint8(), {"[1, 1, 2]"});
+  this->Check(chunked_array, options, expected);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  expected = ChunkedArrayFromJSON(uint8(), {"[null, null, 1]"});
+  this->Check(chunked_array, options, expected);
+}
+
+TYPED_TEST(TestSelectKWithChunkedArray, FullSelectKNull) {
+  auto chunked_array = ChunkedArrayFromJSON(uint8(), {
+                                                         "[null, 1]",
+                                                         "[3, null, 2]",
+                                                         "[1]",
+                                                     });
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending)};
+  auto options = SelectKOptions(10, sort_keys);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  auto expected = ChunkedArrayFromJSON(uint8(), {"[null, null, 1, 1, 2, 3]"});
+  this->Check(chunked_array, options, expected);
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  expected = ChunkedArrayFromJSON(uint8(), {"[1, 1, 2, 3, null, null]"});
+  this->Check(chunked_array, options, expected);
+}
+
+TYPED_TEST(TestSelectKWithChunkedArray, PartialSelectKNullNaN) {
+  auto chunked_array = ChunkedArrayFromJSON(
+      float64(), {"[null, 1]", "[3, null, NaN]", "[10, NaN, 2]", "[1]"});
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending)};
+  auto options = SelectKOptions(3, sort_keys);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  this->CheckIndices(chunked_array, options, "[3, 0, 4]");
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  this->CheckIndices(chunked_array, options, "[5, 2, 7]");
+}
+
+TYPED_TEST(TestSelectKWithChunkedArray, FullSelectKNullNaN) {
+  auto chunked_array = ChunkedArrayFromJSON(
+      float64(), {"[null, 1]", "[3, null, NaN]", "[10, NaN, 2]", "[1]"});
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending)};
+  auto options = SelectKOptions(10, sort_keys);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  this->CheckIndices(chunked_array, options, "[3, 0, 6, 4, 5, 2, 7, 8, 1]");
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  this->CheckIndices(chunked_array, options, "[5, 2, 7, 8, 1, 6, 4, 3, 0]");
 }
 
 template <typename ArrayType, SortOrder order>
@@ -361,6 +520,17 @@ class TestSelectKWithRecordBatch : public ::testing::Test {
     std::shared_ptr<RecordBatch> actual;
     ASSERT_OK(this->DoSelectK(schm, batch_json, options, &actual));
     ASSERT_BATCHES_EQUAL(*RecordBatchFromJSON(schm, expected_batch), *actual);
+  }
+
+  void CheckIndices(const std::shared_ptr<Schema>& schm, const std::string& batch_json,
+                    const SelectKOptions& options, const std::string& expected_json) {
+    auto batch = RecordBatchFromJSON(schm, batch_json);
+    auto expected = ArrayFromJSON(uint64(), expected_json);
+    auto indices = SelectKUnstable(Datum(*batch), options);
+    ASSERT_OK(indices);
+    auto actual = indices.MoveValueUnsafe();
+    ValidateOutput(*actual);
+    AssertArraysEqual(*expected, *actual, /*verbose=*/true);
   }
 
   Status DoSelectK(const std::shared_ptr<Schema>& schm, const std::string& batch_json,
@@ -539,6 +709,128 @@ TEST_F(TestSelectKWithRecordBatch, BottomKNull) {
   Check(schema, batch_input, options, expected_batch);
 }
 
+TEST_F(TestSelectKWithRecordBatch, PartialSelectKNull) {
+  auto schema = ::arrow::schema({
+      {field("a", uint8())},
+      {field("b", uint32())},
+  });
+  auto batch_input = R"([
+    {"a": null, "b": 5},
+    {"a": 30,   "b": 3},
+    {"a": null, "b": 4},
+    {"a": null, "b": 6},
+    {"a": 20,   "b": 5},
+    {"a": null, "b": 5},
+    {"a": 10,   "b": 3},
+    {"a": null, "b": null}
+  ])";
+  std::vector<SortKey> sort_keys{
+      SortKey("a", SortOrder::Ascending, NullPlacement::AtStart),
+      SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(3, sort_keys);
+  auto expected_batch = R"([{"a": null,   "b": 6},
+                            {"a": null,   "b": 5},
+                            {"a": null,   "b": 5}
+                           ])";
+  Check(schema, batch_input, options, expected_batch);
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  expected_batch = R"([{"a": null,    "b": null},
+                       {"a": null,    "b": 6},
+                       {"a": null,    "b": 5}
+                      ])";
+  Check(schema, batch_input, options, expected_batch);
+}
+
+TEST_F(TestSelectKWithRecordBatch, FullSelectKNull) {
+  auto schema = ::arrow::schema({
+      {field("a", uint8())},
+      {field("b", uint32())},
+  });
+  auto batch_input = R"([
+    {"a": null, "b": 5},
+    {"a": 30,   "b": 3},
+    {"a": null, "b": 4},
+    {"a": null, "b": 6},
+    {"a": 20,   "b": 5},
+    {"a": null, "b": 5},
+    {"a": 10,   "b": 3},
+    {"a": null, "b": null}
+  ])";
+  std::vector<SortKey> sort_keys{
+      SortKey("a", SortOrder::Ascending, NullPlacement::AtStart),
+      SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(10, sort_keys);
+  auto expected_batch = R"([{"a": null,  "b": 6},
+                            {"a": null,  "b": 5},
+                            {"a": null,  "b": 5},
+                            {"a": null,  "b": 4},
+                            {"a": null,  "b": null},
+                            {"a": 10,    "b": 3},
+                            {"a": 20,    "b": 5},
+                            {"a": 30,    "b": 3}
+                           ])";
+  Check(schema, batch_input, options, expected_batch);
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  expected_batch = R"([{"a": null,  "b": null},
+                        {"a": null,  "b": 6},
+                        {"a": null,  "b": 5},
+                        {"a": null,  "b": 5},
+                        {"a": null,  "b": 4},
+                        {"a": 10,    "b": 3},
+                        {"a": 20,    "b": 5},
+                        {"a": 30,    "b": 3}
+                      ])";
+  Check(schema, batch_input, options, expected_batch);
+}
+
+TEST_F(TestSelectKWithRecordBatch, PartialSelectKNullNaN) {
+  auto schema = ::arrow::schema({
+      {field("a", float32())},
+      {field("b", float64())},
+  });
+  auto batch_input = R"([
+    {"a": null, "b": 5},
+    {"a": 1,    "b": 3},
+    {"a": 3,    "b": null},
+    {"a": null, "b": null},
+    {"a": 6,    "b": null},
+    {"a": 6,    "b": NaN},
+    {"a": NaN,  "b": 5},
+    {"a": 1,    "b": 5}
+  ])";
+  std::vector<SortKey> sort_keys{
+      SortKey("a", SortOrder::Ascending, NullPlacement::AtStart),
+      SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(3, sort_keys);
+  CheckIndices(schema, batch_input, options, "[0, 3, 6]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  CheckIndices(schema, batch_input, options, "[3, 0, 6]");
+}
+
+TEST_F(TestSelectKWithRecordBatch, FullSelectKNullNaN) {
+  auto schema = ::arrow::schema({
+      {field("a", float32())},
+      {field("b", float64())},
+  });
+  auto batch_input = R"([
+    {"a": null, "b": 5},
+    {"a": 1,    "b": 3},
+    {"a": 3,    "b": null},
+    {"a": null, "b": null},
+    {"a": 6,    "b": null},
+    {"a": 6,    "b": NaN},
+    {"a": NaN,  "b": 5},
+    {"a": 1,    "b": 5}
+  ])";
+  std::vector<SortKey> sort_keys{
+      SortKey("a", SortOrder::Ascending, NullPlacement::AtStart),
+      SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(10, sort_keys);
+  CheckIndices(schema, batch_input, options, "[0, 3, 6, 7, 1, 2, 5, 4]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  CheckIndices(schema, batch_input, options, "[3, 0, 6, 7, 1, 2, 4, 5]");
+}
+
 TEST_F(TestSelectKWithRecordBatch, BottomKOneColumnKey) {
   auto schema = ::arrow::schema({
       {field("country", utf8())},
@@ -603,6 +895,18 @@ struct TestSelectKWithTable : public ::testing::Test {
     std::shared_ptr<Table> actual;
     ASSERT_OK(this->DoSelectK(schm, input_json, options, &actual));
     ASSERT_TABLES_EQUAL(*TableFromJSON(schm, expected), *actual);
+  }
+
+  void CheckIndices(const std::shared_ptr<Schema>& schm,
+                    const std::vector<std::string>& input_json,
+                    const SelectKOptions& options, const std::string& expected_json) {
+    auto table = TableFromJSON(schm, input_json);
+    auto expected = ArrayFromJSON(uint64(), expected_json);
+    auto indices = SelectKUnstable(Datum(*table), options);
+    ASSERT_OK(indices);
+    auto actual = indices.MoveValueUnsafe();
+    ValidateOutput(*actual);
+    AssertArraysEqual(*expected, *actual, /*verbose=*/true);
   }
 
   Status DoSelectK(const std::shared_ptr<Schema>& schm,
@@ -709,6 +1013,144 @@ TEST_F(TestSelectKWithTable, BottomKMultipleColumnKeys) {
                                      {"a": 2,    "b": 5}
                                     ])"};
   Check(schema, input, options, expected);
+}
+
+TEST_F(TestSelectKWithTable, PartialSelectKNull) {
+  auto schema = ::arrow::schema({
+      {field("a", uint8())},
+      {field("b", uint32())},
+  });
+  std::vector<std::string> input = {R"([{"a": null, "b": 5},
+                                        {"a": 1,    "b": 3},
+                                        {"a": 3,    "b": null}
+                                      ])",
+                                    R"([{"a": null, "b": null},
+                                          {"a": 2,    "b": 5},
+                                          {"a": 1,    "b": 5},
+                                          {"a": 3,    "b": 5}
+                                        ])"};
+
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(3, sort_keys);
+  std::vector<std::string> expected = {R"([{"a": 1,    "b": 5},
+                                           {"a": 1,    "b": 3},
+                                           {"a": 2,    "b": 5}
+                                          ])"};
+  Check(schema, input, options, expected);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  expected = {R"([{"a": null, "b": 5},
+                  {"a": null, "b": null},
+                  {"a": 1,    "b": 5}
+                 ])"};
+  Check(schema, input, options, expected);
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  expected = {R"([{"a": null, "b": null},
+                  {"a": null, "b": 5},
+                  {"a": 1,    "b": 5}
+                 ])"};
+  Check(schema, input, options, expected);
+}
+
+TEST_F(TestSelectKWithTable, FullSelectKNull) {
+  auto schema = ::arrow::schema({
+      {field("a", uint8())},
+      {field("b", uint32())},
+  });
+  std::vector<std::string> input = {R"([{"a": null, "b": 5},
+                                        {"a": 1,    "b": 3},
+                                        {"a": 3,    "b": null}
+                                      ])",
+                                    R"([{"a": null, "b": null},
+                                          {"a": 2,    "b": 5},
+                                          {"a": 1,    "b": 5},
+                                          {"a": 3,    "b": 5}
+                                        ])"};
+
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(10, sort_keys);
+  std::vector<std::string> expected = {R"([{"a": 1,    "b": 5},
+                                           {"a": 1,    "b": 3},
+                                           {"a": 2,    "b": 5},
+                                           {"a": 3,    "b": 5},
+                                           {"a": 3,    "b": null},
+                                           {"a": null, "b": 5},
+                                           {"a": null, "b": null}
+                                          ])"};
+  Check(schema, input, options, expected);
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  expected = {R"([{"a": null, "b": 5},
+                  {"a": null, "b": null},
+                  {"a": 1,    "b": 5},
+                  {"a": 1,    "b": 3},
+                  {"a": 2,    "b": 5},
+                  {"a": 3,    "b": 5},
+                  {"a": 3,    "b": null}
+                 ])"};
+  Check(schema, input, options, expected);
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  expected = {R"([{"a": null, "b": null},
+                  {"a": null, "b": 5},
+                  {"a": 1,    "b": 5},
+                  {"a": 1,    "b": 3},
+                  {"a": 2,    "b": 5},
+                  {"a": 3,    "b": null},
+                  {"a": 3,    "b": 5}
+                 ])"};
+  Check(schema, input, options, expected);
+}
+
+TEST_F(TestSelectKWithTable, PartialSelectKNullNaN) {
+  auto schema = ::arrow::schema({
+      {field("a", float32())},
+      {field("b", float64())},
+  });
+  std::vector<std::string> input = {R"([{"a": null, "b": 5},
+                                        {"a": 1,    "b": 3},
+                                        {"a": 3,    "b": null}
+                                      ])",
+                                    R"([{"a": null, "b": null},
+                                        {"a": 6,    "b": null},
+                                        {"a": 6,    "b": NaN},
+                                        {"a": NaN,  "b": 5},
+                                        {"a": 1,    "b": 5}
+                                      ])"};
+
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(3, sort_keys);
+  CheckIndices(schema, input, options, "[7, 1, 2]");
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  CheckIndices(schema, input, options, "[0, 3, 6]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  CheckIndices(schema, input, options, "[3, 0, 6]");
+}
+
+TEST_F(TestSelectKWithTable, FullSelectKNullNaN) {
+  auto schema = ::arrow::schema({
+      {field("a", float32())},
+      {field("b", float64())},
+  });
+  std::vector<std::string> input = {R"([{"a": null, "b": 5},
+                                        {"a": 1,    "b": 3},
+                                        {"a": 3,    "b": null}
+                                      ])",
+                                    R"([{"a": null, "b": null},
+                                        {"a": 6,    "b": null},
+                                        {"a": 6,    "b": NaN},
+                                        {"a": NaN,  "b": 5},
+                                        {"a": 1,    "b": 5}
+                                      ])"};
+
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
+  auto options = SelectKOptions(10, sort_keys);
+  CheckIndices(schema, input, options, "[7, 1, 2, 5, 4, 6, 0, 3]");
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  CheckIndices(schema, input, options, "[0, 3, 6, 7, 1, 2, 5, 4]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
+  CheckIndices(schema, input, options, "[3, 0, 6, 7, 1, 2, 4, 5]");
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -293,8 +293,10 @@ class RankMetaFunction : public MetaFunction {
   static Result<Datum> Rank(const T& input, const RankOptions& options,
                             ExecContext* ctx) {
     SortOrder order = SortOrder::Ascending;
+    NullPlacement null_placement = NullPlacement::AtEnd;
     if (!options.sort_keys.empty()) {
       order = options.sort_keys[0].order;
+      null_placement = options.sort_keys[0].null_placement;
     }
 
     int64_t length = input.length();
@@ -305,8 +307,8 @@ class RankMetaFunction : public MetaFunction {
     std::iota(indices_begin, indices_end, 0);
 
     Datum output;
-    Ranker<T> ranker(ctx, indices_begin, indices_end, input, order,
-                     options.null_placement, options.tiebreaker, &output);
+    Ranker<T> ranker(ctx, indices_begin, indices_end, input, order, null_placement,
+                     options.tiebreaker, &output);
     ARROW_RETURN_NOT_OK(ranker.Run());
     return output;
   }

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1205,9 +1205,8 @@ TEST_F(TestRecordBatchSortIndices, NoNull) {
                                        ])");
 
   for (auto null_placement : AllNullPlacements()) {
-    SortOptions options(
-        {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)},
-        null_placement);
+    SortOptions options({SortKey("a", SortOrder::Ascending, null_placement),
+                         SortKey("b", SortOrder::Descending, null_placement)});
 
     AssertSortIndices(batch, options, "[3, 5, 1, 6, 4, 0, 2]");
   }
@@ -1230,9 +1229,11 @@ TEST_F(TestRecordBatchSortIndices, Null) {
   const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[5, 1, 4, 6, 2, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[0, 3, 5, 1, 4, 6, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 0, 5, 1, 4, 2, 6]");
 }
 
@@ -1251,12 +1252,14 @@ TEST_F(TestRecordBatchSortIndices, NaN) {
                                        {"a": NaN,  "b": 5},
                                        {"a": 1,    "b": 5}
                                       ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[4, 6, 5, 3, 7, 1, 0, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[5, 4, 6, 3, 1, 7, 0, 2]");
 }
 
@@ -1275,12 +1278,14 @@ TEST_F(TestRecordBatchSortIndices, NaNAndNull) {
                                        {"a": NaN,  "b": 5},
                                        {"a": 1,    "b": 5}
                                       ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1299,12 +1304,14 @@ TEST_F(TestRecordBatchSortIndices, Boolean) {
                                        {"a": false,   "b": null},
                                        {"a": null,    "b": true}
                                        ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[3, 1, 6, 2, 4, 0, 7, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[7, 5, 3, 1, 6, 2, 4, 0]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[7, 5, 1, 6, 3, 0, 2, 4]");
 }
 
@@ -1322,12 +1329,15 @@ TEST_F(TestRecordBatchSortIndices, MoreTypes) {
                                        {"a": 2, "b": "05",   "c": "aaa"},
                                        {"a": 1, "b": "05",   "c": "bbb"}
                                        ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending),
-                                       SortKey("c", SortOrder::Ascending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending),
+                                 SortKey("c", SortOrder::Ascending)};
 
   for (auto null_placement : AllNullPlacements()) {
-    SortOptions options(sort_keys, null_placement);
+    SortOptions options(sort_keys);
+    for (size_t i = 0; i < sort_keys.size(); i++) {
+      options.sort_keys[i].null_placement = null_placement;
+    }
     AssertSortIndices(batch, options, "[3, 5, 1, 4, 0, 2]");
   }
 }
@@ -1344,12 +1354,14 @@ TEST_F(TestRecordBatchSortIndices, Decimal) {
                                        {"a": "-12.3", "b": null},
                                        {"a": "-12.3", "b": "-45.67"}
                                        ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[4, 3, 0, 2, 1]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[4, 3, 0, 2, 1]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 4, 0, 2, 1]");
 }
 
@@ -1375,37 +1387,31 @@ TEST_F(TestRecordBatchSortIndices, NullType) {
     for (const auto order : AllOrders()) {
       // Uses radix sorter
       AssertSortIndices(batch,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("i", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("i", order, null_placement),
+                        }),
                         "[0, 1, 2, 3]");
       AssertSortIndices(batch,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("b", SortOrder::Ascending),
-                                SortKey("i", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("b", SortOrder::Ascending, null_placement),
+                            SortKey("i", order, null_placement),
+                        }),
                         "[2, 3, 0, 1]");
       // Uses multiple-key sorter
       AssertSortIndices(batch,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("b", SortOrder::Ascending),
-                                SortKey("c", SortOrder::Ascending),
-                                SortKey("d", SortOrder::Ascending),
-                                SortKey("e", SortOrder::Ascending),
-                                SortKey("f", SortOrder::Ascending),
-                                SortKey("g", SortOrder::Ascending),
-                                SortKey("h", SortOrder::Ascending),
-                                SortKey("i", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("b", SortOrder::Ascending, null_placement),
+                            SortKey("c", SortOrder::Ascending, null_placement),
+                            SortKey("d", SortOrder::Ascending, null_placement),
+                            SortKey("e", SortOrder::Ascending, null_placement),
+                            SortKey("f", SortOrder::Ascending, null_placement),
+                            SortKey("g", SortOrder::Ascending, null_placement),
+                            SortKey("h", SortOrder::Ascending, null_placement),
+                            SortKey("i", order),
+                        }),
                         "[2, 3, 0, 1]");
     }
   }
@@ -1428,14 +1434,16 @@ TEST_F(TestRecordBatchSortIndices, DuplicateSortKeys) {
                                        {"a": NaN,  "b": 5},
                                        {"a": 1,    "b": 5}
                                       ])");
-  const std::vector<SortKey> sort_keys{
+  std::vector<SortKey> sort_keys{
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending),
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Ascending),
       SortKey("a", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1447,16 +1455,19 @@ TEST_F(TestTableSortIndices, EmptyTable) {
       {field("a", uint8())},
       {field("b", uint32())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
   auto table = TableFromJSON(schema, {"[]"});
   auto chunked_table = TableFromJSON(schema, {"[]", "[]"});
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[]");
   AssertSortIndices(chunked_table, options, "[]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[]");
+  AssertSortIndices(chunked_table, options, "[]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[]");
   AssertSortIndices(chunked_table, options, "[]");
 }
@@ -1467,7 +1478,7 @@ TEST_F(TestTableSortIndices, EmptySortKeys) {
       {field("b", uint32())},
   });
   const std::vector<SortKey> sort_keys{};
-  const SortOptions options(sort_keys, NullPlacement::AtEnd);
+  const SortOptions options(sort_keys);
 
   auto table = TableFromJSON(schema, {R"([{"a": null, "b": 5}])"});
   EXPECT_RAISES_WITH_MESSAGE_THAT(
@@ -1486,8 +1497,8 @@ TEST_F(TestTableSortIndices, Null) {
       {field("a", uint8())},
       {field("b", uint32())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
   std::shared_ptr<Table> table;
 
   table = TableFromJSON(schema, {R"([{"a": null, "b": 5},
@@ -1498,9 +1509,11 @@ TEST_F(TestTableSortIndices, Null) {
                                      {"a": 1,    "b": 5},
                                      {"a": 3,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[5, 1, 4, 6, 2, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 5, 1, 4, 6, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 5, 1, 4, 2, 6]");
 
   // Same data, several chunks
@@ -1513,9 +1526,12 @@ TEST_F(TestTableSortIndices, Null) {
                                      {"a": 1,    "b": 5},
                                      {"a": 3,    "b": 5}
                                     ])"});
-  options.null_placement = NullPlacement::AtEnd;
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  options.sort_keys[1].null_placement = NullPlacement::AtEnd;
   AssertSortIndices(table, options, "[5, 1, 4, 6, 2, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 5, 1, 4, 6, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 5, 1, 4, 2, 6]");
 }
 
@@ -1524,8 +1540,8 @@ TEST_F(TestTableSortIndices, NaN) {
       {field("a", float32())},
       {field("b", float64())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
   std::shared_ptr<Table> table;
 
   table = TableFromJSON(schema, {R"([{"a": 3,    "b": 5},
@@ -1537,9 +1553,11 @@ TEST_F(TestTableSortIndices, NaN) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[4, 6, 5, 3, 7, 1, 0, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[5, 4, 6, 3, 1, 7, 0, 2]");
 
   // Same data, several chunks
@@ -1553,9 +1571,12 @@ TEST_F(TestTableSortIndices, NaN) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  options.null_placement = NullPlacement::AtEnd;
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  options.sort_keys[1].null_placement = NullPlacement::AtEnd;
   AssertSortIndices(table, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[4, 6, 5, 3, 7, 1, 0, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[5, 4, 6, 3, 1, 7, 0, 2]");
 }
 
@@ -1564,8 +1585,8 @@ TEST_F(TestTableSortIndices, NaNAndNull) {
       {field("a", float32())},
       {field("b", float64())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
   std::shared_ptr<Table> table;
 
   table = TableFromJSON(schema, {R"([{"a": null, "b": 5},
@@ -1577,9 +1598,11 @@ TEST_F(TestTableSortIndices, NaNAndNull) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 
   // Same data, several chunks
@@ -1593,9 +1616,12 @@ TEST_F(TestTableSortIndices, NaNAndNull) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  options.null_placement = NullPlacement::AtEnd;
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  options.sort_keys[1].null_placement = NullPlacement::AtEnd;
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1604,8 +1630,8 @@ TEST_F(TestTableSortIndices, Boolean) {
       {field("a", boolean())},
       {field("b", boolean())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
   auto table = TableFromJSON(schema, {R"([{"a": true,    "b": null},
                                           {"a": false,   "b": null},
@@ -1617,9 +1643,11 @@ TEST_F(TestTableSortIndices, Boolean) {
                                           {"a": false,   "b": null},
                                           {"a": null,    "b": true}
                                          ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[3, 1, 6, 2, 4, 0, 7, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[7, 5, 3, 1, 6, 2, 4, 0]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[7, 5, 1, 6, 3, 0, 2, 4]");
 }
 
@@ -1628,8 +1656,8 @@ TEST_F(TestTableSortIndices, BinaryLike) {
       {field("a", large_utf8())},
       {field("b", fixed_size_binary(3))},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending),
-                                       SortKey("b", SortOrder::Ascending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending),
+                                 SortKey("b", SortOrder::Ascending)};
 
   auto table = TableFromJSON(schema, {R"([{"a": "one", "b": null},
                                           {"a": "two", "b": "aaa"},
@@ -1641,9 +1669,10 @@ TEST_F(TestTableSortIndices, BinaryLike) {
                                           {"a": "three", "b": "bbb"},
                                           {"a": "four", "b": "aaa"}
                                          ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[1, 5, 2, 6, 4, 0, 7, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[1, 5, 2, 6, 0, 4, 7, 3]");
 }
 
@@ -1652,8 +1681,8 @@ TEST_F(TestTableSortIndices, Decimal) {
       {field("a", decimal128(3, 1))},
       {field("b", decimal256(4, 2))},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
   auto table = TableFromJSON(schema, {R"([{"a": "12.3", "b": "12.34"},
                                           {"a": "45.6", "b": "12.34"},
@@ -1662,9 +1691,11 @@ TEST_F(TestTableSortIndices, Decimal) {
                                       R"([{"a": "-12.3", "b": null},
                                           {"a": "-12.3", "b": "-45.67"}
                                           ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[4, 3, 0, 2, 1]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[4, 3, 0, 2, 1]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 4, 0, 2, 1]");
 }
 
@@ -1687,21 +1718,17 @@ TEST_F(TestTableSortIndices, NullType) {
   for (const auto null_placement : AllNullPlacements()) {
     for (const auto order : AllOrders()) {
       AssertSortIndices(table,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("d", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("d", order, null_placement),
+                        }),
                         "[0, 1, 2, 3]");
       AssertSortIndices(table,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("b", SortOrder::Ascending),
-                                SortKey("d", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("b", SortOrder::Ascending, null_placement),
+                            SortKey("d", order, null_placement),
+                        }),
                         "[2, 3, 0, 1]");
     }
   }
@@ -1714,7 +1741,7 @@ TEST_F(TestTableSortIndices, DuplicateSortKeys) {
       {field("a", float32())},
       {field("b", float64())},
   });
-  const std::vector<SortKey> sort_keys{
+  std::vector<SortKey> sort_keys{
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending),
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Ascending),
       SortKey("a", SortOrder::Descending)};
@@ -1730,9 +1757,11 @@ TEST_F(TestTableSortIndices, DuplicateSortKeys) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1752,13 +1781,17 @@ TEST_F(TestTableSortIndices, HeterogenousChunking) {
   SortOptions options(
       {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 
   options = SortOptions(
       {SortKey("b", SortOrder::Ascending), SortKey("a", SortOrder::Descending)});
   AssertSortIndices(table, options, "[1, 7, 6, 0, 5, 2, 4, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[2, 4, 3, 5, 1, 7, 6, 0]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 4, 2, 5, 1, 0, 6, 7]");
 }
 
@@ -1772,8 +1805,8 @@ TYPED_TEST_SUITE(TestTableSortIndicesForTemporal, TemporalArrowTypes);
 
 TYPED_TEST(TestTableSortIndicesForTemporal, NoNull) {
   auto type = this->GetType();
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
   auto table = TableFromJSON(schema({
                                  {field("a", type)},
                                  {field("b", type)},
@@ -1788,7 +1821,10 @@ TYPED_TEST(TestTableSortIndicesForTemporal, NoNull) {
                                   {"a": 1, "b": 2}
                                  ])"});
   for (auto null_placement : AllNullPlacements()) {
-    SortOptions options(sort_keys, null_placement);
+    SortOptions options(sort_keys);
+    for (size_t i = 0; i < sort_keys.size(); i++) {
+      options.sort_keys[i].null_placement = null_placement;
+    }
     AssertSortIndices(table, options, "[0, 6, 1, 4, 7, 3, 2, 5]");
   }
 }
@@ -1861,12 +1897,12 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
         DCHECK(!sort_key.target.IsNested());
 
         if (auto name = sort_key.target.name()) {
-          sort_columns_.emplace_back(table.GetColumnByName(*name).get(), sort_key.order);
+          sort_columns_.emplace_back(table.GetColumnByName(*name).get(), sort_key);
           continue;
         }
 
         auto index = sort_key.target.field_path()->indices()[0];
-        sort_columns_.emplace_back(table.column(index).get(), sort_key.order);
+        sort_columns_.emplace_back(table.column(index).get(), sort_key);
       }
     }
 
@@ -1874,7 +1910,7 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
     // false otherwise.
     bool operator()(uint64_t lhs, uint64_t rhs) {
       for (const auto& pair : sort_columns_) {
-        ColumnComparator comparator(pair.second, options_.null_placement);
+        ColumnComparator comparator(pair.second.order, pair.second.null_placement);
         const auto& chunked_array = *pair.first;
         int64_t lhs_index = 0, rhs_index = 0;
         const Array* lhs_array = FindTargetArray(chunked_array, lhs, &lhs_index);
@@ -1903,7 +1939,7 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
     }
 
     const SortOptions& options_;
-    std::vector<std::pair<const ChunkedArray*, SortOrder>> sort_columns_;
+    std::vector<std::pair<const ChunkedArray*, SortKey>> sort_columns_;
   };
 
  public:
@@ -2064,7 +2100,9 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
     auto table = Table::Make(schema, std::move(columns));
     for (auto null_placement : AllNullPlacements()) {
       ARROW_SCOPED_TRACE("null_placement = ", null_placement);
-      options.null_placement = null_placement;
+      for (auto& sort_key : sort_keys) {
+        sort_key.null_placement = null_placement;
+      }
       ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(*table), options));
       Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
     }
@@ -2083,7 +2121,9 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
 
   for (auto null_placement : AllNullPlacements()) {
     ARROW_SCOPED_TRACE("null_placement = ", null_placement);
-    options.null_placement = null_placement;
+    for (auto& sort_key : sort_keys) {
+      sort_key.null_placement = null_placement;
+    }
     ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(batch), options));
     Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
   }
@@ -2173,18 +2213,19 @@ class TestNestedSortIndices : public ::testing::Test {
     std::vector<SortKey> sort_keys = {SortKey(FieldRef("a", "a"), SortOrder::Ascending),
                                       SortKey(FieldRef("a", "b"), SortOrder::Descending)};
 
-    SortOptions options(sort_keys, NullPlacement::AtEnd);
+    SortOptions options(sort_keys);
     AssertSortIndices(datum, options, "[7, 6, 3, 4, 0, 2, 1, 8, 5]");
-    options.null_placement = NullPlacement::AtStart;
+    options.sort_keys[0].null_placement = NullPlacement::AtStart;
+    options.sort_keys[1].null_placement = NullPlacement::AtStart;
     AssertSortIndices(datum, options, "[5, 2, 1, 8, 3, 7, 6, 0, 4]");
 
     // Implementations may have an optimized path for cases with one sort key.
     // Additionally, this key references a struct containing another struct, which should
     // work recursively
     options.sort_keys = {SortKey(FieldRef("a"), SortOrder::Ascending)};
-    options.null_placement = NullPlacement::AtEnd;
+    options.sort_keys[0].null_placement = NullPlacement::AtEnd;
     AssertSortIndices(datum, options, "[6, 7, 3, 4, 0, 8, 1, 2, 5]");
-    options.null_placement = NullPlacement::AtStart;
+    options.sort_keys[0].null_placement = NullPlacement::AtStart;
     AssertSortIndices(datum, options, "[5, 8, 1, 2, 3, 6, 7, 0, 4]");
   }
 
@@ -2239,8 +2280,8 @@ class TestRank : public ::testing::Test {
   static void AssertRank(const DatumVector& datums, SortOrder order,
                          NullPlacement null_placement, RankOptions::Tiebreaker tiebreaker,
                          const std::shared_ptr<Array>& expected) {
-    const std::vector<SortKey> sort_keys{SortKey("foo", order)};
-    RankOptions options(sort_keys, null_placement, tiebreaker);
+    const std::vector<SortKey> sort_keys{SortKey("foo", order, null_placement)};
+    RankOptions options(sort_keys, tiebreaker);
     ARROW_SCOPED_TRACE("options = ", options.ToString());
     for (const auto& datum : datums) {
       ASSERT_OK_AND_ASSIGN(auto actual, CallFunction("rank", {datum}, &options));

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -65,6 +65,7 @@ class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
 
 class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
  public:
+  /// DEPRECATED(null_placement has been removed, please use SortKey.null_placement)
   explicit Ordering(std::vector<SortKey> sort_keys) : sort_keys_(std::move(sort_keys)) {}
   /// true if data ordered by other is also ordered by this
   ///

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5477,12 +5477,14 @@ TEST(Substrait, MixedSort) {
                                       conversion_options));
   auto& order_by_options =
       checked_cast<const acero::OrderByNodeOptions&>(*plan_info.root.declaration.options);
+
   EXPECT_THAT(
       order_by_options.ordering.sort_keys(),
-      ElementsAre(arrow::compute::SortKey{"A", arrow::compute::SortOrder::Ascending,
-                                          arrow::compute::NullPlacement::AtStart},
-                  arrow::compute::SortKey{"B", arrow::compute::SortOrder::Ascending,
-                                          arrow::compute::NullPlacement::AtEnd}));
+      ElementsAre(
+          arrow::compute::SortKey{FieldPath({0}), arrow::compute::SortOrder::Ascending,
+                                  arrow::compute::NullPlacement::AtStart},
+          arrow::compute::SortKey{FieldPath({1}), arrow::compute::SortOrder::Ascending,
+                                  arrow::compute::NullPlacement::AtEnd}));
 }
 
 TEST(Substrait, PlanWithExtension) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5378,8 +5378,6 @@ TEST(Substrait, SortAndFetch) {
 }
 
 TEST(Substrait, MixedSort) {
-  // Substrait allows two sort keys with differing direction but Acero
-  // does not.  We should detect this and reject it.
   std::string substrait_json = R"({
   "version": {
     "major_number": 9999,
@@ -5474,10 +5472,9 @@ TEST(Substrait, MixedSort) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  ASSERT_THAT(
-      DeserializePlan(*buf, /*registry=*/nullptr, /*ext_set_out=*/nullptr,
-                      conversion_options),
-      Raises(StatusCode::NotImplemented, testing::HasSubstr("mixed null placement")));
+  ASSERT_OK_AND_ASSIGN(
+      auto plan_info, DeserializePlan(*buf, /*registry=*/nullptr, /*ext_set_out=*/nullptr,
+                                      conversion_options));
 }
 
 TEST(Substrait, PlanWithExtension) {

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5453,10 +5453,10 @@ TEST(Substrait, MixedSort) {
   auto test_schema = schema({field("A", int32()), field("B", int32())});
 
   auto input_table = TableFromJSON(test_schema, {R"([
-      [null, null],
+      [null, 10],
       [5, 8],
       [null, null],
-      [null, null],
+      [null, 3],
       [3, 4],
       [9, 6],
       [4, 5]
@@ -5475,6 +5475,18 @@ TEST(Substrait, MixedSort) {
   ASSERT_OK_AND_ASSIGN(
       auto plan_info, DeserializePlan(*buf, /*registry=*/nullptr, /*ext_set_out=*/nullptr,
                                       conversion_options));
+  ASSERT_OK_AND_ASSIGN(auto result_table,
+                       DeclarationToTable(std::move(plan_info.root.declaration)));
+  auto expected_table = TableFromJSON(test_schema, {R"([
+      [null, 3],
+      [null, 10],
+      [null, null],
+      [3, 4],
+      [4, 5],
+      [5, 8],
+      [9, 6]
+  ])"});
+  AssertTablesEqual(*result_table, *expected_table);
 }
 
 TEST(Substrait, PlanWithExtension) {

--- a/python/pyarrow/_acero.pyx
+++ b/python/pyarrow/_acero.pyx
@@ -233,18 +233,19 @@ class AggregateNodeOptions(_AggregateNodeOptions):
 
 cdef class _OrderByNodeOptions(ExecNodeOptions):
 
-    def _set_options(self, sort_keys, null_placement):
+    def _set_options(self, sort_keys):
         cdef:
             vector[CSortKey] c_sort_keys
 
-        for name, order in sort_keys:
+        for name, order, null_placement in sort_keys:
             c_sort_keys.push_back(
-                CSortKey(_ensure_field_ref(name), unwrap_sort_order(order))
+                CSortKey(_ensure_field_ref(name), unwrap_sort_order(
+                    order), unwrap_null_placement(null_placement))
             )
 
         self.wrapped.reset(
             new COrderByNodeOptions(
-                COrdering(c_sort_keys, unwrap_null_placement(null_placement))
+                COrdering(c_sort_keys)
             )
         )
 
@@ -261,19 +262,16 @@ class OrderByNodeOptions(_OrderByNodeOptions):
 
     Parameters
     ----------
-    sort_keys : sequence of (name, order) tuples
+    sort_keys : sequence of (name, order, null_placement) tuples
         Names of field/column keys to sort the input on,
         along with the order each field/column is sorted in.
         Accepted values for `order` are "ascending", "descending".
+        Accepted values for `null_placement` are "at_start", "at_end".
         Each field reference can be a string column name or expression.
-    null_placement : str, default "at_end"
-        Where nulls in input should be sorted, only applying to
-        columns/fields mentioned in `sort_keys`.
-        Accepted values are "at_start", "at_end".
     """
 
-    def __init__(self, sort_keys=(), *, null_placement="at_end"):
-        self._set_options(sort_keys, null_placement)
+    def __init__(self, sort_keys=(), *):
+        self._set_options(sort_keys)
 
 
 cdef class _HashJoinNodeOptions(ExecNodeOptions):

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -802,11 +802,13 @@ cdef class Dataset(_Weakrefable):
 
         Parameters
         ----------
-        sorting : str or list[tuple(name, order)]
+        sorting : str or list[tuple(name, order, null_placement)]
             Name of the column to use to sort (ascending), or
             a list of multiple sorting conditions where
             each entry is a tuple with column name
             and sorting order ("ascending" or "descending")
+            and nulls and NaNs are placed 
+            at the start or at the end ("at_start" or "at_end")
         **kwargs : dict, optional
             Additional sorting options.
             As allowed by :class:`SortOptions`
@@ -817,7 +819,7 @@ cdef class Dataset(_Weakrefable):
             A new dataset sorted according to the sort keys.
         """
         if isinstance(sorting, str):
-            sorting = [(sorting, "ascending")]
+            sorting = [(sorting, "ascending", "at_end")]
 
         res = _pac()._sort_source(
             self, output_type=InMemoryDataset, sort_keys=sorting, **kwargs

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1501,7 +1501,7 @@ cdef class Array(_PandasConvertible):
         """
         return _pc().index(self, value, start, end, memory_pool=memory_pool)
 
-    def sort(self, order="ascending", **kwargs):
+    def sort(self, order="ascending", null_placement="at_end", **kwargs):
         """
         Sort the Array
 
@@ -1510,6 +1510,9 @@ cdef class Array(_PandasConvertible):
         order : str, default "ascending"
             Which order to sort values in.
             Accepted values are "ascending", "descending".
+        null_placement : str, default "at_end"
+            Whether nulls and NaNs are placed at the start or at the end.
+            Accepted values are "at_end", "at_start".
         **kwargs : dict, optional
             Additional sorting options.
             As allowed by :class:`SortOptions`
@@ -1520,7 +1523,7 @@ cdef class Array(_PandasConvertible):
         """
         indices = _pc().sort_indices(
             self,
-            options=_pc().SortOptions(sort_keys=[("", order)], **kwargs)
+            options=_pc().SortOptions(sort_keys=[("", order, null_placement)], **kwargs)
         )
         return self.take(indices)
 
@@ -3241,7 +3244,7 @@ cdef class StructArray(Array):
         result.validate()
         return result
 
-    def sort(self, order="ascending", by=None, **kwargs):
+    def sort(self, order="ascending", null_placement="at_end", by=None, **kwargs):
         """
         Sort the StructArray
 
@@ -3250,6 +3253,9 @@ cdef class StructArray(Array):
         order : str, default "ascending"
             Which order to sort values in.
             Accepted values are "ascending", "descending".
+        null_placement : str, default "at_end"
+            Whether nulls and NaNs are placed at the start or at the end.
+            Accepted values are "at_end", "at_start".
         by : str or None, default None
             If to sort the array by one of its fields
             or by the whole array.
@@ -3267,7 +3273,7 @@ cdef class StructArray(Array):
             tosort = self
         indices = _pc().sort_indices(
             tosort,
-            options=_pc().SortOptions(sort_keys=[("", order)], **kwargs)
+            options=_pc().SortOptions(sort_keys=[("", order, null_placement)], **kwargs)
         )
         return self.take(indices)
 

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -545,7 +545,7 @@ def fill_null(values, fill_value):
     return call_function("coalesce", [values, fill_value])
 
 
-def top_k_unstable(values, k, sort_keys=None, *, memory_pool=None):
+def top_k_unstable(values, k, sort_keys=None, null_placements=None, *, memory_pool=None):
     """
     Select the indices of the top-k ordered elements from array- or table-like
     data.
@@ -561,6 +561,9 @@ def top_k_unstable(values, k, sort_keys=None, *, memory_pool=None):
         The number of `k` elements to keep.
     sort_keys : List-like
         Column key names to order by when input is table-like data.
+    null_placements : A list of "at_start" or "at_end"
+        Whether nulls and NaNs are placed at the start or at the end.
+        Accepted values are "at_end", "at_start".
     memory_pool : MemoryPool, optional
         If not passed, will allocate memory from the default memory pool.
 
@@ -585,14 +588,15 @@ def top_k_unstable(values, k, sort_keys=None, *, memory_pool=None):
     if sort_keys is None:
         sort_keys = []
     if isinstance(values, (pa.Array, pa.ChunkedArray)):
-        sort_keys.append(("dummy", "descending"))
+        sort_keys.append(("dummy", "descending", "at_end"))
     else:
-        sort_keys = map(lambda key_name: (key_name, "descending"), sort_keys)
+        sort_keys = [(sort_key, "descending", null_placement)
+                     for sort_key, null_placement in zip(sort_keys, null_placements)]
     options = SelectKOptions(k, sort_keys)
     return call_function("select_k_unstable", [values], options, memory_pool)
 
 
-def bottom_k_unstable(values, k, sort_keys=None, *, memory_pool=None):
+def bottom_k_unstable(values, k, sort_keys=None, null_placements=None, *, memory_pool=None):
     """
     Select the indices of the bottom-k ordered elements from
     array- or table-like data.
@@ -608,6 +612,9 @@ def bottom_k_unstable(values, k, sort_keys=None, *, memory_pool=None):
         The number of `k` elements to keep.
     sort_keys : List-like
         Column key names to order by when input is table-like data.
+    null_placements : A list of "at_start" or "at_end"
+        Whether nulls and NaNs are placed at the start or at the end.
+        Accepted values are "at_end", "at_start".
     memory_pool : MemoryPool, optional
         If not passed, will allocate memory from the default memory pool.
 
@@ -632,9 +639,11 @@ def bottom_k_unstable(values, k, sort_keys=None, *, memory_pool=None):
     if sort_keys is None:
         sort_keys = []
     if isinstance(values, (pa.Array, pa.ChunkedArray)):
-        sort_keys.append(("dummy", "ascending"))
+        sort_keys.append(("dummy", "ascending", "at_end"))
     else:
-        sort_keys = map(lambda key_name: (key_name, "ascending"), sort_keys)
+        sort_keys = [(sort_key, "ascending", null_placement)
+                     for sort_key, null_placement in zip(sort_keys, null_placements)]
+
     options = SelectKOptions(k, sort_keys)
     return call_function("select_k_unstable", [values], options, memory_pool)
 

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -545,7 +545,8 @@ def fill_null(values, fill_value):
     return call_function("coalesce", [values, fill_value])
 
 
-def top_k_unstable(values, k, sort_keys=None, null_placements=None, *, memory_pool=None):
+def top_k_unstable(
+        values, k, sort_keys=None, null_placements=None, *, memory_pool=None):
     """
     Select the indices of the top-k ordered elements from array- or table-like
     data.
@@ -596,7 +597,8 @@ def top_k_unstable(values, k, sort_keys=None, null_placements=None, *, memory_po
     return call_function("select_k_unstable", [values], options, memory_pool)
 
 
-def bottom_k_unstable(values, k, sort_keys=None, null_placements=None, *, memory_pool=None):
+def bottom_k_unstable(
+        values, k, sort_keys=None, null_placements=None, *, memory_pool=None):
     """
     Select the indices of the bottom-k ordered elements from
     array- or table-like data.

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2429,18 +2429,18 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CNullPlacement null_placement
 
     cdef cppclass CSortKey" arrow::compute::SortKey":
-        CSortKey(CFieldRef target, CSortOrder order)
+        CSortKey(CFieldRef target, CSortOrder order, CNullPlacement null_placement)
         CFieldRef target
         CSortOrder order
+        CNullPlacement null_placement
 
     cdef cppclass COrdering" arrow::compute::Ordering":
-        COrdering(vector[CSortKey] sort_keys, CNullPlacement null_placement)
+        COrdering(vector[CSortKey] sort_keys)
 
     cdef cppclass CSortOptions \
             "arrow::compute::SortOptions"(CFunctionOptions):
-        CSortOptions(vector[CSortKey] sort_keys, CNullPlacement)
+        CSortOptions(vector[CSortKey] sort_keys)
         vector[CSortKey] sort_keys
-        CNullPlacement null_placement
 
     cdef cppclass CSelectKOptions \
             "arrow::compute::SelectKOptions"(CFunctionOptions):
@@ -2513,10 +2513,8 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CRankOptions \
             "arrow::compute::RankOptions"(CFunctionOptions):
-        CRankOptions(vector[CSortKey] sort_keys, CNullPlacement,
-                     CRankOptionsTiebreaker tiebreaker)
+        CRankOptions(vector[CSortKey] sort_keys, CRankOptionsTiebreaker tiebreaker)
         vector[CSortKey] sort_keys
-        CNullPlacement null_placement
         CRankOptionsTiebreaker tiebreaker
 
     cdef enum DatumType" arrow::Datum::type":

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1081,7 +1081,7 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         return _pc().drop_null(self)
 
-    def sort(self, order="ascending", **kwargs):
+    def sort(self, order="ascending", null_placement="at_end", **kwargs):
         """
         Sort the ChunkedArray
 
@@ -1090,6 +1090,9 @@ cdef class ChunkedArray(_PandasConvertible):
         order : str, default "ascending"
             Which order to sort values in.
             Accepted values are "ascending", "descending".
+        null_placement : str, default "at_end"
+            Whether nulls and NaNs are placed at the start or at the end.
+            Accepted values are "at_end", "at_start".
         **kwargs : dict, optional
             Additional sorting options.
             As allowed by :class:`SortOptions`
@@ -1100,7 +1103,7 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         indices = _pc().sort_indices(
             self,
-            options=_pc().SortOptions(sort_keys=[("", order)], **kwargs)
+            options=_pc().SortOptions(sort_keys=[("", order, null_placement)], **kwargs)
         )
         return self.take(indices)
 
@@ -1922,11 +1925,13 @@ cdef class _Tabular(_PandasConvertible):
 
         Parameters
         ----------
-        sorting : str or list[tuple(name, order)]
+        sorting : str or list[tuple(name, order, null_placement)]
             Name of the column to use to sort (ascending), or
             a list of multiple sorting conditions where
             each entry is a tuple with column name
-            and sorting order ("ascending" or "descending")
+            and sorting order ("ascending" or "descending") 
+            and nulls and NaNs are placed 
+            at the start or at the end ("at_start" or "at_end")
         **kwargs : dict, optional
             Additional sorting options.
             As allowed by :class:`SortOptions`
@@ -1958,7 +1963,7 @@ cdef class _Tabular(_PandasConvertible):
         animal: [["Brittle stars","Centipede","Dog","Flamingo","Horse","Parrot"]]
         """
         if isinstance(sorting, str):
-            sorting = [(sorting, "ascending")]
+            sorting = [(sorting, "ascending", "at_end")]
 
         indices = _pc().sort_indices(
             self,

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -247,19 +247,19 @@ def test_order_by():
     table = pa.table({'a': [1, 2, 3, 4], 'b': [1, 3, None, 2]})
     table_source = Declaration("table_source", TableSourceNodeOptions(table))
 
-    ord_opts = OrderByNodeOptions([("b", "ascending")])
+    ord_opts = OrderByNodeOptions([("b", "ascending", "at_end")])
     decl = Declaration.from_sequence([table_source, Declaration("order_by", ord_opts)])
     result = decl.to_table()
     expected = pa.table({"a": [1, 4, 2, 3], "b": [1, 2, 3, None]})
     assert result.equals(expected)
 
-    ord_opts = OrderByNodeOptions([(field("b"), "descending")])
+    ord_opts = OrderByNodeOptions([(field("b"), "descending", "at_end")])
     decl = Declaration.from_sequence([table_source, Declaration("order_by", ord_opts)])
     result = decl.to_table()
     expected = pa.table({"a": [2, 4, 1, 3], "b": [3, 2, 1, None]})
     assert result.equals(expected)
 
-    ord_opts = OrderByNodeOptions([(1, "descending")], null_placement="at_start")
+    ord_opts = OrderByNodeOptions([(1, "descending", "at_start")])
     decl = Declaration.from_sequence([table_source, Declaration("order_by", ord_opts)])
     result = decl.to_table()
     expected = pa.table({"a": [3, 2, 4, 1], "b": [None, 3, 2, 1]})
@@ -274,10 +274,10 @@ def test_order_by():
         _ = decl.to_table()
 
     with pytest.raises(ValueError, match="\"decreasing\" is not a valid sort order"):
-        _ = OrderByNodeOptions([("b", "decreasing")])
+        _ = OrderByNodeOptions([("b", "decreasing", "at_end")])
 
     with pytest.raises(ValueError, match="\"start\" is not a valid null placement"):
-        _ = OrderByNodeOptions([("b", "ascending")], null_placement="start")
+        _ = OrderByNodeOptions([("b", "ascending", "start")])
 
 
 def test_hash_join():

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2558,7 +2558,8 @@ def test_partition_nth_null_placement():
 
 
 def test_select_k_array():
-    def validate_select_k(select_k_indices, arr, order, null_placement="at_end", stable_sort=False):
+    def validate_select_k(select_k_indices, arr, order, null_placement="at_end",
+                          stable_sort=False):
         sorted_indices = pc.sort_indices(
             arr, sort_keys=[("dummy", order, null_placement)])
         head_k_indices = sorted_indices.slice(0, len(select_k_indices))
@@ -2618,9 +2619,11 @@ def test_select_k_table():
         validate_select_k(result, table, sort_keys=[("a", "ascending", "at_end")])
 
         result = pc.select_k_unstable(
-            table, k=k, sort_keys=[(pc.field("a"), "ascending", "at_end"), ("b", "ascending", "at_end")])
+            table, k=k, sort_keys=[(pc.field("a"), "ascending", "at_end"),
+                                   ("b", "ascending", "at_end")])
         validate_select_k(
-            result, table, sort_keys=[("a", "ascending", "at_end"), ("b", "ascending", "at_end")])
+            result, table, sort_keys=[("a", "ascending", "at_end"),
+                                      ("b", "ascending", "at_end")])
 
         result = pc.top_k_unstable(table, k=k, sort_keys=[
                                    "a"], null_placements=["at_end"])
@@ -2629,7 +2632,8 @@ def test_select_k_table():
         result = pc.bottom_k_unstable(
             table, k=k, sort_keys=["a", "b"], null_placements=["at_end", "at_start"])
         validate_select_k(
-            result, table, sort_keys=[("a", "ascending", "at_end"), ("b", "ascending", "at_start")])
+            result, table, sort_keys=[("a", "ascending", "at_end"), ("b", "ascending",
+                                                                     "at_start")])
 
     with pytest.raises(
             ValueError,
@@ -2710,7 +2714,8 @@ def test_sort_indices_table():
     )
     assert result.to_pylist() == [1, 0, 3, 2]
     result = pc.sort_indices(
-        table, sort_keys=[("a", "descending", "at_start"), ("b", "ascending", "at_start")])
+        table, sort_keys=[("a", "descending", "at_start"), ("b", "ascending",
+                                                            "at_start")])
     assert result.to_pylist() == [2, 1, 0, 3]
     # Positional `sort_keys`
     result = pc.sort_indices(

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -167,7 +167,7 @@ def test_option_class_equality():
         pc.QuantileOptions(),
         pc.RandomOptions(),
         pc.RankOptions(sort_keys="ascending",
-                       null_placement="at_start", tiebreaker="max"),
+                       null_placement="at_end", tiebreaker="max"),
         pc.ReplaceSliceOptions(0, 1, "a"),
         pc.ReplaceSubstringOptions("a", "b"),
         pc.RoundOptions(2, "towards_infinity"),
@@ -175,10 +175,10 @@ def test_option_class_equality():
         pc.RoundTemporalOptions(1, "second", week_starts_monday=True),
         pc.RoundToMultipleOptions(100, "towards_infinity"),
         pc.ScalarAggregateOptions(),
-        pc.SelectKOptions(0, sort_keys=[("b", "ascending")]),
+        pc.SelectKOptions(0, sort_keys=[("b", "ascending", "at_end")]),
         pc.SetLookupOptions(pa.array([1])),
         pc.SliceOptions(0, 1, 1),
-        pc.SortOptions([("dummy", "descending")], null_placement="at_start"),
+        pc.SortOptions([("dummy", "descending", "at_end")]),
         pc.SplitOptions(),
         pc.SplitPatternOptions("pattern"),
         pc.StrftimeOptions(),
@@ -2558,8 +2558,9 @@ def test_partition_nth_null_placement():
 
 
 def test_select_k_array():
-    def validate_select_k(select_k_indices, arr, order, stable_sort=False):
-        sorted_indices = pc.sort_indices(arr, sort_keys=[("dummy", order)])
+    def validate_select_k(select_k_indices, arr, order, null_placement="at_end", stable_sort=False):
+        sorted_indices = pc.sort_indices(
+            arr, sort_keys=[("dummy", order, null_placement)])
         head_k_indices = sorted_indices.slice(0, len(select_k_indices))
         if stable_sort:
             assert select_k_indices == head_k_indices
@@ -2572,8 +2573,8 @@ def test_select_k_array():
     for k in [0, 2, 4]:
         for order in ["descending", "ascending"]:
             result = pc.select_k_unstable(
-                arr, k=k, sort_keys=[("dummy", order)])
-            validate_select_k(result, arr, order)
+                arr, k=k, sort_keys=[("dummy", order, "at_end")])
+            validate_select_k(result, arr, order, "at_end")
 
         result = pc.top_k_unstable(arr, k=k)
         validate_select_k(result, arr, "descending")
@@ -2583,19 +2584,20 @@ def test_select_k_array():
 
     result = pc.select_k_unstable(
         arr, options=pc.SelectKOptions(
-            k=2, sort_keys=[("dummy", "descending")])
+            k=2, sort_keys=[("dummy", "descending", "at_end")])
     )
     validate_select_k(result, arr, "descending")
 
     result = pc.select_k_unstable(
-        arr, options=pc.SelectKOptions(k=2, sort_keys=[("dummy", "ascending")])
+        arr, options=pc.SelectKOptions(
+            k=2, sort_keys=[("dummy", "ascending", "at_end")])
     )
     validate_select_k(result, arr, "ascending")
 
     # Position options
     assert pc.select_k_unstable(arr, 2,
-                                sort_keys=[("dummy", "ascending")]) == result
-    assert pc.select_k_unstable(arr, 2, [("dummy", "ascending")]) == result
+                                sort_keys=[("dummy", "ascending", "at_end")]) == result
+    assert pc.select_k_unstable(arr, 2, [("dummy", "ascending", "at_end")]) == result
 
 
 def test_select_k_table():
@@ -2612,20 +2614,22 @@ def test_select_k_table():
     table = pa.table({"a": [1, 2, 0], "b": [1, 0, 1]})
     for k in [0, 2, 4]:
         result = pc.select_k_unstable(
-            table, k=k, sort_keys=[("a", "ascending")])
-        validate_select_k(result, table, sort_keys=[("a", "ascending")])
+            table, k=k, sort_keys=[("a", "ascending", "at_end")])
+        validate_select_k(result, table, sort_keys=[("a", "ascending", "at_end")])
 
         result = pc.select_k_unstable(
-            table, k=k, sort_keys=[(pc.field("a"), "ascending"), ("b", "ascending")])
+            table, k=k, sort_keys=[(pc.field("a"), "ascending", "at_end"), ("b", "ascending", "at_end")])
         validate_select_k(
-            result, table, sort_keys=[("a", "ascending"), ("b", "ascending")])
+            result, table, sort_keys=[("a", "ascending", "at_end"), ("b", "ascending", "at_end")])
 
-        result = pc.top_k_unstable(table, k=k, sort_keys=["a"])
-        validate_select_k(result, table, sort_keys=[("a", "descending")])
+        result = pc.top_k_unstable(table, k=k, sort_keys=[
+                                   "a"], null_placements=["at_end"])
+        validate_select_k(result, table, sort_keys=[("a", "descending", "at_end")])
 
-        result = pc.bottom_k_unstable(table, k=k, sort_keys=["a", "b"])
+        result = pc.bottom_k_unstable(
+            table, k=k, sort_keys=["a", "b"], null_placements=["at_end", "at_start"])
         validate_select_k(
-            result, table, sort_keys=[("a", "ascending"), ("b", "ascending")])
+            result, table, sort_keys=[("a", "ascending", "at_end"), ("b", "ascending", "at_start")])
 
     with pytest.raises(
             ValueError,
@@ -2634,7 +2638,7 @@ def test_select_k_table():
 
     with pytest.raises(ValueError,
                        match="select_k_unstable requires a nonnegative `k`"):
-        pc.select_k_unstable(table, k=-1, sort_keys=[("a", "ascending")])
+        pc.select_k_unstable(table, k=-1, sort_keys=[("a", "ascending", "at_end")])
 
     with pytest.raises(ValueError,
                        match="select_k_unstable requires a "
@@ -2642,11 +2646,11 @@ def test_select_k_table():
         pc.select_k_unstable(table, k=2, sort_keys=[])
 
     with pytest.raises(ValueError, match="not a valid sort order"):
-        pc.select_k_unstable(table, k=k, sort_keys=[("a", "nonscending")])
+        pc.select_k_unstable(table, k=k, sort_keys=[("a", "nonscending", "at_end")])
 
     with pytest.raises(ValueError,
                        match="Invalid sort key column: No match for.*unknown"):
-        pc.select_k_unstable(table, k=k, sort_keys=[("unknown", "ascending")])
+        pc.select_k_unstable(table, k=k, sort_keys=[("unknown", "ascending", "at_end")])
 
 
 def test_array_sort_indices():
@@ -2672,25 +2676,22 @@ def test_sort_indices_array():
     arr = pa.array([1, 2, None, 0])
     result = pc.sort_indices(arr)
     assert result.to_pylist() == [3, 0, 1, 2]
-    result = pc.sort_indices(arr, sort_keys=[("dummy", "ascending")])
+    result = pc.sort_indices(arr, sort_keys=[("dummy", "ascending", "at_end")])
     assert result.to_pylist() == [3, 0, 1, 2]
-    result = pc.sort_indices(arr, sort_keys=[("dummy", "descending")])
+    result = pc.sort_indices(arr, sort_keys=[("dummy", "descending", "at_end")])
     assert result.to_pylist() == [1, 0, 3, 2]
-    result = pc.sort_indices(arr, sort_keys=[("dummy", "descending")],
-                             null_placement="at_start")
+    result = pc.sort_indices(arr, sort_keys=[("dummy", "descending", "at_start")])
     assert result.to_pylist() == [2, 1, 0, 3]
     # Positional `sort_keys`
-    result = pc.sort_indices(arr, [("dummy", "descending")],
-                             null_placement="at_start")
+    result = pc.sort_indices(arr, [("dummy", "descending", "at_start")])
     assert result.to_pylist() == [2, 1, 0, 3]
     # Using SortOptions
     result = pc.sort_indices(
-        arr, options=pc.SortOptions(sort_keys=[("dummy", "descending")])
+        arr, options=pc.SortOptions(sort_keys=[("dummy", "descending", "at_end")])
     )
     assert result.to_pylist() == [1, 0, 3, 2]
     result = pc.sort_indices(
-        arr, options=pc.SortOptions(sort_keys=[("dummy", "descending")],
-                                    null_placement="at_start")
+        arr, options=pc.SortOptions(sort_keys=[("dummy", "descending", "at_start")])
     )
     assert result.to_pylist() == [2, 1, 0, 3]
 
@@ -2698,26 +2699,22 @@ def test_sort_indices_array():
 def test_sort_indices_table():
     table = pa.table({"a": [1, 1, None, 0], "b": [1, 0, 0, 1]})
 
-    result = pc.sort_indices(table, sort_keys=[("a", "ascending")])
+    result = pc.sort_indices(table, sort_keys=[("a", "ascending", "at_end")])
     assert result.to_pylist() == [3, 0, 1, 2]
-    result = pc.sort_indices(table, sort_keys=[(pc.field("a"), "ascending")],
-                             null_placement="at_start")
+    result = pc.sort_indices(
+        table, sort_keys=[(pc.field("a"), "ascending", "at_start")])
     assert result.to_pylist() == [2, 3, 0, 1]
 
     result = pc.sort_indices(
-        table, sort_keys=[("a", "descending"), ("b", "ascending")]
+        table, sort_keys=[("a", "descending", "at_end"), ("b", "ascending", "at_end")]
     )
     assert result.to_pylist() == [1, 0, 3, 2]
     result = pc.sort_indices(
-        table, sort_keys=[("a", "descending"), ("b", "ascending")],
-        null_placement="at_start"
-    )
+        table, sort_keys=[("a", "descending", "at_start"), ("b", "ascending", "at_start")])
     assert result.to_pylist() == [2, 1, 0, 3]
     # Positional `sort_keys`
     result = pc.sort_indices(
-        table, [("a", "descending"), ("b", "ascending")],
-        null_placement="at_start"
-    )
+        table, [("a", "descending", "at_start"), ("b", "ascending", "at_start")])
     assert result.to_pylist() == [2, 1, 0, 3]
 
     with pytest.raises(ValueError, match="Must specify one or more sort keys"):
@@ -2725,10 +2722,10 @@ def test_sort_indices_table():
 
     with pytest.raises(ValueError,
                        match="Invalid sort key column: No match for.*unknown"):
-        pc.sort_indices(table, sort_keys=[("unknown", "ascending")])
+        pc.sort_indices(table, sort_keys=[("unknown", "ascending", "at_end")])
 
     with pytest.raises(ValueError, match="not a valid sort order"):
-        pc.sort_indices(table, sort_keys=[("a", "nonscending")])
+        pc.sort_indices(table, sort_keys=[("a", "nonscending", "at_end")])
 
 
 def test_is_in():
@@ -3277,7 +3274,7 @@ def test_rank_options():
 
     # Ensure sort_keys tuple usage
     result = pc.rank(arr, options=pc.RankOptions(
-        sort_keys=[("b", "ascending")])
+        sort_keys=[("b", "ascending", "at_end")])
     )
     assert result.equals(expected)
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3893,7 +3893,7 @@ def test_legacy_write_to_dataset_drops_null(tempdir):
 def _sort_table(tab, sort_col):
     import pyarrow.compute as pc
     sorted_indices = pc.sort_indices(
-        tab, options=pc.SortOptions([(sort_col, 'ascending')]))
+        tab, options=pc.SortOptions([(sort_col, 'ascending', 'at_end')]))
     return pc.take(tab, sorted_indices)
 
 
@@ -5349,7 +5349,7 @@ def test_dataset_sort_by(tempdir, dstype):
         "values": [1, 2, 3, 4, 5]
     }
 
-    assert dt.sort_by([("values", "descending")]).to_table().to_pydict() == {
+    assert dt.sort_by([("values", "descending", "at_end")]).to_table().to_pydict() == {
         "keys": ["c", "b", "b", "a", "a"],
         "values": [5, 4, 3, 2, 1]
     }
@@ -5367,12 +5367,12 @@ def test_dataset_sort_by(tempdir, dstype):
     ], names=["a", "b"])
     dt = ds.dataset(table)
 
-    sorted_tab = dt.sort_by([("a", "descending")])
+    sorted_tab = dt.sort_by([("a", "descending", "at_end")])
     sorted_tab_dict = sorted_tab.to_table().to_pydict()
     assert sorted_tab_dict["a"] == [35, 7, 7, 5]
     assert sorted_tab_dict["b"] == ["foobar", "car", "bar", "foo"]
 
-    sorted_tab = dt.sort_by([("a", "ascending")])
+    sorted_tab = dt.sort_by([("a", "ascending", "at_end")])
     sorted_tab_dict = sorted_tab.to_table().to_pydict()
     assert sorted_tab_dict["a"] == [5, 7, 7, 35]
     assert sorted_tab_dict["b"] == ["foo", "car", "bar", "foobar"]

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2501,7 +2501,7 @@ def test_table_sort_by():
         "values": [1, 2, 3, 4, 5]
     }
 
-    assert table.sort_by([("values", "descending")]).to_pydict() == {
+    assert table.sort_by([("values", "descending", "at_end")]).to_pydict() == {
         "keys": ["c", "b", "b", "a", "a"],
         "values": [5, 4, 3, 2, 1]
     }
@@ -2511,12 +2511,12 @@ def test_table_sort_by():
         pa.array(["foo", "car", "bar", "foobar"])
     ], names=["a", "b"])
 
-    sorted_tab = tab.sort_by([("a", "descending")])
+    sorted_tab = tab.sort_by([("a", "descending", "at_end")])
     sorted_tab_dict = sorted_tab.to_pydict()
     assert sorted_tab_dict["a"] == [35, 7, 7, 5]
     assert sorted_tab_dict["b"] == ["foobar", "car", "bar", "foo"]
 
-    sorted_tab = tab.sort_by([("a", "ascending")])
+    sorted_tab = tab.sort_by([("a", "ascending", "at_end")])
     sorted_tab_dict = sorted_tab.to_pydict()
     assert sorted_tab_dict["a"] == [5, 7, 7, 35]
     assert sorted_tab_dict["b"] == ["foo", "car", "bar", "foobar"]
@@ -2529,13 +2529,14 @@ def test_record_batch_sort():
         pa.array(["foo", "car", "bar", "foobar"])
     ], names=["a", "b", "c"])
 
-    sorted_rb = rb.sort_by([("a", "descending"), ("b", "descending")])
+    sorted_rb = rb.sort_by([("a", "descending", "at_end"),
+                           ("b", "descending", "at_end")])
     sorted_rb_dict = sorted_rb.to_pydict()
     assert sorted_rb_dict["a"] == [35, 7, 7, 5]
     assert sorted_rb_dict["b"] == [1, 4, 3, 2]
     assert sorted_rb_dict["c"] == ["car", "foo", "bar", "foobar"]
 
-    sorted_rb = rb.sort_by([("a", "ascending"), ("b", "ascending")])
+    sorted_rb = rb.sort_by([("a", "ascending", "at_end"), ("b", "ascending", "at_end")])
     sorted_rb_dict = sorted_rb.to_pydict()
     assert sorted_rb_dict["a"] == [5, 7, 7, 35]
     assert sorted_rb_dict["b"] == [2, 3, 4, 1]

--- a/ruby/red-arrow/lib/arrow/sort-options.rb
+++ b/ruby/red-arrow/lib/arrow/sort-options.rb
@@ -102,8 +102,8 @@ module Arrow
     #     options.sort_keys.collect(&:to_s) # => ["-price"]
     #
     # @since 4.0.0
-    def add_sort_key(target, order=nil)
-      add_sort_key_raw(SortKey.resolve(target, order))
+    def add_sort_key(target, order=nil, null_placement=nil)
+      add_sort_key_raw(SortKey.resolve(target, order, null_placement))
     end
   end
 end

--- a/ruby/red-arrow/test/test-sort-key.rb
+++ b/ruby/red-arrow/test/test-sort-key.rb
@@ -35,37 +35,37 @@ class SortKeyTest < Test::Unit::TestCase
 
   sub_test_case("#initialize") do
     test("String") do
-      assert_equal("+count",
+      assert_equal("+count_at_end",
                    Arrow::SortKey.new("count").to_s)
     end
 
     test("+String") do
-      assert_equal("+count",
+      assert_equal("+count_at_end",
                    Arrow::SortKey.new("+count").to_s)
     end
 
     test("-String") do
-      assert_equal("-count",
+      assert_equal("-count_at_end",
                    Arrow::SortKey.new("-count").to_s)
     end
 
     test("Symbol") do
-      assert_equal("+-count",
+      assert_equal("+-count_at_end",
                    Arrow::SortKey.new(:"-count").to_s)
     end
 
     test("String, Symbol") do
-      assert_equal("--count",
+      assert_equal("--count_at_end",
                    Arrow::SortKey.new("-count", :desc).to_s)
     end
 
     test("String, String") do
-      assert_equal("--count",
+      assert_equal("--count_at_end",
                    Arrow::SortKey.new("-count", "desc").to_s)
     end
 
     test("String, SortOrder") do
-      assert_equal("--count",
+      assert_equal("--count_at_end",
                    Arrow::SortKey.new("-count",
                                       Arrow::SortOrder::DESCENDING).to_s)
     end

--- a/ruby/red-arrow/test/test-sort-options.rb
+++ b/ruby/red-arrow/test/test-sort-options.rb
@@ -25,7 +25,7 @@ class SortOptionsTest < Test::Unit::TestCase
 
     test("-String, Symbol") do
       options = Arrow::SortOptions.new("-count", :age)
-      assert_equal(["-count", "+age"],
+      assert_equal(["-count_at_end", "+age_at_end"],
                    options.sort_keys.collect(&:to_s))
     end
   end
@@ -38,19 +38,19 @@ class SortOptionsTest < Test::Unit::TestCase
     sub_test_case("#add_sort_key") do
       test("-String") do
         @options.add_sort_key("-count")
-        assert_equal(["-count"],
+        assert_equal(["-count_at_end"],
                      @options.sort_keys.collect(&:to_s))
       end
 
       test("-String, Symbol") do
         @options.add_sort_key("-count", :desc)
-        assert_equal(["--count"],
+        assert_equal(["--count_at_end"],
                      @options.sort_keys.collect(&:to_s))
       end
 
       test("SortKey") do
         @options.add_sort_key(Arrow::SortKey.new("-count"))
-        assert_equal(["-count"],
+        assert_equal(["-count_at_end"],
                      @options.sort_keys.collect(&:to_s))
       end
     end


### PR DESCRIPTION
### Rationale for this change

support multi sortkey nulls first.
```
order by i nulls first, j, k nulls first;
```

The current null sorting only supports all sortkeys, not a certain sortkey, so NullPlacement is extended to the SortKey field. Since the underlying framework is very well written, when modifying this function, you only need to pass the null_placement of each SortKey in. That’s it.

### What changes are included in this PR?

1.SortKey structure, NullPlacemnt transfer logic, sorting logic and Ording related, test related
2.Substriait related.
3.c_glib related.
4.SelectK related.
5.RankOptions related.

### Are these changes tested?

yes,  I changed the code inside vector_sort_test.cc and performed additional tests.

### Are there any user-facing changes?
yes, pg database include null sorting of multiple sort keys.
* Closes: #38558