### PR TITLE
GH-38701: [C++][FS][Azure] Implement `DeleteDirContents()`

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1099,9 +1099,6 @@ class AzureFileSystem::Impl {
     if (location.container.empty()) {
       return internal::InvalidDeleteDirContents(location.all);
     }
-    if (location.path.empty()) {
-      return internal::InvalidDeleteDirContents(location.all);
-    }
 
     ARROW_ASSIGN_OR_RAISE(auto hierarchical_namespace_enabled,
                           hierarchical_namespace_.Enabled(location.container));

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -986,8 +986,7 @@ class AzureFileSystem::Impl {
     try {
       auto list_response = container_client.ListBlobs(options);
       if (!missing_dir_ok && list_response.Blobs.empty()) {
-        return Status::IOError("Specified directory doesn't exist: ", location.path, ": ",
-                               container_client.GetUrl());
+        return PathNotFound(location);
       }
       while (list_response.HasPage() && !list_response.Blobs.empty()) {
         auto batch = container_client.CreateBatch();

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1090,7 +1090,8 @@ class AzureFileSystem::Impl {
             exception);
       }
     } else {
-      return DeleteDirContentsWihtoutHierarchicalNamespace(location, true);
+      return DeleteDirContentsWihtoutHierarchicalNamespace(location,
+                                                           /*missing_dir_ok=*/true);
     }
   }
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -976,7 +976,9 @@ class AzureFileSystem::Impl {
     auto container_client =
         blob_service_client_->GetBlobContainerClient(location.container);
     Azure::Storage::Blobs::ListBlobsOptions options;
-    options.Prefix = internal::EnsureTrailingSlash(location.path);
+    if (!location.path.empty()) {
+      options.Prefix = internal::EnsureTrailingSlash(location.path);
+    }
     // https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch#remarks
     //
     // Only supports up to 256 subrequests in a single batch. The

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -666,6 +666,83 @@ TEST_F(AzuriteFileSystemTest, DeleteDirUri) {
   ASSERT_RAISES(Invalid, fs_->DeleteDir("abfs://" + PreexistingContainerPath()));
 }
 
+TEST_F(AzuriteFileSystemTest, DeleteDirContentsSuccessExist) {
+  const auto directory_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
+  const auto sub_directory_path = internal::ConcatAbstractPath(directory_path, "new-sub");
+  const auto sub_blob_path = internal::ConcatAbstractPath(sub_directory_path, "sub.txt");
+  const auto top_blob_path = internal::ConcatAbstractPath(directory_path, "top.txt");
+  ASSERT_OK(fs_->CreateDir(sub_directory_path, true));
+  ASSERT_OK_AND_ASSIGN(auto output, fs_->OpenOutputStream(sub_blob_path));
+  ASSERT_OK(output->Write(std::string_view("sub")));
+  ASSERT_OK(output->Close());
+  ASSERT_OK_AND_ASSIGN(output, fs_->OpenOutputStream(top_blob_path));
+  ASSERT_OK(output->Write(std::string_view("top")));
+  ASSERT_OK(output->Close());
+
+  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::Directory);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::File);
+  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::File);
+  ASSERT_OK(fs_->DeleteDirContents(directory_path));
+  // GH-38772: We may change this to FileType::Directory.
+  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::NotFound);
+}
+
+TEST_F(AzuriteFileSystemTest, DeleteDirContentsSuccessNonexistent) {
+  const auto directory_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
+  ASSERT_OK(fs_->DeleteDirContents(directory_path, true));
+  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::NotFound);
+}
+
+TEST_F(AzuriteFileSystemTest, DeleteDirContentsFailureNonexistent) {
+  const auto directory_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
+  ASSERT_RAISES(IOError, fs_->DeleteDirContents(directory_path, false));
+}
+
+TEST_F(AzureHierarchicalNamespaceFileSystemTest, DeleteDirContentsSuccessExist) {
+  const auto directory_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
+  const auto sub_directory_path = internal::ConcatAbstractPath(directory_path, "new-sub");
+  const auto sub_blob_path = internal::ConcatAbstractPath(sub_directory_path, "sub.txt");
+  const auto top_blob_path = internal::ConcatAbstractPath(directory_path, "top.txt");
+  ASSERT_OK(fs_->CreateDir(sub_directory_path, true));
+  ASSERT_OK_AND_ASSIGN(auto output, fs_->OpenOutputStream(sub_blob_path));
+  ASSERT_OK(output->Write(std::string_view("sub")));
+  ASSERT_OK(output->Close());
+  ASSERT_OK_AND_ASSIGN(output, fs_->OpenOutputStream(top_blob_path));
+  ASSERT_OK(output->Write(std::string_view("top")));
+  ASSERT_OK(output->Close());
+
+  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::Directory);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::File);
+  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::File);
+  ASSERT_OK(fs_->DeleteDirContents(directory_path));
+  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::NotFound);
+}
+
+TEST_F(AzureHierarchicalNamespaceFileSystemTest, DeleteDirContentsSuccessNonexistent) {
+  const auto directory_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
+  ASSERT_OK(fs_->DeleteDirContents(directory_path, true));
+  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::NotFound);
+}
+
+TEST_F(AzureHierarchicalNamespaceFileSystemTest, DeleteDirContentsFailureNonexistent) {
+  const auto directory_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
+  ASSERT_RAISES(IOError, fs_->DeleteDirContents(directory_path, false));
+}
+
 TEST_F(AzuriteFileSystemTest, OpenInputStreamString) {
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream, fs_->OpenInputStream(PreexistingObjectPath()));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -287,6 +287,45 @@ class AzureFileSystemTest : public ::testing::Test {
 
   void RunGetFileInfoObjectWithNestedStructureTest();
   void RunGetFileInfoObjectTest();
+
+  struct HierarchicalPaths {
+    std::string container;
+    std::string directory;
+    std::vector<std::string> sub_paths;
+  };
+
+  // Need to use "void" as the return type to use ASSERT_* in this method.
+  void CreateHierarchicalData(HierarchicalPaths& paths) {
+    const auto container_path = RandomContainerName();
+    const auto directory_path =
+        internal::ConcatAbstractPath(container_path, RandomDirectoryName());
+    const auto sub_directory_path =
+        internal::ConcatAbstractPath(directory_path, "new-sub");
+    const auto sub_blob_path =
+        internal::ConcatAbstractPath(sub_directory_path, "sub.txt");
+    const auto top_blob_path = internal::ConcatAbstractPath(directory_path, "top.txt");
+    ASSERT_OK(fs_->CreateDir(sub_directory_path, true));
+    ASSERT_OK_AND_ASSIGN(auto output, fs_->OpenOutputStream(sub_blob_path));
+    ASSERT_OK(output->Write(std::string_view("sub")));
+    ASSERT_OK(output->Close());
+    ASSERT_OK_AND_ASSIGN(output, fs_->OpenOutputStream(top_blob_path));
+    ASSERT_OK(output->Write(std::string_view("top")));
+    ASSERT_OK(output->Close());
+
+    AssertFileInfo(fs_.get(), container_path, FileType::Directory);
+    AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
+    AssertFileInfo(fs_.get(), sub_directory_path, FileType::Directory);
+    AssertFileInfo(fs_.get(), sub_blob_path, FileType::File);
+    AssertFileInfo(fs_.get(), top_blob_path, FileType::File);
+
+    paths.container = container_path;
+    paths.directory = directory_path;
+    paths.sub_paths = {
+        sub_directory_path,
+        sub_blob_path,
+        top_blob_path,
+    };
+  };
 };
 
 class AzuriteFileSystemTest : public AzureFileSystemTest {
@@ -671,31 +710,14 @@ TEST_F(AzuriteFileSystemTest, DeleteDirContentsSuccessContainer) {
   GTEST_SKIP() << "This test fails by an Azurite problem: "
                   "https://github.com/Azure/Azurite/pull/2302";
 #endif
-  const auto container_path = RandomContainerName();
-  const auto directory_path =
-      internal::ConcatAbstractPath(container_path, RandomDirectoryName());
-  const auto sub_directory_path = internal::ConcatAbstractPath(directory_path, "new-sub");
-  const auto sub_blob_path = internal::ConcatAbstractPath(sub_directory_path, "sub.txt");
-  const auto top_blob_path = internal::ConcatAbstractPath(directory_path, "top.txt");
-  ASSERT_OK(fs_->CreateDir(sub_directory_path, true));
-  ASSERT_OK_AND_ASSIGN(auto output, fs_->OpenOutputStream(sub_blob_path));
-  ASSERT_OK(output->Write(std::string_view("sub")));
-  ASSERT_OK(output->Close());
-  ASSERT_OK_AND_ASSIGN(output, fs_->OpenOutputStream(top_blob_path));
-  ASSERT_OK(output->Write(std::string_view("top")));
-  ASSERT_OK(output->Close());
-
-  arrow::fs::AssertFileInfo(fs_.get(), container_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::File);
-  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::File);
-  ASSERT_OK(fs_->DeleteDirContents(container_path));
-  arrow::fs::AssertFileInfo(fs_.get(), container_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::NotFound);
+  HierarchicalPaths paths;
+  CreateHierarchicalData(paths);
+  ASSERT_OK(fs_->DeleteDirContents(paths.container));
+  arrow::fs::AssertFileInfo(fs_.get(), paths.container, FileType::Directory);
+  arrow::fs::AssertFileInfo(fs_.get(), paths.directory, FileType::NotFound);
+  for (const auto& sub_path : paths.sub_paths) {
+    arrow::fs::AssertFileInfo(fs_.get(), sub_path, FileType::NotFound);
+  }
 }
 
 TEST_F(AzuriteFileSystemTest, DeleteDirContentsSuccessDirectory) {
@@ -703,29 +725,14 @@ TEST_F(AzuriteFileSystemTest, DeleteDirContentsSuccessDirectory) {
   GTEST_SKIP() << "This test fails by an Azurite problem: "
                   "https://github.com/Azure/Azurite/pull/2302";
 #endif
-  const auto directory_path =
-      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
-  const auto sub_directory_path = internal::ConcatAbstractPath(directory_path, "new-sub");
-  const auto sub_blob_path = internal::ConcatAbstractPath(sub_directory_path, "sub.txt");
-  const auto top_blob_path = internal::ConcatAbstractPath(directory_path, "top.txt");
-  ASSERT_OK(fs_->CreateDir(sub_directory_path, true));
-  ASSERT_OK_AND_ASSIGN(auto output, fs_->OpenOutputStream(sub_blob_path));
-  ASSERT_OK(output->Write(std::string_view("sub")));
-  ASSERT_OK(output->Close());
-  ASSERT_OK_AND_ASSIGN(output, fs_->OpenOutputStream(top_blob_path));
-  ASSERT_OK(output->Write(std::string_view("top")));
-  ASSERT_OK(output->Close());
-
-  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::File);
-  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::File);
-  ASSERT_OK(fs_->DeleteDirContents(directory_path));
+  HierarchicalPaths paths;
+  CreateHierarchicalData(paths);
+  ASSERT_OK(fs_->DeleteDirContents(paths.directory));
   // GH-38772: We may change this to FileType::Directory.
