### PR TITLE
GH-38614: [Java] Add VarBinary and VarCharWriter helper methods to more writers

### DIFF
--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -27,6 +27,9 @@ package org.apache.arrow.vector.complex.impl;
 
 /*
  * This class is generated using freemarker and the ${.template_name} template.
+ * Note that changes to the AbstractFieldWriter template should also get reflected in the
+ * AbstractPromotableFieldWriter, ComplexWriters, UnionFixedSizeListWriter, UnionListWriter
+ * and UnionWriter templates and the PromotableWriter concrete code.
  */
 @SuppressWarnings("unused")
 abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWriter {
@@ -125,19 +128,19 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   </#if>
 
   <#if minor.class?ends_with("VarBinary")>
-  public void writeTo${minor.class}(byte[] value) {
+  public void write${minor.class}(byte[] value) {
     fail("${name}");
   }
 
-  public void writeTo${minor.class}(byte[] value, int offset, int length) {
+  public void write${minor.class}(byte[] value, int offset, int length) {
     fail("${name}");
   }
 
-  public void writeTo${minor.class}(ByteBuffer value) {
+  public void write${minor.class}(ByteBuffer value) {
     fail("${name}");
   }
 
-  public void writeTo${minor.class}(ByteBuffer value, int offset, int length) {
+  public void write${minor.class}(ByteBuffer value, int offset, int length) {
     fail("${name}");
   }
   </#if>

--- a/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -221,6 +221,38 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   }
   </#if>
 
+  <#if minor.class?ends_with("VarBinary")>
+  @Override
+  public void write${minor.class}(byte[] value) {
+    getWriter(MinorType.${name?upper_case}).write${minor.class}(value);
+  }
+
+  @Override
+  public void write${minor.class}(byte[] value, int offset, int length) {
+    getWriter(MinorType.${name?upper_case}).write${minor.class}(value, offset, length);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value) {
+    getWriter(MinorType.${name?upper_case}).write${minor.class}(value);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value, int offset, int length) {
+    getWriter(MinorType.${name?upper_case}).write${minor.class}(value, offset, length);
+  }
+  <#elseif minor.class?ends_with("VarChar")>
+  @Override
+  public void write${minor.class}(Text value) {
+    getWriter(MinorType.${name?upper_case}).write${minor.class}(value);
+  }
+
+  @Override
+  public void write${minor.class}(String value) {
+    getWriter(MinorType.${name?upper_case}).write${minor.class}(value);
+  }
+  </#if>
+
   </#list></#list>
   public void writeNull() {
   }

--- a/java/vector/src/main/codegen/templates/ComplexWriters.java
+++ b/java/vector/src/main/codegen/templates/ComplexWriters.java
@@ -194,22 +194,22 @@ public ${eName}WriterImpl(${name}Vector vector) {
   </#if>
 
   <#if minor.class?ends_with("VarBinary")>
-  public void writeTo${minor.class}(byte[] value) {
+  public void write${minor.class}(byte[] value) {
     vector.setSafe(idx(), value);
     vector.setValueCount(idx() + 1);
   }
 
-  public void writeTo${minor.class}(byte[] value, int offset, int length) {
+  public void write${minor.class}(byte[] value, int offset, int length) {
     vector.setSafe(idx(), value, offset, length);
     vector.setValueCount(idx() + 1);
   }
 
-  public void writeTo${minor.class}(ByteBuffer value) {
+  public void write${minor.class}(ByteBuffer value) {
     vector.setSafe(idx(), value, 0, value.remaining());
     vector.setValueCount(idx() + 1);
   }
 
-  public void writeTo${minor.class}(ByteBuffer value, int offset, int length) {
+  public void write${minor.class}(ByteBuffer value, int offset, int length) {
     vector.setSafe(idx(), value, offset, length);
     vector.setValueCount(idx() + 1);
   }
@@ -259,13 +259,13 @@ public interface ${eName}Writer extends BaseWriter {
 </#if>
 
 <#if minor.class?ends_with("VarBinary")>
-  public void writeTo${minor.class}(byte[] value);
+  public void write${minor.class}(byte[] value);
 
-  public void writeTo${minor.class}(byte[] value, int offset, int length);
+  public void write${minor.class}(byte[] value, int offset, int length);
 
-  public void writeTo${minor.class}(ByteBuffer value);
+  public void write${minor.class}(ByteBuffer value);
 
-  public void writeTo${minor.class}(ByteBuffer value, int offset, int length);
+  public void write${minor.class}(ByteBuffer value, int offset, int length);
 </#if>
 
 <#if minor.class?ends_with("VarChar")>

--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -295,6 +295,62 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
       <#assign name = minor.class?cap_first />
       <#assign fields = minor.fields!type.fields />
       <#assign uncappedName = name?uncap_first/>
+      <#if minor.class?ends_with("VarBinary")>
+  @Override
+  public void write${minor.class}(byte[] value) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
+    }
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  @Override
+  public void write${minor.class}(byte[] value, int offset, int length) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
+    }
+    writer.write${minor.class}(value, offset, length);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
+    }
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value, int offset, int length) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
+    }
+    writer.write${minor.class}(value, offset, length);
+    writer.setPosition(writer.idx() + 1);
+  }
+  <#elseif minor.class?ends_with("VarChar")>
+  @Override
+  public void write${minor.class}(Text value) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
+    }
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  @Override
+  public void write${minor.class}(String value) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
+    }
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+      </#if>
+
       <#if !minor.typeParams?? >
   @Override
   public void write${name}(<#list fields as field>${field.type} ${field.name}<#if field_has_next>, </#if></#list>) {

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -276,6 +276,43 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   }
   </#if>
 
+  <#if minor.class?ends_with("VarBinary")>
+  @Override
+  public void write${minor.class}(byte[] value) {
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  @Override
+  public void write${minor.class}(byte[] value, int offset, int length) {
+    writer.write${minor.class}(value, offset, length);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value) {
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value, int offset, int length) {
+    writer.write${minor.class}(value, offset, length);
+    writer.setPosition(writer.idx() + 1);
+  }
+  <#elseif minor.class?ends_with("VarChar")>
+  @Override
+  public void write${minor.class}(Text value) {
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+
+  public void write${minor.class}(String value) {
+    writer.write${minor.class}(value);
+    writer.setPosition(writer.idx() + 1);
+  }
+  </#if>
+
     </#list>
   </#list>
 }

--- a/java/vector/src/main/codegen/templates/UnionWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionWriter.java
@@ -302,6 +302,42 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     get${name}Writer(arrowType).setPosition(idx());
     get${name}Writer(arrowType).writeBigEndianBytesTo${name}(value, arrowType);
   }
+  <#elseif minor.class?ends_with("VarBinary")>
+  @Override
+  public void write${minor.class}(byte[] value) {
+    get${name}Writer().setPosition(idx());
+    get${name}Writer().write${minor.class}(value);
+  }
+
+  @Override
+  public void write${minor.class}(byte[] value, int offset, int length) {
+    get${name}Writer().setPosition(idx());
+    get${name}Writer().write${minor.class}(value, offset, length);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value) {
+    get${name}Writer().setPosition(idx());
+    get${name}Writer().write${minor.class}(value);
+  }
+
+  @Override
+  public void write${minor.class}(ByteBuffer value, int offset, int length) {
+    get${name}Writer().setPosition(idx());
+    get${name}Writer().write${minor.class}(value, offset, length);
+  }
+  <#elseif minor.class?ends_with("VarChar")>
+  @Override
+  public void write${minor.class}(${friendlyType} value) {
+    get${name}Writer().setPosition(idx());
+    get${name}Writer().write${minor.class}(value);
+  }
+
+  @Override
+  public void write${minor.class}(String value) {
+    get${name}Writer().setPosition(idx());
+    get${name}Writer().write${minor.class}(value);
+  }
   </#if>
       </#if>
     </#list>

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.complex.impl;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.FieldVector;
@@ -37,6 +38,7 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.util.Text;
 import org.apache.arrow.vector.util.TransferPair;
 
 /**
@@ -378,7 +380,66 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
           /*bitWidth=*/256)).writeBigEndianBytesToDecimal256(value, arrowType);
   }
 
