### PR TITLE
MINOR: [Docs][Python] Correct type for requested_schema in docstring of __arrow_c_stream__

### DIFF
--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -823,10 +823,12 @@ cdef class RecordBatchReader(_Weakrefable):
 
         Parameters
         ----------
-        requested_schema: Schema, default None
-            The schema to which the stream should be casted. Currently, this is
-            not supported and will raise a NotImplementedError if the schema 
-            doesn't match the current schema.
+        requested_schema : PyCapsule, default None
+            The schema to which the stream should be casted, passed as a
+            PyCapsule containing a C ArrowSchema representation of the
+            requested schema.
+            Currently, this is not supported and will raise a
+            NotImplementedError if the schema doesn't match the current schema.
 
         Returns
         -------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3039,9 +3039,12 @@ cdef class RecordBatch(_Tabular):
 
         Parameters
         ----------
-        requested_schema : pyarrow.lib.Schema, default None
-            A schema to attempt to cast the streamed data to. This is currently
-            unsupported and will raise an error.
+        requested_schema : PyCapsule, default None
+            The schema to which the stream should be casted, passed as a
+            PyCapsule containing a C ArrowSchema representation of the
+            requested schema.
+            Currently, this is not supported and will raise a
+            NotImplementedError if the schema doesn't match the current schema.
 
         Returns
         -------
@@ -4859,9 +4862,12 @@ cdef class Table(_Tabular):
 
         Parameters
         ----------
-        requested_schema : pyarrow.lib.Schema, default None
-            A schema to attempt to cast the streamed data to. This is currently
-            unsupported and will raise an error.
+        requested_schema : PyCapsule, default None
+            The schema to which the stream should be casted, passed as a
+            PyCapsule containing a C ArrowSchema representation of the
+            requested schema.
+            Currently, this is not supported and will raise a
+            NotImplementedError if the schema doesn't match the current schema.
 
         Returns
         -------


### PR DESCRIPTION
The implementation is correct, but I just noticed that the docstring wasn't fully correct (indicating you could pass a pyarrow Schema, but this actually need to be a PyCapsule). In the docstring of `__arrow_c_array__` it is documented correctly.