### PR TITLE
GH-36912: [Java] JDBC driver stops consuming roots if it sees an empty root

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
@@ -455,4 +455,17 @@ public class ResultSetTest {
       }
     }
   }
+
+  @Test
+  public void testShouldRunSelectQueryWithEmptyVectorsEmbedded() throws Exception {
+    try (Statement statement = connection.createStatement();
+         ResultSet resultSet = statement.executeQuery(
+             CoreMockedSqlProducers.LEGACY_REGULAR_WITH_EMPTY_SQL_CMD)) {
+      long rowCount = 0;
+      while (resultSet.next()) {
+        ++rowCount;
+      }
+      assertEquals(2, rowCount);
+    }
+  }
 }


### PR DESCRIPTION
### Rationale for this change
The JDBC driver for Flight SQL incorrectly stops iterating on a FlightStream if it encounters an empty root.

### What changes are included in this PR?
The driver now waits until FlightStream#next() returns false to determine if a FlightStream is fully-consumed instead of an empty root.

### Are these changes tested?
Yes, new tests have been written.

### Are there any user-facing changes?
No
* Closes: #36912