### PR TITLE
GH-38762: [R] Bump rtools/R version in CI

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -242,8 +242,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 42, rversion: "4.2" }
-        - { rtools: 42, rversion: "devel" }
+        - { rtools: 43, rversion: "4.3" }
+        - { rtools: 43, rversion: "devel" }
     env:
       ARROW_R_CXXFLAGS: "-Werror"
       _R_CHECK_TESTS_NLINES_: 0

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -193,7 +193,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 40, arch: 'ucrt64' }
+        - { rtools: 43, arch: 'ucrt64' }
     steps:
       - run: git config --global core.autocrlf false
       - name: Checkout Arrow
@@ -215,8 +215,8 @@ jobs:
             r-${{ matrix.config.rtools }}-ccache-mingw-${{ matrix.config.arch }}-
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.1"
-          rtools-version: 40
+          r-version: "4.3"
+          rtools-version: 43
           Ncpus: 2
       - name: Build Arrow C++
         shell: bash
@@ -255,10 +255,10 @@ jobs:
           fetch-depth: 0
       - run: mkdir r/windows
       - name: Download artifacts
-        if: ${{ matrix.config.rtools == 42 }}
+        if: ${{ matrix.config.rtools == 43 }}
         uses: actions/download-artifact@v3
         with:
-          name: libarrow-rtools40-ucrt64.zip
+          name: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
           path: r/windows
       - name: Unzip and rezip libarrows
         shell: bash

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -258,8 +258,8 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          # Built with rtools40-ucrt...unrelated to the rtools version here
-          name: libarrow-rtools40-ucrt.zip
+          # Built with rtools40-ucrt64...unrelated to the rtools version here
+          name: libarrow-rtools40-ucrt64.zip
           path: r/windows
       - name: Unzip and rezip libarrows
         shell: bash

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -215,8 +215,9 @@ jobs:
             r-${{ matrix.config.rtools }}-ccache-mingw-${{ matrix.config.arch }}-
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.3"
-          rtools-version: 43
+          # We need RTools40 because our build script does not work with RTools42 or 43.
+          r-version: "4.2"
+          rtools-version: 40
           Ncpus: 2
       - name: Build Arrow C++
         shell: bash
@@ -255,10 +256,10 @@ jobs:
           fetch-depth: 0
       - run: mkdir r/windows
       - name: Download artifacts
-        if: ${{ matrix.config.rtools == 43 }}
         uses: actions/download-artifact@v3
         with:
-          name: libarrow-rtools${{ matrix.config.rtools }}-${{ matrix.config.arch }}.zip
+          # Built with rtools40-ucrt...unrelated to the rtools version here
+          name: libarrow-rtools40-ucrt.zip
           path: r/windows
       - name: Unzip and rezip libarrows
         shell: bash

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -193,7 +193,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 43, arch: 'ucrt64' }
+        # We need RTools40 because our build script does not work with RTools42 or 43.
+        - { rtools: 40, arch: 'ucrt64', rversion: "4.2" }
     steps:
       - run: git config --global core.autocrlf false
       - name: Checkout Arrow
@@ -215,9 +216,8 @@ jobs:
             r-${{ matrix.config.rtools }}-ccache-mingw-${{ matrix.config.arch }}-
       - uses: r-lib/actions/setup-r@v2
         with:
-          # We need RTools40 because our build script does not work with RTools42 or 43.
-          r-version: "4.2"
-          rtools-version: 40
+          r-version: ${{ matrix.config.rversion }}
+          rtools-version: ${{ matrix.config.rtools }}
           Ncpus: 2
       - name: Build Arrow C++
         shell: bash

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -31,9 +31,6 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
 pacman --noconfirm -Syy
 RWINLIB_LIB_DIR="lib"
-: ${MINGW_ARCH:="mingw32 mingw64 ucrt64"}
-
-export MINGW_ARCH
 
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
 printenv

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -36,7 +36,11 @@ RWINLIB_LIB_DIR="lib"
 export MINGW_ARCH
 
 # Needs to depend on RTools version, just checking if this helps for now
-export PATH="/c/rtools42/usr/bin:/c/rtools43/x86_64-w64-mingw32.static.posix/bin:$PATH"
+export PATH="/c/rtools43/usr/bin:/c/rtools43/x86_64-w64-mingw32.static.posix/bin:$PATH"
+
+which strip
+which gcc
+gcc --version
 
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
 printenv

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -35,13 +35,6 @@ RWINLIB_LIB_DIR="lib"
 
 export MINGW_ARCH
 
-# Needs to depend on RTools version, just checking if this helps for now
-export PATH="/c/rtools43/usr/bin:/c/rtools43/x86_64-w64-mingw32.static.posix/bin:$PATH"
-
-which strip
-which gcc
-gcc --version
-
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
 printenv
 makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --cleanbuild

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -31,6 +31,12 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
 pacman --noconfirm -Syy
 RWINLIB_LIB_DIR="lib"
