### PR TITLE
GH-38832: [Java] Avoid building twice in `ci/scripts/java_build.sh`

### DIFF
--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -77,19 +77,19 @@ mvn="${mvn} -T 2C"
 
 pushd ${source_dir}
 
-${mvn} install
-
 if [ "${ARROW_JAVA_SHADE_FLATBUFFERS}" == "ON" ]; then
-  ${mvn} -Pshade-flatbuffers install
+  mvn="${mvn} -Pshade-flatbuffers"
 fi
 
 if [ "${ARROW_JAVA_CDATA}" = "ON" ]; then
-  ${mvn} -Darrow.c.jni.dist.dir=${java_jni_dist_dir} -Parrow-c-data install
+  mvn="${mvn} -Darrow.c.jni.dist.dir=${java_jni_dist_dir} -Parrow-c-data"
 fi
 
 if [ "${ARROW_JAVA_JNI}" = "ON" ]; then
-  ${mvn} -Darrow.cpp.build.dir=${java_jni_dist_dir} -Parrow-jni install
+  mvn="${mvn} -Darrow.cpp.build.dir=${java_jni_dist_dir} -Parrow-jni install"
 fi
+
+${mvn} install
 
 if [ "${BUILD_DOCS_JAVA}" == "ON" ]; then
   # HTTP pooling is turned of to avoid download issues https://issues.apache.org/jira/browse/ARROW-11633

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -86,7 +86,7 @@ if [ "${ARROW_JAVA_CDATA}" = "ON" ]; then
 fi
 
 if [ "${ARROW_JAVA_JNI}" = "ON" ]; then
-  mvn="${mvn} -Darrow.cpp.build.dir=${java_jni_dist_dir} -Parrow-jni install"
+  mvn="${mvn} -Darrow.cpp.build.dir=${java_jni_dist_dir} -Parrow-jni"
 fi
 
 ${mvn} install


### PR DESCRIPTION
### Rationale for this change

`ci/scripts/java_build.sh` can invoke `mvn install` several times on the Arrow Java codebase. This happens especially in JNI and Integration builds, which have some optional components enabled.

### What changes are included in this PR?

Only invoke `mvn install` once. This change seems to save around 5 minutes on the JNI and Integration builds.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* Closes: #38832