### PR TITLE
GH-38766: [R] Add timeout option to try_download

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -79,6 +79,10 @@ find_latest_nightly <- function(description_version,
 }
 
 try_download <- function(from_url, to_file, hush = quietly) {
+  # We download some fairly large files, so ensure the timeout is set appropriately
+  opts <- options(timeout = max(300, getOption("timeout")))
+  on.exit(options(opts))
+
   status <- try(
     suppressWarnings(
       download.file(from_url, to_file, quiet = hush)

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -79,8 +79,10 @@ find_latest_nightly <- function(description_version,
 }
 
 try_download <- function(from_url, to_file, hush = quietly) {
-  # We download some fairly large files, so ensure the timeout is set appropriately
-  opts <- options(timeout = max(300, getOption("timeout")))
+  # We download some fairly large files, so ensure the timeout is set appropriately.
+  # This assumes a static library size of 100 MB (generous) and a download speed
+  # of 1 MB/s (slow).
+  opts <- options(timeout = max(100, getOption("timeout")))
   on.exit(options(opts))
 
   status <- try(

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -87,7 +87,7 @@ try_download <- function(from_url, to_file, hush = quietly) {
 
   status <- try(
     suppressWarnings(
-      download.file(from_url, to_file, quiet = hush)
+      download.file(from_url, to_file, quiet = hush, mode = "wb")
     ),
     silent = hush
   )


### PR DESCRIPTION
### Rationale for this change

The download of static libraries during installation might be causing an install failure: https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/arrow-00install.html

### What changes are included in this PR?

The timeout value is temporarily increased according to guidance in the help for `download.file()`

### Are these changes tested?

Yes, this code runs during install for at least some CI jobs (also used to download cmake)

### Are there any user-facing changes?

No
* Closes: #38766