### PR TITLE
GH-38887: [C++][Parquet] Move EstimatedBufferedValueBytes from TypedColumnWriter to ColumnWriter

### DIFF
--- a/cpp/examples/parquet/low_level_api/reader_writer2.cc
+++ b/cpp/examples/parquet/low_level_api/reader_writer2.cc
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
           static_cast<parquet::BoolWriter*>(rg_writer->column(col_id));
       bool bool_value = ((i % 2) == 0) ? true : false;
       bool_writer->WriteBatch(1, nullptr, nullptr, &bool_value);
-      buffered_values_estimate[col_id] = bool_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = bool_writer->estimated_buffered_value_bytes();
 
       // Write the Int32 column
       col_id++;
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
           static_cast<parquet::Int32Writer*>(rg_writer->column(col_id));
       int32_t int32_value = i;
       int32_writer->WriteBatch(1, nullptr, nullptr, &int32_value);
-      buffered_values_estimate[col_id] = int32_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = int32_writer->estimated_buffered_value_bytes();
 
       // Write the Int64 column. Each row has repeats twice.
       col_id++;
@@ -119,7 +119,7 @@ int main(int argc, char** argv) {
       int64_t int64_value2 = (2 * i + 1);
       repetition_level = 1;  // start of a new record
       int64_writer->WriteBatch(1, &definition_level, &repetition_level, &int64_value2);
-      buffered_values_estimate[col_id] = int64_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = int64_writer->estimated_buffered_value_bytes();
 
       // Write the INT96 column.
       col_id++;
@@ -130,7 +130,7 @@ int main(int argc, char** argv) {
       int96_value.value[1] = i + 1;
       int96_value.value[2] = i + 2;
       int96_writer->WriteBatch(1, nullptr, nullptr, &int96_value);
-      buffered_values_estimate[col_id] = int96_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = int96_writer->estimated_buffered_value_bytes();
 
       // Write the Float column
       col_id++;
@@ -138,7 +138,7 @@ int main(int argc, char** argv) {
           static_cast<parquet::FloatWriter*>(rg_writer->column(col_id));
       float float_value = static_cast<float>(i) * 1.1f;
       float_writer->WriteBatch(1, nullptr, nullptr, &float_value);
-      buffered_values_estimate[col_id] = float_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = float_writer->estimated_buffered_value_bytes();
 
       // Write the Double column
       col_id++;
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
           static_cast<parquet::DoubleWriter*>(rg_writer->column(col_id));
       double double_value = i * 1.1111111;
       double_writer->WriteBatch(1, nullptr, nullptr, &double_value);
-      buffered_values_estimate[col_id] = double_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = double_writer->estimated_buffered_value_bytes();
 
       // Write the ByteArray column. Make every alternate values NULL
       col_id++;
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
         int16_t definition_level = 0;
         ba_writer->WriteBatch(1, &definition_level, nullptr, nullptr);
       }
-      buffered_values_estimate[col_id] = ba_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = ba_writer->estimated_buffered_value_bytes();
 
       // Write the FixedLengthByteArray column
       col_id++;
@@ -178,7 +178,7 @@ int main(int argc, char** argv) {
       flba_value.ptr = reinterpret_cast<const uint8_t*>(&flba[0]);
 
       flba_writer->WriteBatch(1, nullptr, nullptr, &flba_value);
-      buffered_values_estimate[col_id] = flba_writer->EstimatedBufferedValueBytes();
+      buffered_values_estimate[col_id] = flba_writer->estimated_buffered_value_bytes();
     }
 
     // Close the RowGroupWriter

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1313,7 +1313,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     END_PARQUET_CATCH_EXCEPTIONS
   }
 
-  int64_t EstimatedBufferedValueBytes() const override {
+  int64_t estimated_buffered_value_bytes() const override {
     return current_encoder_->EstimatedDataEncodedSize();
   }
 

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -175,6 +175,9 @@ class PARQUET_EXPORT ColumnWriter {
   /// total_bytes_written().
   virtual int64_t total_compressed_bytes_written() const = 0;
 
+  /// \brief Estimated size of the values that are not written to a page yet.
+  virtual int64_t EstimatedBufferedValueBytes() const = 0;
+
   /// \brief The file-level writer properties
   virtual const WriterProperties* properties() = 0;
 
@@ -239,9 +242,6 @@ class TypedColumnWriter : public ColumnWriter {
   virtual void WriteBatchSpaced(int64_t num_values, const int16_t* def_levels,
                                 const int16_t* rep_levels, const uint8_t* valid_bits,
                                 int64_t valid_bits_offset, const T* values) = 0;
-
-  // Estimated size of the values that are not written to a page yet
-  virtual int64_t EstimatedBufferedValueBytes() const = 0;
 };
 
 using BoolWriter = TypedColumnWriter<BooleanType>;

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -176,7 +176,7 @@ class PARQUET_EXPORT ColumnWriter {
   virtual int64_t total_compressed_bytes_written() const = 0;
 
   /// \brief Estimated size of the values that are not written to a page yet.
-  virtual int64_t EstimatedBufferedValueBytes() const = 0;
+  virtual int64_t estimated_buffered_value_bytes() const = 0;
 
   /// \brief The file-level writer properties
   virtual const WriterProperties* properties() = 0;

--- a/cpp/src/parquet/stream_writer.cc
+++ b/cpp/src/parquet/stream_writer.cc
@@ -157,7 +157,7 @@ StreamWriter& StreamWriter::WriteVariableLength(const char* data_ptr,
     writer->WriteBatch(kBatchSizeOne, &kDefLevelZero, &kRepLevelZero, nullptr);
   }
   if (max_row_group_size_ > 0) {
-    row_group_size_ += writer->EstimatedBufferedValueBytes();
+    row_group_size_ += writer->estimated_buffered_value_bytes();
   }
   return *this;
 }
@@ -178,7 +178,7 @@ StreamWriter& StreamWriter::WriteFixedLength(const char* data_ptr, std::size_t d
     writer->WriteBatch(kBatchSizeOne, &kDefLevelZero, &kRepLevelZero, nullptr);
   }
   if (max_row_group_size_ > 0) {
-    row_group_size_ += writer->EstimatedBufferedValueBytes();
+    row_group_size_ += writer->estimated_buffered_value_bytes();
   }
   return *this;
 }

--- a/cpp/src/parquet/stream_writer.h
+++ b/cpp/src/parquet/stream_writer.h
@@ -185,7 +185,7 @@ class PARQUET_EXPORT StreamWriter {
     writer->WriteBatch(kBatchSizeOne, &kDefLevelOne, &kRepLevelZero, &v);
 
     if (max_row_group_size_ > 0) {
-      row_group_size_ += writer->EstimatedBufferedValueBytes();
+      row_group_size_ += writer->estimated_buffered_value_bytes();
     }
     return *this;
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Trying to put `EstimatedBufferedValueBytes` from `TypedColumnWriter` to `ColumnWriter`.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

put `EstimatedBufferedValueBytes` from `TypedColumnWriter` to `ColumnWriter`.

### Are these changes tested?

No, just interface change

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes, interface changed

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38887