### PR TITLE
GH-38348: [C#] Make PrimitiveArray<T> support IReadOnlyList<T?>

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Apache.Arrow.Memory;
 using System.Collections;
-using System.Linq;
 
 namespace Apache.Arrow
 {
@@ -372,8 +371,14 @@ namespace Apache.Arrow
         int IReadOnlyCollection<byte[]>.Count => Length;
         byte[] IReadOnlyList<byte[]>.this[int index] => GetBytes(index).ToArray();
 
-        IEnumerator<byte[]> IEnumerable<byte[]>.GetEnumerator() => Enumerable.Range(0, Length).Select(x => GetBytes(x).ToArray()).GetEnumerator();
+        IEnumerator<byte[]> IEnumerable<byte[]>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetBytes(index).ToArray();
+            }
+        }
 
-        IEnumerator IEnumerable.GetEnumerator() => Enumerable.Range(0, Length).Select(x => GetBytes(x).ToArray()).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<byte[]>)this).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -18,10 +18,12 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Apache.Arrow.Memory;
+using System.Collections;
+using System.Linq;
 
 namespace Apache.Arrow
 {
-    public class BinaryArray : Array
+    public class BinaryArray : Array, IReadOnlyList<byte[]>
     {
         public class Builder : BuilderBase<BinaryArray, Builder>
         {
@@ -366,5 +368,12 @@ namespace Apache.Arrow
 
             return ValueBuffer.Span.Slice(ValueOffsets[index], GetValueLength(index));
         }
+
+        int IReadOnlyCollection<byte[]>.Count => Length;
+        byte[] IReadOnlyList<byte[]>.this[int index] => GetBytes(index).ToArray();
+
+        IEnumerator<byte[]> IEnumerable<byte[]>.GetEnumerator() => Enumerable.Range(0, Length).Select(x => GetBytes(x).ToArray()).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => Enumerable.Range(0, Length).Select(x => GetBytes(x).ToArray()).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -16,11 +16,13 @@
 using Apache.Arrow.Memory;
 using Apache.Arrow.Types;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Apache.Arrow
 {
-    public class BooleanArray: Array
+    public class BooleanArray: Array, IReadOnlyList<bool?>
     {
         public class Builder : IArrowArrayBuilder<bool, BooleanArray, Builder>
         {
@@ -190,5 +192,13 @@ namespace Apache.Arrow
                 ? (bool?)null
                 : BitUtility.GetBit(ValueBuffer.Span, index + Offset);
         }
+
+        int IReadOnlyCollection<bool?>.Count => Length;
+
+        bool? IReadOnlyList<bool?>.this[int index] => GetValue(index);
+
+        IEnumerator<bool?> IEnumerable<bool?>.GetEnumerator() => Enumerable.Range(0, Length).Select(GetValue).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => Enumerable.Range(0, Length).Select(GetValue).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -18,7 +18,6 @@ using Apache.Arrow.Types;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Apache.Arrow
 {
@@ -197,8 +196,14 @@ namespace Apache.Arrow
 
         bool? IReadOnlyList<bool?>.this[int index] => GetValue(index);
 
-        IEnumerator<bool?> IEnumerable<bool?>.GetEnumerator() => Enumerable.Range(0, Length).Select(GetValue).GetEnumerator();
+        IEnumerator<bool?> IEnumerable<bool?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetValue(index);
+            }
+        }
 
-        IEnumerator IEnumerable.GetEnumerator() => Enumerable.Range(0, Length).Select(GetValue).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<bool?>)this).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
@@ -15,6 +15,7 @@
 
 using Apache.Arrow.Types;
 using System;
+using System.Collections.Generic;
 
 namespace Apache.Arrow
 {
@@ -22,7 +23,10 @@ namespace Apache.Arrow
     /// The <see cref="Date32Array"/> class holds an array of dates in the <c>Date32</c> format, where each date is
     /// stored as the number of days since the dawn of (UNIX) time.
     /// </summary>
-    public class Date32Array : PrimitiveArray<int>
+    public class Date32Array : PrimitiveArray<int>, IReadOnlyList<DateTime?>
+#if NET6_0_OR_GREATER
+        , IReadOnlyList<DateOnly?>
+#endif
     {
         private static readonly DateTime _epochDate = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
 #if NET6_0_OR_GREATER
@@ -133,6 +137,30 @@ namespace Apache.Arrow
                 ? DateOnly.FromDayNumber(_epochDayNumber + value.Value)
                 : default(DateOnly?);
         }
+
+        int IReadOnlyCollection<DateOnly?>.Count => Length;
+
+        DateOnly? IReadOnlyList<DateOnly?>.this[int index] => GetDateOnly(index);
+
+        IEnumerator<DateOnly?> IEnumerable<DateOnly?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetDateOnly(index);
+            };
+        }
 #endif
