### PR TITLE
GH-38996: [Java] Update dependencies and plugins for JPMS modules

### DIFF
--- a/java/algorithm/pom.xml
+++ b/java/algorithm/pom.xml
@@ -31,6 +31,7 @@
       <artifactId>arrow-vector</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -149,7 +149,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
         <executions>
           <execution>
             <id>shade-main</id>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -56,10 +56,6 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-context</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
     </dependency>
     <dependency>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -145,6 +145,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <!--
+          Downgrade maven-shade-plugin specifically for this module.
+          Using a newer version up to at least 3.5.1 will cause
+          issues in the arrow-tools tests looking up FlatBuffer
+          dependencies.
+         -->
+        <version>3.2.4</version>
         <executions>
           <execution>
             <id>shade-main</id>

--- a/java/flight/flight-grpc/pom.xml
+++ b/java/flight/flight-grpc/pom.xml
@@ -53,6 +53,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-inprocess</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/flight/flight-grpc/pom.xml
+++ b/java/flight/flight-grpc/pom.xml
@@ -48,12 +48,12 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
+      <artifactId>grpc-stub</artifactId>
     </dependency>
-     <dependency>
-       <groupId>io.grpc</groupId>
-       <artifactId>grpc-stub</artifactId>
-     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-inprocess</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -159,7 +159,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -53,6 +53,7 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-jdbc</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -70,6 +71,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>

--- a/java/performance/pom.xml
+++ b/java/performance/pom.xml
@@ -103,7 +103,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/java/performance/pom.xml
+++ b/java/performance/pom.xml
@@ -26,6 +26,7 @@
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>${jmh.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -37,10 +38,12 @@
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
             <classifier>${arrow.vector.classifier}</classifier>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-memory-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
@@ -51,10 +54,12 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${dep.avro.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-avro</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -65,6 +70,7 @@
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-jdbc</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -409,6 +409,11 @@
           <version>3.0.0-M2</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M7</version>
           <dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -378,7 +378,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -34,7 +34,7 @@
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava-bom.version>31.1-jre</dep.guava-bom.version>
     <dep.netty-bom.version>4.1.100.Final</dep.netty-bom.version>
-    <dep.grpc-bom.version>1.56.0</dep.grpc-bom.version>
+    <dep.grpc-bom.version>1.59.0</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.15.1</dep.jackson-bom.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,7 +45,7 @@
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     <error_prone_core.version>2.22.0</error_prone_core.version>
-    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <mockito.core.version>5.5.0</mockito.core.version>
     <mockito.inline.version>5.2.0</mockito.inline.version>
   </properties>
@@ -400,6 +400,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
+            <useModulePath>false</useModulePath>
             <annotationProcessorPaths>
               <path>
                 <groupId>org.immutables</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -361,7 +361,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.10</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <dep.netty-bom.version>4.1.100.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.59.0</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
-    <dep.jackson-bom.version>2.15.1</dep.jackson-bom.version>
+    <dep.jackson-bom.version>2.16.0</dep.jackson-bom.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.12.0</dep.fbs.version>
     <dep.avro.version>1.10.0</dep.avro.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -411,7 +411,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -378,7 +378,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.1</version>
+          <!--
+            This appears to report a false positive with versions
+            greater than 3.1.2 (tested up to 3.6.0) when compiling
+            arrow-tools about Jackson being only used for tests.
+          -->
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -53,12 +53,10 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
-          <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-          <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -37,6 +37,7 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+          <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -52,10 +53,12 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
+          <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
+          <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -174,6 +174,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <!--
+          Downgrade maven-shade-plugin specifically for this module.
+          Using a newer version up to at least 3.5.1 will cause
+          issues in the arrow-tools tests looking up FlatBuffer
+          dependencies.
+         -->
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -174,7 +174,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### Rationale for this change
Update dependencies and plugins to versions that work correctly with JPMS modules.

### What changes are included in this PR?
* Update several plugins to use module-enabled versions:
  * maven-compiler-plugin is updated to 3.11.0
  * maven-shade-plugin is updated to 3.2.4
  * maven-dependency-plugin is updated to 3.1.2
  * CycloneDX is updated to 2.7.10
* Update grpc-java to 1.59 for module support
* Update jackson to 2.16.0 as 2.15.1 had corrupt module-info.class files that broke module support.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Existing tests only

### Are there any user-facing changes?
Users may need to update their own dependencies if they have the same ones.
* Closes: apache/arrow#38996
* GitHub Issue: #38996