### PR TITLE
GH-39074: [Release][Packaging] Use UTF-8 explicitly for KEYS

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow-release/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow-release/Rakefile
@@ -43,7 +43,7 @@ class ApacheArrowReleasePackageTask < PackageTask
       keys_path = "#{@archive_base_name}/KEYS"
       download("https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/KEYS",
                keys_path)
-      keys = File.read(keys_path)
+      keys = File.read(keys_path, encoding: "UTF-8")
       File.open(keys_path, "w") do |keys_file|
         is_ed25519_key = false
         deny_lists = [


### PR DESCRIPTION
### Rationale for this change

`KEYS` may have UTF-8 (non ASCII) characters. Ruby chooses the default encoding based on `LANG`. If `LANG=C`, Ruby uses the `US-ASCII` encoding as the default encoding. If Ruby uses the `US-ASCII` encoding, we can't process `KEYS` because it has non ASCII characters.

### What changes are included in this PR?

Use the `UTF-8` encoding explicitly for `KEYS`. If we specify the `UTF-8` encoding explicitly, our `KEYS` processing don't depend on `LANG`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39074