### PR TITLE
GH-39045: [C++][Acero] union node output batches should be unordered

### DIFF
--- a/cpp/src/arrow/acero/union_node.cc
+++ b/cpp/src/arrow/acero/union_node.cc
@@ -80,6 +80,9 @@ class UnionNode : public ExecNode, public TracedNode {
     NoteInputReceived(batch);
     ARROW_DCHECK(std::find(inputs_.begin(), inputs_.end(), input) != inputs_.end());
 
+    if (inputs_.size() > 1) {
+      batch.index = compute::kUnsequencedIndex;
+    }
     return output_->InputReceived(this, std::move(batch));
   }
 


### PR DESCRIPTION
### Rationale for this change
Acero's union node produce duplicated batch index if having multiple ordered input nodes, which makes down stream nodes unable to process these batches if ordering is a concern. This PR tries to address this issue.

### What changes are included in this PR?
This PR fixes this issue by setting the index to unsequenced if the order cannot be guaranteed.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No
* Closes: #39045