### PR TITLE
MINOR: [R] Increase timeout for binary download

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -81,8 +81,9 @@ find_latest_nightly <- function(description_version,
 try_download <- function(from_url, to_file, hush = quietly) {
   # We download some fairly large files, so ensure the timeout is set appropriately.
   # This assumes a static library size of 100 MB (generous) and a download speed
-  # of 1 MB/s (slow).
-  opts <- options(timeout = max(100, getOption("timeout")))
+  # of .3 MB/s (slow). This is to anticipate slower user connections or load on
+  # artifactory servers.
+  opts <- options(timeout = max(300, getOption("timeout")))
   on.exit(options(opts))
 
   status <- try(


### PR DESCRIPTION
### Rationale for this change

Download of mac binaries failed on CRAN and would likely fail on my local ancient bandwidth DSL (~300-500kbs) as well so a bit more buffer in the timeour value should help.

### What changes are included in this PR?

Increase timeout.

### Are these changes tested?

Not really testable.

### Are there any user-facing changes?

No.