### PR TITLE
GH-38902: [R] Handle failing library detection with pkg-config

### DIFF
--- a/r/configure
+++ b/r/configure
@@ -412,6 +412,7 @@ if [ -z "${PKG_LIBS// }" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ] && arrow_buil
   S3_LIBS="-lcurl -lssl -lcrypto"
   GCS_LIBS="-lcurl -lssl -lcrypto"
   set_lib_dir_without_pc ${_LIBARROW_FOUND}
+  add_feature_flags
   set_pkg_vars_without_pc ${_LIBARROW_FOUND}
 fi
 

--- a/r/configure
+++ b/r/configure
@@ -407,6 +407,14 @@ if [ "$_LIBARROW_FOUND" != "false" ] && [ "$_LIBARROW_FOUND" != "" ]; then
   set_pkg_vars ${_LIBARROW_FOUND}
 fi
 
+if [ -z "${PKG_LIBS// }" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ] && arrow_built_with ARROW_S3; then
+  echo "*** pkg-config failed to find libcurl, but S3 is enabled. Running detection without pkg-config."
+  S3_LIBS="-lcurl -lssl -lcrypto"
+  GCS_LIBS="-lcurl -lssl -lcrypto"
+  set_lib_dir_without_pc ${_LIBARROW_FOUND}
+  set_pkg_vars_without_pc ${_LIBARROW_FOUND}
+fi
+
 # Test that we can compile something with those flags
 CXX17="`${R_HOME}/bin/R CMD config CXX17` -E"
 CXX17FLAGS=`"${R_HOME}"/bin/R CMD config CXX17FLAGS`

