### PR TITLE
GH-38684: [Integration] Try to strengthen C Data Interface testing

### DIFF
--- a/.env
+++ b/.env
@@ -61,7 +61,7 @@ GCC_VERSION=""
 GO=1.19.13
 STATICCHECK=v0.4.5
 HDFS=3.2.1
-JDK=8
+JDK=17
 KARTOTHEK=latest
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=14

--- a/.env
+++ b/.env
@@ -61,7 +61,7 @@ GCC_VERSION=""
 GO=1.19.13
 STATICCHECK=v0.4.5
 HDFS=3.2.1
-JDK=17
+JDK=8
 KARTOTHEK=latest
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=14

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -48,7 +48,6 @@ env:
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
-
   ubuntu:
     name: AMD64 Ubuntu 22.04 Java JDK ${{ matrix.jdk }} Maven ${{ matrix.maven }}
     runs-on: ubuntu-latest

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -48,7 +48,6 @@ env:
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
-
   docker:
     name: AMD64 manylinux2014 Java JNI
     runs-on: ubuntu-latest

--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -43,6 +43,11 @@ fi
 # Get more detailed context on crashes
 export PYTHONFAULTHANDLER=1
 
+# Due to how Go reads environment variables, we have to set them from the calling
+# process, or they would get ignored.
+# (see https://forum.golangbridge.org/t/are-godebug-and-other-env-vars-ignored-when-loading-a-go-dll-from-foreign-code/33694)
+export GOMEMLIMIT=200MiB
+export GODEBUG=gctrace=1,clobberfree=1
 
 # Rust can be enabled by exporting ARCHERY_INTEGRATION_WITH_RUST=1
 time archery integration \

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -167,6 +167,7 @@ _cpp_c_data_entrypoints = """
 
 @functools.lru_cache
 def _load_ffi(ffi, lib_path=_ARROW_DLL):
+    os.environ['ARROW_DEBUG_MEMORY_POOL'] = 'trap'
     ffi.cdef(_cpp_c_data_entrypoints)
     dll = ffi.dlopen(lib_path)
     dll.ArrowCpp_CDataIntegration_ExportSchemaFromJson

--- a/dev/archery/archery/integration/tester_csharp.py
+++ b/dev/archery/archery/integration/tester_csharp.py
@@ -38,6 +38,8 @@ def _load_clr():
     global _clr_loaded
     if not _clr_loaded:
         _clr_loaded = True
+        os.environ['DOTNET_GCHeapHardLimit'] = '0xC800000'  # 200 MiB
+        os.environ['DOTNET_gcConcurrent'] = '1'
         import pythonnet
         pythonnet.load("coreclr")
         import clr

--- a/dev/archery/archery/integration/tester_csharp.py
+++ b/dev/archery/archery/integration/tester_csharp.py
@@ -39,7 +39,6 @@ def _load_clr():
     if not _clr_loaded:
         _clr_loaded = True
         os.environ['DOTNET_GCHeapHardLimit'] = '0xC800000'  # 200 MiB
-        os.environ['DOTNET_gcConcurrent'] = '1'
         import pythonnet
         pythonnet.load("coreclr")
         import clr

--- a/dev/archery/archery/integration/tester_go.py
+++ b/dev/archery/archery/integration/tester_go.py
@@ -159,6 +159,9 @@ _go_c_data_entrypoints = """
 
 @functools.lru_cache
 def _load_ffi(ffi, lib_path=_INTEGRATION_DLL):
+    # XXX these don't seem to have any effect?
+    os.environ['GOMEMLIMIT'] = '200MiB'
+    os.environ['GODEBUG'] = 'gctrace=1,clobberfree=1'
     ffi.cdef(_go_c_data_entrypoints)
     dll = ffi.dlopen(lib_path)
     return dll

--- a/dev/archery/archery/integration/tester_go.py
+++ b/dev/archery/archery/integration/tester_go.py
@@ -159,9 +159,9 @@ _go_c_data_entrypoints = """
 
 @functools.lru_cache
 def _load_ffi(ffi, lib_path=_INTEGRATION_DLL):
-    # XXX these don't seem to have any effect?
-    os.environ['GOMEMLIMIT'] = '200MiB'
-    os.environ['GODEBUG'] = 'gctrace=1,clobberfree=1'
+    # NOTE that setting Go environment variables here (such as GODEBUG)
+    # would be ignored by the Go runtime. The environment variables need
+    # to be set from the process calling Archery.
     ffi.cdef(_go_c_data_entrypoints)
     dll = ffi.dlopen(lib_path)
     return dll

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1706,7 +1706,8 @@ services:
       args:
         repo: ${REPO}
         arch: ${ARCH}
-        jdk: ${JDK}
+        # Use a newer JDK as it seems to improve stability
+        jdk: 17
         # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
         # be set to ${MAVEN}
         maven: 3.5


### PR DESCRIPTION
### Rationale for this change

C Data Interface integration tests sometimes crash with a complicated traceback involving Java, Go and C# signal handlers.

### What changes are included in this PR?

* Update JDK version in integration build
* Disable signal-based memory management in the JVM so as to improve cooperation with other runtimes
* Set memory limits to the various managed runtimes (Java, .Net, Go)
* Enable some checks in the Go runtime
* Enable debug allocator in Arrow Java

### Are these changes tested?

Yes. I am not able to reproduce any sporadic crash using these changes.

### Are there any user-facing changes?

No.

* Closes: #38684