### PR TITLE
GH-38712: [Python] Remove dead code in _reconstruct_block

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -721,9 +721,6 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
         block = _int.make_block(block_arr, placement=placement,
                                 klass=_int.DatetimeTZBlock,
                                 dtype=dtype)
-    elif 'object' in item:
-        block = _int.make_block(pickle.loads(block_arr),
-                                placement=placement)
     elif 'py_array' in item:
         # create ExtensionBlock
         arr = item['py_array']

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -26,7 +26,6 @@ from copy import deepcopy
 from itertools import zip_longest
 import json
 import operator
-import pickle
 import re
 import warnings
 


### PR DESCRIPTION
### Rationale for this change

It seems the object case in `_reconstruct_block` is a dead code and is not needed anymore so therefore could be removed.

### What changes are included in this PR?

Removal of the object case in `_reconstruct_block` code. Was also looking at the `arrow_to_pandas.cc` code to see if there is any dead code present and I couldn't find any. 

### Are these changes tested?

The change in this PR should not make any of the existing tests fail.

### Are there any user-facing changes?

There shouldn't be.
* Closes: #38712