### PR TITLE
GH-38752: [R] Wrap rosetta detection in tryCatch

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -212,7 +212,7 @@ configure_tzdb <- function() {
         )
       )
     }
-  })
+  }, silent = TRUE)
 }
 
 # Clean up the StopSource that was registered in .onLoad() so that if the

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -271,6 +271,12 @@ wslify_path <- function(path) {
 
 on_rosetta <- function() {
   # make sure to suppress warnings and ignore the stderr so that this is silent where proc_translated doesn't exist
-  identical(tolower(Sys.info()[["sysname"]]), "darwin") &&
-    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)), "1")
+  sysctl_out <- tryCatch(
+    suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)),
+    error = function(e) {
+      # If this has errored, we assume that this is not on rosetta
+      return("0")
+    }
+  )
+  identical(tolower(Sys.info()[["sysname"]]), "darwin") && identical(sysctl_out, "1")
 }

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -271,6 +271,13 @@ wslify_path <- function(path) {
 
 on_rosetta <- function() {
   # make sure to suppress warnings and ignore the stderr so that this is silent where proc_translated doesn't exist
+  sysctl_out <- tryCatch(
+    suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)),
+    error = function(e) {
+      # If this has errored, we assume that this is not on rosetta
+      return("0")
+    }
+  )
   identical(tolower(Sys.info()[["sysname"]]), "darwin") &&
-    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)), "1")
+    identical(sysctl_out, "1")
 }

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -271,13 +271,6 @@ wslify_path <- function(path) {
 
 on_rosetta <- function() {
   # make sure to suppress warnings and ignore the stderr so that this is silent where proc_translated doesn't exist
-  sysctl_out <- tryCatch(
-    suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)),
-    error = function(e) {
-      # If this has errored, we assume that this is not on rosetta
-      return("0")
-    }
-  )
   identical(tolower(Sys.info()[["sysname"]]), "darwin") &&
-    identical(sysctl_out, "1")
+    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE), "1"))
 }

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -272,5 +272,5 @@ wslify_path <- function(path) {
 on_rosetta <- function() {
   # make sure to suppress warnings and ignore the stderr so that this is silent where proc_translated doesn't exist
   identical(tolower(Sys.info()[["sysname"]]), "darwin") &&
-    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE), "1"))
+    identical(suppressWarnings(system("sysctl -n sysctl.proc_translated", intern = TRUE, ignore.stderr = TRUE)), "1")
 }


### PR DESCRIPTION
### Rationale for this change

We should never allow rosetta checking from causing an error

### What changes are included in this PR?

~Wrap rosetta checking in a tryCatch~ our use of `try()` wasn't doing what we thought, it actually needs to have `silent = TRUE` specified to _not_ error.

### Are these changes tested?

I tested them locally by manipulating the system call to a mangled command that doesn't exist, observing the error on load, then wrapping in trycatch. We might consider adding a test in CI, though there would be considerable complexity for something like that

### Are there any user-facing changes?

No, though we will need to pull it into any point release
* Closes: #38752