--- a/r/configure
+++ b/r/configure
@@ -313,7 +313,7 @@ set_pkg_vars_without_pc () {
   if [ -n "$(find "$LIB_DIR" -name 'libarrow_bundled_dependencies.*')" ]; then
     PKG_LIBS="$PKG_LIBS -larrow_bundled_dependencies"
   fi
-  PKG_LIBS="$PKG_LIBS $PKG_LIBS_FEATURES"
+  PKG_LIBS="$PKG_LIBS $PKG_LIBS_FEATURES $SSL_LIBS_WITHOUT_PC"
 
   # If on Raspberry Pi, need to manually link against latomic
   # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81358 for similar example
@@ -377,7 +377,7 @@ add_feature_flags () {
     fi
     if arrow_built_with ARROW_GCS || arrow_built_with ARROW_S3; then
       # If pkg-config is available it will handle this for us automatically
-      PKG_LIBS_FEATURES_WITHOUT_PC="-lcurl -lssl -lcrypto $PKG_LIBS_FEATURES_WITHOUT_PC"
+      SSL_LIBS_WITHOUT_PC="-lcurl -lssl -lcrypto"
     fi
   fi
 }

--- a/r/configure
+++ b/r/configure
@@ -407,7 +407,8 @@ if [ "$_LIBARROW_FOUND" != "false" ] && [ "$_LIBARROW_FOUND" != "" ]; then
   set_pkg_vars ${_LIBARROW_FOUND}
 
   # If we didn't find any libraries with pkg-config, try again without pkg-config
-  if [ -z "`echo "$PKG_LIBS" | tr -d '[:space:]'`" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ]; then
+  FOUND_PKG_LIBS=`echo "$PKG_LIBS" | tr -d '[:space:]'`
+  if [ -z "$FOUND_PKG_LIBS" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ]; then
     echo "*** pkg-config failed to find libraries. Running detection without pkg-config."
     if arrow_built_with ARROW_S3 || arrow_built_with ARROW_GCS; then
       S3_LIBS="-lcurl -lssl -lcrypto"

--- a/r/configure
+++ b/r/configure
@@ -79,9 +79,6 @@ VERSION=`grep '^Version' DESCRIPTION | sed s/Version:\ //`
 UNAME=`uname -s`
 : ${PKG_CONFIG:="pkg-config"}
 
-# These will only be set in the bundled build
-S3_LIBS=""
-GCS_LIBS=""
 
 # If in development mode, run the codegen script to render arrowExports.*
 if [ "$ARROW_R_DEV" = "true" ] && [ -f "data-raw/codegen.R" ]; then
@@ -245,12 +242,6 @@ do_bundled_build () {
           ${LIB_DIR}/pkgconfig/*.pc
         rm -f ${LIB_DIR}/pkgconfig/*.pc.bak
       fi
-    else
-      # This case must be ARROW_DEPENDENCY_SOURCE=BUNDLED.
-      # These would be identified by pkg-config, in Requires.private and Libs.private.
-      # Rather than try to re-implement pkg-config, we can just hard-code them here.
-      S3_LIBS="-lcurl -lssl -lcrypto"
-      GCS_LIBS="-lcurl -lssl -lcrypto"
     fi
   else
     # If the library directory does not exist, the script must not have been successful
@@ -380,11 +371,13 @@ add_feature_flags () {
     fi
     if arrow_built_with ARROW_S3; then
       PKG_CFLAGS_FEATURES="$PKG_CFLAGS_FEATURES -DARROW_R_WITH_S3"
-      PKG_LIBS_FEATURES="$PKG_LIBS_FEATURES $S3_LIBS"
     fi
     if arrow_built_with ARROW_GCS; then
       PKG_CFLAGS_FEATURES="$PKG_CFLAGS_FEATURES -DARROW_R_WITH_GCS"
-      PKG_LIBS_FEATURES="$PKG_LIBS_FEATURES $GCS_LIBS"
+    fi
+    if arrow_built_with ARROW_GCS || arrow_built_with ARROW_S3; then
+      # If pkg-config is available it will handle this for us automatically
+      PKG_LIBS_FEATURES_WITHOUT_PC="-lcurl -lssl -lcrypto $PKG_LIBS_FEATURES_WITHOUT_PC"
     fi
   fi
 }
@@ -410,10 +403,6 @@ if [ "$_LIBARROW_FOUND" != "false" ] && [ "$_LIBARROW_FOUND" != "" ]; then
   FOUND_PKG_LIBS=`echo "$PKG_LIBS" | tr -d '[:space:]'`
   if [ -z "$FOUND_PKG_LIBS" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ]; then
     echo "*** pkg-config failed to find libraries. Running detection without pkg-config."
-    if arrow_built_with ARROW_S3 || arrow_built_with ARROW_GCS; then
-      S3_LIBS="-lcurl -lssl -lcrypto"
-      GCS_LIBS="-lcurl -lssl -lcrypto"
-    fi
     PKG_CONFIG_AVAILABLE="false"
     set_pkg_vars ${_LIBARROW_FOUND}
   fi

--- a/r/configure
+++ b/r/configure
@@ -416,6 +416,7 @@ if [ "$_LIBARROW_FOUND" != "false" ] && [ "$_LIBARROW_FOUND" != "" ]; then
     PKG_CONFIG_AVAILABLE="false"
     set_pkg_vars ${_LIBARROW_FOUND}
   fi
+else
   # To make it easier to debug which code path was taken add a specific 
   # message to the log in addition to the 'NOTE'
   echo "*** Failed to find Arrow C++ libraries."

--- a/r/configure
+++ b/r/configure
@@ -407,7 +407,7 @@ if [ "$_LIBARROW_FOUND" != "false" ] && [ "$_LIBARROW_FOUND" != "" ]; then
   set_pkg_vars ${_LIBARROW_FOUND}
 
   # If we didn't find any libraries with pkg-config, try again without pkg-config
-  if [ -z "${PKG_LIBS// }" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ]; then
+  if [ -z "`echo "$PKG_LIBS" | tr -d '[:space:]'`" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ]; then
     echo "*** pkg-config failed to find libraries. Running detection without pkg-config."
     if arrow_built_with ARROW_S3 || arrow_built_with ARROW_GCS; then
       S3_LIBS="-lcurl -lssl -lcrypto"

--- a/r/configure
+++ b/r/configure
@@ -293,15 +293,15 @@ set_pkg_vars () {
 
 # If we have pkg-config, it will tell us what libarrow needs
 set_lib_dir_with_pc () {
-  LIB_DIR="`${PKG_CONFIG} --variable=libdir --silence-errors ${PKG_CONFIG_NAME}`"
+  LIB_DIR="`${PKG_CONFIG} --variable=libdir  ${PKG_CONFIG_NAME}`"
 }
 set_pkg_vars_with_pc () {
   pkg_config_names="${PKG_CONFIG_NAME} ${PKG_CONFIG_NAMES_FEATURES}"
-  PKG_CFLAGS="`${PKG_CONFIG} --cflags --silence-errors ${pkg_config_names}` $PKG_CFLAGS"
+  PKG_CFLAGS="`${PKG_CONFIG} --cflags  ${pkg_config_names}` $PKG_CFLAGS"
   PKG_CFLAGS="$PKG_CFLAGS $PKG_CFLAGS_FEATURES"
-  PKG_LIBS=`${PKG_CONFIG} --libs-only-l --libs-only-other --silence-errors ${pkg_config_names}`
+  PKG_LIBS=`${PKG_CONFIG} --libs-only-l --libs-only-other ${pkg_config_names}`
   PKG_LIBS="$PKG_LIBS $PKG_LIBS_FEATURES"
-  PKG_DIRS=`${PKG_CONFIG} --libs-only-L --silence-errors ${pkg_config_names}`
+  PKG_DIRS=`${PKG_CONFIG} --libs-only-L  ${pkg_config_names}`
 }
 
 # If we don't have pkg-config, we can make some inferences

--- a/r/configure
+++ b/r/configure
@@ -405,15 +405,20 @@ find_or_build_libarrow
 # Now set `PKG_LIBS`, `PKG_DIRS`, and `PKG_CFLAGS` based on that.
 if [ "$_LIBARROW_FOUND" != "false" ] && [ "$_LIBARROW_FOUND" != "" ]; then
   set_pkg_vars ${_LIBARROW_FOUND}
-fi
 
-if [ -z "${PKG_LIBS// }" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ] && arrow_built_with ARROW_S3; then
-  echo "*** pkg-config failed to find libcurl, but S3 is enabled. Running detection without pkg-config."
-  S3_LIBS="-lcurl -lssl -lcrypto"
-  GCS_LIBS="-lcurl -lssl -lcrypto"
-  set_lib_dir_without_pc ${_LIBARROW_FOUND}
-  add_feature_flags
-  set_pkg_vars_without_pc ${_LIBARROW_FOUND}
+  # If we didn't find any libraries with pkg-config, try again without pkg-config
+  if [ -z "${PKG_LIBS// }" ] && [ "$PKG_CONFIG_AVAILABLE" = "true" ]; then
+    echo "*** pkg-config failed to find libraries. Running detection without pkg-config."
+    if arrow_built_with ARROW_S3 || arrow_built_with ARROW_GCS; then
+      S3_LIBS="-lcurl -lssl -lcrypto"
+      GCS_LIBS="-lcurl -lssl -lcrypto"
+    fi
+    PKG_CONFIG_AVAILABLE="false"
+    set_pkg_vars ${_LIBARROW_FOUND}
+  fi
+  # To make it easier to debug which code path was taken add a specific 
+  # message to the log in addition to the 'NOTE'
+  echo "*** Failed to find Arrow C++ libraries."
 fi
 
 # Test that we can compile something with those flags

--- a/r/configure
+++ b/r/configure
@@ -113,7 +113,9 @@ fi
 # Test if pkg-config is available to use
 if ${PKG_CONFIG} --version >/dev/null 2>&1; then
   PKG_CONFIG_AVAILABLE="true"
+  echo "*** pkg-config found."
 else
+  echo "*** pkg-config not found."
   PKG_CONFIG_AVAILABLE="false"
   ARROW_USE_PKG_CONFIG="false"
 fi

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -72,7 +72,7 @@ find_latest_nightly <- function(description_version,
     lg("Failed to find latest nightly for %s", description_version)
     latest <- description_version
   } else {
-    lg("Found latest nightly for %s: %s", description_version, res)
+    lg("Latest available nightly for %s: %s", description_version, res)
     latest <- res
   }
   latest

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -295,7 +295,7 @@ determine_binary_from_stderr <- function(errs) {
   if (is.null(attr(errs, "status"))) {
     # There was no error in compiling: so we found libcurl and OpenSSL >= 1.1,
     # openssl is < 3.0
-    lg("Found libcurl and OpenSSL >= 1.1")
+    lg("Found headers for libcurl and OpenSSL >= 1.1")
     return("openssl-1.1")
     # Else, check for dealbreakers:
   } else if (!on_macos && any(grepl("Using libc++", errs, fixed = TRUE))) {
@@ -303,13 +303,13 @@ determine_binary_from_stderr <- function(errs) {
     lg("Linux binaries incompatible with libc++")
     return(NULL)
   } else if (header_not_found("curl/curl", errs)) {
-    lg("libcurl not found")
+    lg("Headers for libcurl not found")
     return(NULL)
   } else if (header_not_found("openssl/opensslv", errs)) {
-    lg("OpenSSL not found")
+    lg("Headers for OpenSSL not found")
     return(NULL)
   } else if (any(grepl("OpenSSL version too old", errs))) {
-    lg("OpenSSL found but version >= 1.0.2 is required for some features")
+    lg("Headers for OpenSSL found but version >= 1.0.2 is required for some features")
     return(NULL)
     # Else, determine which other binary will work
   } else if (any(grepl("Using OpenSSL version 1.0", errs))) {
@@ -317,10 +317,10 @@ determine_binary_from_stderr <- function(errs) {
       lg("OpenSSL 1.0 is not supported on macOS")
       return(NULL)
     }
-    lg("Found libcurl and OpenSSL < 1.1")
+    lg("Found headers for libcurl and OpenSSL < 1.1")
     return("openssl-1.0")
   } else if (any(grepl("Using OpenSSL version 3", errs))) {
-    lg("Found libcurl and OpenSSL >= 3.0.0")
+    lg("Found headers for libcurl and OpenSSL >= 3.0.0")
     return("openssl-3.0")
   }
   NULL

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -295,7 +295,7 @@ determine_binary_from_stderr <- function(errs) {
   if (is.null(attr(errs, "status"))) {
     # There was no error in compiling: so we found libcurl and OpenSSL >= 1.1,
     # openssl is < 3.0
-    lg("Found headers for libcurl and OpenSSL >= 1.1")
+    lg("Found libcurl and OpenSSL >= 1.1")
     return("openssl-1.1")
     # Else, check for dealbreakers:
   } else if (!on_macos && any(grepl("Using libc++", errs, fixed = TRUE))) {
@@ -303,13 +303,13 @@ determine_binary_from_stderr <- function(errs) {
     lg("Linux binaries incompatible with libc++")
     return(NULL)
   } else if (header_not_found("curl/curl", errs)) {
-    lg("Headers for libcurl not found")
+    lg("libcurl not found")
     return(NULL)
   } else if (header_not_found("openssl/opensslv", errs)) {
-    lg("Headers for OpenSSL not found")
+    lg("OpenSSL not found")
     return(NULL)
   } else if (any(grepl("OpenSSL version too old", errs))) {
-    lg("Headers for OpenSSL found but version >= 1.0.2 is required for some features")
+    lg("OpenSSL found but version >= 1.0.2 is required for some features")
     return(NULL)
     # Else, determine which other binary will work
   } else if (any(grepl("Using OpenSSL version 1.0", errs))) {
@@ -317,10 +317,10 @@ determine_binary_from_stderr <- function(errs) {
       lg("OpenSSL 1.0 is not supported on macOS")
       return(NULL)
     }
-    lg("Found headers for libcurl and OpenSSL < 1.1")
+    lg("Found libcurl and OpenSSL < 1.1")
     return("openssl-1.0")
   } else if (any(grepl("Using OpenSSL version 3", errs))) {
-    lg("Found headers for libcurl and OpenSSL >= 3.0.0")
+    lg("Found libcurl and OpenSSL >= 3.0.0")
     return("openssl-3.0")
   }
   NULL

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -176,7 +176,7 @@ test_that("find_latest_nightly()", {
       find_latest_nightly(package_version("13.0.1.9000"), list_uri = tf_uri),
       package_version("13.0.0.100000335")
     ),
-    "Found latest nightly"
+    "Latest available nightly"
   )
 
   expect_output(
@@ -184,7 +184,7 @@ test_that("find_latest_nightly()", {
       find_latest_nightly(package_version("14.0.0.9000"), list_uri = tf_uri),
       package_version("14.0.0.100000001")
     ),
-    "Found latest nightly"
+    "Latest available nightly"
   )
 
   expect_output(

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -52,7 +52,7 @@ test_that("determine_binary_from_stderr", {
       determine_binary_from_stderr(compile_test_program("int a;")),
       "openssl-1.1"
     ),
-    "Found headers for libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 1.1"
   )
 
   nixlibs_env$on_macos <- FALSE
@@ -61,7 +61,7 @@ test_that("determine_binary_from_stderr", {
       determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 1.0")),
       "openssl-1.0"
     ),
-    "Found headers for libcurl and OpenSSL < 1.1"
+    "Found libcurl and OpenSSL < 1.1"
   )
   nixlibs_env$on_macos <- TRUE
   expect_output(
@@ -75,7 +75,7 @@ test_that("determine_binary_from_stderr", {
       determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 3")),
       "openssl-3.0"
     ),
-    "Found headers for libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_null(
@@ -92,21 +92,21 @@ test_that("select_binary() with test program", {
       select_binary("linux", "x86_64", "int a;"),
       "linux-openssl-1.1"
     ),
-    "Found headers for libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("linux", "x86_64", "#error Using OpenSSL version 1.0"),
       "linux-openssl-1.0"
     ),
-    "Found headers for libcurl and OpenSSL < 1.1"
+    "Found libcurl and OpenSSL < 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("linux", "x86_64", "#error Using OpenSSL version 3"),
       "linux-openssl-3.0"
     ),
-    "Found headers for libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
   nixlibs_env$on_macos <- TRUE
   expect_output(
@@ -114,28 +114,28 @@ test_that("select_binary() with test program", {
       select_binary("darwin", "x86_64", "int a;"),
       "darwin-x86_64-openssl-1.1"
     ),
-    "Found headers for libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "x86_64", "#error Using OpenSSL version 3"),
       "darwin-x86_64-openssl-3.0"
     ),
-    "Found headers for libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", "int a;"),
       "darwin-arm64-openssl-1.1"
     ),
-    "Found headers for libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", "#error Using OpenSSL version 3"),
       "darwin-arm64-openssl-3.0"
     ),
-    "Found headers for libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_null(

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -52,7 +52,7 @@ test_that("determine_binary_from_stderr", {
       determine_binary_from_stderr(compile_test_program("int a;")),
       "openssl-1.1"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found headers for libcurl and OpenSSL >= 1.1"
   )
 
   nixlibs_env$on_macos <- FALSE
@@ -61,7 +61,7 @@ test_that("determine_binary_from_stderr", {
       determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 1.0")),
       "openssl-1.0"
     ),
-    "Found libcurl and OpenSSL < 1.1"
+    "Found headers for libcurl and OpenSSL < 1.1"
   )
   nixlibs_env$on_macos <- TRUE
   expect_output(
@@ -75,7 +75,7 @@ test_that("determine_binary_from_stderr", {
       determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 3")),
       "openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found headers for libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_null(
@@ -92,21 +92,21 @@ test_that("select_binary() with test program", {
       select_binary("linux", "x86_64", "int a;"),
       "linux-openssl-1.1"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found headers for libcurl and OpenSSL >= 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("linux", "x86_64", "#error Using OpenSSL version 1.0"),
       "linux-openssl-1.0"
     ),
-    "Found libcurl and OpenSSL < 1.1"
+    "Found headers for libcurl and OpenSSL < 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("linux", "x86_64", "#error Using OpenSSL version 3"),
       "linux-openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found headers for libcurl and OpenSSL >= 3.0.0"
   )
   nixlibs_env$on_macos <- TRUE
   expect_output(
@@ -114,28 +114,28 @@ test_that("select_binary() with test program", {
       select_binary("darwin", "x86_64", "int a;"),
       "darwin-x86_64-openssl-1.1"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found headers for libcurl and OpenSSL >= 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "x86_64", "#error Using OpenSSL version 3"),
       "darwin-x86_64-openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found headers for libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", "int a;"),
       "darwin-arm64-openssl-1.1"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found headers for libcurl and OpenSSL >= 1.1"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", "#error Using OpenSSL version 3"),
       "darwin-arm64-openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found headers for libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_null(


### PR DESCRIPTION
### Rationale for this change

We can get into a broken state with a working test compile in `nixlibs.R` but empty `PKG_LIBS` when pkg-config fails to find some libraries (e.g. libcurl on mac due to missing system stubs) in `configure`. This leads to a failed test compile in configure with pc errors silenced.

### What changes are included in this PR?

Catch this and rerun the pkg-config-less library detection that should fix this in most cases.

### Are these changes tested?

locally and on cran (where this error first surfaced)
* Closes: #38902