### PR TITLE
GH-38683: [Python][Docs] Update docstrings for Time32Type and Time64Type

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1124,7 +1124,7 @@ cdef class Time32Type(DataType):
     @property
     def unit(self):
         """
-        The time unit ('s', 'ms', 'us' or 'ns').
+        The time unit ('s' or 'ms').
 
         Examples
         --------
@@ -1156,7 +1156,7 @@ cdef class Time64Type(DataType):
     @property
     def unit(self):
         """
-        The time unit ('s', 'ms', 'us' or 'ns').
+        The time unit ('us' or 'ns').
 
         Examples
         --------

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1108,6 +1108,9 @@ cdef class Time32Type(DataType):
     """
     Concrete class for time32 data types.
 
+    Supported time unit resolutions are 's' [second]
+    and 'ms' [millisecond].
+
     Examples
     --------
     Create an instance of time32 type:
@@ -1139,6 +1142,9 @@ cdef class Time32Type(DataType):
 cdef class Time64Type(DataType):
     """
     Concrete class for time64 data types.
+
+    Supported time unit resolutions are 'us' [microsecond]
+    and 'ns' [nanosecond].
 
     Examples
     --------


### PR DESCRIPTION
### Rationale for this change

`Time32Type` and `Time64Type` unit docs are not correctly documented.

### What changes are included in this PR?

Update the docstrings for `Time32Type` and `Time64Type` `unit`.
* Closes: #38683