### PR TITLE
GH-39037: [Java] Remove (Contrib/Experimental) mention in Flight SQL

### DIFF
--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -23,7 +23,7 @@
 
     <artifactId>flight-sql-jdbc-core</artifactId>
     <name>Arrow Flight SQL JDBC Driver Core</name>
-    <description>(Contrib/Experimental) Core implementation of JDBC driver based on Arrow Flight SQL.</description>
+    <description>Core implementation of JDBC driver based on Arrow Flight SQL.</description>
     <packaging>jar</packaging>
     <url>https://arrow.apache.org</url>
 

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -23,7 +23,7 @@
 
     <artifactId>flight-sql-jdbc-driver</artifactId>
     <name>Arrow Flight SQL JDBC Driver</name>
-    <description>(Contrib/Experimental) A JDBC driver based on Arrow Flight SQL.</description>
+    <description>A JDBC driver based on Arrow Flight SQL.</description>
     <packaging>jar</packaging>
     <url>https://arrow.apache.org</url>
 


### PR DESCRIPTION
### Rationale for this change

Considering that Flight SQL has been present for a while and should be fairly stable, remove the `(Contrib/Experimental)` mention from the pom file which also shows up on Maven Central UI pages

### Are these changes tested?

Local test but there's no code change, only cosmetic

### Are there any user-facing changes?

None

* Closes: #39037