- 
+  @Override
+  public void writeVarBinary(byte[] value) {
+    getWriter(MinorType.VARBINARY).writeVarBinary(value);
+  }
+
+  @Override
+  public void writeVarBinary(byte[] value, int offset, int length) {
+    getWriter(MinorType.VARBINARY).writeVarBinary(value, offset, length);
+  }
+
+  @Override
+  public void writeVarBinary(ByteBuffer value) {
+    getWriter(MinorType.VARBINARY).writeVarBinary(value);
+  }
+
+  @Override
+  public void writeVarBinary(ByteBuffer value, int offset, int length) {
+    getWriter(MinorType.VARBINARY).writeVarBinary(value, offset, length);
+  }
+
+  @Override
+  public void writeLargeVarBinary(byte[] value) {
+    getWriter(MinorType.LARGEVARBINARY).writeLargeVarBinary(value);
+  }
+
+  @Override
+  public void writeLargeVarBinary(byte[] value, int offset, int length) {
+    getWriter(MinorType.LARGEVARBINARY).writeLargeVarBinary(value, offset, length);
+  }
+
+  @Override
+  public void writeLargeVarBinary(ByteBuffer value) {
+    getWriter(MinorType.LARGEVARBINARY).writeLargeVarBinary(value);
+  }
+
+  @Override
+  public void writeLargeVarBinary(ByteBuffer value, int offset, int length) {
+    getWriter(MinorType.LARGEVARBINARY).writeLargeVarBinary(value, offset, length);
+  }
+
+  @Override
+  public void writeVarChar(Text value) {
+    getWriter(MinorType.VARCHAR).writeVarChar(value);
+  }
+
+  @Override
+  public void writeVarChar(String value) {
+    getWriter(MinorType.VARCHAR).writeVarChar(value);
+  }
+
+  @Override
+  public void writeLargeVarChar(Text value) {
+    getWriter(MinorType.LARGEVARCHAR).writeLargeVarChar(value);
+  }
+
+  @Override
+  public void writeLargeVarChar(String value) {
+    getWriter(MinorType.LARGEVARCHAR).writeLargeVarChar(value);
+  }
+
   @Override
   public void allocate() {
     getWriter().allocate();

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestSimpleWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestSimpleWriter.java
@@ -54,7 +54,7 @@ public class TestSimpleWriter {
     try (VarBinaryVector vector = new VarBinaryVector("test", allocator);
          VarBinaryWriter writer = new VarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
-      writer.writeToVarBinary(input);
+      writer.writeVarBinary(input);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(input, result);
     }
@@ -65,7 +65,7 @@ public class TestSimpleWriter {
     try (VarBinaryVector vector = new VarBinaryVector("test", allocator);
          VarBinaryWriter writer = new VarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
-      writer.writeToVarBinary(input, 1, 1);
+      writer.writeVarBinary(input, 1, 1);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(new byte[] { 0x02 }, result);
     }
@@ -77,7 +77,7 @@ public class TestSimpleWriter {
          VarBinaryWriter writer = new VarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
       ByteBuffer buffer = ByteBuffer.wrap(input);
-      writer.writeToVarBinary(buffer);
+      writer.writeVarBinary(buffer);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(input, result);
     }
@@ -89,7 +89,7 @@ public class TestSimpleWriter {
          VarBinaryWriter writer = new VarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
       ByteBuffer buffer = ByteBuffer.wrap(input);
-      writer.writeToVarBinary(buffer, 1, 1);
+      writer.writeVarBinary(buffer, 1, 1);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(new byte[] { 0x02 }, result);
     }
@@ -100,7 +100,7 @@ public class TestSimpleWriter {
     try (LargeVarBinaryVector vector = new LargeVarBinaryVector("test", allocator);
          LargeVarBinaryWriter writer = new LargeVarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
-      writer.writeToLargeVarBinary(input);
+      writer.writeLargeVarBinary(input);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(input, result);
     }
@@ -111,7 +111,7 @@ public class TestSimpleWriter {
     try (LargeVarBinaryVector vector = new LargeVarBinaryVector("test", allocator);
          LargeVarBinaryWriter writer = new LargeVarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
-      writer.writeToLargeVarBinary(input, 1, 1);
+      writer.writeLargeVarBinary(input, 1, 1);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(new byte[] { 0x02 }, result);
     }
@@ -123,7 +123,7 @@ public class TestSimpleWriter {
          LargeVarBinaryWriter writer = new LargeVarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
       ByteBuffer buffer = ByteBuffer.wrap(input);
-      writer.writeToLargeVarBinary(buffer);
+      writer.writeLargeVarBinary(buffer);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(input, result);
     }
@@ -135,7 +135,7 @@ public class TestSimpleWriter {
          LargeVarBinaryWriter writer = new LargeVarBinaryWriterImpl(vector)) {
       byte[] input = new byte[] { 0x01, 0x02 };
       ByteBuffer buffer = ByteBuffer.wrap(input);
-      writer.writeToLargeVarBinary(buffer, 1, 1);
+      writer.writeLargeVarBinary(buffer, 1, 1);
       byte[] result = vector.get(0);
       Assert.assertArrayEquals(new byte[] { 0x02 }, result);
     }


### PR DESCRIPTION
### Rationale for this change
Add the overrides for new convenience Writer methods added to VarCharWriter and VarBinaryWriter so that classes that
use composition such as UnionWriter and PromotableWriter can invoke them properly.

### What changes are included in this PR?
- Rename from writeTo$type to write$type for consistency with other methods
- Add new helper methods to PromotableWriter
- Add new helper methods to complex writers such as list and union

### Are these changes tested?
Yes. New unit tests added for several Writer classes.

 **This PR includes breaking changes to public APIs.** 
The writeTo<Type>() and similar methods in Writers have been renamed to just write<Type>()

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38614