### PR TITLE
GH-38844: [C++] S3FileSystem export s3 sdk config "use_virtual_addressing" to arrow::fs::S3Options

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -951,7 +951,8 @@ class ClientBuilder {
       client_config_.caPath = ToAwsString(internal::global_options.tls_ca_dir_path);
     }
 
-    const bool use_virtual_addressing = options_.use_virtual_addressing;
+    const bool use_virtual_addressing =
+        options_.endpoint_override.empty() || options_.force_virtual_addressing;
 
     // Set proxy options if provided
     if (!options_.proxy_options.scheme.empty()) {

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -951,7 +951,7 @@ class ClientBuilder {
       client_config_.caPath = ToAwsString(internal::global_options.tls_ca_dir_path);
     }
 
-    const bool use_virtual_addressing = options_.endpoint_override.empty();
+    const bool use_virtual_addressing = options_.use_virtual_addressing;
 
     // Set proxy options if provided
     if (!options_.proxy_options.scheme.empty()) {

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -144,8 +144,8 @@ struct ARROW_EXPORT S3Options {
   /// Type of credentials being used. Set along with credentials_provider.
   S3CredentialsKind credentials_kind = S3CredentialsKind::Default;
 
-  /// Whether to use virtual addressing (bucket.s3.amazonaws.com) or path-style
-  bool use_virtual_addressing = false;
+  /// Whether to use virtual addressing of buckets
+  bool force_virtual_addressing = false;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -145,7 +145,7 @@ struct ARROW_EXPORT S3Options {
   S3CredentialsKind credentials_kind = S3CredentialsKind::Default;
 
   /// Whether to use virtual addressing (bucket.s3.amazonaws.com) or path-style
-  bool use_virtual_addressing = true;
+  bool use_virtual_addressing = false;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -148,6 +148,8 @@ struct ARROW_EXPORT S3Options {
   ///
   /// If true, then virtual addressing is always enabled.
   /// If false, then virtual addressing is only enabled if `endpoint_override` is empty.
+  ///
+  /// This can be used for non-AWS backends that only support virtual hosted-style access.
   bool force_virtual_addressing = false;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -145,6 +145,9 @@ struct ARROW_EXPORT S3Options {
   S3CredentialsKind credentials_kind = S3CredentialsKind::Default;
 
   /// Whether to use virtual addressing of buckets
+  ///
+  /// If true, then virtual addressing is always enabled.
+  /// If false, then virtual addressing is only enabled if `endpoint_override` is empty.
   bool force_virtual_addressing = false;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -148,9 +148,6 @@ struct ARROW_EXPORT S3Options {
   ///
   /// If true, then virtual addressing is always enabled.
   /// If false, then virtual addressing is only enabled if `endpoint_override` is empty.
-  ///
-  /// If true, then virtual addressing is always enabled.
-  /// If false, then virtual addressing is only enabled if `endpoint_override` is empty.
   bool force_virtual_addressing = false;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -148,6 +148,9 @@ struct ARROW_EXPORT S3Options {
   ///
   /// If true, then virtual addressing is always enabled.
   /// If false, then virtual addressing is only enabled if `endpoint_override` is empty.
+  ///
+  /// If true, then virtual addressing is always enabled.
+  /// If false, then virtual addressing is only enabled if `endpoint_override` is empty.
   bool force_virtual_addressing = false;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -144,6 +144,9 @@ struct ARROW_EXPORT S3Options {
   /// Type of credentials being used. Set along with credentials_provider.
   S3CredentialsKind credentials_kind = S3CredentialsKind::Default;
 
+  /// Whether to use virtual addressing (bucket.s3.amazonaws.com) or path-style
+  bool use_virtual_addressing = true;
+
   /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
See #38844 . we should export s3 sdk config "use_virtual_addressing" to arrow::fs::S3Options so that user can decide whether to use virtual hosted by themselves. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
I tested it with my own OSS(aliyun object store service) bucket.As the it is a S3 compatiable service, I think 
 these changes are covered by existing tests)
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Closes: #38844  
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38844