### PR TITLE
MINOR: [R] Fix .lintr config file for updated lintr dependency

### DIFF
--- a/r/.lintr
+++ b/r/.lintr
@@ -1,4 +1,4 @@
-license:  #  Licensed to the Apache Software Foundation (ASF) under one
+license:  '#  Licensed to the Apache Software Foundation (ASF) under one
   #  or more contributor license agreements.  See the NOTICE file
   #  distributed with this work for additional information
   #  regarding copyright ownership.  The ASF licenses this file
@@ -13,7 +13,7 @@ license:  #  Licensed to the Apache Software Foundation (ASF) under one
   #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
   #  KIND, either express or implied.  See the License for the
   #  specific language governing permissions and limitations
-  #  under the License.
+  #  under the License.'
 linters: linters_with_defaults(
   indentation_linter = NULL,
   line_length_linter = line_length_linter(120),


### PR DESCRIPTION
### Rationale for this change

The lint CI job is failing because an update to a dependency of lintr now does more strict DCF checking on the .lintr file

### What changes are included in this PR?

The 'license' field was wrapped in quotes so that .lintr passes validation

### Are these changes tested?

Yes, by existing CI job

### Are there any user-facing changes?

No