### PR TITLE
GH-34017: [Python][FlightRPC][Doc] Fix `read_chunk` docstring for FlightStreamReader and MetadataRecordBatchReader

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1014,11 +1014,8 @@ cdef class _MetadataRecordBatchReader(_Weakrefable, _ReadPandasMixin):
 
         Returns
         -------
-        data : FlightStreamChunk
+        chunk : FlightStreamChunk
             The next FlightStreamChunk in the stream.
-        app_metadata : Buffer or None
-            Application-specific metadata for the batch as defined by
-            Flight.
 
         Raises
         ------


### PR DESCRIPTION
### Rationale for this change

The docs for `FlightStreamReader` and `MetadataRecordBatchReader` currently list an incorrect return type for the `read_chunk` method - see #34017. NB: this issue was partially addressed by #35583.

### What changes are included in this PR?

Simple docstring update for `read_chunk`.

### Are these changes tested?

No (v minor docstring only change)

### Are there any user-facing changes?

Yes
* Closes: #34017