### PR TITLE
GH-38779: [R][CI] Use devtools on self-hosted machines and use macos-11 for intel package build

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -225,8 +225,8 @@ jobs:
         run: |
           # rig is a system utility that allows for switching
           # between pre-installed R version on the self-hosted runners
-          rig add {{ '${{ matrix.r_version }}' }}-arm64
-          rig default {{ '${{ matrix.r_version }}' }}-arm64
+          # rig add {{ '${{ matrix.r_version }}' }} #uncomment this to install latest release/oldrel
+          rig default {{ '${{ matrix.r_version }}' }}
 
           rig system setup-user-lib
       {{ macros.github_setup_local_r_repo(false, true, true)|indent }}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -234,17 +234,21 @@ jobs:
           rig default {{ '${{ matrix.r_version.r }}' }}$rig_arch
 
           rig system setup-user-lib
-          rig system add-pak
       {{ macros.github_setup_local_r_repo(false, true, true)|indent }}
       - name: Prepare Dependency Installation
         shell: bash
         run: |
           tar -xzf repo/src/contrib/arrow_*.tar.gz arrow/DESCRIPTION
       - name: Install dependencies
+        if: {{ "${{ !contains(matrix.platform.runs_on, 'self-hosted') }}" }}
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
            working-directory: 'arrow'
            extra-packages: cpp11
+      - name: Install dependencies self-hosted
+        if: {{ "${{ contains(matrix.platform.runs_on, 'self-hosted') }}" }}
+        shell: Rscript {0}
+        run: devtools::install_dev_deps('./arrow')
       - name: Set CRAN like openssl
         if: contains(matrix.platform.runs_on, 'arm64')
         run: |

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -211,27 +211,22 @@ jobs:
       matrix:
         platform:
           - { runs_on: 'windows-latest', name: "Windows"}
-          - { runs_on: ["self-hosted", "macos-10.13"], name: "macOS High Sierra"}
-          - { runs_on: ["self-hosted", "macOS", "arm64", "devops-managed"], name: "macOS Big Sur" }
-        r_version:
-          - { rtools: "{{ macros.r_release.rt }}", r: "{{ macros.r_release.ver }}" }
-          - { rtools: "{{ macros.r_oldrel.rt }}", r: "{{ macros.r_oldrel.ver }}" }
+          - { runs_on: macos-11 , name: "macOS Big Sur"}
+          - { runs_on: ["self-hosted", "macOS", "arm64", "devops-managed"], name: "macOS Big Sur (M1)" }
+        r_version: [oldrel, release]
     steps:
       - uses: r-lib/actions/setup-r@v2
         # expression marker prevents the ! being parsed as yaml tag
         if: {{ "${{ !contains(matrix.platform.runs_on, 'self-hosted') }}" }}
         with:
-          r-version: {{ '${{ matrix.r_version.r }}' }}
-          rtools-version: {{ '${{ matrix.r_version.rtools }}' }}
+          r-version: {{ '${{ matrix.r_version }}' }}
       - name: Setup R Self-Hosted
         if: contains(matrix.platform.runs_on, 'self-hosted')
         run: |
-          if [ "{{ "${{ contains(matrix.platform.runs_on, 'arm64') }}" }}" == "true" ]; then
-            rig_arch="-arm64"
-          fi
           # rig is a system utility that allows for switching
           # between pre-installed R version on the self-hosted runners
-          rig default {{ '${{ matrix.r_version.r }}' }}$rig_arch
+          rig add {{ '${{ matrix.r_version }}' }}-arm64
+          rig default {{ '${{ matrix.r_version }}' }}-arm64
 
           rig system setup-user-lib
       {{ macros.github_setup_local_r_repo(false, true, true)|indent }}
@@ -252,8 +247,6 @@ jobs:
           if (!requireNamespace("devtools", quietly = TRUE)) {
             install.packages("devtools")
           }
-          # CRAN doesn't have binaries for 4.1 see #38761
-          options(repos = c(CRAN = "https://packagemanager.posit.co/cran/latest"))
           devtools::install_dev_deps('./arrow')
       - name: Set CRAN like openssl
         if: contains(matrix.platform.runs_on, 'arm64')

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -248,7 +248,11 @@ jobs:
       - name: Install dependencies self-hosted
         if: {{ "${{ contains(matrix.platform.runs_on, 'self-hosted') }}" }}
         shell: Rscript {0}
-        run: devtools::install_dev_deps('./arrow')
+        run: |
+          if (!requireNamespace("devtools", quietly = TRUE)) {
+            install.packages("devtools")
+          }
+          devtools::install_dev_deps('./arrow')
       - name: Set CRAN like openssl
         if: contains(matrix.platform.runs_on, 'arm64')
         run: |

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -252,6 +252,8 @@ jobs:
           if (!requireNamespace("devtools", quietly = TRUE)) {
             install.packages("devtools")
           }
+          # CRAN doesn't have binaries for 4.1 see #38761
+          options(repos = c(CRAN = "https://packagemanager.posit.co/cran/latest"))
           devtools::install_dev_deps('./arrow')
       - name: Set CRAN like openssl
         if: contains(matrix.platform.runs_on, 'arm64')

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -977,11 +977,11 @@ tasks:
       - r-lib__libarrow__bin__darwin-arm64-openssl-3.0__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__darwin-x86_64-openssl-1.1__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__darwin-x86_64-openssl-3.0__arrow-{no_rc_r_version}\.zip
-      - r-pkg__bin__windows__contrib__4.1__arrow_{no_rc_r_version}\.zip
+      - r-pkg__bin__windows__contrib__4.3__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.2__arrow_{no_rc_r_version}\.zip
-      - r-pkg__bin__macosx__contrib__4.1__arrow_{no_rc_r_version}\.tgz
+      - r-pkg__bin__macosx__contrib__4.3__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__contrib__4.2__arrow_{no_rc_r_version}\.tgz
-      - r-pkg__bin__macosx__big-sur-arm64__contrib__4.1__arrow_{no_rc_r_version}\.tgz
+      - r-pkg__bin__macosx__big-sur-arm64__contrib__4.3__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-arm64__contrib__4.2__arrow_{no_rc_r_version}\.tgz
       - r-pkg__src__contrib__arrow_{no_rc_r_version}\.tar\.gz
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -979,7 +979,7 @@ tasks:
       - r-lib__libarrow__bin__darwin-x86_64-openssl-3.0__arrow-{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.3__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.2__arrow_{no_rc_r_version}\.zip
-      - r-pkg__bin__macosx__contrib__4.3__arrow_{no_rc_r_version}\.tgz
+      - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.3__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__contrib__4.2__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-arm64__contrib__4.3__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-arm64__contrib__4.2__arrow_{no_rc_r_version}\.tgz


### PR DESCRIPTION

### Rationale for this change

The action does not work smoothly on the self-hosted runners.

### What changes are included in this PR?

Use devtools instead.

### Are these changes tested?
crossbow
* Closes: #38779