### PR TITLE
GH-33094: [R] Update the valgrind job to use LIBARROW_MINIMAL=true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1531,7 +1531,7 @@ services:
       # so some build might pass without this setting, but we want to ensure that we stay to AVX2 regardless of runner.
       EXTRA_CMAKE_FLAGS: "-DARROW_RUNTIME_SIMD_LEVEL=AVX2"
       ARROW_SOURCE_HOME: "/arrow"
-      INSTALL_ARGS: '--configure-vars="LIBARROW_MINIMAL=true"'
+      LIBARROW_MINIMAL: "true"
     volumes: *ubuntu-volumes
     command: >
       /bin/bash -c "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1531,6 +1531,7 @@ services:
       # so some build might pass without this setting, but we want to ensure that we stay to AVX2 regardless of runner.
       EXTRA_CMAKE_FLAGS: "-DARROW_RUNTIME_SIMD_LEVEL=AVX2"
       ARROW_SOURCE_HOME: "/arrow"
+      INSTALL_ARGS: '--configure-vars="LIBARROW_MINIMAL=true"'
     volumes: *ubuntu-volumes
     command: >
       /bin/bash -c "


### PR DESCRIPTION
### Rationale for this change

The [test-r-linux-valgrind](https://github.com/ursacomputing/crossbow/runs/19311424379) job has been failing for over a year, mostly because it times out. At one time the purpose of this job may have been to find memory issues in Arrow C++; however, R is not a good venue for this because the people that can diagnose and fix these problems do not typically have an R setup. Mostly, this job has been timing out for many months and giving us no information regarding whether or not the CRAN valgrind run will identify issues of which we were not previously aware.

### What changes are included in this PR?

Updated INSTALL_ARGS to ensure that the valgrind run passes LIBARROW_MINIMAL=true

### Are these changes tested?

Yes, via crossbow.

### Are there any user-facing changes?

No
* Closes: #33094