### PR TITLE
GH-39041:[R] Improve `update-checksum.R` output

### DIFF
--- a/r/tools/update-checksums.R
+++ b/r/tools/update-checksums.R
@@ -38,6 +38,7 @@ if (!file.exists(tasks_yml)) {
   stop("Run this script from the r/ directory of the arrow repo")
 }
 
+print("Extracting libarrow binary paths from tasks.yml")
 # Get the libarrow binary paths from the tasks.yml file
 binary_paths <- readLines(tasks_yml) |>
   grep("r-lib__libarrow", x = _, value = TRUE) |>
@@ -53,11 +54,13 @@ for (path in binary_paths) {
   sha_path <- paste0(path, ".sha512")
   file <- file.path("tools/checksums", sha_path)
   dirname(file) |> dir.create(path = _, recursive = TRUE, showWarnings = FALSE)
-
+  
+  print(paste0("Downloading ", sha_path))
   url <- sprintf(artifactory_root, VERSION, sha_path)
   download.file(url, file, quiet = TRUE, cacheOK = FALSE)
 
   if (grepl("windows", path)) {
+    print(paste0("Converting ", path, " to windows style line endings"))
     # UNIX style line endings cause errors with mysys2 sha512sum
     sed_status <- system2("sed", args = c("-i", "s/\\\\r//", file))
     if (sed_status != 0) {
@@ -65,3 +68,5 @@ for (path in binary_paths) {
     }
   }
 }
+
+print("Checksums updated successfully!")

--- a/r/tools/update-checksums.R
+++ b/r/tools/update-checksums.R
@@ -38,7 +38,7 @@ if (!file.exists(tasks_yml)) {
   stop("Run this script from the r/ directory of the arrow repo")
 }
 
-print("Extracting libarrow binary paths from tasks.yml")
+cat("Extracting libarrow binary paths from tasks.yml\n")
 # Get the libarrow binary paths from the tasks.yml file
 binary_paths <- readLines(tasks_yml) |>
   grep("r-lib__libarrow", x = _, value = TRUE) |>
@@ -55,12 +55,12 @@ for (path in binary_paths) {
   file <- file.path("tools/checksums", sha_path)
   dirname(file) |> dir.create(path = _, recursive = TRUE, showWarnings = FALSE)
   
-  print(paste0("Downloading ", sha_path))
+  cat(paste0("Downloading ", sha_path, "\n"))
   url <- sprintf(artifactory_root, VERSION, sha_path)
   download.file(url, file, quiet = TRUE, cacheOK = FALSE)
 
   if (grepl("windows", path)) {
-    print(paste0("Converting ", path, " to windows style line endings"))
+    cat(paste0("Converting ", path, " to windows style line endings\n"))
     # UNIX style line endings cause errors with mysys2 sha512sum
     sed_status <- system2("sed", args = c("-i", "s/\\\\r//", file))
     if (sed_status != 0) {
@@ -69,4 +69,4 @@ for (path in binary_paths) {
   }
 }
 
-print("Checksums updated successfully!")
+cat("Checksums updated successfully!\n")

--- a/r/tools/update-checksums.R
+++ b/r/tools/update-checksums.R
@@ -59,7 +59,7 @@ for (path in binary_paths) {
 
   if (grepl("windows", path)) {
     # UNIX style line endings cause errors with mysys2 sha512sum
-    sed_status <- system2("sed", args = c("-i", "s/\\r//", file))
+    sed_status <- system2("sed", args = c("-i", "s/\\\\r//", file))
     if (sed_status != 0) {
       stop("Failed to remove \\r from windows checksum file. Exit code: ", sed_status)
     }


### PR DESCRIPTION

### Rationale for this change

The script was to quiet.

### What changes are included in this PR?

Fix regex and add some output: 
```
Rscript tools/update-checksums.R 14.0.0                                                                           1 ✘
[1] "Extracting libarrow binary paths from tasks.yml"
[1] "Downloading windows/arrow-14.0.0.zip.sha512"
[1] "Converting windows/arrow-14.0.0.zip to windows style line endings"
[1] "Downloading linux-openssl-1.0/arrow-14.0.0.zip.sha512"
[1] "Downloading linux-openssl-1.1/arrow-14.0.0.zip.sha512"
[1] "Downloading linux-openssl-3.0/arrow-14.0.0.zip.sha512"
[1] "Downloading darwin-arm64-openssl-1.1/arrow-14.0.0.zip.sha512"
[1] "Downloading darwin-arm64-openssl-3.0/arrow-14.0.0.zip.sha512"
[1] "Downloading darwin-x86_64-openssl-1.1/arrow-14.0.0.zip.sha512"
[1] "Downloading darwin-x86_64-openssl-3.0/arrow-14.0.0.zip.sha512"
[1] "Checksums updated successfully!"
```

### Are these changes tested?
locally 

### Are there any user-facing changes?
no
* Closes: #39041