### PR TITLE
GH-38627: [Java][FlightRPC] Handle null parameter values

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/AvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/AvaticaParameterConverter.java
@@ -33,10 +33,15 @@ public interface AvaticaParameterConverter {
    *
    * @param vector FieldVector that the parameter should be bound to.
    * @param typedValue TypedValue to bind as a parameter.
-   * @param index Vector index that the TypedValue should be bound to.
+   * @param index Vector index (0-indexed) that the TypedValue should be bound to.
    * @return Whether the value was set successfully.
    */
   boolean bindParameter(FieldVector vector, TypedValue typedValue, int index);
 
+  /**
+   * Create an AvaticaParameter from the given Field.
+   *
+   * @param field Arrow Field to generate an AvaticaParameter from.
+   */
   AvaticaParameter createParameter(Field field);
 }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
@@ -41,7 +41,6 @@ public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConv
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {
-    // FIXME: how should we handle TZ? Do we need to convert the value to the TZ on the vector?
     long value = (long) typedValue.toLocal();
     if (vector instanceof TimeStampSecVector) {
       ((TimeStampSecVector) vector).setSafe(index, value);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java
@@ -102,12 +102,18 @@ public class AvaticaParameterBinder {
    */
   private void bind(FieldVector vector, TypedValue typedValue, int index) {
     try {
-      if (!vector.getField().getType().accept(new BinderVisitor(vector, typedValue, index))) {
-        throw new RuntimeException(
+      if (typedValue.value == null) {
+        if (vector.getField().isNullable()) {
+          vector.setNull(index);
+        } else {
+          throw new UnsupportedOperationException("Can't set null on non-nullable parameter");
+        }
+      } else if (!vector.getField().getType().accept(new BinderVisitor(vector, typedValue, index))) {
+        throw new UnsupportedOperationException(
                 String.format("Binding to vector type %s is not yet supported", vector.getClass()));
       }
     } catch (ClassCastException e) {
-      throw new RuntimeException(
+      throw new UnsupportedOperationException(
               String.format("Binding value of type %s is not yet supported for expected Arrow type %s",
                       typedValue.type, vector.getField().getType()));
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

We want to make sure we correctly handle binding `null` values to JDBC parameters.
We also want better exceptions when handling parameter binding.

### What changes are included in this PR?

- Handle adding null values to parameters if it's a nullable vector, else throw `UnsupportedOperationException`
- For unsupported parameter types or casts, throw `UnsupportedOperationException` instead of `RuntimeException`
* Closes: #38627