-  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::NotFound);
+  arrow::fs::AssertFileInfo(fs_.get(), paths.directory, FileType::NotFound);
+  for (const auto& sub_path : paths.sub_paths) {
+    arrow::fs::AssertFileInfo(fs_.get(), sub_path, FileType::NotFound);
+  }
 }
 
 TEST_F(AzuriteFileSystemTest, DeleteDirContentsSuccessNonexistent) {
@@ -742,28 +749,13 @@ TEST_F(AzuriteFileSystemTest, DeleteDirContentsFailureNonexistent) {
 }
 
 TEST_F(AzureHierarchicalNamespaceFileSystemTest, DeleteDirContentsSuccessExist) {
-  const auto directory_path =
-      internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
-  const auto sub_directory_path = internal::ConcatAbstractPath(directory_path, "new-sub");
-  const auto sub_blob_path = internal::ConcatAbstractPath(sub_directory_path, "sub.txt");
-  const auto top_blob_path = internal::ConcatAbstractPath(directory_path, "top.txt");
-  ASSERT_OK(fs_->CreateDir(sub_directory_path, true));
-  ASSERT_OK_AND_ASSIGN(auto output, fs_->OpenOutputStream(sub_blob_path));
-  ASSERT_OK(output->Write(std::string_view("sub")));
-  ASSERT_OK(output->Close());
-  ASSERT_OK_AND_ASSIGN(output, fs_->OpenOutputStream(top_blob_path));
-  ASSERT_OK(output->Write(std::string_view("top")));
-  ASSERT_OK(output->Close());
-
-  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::File);
-  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::File);
-  ASSERT_OK(fs_->DeleteDirContents(directory_path));
-  arrow::fs::AssertFileInfo(fs_.get(), directory_path, FileType::Directory);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_directory_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), sub_blob_path, FileType::NotFound);
-  arrow::fs::AssertFileInfo(fs_.get(), top_blob_path, FileType::NotFound);
+  HierarchicalPaths paths;
+  CreateHierarchicalData(paths);
+  ASSERT_OK(fs_->DeleteDirContents(paths.directory));
+  arrow::fs::AssertFileInfo(fs_.get(), paths.directory, FileType::Directory);
+  for (const auto& sub_path : paths.sub_paths) {
+    arrow::fs::AssertFileInfo(fs_.get(), sub_path, FileType::NotFound);
+  }
 }
 
 TEST_F(AzureHierarchicalNamespaceFileSystemTest, DeleteDirContentsSuccessNonexistent) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -325,7 +325,7 @@ class AzureFileSystemTest : public ::testing::Test {
         sub_blob_path,
         top_blob_path,
     };
-  };
+  }
 };
 
 class AzuriteFileSystemTest : public AzureFileSystemTest {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -667,6 +667,10 @@ TEST_F(AzuriteFileSystemTest, DeleteDirUri) {
 }
 
 TEST_F(AzuriteFileSystemTest, DeleteDirContentsSuccessExist) {
+#ifdef __APPLE__
+  GTEST_SKIP() << "This test fails by an Azurite problem: "
+                  "https://github.com/Azure/Azurite/pull/2302";
+#endif
   const auto directory_path =
       internal::ConcatAbstractPath(PreexistingContainerName(), RandomDirectoryName());
   const auto sub_directory_path = internal::ConcatAbstractPath(directory_path, "new-sub");


### PR DESCRIPTION
### Rationale for this change

`DeleteDirContents()` deletes the given directory contents recursively like other filesystem implementations.

Azure file system treats the following cases as root directory:
* Empty container
* Empty path

### What changes are included in this PR?

List and delete approach is used with/without hierarchical namespace support. Because Azure doesn't provide "DeleteDirContents" API with hierarchical namespace support. We may want to use delete the given directory and create an empty approach instead of list and delete approach for performance but it may not be acceptable with some use cases. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #38701