+
+        int IReadOnlyCollection<DateTime?>.Count => Length;
+
+        DateTime? IReadOnlyList<DateTime?>.this[int index] => GetDateTime(index);
+
+        IEnumerator<DateTime?> IEnumerable<DateTime?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetDateTime(index);
+            };
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -15,6 +15,7 @@
 
 using Apache.Arrow.Types;
 using System;
+using System.Collections.Generic;
 
 namespace Apache.Arrow
 {
@@ -23,7 +24,10 @@ namespace Apache.Arrow
     /// stored as the number of milliseconds since the dawn of (UNIX) time, excluding leap seconds, in multiples of
     /// 86400000.
     /// </summary>
-    public class Date64Array: PrimitiveArray<long>
+    public class Date64Array : PrimitiveArray<long>, IReadOnlyList<DateTime?>
+#if NET6_0_OR_GREATER
+        , IReadOnlyList<DateOnly?>
+#endif
     {
         private const long MillisecondsPerDay = 86400000;
 
@@ -39,7 +43,7 @@ namespace Apache.Arrow
         /// </summary>
         public class Builder : DateArrayBuilder<long, Date64Array, Builder>
         {
-            private class DateBuilder: PrimitiveArrayBuilder<long, Date64Array, DateBuilder>
+            private class DateBuilder : PrimitiveArrayBuilder<long, Date64Array, DateBuilder>
             {
                 protected override Date64Array Build(
                     ArrowBuffer valueBuffer, ArrowBuffer nullBitmapBuffer,
@@ -135,6 +139,30 @@ namespace Apache.Arrow
                 ? DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeMilliseconds(value.Value).UtcDateTime)
                 : default(DateOnly?);
         }
+
+        int IReadOnlyCollection<DateOnly?>.Count => Length;
+
+        DateOnly? IReadOnlyList<DateOnly?>.this[int index] => GetDateOnly(index);
+
+        IEnumerator<DateOnly?> IEnumerable<DateOnly?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetDateOnly(index);
+            };
+        }
 #endif
+
+        int IReadOnlyCollection<DateTime?>.Count => Length;
+
+        DateTime? IReadOnlyList<DateTime?>.this[int index] => GetDateTime(index);
+
+        IEnumerator<DateTime?> IEnumerable<DateTime?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetDateTime(index);
+            };
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -14,12 +14,13 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Apache.Arrow
 {
-    public abstract class PrimitiveArray<T> : Array
+    public abstract class PrimitiveArray<T> : Array, IReadOnlyList<T?>
         where T : struct
     {
         protected PrimitiveArray(ArrayData data)
@@ -65,6 +66,25 @@ namespace Apache.Arrow
             }
 
             return list;
+        }
+
+        T? IReadOnlyList<T?>.this[int index] => GetValue(index);
+        int IReadOnlyCollection<T?>.Count => Length;
+
+        IEnumerator<T?> IEnumerable<T?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return IsValid(index) ? Values[index] : null;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return IsValid(index) ? Values[index] : null;
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -68,8 +68,8 @@ namespace Apache.Arrow
             return list;
         }
 
-        T? IReadOnlyList<T?>.this[int index] => GetValue(index);
         int IReadOnlyCollection<T?>.Count => Length;
+        T? IReadOnlyList<T?>.this[int index] => GetValue(index);
 
         IEnumerator<T?> IEnumerable<T?>.GetEnumerator()
         {

--- a/csharp/src/Apache.Arrow/Arrays/StringArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StringArray.cs
@@ -15,13 +15,15 @@
 
 using Apache.Arrow.Types;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Apache.Arrow
 {
-    public class StringArray: BinaryArray
+    public class StringArray: BinaryArray, IReadOnlyList<string>
     {
         public static readonly Encoding DefaultEncoding = Encoding.UTF8;
 
@@ -91,5 +93,19 @@ namespace Apache.Arrow
                     return encoding.GetString(data, bytes.Length);
             }
         }
+
+        int IReadOnlyCollection<string>.Count => Length;
+
+        string IReadOnlyList<string>.this[int index] => GetString(index);
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetString(index);
+            };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<string>)this).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/StringArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StringArray.cs
@@ -17,7 +17,6 @@ using Apache.Arrow.Types;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
@@ -17,7 +17,6 @@ using Apache.Arrow.Types;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Apache.Arrow
 {
@@ -165,7 +164,13 @@ namespace Apache.Arrow
 
         TimeOnly? IReadOnlyList<TimeOnly?>.this[int index] => GetTime(index);
 
-        IEnumerator<TimeOnly?> IEnumerable<TimeOnly?>.GetEnumerator() => Enumerable.Range(0, Length).Select(GetTime).GetEnumerator();
+        IEnumerator<TimeOnly?> IEnumerable<TimeOnly?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetTime(index);
+            };
+        }
 #endif
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
@@ -15,7 +15,9 @@
 
 using Apache.Arrow.Types;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Apache.Arrow
 {
@@ -24,6 +26,9 @@ namespace Apache.Arrow
     /// stored as the number of seconds/ milliseconds (depending on the Time32Type) since midnight.
     /// </summary>
     public class Time32Array : PrimitiveArray<int>
+#if NET6_0_OR_GREATER
+        , IReadOnlyList<TimeOnly?>
+#endif
     {
         /// <summary>
         /// The <see cref="Builder"/> class can be used to fluently build <see cref="Time32Array"/> objects.
@@ -155,6 +160,12 @@ namespace Apache.Arrow
                 _ => throw new InvalidDataException($"Unsupported time unit for Time32Type: {unit}")
             };
         }
