### PR TITLE
GH-39072: [Release][CI] Python3.11-devel is required for the verification job on AlmaLinux 8

### DIFF
--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -44,7 +44,7 @@ dnf -y install \
   ninja-build \
   nodejs \
   openssl-devel \
-  python3-devel \
+  python3.11-devel \
   ruby-devel \
   sqlite-devel \
   vala-devel \

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -44,7 +44,7 @@ dnf -y install \
   ninja-build \
   nodejs \
   openssl-devel \
-  python3-dev \
+  python311-devel \
   ruby-devel \
   sqlite-devel \
   vala-devel \

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -44,7 +44,7 @@ dnf -y install \
   ninja-build \
   nodejs \
   openssl-devel \
-  python311-devel \
+  python3.11-devel \
   ruby-devel \
   sqlite-devel \
   vala-devel \

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -44,7 +44,7 @@ dnf -y install \
   ninja-build \
   nodejs \
   openssl-devel \
-  python3.11-devel \
+  python3-devel \
   ruby-devel \
   sqlite-devel \
   vala-devel \

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -44,6 +44,7 @@ dnf -y install \
   ninja-build \
   nodejs \
   openssl-devel \
+  python3-dev \
   ruby-devel \
   sqlite-devel \
   vala-devel \


### PR DESCRIPTION
### Rationale for this change

The verification task for Almalinux 8 was failing.

### What changes are included in this PR?

Add required python3.11-devel to the Docker image.

### Are these changes tested?

Yes via archery task.

### Are there any user-facing changes?

No

* Closes: #39072