### PR TITLE
GH-38764: [Java] Clarify warning about `--add-opens=java.base/java.nio=ALL-UNNAMED`

### DIFF
--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -141,8 +141,8 @@ public class MemoryUtil {
       // This exception will get swallowed, but it's necessary for the static analysis that ensures
       // the static fields above get initialized
       final RuntimeException failure = new RuntimeException(
-          "Failed to initialize MemoryUtil. Was Java started with " +
-              "`--add-opens=java.base/java.nio=ALL-UNNAMED`? " +
+          "Failed to initialize MemoryUtil. You must start Java with " +
+              "`--add-opens=java.base/java.nio=ALL-UNNAMED` " +
               "(See https://arrow.apache.org/docs/java/install.html)", e);
       failure.printStackTrace();
       throw failure;


### PR DESCRIPTION
### Rationale for this change

When someone encounters this message, it's precisely because they did *not* include `--add-opens=java.base/java.nio=ALL-UNNAMED`, but in order for arrow to work, they will need to add it.

#38764

### What changes are included in this PR?

Changes `with` to `without`

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

The error message when arrow is run on a modern JVM will change from `with` to `without`:
> java.lang.RuntimeException: Failed to initialize MemoryUtil. Was Java started without `--add-opens=java.base/java.nio=ALL-UNNAMED`? (See https://arrow.apache.org/docs/java/install.html)

* Closes: #38764