### PR TITLE
GH-39020: [CI][Release][JS] Use Node.js 18 instead of 16

### DIFF
--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -27,7 +27,7 @@ dnf -y install 'dnf-command(config-manager)'
 dnf config-manager --set-enabled powertools
 dnf -y update
 dnf -y module disable nodejs
-dnf -y module enable nodejs:16
+dnf -y module enable nodejs:18
 dnf -y module disable ruby
 dnf -y module enable ruby:2.7
 dnf -y groupinstall "Development Tools"

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -23,7 +23,7 @@
 # - Maven >= 3.3.9
 # - JDK >=7
 # - gcc >= 4.8
-# - Node.js >= 11.12 (best way is to use nvm)
+# - Node.js >= 18
 # - Go >= 1.19
 # - Docker
 #

--- a/dev/tasks/verify-rc/github.linux.amd64.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.yml
@@ -59,10 +59,6 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-
       - name: Run verification
         shell: bash
         env:

--- a/dev/tasks/verify-rc/github.macos.amd64.yml
+++ b/dev/tasks/verify-rc/github.macos.amd64.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           dotnet-version: '7.0.x'
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Run verification
         shell: bash

--- a/dev/tasks/verify-rc/github.macos.arm64.yml
+++ b/dev/tasks/verify-rc/github.macos.arm64.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile
-          export PATH="$(brew --prefix node@16)/bin:$PATH"
+          export PATH="$(brew --prefix node@18)/bin:$PATH"
           export PATH="$(brew --prefix ruby)/bin:$PATH"
           export PKG_CONFIG_PATH="$(brew --prefix ruby)/lib/pkgconfig"
           arrow/dev/release/verify-release-candidate.sh \


### PR DESCRIPTION
### Rationale for this change

Node.js 16 reached EOL.

### What changes are included in this PR?

Use Node.js 18. It's the oldest maintained LTS.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39020