### PR TITLE
GH-38630: [MATLAB] `arrow.array.BooleanArray`'s `toMATLAB` method does not take slice offsets into account

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.cc
@@ -100,7 +100,7 @@ namespace arrow::matlab::array::proxy {
         }
 
         auto validity_bitmap = array->null_bitmap();
-        auto valid_elements_mda = bit::unpack(validity_bitmap, array_length);
+        auto valid_elements_mda = bit::unpack(validity_bitmap, array_length, array->offset());
         context.outputs[0] = valid_elements_mda;
     }
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/boolean_array.cc
@@ -53,7 +53,7 @@ namespace arrow::matlab::array::proxy {
         void BooleanArray::toMATLAB(libmexclass::proxy::method::Context& context) {
             auto array_length = array->length();
             auto packed_logical_data_buffer = std::static_pointer_cast<arrow::BooleanArray>(array)->values();
-            auto logical_array_mda = bit::unpack(packed_logical_data_buffer, array_length);
+            auto logical_array_mda = bit::unpack(packed_logical_data_buffer, array_length, array->offset());
             context.outputs[0] = logical_array_mda;
         }
 }

--- a/matlab/src/cpp/arrow/matlab/bit/unpack.cc
+++ b/matlab/src/cpp/arrow/matlab/bit/unpack.cc
@@ -20,7 +20,7 @@
 #include "arrow/util/bitmap_visit.h"
 
 namespace arrow::matlab::bit {
-    ::matlab::data::TypedArray<bool> unpack(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length) {
+    ::matlab::data::TypedArray<bool> unpack(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length, int64_t start_offset) {
         const auto packed_buffer_ptr = packed_buffer->data();
 
         ::matlab::data::ArrayFactory factory;
@@ -31,7 +31,6 @@ namespace arrow::matlab::bit {
         auto unpacked_buffer_ptr = unpacked_buffer.get();
         auto visitFcn = [&](const bool is_valid) { *unpacked_buffer_ptr++ = is_valid; };
 
-        const int64_t start_offset = 0;
         arrow::internal::VisitBitsUnrolled(packed_buffer_ptr, start_offset, length, visitFcn);
 
         ::matlab::data::TypedArray<bool> unpacked_matlab_logical_Array = factory.createArrayFromBuffer({array_length, 1}, std::move(unpacked_buffer));

--- a/matlab/src/cpp/arrow/matlab/bit/unpack.h
+++ b/matlab/src/cpp/arrow/matlab/bit/unpack.h
@@ -22,6 +22,6 @@
 #include "MatlabDataArray.hpp"
 
 namespace arrow::matlab::bit {
-    ::matlab::data::TypedArray<bool> unpack(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length);
+    ::matlab::data::TypedArray<bool> unpack(const std::shared_ptr<arrow::Buffer>& packed_buffer, int64_t length, int64_t start_offset);
     const uint8_t* extract_ptr(const ::matlab::data::TypedArray<bool>& unpacked_validity_bitmap);
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

While working on #38415, I noticed that the `toMATLAB` method of `arrow.array.BooleanArray` does not take the slice offset into account. This will cause the `toMATLAB` method to return the wrong value.

### What changes are included in this PR?

1. Updated `arrow::matlab::bit::unpack` function to accept a `start_offset` as input.
2. Updated clients (`BooleanArray::toMATLAB` and `Array::getValid`) to supply the array `offset` as the `start_offset`.


### Are these changes tested?

The existing tests cover these changes. Additionally, the changes for #38415 will include tests that verify the `toMATLAB` method returns the correct MATLAB array when the underlying Arrow array has been sliced.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38630