### PR TITLE
MINOR: [R] Fix broken link in README.md

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -101,7 +101,7 @@ issue you want to create. Add a meaningful title prefixed with **`[R]`**
 followed by a space, the issue summary and select component **R** from the
 dropdown list. For more information, see the **Report bugs and propose
 features** section of the [Contributing to Apache
-Arrow](https://arrow.apache.org/docs/developers/contributing.html) page
+Arrow](https://arrow.apache.org/docs/developers/guide/index.html) page
 in the Arrow developer documentation.
 
 We welcome questions, discussion, and contributions from users of the

--- a/r/README.md
+++ b/r/README.md
@@ -101,7 +101,7 @@ issue you want to create. Add a meaningful title prefixed with **`[R]`**
 followed by a space, the issue summary and select component **R** from the
 dropdown list. For more information, see the **Report bugs and propose
 features** section of the [Contributing to Apache
-Arrow](https://arrow.apache.org/docs/developers/guide/index.html) page
+Arrow](https://arrow.apache.org/docs/developers/#contributing) page
 in the Arrow developer documentation.
 
 We welcome questions, discussion, and contributions from users of the


### PR DESCRIPTION

### Rationale for this change

There is a broken link in README.md that refers to an old URL in the Arrow documentation. This causes the CRAN incoming check to fail.

### What changes are included in this PR?

The link was updated.

### Are these changes tested?

Not needed (docs only)

### Are there any user-facing changes?

No