### PR TITLE
GH-39088: [Dev][Java] Add Dependabot configuration for Java

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [CI] "
+  - package-ecosystem: "maven"
+    directory: "/java/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "MINOR: [Java] "
   - package-ecosystem: "npm"
     directory: "/js/"
     schedule:


### PR DESCRIPTION
### Rationale for this change

We can add `MINOR: [Java] ` prefix to PRs from Dependabot automatically.

### What changes are included in this PR?

Add a configuration for Maven.

### Are these changes tested?

No. I want to test this by merging this to main.

### Are there any user-facing changes?

No.
* Closes: #39088