### PR TITLE
GH-38705: [C++][FS][Azure] Implement CopyFile()

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1157,8 +1157,9 @@ class AzureFileSystem::Impl {
     }
   }
 
- private:
-  Status CopyFileInternal(const AzureLocation& src, const AzureLocation& dest) {
+  Status CopyFile(const AzureLocation& src, const AzureLocation& dest) {
+    RETURN_NOT_OK(ValidateFileLocation(src));
+    RETURN_NOT_OK(ValidateFileLocation(dest));
     if (src == dest) {
       return Status::OK();
     }
@@ -1175,20 +1176,6 @@ class AzureFileSystem::Impl {
           exception);
     }
     return Status::OK();
-  }
-
- public:
-  Status CopyFile(const AzureLocation& src, const AzureLocation& dest) {
-    RETURN_NOT_OK(ValidateFileLocation(src));
-    if (dest.container.empty()) {
-      return PathNotFound(dest);
-    }
-    if (dest.path.empty() || internal::HasTrailingSlash(dest.path)) {
-      ARROW_ASSIGN_OR_RAISE(auto real_dest, dest.join(src.path_parts.back()));
-      return CopyFileInternal(src, real_dest);
-    } else {
-      return CopyFileInternal(src, dest);
-    }
   }
 };
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -153,6 +153,7 @@ Status ValidateFileLocation(const AzureLocation& location) {
   if (location.path.empty()) {
     return NotAFile(location);
   }
+  ARROW_RETURN_NOT_OK(internal::AssertNoTrailingSlash(location.path));
   return Status::OK();
 }
 
@@ -822,7 +823,6 @@ class AzureFileSystem::Impl {
   Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const AzureLocation& location,
                                                          AzureFileSystem* fs) {
     RETURN_NOT_OK(ValidateFileLocation(location));
-    ARROW_RETURN_NOT_OK(internal::AssertNoTrailingSlash(location.path));
     auto blob_client = std::make_shared<Azure::Storage::Blobs::BlobClient>(
         blob_service_client_->GetBlobContainerClient(location.container)
             .GetBlobClient(location.path));
@@ -835,7 +835,6 @@ class AzureFileSystem::Impl {
 
   Result<std::shared_ptr<ObjectInputFile>> OpenInputFile(const FileInfo& info,
                                                          AzureFileSystem* fs) {
-    ARROW_RETURN_NOT_OK(internal::AssertNoTrailingSlash(info.path()));
     if (info.type() == FileType::NotFound) {
       return ::arrow::fs::internal::PathNotFound(info.path());
     }
@@ -955,7 +954,6 @@ class AzureFileSystem::Impl {
       const std::shared_ptr<const KeyValueMetadata>& metadata, const bool truncate,
       AzureFileSystem* fs) {
     RETURN_NOT_OK(ValidateFileLocation(location));
-    ARROW_RETURN_NOT_OK(internal::AssertNoTrailingSlash(location.path));
 
     auto block_blob_client = std::make_shared<Azure::Storage::Blobs::BlockBlobClient>(
         blob_service_client_->GetBlobContainerClient(location.container)

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -771,6 +771,70 @@ TEST_F(AzureHierarchicalNamespaceFileSystemTest, DeleteDirContentsFailureNonexis
   ASSERT_RAISES(IOError, fs_->DeleteDirContents(directory_path, false));
 }
 
+TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationNonexistent) {
+  const auto destination_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), "copy-destionation");
+  ASSERT_OK(fs_->CopyFile(PreexistingObjectPath(), destination_path));
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(destination_path));
+  ASSERT_OK_AND_ASSIGN(auto stream, fs_->OpenInputStream(info));
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
+  EXPECT_EQ(kLoremIpsum, buffer->ToString());
+}
+
+TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationSame) {
+  ASSERT_OK(fs_->CopyFile(PreexistingObjectPath(), PreexistingObjectPath()));
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(PreexistingObjectPath()));
+  ASSERT_OK_AND_ASSIGN(auto stream, fs_->OpenInputStream(info));
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
+  EXPECT_EQ(kLoremIpsum, buffer->ToString());
+}
+
+TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationContainer) {
+  const auto container_name = RandomContainerName();
+  ASSERT_OK(fs_->CreateDir(container_name));
+  ASSERT_OK(fs_->CopyFile(PreexistingObjectPath(), container_name));
+  const auto destination_path =
+      internal::ConcatAbstractPath(container_name, PreexistingObjectName());
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(destination_path));
+  ASSERT_OK_AND_ASSIGN(auto stream, fs_->OpenInputStream(info));
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
+  EXPECT_EQ(kLoremIpsum, buffer->ToString());
+}
+
+TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationDirectory) {
+  const auto directory_path = internal::EnsureTrailingSlash(
+      internal::ConcatAbstractPath(RandomContainerName(), RandomDirectoryName()));
+  ASSERT_OK(fs_->CreateDir(directory_path, true));
+  ASSERT_OK(fs_->CopyFile(PreexistingObjectPath(), directory_path));
+  const auto destination_path =
+      internal::ConcatAbstractPath(directory_path, PreexistingObjectName());
+  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(destination_path));
+  ASSERT_OK_AND_ASSIGN(auto stream, fs_->OpenInputStream(info));
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
+  EXPECT_EQ(kLoremIpsum, buffer->ToString());
+}
+
+TEST_F(AzuriteFileSystemTest, CopyFileFailureSourceNonexistent) {
+  const auto destination_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), "copy-destionation");
+  ASSERT_RAISES(IOError, fs_->CopyFile(NotFoundObjectPath(), destination_path));
+}
+
+TEST_F(AzuriteFileSystemTest, CopyFileFailureDestinationParentNonexistent) {
+  const auto destination_path =
+      internal::ConcatAbstractPath(RandomContainerName(), "copy-destionation");
+  ASSERT_RAISES(IOError, fs_->CopyFile(PreexistingObjectPath(), destination_path));
+}
+
+TEST_F(AzuriteFileSystemTest, CopyFileUri) {
+  const auto destination_path =
+      internal::ConcatAbstractPath(PreexistingContainerName(), "copy-destionation");
+  ASSERT_RAISES(Invalid,
+                fs_->CopyFile("abfs://" + PreexistingObjectPath(), destination_path));
+  ASSERT_RAISES(Invalid,
+                fs_->CopyFile(PreexistingObjectPath(), "abfs://" + destination_path));
+}
+
 TEST_F(AzuriteFileSystemTest, OpenInputStreamString) {
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream, fs_->OpenInputStream(PreexistingObjectPath()));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -789,31 +789,6 @@ TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationSame) {
   EXPECT_EQ(kLoremIpsum, buffer->ToString());
 }
 
-TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationContainer) {
-  const auto container_name = RandomContainerName();
-  ASSERT_OK(fs_->CreateDir(container_name));
-  ASSERT_OK(fs_->CopyFile(PreexistingObjectPath(), container_name));
-  const auto destination_path =
-      internal::ConcatAbstractPath(container_name, PreexistingObjectName());
-  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(destination_path));
-  ASSERT_OK_AND_ASSIGN(auto stream, fs_->OpenInputStream(info));
-  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
-  EXPECT_EQ(kLoremIpsum, buffer->ToString());
-}
-
-TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationDirectory) {
-  const auto directory_path = internal::EnsureTrailingSlash(
-      internal::ConcatAbstractPath(RandomContainerName(), RandomDirectoryName()));
-  ASSERT_OK(fs_->CreateDir(directory_path, true));
-  ASSERT_OK(fs_->CopyFile(PreexistingObjectPath(), directory_path));
-  const auto destination_path =
-      internal::ConcatAbstractPath(directory_path, PreexistingObjectName());
-  ASSERT_OK_AND_ASSIGN(auto info, fs_->GetFileInfo(destination_path));
-  ASSERT_OK_AND_ASSIGN(auto stream, fs_->OpenInputStream(info));
-  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
-  EXPECT_EQ(kLoremIpsum, buffer->ToString());
-}
-
 TEST_F(AzuriteFileSystemTest, CopyFileFailureSourceNonexistent) {
   const auto destination_path =
       internal::ConcatAbstractPath(PreexistingContainerName(), "copy-destionation");

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -789,6 +789,12 @@ TEST_F(AzuriteFileSystemTest, CopyFileSuccessDestinationSame) {
   EXPECT_EQ(kLoremIpsum, buffer->ToString());
 }
 
+TEST_F(AzuriteFileSystemTest, CopyFileFailureDestinationTrailingSlash) {
+  ASSERT_RAISES(IOError,
+                fs_->CopyFile(PreexistingObjectPath(),
+                              internal::EnsureTrailingSlash(PreexistingObjectPath())));
+}
+
 TEST_F(AzuriteFileSystemTest, CopyFileFailureSourceNonexistent) {
   const auto destination_path =
       internal::ConcatAbstractPath(PreexistingContainerName(), "copy-destionation");


### PR DESCRIPTION
### Rationale for this change

`CopyFile()` copies the given source to the given destination. Both of source and destination must be blob name like other filesystem implementations.

### What changes are included in this PR?

Use `CopyFromUri()` API that should use server-side copy.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38705