### PR TITLE
GH-38745: [Integration] Fix huge integration test

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1520,8 +1520,7 @@ def generate_decimal128_case():
         for i, precision in enumerate(range(3, 39))
     ]
 
-    possible_batch_sizes = 7, 10
-    batch_sizes = [possible_batch_sizes[i % 2] for i in range(len(fields))]
+    batch_sizes = [7, 10]
     # 'decimal' is the original name for the test, and it must match
     # provide "gold" files that test backwards compatibility, so they
     # can be appropriately skipped.
@@ -1535,8 +1534,7 @@ def generate_decimal256_case():
         for i, precision in enumerate(range(37, 70))
     ]
 
-    possible_batch_sizes = 7, 10
-    batch_sizes = [possible_batch_sizes[i % 2] for i in range(len(fields))]
+    batch_sizes = [7, 10]
     return _generate_file('decimal256', fields, batch_sizes)
 
 


### PR DESCRIPTION
### Rationale for this change

For some reason, the decimal files generated by the integration test suite have as many record batches as columns.
This looks like a programming error rather than something deliberate.

### What changes are included in this PR?

Use similar batch sizes as for other test files.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* Closes: #38745