### PR TITLE
GH-38857: [Python] Fix append mode for cython 2

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1386,7 +1386,8 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         CResult[shared_ptr[COutputStream]] Open(const c_string& path)
 
         @staticmethod
-        CResult[shared_ptr[COutputStream]] Open(const c_string& path, c_bool append)
+        CResult[shared_ptr[COutputStream]] OpenWithAppend" Open"(
+            const c_string& path, c_bool append)
 
         int file_descriptor()
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1167,7 +1167,9 @@ cdef class OSFile(NativeFile):
 
     cdef _open_writable(self, c_string path, c_bool append=False):
         with nogil:
-            self.output_stream = GetResultValue(FileOutputStream.Open(path, append))
+            self.output_stream = GetResultValue(
+                FileOutputStream.OpenWithAppend(path, append)
+            )
         self.is_writable = True
         self._is_appending = append
 


### PR DESCRIPTION
### Rationale for this change

Small fixup of the change in https://github.com/apache/arrow/pull/38820 to fix the build failure on cython 2 (nightly crossbow build)
* Closes: #38857