### PR TITLE
GH-38648: [Java] Regenerate Flatbuffers

### DIFF
--- a/java/format/src/main/java/org/apache/arrow/flatbuf/BinaryView.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/BinaryView.java
@@ -25,32 +25,24 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 /**
- * Date is either a 32-bit or 64-bit signed integer type representing an
- * elapsed time since UNIX epoch (1970-01-01), stored in either of two units:
+ * Logically the same as Binary, but the internal representation uses a view
+ * struct that contains the string length and either the string's entire data
+ * inline (for small strings) or an inlined prefix, an index of another buffer,
+ * and an offset pointing to a slice in that buffer (for non-small strings).
  *
- * * Milliseconds (64 bits) indicating UNIX time elapsed since the epoch (no
- *   leap seconds), where the values are evenly divisible by 86400000
- * * Days (32 bits) since the UNIX epoch
+ * Since it uses a variable number of data buffers, each Field with this type
+ * must have a corresponding entry in `variadicBufferCounts`.
  */
-public final class Date extends Table {
+public final class BinaryView extends Table {
   public static void ValidateVersion() { Constants.FLATBUFFERS_1_12_0(); }
-  public static Date getRootAsDate(ByteBuffer _bb) { return getRootAsDate(_bb, new Date()); }
-  public static Date getRootAsDate(ByteBuffer _bb, Date obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public static BinaryView getRootAsBinaryView(ByteBuffer _bb) { return getRootAsBinaryView(_bb, new BinaryView()); }
+  public static BinaryView getRootAsBinaryView(ByteBuffer _bb, BinaryView obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
-  public Date __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+  public BinaryView __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public short unit() { int o = __offset(4); return o != 0 ? bb.getShort(o + bb_pos) : 1; }
 
-  public static int createDate(FlatBufferBuilder builder,
-      short unit) {
-    builder.startTable(1);
-    Date.addUnit(builder, unit);
-    return Date.endDate(builder);
-  }
-
-  public static void startDate(FlatBufferBuilder builder) { builder.startTable(1); }
-  public static void addUnit(FlatBufferBuilder builder, short unit) { builder.addShort(0, unit, 1); }
-  public static int endDate(FlatBufferBuilder builder) {
+  public static void startBinaryView(FlatBufferBuilder builder) { builder.startTable(0); }
+  public static int endBinaryView(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
   }
@@ -58,8 +50,8 @@ public final class Date extends Table {
   public static final class Vector extends BaseVector {
     public Vector __assign(int _vector, int _element_size, ByteBuffer _bb) { __reset(_vector, _element_size, _bb); return this; }
 
-    public Date get(int j) { return get(new Date(), j); }
-    public Date get(Date obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
+    public BinaryView get(int j) { return get(new BinaryView(), j); }
+    public BinaryView get(BinaryView obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
   }
 }
 

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/BodyCompression.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/BodyCompression.java
@@ -37,7 +37,8 @@ public final class BodyCompression extends Table {
   public BodyCompression __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
   /**
-   * Compressor library
+   * Compressor library.
+   * For LZ4_FRAME, each compressed buffer must consist of a single frame.
    */
   public byte codec() { int o = __offset(4); return o != 0 ? bb.get(o + bb_pos) : 0; }
   /**

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/LargeListView.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/LargeListView.java
@@ -25,32 +25,19 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 /**
- * Date is either a 32-bit or 64-bit signed integer type representing an
- * elapsed time since UNIX epoch (1970-01-01), stored in either of two units:
- *
- * * Milliseconds (64 bits) indicating UNIX time elapsed since the epoch (no
- *   leap seconds), where the values are evenly divisible by 86400000
- * * Days (32 bits) since the UNIX epoch
+ * Same as ListView, but with 64-bit offsets and sizes, allowing to represent
+ * extremely large data values.
  */
-public final class Date extends Table {
+public final class LargeListView extends Table {
   public static void ValidateVersion() { Constants.FLATBUFFERS_1_12_0(); }
-  public static Date getRootAsDate(ByteBuffer _bb) { return getRootAsDate(_bb, new Date()); }
-  public static Date getRootAsDate(ByteBuffer _bb, Date obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public static LargeListView getRootAsLargeListView(ByteBuffer _bb) { return getRootAsLargeListView(_bb, new LargeListView()); }
+  public static LargeListView getRootAsLargeListView(ByteBuffer _bb, LargeListView obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
-  public Date __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+  public LargeListView __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public short unit() { int o = __offset(4); return o != 0 ? bb.getShort(o + bb_pos) : 1; }
 
-  public static int createDate(FlatBufferBuilder builder,
-      short unit) {
-    builder.startTable(1);
-    Date.addUnit(builder, unit);
-    return Date.endDate(builder);
-  }
-
-  public static void startDate(FlatBufferBuilder builder) { builder.startTable(1); }
-  public static void addUnit(FlatBufferBuilder builder, short unit) { builder.addShort(0, unit, 1); }
-  public static int endDate(FlatBufferBuilder builder) {
+  public static void startLargeListView(FlatBufferBuilder builder) { builder.startTable(0); }
+  public static int endLargeListView(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
   }
@@ -58,8 +45,8 @@ public final class Date extends Table {
   public static final class Vector extends BaseVector {
     public Vector __assign(int _vector, int _element_size, ByteBuffer _bb) { __reset(_vector, _element_size, _bb); return this; }
 
-    public Date get(int j) { return get(new Date(), j); }
-    public Date get(Date obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
+    public LargeListView get(int j) { return get(new LargeListView(), j); }
+    public LargeListView get(LargeListView obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
   }
 }
 

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/ListView.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/ListView.java
@@ -25,32 +25,20 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 /**
- * Date is either a 32-bit or 64-bit signed integer type representing an
- * elapsed time since UNIX epoch (1970-01-01), stored in either of two units:
- *
- * * Milliseconds (64 bits) indicating UNIX time elapsed since the epoch (no
- *   leap seconds), where the values are evenly divisible by 86400000
- * * Days (32 bits) since the UNIX epoch
+ * Represents the same logical types that List can, but contains offsets and
+ * sizes allowing for writes in any order and sharing of child values among
+ * list values.
  */
-public final class Date extends Table {
+public final class ListView extends Table {
   public static void ValidateVersion() { Constants.FLATBUFFERS_1_12_0(); }
-  public static Date getRootAsDate(ByteBuffer _bb) { return getRootAsDate(_bb, new Date()); }
-  public static Date getRootAsDate(ByteBuffer _bb, Date obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public static ListView getRootAsListView(ByteBuffer _bb) { return getRootAsListView(_bb, new ListView()); }
+  public static ListView getRootAsListView(ByteBuffer _bb, ListView obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
-  public Date __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+  public ListView __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public short unit() { int o = __offset(4); return o != 0 ? bb.getShort(o + bb_pos) : 1; }
 
-  public static int createDate(FlatBufferBuilder builder,
-      short unit) {
-    builder.startTable(1);
-    Date.addUnit(builder, unit);
-    return Date.endDate(builder);
-  }
-
-  public static void startDate(FlatBufferBuilder builder) { builder.startTable(1); }
-  public static void addUnit(FlatBufferBuilder builder, short unit) { builder.addShort(0, unit, 1); }
-  public static int endDate(FlatBufferBuilder builder) {
+  public static void startListView(FlatBufferBuilder builder) { builder.startTable(0); }
+  public static int endListView(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
   }
@@ -58,8 +46,8 @@ public final class Date extends Table {
   public static final class Vector extends BaseVector {
     public Vector __assign(int _vector, int _element_size, ByteBuffer _bb) { __reset(_vector, _element_size, _bb); return this; }
 
-    public Date get(int j) { return get(new Date(), j); }
-    public Date get(Date obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
+    public ListView get(int j) { return get(new ListView(), j); }
+    public ListView get(ListView obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
   }
 }
 

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/RecordBatch.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/RecordBatch.java
@@ -67,27 +67,54 @@ public final class RecordBatch extends Table {
    */
   public org.apache.arrow.flatbuf.BodyCompression compression() { return compression(new org.apache.arrow.flatbuf.BodyCompression()); }
   public org.apache.arrow.flatbuf.BodyCompression compression(org.apache.arrow.flatbuf.BodyCompression obj) { int o = __offset(10); return o != 0 ? obj.__assign(__indirect(o + bb_pos), bb) : null; }
+  /**
+   * Some types such as Utf8View are represented using a variable number of buffers.
+   * For each such Field in the pre-ordered flattened logical schema, there will be
+   * an entry in variadicBufferCounts to indicate the number of number of variadic
+   * buffers which belong to that Field in the current RecordBatch.
+   *
+   * For example, the schema
+   *     col1: Struct<alpha: Int32, beta: BinaryView, gamma: Float64>
+   *     col2: Utf8View
+   * contains two Fields with variadic buffers so variadicBufferCounts will have
+   * two entries, the first counting the variadic buffers of `col1.beta` and the
+   * second counting `col2`'s.
+   *
+   * This field may be omitted if and only if the schema contains no Fields with
+   * a variable number of buffers, such as BinaryView and Utf8View.
+   */
+  public long variadicBufferCounts(int j) { int o = __offset(12); return o != 0 ? bb.getLong(__vector(o) + j * 8) : 0; }
+  public int variadicBufferCountsLength() { int o = __offset(12); return o != 0 ? __vector_len(o) : 0; }
+  public LongVector variadicBufferCountsVector() { return variadicBufferCountsVector(new LongVector()); }
+  public LongVector variadicBufferCountsVector(LongVector obj) { int o = __offset(12); return o != 0 ? obj.__assign(__vector(o), bb) : null; }
+  public ByteBuffer variadicBufferCountsAsByteBuffer() { return __vector_as_bytebuffer(12, 8); }
+  public ByteBuffer variadicBufferCountsInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 12, 8); }
 
   public static int createRecordBatch(FlatBufferBuilder builder,
       long length,
       int nodesOffset,
       int buffersOffset,
-      int compressionOffset) {
-    builder.startTable(4);
+      int compressionOffset,
+      int variadicBufferCountsOffset) {
+    builder.startTable(5);
     RecordBatch.addLength(builder, length);
+    RecordBatch.addVariadicBufferCounts(builder, variadicBufferCountsOffset);
     RecordBatch.addCompression(builder, compressionOffset);
     RecordBatch.addBuffers(builder, buffersOffset);
     RecordBatch.addNodes(builder, nodesOffset);
     return RecordBatch.endRecordBatch(builder);
   }
 
-  public static void startRecordBatch(FlatBufferBuilder builder) { builder.startTable(4); }
+  public static void startRecordBatch(FlatBufferBuilder builder) { builder.startTable(5); }
   public static void addLength(FlatBufferBuilder builder, long length) { builder.addLong(0, length, 0L); }
   public static void addNodes(FlatBufferBuilder builder, int nodesOffset) { builder.addOffset(1, nodesOffset, 0); }
   public static void startNodesVector(FlatBufferBuilder builder, int numElems) { builder.startVector(16, numElems, 8); }
   public static void addBuffers(FlatBufferBuilder builder, int buffersOffset) { builder.addOffset(2, buffersOffset, 0); }
   public static void startBuffersVector(FlatBufferBuilder builder, int numElems) { builder.startVector(16, numElems, 8); }
   public static void addCompression(FlatBufferBuilder builder, int compressionOffset) { builder.addOffset(3, compressionOffset, 0); }
+  public static void addVariadicBufferCounts(FlatBufferBuilder builder, int variadicBufferCountsOffset) { builder.addOffset(4, variadicBufferCountsOffset, 0); }
+  public static int createVariadicBufferCountsVector(FlatBufferBuilder builder, long[] data) { builder.startVector(8, data.length, 8); for (int i = data.length - 1; i >= 0; i--) builder.addLong(data[i]); return builder.endVector(); }
+  public static void startVariadicBufferCountsVector(FlatBufferBuilder builder, int numElems) { builder.startVector(8, numElems, 8); }
   public static int endRecordBatch(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/RunEndEncoded.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/RunEndEncoded.java
@@ -25,32 +25,22 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 /**
- * Date is either a 32-bit or 64-bit signed integer type representing an
- * elapsed time since UNIX epoch (1970-01-01), stored in either of two units:
- *
- * * Milliseconds (64 bits) indicating UNIX time elapsed since the epoch (no
- *   leap seconds), where the values are evenly divisible by 86400000
- * * Days (32 bits) since the UNIX epoch
+ * Contains two child arrays, run_ends and values.
+ * The run_ends child array must be a 16/32/64-bit integer array
+ * which encodes the indices at which the run with the value in 
+ * each corresponding index in the values child array ends.
+ * Like list/struct types, the value array can be of any type.
  */
-public final class Date extends Table {
+public final class RunEndEncoded extends Table {
   public static void ValidateVersion() { Constants.FLATBUFFERS_1_12_0(); }
-  public static Date getRootAsDate(ByteBuffer _bb) { return getRootAsDate(_bb, new Date()); }
-  public static Date getRootAsDate(ByteBuffer _bb, Date obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public static RunEndEncoded getRootAsRunEndEncoded(ByteBuffer _bb) { return getRootAsRunEndEncoded(_bb, new RunEndEncoded()); }
+  public static RunEndEncoded getRootAsRunEndEncoded(ByteBuffer _bb, RunEndEncoded obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
-  public Date __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+  public RunEndEncoded __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public short unit() { int o = __offset(4); return o != 0 ? bb.getShort(o + bb_pos) : 1; }
 
-  public static int createDate(FlatBufferBuilder builder,
-      short unit) {
-    builder.startTable(1);
-    Date.addUnit(builder, unit);
-    return Date.endDate(builder);
-  }
-
-  public static void startDate(FlatBufferBuilder builder) { builder.startTable(1); }
-  public static void addUnit(FlatBufferBuilder builder, short unit) { builder.addShort(0, unit, 1); }
-  public static int endDate(FlatBufferBuilder builder) {
+  public static void startRunEndEncoded(FlatBufferBuilder builder) { builder.startTable(0); }
+  public static int endRunEndEncoded(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
   }
@@ -58,8 +48,8 @@ public final class Date extends Table {
   public static final class Vector extends BaseVector {
     public Vector __assign(int _vector, int _element_size, ByteBuffer _bb) { __reset(_vector, _element_size, _bb); return this; }
 
-    public Date get(int j) { return get(new Date(), j); }
-    public Date get(Date obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
+    public RunEndEncoded get(int j) { return get(new RunEndEncoded(), j); }
+    public RunEndEncoded get(RunEndEncoded obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
   }
 }
 

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/Time.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/Time.java
@@ -25,9 +25,20 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 /**
- * Time type. The physical storage type depends on the unit
- * - SECOND and MILLISECOND: 32 bits
- * - MICROSECOND and NANOSECOND: 64 bits
+ * Time is either a 32-bit or 64-bit signed integer type representing an
+ * elapsed time since midnight, stored in either of four units: seconds,
+ * milliseconds, microseconds or nanoseconds.
+ *
+ * The integer `bitWidth` depends on the `unit` and must be one of the following:
+ * * SECOND and MILLISECOND: 32 bits
+ * * MICROSECOND and NANOSECOND: 64 bits
+ *
+ * The allowed values are between 0 (inclusive) and 86400 (=24*60*60) seconds
+ * (exclusive), adjusted for the time unit (for example, up to 86400000
+ * exclusive for the MILLISECOND unit).
+ * This definition doesn't allow for leap seconds. Time values from
+ * measurements with leap seconds will need to be corrected when ingesting
+ * into Arrow (for example by replacing the value 86400 with 86399).
  */
 public final class Time extends Table {
   public static void ValidateVersion() { Constants.FLATBUFFERS_1_12_0(); }

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/Type.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/Type.java
@@ -47,8 +47,13 @@ public final class Type {
   public static final byte LargeBinary = 19;
   public static final byte LargeUtf8 = 20;
   public static final byte LargeList = 21;
+  public static final byte RunEndEncoded = 22;
+  public static final byte BinaryView = 23;
+  public static final byte Utf8View = 24;
+  public static final byte ListView = 25;
+  public static final byte LargeListView = 26;
 
-  public static final String[] names = { "NONE", "Null", "Int", "FloatingPoint", "Binary", "Utf8", "Bool", "Decimal", "Date", "Time", "Timestamp", "Interval", "List", "Struct_", "Union", "FixedSizeBinary", "FixedSizeList", "Map", "Duration", "LargeBinary", "LargeUtf8", "LargeList", };
+  public static final String[] names = { "NONE", "Null", "Int", "FloatingPoint", "Binary", "Utf8", "Bool", "Decimal", "Date", "Time", "Timestamp", "Interval", "List", "Struct_", "Union", "FixedSizeBinary", "FixedSizeList", "Map", "Duration", "LargeBinary", "LargeUtf8", "LargeList", "RunEndEncoded", "BinaryView", "Utf8View", "ListView", "LargeListView", };
 
   public static String name(int e) { return names[e]; }
 }

--- a/java/format/src/main/java/org/apache/arrow/flatbuf/Utf8View.java
+++ b/java/format/src/main/java/org/apache/arrow/flatbuf/Utf8View.java
@@ -25,32 +25,24 @@ import com.google.flatbuffers.*;
 
 @SuppressWarnings("unused")
 /**
- * Date is either a 32-bit or 64-bit signed integer type representing an
- * elapsed time since UNIX epoch (1970-01-01), stored in either of two units:
+ * Logically the same as Utf8, but the internal representation uses a view
+ * struct that contains the string length and either the string's entire data
+ * inline (for small strings) or an inlined prefix, an index of another buffer,
+ * and an offset pointing to a slice in that buffer (for non-small strings).
  *
- * * Milliseconds (64 bits) indicating UNIX time elapsed since the epoch (no
- *   leap seconds), where the values are evenly divisible by 86400000
- * * Days (32 bits) since the UNIX epoch
+ * Since it uses a variable number of data buffers, each Field with this type
+ * must have a corresponding entry in `variadicBufferCounts`.
  */
-public final class Date extends Table {
+public final class Utf8View extends Table {
   public static void ValidateVersion() { Constants.FLATBUFFERS_1_12_0(); }
-  public static Date getRootAsDate(ByteBuffer _bb) { return getRootAsDate(_bb, new Date()); }
-  public static Date getRootAsDate(ByteBuffer _bb, Date obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public static Utf8View getRootAsUtf8View(ByteBuffer _bb) { return getRootAsUtf8View(_bb, new Utf8View()); }
+  public static Utf8View getRootAsUtf8View(ByteBuffer _bb, Utf8View obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
   public void __init(int _i, ByteBuffer _bb) { __reset(_i, _bb); }
-  public Date __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+  public Utf8View __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public short unit() { int o = __offset(4); return o != 0 ? bb.getShort(o + bb_pos) : 1; }
 
-  public static int createDate(FlatBufferBuilder builder,
-      short unit) {
-    builder.startTable(1);
-    Date.addUnit(builder, unit);
-    return Date.endDate(builder);
-  }
-
-  public static void startDate(FlatBufferBuilder builder) { builder.startTable(1); }
-  public static void addUnit(FlatBufferBuilder builder, short unit) { builder.addShort(0, unit, 1); }
-  public static int endDate(FlatBufferBuilder builder) {
+  public static void startUtf8View(FlatBufferBuilder builder) { builder.startTable(0); }
+  public static int endUtf8View(FlatBufferBuilder builder) {
     int o = builder.endTable();
     return o;
   }
@@ -58,8 +50,8 @@ public final class Date extends Table {
   public static final class Vector extends BaseVector {
     public Vector __assign(int _vector, int _element_size, ByteBuffer _bb) { __reset(_vector, _element_size, _bb); return this; }
 
-    public Date get(int j) { return get(new Date(), j); }
-    public Date get(Date obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
+    public Utf8View get(int j) { return get(new Utf8View(), j); }
+    public Utf8View get(Utf8View obj, int j) {  return obj.__assign(__indirect(__element(j), bb), bb); }
   }
 }
 


### PR DESCRIPTION
### Rationale for this change

Regenerate the Flatbuffers to include new formats. Flatbuffers are always forwards/backwards compatible as long as the code is generated from the same `flatc` compiler version.

### What changes are included in this PR?

* Flatbuffers regenerated with `flatc` v1.12.0

### Are these changes tested?

Yes, via unit tests.

### Are there any user-facing changes?

Yes, RecordBatch.java was modified.
* Closes: #38648