### PR TITLE
GH-38782: [C++][FS][Azure] Do nothing for CreateDir("/container", true)

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -708,16 +708,18 @@ class AzureFileSystem::Impl {
       return Status::OK();
     }
 
-    auto directory_client =
-        datalake_service_client_->GetFileSystemClient(location.container)
-            .GetDirectoryClient(location.path);
-    try {
-      directory_client.CreateIfNotExists();
-    } catch (const Azure::Storage::StorageException& exception) {
-      return internal::ExceptionToStatus(
-          "Failed to create a directory: " + location.path + " (" +
-              directory_client.GetUrl() + ")",
-          exception);
+    if (!location.path.empty()) {
+      auto directory_client =
+          datalake_service_client_->GetFileSystemClient(location.container)
+              .GetDirectoryClient(location.path);
+      try {
+        directory_client.CreateIfNotExists();
+      } catch (const Azure::Storage::StorageException& exception) {
+        return internal::ExceptionToStatus(
+            "Failed to create a directory: " + location.path + " (" +
+                directory_client.GetUrl() + ")",
+            exception);
+      }
     }
 
     return Status::OK();


### PR DESCRIPTION
### Rationale for this change

It's failed with hierarchical namespace support. And we don't need to do nothing for the case because container must exist in the case.

### What changes are included in this PR?

Add a missing `location.path.empty()` check.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #38782