### PR TITLE
GH-38984: [Python][Packaging] Verification of wheels on AlmaLinux 8 are failing due to missing pip

### DIFF
--- a/ci/docker/almalinux-8-verify-rc.dockerfile
+++ b/ci/docker/almalinux-8-verify-rc.dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG arch=amd64
-FROM ${arch}/almalinux:8.8
+FROM ${arch}/almalinux:8
 
 COPY dev/release/setup-rhel-rebuilds.sh /
 RUN /setup-rhel-rebuilds.sh && \

--- a/ci/docker/almalinux-8-verify-rc.dockerfile
+++ b/ci/docker/almalinux-8-verify-rc.dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG arch=amd64
-FROM ${arch}/almalinux:8
+FROM ${arch}/almalinux:8.8
 
 COPY dev/release/setup-rhel-rebuilds.sh /
 RUN /setup-rhel-rebuilds.sh && \

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -44,8 +44,6 @@ dnf -y install \
   ninja-build \
   nodejs \
   openssl-devel \
-  python38-devel \
-  python38-pip \
   ruby-devel \
   sqlite-devel \
   vala-devel \

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -54,5 +54,5 @@ dnf -y install \
 
 npm install -g yarn
 
-python3 -m pip install -U pip
+python3 -m ensurepip --upgrade
 alternatives --set python /usr/bin/python3


### PR DESCRIPTION
### Rationale for this change

Almalinux 8 has been updated from 8.8 to 8.9. When using 8.9 python3 seems to be shipped without pip as  the command `python3 -m pip install -U pip` fails to find pip.

### What changes are included in this PR?

Use the [ensurepip package](https://docs.python.org/3/library/ensurepip.html) which provides support for bootstrapping the pip installer into an existing Python installation.

### Are these changes tested?

Yes via archery.

### Are there any user-facing changes?

No
* Closes: #38984