+
+        int IReadOnlyCollection<TimeOnly?>.Count => Length;
+
+        TimeOnly? IReadOnlyList<TimeOnly?>.this[int index] => GetTime(index);
+
+        IEnumerator<TimeOnly?> IEnumerable<TimeOnly?>.GetEnumerator() => Enumerable.Range(0, Length).Select(GetTime).GetEnumerator();
 #endif
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -17,7 +17,6 @@ using Apache.Arrow.Types;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Apache.Arrow
 {
@@ -156,7 +155,13 @@ namespace Apache.Arrow
 
         TimeOnly? IReadOnlyList<TimeOnly?>.this[int index] => GetTime(index);
 
-        IEnumerator<TimeOnly?> IEnumerable<TimeOnly?>.GetEnumerator() => Enumerable.Range(0, Length).Select(GetTime).GetEnumerator();
+        IEnumerator<TimeOnly?> IEnumerable<TimeOnly?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetTime(index);
+            };
+        }
 #endif
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -15,7 +15,9 @@
 
 using Apache.Arrow.Types;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Apache.Arrow
 {
@@ -24,6 +26,9 @@ namespace Apache.Arrow
     /// stored as the number of microseconds/nanoseconds (depending on the Time64Type) since midnight.
     /// </summary>
     public class Time64Array : PrimitiveArray<long>
+#if NET6_0_OR_GREATER
+        , IReadOnlyList<TimeOnly?>
+#endif
     {
         /// <summary>
         /// The <see cref="Builder"/> class can be used to fluently build <see cref="Time64Array"/> objects.
@@ -146,6 +151,12 @@ namespace Apache.Arrow
 
             return new TimeOnly(((Time64Type)Data.DataType).Unit.ConvertToTicks(value.Value));
         }
+
+        int IReadOnlyCollection<TimeOnly?>.Count => Length;
+
+        TimeOnly? IReadOnlyList<TimeOnly?>.this[int index] => GetTime(index);
+
+        IEnumerator<TimeOnly?> IEnumerable<TimeOnly?>.GetEnumerator() => Enumerable.Range(0, Length).Select(GetTime).GetEnumerator();
 #endif
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -15,12 +15,13 @@
 
 using Apache.Arrow.Types;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
 namespace Apache.Arrow
 {
-    public class TimestampArray: PrimitiveArray<long>
+    public class TimestampArray : PrimitiveArray<long>, IReadOnlyList<DateTimeOffset?>
     {
         private static readonly DateTimeOffset s_epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
 
@@ -145,5 +146,16 @@ namespace Apache.Arrow
             return GetTimestampUnchecked(index);
         }
 
+        int IReadOnlyCollection<DateTimeOffset?>.Count => Length;
+
+        DateTimeOffset? IReadOnlyList<DateTimeOffset?>.this[int index] => GetTimestamp(index);
+
+        IEnumerator<DateTimeOffset?> IEnumerable<DateTimeOffset?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetTimestamp(index);
+            };
+        }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Numerics;
 using Xunit;
 
@@ -91,6 +93,33 @@ namespace Apache.Arrow.Tests
                     }
                 }
             }
+        }
+
+        [Fact]
+        public void EnumerateArray()
+        {
+            var array = new Int64Array.Builder().Append(1).Append(2).Build();
+
+            foreach(long? foo in (IEnumerable<long?>)array)
+            {
+                Assert.InRange(foo.Value, 1, 2);
+            }
+
+            foreach (object foo in (IEnumerable)array)
+            {
+                Assert.InRange((long)foo, 1, 2);
+            }
+        }
+
+        [Fact]
+        public void ArrayAsReadOnlyList()
+        {
+            Int64Array array = new Int64Array.Builder().Append(1).Append(2).Build();
+            var readOnlyList = (IReadOnlyList<long?>)array;
+
+            Assert.Equal(array.Length, readOnlyList.Count);
+            Assert.Equal(readOnlyList[0], 1);
+            Assert.Equal(readOnlyList[1], 2);
         }
 
 #if NET5_0_OR_GREATER


### PR DESCRIPTION
### What changes are included in this PR?

Make Arrow arrays of scalar type T implement the same semantic contract as IReadOnlyList<T?>.
Note that this PR does not include similar support for ICollection<T?>. I could add that support in this PR or a future PR.

### Are these changes tested?

This PR includes unit tests of the implemented IReadOnlyList<T?> methods.
* Closes: #38348