### PR TITLE
MINOR: [Java][CI][Docs] Add Java crossbow task group

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -77,6 +77,9 @@ groups:
   c-glib:
     - test-*c-glib*
 
+  java:
+    - "*java*"
+
   python:
     - test-*python*
 

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -32,8 +32,11 @@ Arrow Java uses the `Maven <https://maven.apache.org/>`_ build system.
 
 Building requires:
 
-* JDK 8, 9, 10, 11, 17, or 18, but only JDK 8, 11 and 17 are tested in CI.
+* JDK 8+
 * Maven 3+
+
+.. note::
+    CI will test all supported JDK LTS versions, plus the latest non-LTS version.
 
 Building
 ========


### PR DESCRIPTION
### Rationale for this change

Add a crossbow task group for java, since it is not intuitive to newcomers that "crossbow submit *java*" should be `crossbow submit *java*`.

Also, clarify what is supported/tested in CI under Java build documentation.

### What changes are included in this PR?

* Java crossbow task group added
* Java docs updated to clarify supported JDK versions

### Are these changes tested?

Yes, the crossbow task will be verified in this PR via a github actions request comment.

### Are there any user-facing changes?

No.