### PR TITLE
GH-38883: [Docs] Fix struct example to show hiding a child's entry

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -664,7 +664,9 @@ type.
 
 **Example Layout: ``Struct<VarBinary, Int32>``**
 
-The layout for ``[{'joe', 1}, {null, 2}, null, {'mark', 4}]`` would be: ::
+The layout for ``[{'joe', 1}, {null, 2}, null, {'mark', 4}]``, having
+child arrays ``['joe', null, 'alice', 'mark']`` and ``[1, 2, null, 4]``
+would be: ::
 
     * Length: 4, Null count: 1
     * Validity bitmap buffer:
@@ -675,24 +677,24 @@ The layout for ``[{'joe', 1}, {null, 2}, null, {'mark', 4}]`` would be: ::
 
     * Children arrays:
       * field-0 array (`VarBinary`):
-        * Length: 4, Null count: 2
+        * Length: 4, Null count: 1
         * Validity bitmap buffer:
 
           | Byte 0 (validity bitmap) | Bytes 1-63            |
           |--------------------------|-----------------------|
-          | 00001001                 | 0 (padding)           |
+          | 00001101                 | 0 (padding)           |
 
         * Offsets buffer:
 
           | Bytes 0-19     | Bytes 20-63           |
           |----------------|-----------------------|
-          | 0, 3, 3, 3, 7  | unspecified (padding) |
+          | 0, 3, 3, 8, 12 | unspecified (padding) |
 
          * Value buffer:
 
-          | Bytes 0-6      | Bytes 7-63            |
+          | Bytes 0-11     | Bytes 12-63           |
           |----------------|-----------------------|
-          | joemark        | unspecified (padding) |
+          | joealicemark   | unspecified (padding) |
 
       * field-1 array (int32 array):
         * Length: 4, Null count: 1
@@ -722,10 +724,10 @@ Therefore, to know whether a particular child entry is valid, one must
 take the logical AND of the corresponding bits in the two validity bitmaps
 (the struct array's and the child array's).
 
-This is illustrated in the example above, the child arrays have valid entries
-for the null struct but they are "hidden" by the struct array's validity
-bitmap. However, when treated independently, corresponding entries of the
-children array will be non-null.
+This is illustrated in the example above, one of the child arrays has a
+valid entry ``'alice'`` for the null struct but it is "hidden" by the
+struct array's validity bitmap. However, when treated independently,
+corresponding entries of the children array will be non-null.
 
 Union Layout
 ------------


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
See the issue.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
The struct example now demonstrates what it's supposed to.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Renders well
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Just docs.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38883