### PR TITLE
GH-37069: [C#] Allow for record batches larger than 2 GB

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
+++ b/csharp/src/Apache.Arrow.Flight/Internal/FlightDataStream.cs
@@ -91,7 +91,7 @@ namespace Apache.Arrow.Flight.Internal
             await _clientStreamWriter.WriteAsync(_currentFlightData).ConfigureAwait(false);
         }
 
-        private protected override ValueTask<long> WriteMessageAsync<T>(MessageHeader headerType, Offset<T> headerOffset, int bodyLength, CancellationToken cancellationToken)
+        private protected override ValueTask<long> WriteMessageAsync<T>(MessageHeader headerType, Offset<T> headerOffset, long bodyLength, CancellationToken cancellationToken)
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
                 Builder, CurrentMetadataVersion, headerType, headerOffset.Value,

--- a/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
@@ -250,6 +250,5 @@ namespace Apache.Arrow
             }
 
         }
-
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -78,7 +78,7 @@ namespace Apache.Arrow.Ipc
 
             public IReadOnlyList<Buffer> Buffers => _buffers;
 
-            public int TotalLength { get; private set; }
+            public long TotalLength { get; private set; }
 
             public ArrowRecordBatchFlatBufferBuilder()
             {
@@ -204,7 +204,7 @@ namespace Apache.Arrow.Ipc
 
             private Buffer CreateBuffer(ArrowBuffer buffer)
             {
-                int offset = TotalLength;
+                int offset = checked((int)TotalLength);
 
                 int paddedLength = checked((int)BitUtility.RoundUpToMultipleOf8(buffer.Length));
                 TotalLength += paddedLength;
@@ -823,7 +823,7 @@ namespace Apache.Arrow.Ipc
         /// The number of bytes written to the stream.
         /// </returns>
         private protected long WriteMessage<T>(
-            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength)
+            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, long bodyLength)
             where T : struct
         {
             Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
@@ -853,7 +853,7 @@ namespace Apache.Arrow.Ipc
         /// The number of bytes written to the stream.
         /// </returns>
         private protected virtual async ValueTask<long> WriteMessageAsync<T>(
-            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength,
+            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, long bodyLength,
             CancellationToken cancellationToken)
             where T : struct
         {


### PR DESCRIPTION
### Rationale for this change
Allow for record batches larger than 2 GB.

### What changes are included in this PR?
Make TotalLength a long instead of an int to allow for a larger record batch.

### Are these changes tested?
Not yet, tests are WIP.

Potential issues:
- Even with TotalLength allowed to be larger than 2GB, will underlying buffer(s) support data larger than 2GB?
- How to test this? A test that generates a 2GB+ buffer to exercise this functionality, may be fairly slow.

### Are there any user-facing changes?
No
* Closes: #37069