### PR TITLE
MINOR: [C++][Parquet] Fix GzipMembers tests when built w/o zlib

### DIFF
--- a/cpp/src/arrow/util/compression_test.cc
+++ b/cpp/src/arrow/util/compression_test.cc
@@ -369,6 +369,9 @@ TEST_P(CodecTest, CodecRoundtrip) {
 }
 
 TEST(CodecTest, CodecRoundtripGzipMembers) {
+#ifndef ARROW_WITH_ZLIB
+  GTEST_SKIP() << "Test requires Zlib compression";
+#endif
   std::unique_ptr<Codec> gzip_codec;
   ASSERT_OK_AND_ASSIGN(gzip_codec, Codec::Create(Compression::GZIP));
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -783,6 +783,9 @@ TEST_F(TestCheckDataPageCrc, CorruptDict) {
 }
 
 TEST(TestGzipMembersRead, TwoConcatenatedMembers) {
+#ifndef ARROW_WITH_ZLIB
+  GTEST_SKIP() << "Test requires Zlib compression";
+#endif
   auto file_reader = ParquetFileReader::OpenFile(concatenated_gzip_members(),
                                                  /*memory_map=*/false);
   auto col_reader = std::dynamic_pointer_cast<TypedColumnReader<Int64Type>>(


### PR DESCRIPTION
### Rationale for this change

[----------] 1 test from TestGzipMembersRead
[ RUN      ] TestGzipMembersRead.TwoConcatenatedMembers
unknown file: Failure
C++ exception with description "NotImplemented: Support for codec 'gzip' not built" thrown in the test body.
[  FAILED  ] TestGzipMembersRead.TwoConcatenatedMembers (0 ms)
[----------] 1 test from TestGzipMembersRead (0 ms total)


[----------] 1 test from CodecTest
[ RUN      ] CodecTest.CodecRoundtripGzipMembers
/Users/gangwu/Projects/arrow/cpp/src/arrow/util/compression_test.cc:373: Failure
Failed
'_error_or_value43.status()' failed with NotImplemented: Support for codec 'gzip' not built
[  FAILED  ] CodecTest.CodecRoundtripGzipMembers (0 ms)
[----------] 1 test from CodecTest (0 ms total)

### What changes are included in this PR?

Skip failed tests with zlib is not built.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.