### PR TITLE
GH-38333: [C++][FS][Azure] Implement file writes

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -629,7 +629,7 @@ class ObjectAppendStream final : public io::OutputStream {
                   std::shared_ptr<Buffer> owned_buffer = nullptr) {
     RETURN_NOT_OK(CheckClosed("append"));
     auto append_data = reinterpret_cast<const uint8_t*>(data);
-    auto block_content = Azure::Core::IO::MemoryBodyStream(append_data, nbytes);
+    Azure::Core::IO::MemoryBodyStream block_content(append_data, nbytes);
     if (block_content.Length() == 0) {
       return Status::OK();
     }
@@ -639,7 +639,7 @@ class ObjectAppendStream final : public io::OutputStream {
     // New block ID must always be distinct from the existing block IDs. Otherwise we
     // will accidentally replace the content of existing blocks, causing corruption.
     // We will use monotonically increasing integers.
-    std::string new_block_id = std::to_string(n_block_ids);
+    auto new_block_id = std::to_string(n_block_ids);
 
     // Pad to 5 digits, because Azure allows a maximum of 50,000 blocks.
     const size_t target_number_of_digits = 5;

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -554,7 +554,6 @@ class ObjectAppendStream final : public io::OutputStream {
     } else {
       try {
         auto properties = block_blob_client_->GetProperties();
-        // TODO: Consider adding a check for whether its a directory.
         content_length_ = properties.Value.BlobSize;
         pos_ = content_length_;
       } catch (const Azure::Storage::StorageException& exception) {
@@ -949,7 +948,8 @@ class AzureFileSystem::Impl {
       const AzureLocation& location,
       const std::shared_ptr<const KeyValueMetadata>& metadata, const bool truncate,
       AzureFileSystem* fs) {
-    // TODO: Ensure cheap checks which don't require a call to Azure are done.
+    RETURN_NOT_OK(ValidateFileLocation(location));
+    ARROW_RETURN_NOT_OK(internal::AssertNoTrailingSlash(location.path));
     if (location.empty() || location.path.empty()) {
       return ::arrow::fs::internal::PathNotFound(location.path);
     }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -646,10 +646,10 @@ class ObjectAppendStream final : public io::OutputStream {
     const auto required_padding_digits =
         target_number_of_digits - std::min(target_number_of_digits, new_block_id.size());
     new_block_id.insert(0, required_padding_digits, '0');
-    // There is a small risk when appending to a blob created by another client that 
-    // `new_block_id` may overlapping with an existing block id. Adding the `-arrow` 
-    // suffix significantly reduces the risk, but does not 100% eliminate it. For example 
-    // if the blob was previously created with one block, with id `00001-arrow` then the 
+    // There is a small risk when appending to a blob created by another client that
+    // `new_block_id` may overlapping with an existing block id. Adding the `-arrow`
+    // suffix significantly reduces the risk, but does not 100% eliminate it. For example
+    // if the blob was previously created with one block, with id `00001-arrow` then the
     // next block we append will conflict with that, and cause corruption.
     new_block_id += "-arrow";
     new_block_id = Azure::Core::Convert::Base64Encode(

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -881,9 +881,9 @@ class AzureFileSystem::Impl {
     return Status::OK();
   }
   
-  Result<std::shared_ptr<ObjectAppendStream>> OpenOutputStream(
+  Result<std::shared_ptr<ObjectAppendStream>> OpenAppendStream(
       const std::string& s, const std::shared_ptr<const KeyValueMetadata>& metadata,
-      AzureFileSystem* fs) {
+      const bool truncate, AzureFileSystem* fs) {
     ARROW_ASSIGN_OR_RAISE(auto path, AzurePath::FromString(s));
 
     // TODO: Ensure cheap checks which don't require a call to Azure are done.
@@ -895,78 +895,18 @@ class AzureFileSystem::Impl {
         blob_service_client_->GetBlobContainerClient(path.container)
             .GetBlockBlobClient(path.path_to_file));
 
-    auto ptr = std::make_shared<ObjectAppendStream>(block_blob_client, fs->io_context(),
-                                                    path, metadata);
+    std::shared_ptr<ObjectAppendStream> ptr;
+    if (truncate) {
+      RETURN_NOT_OK(CreateEmptyBlockBlob(block_blob_client));
+      ptr = std::make_shared<ObjectAppendStream>(block_blob_client, fs->io_context(),
+                                                 path, metadata, 0);
+    } else {
+      ptr = std::make_shared<ObjectAppendStream>(block_blob_client, fs->io_context(),
+                                                 path, metadata);
+    }
     RETURN_NOT_OK(ptr->Init());
     return ptr;
   }
-
-  // Result<std::shared_ptr<ObjectAppendStream>> OpenAppendStream(
-  //     const std::string& s, const std::shared_ptr<const KeyValueMetadata>& metadata,
-  //     AzureBlobFileSystem* fs) {
-  //   ARROW_ASSIGN_OR_RAISE(auto path, AzurePath::FromString(s));
-
-  //   if (path.empty() || path.path_to_file.empty()) {
-  //     return ::arrow::fs::internal::PathNotFound(path.full_path);
-  //   }
-  //   std::string endpoint_url = dfs_endpoint_url_;
-  //   if (!is_hierarchical_namespace_enabled_) {
-  //     if (path.path_to_file_parts.size() > 1) {
-  //       return Status::IOError(
-  //           "Invalid Azure Blob Storage path provided,"
-  //           " hierarchical namespace not enabled in storage account");
-  //     }
-  //     endpoint_url = blob_endpoint_url_;
-  //   }
-  //   ARROW_ASSIGN_OR_RAISE(auto response, DirExists(dfs_endpoint_url_ +
-  //   path.full_path)); if (response) {
-  //     return ::arrow::fs::internal::PathNotFound(path.full_path);
-  //   }
-  //   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakePathClient> path_client;
-  //   ARROW_ASSIGN_OR_RAISE(
-  //       path_client,
-  //       InitPathClient<Azure::Storage::Files::DataLake::DataLakePathClient>(
-  //           options_, endpoint_url + path.full_path, path.container,
-  //           path.path_to_file));
-
-  //   std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeFileClient> file_client;
-  //   ARROW_ASSIGN_OR_RAISE(
-  //       file_client,
-  //       InitPathClient<Azure::Storage::Files::DataLake::DataLakeFileClient>(
-  //           options_, endpoint_url + path.full_path, path.container,
-  //           path.path_to_file));
-
-  //   std::shared_ptr<Azure::Storage::Blobs::BlockBlobClient> blob_client;
-  //   ARROW_ASSIGN_OR_RAISE(
-  //       blob_client,
-  //       InitPathClient<Azure::Storage::Blobs::BlockBlobClient>(
-  //           options_, endpoint_url + path.full_path, path.container,
-  //           path.path_to_file));
-
-  //   if (path.has_parent()) {
-  //     AzurePath parent_path = path.parent();
-  //     if (parent_path.path_to_file.empty()) {
-  //       ARROW_ASSIGN_OR_RAISE(response, ContainerExists(parent_path.container));
-  //       if (!response) {
-  //         return Status::IOError("Cannot write to file '", path.full_path,
-  //                                "': parent directory does not exist");
-  //       }
-  //     } else {
-  //       ARROW_ASSIGN_OR_RAISE(response,
-  //                             DirExists(dfs_endpoint_url_ + parent_path.full_path));
-  //       if (!response) {
-  //         return Status::IOError("Cannot write to file '", path.full_path,
-  //                                "': parent directory does not exist");
-  //       }
-  //     }
-  //   }
-  //   auto ptr = std::make_shared<ObjectAppendStream>(path_client, file_client,
-  //   blob_client,
-  //                                                   is_hierarchical_namespace_enabled_,
-  //                                                   fs->io_context(), path, metadata);
-  //   RETURN_NOT_OK(ptr->Init());
-  //   return ptr;
-  // }
 };
 
 const AzureOptions& AzureFileSystem::options() const { return impl_->options(); }
@@ -1048,12 +988,12 @@ Result<std::shared_ptr<io::RandomAccessFile>> AzureFileSystem::OpenInputFile(
 
 Result<std::shared_ptr<io::OutputStream>> AzureFileSystem::OpenOutputStream(
     const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
-  return impl_->OpenOutputStream(path, metadata, this);
+  return impl_->OpenAppendStream(path, metadata, true, this);
 }
 
 Result<std::shared_ptr<io::OutputStream>> AzureFileSystem::OpenAppendStream(
-    const std::string&, const std::shared_ptr<const KeyValueMetadata>&) {
-  return Status::NotImplemented("The Azure FileSystem is not fully implemented");
+    const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
+  return impl_->OpenAppendStream(path, metadata, false, this);
 }
 
 Result<std::shared_ptr<AzureFileSystem>> AzureFileSystem::Make(

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -461,6 +461,196 @@ class ObjectInputFile final : public io::RandomAccessFile {
   int64_t content_length_ = kNoSize;
   std::shared_ptr<const KeyValueMetadata> metadata_;
 };
+
+class ObjectAppendStream final : public io::OutputStream {
+ public:
+  ObjectAppendStream(
+      std::shared_ptr<Azure::Storage::Files::DataLake::DataLakePathClient>& path_client,
+      std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeFileClient>& file_client,
+      std::shared_ptr<Azure::Storage::Blobs::BlockBlobClient>& blob_client,
+      const bool is_hierarchical_namespace_enabled, const io::IOContext& io_context,
+      const AzurePath& path, const std::shared_ptr<const KeyValueMetadata>& metadata)
+      : path_client_(std::move(path_client)),
+        file_client_(std::move(file_client)),
+        blob_client_(std::move(blob_client)),
+        is_hierarchical_namespace_enabled_(is_hierarchical_namespace_enabled),
+        io_context_(io_context),
+        path_(path) {}
+
+  ~ObjectAppendStream() override {
+    // For compliance with the rest of the IO stack, Close rather than Abort,
+    // even though it may be more expensive.
+    io::internal::CloseFromDestructor(this);
+  }
+
+  Status Init() {
+    closed_ = false;
+    if (content_length_ != kNoSize) {
+      DCHECK_GE(content_length_, 0);
+      return Status::OK();
+    }
+    try {
+      auto properties = path_client_->GetProperties();
+      if (properties.Value.IsDirectory) {
+        return ::arrow::fs::internal::NotAFile(path_.full_path);
+      }
+      content_length_ = properties.Value.FileSize;
+      pos_ = content_length_;
+    } catch (const Azure::Storage::StorageException& exception) {
+      // new file
+      if (is_hierarchical_namespace_enabled_) {
+        try {
+          file_client_->CreateIfNotExists();
+        } catch (const Azure::Storage::StorageException& exception) {
+          return Status::IOError(exception.RawResponse->GetReasonPhrase());
+        }
+      } else {
+        std::string s = "";
+        try {
+          file_client_->UploadFrom(
+              const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(s.data())), s.size());
+        } catch (const Azure::Storage::StorageException& exception) {
+          return Status::IOError(exception.RawResponse->GetReasonPhrase());
+        }
+      }
+      content_length_ = 0;
+    }
+    return Status::OK();
+  }
+
+  Status Abort() override {
+    if (closed_) {
+      return Status::OK();
+    }
+    path_client_ = nullptr;
+    file_client_ = nullptr;
+    blob_client_ = nullptr;
+    closed_ = true;
+    return Status::OK();
+  }
+
+  // OutputStream interface
+
+  Status Close() override {
+    if (closed_) {
+      return Status::OK();
+    }
+    path_client_ = nullptr;
+    file_client_ = nullptr;
+    blob_client_ = nullptr;
+    closed_ = true;
+    return Status::OK();
+  }
+
+  bool closed() const override { return closed_; }
+
+  Result<int64_t> Tell() const override {
+    if (closed_) {
+      return Status::Invalid("Operation on closed stream");
+    }
+    return pos_;
+  }
+
+  Status Write(const std::shared_ptr<Buffer>& buffer) override {
+    return DoAppend(buffer->data(), buffer->size(), buffer);
+  }
+
+  Status Write(const void* data, int64_t nbytes) override {
+    return DoAppend(data, nbytes);
+  }
+
+  Status DoAppend(const void* data, int64_t nbytes,
+                  std::shared_ptr<Buffer> owned_buffer = nullptr) {
+    if (closed_) {
+      return Status::Invalid("Operation on closed stream");
+    }
+    if (is_hierarchical_namespace_enabled_) {
+      try {
+        auto buffer_stream = std::make_unique<Azure::Core::IO::MemoryBodyStream>(
+            Azure::Core::IO::MemoryBodyStream(
+                const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(data)), nbytes));
+        if (buffer_stream->Length() == 0) {
+          return Status::OK();
+        }
+        auto result = file_client_->Append(*buffer_stream, pos_);
+        pos_ += nbytes;
+        file_client_->Flush(pos_);
+      } catch (const Azure::Storage::StorageException& exception) {
+        return Status::IOError(exception.RawResponse->GetReasonPhrase());
+      }
+    } else {
+      try {
+        auto append_data = static_cast<uint8_t*>((void*)data);
+        auto res = blob_client_->GetBlockList().Value;
+        auto size = res.CommittedBlocks.size();
+        std::string block_id;
+        {
+          block_id = std::to_string(size + 1);
+          size_t n = 8;
+          int precision = n - std::min(n, block_id.size());
+          block_id.insert(0, precision, '0');
+        }
+        block_id = Azure::Core::Convert::Base64Encode(
+            std::vector<uint8_t>(block_id.begin(), block_id.end()));
+        auto block_content = Azure::Core::IO::MemoryBodyStream(
+            append_data, strlen(reinterpret_cast<char*>(append_data)));
+        if (block_content.Length() == 0) {
+          return Status::OK();
+        }
+        blob_client_->StageBlock(block_id, block_content);
+        std::vector<std::string> block_ids;
+        for (auto block : res.CommittedBlocks) {
+          block_ids.push_back(block.Name);
+        }
+        block_ids.push_back(block_id);
+        blob_client_->CommitBlockList(block_ids);
+        pos_ += nbytes;
+      } catch (const Azure::Storage::StorageException& exception) {
+        return Status::IOError(exception.RawResponse->GetReasonPhrase());
+      }
+    }
+    content_length_ += nbytes;
+    return Status::OK();
+  }
+
+  Status Flush() override {
+    if (closed_) {
+      return Status::Invalid("Operation on closed stream");
+    }
+    if (is_hierarchical_namespace_enabled_) {
+      try {
+        file_client_->Flush(content_length_);
+      } catch (const Azure::Storage::StorageException& exception) {
+        return Status::IOError(exception.RawResponse->GetReasonPhrase());
+      }
+    } else {
+      try {
+        auto res = blob_client_->GetBlockList().Value;
+        std::vector<std::string> block_ids;
+        for (auto block : res.UncommittedBlocks) {
+          block_ids.push_back(block.Name);
+        }
+        blob_client_->CommitBlockList(block_ids);
+      } catch (const Azure::Storage::StorageException& exception) {
+        return Status::IOError(exception.RawResponse->GetReasonPhrase());
+      }
+    }
+    return Status::OK();
+  }
+
+ protected:
+  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakePathClient> path_client_;
+  std::shared_ptr<Azure::Storage::Files::DataLake::DataLakeFileClient> file_client_;
+  std::shared_ptr<Azure::Storage::Blobs::BlockBlobClient> blob_client_;
+  const bool is_hierarchical_namespace_enabled_;
+  const io::IOContext io_context_;
+  const AzurePath path_;
+
+  bool closed_ = true;
+  int64_t pos_ = 0;
+  int64_t content_length_ = kNoSize;
+};
+
 }  // namespace
 
 // -----------------------------------------------------------------------

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -646,8 +646,12 @@ class ObjectAppendStream final : public io::OutputStream {
     const auto required_padding_digits =
         target_number_of_digits - std::min(target_number_of_digits, new_block_id.size());
     new_block_id.insert(0, required_padding_digits, '0');
-    new_block_id += "-arrow";  // Add a suffix to reduce risk of block_id collisions with
-                               // blocks created by other applications.
+    // There is a small risk when appending to a blob created by another client that 
+    // `new_block_id` may overlapping with an existing block id. Adding the `-arrow` 
+    // suffix significantly reduces the risk, but does not 100% eliminate it. For example 
+    // if the blob was previously created with one block, with id `00001-arrow` then the 
+    // next block we append will conflict with that, and cause corruption.
+    new_block_id += "-arrow";
     new_block_id = Azure::Core::Convert::Base64Encode(
         std::vector<uint8_t>(new_block_id.begin(), new_block_id.end()));
 

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -77,6 +77,11 @@ struct ARROW_EXPORT AzureOptions {
   std::shared_ptr<Azure::Core::Credentials::TokenCredential>
       service_principle_credentials_provider;
 
+  /// \brief Default metadata for OpenOutputStream.
+  ///
+  /// This will be ignored if non-empty metadata is passed to OpenOutputStream.
+  std::shared_ptr<const KeyValueMetadata> default_metadata;
+
   AzureOptions();
 
   Status ConfigureAccountKeyCredentials(const std::string& account_name,

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -675,8 +675,7 @@ TEST_F(AzuriteFileSystemTest, TestWriteMetadata) {
                   location, /*metadata=*/arrow::key_value_metadata({{"bar", "foo"}})));
   ASSERT_OK(output->Write(expected.data(), expected.size()));
   ASSERT_OK(output->Close());
-  blob_metadata =
-      blob_service_client_->GetBlobContainerClient(PreexistingContainerName())
+  blob_metadata = blob_service_client_->GetBlobContainerClient(PreexistingContainerName())
           .GetBlockBlobClient(path)
           .GetProperties()
           .Value.Metadata;

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -796,7 +796,8 @@ TEST_F(AzuriteFileSystemTest, OpenAppendStreamDoesNotTruncateExistingFile) {
   ASSERT_OK(output->Write(expected1.data(), expected1.size()));
   ASSERT_OK(output->Close());
 
-  // Verify that the initial content has been overwritten.
+  // Verify that the initial content has not been overwritten and that the block from
+  // the other client was not committed.
   ASSERT_OK_AND_ASSIGN(input, fs_->OpenInputStream(path));
   ASSERT_OK_AND_ASSIGN(size, input->Read(inbuf.size(), inbuf.data()));
   EXPECT_EQ(std::string(inbuf.data(), size), expected0 + expected1);

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -696,7 +696,7 @@ TEST_F(AzuriteFileSystemTest, OpenOutputStreamSmall) {
   ASSERT_OK_AND_ASSIGN(auto input, fs_->OpenInputStream(path));
 
   std::array<char, 1024> inbuf{};
-  ASSERT_OK_AND_ASSIGN(auto size, input->Read(inbuf.size(), inbuf.data())); 
+  ASSERT_OK_AND_ASSIGN(auto size, input->Read(inbuf.size(), inbuf.data()));
 
   EXPECT_EQ(expected, std::string_view(inbuf.data(), size));
 }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -647,6 +647,130 @@ TEST_F(AzuriteFileSystemTest, OpenInputStreamClosed) {
   ASSERT_RAISES(Invalid, stream->Tell());
 }
 
+
+TEST_F(GcsIntegrationTest, TestWriteWithDefaults) {
+  auto options = TestGcsOptions();
+  options.default_bucket_location = "utopia";
+  options.default_metadata = arrow::key_value_metadata({{"foo", "bar"}});
+  auto fs = GcsFileSystem::Make(options);
+  std::string bucket = "new_bucket_with_default_location";
+  auto file_name = "object_with_defaults";
+  ASSERT_OK(fs->CreateDir(bucket, /*recursive=*/false));
+  const auto path = bucket + "/" + file_name;
+  std::shared_ptr<io::OutputStream> output;
+  ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, /*metadata=*/{}));
+  const auto expected = std::string(kLoremIpsum);
+  ASSERT_OK(output->Write(expected.data(), expected.size()));
+  ASSERT_OK(output->Close());
+
+  // Verify we can read the object back.
+  std::shared_ptr<io::InputStream> input;
+  ASSERT_OK_AND_ASSIGN(input, fs->OpenInputStream(path));
+
+  std::array<char, 1024> inbuf{};
+  std::int64_t size;
+  ASSERT_OK_AND_ASSIGN(size, input->Read(inbuf.size(), inbuf.data()));
+
+  EXPECT_EQ(std::string(inbuf.data(), size), expected);
+  auto object = GcsClient().GetObjectMetadata(bucket, file_name);
+  ASSERT_TRUE(object.ok()) << "status=" << object.status();
+  EXPECT_EQ(object->mutable_metadata()["foo"], "bar");
+  auto bucket_info = GcsClient().GetBucketMetadata(bucket);
+  ASSERT_TRUE(bucket_info.ok()) << "status=" << object.status();
+  EXPECT_EQ(bucket_info->location(), "utopia");
+
+  // Check that explicit metadata overrides the defaults.
+  ASSERT_OK_AND_ASSIGN(
+      output, fs->OpenOutputStream(
+                  path, /*metadata=*/arrow::key_value_metadata({{"bar", "foo"}})));
+  ASSERT_OK(output->Write(expected.data(), expected.size()));
+  ASSERT_OK(output->Close());
+  object = GcsClient().GetObjectMetadata(bucket, file_name);
+  ASSERT_TRUE(object.ok()) << "status=" << object.status();
+  EXPECT_EQ(object->mutable_metadata()["bar"], "foo");
+  // Defaults are overwritten and not merged.
+  EXPECT_FALSE(object->has_metadata("foo"));
+}
+
+TEST_F(GcsIntegrationTest, OpenOutputStreamSmall) {
+  auto fs = GcsFileSystem::Make(TestGcsOptions());
+
+  const auto path = PreexistingBucketPath() + "test-write-object";
+  std::shared_ptr<io::OutputStream> output;
+  ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
+  const auto expected = std::string(kLoremIpsum);
+  ASSERT_OK(output->Write(expected.data(), expected.size()));
+  ASSERT_OK(output->Close());
+
+  // Verify we can read the object back.
+  std::shared_ptr<io::InputStream> input;
+  ASSERT_OK_AND_ASSIGN(input, fs->OpenInputStream(path));
+
+  std::array<char, 1024> inbuf{};
+  std::int64_t size;
+  ASSERT_OK_AND_ASSIGN(size, input->Read(inbuf.size(), inbuf.data()));
+
+  EXPECT_EQ(std::string(inbuf.data(), size), expected);
+}
+
+TEST_F(GcsIntegrationTest, OpenOutputStreamLarge) {
+  auto fs = GcsFileSystem::Make(TestGcsOptions());
+
+  const auto path = PreexistingBucketPath() + "test-write-object";
+  std::shared_ptr<io::OutputStream> output;
+  ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
+  // These buffer sizes are intentionally not multiples of the upload quantum (256 KiB).
+  std::array<std::int64_t, 3> sizes{257 * 1024, 258 * 1024, 259 * 1024};
+  std::array<std::string, 3> buffers{
+      std::string(sizes[0], 'A'),
+      std::string(sizes[1], 'B'),
+      std::string(sizes[2], 'C'),
+  };
+  auto expected = std::int64_t{0};
+  for (auto i = 0; i != 3; ++i) {
+    ASSERT_OK(output->Write(buffers[i].data(), buffers[i].size()));
+    expected += sizes[i];
+    ASSERT_EQ(output->Tell(), expected);
+  }
+  ASSERT_OK(output->Close());
+
+  // Verify we can read the object back.
+  std::shared_ptr<io::InputStream> input;
+  ASSERT_OK_AND_ASSIGN(input, fs->OpenInputStream(path));
+
+  std::string contents;
+  std::shared_ptr<Buffer> buffer;
+  do {
+    ASSERT_OK_AND_ASSIGN(buffer, input->Read(128 * 1024));
+    ASSERT_TRUE(buffer);
+    contents.append(buffer->ToString());
+  } while (buffer->size() != 0);
+
+  EXPECT_EQ(contents, buffers[0] + buffers[1] + buffers[2]);
+}
+
+TEST_F(GcsIntegrationTest, OpenOutputStreamClosed) {
+  auto fs = GcsFileSystem::Make(TestGcsOptions());
+
+  const auto path = internal::ConcatAbstractPath(PreexistingBucketName(),
+                                                 "open-output-stream-closed.txt");
+  std::shared_ptr<io::OutputStream> output;
+  ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
+  ASSERT_OK(output->Close());
+  ASSERT_RAISES(Invalid, output->Write(kLoremIpsum, std::strlen(kLoremIpsum)));
+  ASSERT_RAISES(Invalid, output->Flush());
+  ASSERT_RAISES(Invalid, output->Tell());
+}
+
+TEST_F(GcsIntegrationTest, OpenOutputStreamUri) {
+  auto fs = GcsFileSystem::Make(TestGcsOptions());
+
+  const auto path =
+      internal::ConcatAbstractPath(PreexistingBucketName(), "open-output-stream-uri.txt");
+  ASSERT_RAISES(Invalid, fs->OpenInputStream("gs://" + path));
+}
+
+
 TEST_F(AzuriteFileSystemTest, OpenInputFileMixedReadVsReadAt) {
   // Create a file large enough to make the random access tests non-trivial.
   auto constexpr kLineWidth = 100;

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -686,8 +686,7 @@ TEST_F(AzuriteFileSystemTest, TestWriteMetadata) {
 
 TEST_F(AzuriteFileSystemTest, OpenOutputStreamSmall) {
   const auto path = PreexistingContainerPath() + "test-write-object";
-  std::shared_ptr<io::OutputStream> output;
-  ASSERT_OK_AND_ASSIGN(output, fs_->OpenOutputStream(path, {}));
+  ASSERT_OK_AND_ASSIGN(auto output, fs_->OpenOutputStream(path, {}));
   const std::string_view expected(kLoremIpsum);
   ASSERT_OK(output->Write(expected));
   ASSERT_OK(output->Close());


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Writing files is an important part of the filesystem

### What changes are included in this PR?
Implements `OpenOutputStream` and `OpenAppendStream` for Azure.

- Initially I started with the implementation from https://github.com/apache/arrow/pull/12914 but I made quite a few changes:
  - Removed the different code path for hierarchical namespace accounts. There should not be any performance advantage to using special APIs only available on hierachical namespace accounts. 
  - Only implement `ObjectAppendStream`, not `ObjectOutputStream`. `OpenOutputStream` is implemented by truncating the existing file then returning a `ObjectAppendStream`.
  - More precise use of `try` `catch`. Every call to Azure is wrapped in a `try` `catch` and should return a descriptive error status. 
  - Avoid unnecessary calls to Azure. For example we now maintain the block list in memory and commit it only once on flush. https://github.com/apache/arrow/pull/12914 committed the block list after each block that was staged and on flush queried Azure to get the list of uncommitted blocks. The new approach is consistent with the Azure fsspec implementation https://github.com/fsspec/adlfs/blob/092685f102c5cd215550d10e8347e5bce0e2b93d/adlfs/spec.py#L2009
  - Adjust the block_ids slightly to minimise the risk of them conflicting with blocks written by other blob storage clients. 
  - Implement metadata writes. Includes adding default metadata to `AzureOptions`.
- Tests are based on the `gscfs_test.cc` but I added a couple of extra. 
- Handle the TODO(GH-38780) comments for using the Azure fs to write data in tests

### Are these changes tested?
Yes. Everything should be covered by azurite tests

### Are there any user-facing changes?
Yes. The Azure filesystem now supports file writes. 

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38333