### PR TITLE
GH-38715: [R] Fix possible bashism in configure script

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -126,7 +126,7 @@ fi
 # but doing it now allows us to catch it in
 # nixlibs.R and activate S3 and GCS support for the source build.
 
-# macOS ships with libressl. openssl is installable with brew, but it is 
+# macOS ships with libressl. openssl is installable with brew, but it is
 # generally not linked. We can over-ride this and find
 # openssl by setting OPENSSL_ROOT_DIR (which cmake will pick up later in
 # the installation process).
@@ -135,7 +135,7 @@ if [ "${OPENSSL_ROOT_DIR}" = "" ] && brew --prefix openssl >/dev/null 2>&1; then
   export PKG_CONFIG_PATH="${OPENSSL_ROOT_DIR}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 fi
 # Look for openssl with pkg-config for non-brew sources(e.g. CRAN) and Linux
-if [ "${OPENSSL_ROOT_DIR}" = "" -a "${PKG_CONFIG_AVAILABLE}" = "true" ]; then
+if [ "${OPENSSL_ROOT_DIR}" = "" ] && [ "${PKG_CONFIG_AVAILABLE}" = "true" ]; then
   if ${PKG_CONFIG} --exists openssl; then
     export OPENSSL_ROOT_DIR="`${PKG_CONFIG} --variable=prefix openssl`"
   fi
@@ -282,7 +282,7 @@ set_pkg_vars () {
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
 
-  # We use expr because the product version returns more than just 10.13 and we want to 
+  # We use expr because the product version returns more than just 10.13 and we want to
   # match the substring. However, expr always outputs the number of matched characters
   # to stdout, to avoid noise in the log we redirect the output to /dev/null
   if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then


### PR DESCRIPTION

### Rationale for this change

The CRAN incoming check for 14.0.0 is failing with a NOTE about a possible bashism

### What changes are included in this PR?

One `test -a` usage was replaced with `&&`.

### Are these changes tested?

Yes (via crossbow, below)

### Are there any user-facing changes?

No
* Closes: #38715