### PR TITLE
GH-38906: [R] Improve Windows CI configuration

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ["release"]
+        r: ["4.3"]
         ubuntu: [20.04]
         force-tests: ["true"]
     env:
@@ -72,16 +72,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: .docker
-          # As this key is identical on both matrix builds only one will be able to successfully cache,
-          # this is fine as there are no differences in the build
-          key: ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-${{ github.run_id }}
-          restore-keys: |
-            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-
-            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ["4.2"]
+        r: ["release"]
         ubuntu: [20.04]
         force-tests: ["true"]
     env:
@@ -216,7 +216,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           # Note: RTools must be 40 here because RTools40 + ucrt is how we build the Arrow C++
-          # static library. The r-version is not used here but R 4.1 was the last R to use
+          # static library. The R is not used here but R 4.1 was the last R to use
           # Rtools40.
           r-version: "4.1"
           rtools-version: 40
@@ -319,7 +319,7 @@ jobs:
             timeout = 3600
           )
       - name: Run lintr
-        if: ${{ matrix.config.rversion == '4.2' }}
+        if: ${{ matrix.config.rversion == 'release' }}
         env:
           NOT_CRAN: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -72,6 +72,16 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Cache Docker Volumes
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: .docker
+          # As this key is identical on both matrix builds only one will be able to successfully cache,
+          # this is fine as there are no differences in the build
+          key: ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-${{ github.run_id }}
+          restore-keys: |
+            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-
+            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
@@ -133,16 +143,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Cache Docker Volumes
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: .docker
-          # As this key is identical on both matrix builds only one will be able to successfully cache,
-          # this is fine as there are no differences in the build
-          key: ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-${{ github.run_id }}
-          restore-keys: |
-            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-
-            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -215,6 +215,9 @@ jobs:
             r-${{ matrix.config.rtools }}-ccache-mingw-${{ matrix.config.arch }}-
       - uses: r-lib/actions/setup-r@v2
         with:
+          # Note: RTools must be 40 here because RTools40 + ucrt is how we build the Arrow C++
+          # static library. The r-version is not used here but R 4.1 was the last R to use
+          # Rtools40.
           r-version: "4.1"
           rtools-version: 40
           Ncpus: 2
@@ -234,7 +237,7 @@ jobs:
 
   windows-r:
     needs: [windows-cpp]
-    name: AMD64 Windows R ${{ matrix.config.rversion }} RTools ${{ matrix.config.rtools }}
+    name: AMD64 Windows R ${{ matrix.config.rversion }}
     runs-on: windows-2019
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 75
@@ -242,8 +245,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { rtools: 42, rversion: "4.2" }
-        - { rtools: 42, rversion: "devel" }
+        - { rversion: "release" }
+
     env:
       ARROW_R_CXXFLAGS: "-Werror"
       _R_CHECK_TESTS_NLINES_: 0
@@ -255,7 +258,6 @@ jobs:
           fetch-depth: 0
       - run: mkdir r/windows
       - name: Download artifacts
-        if: ${{ matrix.config.rtools == 42 }}
         uses: actions/download-artifact@v3
         with:
           name: libarrow-rtools40-ucrt64.zip
@@ -269,7 +271,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.rversion }}
-          rtools-version: ${{ matrix.config.rtools }}
           Ncpus: 2
       - uses: r-lib/actions/setup-r-dependencies@v2
         env:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -133,6 +133,16 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Cache Docker Volumes
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: .docker
+          # As this key is identical on both matrix builds only one will be able to successfully cache,
+          # this is fine as there are no differences in the build
+          key: ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-${{ github.run_id }}
+          restore-keys: |
+            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/src/**/*.cc','cpp/src/**/*.h)') }}-
+            ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:


### PR DESCRIPTION
### Rationale for this change

The Windows/R-devel job is causing CI to fail on many PRs that are unrelated to Windows/R-devel. We also have some outdated version numbers in the Windows action.

### What changes are included in this PR?

The version for Windows was updated to "release", which should keep it current without explicit maintenance (since clearly we had forgotten to update the version numbers ourselves 😬 ). The devel version was removed because (1) it is failing and won't stop failing until an upstream PR to cpp11 is merged and (2) it's unclear to me that this check adds anything useful (we already test r-devel in another commit-level job). It may have dated from a time that r-devel on Windows was much different than r-release (it no longer is).

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* Closes: #38906