### PR TITLE
GH-38879: [C++][Gandiva] Fix Gandiva to_date function's validation for supress errors parameter

### DIFF
--- a/cpp/src/gandiva/to_date_holder.cc
+++ b/cpp/src/gandiva/to_date_holder.cc
@@ -50,7 +50,7 @@ Result<std::shared_ptr<ToDateHolder>> ToDateHolder::Make(const FunctionNode& nod
   if (node.children().size() == 3) {
     auto literal_suppress_errors =
         dynamic_cast<LiteralNode*>(node.children().at(2).get());
-    if (literal_pattern == nullptr) {
+    if (literal_suppress_errors == nullptr) {
       return Status::Invalid(
           "The (optional) third parameter to 'to_date' function needs to an integer "
           "literal to indicate whether to suppress the error");

--- a/cpp/src/gandiva/to_date_holder_test.cc
+++ b/cpp/src/gandiva/to_date_holder_test.cc
@@ -29,14 +29,18 @@ namespace gandiva {
 
 class TestToDateHolder : public ::testing::Test {
  public:
-  FunctionNode BuildToDate(std::string pattern) {
+  FunctionNode BuildToDate(std::string pattern,
+                           std::shared_ptr<Node> suppress_error_node = nullptr) {
     auto field = std::make_shared<FieldNode>(arrow::field("in", arrow::utf8()));
     auto pattern_node =
         std::make_shared<LiteralNode>(arrow::utf8(), LiteralHolder(pattern), false);
-    auto suppress_error_node =
-        std::make_shared<LiteralNode>(arrow::int32(), LiteralHolder(0), false);
-    return FunctionNode("to_date_utf8_utf8_int32",
-                        {field, pattern_node, suppress_error_node}, arrow::int64());
+    if (suppress_error_node == nullptr) {
+      suppress_error_node =
+          std::make_shared<LiteralNode>(arrow::int32(), LiteralHolder(0), false);
+    }
+    return {"to_date_utf8_utf8_int32",
+            {field, pattern_node, std::move(suppress_error_node)},
+            arrow::int64()};
   }
 
  protected:
@@ -167,4 +171,14 @@ TEST_F(TestToDateHolder, TestSimpleDateYear) {
   EXPECT_EQ(millis_since_epoch, 915148800000);
 }
 
+TEST_F(TestToDateHolder, TestMakeFromFunctionNode) {
+  auto to_date_func = BuildToDate("YYYY");
+  EXPECT_OK_AND_ASSIGN(auto to_date_holder, ToDateHolder::Make(to_date_func));
+}
+
+TEST_F(TestToDateHolder, TestMakeFromInvalidSurpressParamFunctionNode) {
+  auto non_literal_param = std::make_shared<FieldNode>(arrow::field("in", arrow::utf8()));
+  auto to_date_func = BuildToDate("YYYY", std::move(non_literal_param));
+  ASSERT_RAISES(Invalid, ToDateHolder::Make(to_date_func).status());
+}
 }  // namespace gandiva


### PR DESCRIPTION
### Rationale for this change
* This PR fixes the `to_date_utf8_utf8_int32` gandiva function to avoid crash for invalid input

### What changes are included in this PR?
* A bug fix for to_date_utf8_utf8_int32 parameter validation

### Are these changes tested?
Yes, new tests are added to verify non literal input won't crash the to_date_utf8_utf8_int32 function

### Are there any user-facing changes?
No
* Closes: #38879