### PR TITLE
GH-38792: [C++][Gandiva] Optimize cache

### DIFF
--- a/cpp/src/gandiva/annotator.h
+++ b/cpp/src/gandiva/annotator.h
@@ -60,6 +60,8 @@ class GANDIVA_EXPORT Annotator {
   EvalBatchPtr PrepareEvalBatch(const arrow::RecordBatch& record_batch,
                                 const ArrayDataVector& out_vector) const;
 
+  const Status CheckEvalBatchFieldType(const arrow::RecordBatch& record_batch) const;
+
   int buffer_count() const { return buffer_count_; }
 
  private:

--- a/cpp/src/gandiva/expr_validator.cc
+++ b/cpp/src/gandiva/expr_validator.cc
@@ -72,20 +72,6 @@ Status ExprValidator::Visit(const FieldNode& node) {
                   Status::ExpressionValidationError("Field ", node.field()->name(),
                                                     " has unsupported data type ",
                                                     node.return_type()->name()));
-
-  // Ensure that field is found in schema
-  auto field_in_schema_entry = field_map_.find(node.field()->name());
-  ARROW_RETURN_IF(field_in_schema_entry == field_map_.end(),
-                  Status::ExpressionValidationError("Field ", node.field()->name(),
-                                                    " not in schema."));
-
-  // Ensure that the found field matches.
-  FieldPtr field_in_schema = field_in_schema_entry->second;
-  ARROW_RETURN_IF(!field_in_schema->Equals(node.field()),
-                  Status::ExpressionValidationError(
-                      "Field definition in schema ", field_in_schema->ToString(),
-                      " different from field in expression ", node.field()->ToString()));
-
   return Status::OK();
 }
 

