### PR TITLE
GH-38709: [C++] Protect against PREALLOCATE preprocessor defined on macOS

### DIFF
--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -37,8 +37,9 @@
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
-// MacOSX defines PREALLOCATE as a preprocessor define in the header sys/vnode.h
-// No other BSD seems to do so.  The name is used as an identifier in MemAllocation enum
+
+// macOS defines PREALLOCATE as a preprocessor macro in the header sys/vnode.h.
+// No other BSD seems to do so. The name is used as an identifier in MemAllocation enum.
 #if defined(__APPLE__) && defined(PREALLOCATE)
 # undef PREALLOCATE 
 #endif  

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -41,8 +41,8 @@
 // macOS defines PREALLOCATE as a preprocessor macro in the header sys/vnode.h.
 // No other BSD seems to do so. The name is used as an identifier in MemAllocation enum.
 #if defined(__APPLE__) && defined(PREALLOCATE)
-# undef PREALLOCATE 
-#endif  
+#undef PREALLOCATE
+#endif
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -39,7 +39,7 @@
 #include "arrow/util/visibility.h"
 // MacOSX defines PREALLOCATE as a preprocessor define in the header sys/vnode.h
 // No other BSD seems to do so.  The name is used as an identifier in MemAllocation enum
-#if defined(__APPLE__) and defined(PREALLOCATE)
+#if defined(__APPLE__) && defined(PREALLOCATE)
 # undef PREALLOCATE 
 #endif  
 

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -37,6 +37,11 @@
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
+// MacOSX defines PREALLOCATE as a preprocessor define in the header sys/vnode.h
+// No other BSD seems to do so.  The name is used as an identifier in MemAllocation enum
+#if defined(__APPLE__) and defined(PREALLOCATE)
+# undef PREALLOCATE 
+#endif  
 
 namespace arrow {
 namespace compute {


### PR DESCRIPTION
### Rationale for this change

The macOS header `sys/vnode.h` defines `PREALLOCATE` as a preprocessor macro, which causes a conflict in `arrow/compute/kernel.h` where the same name is defined as an identifier. 

Other BSDs does not seem to define this macro. 

### What changes are included in this PR?

`#undef PREALLOCATE` on macOS and if defined. 

### Are these changes tested?

Somewhat, in a different context. 

### Are there any user-facing changes?

If some code specific to macOS actually uses the `PREALLOCATE` macro, then that code may have problems.  However, it is unlikely that any user code would use this macro as it seems to be intended for internal use in the BSD kernel of macOS. 

* Closes: #38709