### PR TITLE
GH-38798: [Integration] Enable C Data Interface integration testing on Rust

### DIFF
--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -43,6 +43,7 @@ fi
 # Get more detailed context on crashes
 export PYTHONFAULTHANDLER=1
 
+
 # Rust can be enabled by exporting ARCHERY_INTEGRATION_WITH_RUST=1
 time archery integration \
     --run-c-data \

--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -21,6 +21,7 @@ set -e
 
 arrow_dir=${1}
 source_dir=${1}/rust
+build_dir=${2}/rust
 
 # This file is used to build the rust binaries needed for the archery
 # integration tests. Testing of the rust implementation in normal CI is handled
@@ -54,7 +55,7 @@ rustup show
 pushd ${source_dir}
 
 # build only the integration testing binaries
-cargo build -p arrow-integration-testing
+cargo build -p arrow-integration-testing --target-dir ${build_dir}
 
 # Save disk space by removing large temporary build products
 rm -rf target/debug/deps

--- a/dev/archery/archery/integration/cdata.py
+++ b/dev/archery/archery/integration/cdata.py
@@ -18,9 +18,18 @@
 import cffi
 from contextlib import contextmanager
 import functools
+import os
+import sys
 
 from .tester import CDataExporter, CDataImporter
 
+
+if sys.platform == "darwin":
+    dll_suffix = ".dylib"
+elif os.name == "nt":
+    dll_suffix = ".dll"
+else:
+    dll_suffix = ".so"
 
 _c_data_decls = """
     struct ArrowSchema {

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -18,7 +18,6 @@
 import contextlib
 import functools
 import os
-import sys
 import subprocess
 
 from . import cdata
@@ -42,15 +41,8 @@ _FLIGHT_CLIENT_CMD = [
     "localhost",
 ]
 
-if sys.platform == "darwin":
-    _dll_suffix = ".dylib"
-elif os.name == "nt":
-    _dll_suffix = ".dll"
-else:
-    _dll_suffix = ".so"
-
 _DLL_PATH = _EXE_PATH
-_ARROW_DLL = os.path.join(_DLL_PATH, "libarrow" + _dll_suffix)
+_ARROW_DLL = os.path.join(_DLL_PATH, "libarrow" + cdata.dll_suffix)
 
 
 class CppTester(Tester):

--- a/dev/archery/archery/integration/tester_go.py
+++ b/dev/archery/archery/integration/tester_go.py
@@ -18,7 +18,6 @@
 import contextlib
 import functools
 import os
-import sys
 import subprocess
 
 from . import cdata
@@ -43,17 +42,10 @@ _FLIGHT_CLIENT_CMD = [
     "localhost",
 ]
 
-if sys.platform == "darwin":
-    _dll_suffix = ".dylib"
-elif os.name == "nt":
-    _dll_suffix = ".dll"
-else:
-    _dll_suffix = ".so"
-
 _DLL_PATH = os.path.join(
     ARROW_ROOT_DEFAULT,
     "go/arrow/internal/cdata_integration")
-_INTEGRATION_DLL = os.path.join(_DLL_PATH, "arrow_go_integration" + _dll_suffix)
+_INTEGRATION_DLL = os.path.join(_DLL_PATH, "arrow_go_integration" + cdata.dll_suffix)
 
 
 class GoTester(Tester):

--- a/dev/archery/archery/integration/tester_rust.py
+++ b/dev/archery/archery/integration/tester_rust.py
@@ -205,7 +205,7 @@ class RustCDataExporter(CDataExporter, _CDataBase):
         return True
 
     def record_allocation_state(self):
-        # FIXME is it possible to measure the amount of Rust-allocated memory?
+        # FIXME we should track the amount of Rust-allocated memory (GH-38822)
         return 0
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1716,8 +1716,9 @@ services:
     environment:
       <<: [*common, *ccache]
       ARCHERY_INTEGRATION_WITH_RUST: 0
-      # Tell Archery where the arrow C++ binaries are located
+      # Tell Archery where Arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug
+      ARROW_RUST_EXE_PATH: /build/rust/debug
     command:
       ["/arrow/ci/scripts/integration_arrow_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_arrow.sh /arrow /build"]


### PR DESCRIPTION
### Rationale for this change

Arrow Rust has added entrypoints for C Data Interface integration testing, so this can now be enabled on our side:
https://github.com/apache/arrow-rs/pull/5080

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38798