### PR TITLE
GH-34610: [Java] Fix valueCount and field name when loading/transferring NullVector

### DIFF
--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -477,6 +477,13 @@ public class RoundtripTest {
   }
 
   @Test
+  public void testNullVector() {
+    try (final NullVector vector = new NullVector("v", 1024)) {
+      assertTrue(roundtrip(vector, NullVector.class));
+    }
+  }
+
+  @Test
   public void testVarBinaryVector() {
     try (final VarBinaryVector vector = new VarBinaryVector("v", allocator)) {
       setVector(vector, "abc".getBytes(), "def".getBytes(), null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -58,6 +58,16 @@ public class NullVector implements FieldVector {
   }
 
   /**
+   * Instantiate a NullVector with the given number of values.
+   *
+   * @param name name of the vector
+   * @param valueCount number of values (i.e., nulls) in this vector.
+   */
+  public NullVector(String name, int valueCount) {
+    this(new Field(name, FieldType.nullable(Types.MinorType.NULL.getType()), null), valueCount);
+  }
+
+  /**
    * Instantiate a NullVector.
    *
    * @param name      name of the vector
@@ -73,8 +83,18 @@ public class NullVector implements FieldVector {
    * @param field field materialized by this vector.
    */
   public NullVector(Field field) {
-    this.valueCount = 0;
+    this(field, 0);
+  }
+
+  /**
+   * Instantiate a NullVector with the given number of values.
+   *
+   * @param field field materialized by this vector.
+   * @param valueCount number of values (i.e., nulls) in this vector.
+   */
+  public NullVector(Field field, int valueCount) {
     this.field = field;
+    this.valueCount = valueCount;
   }
 
   @Deprecated
@@ -106,7 +126,7 @@ public class NullVector implements FieldVector {
 
   @Override
   public TransferPair getTransferPair(BufferAllocator allocator) {
-    return getTransferPair((String) null, allocator);
+    return getTransferPair(getName(), allocator);
   }
 
   @Override
@@ -159,12 +179,12 @@ public class NullVector implements FieldVector {
 
   @Override
   public TransferPair getTransferPair(String ref, BufferAllocator allocator) {
-    return new TransferImpl();
+    return new TransferImpl(ref);
   }
 
   @Override
   public TransferPair getTransferPair(Field field, BufferAllocator allocator) {
-    return new TransferImpl();
+    return new TransferImpl(field.getName());
   }
 
   @Override


### PR DESCRIPTION
### Rationale for this change

This is a follow up of https://github.com/apache/arrow/pull/34611 (thanks @sunchao)
We should set `valueCount` when loading `NullVector`. Unfortunately there's no `nullCount` field.

### What changes are included in this PR?

* `valueCount` added to NullVector
* `name` added to NullVector's TransferPair

### Are these changes tested?

Yes. unit tested.

### Are there any user-facing changes?

Yes, a NullVector with a non-null name will maintain the name when transferred via `TransferPair` instead of defaulting to the default name `$data$`.
* Closes: #34610