### PR TITLE
GH-38920: [C++][Gandiva] Refactor function holder to return arrow Result

### DIFF
--- a/cpp/src/gandiva/function_holder_maker_registry.cc
+++ b/cpp/src/gandiva/function_holder_maker_registry.cc
@@ -41,9 +41,7 @@ arrow::Status FunctionHolderMakerRegistry::Register(const std::string& name,
 
 template <typename HolderType>
 static arrow::Result<FunctionHolderPtr> HolderMaker(const FunctionNode& node) {
-  std::shared_ptr<HolderType> derived_instance;
-  ARROW_RETURN_NOT_OK(HolderType::Make(node, &derived_instance));
-  return derived_instance;
+  return HolderType::Make(node);
 }
 
 arrow::Result<FunctionHolderPtr> FunctionHolderMakerRegistry::Make(

--- a/cpp/src/gandiva/interval_holder.cc
+++ b/cpp/src/gandiva/interval_holder.cc
@@ -258,26 +258,26 @@ int64_t IntervalDaysHolder::operator()(ExecutionContext* ctx, const char* data,
   return 0;
 }
 
-Status IntervalDaysHolder::Make(const FunctionNode& node,
-                                std::shared_ptr<IntervalDaysHolder>* holder) {
+Result<std::shared_ptr<IntervalDaysHolder>> IntervalDaysHolder::Make(
+    const FunctionNode& node) {
   const std::string function_name("castINTERVALDAY");
-  return IntervalHolder<IntervalDaysHolder>::Make(node, holder, function_name);
+  return IntervalHolder<IntervalDaysHolder>::Make(node, function_name);
 }
 
-Status IntervalDaysHolder::Make(int32_t suppress_errors,
-                                std::shared_ptr<IntervalDaysHolder>* holder) {
-  return IntervalHolder<IntervalDaysHolder>::Make(suppress_errors, holder);
+Result<std::shared_ptr<IntervalDaysHolder>> IntervalDaysHolder::Make(
+    int32_t suppress_errors) {
+  return IntervalHolder<IntervalDaysHolder>::Make(suppress_errors);
 }
 
-Status IntervalYearsHolder::Make(const FunctionNode& node,
-                                 std::shared_ptr<IntervalYearsHolder>* holder) {
+Result<std::shared_ptr<IntervalYearsHolder>> IntervalYearsHolder::Make(
+    const FunctionNode& node) {
   const std::string function_name("castINTERVALYEAR");
-  return IntervalHolder<IntervalYearsHolder>::Make(node, holder, function_name);
+  return IntervalHolder<IntervalYearsHolder>::Make(node, function_name);
 }
 
-Status IntervalYearsHolder::Make(int32_t suppress_errors,
-                                 std::shared_ptr<IntervalYearsHolder>* holder) {
-  return IntervalHolder<IntervalYearsHolder>::Make(suppress_errors, holder);
+Result<std::shared_ptr<IntervalYearsHolder>> IntervalYearsHolder::Make(
+    int32_t suppress_errors) {
+  return IntervalHolder<IntervalYearsHolder>::Make(suppress_errors);
 }
 
 // The operator will cast a generic string defined by the user into an interval of months.

--- a/cpp/src/gandiva/interval_holder.h
+++ b/cpp/src/gandiva/interval_holder.h
@@ -39,8 +39,8 @@ class GANDIVA_EXPORT IntervalHolder : public FunctionHolder {
   ~IntervalHolder() override = default;
 
  protected:
-  static Status Make(const FunctionNode& node, std::shared_ptr<INTERVAL_TYPE>* holder,
-                     const std::string& function_name) {
+  static Result<std::shared_ptr<INTERVAL_TYPE>> Make(const FunctionNode& node,
+                                                     const std::string& function_name) {
     ARROW_RETURN_IF(node.children().size() != 1 && node.children().size() != 2,
                     Status::Invalid(function_name + " requires one or two parameters"));
 
@@ -63,14 +63,11 @@ class GANDIVA_EXPORT IntervalHolder : public FunctionHolder {
       suppress_errors = std::get<int>(literal_suppress_errors->holder());
     }
 
-    return Make(suppress_errors, holder);
+    return Make(suppress_errors);
   }
 
-  static Status Make(int32_t suppress_errors, std::shared_ptr<INTERVAL_TYPE>* holder) {
-    auto lholder = std::make_shared<INTERVAL_TYPE>(suppress_errors);
-
-    *holder = lholder;
-    return Status::OK();
+  static Result<std::shared_ptr<INTERVAL_TYPE>> Make(int32_t suppress_errors) {
+    return std::make_shared<INTERVAL_TYPE>(suppress_errors);
   }
 
   explicit IntervalHolder(int32_t supress_errors) : suppress_errors_(supress_errors) {}
@@ -94,11 +91,9 @@ class GANDIVA_EXPORT IntervalDaysHolder : public IntervalHolder<IntervalDaysHold
  public:
   ~IntervalDaysHolder() override = default;
 
-  static Status Make(const FunctionNode& node,
-                     std::shared_ptr<IntervalDaysHolder>* holder);
+  static Result<std::shared_ptr<IntervalDaysHolder>> Make(const FunctionNode& node);
 
-  static Status Make(int32_t suppress_errors,
-                     std::shared_ptr<IntervalDaysHolder>* holder);
+  static Result<std::shared_ptr<IntervalDaysHolder>> Make(int32_t suppress_errors);
 
   /// Cast a generic string to an interval
   int64_t operator()(ExecutionContext* ctx, const char* data, int32_t data_len,
@@ -131,11 +126,9 @@ class GANDIVA_EXPORT IntervalYearsHolder : public IntervalHolder<IntervalYearsHo
  public:
   ~IntervalYearsHolder() override = default;
 
-  static Status Make(const FunctionNode& node,
-                     std::shared_ptr<IntervalYearsHolder>* holder);
+  static Result<std::shared_ptr<IntervalYearsHolder>> Make(const FunctionNode& node);
 
-  static Status Make(int32_t suppress_errors,
-                     std::shared_ptr<IntervalYearsHolder>* holder);
+  static Result<std::shared_ptr<IntervalYearsHolder>> Make(int32_t suppress_errors);
 
   /// Cast a generic string to an interval
   int32_t operator()(ExecutionContext* ctx, const char* data, int32_t data_len,

--- a/cpp/src/gandiva/interval_holder_test.cc
+++ b/cpp/src/gandiva/interval_holder_test.cc
@@ -20,8 +20,8 @@
 #include <gtest/gtest.h>
 
 #include <memory>
-#include <vector>
 
+#include "arrow/testing/gtest_util.h"
 #include "gandiva/execution_context.h"
 
 namespace gandiva {
@@ -32,14 +32,8 @@ class TestIntervalHolder : public ::testing::Test {
 };
 
 TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
-  std::shared_ptr<IntervalDaysHolder> interval_days_holder;
-  std::shared_ptr<IntervalYearsHolder> interval_years_holder;
-
-  auto status = IntervalDaysHolder::Make(0, &interval_days_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
-
-  status = IntervalYearsHolder::Make(0, &interval_years_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
+  EXPECT_OK_AND_ASSIGN(auto interval_days_holder, IntervalDaysHolder::Make(0));
+  EXPECT_OK_AND_ASSIGN(auto interval_years_holder, IntervalYearsHolder::Make(0));
 
   auto& cast_interval_day = *interval_days_holder;
   auto& cast_interval_year = *interval_years_holder;
@@ -289,14 +283,8 @@ TEST_F(TestIntervalHolder, TestMatchAllPeriods) {
 }
 
 TEST_F(TestIntervalHolder, TestMatchErrorsForCastIntervalDay) {
-  std::shared_ptr<IntervalDaysHolder> interval_days_holder;
-  std::shared_ptr<IntervalYearsHolder> interval_years_holder;
-
-  auto status = IntervalDaysHolder::Make(0, &interval_days_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
-
-  status = IntervalYearsHolder::Make(0, &interval_years_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
+  EXPECT_OK_AND_ASSIGN(auto interval_days_holder, IntervalDaysHolder::Make(0));
+  EXPECT_OK_AND_ASSIGN(auto interval_years_holder, IntervalYearsHolder::Make(0));
 
   auto& cast_interval_day = *interval_days_holder;
   auto& cast_interval_year = *interval_years_holder;
@@ -440,12 +428,8 @@ TEST_F(TestIntervalHolder, TestMatchErrorsForCastIntervalDay) {
 }
 
 TEST_F(TestIntervalHolder, TestUsingWeekFormatterForCastIntervalDay) {
-  std::shared_ptr<IntervalDaysHolder> interval_holder;
-
-  auto status = IntervalDaysHolder::Make(0, &interval_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
-
-  auto& cast_interval_day = *interval_holder;
+  EXPECT_OK_AND_ASSIGN(auto interval_days_holder, IntervalDaysHolder::Make(0));
+  auto& cast_interval_day = *interval_days_holder;
 
   bool out_valid;
   std::string data("P1W");
@@ -465,12 +449,8 @@ TEST_F(TestIntervalHolder, TestUsingWeekFormatterForCastIntervalDay) {
 }
 
 TEST_F(TestIntervalHolder, TestUsingCompleteFormatterForCastIntervalDay) {
-  std::shared_ptr<IntervalDaysHolder> interval_holder;
-
-  auto status = IntervalDaysHolder::Make(0, &interval_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
-
-  auto& cast_interval_day = *interval_holder;
+  EXPECT_OK_AND_ASSIGN(auto interval_days_holder, IntervalDaysHolder::Make(0));
+  auto& cast_interval_day = *interval_days_holder;
 
   bool out_valid;
   std::string data("1742461111");
@@ -528,11 +508,7 @@ TEST_F(TestIntervalHolder, TestUsingCompleteFormatterForCastIntervalDay) {
 }
 
 TEST_F(TestIntervalHolder, TestUsingCompleteFormatterForCastIntervalYear) {
-  std::shared_ptr<IntervalYearsHolder> interval_years_holder;
-
-  auto status = IntervalYearsHolder::Make(0, &interval_years_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
-
+  EXPECT_OK_AND_ASSIGN(auto interval_years_holder, IntervalYearsHolder::Make(0));
   auto& cast_interval_years = *interval_years_holder;
 
   bool out_valid;

--- a/cpp/src/gandiva/random_generator_holder.cc
+++ b/cpp/src/gandiva/random_generator_holder.cc
@@ -19,14 +19,13 @@
 #include "gandiva/node.h"
 
 namespace gandiva {
-Status RandomGeneratorHolder::Make(const FunctionNode& node,
-                                   std::shared_ptr<RandomGeneratorHolder>* holder) {
+Result<std::shared_ptr<RandomGeneratorHolder>> RandomGeneratorHolder::Make(
+    const FunctionNode& node) {
   ARROW_RETURN_IF(node.children().size() > 1,
                   Status::Invalid("'random' function requires at most one parameter"));
 
   if (node.children().size() == 0) {
-    *holder = std::shared_ptr<RandomGeneratorHolder>(new RandomGeneratorHolder());
-    return Status::OK();
+    return std::shared_ptr<RandomGeneratorHolder>(new RandomGeneratorHolder());
   }
 
   auto literal = dynamic_cast<LiteralNode*>(node.children().at(0).get());
@@ -38,8 +37,7 @@ Status RandomGeneratorHolder::Make(const FunctionNode& node,
       literal_type != arrow::Type::INT32,
       Status::Invalid("'random' function requires an int32 literal as parameter"));
 
-  *holder = std::shared_ptr<RandomGeneratorHolder>(new RandomGeneratorHolder(
+  return std::shared_ptr<RandomGeneratorHolder>(new RandomGeneratorHolder(
       literal->is_null() ? 0 : std::get<int32_t>(literal->holder())));
-  return Status::OK();
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/random_generator_holder.h
+++ b/cpp/src/gandiva/random_generator_holder.h
@@ -34,8 +34,7 @@ class GANDIVA_EXPORT RandomGeneratorHolder : public FunctionHolder {
  public:
   ~RandomGeneratorHolder() override = default;
 
-  static Status Make(const FunctionNode& node,
-                     std::shared_ptr<RandomGeneratorHolder>* holder);
+  static Result<std::shared_ptr<RandomGeneratorHolder>> Make(const FunctionNode& node);
 
   double operator()() { return distribution_(generator_); }
 

--- a/cpp/src/gandiva/random_generator_holder_test.cc
+++ b/cpp/src/gandiva/random_generator_holder_test.cc
@@ -21,38 +21,35 @@
 
 #include <gtest/gtest.h>
 
+#include "arrow/testing/gtest_util.h"
+
 namespace gandiva {
 
 class TestRandGenHolder : public ::testing::Test {
  public:
-  FunctionNode BuildRandFunc() { return FunctionNode("random", {}, arrow::float64()); }
+  FunctionNode BuildRandFunc() { return {"random", {}, arrow::float64()}; }
 
   FunctionNode BuildRandWithSeedFunc(int32_t seed, bool seed_is_null) {
     auto seed_node =
         std::make_shared<LiteralNode>(arrow::int32(), LiteralHolder(seed), seed_is_null);
-    return FunctionNode("rand", {seed_node}, arrow::float64());
+    return {"rand", {seed_node}, arrow::float64()};
   }
 };
 
 TEST_F(TestRandGenHolder, NoSeed) {
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder;
   FunctionNode rand_func = BuildRandFunc();
-  auto status = RandomGeneratorHolder::Make(rand_func, &rand_gen_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder, RandomGeneratorHolder::Make(rand_func));
 
   auto& random = *rand_gen_holder;
   EXPECT_NE(random(), random());
 }
 
 TEST_F(TestRandGenHolder, WithValidEqualSeeds) {
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder_1;
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder_2;
   FunctionNode rand_func_1 = BuildRandWithSeedFunc(12, false);
   FunctionNode rand_func_2 = BuildRandWithSeedFunc(12, false);
-  auto status = RandomGeneratorHolder::Make(rand_func_1, &rand_gen_holder_1);
-  EXPECT_EQ(status.ok(), true) << status.message();
-  status = RandomGeneratorHolder::Make(rand_func_2, &rand_gen_holder_2);
-  EXPECT_EQ(status.ok(), true) << status.message();
+
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder_1, RandomGeneratorHolder::Make(rand_func_1));
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder_2, RandomGeneratorHolder::Make(rand_func_2));
 
   auto& random_1 = *rand_gen_holder_1;
   auto& random_2 = *rand_gen_holder_2;
@@ -65,18 +62,12 @@ TEST_F(TestRandGenHolder, WithValidEqualSeeds) {
 }
 
 TEST_F(TestRandGenHolder, WithValidSeeds) {
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder_1;
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder_2;
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder_3;
   FunctionNode rand_func_1 = BuildRandWithSeedFunc(11, false);
   FunctionNode rand_func_2 = BuildRandWithSeedFunc(12, false);
   FunctionNode rand_func_3 = BuildRandWithSeedFunc(-12, false);
-  auto status = RandomGeneratorHolder::Make(rand_func_1, &rand_gen_holder_1);
-  EXPECT_EQ(status.ok(), true) << status.message();
-  status = RandomGeneratorHolder::Make(rand_func_2, &rand_gen_holder_2);
-  EXPECT_EQ(status.ok(), true) << status.message();
-  status = RandomGeneratorHolder::Make(rand_func_3, &rand_gen_holder_3);
-  EXPECT_EQ(status.ok(), true) << status.message();
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder_1, RandomGeneratorHolder::Make(rand_func_1));
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder_2, RandomGeneratorHolder::Make(rand_func_2));
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder_3, RandomGeneratorHolder::Make(rand_func_3));
 
   auto& random_1 = *rand_gen_holder_1;
   auto& random_2 = *rand_gen_holder_2;
@@ -86,14 +77,10 @@ TEST_F(TestRandGenHolder, WithValidSeeds) {
 }
 
 TEST_F(TestRandGenHolder, WithInValidSeed) {
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder_1;
-  std::shared_ptr<RandomGeneratorHolder> rand_gen_holder_2;
   FunctionNode rand_func_1 = BuildRandWithSeedFunc(12, true);
   FunctionNode rand_func_2 = BuildRandWithSeedFunc(0, false);
-  auto status = RandomGeneratorHolder::Make(rand_func_1, &rand_gen_holder_1);
-  EXPECT_EQ(status.ok(), true) << status.message();
-  status = RandomGeneratorHolder::Make(rand_func_2, &rand_gen_holder_2);
-  EXPECT_EQ(status.ok(), true) << status.message();
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder_1, RandomGeneratorHolder::Make(rand_func_1));
+  EXPECT_OK_AND_ASSIGN(auto rand_gen_holder_2, RandomGeneratorHolder::Make(rand_func_2));
 
   auto& random_1 = *rand_gen_holder_1;
   auto& random_2 = *rand_gen_holder_2;

--- a/cpp/src/gandiva/regex_functions_holder.cc
+++ b/cpp/src/gandiva/regex_functions_holder.cc
@@ -152,7 +152,7 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_patt
                   Status::Invalid("Building RE2 pattern '", pcre_pattern,
                                   "' failed with: ", lholder->regex_.error()));
 
-  return std::move(lholder);
+  return lholder;
 }
 
 Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_pattern,
@@ -160,8 +160,7 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_patt
   std::string pcre_pattern;
   ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
 
-  std::shared_ptr<LikeHolder> lholder;
-  lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern, regex_op));
+  auto lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern, regex_op));
 
   ARROW_RETURN_IF(!lholder->regex_.ok(),
                   Status::Invalid("Building RE2 pattern '", pcre_pattern,

--- a/cpp/src/gandiva/regex_functions_holder.cc
+++ b/cpp/src/gandiva/regex_functions_holder.cc
@@ -48,9 +48,9 @@ const FunctionNode LikeHolder::TryOptimize(const FunctionNode& node) {
     global_checked = true;
   }
 
-  std::shared_ptr<LikeHolder> holder;
-  auto status = Make(node, &holder);
-  if (status.ok()) {
+  auto maybe_holder = Make(node);
+  if (maybe_holder.ok()) {
+    auto holder = *maybe_holder;
     std::string& pattern = holder->pattern_;
     auto literal_type = node.children().at(1)->return_type();
 
@@ -83,7 +83,7 @@ const FunctionNode LikeHolder::TryOptimize(const FunctionNode& node) {
   return node;
 }
 
-Status LikeHolder::Make(const FunctionNode& node, std::shared_ptr<LikeHolder>* holder) {
+Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const FunctionNode& node) {
   ARROW_RETURN_IF(node.children().size() != 2 && node.children().size() != 3,
                   Status::Invalid("'like' function requires two or three parameters"));
 
@@ -102,10 +102,10 @@ Status LikeHolder::Make(const FunctionNode& node, std::shared_ptr<LikeHolder>* h
   if (node.descriptor()->name() == "ilike") {
     regex_op.set_case_sensitive(false);  // set case-insensitive for ilike function.
 
-    return Make(std::get<std::string>(literal->holder()), holder, regex_op);
+    return Make(std::get<std::string>(literal->holder()), regex_op);
   }
   if (node.children().size() == 2) {
-    return Make(std::get<std::string>(literal->holder()), holder);
+    return Make(std::get<std::string>(literal->holder()));
   } else {
     auto escape_char = dynamic_cast<LiteralNode*>(node.children().at(2).get());
     ARROW_RETURN_IF(
@@ -118,12 +118,11 @@ Status LikeHolder::Make(const FunctionNode& node, std::shared_ptr<LikeHolder>* h
         Status::Invalid(
             "'like' function requires a string literal as the third parameter"));
     return Make(std::get<std::string>(literal->holder()),
-                std::get<std::string>(escape_char->holder()), holder);
+                std::get<std::string>(escape_char->holder()));
   }
 }
 
-Status LikeHolder::Make(const std::string& sql_pattern,
-                        std::shared_ptr<LikeHolder>* holder) {
+Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_pattern) {
   std::string pcre_pattern;
   ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
 
@@ -132,12 +131,11 @@ Status LikeHolder::Make(const std::string& sql_pattern,
                   Status::Invalid("Building RE2 pattern '", pcre_pattern,
                                   "' failed with: ", lholder->regex_.error()));
 
-  *holder = std::move(lholder);
-  return Status::OK();
+  return lholder;
 }
 
-Status LikeHolder::Make(const std::string& sql_pattern, const std::string& escape_char,
-                        std::shared_ptr<LikeHolder>* holder) {
+Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_pattern,
+                                                     const std::string& escape_char) {
   ARROW_RETURN_IF(escape_char.length() > 1,
                   Status::Invalid("The length of escape char ", escape_char,
                                   " in 'like' function is greater than 1"));
@@ -154,12 +152,11 @@ Status LikeHolder::Make(const std::string& sql_pattern, const std::string& escap
                   Status::Invalid("Building RE2 pattern '", pcre_pattern,
                                   "' failed with: ", lholder->regex_.error()));
 
-  *holder = std::move(lholder);
-  return Status::OK();
+  return std::move(lholder);
 }
 
-Status LikeHolder::Make(const std::string& sql_pattern,
-                        std::shared_ptr<LikeHolder>* holder, RE2::Options regex_op) {
+Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_pattern,
+                                                     RE2::Options regex_op) {
   std::string pcre_pattern;
   ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
 
@@ -170,12 +167,10 @@ Status LikeHolder::Make(const std::string& sql_pattern,
                   Status::Invalid("Building RE2 pattern '", pcre_pattern,
                                   "' failed with: ", lholder->regex_.error()));
 
-  *holder = std::move(lholder);
-  return Status::OK();
+  return lholder;
 }
 
-Status ReplaceHolder::Make(const FunctionNode& node,
-                           std::shared_ptr<ReplaceHolder>* holder) {
+Result<std::shared_ptr<ReplaceHolder>> ReplaceHolder::Make(const FunctionNode& node) {
   ARROW_RETURN_IF(node.children().size() != 3,
                   Status::Invalid("'replace' function requires three parameters"));
 
@@ -190,18 +185,17 @@ Status ReplaceHolder::Make(const FunctionNode& node,
       Status::Invalid(
           "'replace' function requires a string literal as the second parameter"));
 
-  return Make(std::get<std::string>(literal->holder()), holder);
+  return Make(std::get<std::string>(literal->holder()));
 }
 
-Status ReplaceHolder::Make(const std::string& sql_pattern,
-                           std::shared_ptr<ReplaceHolder>* holder) {
+Result<std::shared_ptr<ReplaceHolder>> ReplaceHolder::Make(
+    const std::string& sql_pattern) {
   auto lholder = std::shared_ptr<ReplaceHolder>(new ReplaceHolder(sql_pattern));
   ARROW_RETURN_IF(!lholder->regex_.ok(),
                   Status::Invalid("Building RE2 pattern '", sql_pattern,
                                   "' failed with: ", lholder->regex_.error()));
 
-  *holder = std::move(lholder);
-  return Status::OK();
+  return lholder;
 }
 
 void ReplaceHolder::return_error(ExecutionContext* context, std::string& data,
@@ -211,8 +205,7 @@ void ReplaceHolder::return_error(ExecutionContext* context, std::string& data,
   context->set_error_msg(err_msg.c_str());
 }
 
-Status ExtractHolder::Make(const FunctionNode& node,
-                           std::shared_ptr<ExtractHolder>* holder) {
+Result<std::shared_ptr<ExtractHolder>> ExtractHolder::Make(const FunctionNode& node) {
   ARROW_RETURN_IF(node.children().size() != 3,
                   Status::Invalid("'extract' function requires three parameters"));
 
@@ -221,18 +214,17 @@ Status ExtractHolder::Make(const FunctionNode& node,
       literal == nullptr || !IsArrowStringLiteral(literal->return_type()->id()),
       Status::Invalid("'extract' function requires a literal as the second parameter"));
 
-  return ExtractHolder::Make(std::get<std::string>(literal->holder()), holder);
+  return ExtractHolder::Make(std::get<std::string>(literal->holder()));
 }
 
-Status ExtractHolder::Make(const std::string& sql_pattern,
-                           std::shared_ptr<ExtractHolder>* holder) {
+Result<std::shared_ptr<ExtractHolder>> ExtractHolder::Make(
+    const std::string& sql_pattern) {
   auto lholder = std::shared_ptr<ExtractHolder>(new ExtractHolder(sql_pattern));
   ARROW_RETURN_IF(!lholder->regex_.ok(),
                   Status::Invalid("Building RE2 pattern '", sql_pattern,
                                   "' failed with: ", lholder->regex_.error()));
 
-  *holder = std::move(lholder);
-  return Status::OK();
+  return lholder;
 }
 
 const char* ExtractHolder::operator()(ExecutionContext* ctx, const char* user_input,

--- a/cpp/src/gandiva/regex_functions_holder.h
+++ b/cpp/src/gandiva/regex_functions_holder.h
@@ -35,15 +35,15 @@ class GANDIVA_EXPORT LikeHolder : public FunctionHolder {
  public:
   ~LikeHolder() override = default;
 
-  static Status Make(const FunctionNode& node, std::shared_ptr<LikeHolder>* holder);
+  static Result<std::shared_ptr<LikeHolder>> Make(const FunctionNode& node);
 
-  static Status Make(const std::string& sql_pattern, std::shared_ptr<LikeHolder>* holder);
+  static Result<std::shared_ptr<LikeHolder>> Make(const std::string& sql_pattern);
 
-  static Status Make(const std::string& sql_pattern, const std::string& escape_char,
-                     std::shared_ptr<LikeHolder>* holder);
+  static Result<std::shared_ptr<LikeHolder>> Make(const std::string& sql_pattern,
+                                                  const std::string& escape_char);
 
-  static Status Make(const std::string& sql_pattern, std::shared_ptr<LikeHolder>* holder,
-                     RE2::Options regex_op);
+  static Result<std::shared_ptr<LikeHolder>> Make(const std::string& sql_pattern,
+                                                  RE2::Options regex_op);
 
   // Try and optimise a function node with a "like" pattern.
   static const FunctionNode TryOptimize(const FunctionNode& node);
@@ -66,10 +66,9 @@ class GANDIVA_EXPORT ReplaceHolder : public FunctionHolder {
  public:
   ~ReplaceHolder() override = default;
 
-  static Status Make(const FunctionNode& node, std::shared_ptr<ReplaceHolder>* holder);
+  static Result<std::shared_ptr<ReplaceHolder>> Make(const FunctionNode& node);
 
-  static Status Make(const std::string& sql_pattern,
-                     std::shared_ptr<ReplaceHolder>* holder);
+  static Result<std::shared_ptr<ReplaceHolder>> Make(const std::string& sql_pattern);
 
   /// Return a new string with the pattern that matched the regex replaced for
   /// the replace_input parameter.
@@ -130,10 +129,9 @@ class GANDIVA_EXPORT ExtractHolder : public FunctionHolder {
  public:
   ~ExtractHolder() override = default;
 
-  static Status Make(const FunctionNode& node, std::shared_ptr<ExtractHolder>* holder);
+  static Result<std::shared_ptr<ExtractHolder>> Make(const FunctionNode& node);
 
-  static Status Make(const std::string& sql_pattern,
-                     std::shared_ptr<ExtractHolder>* holder);
+  static Result<std::shared_ptr<ExtractHolder>> Make(const std::string& sql_pattern);
 
   /// Extracts the matching text from a string using a regex
   const char* operator()(ExecutionContext* ctx, const char* user_input,

--- a/cpp/src/gandiva/regex_functions_holder_test.cc
+++ b/cpp/src/gandiva/regex_functions_holder_test.cc
@@ -79,8 +79,7 @@ TEST_F(TestLikeHolder, TestPcreSpecial) {
 
 TEST_F(TestLikeHolder, TestRegexEscape) {
   std::string res;
-  auto status = RegexUtil::SqlLikePatternToPcre("#%hello#_abc_def##", '#', res);
-  EXPECT_TRUE(status.ok()) << status.message();
+  ARROW_EXPECT_OK(RegexUtil::SqlLikePatternToPcre("#%hello#_abc_def##", '#', res));
 
   EXPECT_EQ(res, "%hello_abc.def#");
 }
@@ -224,8 +223,7 @@ TEST_F(TestLikeHolder, TestEmptyEscapeChar) {
 }
 
 TEST_F(TestLikeHolder, TestMultipleEscapeChar) {
-  auto status = LikeHolder::Make("ab\\_", "\\\\").status();
-  EXPECT_EQ(status.ok(), false) << status.message();
+  ASSERT_RAISES(Invalid, LikeHolder::Make("ab\\_", "\\\\").status());
 }
 
 class TestILikeHolder : public ::testing::Test {
@@ -368,9 +366,7 @@ TEST_F(TestReplaceHolder, TestReplaceSameSize) {
 }
 
 TEST_F(TestReplaceHolder, TestReplaceInvalidPattern) {
-  auto replace_holder = ReplaceHolder::Make("+");
-  EXPECT_EQ(replace_holder.ok(), false) << replace_holder.status().message();
-
+  ASSERT_RAISES(Invalid, ReplaceHolder::Make("+"));
   execution_context_.Reset();
 }
 
@@ -586,8 +582,7 @@ TEST_F(TestExtractHolder, TestInvalidRange) {
 }
 
 TEST_F(TestExtractHolder, TestExtractInvalidPattern) {
-  auto extract_holder = ExtractHolder::Make("+");
-  EXPECT_EQ(extract_holder.ok(), false) << extract_holder.status().message();
+  ASSERT_RAISES(Invalid, ExtractHolder::Make("+"));
   execution_context_.Reset();
 }
 
@@ -600,9 +595,9 @@ TEST_F(TestExtractHolder, TestErrorWhileBuildingHolder) {
       FunctionNode("regexp_extract", {field, pattern_node}, arrow::utf8());
 
   auto extract_holder = ExtractHolder::Make(function_node);
-  EXPECT_EQ(extract_holder.ok(), false);
-  EXPECT_THAT(extract_holder.status().message(),
-              ::testing::HasSubstr("'extract' function requires three parameters"));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::HasSubstr("'extract' function requires three parameters"),
+      extract_holder.status());
 
   execution_context_.Reset();
 
@@ -614,10 +609,11 @@ TEST_F(TestExtractHolder, TestErrorWhileBuildingHolder) {
       FunctionNode("regexp_extract", {field, pattern_node, index_node}, arrow::utf8());
 
   extract_holder = ExtractHolder::Make(function_node);
-  EXPECT_EQ(extract_holder.ok(), false);
-  EXPECT_THAT(extract_holder.status().message(),
-              ::testing::HasSubstr(
-                  "'extract' function requires a literal as the second parameter"));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid,
+      ::testing::HasSubstr(
+          "'extract' function requires a literal as the second parameter"),
+      extract_holder.status());
 
   execution_context_.Reset();
 
@@ -630,10 +626,11 @@ TEST_F(TestExtractHolder, TestErrorWhileBuildingHolder) {
       FunctionNode("regexp_extract", {field, pattern_as_node, index_node}, arrow::utf8());
 
   extract_holder = ExtractHolder::Make(function_node);
-  EXPECT_EQ(extract_holder.ok(), false);
-  EXPECT_THAT(extract_holder.status().message(),
-              ::testing::HasSubstr(
-                  "'extract' function requires a literal as the second parameter"));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid,
+      ::testing::HasSubstr(
+          "'extract' function requires a literal as the second parameter"),
+      extract_holder.status());
 
   execution_context_.Reset();
 }

--- a/cpp/src/gandiva/to_date_holder.cc
+++ b/cpp/src/gandiva/to_date_holder.cc
@@ -28,8 +28,7 @@
 
 namespace gandiva {
 
-Status ToDateHolder::Make(const FunctionNode& node,
-                          std::shared_ptr<ToDateHolder>* holder) {
+Result<std::shared_ptr<ToDateHolder>> ToDateHolder::Make(const FunctionNode& node) {
   if (node.children().size() != 2 && node.children().size() != 3) {
     return Status::Invalid("'to_date' function requires two or three parameters");
   }
@@ -66,17 +65,15 @@ Status ToDateHolder::Make(const FunctionNode& node,
     suppress_errors = std::get<int>(literal_suppress_errors->holder());
   }
 
-  return Make(pattern, suppress_errors, holder);
+  return Make(pattern, suppress_errors);
 }
 
-Status ToDateHolder::Make(const std::string& sql_pattern, int32_t suppress_errors,
-                          std::shared_ptr<ToDateHolder>* holder) {
+Result<std::shared_ptr<ToDateHolder>> ToDateHolder::Make(const std::string& sql_pattern,
+                                                         int32_t suppress_errors) {
   std::shared_ptr<std::string> transformed_pattern;
   ARROW_RETURN_NOT_OK(DateUtils::ToInternalFormat(sql_pattern, &transformed_pattern));
-  auto lholder = std::shared_ptr<ToDateHolder>(
-      new ToDateHolder(*(transformed_pattern.get()), suppress_errors));
-  *holder = lholder;
-  return Status::OK();
+  return std::shared_ptr<ToDateHolder>(
+      new ToDateHolder(*transformed_pattern, suppress_errors));
 }
 
 int64_t ToDateHolder::operator()(ExecutionContext* context, const char* data,

--- a/cpp/src/gandiva/to_date_holder.h
+++ b/cpp/src/gandiva/to_date_holder.h
@@ -35,10 +35,10 @@ class GANDIVA_EXPORT ToDateHolder : public FunctionHolder {
  public:
   ~ToDateHolder() override = default;
 
-  static Status Make(const FunctionNode& node, std::shared_ptr<ToDateHolder>* holder);
+  static Result<std::shared_ptr<ToDateHolder>> Make(const FunctionNode& node);
 
-  static Status Make(const std::string& sql_pattern, int32_t suppress_errors,
-                     std::shared_ptr<ToDateHolder>* holder);
+  static Result<std::shared_ptr<ToDateHolder>> Make(const std::string& sql_pattern,
+                                                    int32_t suppress_errors);
 
   /// Return true if the data matches the pattern.
   int64_t operator()(ExecutionContext* context, const char* data, int data_len,

--- a/cpp/src/gandiva/to_date_holder_test.cc
+++ b/cpp/src/gandiva/to_date_holder_test.cc
@@ -137,8 +137,7 @@ TEST_F(TestToDateHolder, TestSimpleDateTimeError) {
 
 TEST_F(TestToDateHolder, TestSimpleDateTimeMakeError) {
   // reject time stamps for now.
-  auto const status = ToDateHolder::Make("YYYY-MM-DD HH:MI:SS tzo", 0).status();
-  EXPECT_EQ(status.IsInvalid(), true) << status.message();
+  ASSERT_RAISES(Invalid, ToDateHolder::Make("YYYY-MM-DD HH:MI:SS tzo", 0).status());
 }
 
 TEST_F(TestToDateHolder, TestSimpleDateYearMonth) {

--- a/cpp/src/gandiva/to_date_holder_test.cc
+++ b/cpp/src/gandiva/to_date_holder_test.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <memory>
-#include <vector>
 
 #include "arrow/testing/gtest_util.h"
 
@@ -45,8 +44,7 @@ class TestToDateHolder : public ::testing::Test {
 };
 
 TEST_F(TestToDateHolder, TestSimpleDateTime) {
-  std::shared_ptr<ToDateHolder> to_date_holder;
-  ASSERT_OK(ToDateHolder::Make("YYYY-MM-DD HH:MI:SS", 1, &to_date_holder));
+  EXPECT_OK_AND_ASSIGN(auto to_date_holder, ToDateHolder::Make("YYYY-MM-DD HH:MI:SS", 1));
 
   auto& to_date = *to_date_holder;
   bool out_valid;
@@ -86,8 +84,7 @@ TEST_F(TestToDateHolder, TestSimpleDateTime) {
 }
 
 TEST_F(TestToDateHolder, TestSimpleDate) {
-  std::shared_ptr<ToDateHolder> to_date_holder;
-  ASSERT_OK(ToDateHolder::Make("YYYY-MM-DD", 1, &to_date_holder));
+  EXPECT_OK_AND_ASSIGN(auto to_date_holder, ToDateHolder::Make("YYYY-MM-DD", 1));
 
   auto& to_date = *to_date_holder;
   bool out_valid;
@@ -119,10 +116,7 @@ TEST_F(TestToDateHolder, TestSimpleDate) {
 }
 
 TEST_F(TestToDateHolder, TestSimpleDateTimeError) {
-  std::shared_ptr<ToDateHolder> to_date_holder;
-
-  auto status = ToDateHolder::Make("YYYY-MM-DD HH:MI:SS", 0, &to_date_holder);
-  EXPECT_EQ(status.ok(), true) << status.message();
+  EXPECT_OK_AND_ASSIGN(auto to_date_holder, ToDateHolder::Make("YYYY-MM-DD HH:MI:SS", 0));
   auto& to_date = *to_date_holder;
   bool out_valid;
 
@@ -132,8 +126,7 @@ TEST_F(TestToDateHolder, TestSimpleDateTimeError) {
   EXPECT_EQ(0, millis_since_epoch);
   std::string expected_error =
       "Error parsing value 1986-01-40 01:01:01 +0800 for given format";
-  EXPECT_TRUE(execution_context_.get_error().find(expected_error) != std::string::npos)
-      << status.message();
+  EXPECT_TRUE(execution_context_.get_error().find(expected_error) != std::string::npos);
 
   // not valid should not return error
   execution_context_.Reset();
@@ -143,15 +136,13 @@ TEST_F(TestToDateHolder, TestSimpleDateTimeError) {
 }
 
 TEST_F(TestToDateHolder, TestSimpleDateTimeMakeError) {
-  std::shared_ptr<ToDateHolder> to_date_holder;
   // reject time stamps for now.
-  auto status = ToDateHolder::Make("YYYY-MM-DD HH:MI:SS tzo", 0, &to_date_holder);
+  auto const status = ToDateHolder::Make("YYYY-MM-DD HH:MI:SS tzo", 0).status();
   EXPECT_EQ(status.IsInvalid(), true) << status.message();
 }
 
 TEST_F(TestToDateHolder, TestSimpleDateYearMonth) {
-  std::shared_ptr<ToDateHolder> to_date_holder;
-  ASSERT_OK(ToDateHolder::Make("YYYY-MM", 1, &to_date_holder));
+  EXPECT_OK_AND_ASSIGN(auto to_date_holder, ToDateHolder::Make("YYYY-MM", 1));
 
   auto& to_date = *to_date_holder;
   bool out_valid;
@@ -167,8 +158,7 @@ TEST_F(TestToDateHolder, TestSimpleDateYearMonth) {
 }
 
 TEST_F(TestToDateHolder, TestSimpleDateYear) {
-  std::shared_ptr<ToDateHolder> to_date_holder;
-  ASSERT_OK(ToDateHolder::Make("YYYY", 1, &to_date_holder));
+  EXPECT_OK_AND_ASSIGN(auto to_date_holder, ToDateHolder::Make("YYYY", 1));
 
   auto& to_date = *to_date_holder;
   bool out_valid;


### PR DESCRIPTION
### Rationale for this change
* This PR tries to make Gandiva `FunctionHolder` classes to return `arrow::Result` instead of using output parameters, and this tries to address the follow up task mentioned in https://github.com/apache/arrow/pull/38632#discussion_r1388576545 and makes the code slightly simpler

### What changes are included in this PR?
* A refactoring task to return `arrow::Result` in Gandiva FunctionHolder classes

### Are these changes tested?
It should be covered by existing unit tests.

### Are there any user-facing changes?
No
* Closes: #38920