### PR TITLE
GH-38626: [Python] Fix segfault when PyArrow is imported at shutdown

### DIFF
--- a/python/pyarrow/tests/test_misc.py
+++ b/python/pyarrow/tests/test_misc.py
@@ -117,6 +117,19 @@ def test_runtime_info():
         subprocess.check_call([sys.executable, "-c", code], env=env)
 
 
+def test_import_at_shutdown():
+    # GH-38626: importing PyArrow at interpreter shutdown would crash
+    code = """if 1:
+        import atexit
+
+        def import_arrow():
+            import pyarrow
+
+        atexit.register(import_arrow)
+        """
+    subprocess.check_call([sys.executable, "-c", code])
+
+
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="Path to timezone database is not configurable "
                            "on non-Windows platforms")


### PR DESCRIPTION

### Rationale for this change

Some C++ destructors may be called after the Python interpreter has ceased to exist.
If such a destructor tries to call back in the Python interpreter, for example by calling `Py_DECREF`, we get a crash.

### What changes are included in this PR?

Protect `OwnedRef` and `OwneRefNoGIL` destructors against decref'ing a Python object after Python finalization.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38626