+: ${MINGW_ARCH:="mingw32 mingw64 ucrt64"}
+
+export MINGW_ARCH
+
+# Needs to depend on RTools version, just checking if this helps for now
+export PATH="/c/rtools42/usr/bin:/c/rtools43/x86_64-w64-mingw32.static.posix/bin:$PATH"
 
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
 printenv

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -362,8 +362,8 @@ on:
   {# use filter to cast to string and convert to lowercase to match yaml boolean #}
   {% set is_fork = (not is_upstream_b)|lower %}
 
-{% set r_release = {"ver": "4.2", "rt" : "42"} %}
-{% set r_oldrel = {"ver": "4.1", "rt" : "40"} %}
+{% set r_release = {"ver": "4.3", "rt" : "43"} %}
+{% set r_oldrel = {"ver": "4.2", "rt" : "42"} %}
 
 {%- macro github_set_env(env) -%}
   {% if env is defined %}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -153,7 +153,7 @@ jobs:
           PKG_FILE: arrow-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
           VERSION: {{ '${{ needs.source.outputs.pkg_version }}' }}
         run: |
-          # These files were created by the docker user so we have to chown them 
+          # These files were created by the docker user so we have to chown them
           sudo chown -R $USER:$USER arrow/r/libarrow
 
           cd arrow/r/libarrow/dist
@@ -204,34 +204,35 @@ jobs:
 
   r-packages:
     needs: [source, windows-cpp, macos-cpp]
-    name: {{ '${{ matrix.platform.name }} ${{ matrix.r_version.r }}' }}
-    runs-on: {{ '${{ matrix.platform.runs_on }}' }}
+    name: {{ '${{ matrix.config.name }} ${{ matrix.config.r_version.r }}' }}
+    runs-on: {{ '${{ matrix.config.runs_on }}' }}
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - { runs_on: 'windows-latest', name: "Windows"}
-          - { runs_on: ["self-hosted", "macos-10.13"], name: "macOS High Sierra"}
-          - { runs_on: ["self-hosted", "macOS", "arm64", "devops-managed"], name: "macOS Big Sur" }
-        r_version:
-          - { rtools: "{{ macros.r_release.rt }}", r: "{{ macros.r_release.ver }}" }
-          - { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
+        config:
+          - { runs_on: 'windows-latest', name: "Windows", r_version: { rtools: "{{ macros.r_release.rt }}", r: "{{ macros.r_release.ver }}" } },
+          - { runs_on: 'windows-latest', name: "Windows", r_version: { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" } },
+          # While R 4.2 is still oldrel
+          - { runs_on: ["self-hosted", "macos-10.13"], name: "macOS High Sierra", r_version: { r: "{{ macros.r_oldrel.ver }}" } }
+          - { runs_on: ["self-hosted", "macOS", "arm64", "devops-managed"], name: "macOS Big Sur", r_version: { r: "{{ macros.r_release.ver }}" } }
+          - { runs_on: ["self-hosted", "macOS", "arm64", "devops-managed"], name: "macOS Big Sur", r_version: { r: "{{ macros.r_oldrel.ver }}" } }
+
     steps:
       - uses: r-lib/actions/setup-r@v2
         # expression marker prevents the ! being parsed as yaml tag
-        if: {{ "${{ !contains(matrix.platform.runs_on, 'self-hosted') }}" }}
+        if: {{ "${{ !contains(matrix.config.runs_on, 'self-hosted') }}" }}
         with:
-          r-version: {{ '${{ matrix.r_version.r }}' }}
-          rtools-version: {{ '${{ matrix.r_version.rtools }}' }}
+          r-version: {{ '${{ matrix.config.r_version.r }}' }}
+          rtools-version: {{ '${{ matrix.config.r_version.rtools }}' }}
       - name: Setup R Self-Hosted
-        if: contains(matrix.platform.runs_on, 'self-hosted')
+        if: contains(matrix.config.runs_on, 'self-hosted')
         run: |
-          if [ "{{ "${{ contains(matrix.platform.runs_on, 'arm64') }}" }}" == "true" ]; then
+          if [ "{{ "${{ contains(matrix.config.runs_on, 'arm64') }}" }}" == "true" ]; then
             rig_arch="-arm64"
           fi
           # rig is a system utility that allows for switching
           # between pre-installed R version on the self-hosted runners
-          rig default {{ '${{ matrix.r_version.r }}' }}$rig_arch
+          rig default {{ '${{ matrix.config.r_version.r }}' }}$rig_arch
 
           rig system setup-user-lib
           rig system add-pak
@@ -246,7 +247,7 @@ jobs:
            working-directory: 'arrow'
            extra-packages: cpp11
       - name: Set CRAN like openssl
-        if: contains(matrix.platform.runs_on, 'arm64')
+        if: contains(matrix.config.runs_on, 'arm64')
         run: |
           # The arm64 runners contain openssl 1.1.1t in this path that is always included first so we need to override the
           # default setting of the brew --prefix as root dir to avoid version conflicts.


### PR DESCRIPTION

### Rationale for this change

The versions of Rtools and R in the CI config are no longer current

### What changes are included in this PR?

The versions are bumped: r-release is now 4.3 and both r-release and r-devel use Rtools43.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #38762