### PR TITLE
GH-38699: [C++][FS][Azure] Implement `CreateDir()`

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -152,6 +152,9 @@ Status StatusFromErrorResponse(const std::string& url,
                                Azure::Core::Http::RawResponse* raw_response,
                                const std::string& context) {
   const auto& body = raw_response->GetBody();
+  // There isn't an Azure specification that response body on error
+  // doesn't contain any binary data but we assume it. We hope that
+  // error response body has useful information for the error.
   std::string_view body_text(reinterpret_cast<const char*>(body.data()), body.size());
   return Status::IOError(context, ": ", url, ": ", raw_response->GetReasonPhrase(), " (",
                          static_cast<int>(raw_response->GetStatusCode()),

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -653,9 +653,9 @@ class AzureFileSystem::Impl {
     ARROW_ASSIGN_OR_RAISE(auto hierarchical_namespace_enabled,
                           hierarchical_namespace_.Enabled(path.container));
     if (!hierarchical_namespace_enabled) {
-      // Without hierarchical namespace enabled Azure blob storage has no directories. 
-      // Therefore we can't, and don't need to create one. Simply creating a blob with `/` in the name
-      // implies directories. 
+      // Without hierarchical namespace enabled Azure blob storage has no directories.
+      // Therefore we can't, and don't need to create one. Simply creating a blob with `/`
+      // in the name implies directories.
       return Status::OK();
     }
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -650,11 +650,9 @@ class AzureFileSystem::Impl {
     ARROW_ASSIGN_OR_RAISE(auto hierarchical_namespace_enabled,
                           hierarchical_namespace_.Enabled(path.container));
     if (!hierarchical_namespace_enabled) {
-      // We can't create a directory without hierarchical namespace
-      // support. There is only "virtual directory" without
-      // hierarchical namespace support. And a "virtual directory" is
-      // (virtually) created a blob with ".../.../blob" blob name
-      // automatically.
+      // Without hierarchical namespace enabled Azure blob storage has no directories. 
+      // Therefore we can't, and don't need to create one. Simply creating a blob with `/` in the name
+      // implies directories. 
       return Status::OK();
     }
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -704,23 +704,15 @@ class AzureFileSystem::Impl {
       return Status::OK();
     }
 
-    std::string current_path;
-    for (const auto& part : path.path_to_file_parts) {
-      if (!current_path.empty()) {
-        current_path += internal::kSep;
-      }
-      current_path += part;
-      auto directory_client =
-          datalake_service_client_->GetFileSystemClient(path.container)
-              .GetDirectoryClient(current_path);
-      try {
-        directory_client.CreateIfNotExists();
-      } catch (const Azure::Storage::StorageException& exception) {
-        return internal::ExceptionToStatus(
-            "Failed to create a directory: " + current_path + " (" +
-                directory_client.GetUrl() + ")",
-            exception);
-      }
+    auto directory_client = datalake_service_client_->GetFileSystemClient(path.container)
+                                .GetDirectoryClient(path.path_to_file);
+    try {
+      directory_client.CreateIfNotExists();
+    } catch (const Azure::Storage::StorageException& exception) {
+      return internal::ExceptionToStatus(
+          "Failed to create a directory: " + path.path_to_file + " (" +
+              directory_client.GetUrl() + ")",
+          exception);
     }
 
     return Status::OK();

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -411,10 +411,12 @@ TEST_F(AzuriteFileSystemTest, CreateDirSuccessContainerOnly) {
   arrow::fs::AssertFileInfo(fs_.get(), container_name, FileType::Directory);
 }
 
-TEST_F(AzuriteFileSystemTest, CreateDirFailureContainerAndDirectory) {
+TEST_F(AzuriteFileSystemTest, CreateDirSuccessContainerAndDirectory) {
   const auto path = PreexistingContainerPath() + RandomDirectoryName();
-  // Can't create a directory without hierarchical namespace support.
-  ASSERT_RAISES(NotImplemented, fs_->CreateDir(path, false));
+  ASSERT_OK(fs_->CreateDir(path, false));
+  // There is only virtual directory without hierarchical namespace
+  // support. So the CreateDir() does nothing.
+  arrow::fs::AssertFileInfo(fs_.get(), path, FileType::NotFound);
 }
 
 TEST_F(AzureHierarchicalNamespaceFileSystemTest, CreateDirSuccessContainerAndDirectory) {
@@ -438,9 +440,10 @@ TEST_F(AzureHierarchicalNamespaceFileSystemTest, CreateDirRecursiveSuccessContai
   arrow::fs::AssertFileInfo(fs_.get(), container_name, FileType::Directory);
 }
 
-TEST_F(AzuriteFileSystemTest, CreateDirRecursiveFailureContainerOnly) {
+TEST_F(AzuriteFileSystemTest, CreateDirRecursiveSuccessContainerOnly) {
   auto container_name = RandomContainerName();
-  ASSERT_RAISES(NotImplemented, fs_->CreateDir(container_name, true));
+  ASSERT_OK(fs_->CreateDir(container_name, true));
+  arrow::fs::AssertFileInfo(fs_.get(), container_name, FileType::Directory);
 }
 
 TEST_F(AzureHierarchicalNamespaceFileSystemTest, CreateDirRecursiveSuccessDirectoryOnly) {
@@ -451,10 +454,14 @@ TEST_F(AzureHierarchicalNamespaceFileSystemTest, CreateDirRecursiveSuccessDirect
   arrow::fs::AssertFileInfo(fs_.get(), parent, FileType::Directory);
 }
 
-TEST_F(AzuriteFileSystemTest, CreateDirRecursiveFailureDirectoryOnly) {
+TEST_F(AzuriteFileSystemTest, CreateDirRecursiveSuccessDirectoryOnly) {
   const auto parent = PreexistingContainerPath() + RandomDirectoryName();
   const auto path = internal::ConcatAbstractPath(parent, "new-sub");
-  ASSERT_RAISES(NotImplemented, fs_->CreateDir(path, true));
+  ASSERT_OK(fs_->CreateDir(path, true));
+  // There is only virtual directory without hierarchical namespace
+  // support. So the CreateDir() does nothing.
+  arrow::fs::AssertFileInfo(fs_.get(), path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), parent, FileType::NotFound);
 }
 
 TEST_F(AzureHierarchicalNamespaceFileSystemTest,
@@ -468,11 +475,16 @@ TEST_F(AzureHierarchicalNamespaceFileSystemTest,
   arrow::fs::AssertFileInfo(fs_.get(), container_name, FileType::Directory);
 }
 
-TEST_F(AzuriteFileSystemTest, CreateDirRecursiveFailureContainerAndDirectory) {
+TEST_F(AzuriteFileSystemTest, CreateDirRecursiveSuccessContainerAndDirectory) {
   auto container_name = RandomContainerName();
   const auto parent = internal::ConcatAbstractPath(container_name, RandomDirectoryName());
   const auto path = internal::ConcatAbstractPath(parent, "new-sub");
-  ASSERT_RAISES(NotImplemented, fs_->CreateDir(path, true));
+  ASSERT_OK(fs_->CreateDir(path, true));
+  // There is only virtual directory without hierarchical namespace
+  // support. So the CreateDir() does nothing.
+  arrow::fs::AssertFileInfo(fs_.get(), path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), parent, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), container_name, FileType::Directory);
 }
 
 TEST_F(AzuriteFileSystemTest, CreateDirUri) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -272,6 +272,22 @@ class AzureFlatNamespaceFileSystemTest : public AzureFileSystemTest {
   }
 };
 
+// How to enable this test:
+//
+// You need an Azure account. You should be able to create a free
+// account at https://azure.microsoft.com/en-gb/free/ . You should be
+// able to create a storage account through the portal Web UI.
+//
+// See also the official document how to create a storage account:
+// https://learn.microsoft.com/en-us/azure/storage/blobs/create-data-lake-storage-account
+//
+// A few suggestions on configuration:
+//
+// * Use Standard general-purpose v2 not premium
+// * Use LRS redundancy
+// * Obviously you need to enable hierarchical namespace.
+// * Set the default access tier to hot
+// * SFTP, NFS and file shares are not required.
 class AzureHierarchicalNamespaceFileSystemTest : public AzureFileSystemTest {
   Result<AzureOptions> MakeOptions() override {
     AzureOptions options;


### PR DESCRIPTION
### Rationale for this change

It seems that we can't create a directory explicitly without hierarchical namespace support.

It seems that Azure Blob Storage supports only virtual directory. There is no directory. If a file (blob) name has "/", it's treated that the file (blob) exists under a virtual directory.

It seems that Azure Data Lake Storage Gen2 supports a real directory.

See also:
https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction

### What changes are included in this PR?

This change chooses the following behavior:

* Container can be created with/without hierarchical namespace support.
* Directory can be created with hierarchical namespace support.
* Directory can't be created without hierarchical namespace support. So do nothing without hierachical namespace support. (`arrow::Status::OK()` is just returned.)

### Are these changes tested?

Azurite doesn't support hierarchical namespace yet. So I can't test the implementation for hierarchical namespace yet. Sorry.

### Are there any user-facing changes?

Yes.
* Closes: #38699