### PR TITLE
GH-39003: [CI][macOS] Don't update Homebrew

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -193,12 +193,6 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         run: |
-          rm -f /usr/local/bin/2to3* || :
-          rm -f /usr/local/bin/idle3* || :
-          rm -f /usr/local/bin/pydoc3* || :
-          rm -f /usr/local/bin/python3* || :
-          rm -f /usr/local/bin/python3-config || :
-          brew update --preinstall || :
           brew bundle --file=cpp/Brewfile
       - name: Install MinIO
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -167,15 +167,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          rm -f /usr/local/bin/2to3* || :
-          rm -f /usr/local/bin/idle3* || :
-          rm -f /usr/local/bin/pydoc3* || :
-          rm -f /usr/local/bin/python3* || :
-          rm -f /usr/local/bin/python3-config || :
-          brew update --preinstall || :
-          brew install --overwrite git
           brew bundle --file=cpp/Brewfile
-          brew install coreutils
           python -m pip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -149,13 +149,6 @@ jobs:
       - name: Install Homebrew Dependencies
         shell: bash
         run: |
-          rm -f /usr/local/bin/2to3* || :
-          rm -f /usr/local/bin/idle3* || :
-          rm -f /usr/local/bin/pydoc3* || :
-          rm -f /usr/local/bin/python3* || :
-          rm -f /usr/local/bin/python3-config || :
-          brew update --preinstall || :
-          brew install --overwrite git
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile
       - name: Install Ruby Dependencies

--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -43,12 +43,6 @@ jobs:
       - name: Install System Dependencies
         shell: bash
         run: |
-          rm -f /usr/local/bin/2to3*
-          rm -f /usr/local/bin/idle*
-          rm -f /usr/local/bin/pydoc3*
-          rm -f /usr/local/bin/python3*
-          brew update || echo "brew update did not finish successfully"
-          brew install --overwrite git
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile
       {% endif %}


### PR DESCRIPTION
### Rationale for this change

It's better that we always use the latest Homebrew to check with the latest Homebrew that are used by most users. But it's difficult to maintain.

### What changes are included in this PR?

We don't update Homebrew manually. GitHub hosted GitHub Actions Runners update Homebrew periodically. We depend on it instead of manual `brew update`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39003