### PR TITLE
GH-38024: [Java][FlightRPC] Expose appMetadata through JDBC ResultSet

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
@@ -48,6 +48,7 @@ public final class ArrowFlightJdbcFlightStreamResultSet
     extends ArrowFlightJdbcVectorSchemaRootResultSet {
 
   private final ArrowFlightConnection connection;
+  private final FlightInfo flightInfo;
   private CloseableEndpointStreamPair currentEndpointData;
   private FlightEndpointDataQueue flightEndpointDataQueue;
 
@@ -56,6 +57,9 @@ public final class ArrowFlightJdbcFlightStreamResultSet
 
   private Schema schema;
 
+  /**
+   * Public constructor used by ArrowFlightJdbcFactory.
+   */
   ArrowFlightJdbcFlightStreamResultSet(final AvaticaStatement statement,
                                        final QueryState state,
                                        final Meta.Signature signature,
@@ -64,20 +68,28 @@ public final class ArrowFlightJdbcFlightStreamResultSet
                                        final Meta.Frame firstFrame) throws SQLException {
     super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
     this.connection = (ArrowFlightConnection) statement.connection;
-  }
-
-  ArrowFlightJdbcFlightStreamResultSet(final ArrowFlightConnection connection,
-                                       final QueryState state,
-                                       final Meta.Signature signature,
-                                       final ResultSetMetaData resultSetMetaData,
-                                       final TimeZone timeZone,
-                                       final Meta.Frame firstFrame) throws SQLException {
-    super(null, state, signature, resultSetMetaData, timeZone, firstFrame);
-    this.connection = connection;
+    this.flightInfo = ((ArrowFlightInfoStatement) statement).executeFlightInfoQuery();
   }
 
   /**
-   * Create a {@link ResultSet} which pulls data from given {@link FlightInfo}.
+   * Private constructor for fromFlightInfo.
+   */
+  private ArrowFlightJdbcFlightStreamResultSet(final ArrowFlightConnection connection,
+                                               final QueryState state,
+                                               final Meta.Signature signature,
+                                               final ResultSetMetaData resultSetMetaData,
+                                               final TimeZone timeZone,
+                                               final Meta.Frame firstFrame,
+                                               final FlightInfo flightInfo
+  ) throws SQLException {
+    super(null, state, signature, resultSetMetaData, timeZone, firstFrame);
+    this.connection = connection;
+    this.flightInfo = flightInfo;
+  }
+
+  /**
+   * Create a {@link ResultSet} which pulls data from given {@link FlightInfo}. This is used to fetch result sets
+   * from DatabaseMetadata calls and skips the Avatica factory.
    *
    * @param connection  The connection linked to the returned ResultSet.
    * @param flightInfo  The FlightInfo from which data will be iterated by the returned ResultSet.
@@ -99,11 +111,11 @@ public final class ArrowFlightJdbcFlightStreamResultSet
         new AvaticaResultSetMetaData(null, null, signature);
     final ArrowFlightJdbcFlightStreamResultSet resultSet =
         new ArrowFlightJdbcFlightStreamResultSet(connection, state, signature, resultSetMetaData,
-            timeZone, null);
+            timeZone, null, flightInfo);
 
     resultSet.transformer = transformer;
 
-    resultSet.populateData(flightInfo);
+    resultSet.populateData();
     return resultSet;
   }
 
@@ -121,16 +133,14 @@ public final class ArrowFlightJdbcFlightStreamResultSet
 
   @Override
   protected AvaticaResultSet execute() throws SQLException {
-    final FlightInfo flightInfo = ((ArrowFlightInfoStatement) statement).executeFlightInfoQuery();
-
     if (flightInfo != null) {
       schema = flightInfo.getSchemaOptional().orElse(null);
-      populateData(flightInfo);
+      populateData();
     }
     return this;
   }
 
-  private void populateData(final FlightInfo flightInfo) throws SQLException {
+  private void populateData() throws SQLException {
     loadNewQueue();
     flightEndpointDataQueue.enqueue(connection.getClientHandler().getStreams(flightInfo));
     loadNewFlightStream();
@@ -155,6 +165,10 @@ public final class ArrowFlightJdbcFlightStreamResultSet
     }
 
     populateData(currentVectorSchemaRoot, schema);
+  }
+
+  public byte[] getAppMetadata() {
+    return flightInfo.getAppMetadata();
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
@@ -167,6 +167,9 @@ public final class ArrowFlightJdbcFlightStreamResultSet
     populateData(currentVectorSchemaRoot, schema);
   }
 
+  /**
+   * Expose appMetadata associated with the underlying FlightInfo for this ResultSet.
+   */
   public byte[] getAppMetadata() {
     return flightInfo.getAppMetadata();
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
@@ -477,7 +477,8 @@ public class ResultSetTest {
     try (Statement statement = connection.createStatement();
          ResultSet resultSet = statement.executeQuery(
              CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
-      assertArrayEquals(((ArrowFlightJdbcFlightStreamResultSet) resultSet).getAppMetadata(), "foo".getBytes(StandardCharsets.UTF_8));
+      assertArrayEquals(((ArrowFlightJdbcFlightStreamResultSet) resultSet).getAppMetadata(),
+              "foo".getBytes(StandardCharsets.UTF_8));
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
@@ -25,10 +25,12 @@ import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -467,6 +469,15 @@ public class ResultSetTest {
         ++rowCount;
       }
       assertEquals(2, rowCount);
+    }
+  }
+
+  @Test
+  public void testResultSetAppMetadata() throws Exception {
+    try (Statement statement = connection.createStatement();
+         ResultSet resultSet = statement.executeQuery(
+             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+      assertArrayEquals(((ArrowFlightJdbcFlightStreamResultSet) resultSet).getAppMetadata(), "foo".getBytes(StandardCharsets.UTF_8));
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/MockFlightSqlProducer.java
@@ -270,7 +270,9 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
             .map(TicketConversionUtils::getTicketStatementQueryFromHandle)
             .map(TicketConversionUtils::getEndpointFromMessage)
             .collect(toList());
-    return new FlightInfo(queryInfo.getKey(), flightDescriptor, endpoints, -1, -1);
+    return FlightInfo.builder(queryInfo.getKey(), flightDescriptor, endpoints)
+            .setAppMetadata("foo".getBytes(StandardCharsets.UTF_8))
+            .build();
   }
 
   @Override
@@ -293,7 +295,9 @@ public final class MockFlightSqlProducer implements FlightSqlProducer {
             .map(TicketConversionUtils::getCommandPreparedStatementQueryFromHandle)
             .map(TicketConversionUtils::getEndpointFromMessage)
             .collect(toList());
-    return new FlightInfo(queryInfo.getKey(), flightDescriptor, endpoints, -1, -1);
+    return FlightInfo.builder(queryInfo.getKey(), flightDescriptor, endpoints)
+            .setAppMetadata("foo".getBytes(StandardCharsets.UTF_8))
+            .build();
   }
 
   @Override


### PR DESCRIPTION
FlightInfo can now contain appMetadata. This PR exposes that metadata through the JDBC interface through `ArrowFlightJdbcFlightStreamResultSet.getAppMetadata`.
* Closes: #38024