### PR TITLE
GH-38881: [C++][Parquet] Reuse FLBA array data for decimal conversion when possible

### DIFF
--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -556,10 +556,11 @@ struct DecimalConverter<DecimalArrayType, FLBAType> {
     const int32_t byte_width =
         checked_cast<const ::arrow::FixedSizeBinaryType&>(*fixed_size_binary_array.type())
             .byte_width();
-    // allocate memory for the decimal array
-    ARROW_ASSIGN_OR_RAISE(auto data, ::arrow::AllocateBuffer(length * type_length, pool));
 
-    // raw bytes that we can write to
+    DCHECK(byte_width >= type_length);
+    // As the byte width of the FixedSizeBinaryArray is greater than or equal to the given
+    // array then we can reuse its data buffer to write the decimal array
+    auto data = fixed_size_binary_array.data()->buffers[1];
     uint8_t* out_ptr = data->mutable_data();
 
     // convert each FixedSizeBinary value to valid decimal bytes

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -557,10 +557,15 @@ struct DecimalConverter<DecimalArrayType, FLBAType> {
         checked_cast<const ::arrow::FixedSizeBinaryType&>(*fixed_size_binary_array.type())
             .byte_width();
 
-    DCHECK(byte_width >= type_length);
-    // As the byte width of the FixedSizeBinaryArray is greater than or equal to the given
+    // raw bytes that we can write to
+    std::shared_ptr<::arrow::Buffer> data;
+    // if the byte width of the FixedSizeBinaryArray is greater than or equal to the given
     // array then we can reuse its data buffer to write the decimal array
-    auto data = fixed_size_binary_array.data()->buffers[1];
+    if (byte_width >= type_length) {
+      data = fixed_size_binary_array.data()->buffers[1];
+    } else {
+      ARROW_ASSIGN_OR_RAISE(data, ::arrow::AllocateBuffer(length * type_length, pool));
+    }
     uint8_t* out_ptr = data->mutable_data();
 
     // convert each FixedSizeBinary value to valid decimal bytes


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, parquet-arrow-test tests this and if we don't downgrade to allocations when needed segfaults
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38881