### PR TITLE
GH-38700: [C++][FS][Azure] Implement `DeleteDir()`

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1048,8 +1048,14 @@ class AzureFileSystem::Impl {
           std::vector<std::string> failed_blob_names;
           for (size_t i = 0; i < deferred_responses.size(); ++i) {
             const auto& deferred_response = deferred_responses[i];
-            auto delete_response = deferred_response.GetResponse();
-            if (!delete_response.Value.Deleted) {
+            bool success = true;
+            try {
+              auto delete_result = deferred_response.GetResponse();
+              success = delete_result.Value.Deleted;
+            } catch (const Azure::Storage::StorageException& exception) {
+              success = false;
+            }
+            if (!success) {
               const auto& blob_item = list_response.Blobs[i];
               failed_blob_names.push_back(blob_item.Name);
             }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1027,33 +1027,51 @@ class AzureFileSystem::Impl {
       // size of the body for a batch request can't exceed 4 MB.
       const int32_t kNumMaxRequestsInBatch = 256;
       options.PageSizeHint = kNumMaxRequestsInBatch;
-      auto list_response = container_client.ListBlobs(options);
-      while (list_response.HasPage() && !list_response.Blobs.empty()) {
-        auto batch = container_client.CreateBatch();
-        std::vector<Azure::Storage::DeferredResponse<
-            Azure::Storage::Blobs::Models::DeleteBlobResult>>
-            deferred_responses;
-        for (const auto& blob_item : list_response.Blobs) {
-          deferred_responses.push_back(batch.DeleteBlob(blob_item.Name));
-        }
-        try {
-          container_client.SubmitBatch(batch);
-        } catch (const Azure::Storage::StorageException& exception) {
-          return internal::ExceptionToStatus(
-              "Failed to delete blobs in a directory: " + location.path + ": " +
-                  container_client.GetUrl(),
-              exception);
-        }
-        for (size_t i = 0; i < deferred_responses.size(); ++i) {
-          const auto& deferred_response = deferred_responses[i];
-          auto delete_response = deferred_response.GetResponse();
-          if (!delete_response.Value.Deleted) {
-            const auto& blob_item = list_response.Blobs[i];
-            return Status::IOError("Failed to delete a blob: ", blob_item.Name,
-                                   ": " + container_client.GetUrl());
+      try {
+        auto list_response = container_client.ListBlobs(options);
+        while (list_response.HasPage() && !list_response.Blobs.empty()) {
+          auto batch = container_client.CreateBatch();
+          std::vector<Azure::Storage::DeferredResponse<
+              Azure::Storage::Blobs::Models::DeleteBlobResult>>
+              deferred_responses;
+          for (const auto& blob_item : list_response.Blobs) {
+            deferred_responses.push_back(batch.DeleteBlob(blob_item.Name));
           }
+          try {
+            container_client.SubmitBatch(batch);
+          } catch (const Azure::Storage::StorageException& exception) {
+            return internal::ExceptionToStatus(
+                "Failed to delete blobs in a directory: " + location.path + ": " +
+                    container_client.GetUrl(),
+                exception);
+          }
+          std::vector<std::string> failed_blob_names;
+          for (size_t i = 0; i < deferred_responses.size(); ++i) {
+            const auto& deferred_response = deferred_responses[i];
+            auto delete_response = deferred_response.GetResponse();
+            if (!delete_response.Value.Deleted) {
+              const auto& blob_item = list_response.Blobs[i];
+              failed_blob_names.push_back(blob_item.Name);
+            }
+          }
+          if (!failed_blob_names.empty()) {
+            if (failed_blob_names.size() == 1) {
+              return Status::IOError("Failed to delete a blob: ", failed_blob_names[0],
+                                     ": " + container_client.GetUrl());
+            } else {
+              return Status::IOError(
+                  "Failed to delete blobs: [",
+                  arrow::internal::JoinStrings(failed_blob_names, ", "),
+                  "]: " + container_client.GetUrl());
+            }
+          }
+          list_response.MoveToNextPage();
         }
-        list_response.MoveToNextPage();
+      } catch (const Azure::Storage::StorageException& exception) {
+        return internal::ExceptionToStatus(
+            "Failed to list blobs in a directory: " + location.path + ": " +
+                container_client.GetUrl(),
+            exception);
       }
       return Status::OK();
     }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -598,6 +598,10 @@ TEST_F(AzuriteFileSystemTest, DeleteDirSuccessNonexistent) {
 }
 
 TEST_F(AzuriteFileSystemTest, DeleteDirSuccessHaveBlobs) {
+#ifdef __APPLE__
+  GTEST_SKIP() << "This test fails by an Azurite problem: "
+                  "https://github.com/Azure/Azurite/pull/2302";
+#endif
   const auto directory_path =
       internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
   // We must use 257 or more blobs here to test pagination of ListBlobs().

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -276,7 +276,7 @@ class AzureFileSystemTest : public ::testing::Test {
 };
 
 class AzuriteFileSystemTest : public AzureFileSystemTest {
-  Result<AzureOptions> MakeOptions() {
+  Result<AzureOptions> MakeOptions() override {
     EXPECT_THAT(GetAzuriteEnv(), NotNull());
     ARROW_EXPECT_OK(GetAzuriteEnv()->status());
     AzureOptions options;

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -543,7 +543,7 @@ TEST_F(AzuriteFileSystemTest, DeleteDirSuccessHaveBlobs) {
       internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
   // We must use 257 or more blobs here to test pagination of ListBlobs().
   // Because we can't add 257 or more delete blob requests to one SubmitBatch().
-  int64_t n_blobs = 300;
+  int64_t n_blobs = 257;
   for (int64_t i = 0; i < n_blobs; ++i) {
     const auto blob_path =
         internal::ConcatAbstractPath(directory_path, std::to_string(i) + ".txt");


### PR DESCRIPTION
### Rationale for this change

`DeleteDir()` deletes the given directory recursively like other filesystem implementations.

### What changes are included in this PR?

* Container can be deleted with/without hierarchical namespace support.
* Directory can be deleted with hierarchical namespace support.
* Directory can't be deleted without hierarchical namespace support. But blobs under the given path can be deleted. So these blobs are deleted and the given virtual directory is also deleted.
    
### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #38700