### PR TITLE
GH-38697: [C++][Gandiva] Use arrow io util to replace std::filesystem::path in gandiva

### DIFF
--- a/cpp/src/gandiva/tests/test_util.cc
+++ b/cpp/src/gandiva/tests/test_util.cc
@@ -32,7 +32,7 @@ std::shared_ptr<Configuration> TestConfiguration() {
 std::string GetTestFunctionLLVMIRPath() {
   const auto base =
       arrow::internal::PlatformFilename::FromString(GANDIVA_EXTENSION_TEST_DIR);
-  DCHECK_OK(base);
+  DCHECK_OK(base.status());
   return base->Join("multiply_by_two.bc")->ToString();
 }
 

--- a/cpp/src/gandiva/tests/test_util.cc
+++ b/cpp/src/gandiva/tests/test_util.cc
@@ -32,7 +32,7 @@ std::shared_ptr<Configuration> TestConfiguration() {
 std::string GetTestFunctionLLVMIRPath() {
   const auto base =
       arrow::internal::PlatformFilename::FromString(GANDIVA_EXTENSION_TEST_DIR);
-  DCHECK(base.ok());
+  DCHECK_OK(base);
   return base->Join("multiply_by_two.bc")->ToString();
 }
 

--- a/cpp/src/gandiva/tests/test_util.cc
+++ b/cpp/src/gandiva/tests/test_util.cc
@@ -17,12 +17,12 @@
 
 #include "gandiva/tests/test_util.h"
 
-#include <filesystem>
+#include "arrow/util/io_util.h"
+#include "arrow/util/logging.h"
 
 namespace gandiva {
 std::shared_ptr<Configuration> TestConfiguration() {
-  auto builder = ConfigurationBuilder();
-  return builder.DefaultConfiguration();
+  return ConfigurationBuilder::DefaultConfiguration();
 }
 
 #ifndef GANDIVA_EXTENSION_TEST_DIR
@@ -30,9 +30,10 @@ std::shared_ptr<Configuration> TestConfiguration() {
 #endif
 
 std::string GetTestFunctionLLVMIRPath() {
-  std::filesystem::path base(GANDIVA_EXTENSION_TEST_DIR);
-  std::filesystem::path ir_file = base / "multiply_by_two.bc";
-  return ir_file.string();
+  const auto base =
+      arrow::internal::PlatformFilename::FromString(GANDIVA_EXTENSION_TEST_DIR);
+  DCHECK(base.ok());
+  return base->Join("multiply_by_two.bc")->ToString();
 }
 
 NativeFunction GetTestExternalFunction() {


### PR DESCRIPTION
### Rationale for this change
AlmaLinux 8 CI reported linker failure when `std::filesystem::path` is used, and This PR tries to it.

### What changes are included in this PR?
Replace `std::filesystem::path` in Gandiva with Arrow's internal io util so that AlmaLinux 8 CI build can work.

### Are these changes tested?
It should be covered by existing tests and CI.

### Are there any user-facing changes?
No
* Closes: #38697