### PR TITLE
MINOR: [Python] Fix name of new keyword in the concat_tables future warning

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5226,7 +5226,8 @@ def concat_tables(tables, MemoryPool memory_pool=None, str promote_options="none
 
     if "promote" in kwargs:
         warnings.warn(
-            "promote has been superseded by mode='default'.", FutureWarning, stacklevel=2)
+            "promote has been superseded by promote_options='default'.",
+            FutureWarning, stacklevel=2)
         if kwargs['promote'] is True:
             promote_options = "default"
 


### PR DESCRIPTION
We renamed the new keyword in a final iteration of the PR, but apparently forgot to update the warning message.