### PR TITLE
MINOR: [C++][Docs] Add \deprecated tag to deprecated BufferReader constructor

### DIFF
--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -159,6 +159,8 @@ class ARROW_EXPORT BufferReader
   BufferReader(const uint8_t* data, int64_t size);
 
   /// \brief Instantiate from std::string_view. Does not own data
+  /// \deprecated Deprecated in 14.0.0. Use FromString or
+  /// BufferReader(std::shared_ptr<Buffer> buffer) instead.
   ARROW_DEPRECATED(
       "Deprecated in 14.0.0. Use FromString or BufferReader(std::shared_ptr<Buffer> "
       "buffer) instead.")


### PR DESCRIPTION
### Rationale for this change

The PR [GH-37360](https://github.com/apache/arrow/pull/37360) for issue [GH-37212](https://github.com/apache/arrow/issues/37212) deprecated three BufferReader constructors and I noticed one of them was missing a `\deprecated` command.

### What changes are included in this PR?

This adds a `\deprecated` command one of the deprecated constructors with a message. The other two didn't need it because they weren't already documented. i.e., they weren't listed under https://arrow.apache.org/docs/cpp/api/io.html so documenting them at this point just to add `\deprecated` wouldn't make sense.

### Are these changes tested?

No, this is a simple docs change.

### Are there any user-facing changes?

Yes, this adds a notice to the docs for this particular method.