--- a/cpp/src/gandiva/expression.cc
+++ b/cpp/src/gandiva/expression.cc
@@ -22,4 +22,6 @@ namespace gandiva {
 
 std::string Expression::ToString() { return root()->ToString(); }
 
+std::string Expression::ToCacheKeyString() {return root()->ToCacheKeyString();}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/expression.h
+++ b/cpp/src/gandiva/expression.h
@@ -38,6 +38,8 @@ class GANDIVA_EXPORT Expression {
 
   std::string ToString();
 
+  std::string ToCacheKeyString();
+
  private:
   const NodePtr root_;
   const FieldPtr result_;

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -91,8 +91,6 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
 Status Filter::Evaluate(const arrow::RecordBatch& batch,
                         std::shared_ptr<SelectionVector> out_selection) {
   const auto num_rows = batch.num_rows();
-  ARROW_RETURN_IF(!batch.schema()->Equals(*schema_),
-                  Status::Invalid("RecordBatch schema must expected filter schema"));
   ARROW_RETURN_IF(num_rows == 0, Status::Invalid("RecordBatch must be non-empty."));
   ARROW_RETURN_IF(out_selection == nullptr,
                   Status::Invalid("out_selection must be non-null."));

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -129,6 +129,10 @@ Status LLVMGenerator::Execute(const arrow::RecordBatch& record_batch,
                               const ArrayDataVector& output_vector) const {
   DCHECK_GT(record_batch.num_rows(), 0);
 
+  auto status = annotator_.CheckEvalBatchFieldType(record_batch);
+
+  ARROW_RETURN_IF(!status.ok(), status);
+
   auto eval_batch = annotator_.PrepareEvalBatch(record_batch, output_vector);
   DCHECK_GT(eval_batch->GetNumBuffers(), 0);
 

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -230,8 +230,6 @@ Status Projector::AllocArrayData(const DataTypePtr& type, int64_t num_records,
 }
 
 Status Projector::ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch) const {
-  ARROW_RETURN_IF(!batch.schema()->Equals(*schema_),
-                  Status::Invalid("Schema in RecordBatch must match schema in Make()"));
   ARROW_RETURN_IF(batch.num_rows() == 0,
                   Status::Invalid("RecordBatch must be non-empty."));
 

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -42,16 +42,16 @@ class TestFilter : public ::testing::Test {
 
 TEST_F(TestFilter, TestFilterCache) {
   // schema for input fields
-  auto field0 = field("f0_filter_cache", int32());
-  auto field1 = field("f1_filter_cache", int32());
+  auto field0 = field("f0_filter_cache", int64());
+  auto field1 = field("f1_filter_cache", int64());
   auto schema = arrow::schema({field0, field1});
 
   // Build condition f0 + f1 < 10
   auto node_f0 = TreeExprBuilder::MakeField(field0);
   auto node_f1 = TreeExprBuilder::MakeField(field1);
   auto sum_func =
-      TreeExprBuilder::MakeFunction("add", {node_f0, node_f1}, arrow::int32());
-  auto literal_10 = TreeExprBuilder::MakeLiteral((int32_t)10);
+      TreeExprBuilder::MakeFunction("add", {node_f0, node_f1}, arrow::int64());
+  auto literal_10 = TreeExprBuilder::MakeLiteral((int64_t)10);
   auto less_than_10 = TreeExprBuilder::MakeFunction("less_than", {sum_func, literal_10},
                                                     arrow::boolean());
   auto condition = TreeExprBuilder::MakeCondition(less_than_10);
@@ -69,13 +69,13 @@ TEST_F(TestFilter, TestFilterCache) {
   EXPECT_TRUE(cached_filter->GetBuiltFromCache());
 
   // schema is different should return a new filter.
-  auto field2 = field("f2_filter_cache", int32());
+  auto field2 = field("f2_filter_cache", int64());
   auto different_schema = arrow::schema({field0, field1, field2});
   std::shared_ptr<Filter> should_be_new_filter;
   status =
       Filter::Make(different_schema, condition, configuration, &should_be_new_filter);
   EXPECT_TRUE(status.ok());
-  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+  EXPECT_TRUE(should_be_new_filter->GetBuiltFromCache());
 
   // condition is different, should return a new filter.
   auto greater_than_10 = TreeExprBuilder::MakeFunction(
@@ -84,7 +84,7 @@ TEST_F(TestFilter, TestFilterCache) {
   std::shared_ptr<Filter> should_be_new_filter1;
   status = Filter::Make(schema, new_condition, configuration, &should_be_new_filter1);
   EXPECT_TRUE(status.ok());
-  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+  EXPECT_FALSE(should_be_new_filter1->GetBuiltFromCache());
 }
 
 TEST_F(TestFilter, TestFilterCacheNullTreatment) {

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -611,10 +611,10 @@ TEST_F(TestUtf8, TestConvertUtf8) {
 
   // Create a row-batch with some sample data
   int num_records = 3;
-  auto array_a = MakeArrowArrayUtf8({"ok-\xf8\x28"
-                                     "-a",
-                                     "all-valid", "ok-\xa0\xa1-valid"},
-                                    {true, true, true});
+  auto array_a = MakeArrowArrayBinary({"ok-\xf8\x28"
+                                       "-a",
+                                       "all-valid", "ok-\xa0\xa1-valid"},
+                                      {true, true, true});
 
   auto array_b =
       MakeArrowArrayUtf8({"ok-z(-a", "all-valid", "ok-zz-valid"}, {true, true, true});


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
In Gandiva, it has been observed that the tool caches compiled expressions. However, when using the expression cache, Gandiva takes into account the schema, expr->ToString, and specific parameters. Nevertheless, in llvm_generator.cc, Gandiva still traverses the expressions to generate LLVM IR code and then produces specific JIT functions. Considering that llvm_generator traverses expressions and calculates the memory start positions of fields involved in the computation, we can further enhance Gandiva's caching mechanism.

Specifically, we can exclude the influence of the schema. Simultaneously, we can also exclude the field names' information involved in the expression computation. For example, for a schema {f0:int32, f1:int32} with an expression add(f0, f1), we can cache it initially. Then, for a schema {a0:int32, a1:int32, a2:int32} with an expression add(a1, a2), it should not require recompilation; it can directly reuse the JIT function generated by the expression {f0:int32, f1:int32}, add(f0, f1).

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR primarily alters the construction of the cache key and makes modifications to the schema validation in both the projector and filter. It also adjusts the validation of fields in expr_validator. Additionally, a ToCacheKeyString function has been added to each node. This PR mainly focuses on these areas.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes,these changes are tested.

### Are there any user-facing changes?

No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
https://github.com/apache/arrow/issues/38792
* Closes: #38792