### PR TITLE
MINOR: [Release][Docs] Document how to avoid default pushing to main when running bump-versions

### DIFF
--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -567,6 +567,9 @@ Be sure to go through on the following checklist:
 
    .. code-block:: Bash
 
+      # You can run the script with BUMP_TAG=0 and BUMP_PUSH=0
+      # this will avoid default pushing to main and pushing the tag
+      # but you will require to push manually after reviewing the commits.
       # dev/release/post-11-bump-versions.sh 10.0.0 11.0.0
       dev/release/post-11-bump-versions.sh X.Y.Z NEXT_X.NEXT_Y.NEXT_Z
 


### PR DESCRIPTION
### Rationale for this change

This is the second time I've had to revert some commits after bumping versions. Usually happened on patch versions. This documentation is a reminder to the release manager to avoid default pushing so we can review changes locally before.

### What changes are included in this PR?

Just a minor note on the documentation

### Are these changes tested?

Does not apply.

### Are there any user-facing changes?

No