### PR TITLE
GH-31303: [Python] Remove the legacy ParquetDataset custom python-based implementation

### DIFF
--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -511,36 +511,20 @@ from a remote filesystem into a pandas dataframe you may need to run
 ``sort_index`` to maintain row ordering (as long as the ``preserve_index``
 option was enabled on write).
 
-.. note::
+Other features:
 
-   The ParquetDataset is being reimplemented based on the new generic Dataset
-   API (see the :ref:`dataset` docs for an overview). This is not yet the
-   default, but can already be enabled by passing the ``use_legacy_dataset=False``
-   keyword to :class:`ParquetDataset` or :func:`read_table`::
+- Filtering on all columns (using row group statistics) instead of only on
+   the partition keys.
+- Fine-grained partitioning: support for a directory partitioning scheme
+   in addition to the Hive-like partitioning (e.g. "/2019/11/15/" instead of
+   "/year=2019/month=11/day=15/"), and the ability to specify a schema for
+   the partition keys.
 
-      pq.ParquetDataset('dataset_name/', use_legacy_dataset=False)
+Note:
 
-   Enabling this gives the following new features:
-
-   - Filtering on all columns (using row group statistics) instead of only on
-     the partition keys.
-   - More fine-grained partitioning: support for a directory partitioning scheme
-     in addition to the Hive-like partitioning (e.g. "/2019/11/15/" instead of
-     "/year=2019/month=11/day=15/"), and the ability to specify a schema for
-     the partition keys.
-   - General performance improvement and bug fixes.
-
-   It also has the following changes in behaviour:
-
-   - The partition keys need to be explicitly included in the ``columns``
-     keyword when you want to include them in the result while reading a
-     subset of the columns
-
-   This new implementation is already enabled in ``read_table``, and in the
-   future, this will be turned on by default for ``ParquetDataset``. The new
-   implementation does not yet cover all existing ParquetDataset features (e.g.
-   specifying the ``metadata``, or the ``pieces`` property API). Feedback is
-   very welcome.
+- The partition keys need to be explicitly included in the ``columns``
+   keyword when you want to include them in the result while reading a
+   subset of the columns
 
 
 Using with Spark

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -514,17 +514,17 @@ option was enabled on write).
 Other features:
 
 - Filtering on all columns (using row group statistics) instead of only on
-   the partition keys.
+  the partition keys.
 - Fine-grained partitioning: support for a directory partitioning scheme
-   in addition to the Hive-like partitioning (e.g. "/2019/11/15/" instead of
-   "/year=2019/month=11/day=15/"), and the ability to specify a schema for
-   the partition keys.
+  in addition to the Hive-like partitioning (e.g. "/2019/11/15/" instead of
+  "/year=2019/month=11/day=15/"), and the ability to specify a schema for
+  the partition keys.
 
 Note:
 
 - The partition keys need to be explicitly included in the ``columns``
-   keyword when you want to include them in the result while reading a
-   subset of the columns
+  keyword when you want to include them in the result while reading a
+  subset of the columns
 
 
 Using with Spark

--- a/python/benchmarks/parquet.py
+++ b/python/benchmarks/parquet.py
@@ -29,35 +29,6 @@ except ImportError:
     pq = None
 
 
-class ParquetManifestCreation(object):
-    """Benchmark creating a parquet manifest."""
-
-    size = 10 ** 6
-    tmpdir = None
-
-    param_names = ('num_partitions', 'num_threads')
-    params = [(10, 100, 1000), (1, 8)]
-
-    def setup(self, num_partitions, num_threads):
-        if pq is None:
-            raise NotImplementedError("Parquet support not enabled")
-
-        self.tmpdir = tempfile.mkdtemp('benchmark_parquet')
-        rnd = np.random.RandomState(42)
-        num1 = rnd.randint(0, num_partitions, size=self.size)
-        num2 = rnd.randint(0, 1000, size=self.size)
-        output_df = pd.DataFrame({'num1': num1, 'num2': num2})
-        output_table = pa.Table.from_pandas(output_df)
-        pq.write_to_dataset(output_table, self.tmpdir, ['num1'])
-
-    def teardown(self, num_partitions, num_threads):
-        if self.tmpdir is not None:
-            shutil.rmtree(self.tmpdir)
-
-    def time_manifest_creation(self, num_partitions, num_threads):
-        pq.ParquetManifest(self.tmpdir, metadata_nthreads=num_threads)
-
-
 class ParquetWriteBinary(object):
 
     def setup(self):

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -223,8 +223,12 @@ class FileSystem:
         table : pyarrow.Table
         """
         from pyarrow.parquet import ParquetDataset
-        dataset = ParquetDataset(path, schema=schema, metadata=metadata,
-                                 filesystem=self)
+
+        if metadata is not None:
+            raise ValueError(
+                "Keyword 'metadata' is not supported with the Dataset API")
+
+        dataset = ParquetDataset(path, schema=schema, filesystem=self)
         return dataset.read(columns=columns, use_threads=use_threads,
                             use_pandas_metadata=use_pandas_metadata)
 

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -223,12 +223,8 @@ class FileSystem:
         table : pyarrow.Table
         """
         from pyarrow.parquet import ParquetDataset
-
-        if metadata is not None:
-            raise ValueError(
-                "Keyword 'metadata' is not supported with the Dataset API")
-
-        dataset = ParquetDataset(path, schema=schema, filesystem=self)
+        dataset = ParquetDataset(path, schema=schema, metadata=metadata,
+                                 filesystem=self)
         return dataset.read(columns=columns, use_threads=use_threads,
                             use_pandas_metadata=use_pandas_metadata)
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1200,8 +1200,7 @@ filesystem : FileSystem, default None
 schema : pyarrow.parquet.Schema
     Optionally provide the Schema for the Dataset, in which case it will
     not be inferred from the source.
-filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]],
-default None
+filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]], default None
     Rows which do not match the filter predicate will be removed from scanned
     data. Partition keys embedded in a nested directory structure will be
     exploited to avoid loading files at all if they contain no matching rows.
@@ -1242,6 +1241,9 @@ page_checksum_verification : bool, default False
     If True, verify the page checksum for each page read from the file.
 use_legacy_dataset : bool, optional
     Deprecated and has no effect from PyArrow version 15.0.0.
+
+Keywords `metadata`, `split_row_groups=True` and `validate_schema=False`
+are not yet supported.
 
 Examples
 --------

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1808,7 +1808,7 @@ def read_table(source, *, columns=None, use_threads=True,
             source = filesystem.open_input_file(path)
         # TODO test that source is not a directory or a list
         dataset = ParquetFile(
-            source, metadata=metadata, read_dictionary=read_dictionary,
+            source, read_dictionary=read_dictionary,
             memory_map=memory_map, buffer_size=buffer_size,
             pre_buffer=pre_buffer,
             coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1149,102 +1149,104 @@ default "hive"
 _parquet_dataset_example = """\
 Generate an example PyArrow Table and write it to a partitioned dataset:
 
-    >>> import pyarrow as pa
-    >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
-    ...                   'n_legs': [2, 2, 4, 4, 5, 100],
-    ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
-    ...                              "Brittle stars", "Centipede"]})
-    >>> import pyarrow.parquet as pq
-    >>> pq.write_to_dataset(table, root_path='dataset_v2',
-    ...                     partition_cols=['year'])
+>>> import pyarrow as pa
+>>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+...                   'n_legs': [2, 2, 4, 4, 5, 100],
+...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+...                              "Brittle stars", "Centipede"]})
+>>> import pyarrow.parquet as pq
+>>> pq.write_to_dataset(table, root_path='dataset_v2',
+...                     partition_cols=['year'])
 
-    create a ParquetDataset object from the dataset source:
+create a ParquetDataset object from the dataset source:
 
-    >>> dataset = pq.ParquetDataset('dataset_v2/')
+>>> dataset = pq.ParquetDataset('dataset_v2/')
 
-    and read the data:
+and read the data:
 
-    >>> dataset.read().to_pandas()
-       n_legs         animal  year
-    0       5  Brittle stars  2019
-    1       2       Flamingo  2020
-    2       4            Dog  2021
-    3     100      Centipede  2021
-    4       2         Parrot  2022
-    5       4          Horse  2022
+>>> dataset.read().to_pandas()
+    n_legs         animal  year
+0       5  Brittle stars  2019
+1       2       Flamingo  2020
+2       4            Dog  2021
+3     100      Centipede  2021
+4       2         Parrot  2022
+5       4          Horse  2022
 
-    create a ParquetDataset object with filter:
+create a ParquetDataset object with filter:
 
-    >>> dataset = pq.ParquetDataset('dataset_v2/',
-    ...                             filters=[('n_legs','=',4)])
-    >>> dataset.read().to_pandas()
-       n_legs animal  year
-    0       4    Dog  2021
-    1       4  Horse  2022
+>>> dataset = pq.ParquetDataset('dataset_v2/',
+...                             filters=[('n_legs','=',4)])
+>>> dataset.read().to_pandas()
+    n_legs animal  year
+0       4    Dog  2021
+1       4  Horse  2022
 """
 
 
 class ParquetDataset:
     __doc__ = """
-    Encapsulates details of reading a complete Parquet dataset possibly
-    consisting of multiple files and partitions in subdirectories.
+Encapsulates details of reading a complete Parquet dataset possibly
+consisting of multiple files and partitions in subdirectories.
 
-    Parameters
-    ----------
-    path_or_paths : str or List[str]
-        A directory name, single file name, or list of file names.
-    filesystem : FileSystem, default None
-        If nothing passed, will be inferred based on path.
-        Path will try to be found in the local on-disk filesystem otherwise
-        it will be parsed as an URI to determine the filesystem.
-    schema : pyarrow.parquet.Schema
-        Optionally provide the Schema for the Dataset, in which case it will
-        not be inferred from the source.
-    filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]],
-    default None
-        Rows which do not match the filter predicate will be removed from scanned
-        data. Partition keys embedded in a nested directory structure will be
-        exploited to avoid loading files at all if they contain no matching rows.
-        Within-file level filtering and different partitioning schemes are supported.
+Parameters
+----------
+path_or_paths : str or List[str]
+    A directory name, single file name, or list of file names.
+filesystem : FileSystem, default None
+    If nothing passed, will be inferred based on path.
+    Path will try to be found in the local on-disk filesystem otherwise
+    it will be parsed as an URI to determine the filesystem.
+schema : pyarrow.parquet.Schema
+    Optionally provide the Schema for the Dataset, in which case it will
+    not be inferred from the source.
+filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]],
+default None
+    Rows which do not match the filter predicate will be removed from scanned
+    data. Partition keys embedded in a nested directory structure will be
+    exploited to avoid loading files at all if they contain no matching rows.
+    Within-file level filtering and different partitioning schemes are supported.
 
-        {1}
-    {0}
-    ignore_prefixes : list, optional
-        Files matching any of these prefixes will be ignored by the
-        discovery process.
-        This is matched to the basename of a path.
-        By default this is ['.', '_'].
-        Note that discovery happens only if a directory is passed as source.
-    pre_buffer : bool, default True
-        Coalesce and issue file reads in parallel to improve performance on
-        high-latency filesystems (e.g. S3, GCS). If True, Arrow will use a
-        background I/O thread pool. If using a filesystem layer that itself
-        performs readahead (e.g. fsspec's S3FS), disable readahead for best
-        results. Set to False if you want to prioritize minimal memory usage
-        over maximum speed.
-    coerce_int96_timestamp_unit : str, default None
-        Cast timestamps that are stored in INT96 format to a particular resolution
-        (e.g. 'ms'). Setting to None is equivalent to 'ns' and therefore INT96
-        timestamps will be inferred as timestamps in nanoseconds.
-    decryption_properties : FileDecryptionProperties or None
-        File-level decryption properties.
-        The decryption properties can be created using
-        ``CryptoFactory.file_decryption_properties()``.
-    thrift_string_size_limit : int, default None
-        If not None, override the maximum total string size allocated
-        when decoding Thrift structures. The default limit should be
-        sufficient for most Parquet files.
-    thrift_container_size_limit : int, default None
-        If not None, override the maximum total size of containers allocated
-        when decoding Thrift structures. The default limit should be
-        sufficient for most Parquet files.
-    page_checksum_verification : bool, default False
-        If True, verify the page checksum for each page read from the file.
+    {1}
+{0}
+ignore_prefixes : list, optional
+    Files matching any of these prefixes will be ignored by the
+    discovery process.
+    This is matched to the basename of a path.
+    By default this is ['.', '_'].
+    Note that discovery happens only if a directory is passed as source.
+pre_buffer : bool, default True
+    Coalesce and issue file reads in parallel to improve performance on
+    high-latency filesystems (e.g. S3, GCS). If True, Arrow will use a
+    background I/O thread pool. If using a filesystem layer that itself
+    performs readahead (e.g. fsspec's S3FS), disable readahead for best
+    results. Set to False if you want to prioritize minimal memory usage
+    over maximum speed.
+coerce_int96_timestamp_unit : str, default None
+    Cast timestamps that are stored in INT96 format to a particular resolution
+    (e.g. 'ms'). Setting to None is equivalent to 'ns' and therefore INT96
+    timestamps will be inferred as timestamps in nanoseconds.
+decryption_properties : FileDecryptionProperties or None
+    File-level decryption properties.
+    The decryption properties can be created using
+    ``CryptoFactory.file_decryption_properties()``.
+thrift_string_size_limit : int, default None
+    If not None, override the maximum total string size allocated
+    when decoding Thrift structures. The default limit should be
+    sufficient for most Parquet files.
+thrift_container_size_limit : int, default None
+    If not None, override the maximum total size of containers allocated
+    when decoding Thrift structures. The default limit should be
+    sufficient for most Parquet files.
+page_checksum_verification : bool, default False
+    If True, verify the page checksum for each page read from the file.
+use_legacy_dataset : bool
+    Deprecated and has no effect from PyArrow version 15.0.0.
 
-    Examples
-    --------
-    {2}
-    """.format(_read_docstring_common, _DNF_filter_doc, _parquet_dataset_example)
+Examples
+--------
+{2}
+""".format(_read_docstring_common, _DNF_filter_doc, _parquet_dataset_example)
 
     def __init__(self, path_or_paths, filesystem=None, schema=None, *, filters=None,
                  partitioning="hive", read_dictionary=None, buffer_size=None,
@@ -1253,9 +1255,8 @@ class ParquetDataset:
                  decryption_properties=None, thrift_string_size_limit=None,
                  thrift_container_size_limit=None,
                  page_checksum_verification=False,
-                 **kwargs):
+                 use_legacy_dataset=None):
 
-        use_legacy_dataset = kwargs.pop('use_legacy_dataset', None)
         if use_legacy_dataset is not None:
             warnings.warn(
                 "Passing 'use_legacy_dataset' is deprecated as of pyarrow 15.0.0 "
@@ -1263,15 +1264,6 @@ class ParquetDataset:
                 FutureWarning, stacklevel=2)
 
         import pyarrow.dataset as ds
-
-        # Raise error for not supported keywords
-        for keyword, default in [
-                ("metadata", None), ("split_row_groups", False),
-                ("validate_schema", True), ("metadata_nthreads", None)]:
-            if keyword in kwargs and kwargs[keyword] is not default:
-                raise ValueError(
-                    "Keyword '{0}' is not yet supported with the new "
-                    "Dataset API".format(keyword))
 
         # map format arguments
         read_options = {
@@ -1503,7 +1495,12 @@ class ParquetDataset:
     def read_pandas(self, **kwargs):
         """
         Read dataset including pandas metadata, if any. Other arguments passed
-        through to ParquetDataset.read, see docstring for further details.
+        through to :func:`read`, see docstring for further details.
+
+        Parameters
+        ----------
+        **kwargs : optional
+            Additional options for :func:`read`
 
         Examples
         --------
@@ -1635,6 +1632,8 @@ filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]], defaul
     Within-file level filtering and different partitioning schemes are supported.
 
     {3}
+use_legacy_dataset : bool
+    Deprecated and has no effect from PyArrow version 15.0.0.
 ignore_prefixes : list, optional
     Files matching any of these prefixes will be ignored by the
     discovery process.
@@ -2006,6 +2005,8 @@ def write_to_dataset(table, root_path, partition_cols=None,
         If nothing passed, will be inferred based on path.
         Path will try to be found in the local on-disk filesystem otherwise
         it will be parsed as an URI to determine the filesystem.
+    use_legacy_dataset : bool
+        Deprecated and has no effect from PyArrow version 15.0.0.
     schema : Schema, optional
         This Schema of the dataset.
     partitioning : Partitioning or list[str], optional
@@ -2059,10 +2060,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
         the entire directory will be deleted.  This allows you to overwrite
         old partitions completely.
     **kwargs : dict,
-        Used as additional kwargs for `dataset.write_dataset` function for
-        matching kwargs, and remainder to `ParquetFileFormat.make_write_options`.
-        See the docstring of `write_table` and `dataset.write_dataset` for
-        the available options.
+        Used as additional kwargs for :func:`pyarrow.dataset.write_dataset`
+        function for matching kwargs, and remainder to
+        :func:`pyarrow.dataset.ParquetFileFormat.make_write_options`.
+        See the docstring of :func:`write_table` and
+        :func:`pyarrow.dataset.write_dataset` for the available options.
         Using `metadata_collector` in kwargs allows one to collect the
         file metadata instances of dataset pieces. The file paths in the
         ColumnChunkMetaData will be set relative to `root_path`.

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1240,7 +1240,7 @@ thrift_container_size_limit : int, default None
     sufficient for most Parquet files.
 page_checksum_verification : bool, default False
     If True, verify the page checksum for each page read from the file.
-use_legacy_dataset : bool
+use_legacy_dataset : bool, optional
     Deprecated and has no effect from PyArrow version 15.0.0.
 
 Examples
@@ -1632,7 +1632,7 @@ filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]], defaul
     Within-file level filtering and different partitioning schemes are supported.
 
     {3}
-use_legacy_dataset : bool
+use_legacy_dataset : bool, optional
     Deprecated and has no effect from PyArrow version 15.0.0.
 ignore_prefixes : list, optional
     Files matching any of these prefixes will be ignored by the
@@ -2005,7 +2005,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
         If nothing passed, will be inferred based on path.
         Path will try to be found in the local on-disk filesystem otherwise
         it will be parsed as an URI to determine the filesystem.
-    use_legacy_dataset : bool
+    use_legacy_dataset : bool, optional
         Deprecated and has no effect from PyArrow version 15.0.0.
     schema : Schema, optional
         This Schema of the dataset.

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1956,8 +1956,7 @@ Examples
 
 
 def write_to_dataset(table, root_path, partition_cols=None,
-                     partition_filename_cb=None, filesystem=None,
-                     schema=None,
+                     filesystem=None, schema=None,
                      partitioning=None, basename_template=None,
                      use_threads=None, file_visitor=None,
                      existing_data_behavior=None,
@@ -2085,10 +2084,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         "The '{1}' argument is not supported. "
         "Use only '{0}' instead."
     )
-    if partition_filename_cb is not None and basename_template is not None:
-        raise ValueError(msg_confl.format("basename_template",
-                                          "partition_filename_cb"))
-
     if partition_cols is not None and partitioning is not None:
         raise ValueError(msg_confl.format("partitioning",
                                           "partition_cols"))
@@ -2108,16 +2103,10 @@ def write_to_dataset(table, root_path, partition_cols=None,
     write_dataset_kwargs['max_rows_per_group'] = kwargs.pop(
         'row_group_size', kwargs.pop("chunk_size", None)
     )
-    # raise for unsupported keywords
-    msg = (
-        "The '{}' argument is not supported with the new dataset "
-        "implementation."
-    )
+
     if metadata_collector is not None:
         def file_visitor(written_file):
             metadata_collector.append(written_file.metadata)
-    if partition_filename_cb is not None:
-        raise ValueError(msg.format("partition_filename_cb"))
 
     # map format arguments
     parquet_format = ds.ParquetFileFormat()

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1189,9 +1189,6 @@ class ParquetDataset:
 Encapsulates details of reading a complete Parquet dataset possibly
 consisting of multiple files and partitions in subdirectories.
 
-Keywords `metadata`, `split_row_groups=True` and `validate_schema=False`
-are not yet supported.
-
 Parameters
 ----------
 path_or_paths : str or List[str]

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -2306,7 +2306,6 @@ def write_to_dataset(table, root_path, partition_cols=None,
         raise ValueError(msg_confl.format("partitioning",
                                           "partition_cols"))
 
-    metadata_collector = kwargs.pop('metadata_collector', None)
     if metadata_collector is not None and file_visitor is not None:
         raise ValueError(msg_confl.format("file_visitor",
                                           "metadata_collector"))

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -25,6 +25,7 @@ import json
 import os
 import re
 import operator
+import warnings
 
 import pyarrow as pa
 
@@ -1253,6 +1254,14 @@ class ParquetDataset:
                  thrift_container_size_limit=None,
                  page_checksum_verification=False,
                  **kwargs):
+
+        use_legacy_dataset = kwargs.pop('use_legacy_dataset', None)
+        if use_legacy_dataset is not None:
+            warnings.warn(
+                "Passing 'use_legacy_dataset' is deprecated as of pyarrow 15.0.0 "
+                "and will be removed in a future version.",
+                FutureWarning, stacklevel=2)
+
         import pyarrow.dataset as ds
 
         # Raise error for not supported keywords
@@ -1747,12 +1756,18 @@ Read data from a single Parquet file:
 def read_table(source, *, columns=None, use_threads=True,
                schema=None, use_pandas_metadata=False, read_dictionary=None,
                memory_map=False, buffer_size=0, partitioning="hive",
-               filesystem=None, filters=None,
+               filesystem=None, filters=None, use_legacy_dataset=None,
                ignore_prefixes=None, pre_buffer=True,
                coerce_int96_timestamp_unit=None,
                decryption_properties=None, thrift_string_size_limit=None,
                thrift_container_size_limit=None,
                page_checksum_verification=False, metadata=None,):
+
+    if use_legacy_dataset is not None:
+        warnings.warn(
+            "Passing 'use_legacy_dataset' is deprecated as of pyarrow 15.0.0 "
+            "and will be removed in a future version.",
+            FutureWarning, stacklevel=2)
 
     if metadata is not None:
         raise ValueError(
@@ -1956,10 +1971,10 @@ Examples
 
 
 def write_to_dataset(table, root_path, partition_cols=None,
-                     filesystem=None, schema=None,
-                     partitioning=None, basename_template=None,
-                     use_threads=None, file_visitor=None,
-                     existing_data_behavior=None,
+                     filesystem=None, use_legacy_dataset=None,
+                     schema=None, partitioning=None,
+                     basename_template=None, use_threads=None,
+                     file_visitor=None, existing_data_behavior=None,
                      **kwargs):
     """Wrapper around dataset.write_dataset for writing a Table to
     Parquet format by partitions.
@@ -2076,6 +2091,11 @@ def write_to_dataset(table, root_path, partition_cols=None,
     >>> pq.ParquetDataset('dataset_name_4/').files
     ['dataset_name_4/...-0.parquet']
     """
+    if use_legacy_dataset is not None:
+        warnings.warn(
+            "Passing 'use_legacy_dataset' is deprecated as of pyarrow 15.0.0 "
+            "and will be removed in a future version.",
+            FutureWarning, stacklevel=2)
 
     metadata_collector = kwargs.pop('metadata_collector', None)
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1165,7 +1165,7 @@ create a ParquetDataset object from the dataset source:
 and read the data:
 
 >>> dataset.read().to_pandas()
-    n_legs         animal  year
+   n_legs         animal  year
 0       5  Brittle stars  2019
 1       2       Flamingo  2020
 2       4            Dog  2021
@@ -1178,7 +1178,7 @@ create a ParquetDataset object with filter:
 >>> dataset = pq.ParquetDataset('dataset_v2/',
 ...                             filters=[('n_legs','=',4)])
 >>> dataset.read().to_pandas()
-    n_legs animal  year
+   n_legs animal  year
 0       4    Dog  2021
 1       4  Horse  2022
 """

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1665,9 +1665,6 @@ thrift_container_size_limit : int, default None
     sufficient for most Parquet files.
 page_checksum_verification : bool, default False
     If True, verify the checksum for each page read from the file.
-metadata : FileMetaData
-    This keyword is no longer supported and is being deprecated with
-    PyArrow version 15.0.0.
 
 Returns
 -------
@@ -1763,7 +1760,7 @@ def read_table(source, *, columns=None, use_threads=True,
                coerce_int96_timestamp_unit=None,
                decryption_properties=None, thrift_string_size_limit=None,
                thrift_container_size_limit=None,
-               page_checksum_verification=False, metadata=None,):
+               page_checksum_verification=False):
 
     if use_legacy_dataset is not None:
         warnings.warn(
@@ -1771,12 +1768,6 @@ def read_table(source, *, columns=None, use_threads=True,
             "and will be removed in a future version.",
             FutureWarning, stacklevel=2)
 
-    if metadata is not None:
-        raise ValueError(
-            "The 'metadata' keyword is no longer supported with the new "
-            "datasets-based implementation and will be removed in future "
-            "versions."
-        )
     try:
         dataset = ParquetDataset(
             source,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1189,6 +1189,9 @@ class ParquetDataset:
 Encapsulates details of reading a complete Parquet dataset possibly
 consisting of multiple files and partitions in subdirectories.
 
+Keywords `metadata`, `split_row_groups=True` and `validate_schema=False`
+are not yet supported.
+
 Parameters
 ----------
 path_or_paths : str or List[str]
@@ -1241,9 +1244,6 @@ page_checksum_verification : bool, default False
     If True, verify the page checksum for each page read from the file.
 use_legacy_dataset : bool, optional
     Deprecated and has no effect from PyArrow version 15.0.0.
-
-Keywords `metadata`, `split_row_groups=True` and `validate_schema=False`
-are not yet supported.
 
 Examples
 --------
@@ -1617,8 +1617,6 @@ columns : list
     no columns.
 use_threads : bool, default True
     Perform multi-threaded column reads.
-metadata : FileMetaData
-    If separately computed
 schema : Schema, optional
     Optionally provide the Schema for the parquet dataset, in which case it
     will not be inferred from the source.
@@ -1667,6 +1665,9 @@ thrift_container_size_limit : int, default None
     sufficient for most Parquet files.
 page_checksum_verification : bool, default False
     If True, verify the checksum for each page read from the file.
+metadata : FileMetaData
+    This keyword is no longer supported and is being deprecated with
+    PyArrow version 15.0.0.
 
 Returns
 -------
@@ -1773,7 +1774,8 @@ def read_table(source, *, columns=None, use_threads=True,
     if metadata is not None:
         raise ValueError(
             "The 'metadata' keyword is no longer supported with the new "
-            "datasets-based implementation."
+            "datasets-based implementation and will be removed in future "
+            "versions."
         )
     try:
         dataset = ParquetDataset(

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1251,8 +1251,8 @@ Examples
 """.format(_read_docstring_common, _DNF_filter_doc, _parquet_dataset_example)
 
     def __init__(self, path_or_paths, filesystem=None, schema=None, *, filters=None,
-                 partitioning="hive", read_dictionary=None, buffer_size=None,
-                 memory_map=False, ignore_prefixes=None, pre_buffer=True,
+                 read_dictionary=None, memory_map=False, buffer_size=None,
+                 partitioning="hive", ignore_prefixes=None, pre_buffer=True,
                  coerce_int96_timestamp_unit=None,
                  decryption_properties=None, thrift_string_size_limit=None,
                  thrift_container_size_limit=None,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -17,19 +17,16 @@
 
 
 from collections import defaultdict
-from concurrent import futures
 from contextlib import nullcontext
-from functools import partial, reduce
+from functools import reduce
 
 import inspect
 import json
 from collections.abc import Collection
-import numpy as np
 import os
 import re
 import operator
 import urllib.parse
-import warnings
 
 import pyarrow as pa
 import pyarrow.lib as lib
@@ -1329,6 +1326,7 @@ def _is_local_file_system(fs):
         fs, legacyfs.LocalFileSystem
     )
 
+
 _read_docstring_common = """\
 read_dictionary : list, default None
     List of names or column paths (for nested types) to read directly
@@ -1406,7 +1404,8 @@ class ParquetDataset:
     schema : pyarrow.parquet.Schema
         Optionally provide the Schema for the Dataset, in which case it will
         not be inferred from the source.
-    filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]], default None
+    filters : pyarrow.compute.Expression or List[Tuple] or List[List[Tuple]],
+    default None
         Rows which do not match the filter predicate will be removed from scanned
         data. Partition keys embedded in a nested directory structure will be
         exploited to avoid loading files at all if they contain no matching rows.
@@ -1448,6 +1447,7 @@ class ParquetDataset:
 
     Examples
     --------
+    {2}
     """.format(_read_docstring_common, _DNF_filter_doc, _parquet_dataset_example)
 
     def __init__(self, path_or_paths, filesystem=None, schema=None, *, filters=None,
@@ -2309,7 +2309,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     if metadata_collector is not None and file_visitor is not None:
         raise ValueError(msg_confl.format("file_visitor",
                                           "metadata_collector"))
-    
+
     import pyarrow.dataset as ds
 
     # extract write_dataset specific options

--- a/python/pyarrow/tests/parquet/__init__.py
+++ b/python/pyarrow/tests/parquet/__init__.py
@@ -21,7 +21,4 @@ import pytest
 # Ignore these with pytest ... -m 'not parquet'
 pytestmark = [
     pytest.mark.parquet,
-    pytest.mark.filterwarnings(
-        "ignore:Passing 'use_legacy_dataset=True':FutureWarning"
-    ),
 ]

--- a/python/pyarrow/tests/parquet/common.py
+++ b/python/pyarrow/tests/parquet/common.py
@@ -23,26 +23,6 @@ import pytest
 import pyarrow as pa
 from pyarrow.tests import util
 
-legacy_filter_mark = pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy:FutureWarning"
-)
-
-parametrize_legacy_dataset = pytest.mark.parametrize(
-    "use_legacy_dataset",
-    [pytest.param(True, marks=legacy_filter_mark),
-     pytest.param(False, marks=pytest.mark.dataset)]
-)
-parametrize_legacy_dataset_not_supported = pytest.mark.parametrize(
-    "use_legacy_dataset",
-    [pytest.param(True, marks=legacy_filter_mark),
-     pytest.param(False, marks=pytest.mark.skip)]
-)
-parametrize_legacy_dataset_fixed = pytest.mark.parametrize(
-    "use_legacy_dataset",
-    [pytest.param(True, marks=[pytest.mark.xfail, legacy_filter_mark]),
-     pytest.param(False, marks=pytest.mark.dataset)]
-)
-
 
 def _write_table(table, path, **kwargs):
     # So we see the ImportError somewhere
@@ -65,19 +45,18 @@ def _read_table(*args, **kwargs):
 
 
 def _roundtrip_table(table, read_table_kwargs=None,
-                     write_table_kwargs=None, use_legacy_dataset=False):
+                     write_table_kwargs=None):
     read_table_kwargs = read_table_kwargs or {}
     write_table_kwargs = write_table_kwargs or {}
 
     writer = pa.BufferOutputStream()
     _write_table(table, writer, **write_table_kwargs)
     reader = pa.BufferReader(writer.getvalue())
-    return _read_table(reader, use_legacy_dataset=use_legacy_dataset,
-                       **read_table_kwargs)
+    return _read_table(reader, **read_table_kwargs)
 
 
 def _check_roundtrip(table, expected=None, read_table_kwargs=None,
-                     use_legacy_dataset=False, **write_table_kwargs):
+                     **write_table_kwargs):
     if expected is None:
         expected = table
 
@@ -85,20 +64,17 @@ def _check_roundtrip(table, expected=None, read_table_kwargs=None,
 
     # intentionally check twice
     result = _roundtrip_table(table, read_table_kwargs=read_table_kwargs,
-                              write_table_kwargs=write_table_kwargs,
-                              use_legacy_dataset=use_legacy_dataset)
+                              write_table_kwargs=write_table_kwargs)
     assert result.equals(expected)
     result = _roundtrip_table(result, read_table_kwargs=read_table_kwargs,
-                              write_table_kwargs=write_table_kwargs,
-                              use_legacy_dataset=use_legacy_dataset)
+                              write_table_kwargs=write_table_kwargs)
     assert result.equals(expected)
 
 
-def _roundtrip_pandas_dataframe(df, write_kwargs, use_legacy_dataset=False):
+def _roundtrip_pandas_dataframe(df, write_kwargs):
     table = pa.Table.from_pandas(df)
     result = _roundtrip_table(
-        table, write_table_kwargs=write_kwargs,
-        use_legacy_dataset=use_legacy_dataset)
+        table, write_table_kwargs=write_kwargs)
     return result.to_pandas()
 
 

--- a/python/pyarrow/tests/parquet/common.py
+++ b/python/pyarrow/tests/parquet/common.py
@@ -18,7 +18,6 @@
 import io
 
 import numpy as np
-import pytest
 
 import pyarrow as pa
 from pyarrow.tests import util

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -938,3 +938,22 @@ def test_checksum_write_to_dataset(tempdir):
     # checksum verification enabled raises an exception
     with pytest.raises(OSError, match="CRC checksum verification"):
         _ = pq.read_table(corrupted_file_path, page_checksum_verification=True)
+
+
+def test_deprecated_use_legacy_dataset(tempdir):
+    # Test that specifying use_legacy_dataset in ParquetDataset, write_to_dataset
+    # and read_table doesn't raise an error but gives a warning.
+    table = pa.table({"a": [1, 2, 3]})
+    path = tempdir / "deprecate_legacy"
+
+    msg = "Passing 'use_legacy_dataset'"
+    with pytest.warns(FutureWarning, match=msg):
+        pq.write_to_dataset(table, path, use_legacy_dataset=False)
+
+    pq.write_to_dataset(table, path)
+
+    with pytest.warns(FutureWarning, match=msg):
+        pq.read_table(path, use_legacy_dataset=False)
+
+    with pytest.warns(FutureWarning, match=msg):
+        pq.ParquetDataset(path, use_legacy_dataset=False)

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -28,7 +28,6 @@ from pyarrow import fs
 from pyarrow.filesystem import LocalFileSystem, FileSystem
 from pyarrow.tests import util
 from pyarrow.tests.parquet.common import (_check_roundtrip, _roundtrip_table,
-                                          parametrize_legacy_dataset,
                                           _test_dataframe)
 
 try:
@@ -63,21 +62,20 @@ def test_parquet_invalid_version(tempdir):
                      data_page_version="2.2")
 
 
-@parametrize_legacy_dataset
-def test_set_data_page_size(use_legacy_dataset):
+@pytest.mark.dataset
+def test_set_data_page_size():
     arr = pa.array([1, 2, 3] * 100000)
     t = pa.Table.from_arrays([arr], names=['f0'])
 
     # 128K, 512K
     page_sizes = [2 << 16, 2 << 18]
     for target_page_size in page_sizes:
-        _check_roundtrip(t, data_page_size=target_page_size,
-                         use_legacy_dataset=use_legacy_dataset)
+        _check_roundtrip(t, data_page_size=target_page_size)
 
 
+@pytest.mark.dataset
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_set_write_batch_size(use_legacy_dataset):
+def test_set_write_batch_size():
     df = _test_dataframe(100)
     table = pa.Table.from_pandas(df, preserve_index=False)
 
@@ -86,9 +84,9 @@ def test_set_write_batch_size(use_legacy_dataset):
     )
 
 
+@pytest.mark.dataset
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_set_dictionary_pagesize_limit(use_legacy_dataset):
+def test_set_dictionary_pagesize_limit():
     df = _test_dataframe(100)
     table = pa.Table.from_pandas(df, preserve_index=False)
 
@@ -100,9 +98,9 @@ def test_set_dictionary_pagesize_limit(use_legacy_dataset):
                          data_page_size=10, version='2.4')
 
 
+@pytest.mark.dataset
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_chunked_table_write(use_legacy_dataset):
+def test_chunked_table_write():
     # ARROW-232
     tables = []
     batch = pa.RecordBatch.from_pandas(alltypes_sample(size=10))
@@ -116,66 +114,61 @@ def test_chunked_table_write(use_legacy_dataset):
             for table in tables:
                 _check_roundtrip(
                     table, version='2.6',
-                    use_legacy_dataset=use_legacy_dataset,
                     data_page_version=data_page_version,
                     use_dictionary=use_dictionary)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_memory_map(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_memory_map(tempdir):
     df = alltypes_sample(size=10)
 
     table = pa.Table.from_pandas(df)
     _check_roundtrip(table, read_table_kwargs={'memory_map': True},
-                     version='2.6', use_legacy_dataset=use_legacy_dataset)
+                     version='2.6')
 
     filename = str(tempdir / 'tmp_file')
     with open(filename, 'wb') as f:
         _write_table(table, f, version='2.6')
-    table_read = pq.read_pandas(filename, memory_map=True,
-                                use_legacy_dataset=use_legacy_dataset)
+    table_read = pq.read_pandas(filename, memory_map=True)
     assert table_read.equals(table)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_enable_buffered_stream(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_enable_buffered_stream(tempdir):
     df = alltypes_sample(size=10)
 
     table = pa.Table.from_pandas(df)
     _check_roundtrip(table, read_table_kwargs={'buffer_size': 1025},
-                     version='2.6', use_legacy_dataset=use_legacy_dataset)
+                     version='2.6')
 
     filename = str(tempdir / 'tmp_file')
     with open(filename, 'wb') as f:
         _write_table(table, f, version='2.6')
-    table_read = pq.read_pandas(filename, buffer_size=4096,
-                                use_legacy_dataset=use_legacy_dataset)
+    table_read = pq.read_pandas(filename, buffer_size=4096)
     assert table_read.equals(table)
 
 
-@parametrize_legacy_dataset
-def test_special_chars_filename(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_special_chars_filename(tempdir):
     table = pa.Table.from_arrays([pa.array([42])], ["ints"])
     filename = "foo # bar"
     path = tempdir / filename
     assert not path.exists()
     _write_table(table, str(path))
     assert path.exists()
-    table_read = _read_table(str(path), use_legacy_dataset=use_legacy_dataset)
+    table_read = _read_table(str(path))
     assert table_read.equals(table)
 
 
-@parametrize_legacy_dataset
-def test_invalid_source(use_legacy_dataset):
+@pytest.mark.dataset
+def test_invalid_source():
     # Test that we provide an helpful error message pointing out
     # that None wasn't expected when trying to open a Parquet None file.
     #
-    # Depending on use_legacy_dataset the message changes slightly
-    # but in both cases it should point out that None wasn't expected.
     with pytest.raises(TypeError, match="None"):
-        pq.read_table(None, use_legacy_dataset=use_legacy_dataset)
+        pq.read_table(None)
 
     with pytest.raises(TypeError, match="None"):
         pq.ParquetFile(None)
@@ -193,8 +186,8 @@ def test_file_with_over_int16_max_row_groups():
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_empty_table_roundtrip(use_legacy_dataset):
+@pytest.mark.dataset
+def test_empty_table_roundtrip():
     df = alltypes_sample(size=10)
 
     # Create a non-empty table to infer the types correctly, then slice to 0
@@ -206,19 +199,19 @@ def test_empty_table_roundtrip(use_legacy_dataset):
     assert table.schema.field('null').type == pa.null()
     assert table.schema.field('null_list').type == pa.list_(pa.null())
     _check_roundtrip(
-        table, version='2.6', use_legacy_dataset=use_legacy_dataset)
+        table, version='2.6')
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_empty_table_no_columns(use_legacy_dataset):
+@pytest.mark.dataset
+def test_empty_table_no_columns():
     df = pd.DataFrame()
     empty = pa.Table.from_pandas(df, preserve_index=False)
-    _check_roundtrip(empty, use_legacy_dataset=use_legacy_dataset)
+    _check_roundtrip(empty)
 
 
-@parametrize_legacy_dataset
-def test_write_nested_zero_length_array_chunk_failure(use_legacy_dataset):
+@pytest.mark.dataset
+def test_write_nested_zero_length_array_chunk_failure():
     # Bug report in ARROW-3792
     cols = OrderedDict(
         int32=pa.int32(),
@@ -243,17 +236,17 @@ def test_write_nested_zero_length_array_chunk_failure(use_legacy_dataset):
     my_batches = [pa.RecordBatch.from_arrays(batch, schema=pa.schema(cols))
                   for batch in my_arrays]
     tbl = pa.Table.from_batches(my_batches, pa.schema(cols))
-    _check_roundtrip(tbl, use_legacy_dataset=use_legacy_dataset)
+    _check_roundtrip(tbl)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_multiple_path_types(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_multiple_path_types(tempdir):
     # Test compatibility with PEP 519 path-like objects
     path = tempdir / 'zzz.parquet'
     df = pd.DataFrame({'x': np.arange(10, dtype=np.int64)})
     _write_table(df, path)
-    table_read = _read_table(path, use_legacy_dataset=use_legacy_dataset)
+    table_read = _read_table(path)
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)
 
@@ -261,13 +254,13 @@ def test_multiple_path_types(tempdir, use_legacy_dataset):
     path = str(tempdir) + 'zzz.parquet'
     df = pd.DataFrame({'x': np.arange(10, dtype=np.int64)})
     _write_table(df, path)
-    table_read = _read_table(path, use_legacy_dataset=use_legacy_dataset)
+    table_read = _read_table(path)
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)
 
 
-@parametrize_legacy_dataset
-def test_fspath(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_fspath(tempdir):
     # ARROW-12472 support __fspath__ objects without using str()
     path = tempdir / "test.parquet"
     table = pa.table({"a": [1, 2, 3]})
@@ -275,9 +268,7 @@ def test_fspath(tempdir, use_legacy_dataset):
 
     fs_protocol_obj = util.FSProtocolClass(path)
 
-    result = _read_table(
-        fs_protocol_obj, use_legacy_dataset=use_legacy_dataset
-    )
+    result = _read_table(fs_protocol_obj)
     assert result.equals(table)
 
     # combined with non-local filesystem raises
@@ -286,14 +277,11 @@ def test_fspath(tempdir, use_legacy_dataset):
 
 
 @pytest.mark.dataset
-@parametrize_legacy_dataset
 @pytest.mark.parametrize("filesystem", [
     None, fs.LocalFileSystem(), LocalFileSystem._get_instance()
 ])
 @pytest.mark.parametrize("name", ("data.parquet", "例.parquet"))
-def test_relative_paths(tempdir, use_legacy_dataset, filesystem, name):
-    if use_legacy_dataset and isinstance(filesystem, fs.FileSystem):
-        pytest.skip("Passing new filesystem not supported for legacy reader")
+def test_relative_paths(tempdir, filesystem, name):
     # reading and writing from relative paths
     table = pa.table({"a": [1, 2, 3]})
     path = tempdir / name
@@ -301,8 +289,7 @@ def test_relative_paths(tempdir, use_legacy_dataset, filesystem, name):
     # reading
     pq.write_table(table, str(path))
     with util.change_cwd(tempdir):
-        result = pq.read_table(name, filesystem=filesystem,
-                               use_legacy_dataset=use_legacy_dataset)
+        result = pq.read_table(name, filesystem=filesystem)
     assert result.equals(table)
 
     path.unlink()
@@ -315,12 +302,14 @@ def test_relative_paths(tempdir, use_legacy_dataset, filesystem, name):
     assert result.equals(table)
 
 
+@pytest.mark.dataset
 def test_read_non_existing_file():
     # ensure we have a proper error message
     with pytest.raises(FileNotFoundError):
         pq.read_table('i-am-not-existing.parquet')
 
 
+@pytest.mark.dataset
 def test_file_error_python_exception():
     class BogusFile(io.BytesIO):
         def read(self, *args):
@@ -334,24 +323,23 @@ def test_file_error_python_exception():
         pq.read_table(BogusFile(b""))
 
 
-@parametrize_legacy_dataset
-def test_parquet_read_from_buffer(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_parquet_read_from_buffer(tempdir):
     # reading from a buffer from python's open()
     table = pa.table({"a": [1, 2, 3]})
     pq.write_table(table, str(tempdir / "data.parquet"))
 
     with open(str(tempdir / "data.parquet"), "rb") as f:
-        result = pq.read_table(f, use_legacy_dataset=use_legacy_dataset)
+        result = pq.read_table(f)
     assert result.equals(table)
 
     with open(str(tempdir / "data.parquet"), "rb") as f:
-        result = pq.read_table(pa.PythonFile(f),
-                               use_legacy_dataset=use_legacy_dataset)
+        result = pq.read_table(pa.PythonFile(f))
     assert result.equals(table)
 
 
-@parametrize_legacy_dataset
-def test_byte_stream_split(use_legacy_dataset):
+@pytest.mark.dataset
+def test_byte_stream_split():
     # This is only a smoke test.
     arr_float = pa.array(list(map(float, range(100))))
     arr_int = pa.array(list(map(int, range(100))))
@@ -385,12 +373,11 @@ def test_byte_stream_split(use_legacy_dataset):
     table = pa.Table.from_arrays([arr_int], names=['tmp'])
     with pytest.raises(IOError):
         _check_roundtrip(table, expected=table, use_byte_stream_split=True,
-                         use_dictionary=False,
-                         use_legacy_dataset=use_legacy_dataset)
+                         use_dictionary=False)
 
 
-@parametrize_legacy_dataset
-def test_column_encoding(use_legacy_dataset):
+@pytest.mark.dataset
+def test_column_encoding():
     arr_float = pa.array(list(map(float, range(100))))
     arr_int = pa.array(list(map(int, range(100))))
     arr_bin = pa.array([str(x) for x in range(100)], type=pa.binary())
@@ -406,30 +393,26 @@ def test_column_encoding(use_legacy_dataset):
     _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
                      column_encoding={'a': "BYTE_STREAM_SPLIT",
                                       'b': "PLAIN",
-                                      'c': "PLAIN"},
-                     use_legacy_dataset=use_legacy_dataset)
+                                      'c': "PLAIN"})
 
     # Check "PLAIN" for all columns.
     _check_roundtrip(mixed_table, expected=mixed_table,
                      use_dictionary=False,
-                     column_encoding="PLAIN",
-                     use_legacy_dataset=use_legacy_dataset)
+                     column_encoding="PLAIN")
 
     # Check "DELTA_BINARY_PACKED" for integer columns.
     _check_roundtrip(mixed_table, expected=mixed_table,
                      use_dictionary=False,
                      column_encoding={'a': "PLAIN",
                                       'b': "DELTA_BINARY_PACKED",
-                                      'c': "PLAIN"},
-                     use_legacy_dataset=use_legacy_dataset)
+                                      'c': "PLAIN"})
 
     # Check "DELTA_LENGTH_BYTE_ARRAY" for byte columns.
     _check_roundtrip(mixed_table, expected=mixed_table,
                      use_dictionary=False,
                      column_encoding={'a': "PLAIN",
                                       'b': "DELTA_BINARY_PACKED",
-                                      'c': "DELTA_LENGTH_BYTE_ARRAY"},
-                     use_legacy_dataset=use_legacy_dataset)
+                                      'c': "DELTA_LENGTH_BYTE_ARRAY"})
 
     # Check "DELTA_BYTE_ARRAY" for byte columns.
     _check_roundtrip(mixed_table, expected=mixed_table,
@@ -437,14 +420,12 @@ def test_column_encoding(use_legacy_dataset):
                      column_encoding={'a': "PLAIN",
                                       'b': "DELTA_BINARY_PACKED",
                                       'c': "DELTA_BYTE_ARRAY",
-                                      'd': "DELTA_BYTE_ARRAY"},
-                     use_legacy_dataset=use_legacy_dataset)
+                                      'd': "DELTA_BYTE_ARRAY"})
 
     # Check "RLE" for boolean columns.
     _check_roundtrip(mixed_table, expected=mixed_table,
                      use_dictionary=False,
-                     column_encoding={'e': "RLE"},
-                     use_legacy_dataset=use_legacy_dataset)
+                     column_encoding={'e': "RLE"})
 
     # Try to pass "BYTE_STREAM_SPLIT" column encoding for integer column 'b'.
     # This should throw an error as it is only supports FLOAT and DOUBLE.
@@ -455,8 +436,7 @@ def test_column_encoding(use_legacy_dataset):
                          use_dictionary=False,
                          column_encoding={'a': "PLAIN",
                                           'b': "BYTE_STREAM_SPLIT",
-                                          'c': "PLAIN"},
-                         use_legacy_dataset=use_legacy_dataset)
+                                          'c': "PLAIN"})
 
     # Try to pass use "DELTA_BINARY_PACKED" encoding on float column.
     # This should throw an error as only integers are supported.
@@ -465,8 +445,7 @@ def test_column_encoding(use_legacy_dataset):
                          use_dictionary=False,
                          column_encoding={'a': "DELTA_BINARY_PACKED",
                                           'b': "PLAIN",
-                                          'c': "PLAIN"},
-                         use_legacy_dataset=use_legacy_dataset)
+                                          'c': "PLAIN"})
 
     # Try to pass "RLE_DICTIONARY".
     # This should throw an error as dictionary encoding is already used by
@@ -474,30 +453,26 @@ def test_column_encoding(use_legacy_dataset):
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
-                         column_encoding="RLE_DICTIONARY",
-                         use_legacy_dataset=use_legacy_dataset)
+                         column_encoding="RLE_DICTIONARY")
 
     # Try to pass unsupported encoding.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
-                         column_encoding={'a': "MADE_UP_ENCODING"},
-                         use_legacy_dataset=use_legacy_dataset)
+                         column_encoding={'a': "MADE_UP_ENCODING"})
 
     # Try to pass column_encoding and use_dictionary.
     # This should throw an error.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=['b'],
-                         column_encoding={'b': "PLAIN"},
-                         use_legacy_dataset=use_legacy_dataset)
+                         column_encoding={'b': "PLAIN"})
 
     # Try to pass column_encoding and use_dictionary=True (default value).
     # This should throw an error.
     with pytest.raises(ValueError):
         _check_roundtrip(mixed_table, expected=mixed_table,
-                         column_encoding={'b': "PLAIN"},
-                         use_legacy_dataset=use_legacy_dataset)
+                         column_encoding={'b': "PLAIN"})
 
     # Try to pass column_encoding and use_byte_stream_split on same column.
     # This should throw an error.
@@ -507,8 +482,7 @@ def test_column_encoding(use_legacy_dataset):
                          use_byte_stream_split=['a'],
                          column_encoding={'a': "RLE",
                                           'b': "BYTE_STREAM_SPLIT",
-                                          'c': "PLAIN"},
-                         use_legacy_dataset=use_legacy_dataset)
+                                          'c': "PLAIN"})
 
     # Try to pass column_encoding and use_byte_stream_split=True.
     # This should throw an error.
@@ -518,54 +492,46 @@ def test_column_encoding(use_legacy_dataset):
                          use_byte_stream_split=True,
                          column_encoding={'a': "RLE",
                                           'b': "BYTE_STREAM_SPLIT",
-                                          'c': "PLAIN"},
-                         use_legacy_dataset=use_legacy_dataset)
+                                          'c': "PLAIN"})
 
     # Try to pass column_encoding=True.
     # This should throw an error.
     with pytest.raises(TypeError):
         _check_roundtrip(mixed_table, expected=mixed_table,
                          use_dictionary=False,
-                         column_encoding=True,
-                         use_legacy_dataset=use_legacy_dataset)
+                         column_encoding=True)
 
 
-@parametrize_legacy_dataset
-def test_compression_level(use_legacy_dataset):
+@pytest.mark.dataset
+def test_compression_level():
     arr = pa.array(list(map(int, range(1000))))
     data = [arr, arr]
     table = pa.Table.from_arrays(data, names=['a', 'b'])
 
     # Check one compression level.
     _check_roundtrip(table, expected=table, compression="gzip",
-                     compression_level=1,
-                     use_legacy_dataset=use_legacy_dataset)
+                     compression_level=1)
 
     # Check another one to make sure that compression_level=1 does not
     # coincide with the default one in Arrow.
     _check_roundtrip(table, expected=table, compression="gzip",
-                     compression_level=5,
-                     use_legacy_dataset=use_legacy_dataset)
+                     compression_level=5)
 
     # Check that the user can provide a compression per column
     _check_roundtrip(table, expected=table,
-                     compression={'a': "gzip", 'b': "snappy"},
-                     use_legacy_dataset=use_legacy_dataset)
+                     compression={'a': "gzip", 'b': "snappy"})
 
     # Check that the user can provide a compression level per column
     _check_roundtrip(table, expected=table, compression="gzip",
-                     compression_level={'a': 2, 'b': 3},
-                     use_legacy_dataset=use_legacy_dataset)
+                     compression_level={'a': 2, 'b': 3})
 
     # Check if both LZ4 compressors are working
     # (level < 3 -> fast, level >= 3 -> HC)
     _check_roundtrip(table, expected=table, compression="lz4",
-                     compression_level=1,
-                     use_legacy_dataset=use_legacy_dataset)
+                     compression_level=1)
 
     _check_roundtrip(table, expected=table, compression="lz4",
-                     compression_level=9,
-                     use_legacy_dataset=use_legacy_dataset)
+                     compression_level=9)
 
     # Check that specifying a compression level for a codec which does allow
     # specifying one, results into an error.
@@ -594,8 +560,8 @@ def test_sanitized_spark_field_names():
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_multithreaded_read(use_legacy_dataset):
+@pytest.mark.dataset
+def test_multithreaded_read():
     df = alltypes_sample(size=10000)
 
     table = pa.Table.from_pandas(df)
@@ -604,19 +570,17 @@ def test_multithreaded_read(use_legacy_dataset):
     _write_table(table, buf, compression='SNAPPY', version='2.6')
 
     buf.seek(0)
-    table1 = _read_table(
-        buf, use_threads=True, use_legacy_dataset=use_legacy_dataset)
+    table1 = _read_table(buf, use_threads=True)
 
     buf.seek(0)
-    table2 = _read_table(
-        buf, use_threads=False, use_legacy_dataset=use_legacy_dataset)
+    table2 = _read_table(buf, use_threads=False)
 
     assert table1.equals(table2)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_min_chunksize(use_legacy_dataset):
+@pytest.mark.dataset
+def test_min_chunksize():
     data = pd.DataFrame([np.arange(4)], columns=['A', 'B', 'C', 'D'])
     table = pa.Table.from_pandas(data.reset_index())
 
@@ -624,7 +588,7 @@ def test_min_chunksize(use_legacy_dataset):
     _write_table(table, buf, chunk_size=-1)
 
     buf.seek(0)
-    result = _read_table(buf, use_legacy_dataset=use_legacy_dataset)
+    result = _read_table(buf)
 
     assert result.equals(table)
 
@@ -659,57 +623,50 @@ def test_write_error_deletes_incomplete_file(tempdir):
     assert not filename.exists()
 
 
-@parametrize_legacy_dataset
-def test_read_non_existent_file(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_non_existent_file(tempdir):
     path = 'nonexistent-file.parquet'
     try:
-        pq.read_table(path, use_legacy_dataset=use_legacy_dataset)
+        pq.read_table(path)
     except Exception as e:
         assert path in e.args[0]
 
 
-@parametrize_legacy_dataset
-def test_read_table_doesnt_warn(datadir, use_legacy_dataset):
-    if use_legacy_dataset:
-        msg = "Passing 'use_legacy_dataset=True'"
-        with pytest.warns(FutureWarning, match=msg):
-            pq.read_table(datadir / 'v0.7.1.parquet',
-                          use_legacy_dataset=use_legacy_dataset)
-    else:
-        with warnings.catch_warnings():
-            warnings.simplefilter(action="error")
-            pq.read_table(datadir / 'v0.7.1.parquet',
-                          use_legacy_dataset=use_legacy_dataset)
+@pytest.mark.dataset
+def test_read_table_doesnt_warn(datadir):
+    with warnings.catch_warnings():
+        warnings.simplefilter(action="error")
+        pq.read_table(datadir / 'v0.7.1.parquet')
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_zlib_compression_bug(use_legacy_dataset):
+@pytest.mark.dataset
+def test_zlib_compression_bug():
     # ARROW-3514: "zlib deflate failed, output buffer too small"
     table = pa.Table.from_arrays([pa.array(['abc', 'def'])], ['some_col'])
     f = io.BytesIO()
     pq.write_table(table, f, compression='gzip')
 
     f.seek(0)
-    roundtrip = pq.read_table(f, use_legacy_dataset=use_legacy_dataset)
+    roundtrip = pq.read_table(f)
     tm.assert_frame_equal(roundtrip.to_pandas(), table.to_pandas())
 
 
-@parametrize_legacy_dataset
-def test_parquet_file_too_small(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_parquet_file_too_small(tempdir):
     path = str(tempdir / "test.parquet")
     # TODO(dataset) with datasets API it raises OSError instead
     with pytest.raises((pa.ArrowInvalid, OSError),
                        match='size is 0 bytes'):
         with open(path, 'wb') as f:
             pass
-        pq.read_table(path, use_legacy_dataset=use_legacy_dataset)
+        pq.read_table(path)
 
     with pytest.raises((pa.ArrowInvalid, OSError),
                        match='size is 4 bytes'):
         with open(path, 'wb') as f:
             f.write(b'ffff')
-        pq.read_table(path, use_legacy_dataset=use_legacy_dataset)
+        pq.read_table(path)
 
 
 @pytest.mark.pandas
@@ -752,7 +709,7 @@ def test_fastparquet_cross_compatibility(tempdir):
     tm.assert_frame_equal(table_fp.to_pandas(), df)
 
 
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @pytest.mark.parametrize('array_factory', [
     lambda: pa.array([0, None] * 10),
     lambda: pa.array([0, None] * 10).dictionary_encode(),
@@ -762,7 +719,7 @@ def test_fastparquet_cross_compatibility(tempdir):
 @pytest.mark.parametrize('use_dictionary', [False, True])
 @pytest.mark.parametrize('read_dictionary', [False, True])
 def test_buffer_contents(
-        array_factory, use_dictionary, read_dictionary, use_legacy_dataset
+        array_factory, use_dictionary, read_dictionary
 ):
     # Test that null values are deterministically initialized to zero
     # after a roundtrip through Parquet.
@@ -773,8 +730,7 @@ def test_buffer_contents(
     bio.seek(0)
     read_dictionary = ['col'] if read_dictionary else None
     table = pq.read_table(bio, use_threads=False,
-                          read_dictionary=read_dictionary,
-                          use_legacy_dataset=use_legacy_dataset)
+                          read_dictionary=read_dictionary)
 
     for col in table.columns:
         [chunk] = col.chunks
@@ -844,18 +800,6 @@ def test_permutation_of_column_order(tempdir):
                       names=['a', 'b'])
 
     assert table == table2
-
-
-def test_read_table_legacy_deprecated(tempdir):
-    # ARROW-15870
-    table = pa.table({'a': [1, 2, 3]})
-    path = tempdir / 'data.parquet'
-    pq.write_table(table, path)
-
-    with pytest.warns(
-        FutureWarning, match="Passing 'use_legacy_dataset=True'"
-    ):
-        pq.read_table(path, use_legacy_dataset=True)
 
 
 def test_thrift_size_limits(tempdir):
@@ -942,28 +886,9 @@ def test_page_checksum_verification_write_table(tempdir):
     with pytest.raises(OSError, match="CRC checksum verification"):
         _ = corrupted_pq_file.read()
 
-    # Case 5: Check that enabling page checksum verification in combination
-    # with legacy dataset raises an exception
-    with pytest.raises(ValueError, match="page_checksum_verification"):
-        _ = pq.read_table(corrupted_path,
-                          page_checksum_verification=True,
-                          use_legacy_dataset=True)
-
 
 @pytest.mark.dataset
-@pytest.mark.parametrize(
-    "use_legacy_dataset",
-    [
-        False,
-        pytest.param(
-            True,
-            marks=pytest.mark.filterwarnings(
-                "ignore:Passing 'use_legacy_dataset=True':FutureWarning"
-            ),
-        ),
-    ],
-)
-def test_checksum_write_to_dataset(tempdir, use_legacy_dataset):
+def test_checksum_write_to_dataset(tempdir):
     """Check that checksum verification works for datasets created with
     pq.write_to_dataset"""
 
@@ -973,8 +898,7 @@ def test_checksum_write_to_dataset(tempdir, use_legacy_dataset):
     original_dir_path = tempdir / 'correct_dir'
     pq.write_to_dataset(table_orig,
                         original_dir_path,
-                        write_page_checksum=True,
-                        use_legacy_dataset=use_legacy_dataset)
+                        write_page_checksum=True)
 
     # Read file and verify that the data is correct
     original_file_path_list = list(original_dir_path.iterdir())

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -62,7 +62,6 @@ def test_parquet_invalid_version(tempdir):
                      data_page_version="2.2")
 
 
-@pytest.mark.dataset
 def test_set_data_page_size():
     arr = pa.array([1, 2, 3] * 100000)
     t = pa.Table.from_arrays([arr], names=['f0'])
@@ -73,7 +72,6 @@ def test_set_data_page_size():
         _check_roundtrip(t, data_page_size=target_page_size)
 
 
-@pytest.mark.dataset
 @pytest.mark.pandas
 def test_set_write_batch_size():
     df = _test_dataframe(100)
@@ -84,7 +82,6 @@ def test_set_write_batch_size():
     )
 
 
-@pytest.mark.dataset
 @pytest.mark.pandas
 def test_set_dictionary_pagesize_limit():
     df = _test_dataframe(100)
@@ -98,7 +95,6 @@ def test_set_dictionary_pagesize_limit():
                          data_page_size=10, version='2.4')
 
 
-@pytest.mark.dataset
 @pytest.mark.pandas
 def test_chunked_table_write():
     # ARROW-232
@@ -119,7 +115,6 @@ def test_chunked_table_write():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_memory_map(tempdir):
     df = alltypes_sample(size=10)
 
@@ -135,7 +130,6 @@ def test_memory_map(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_enable_buffered_stream(tempdir):
     df = alltypes_sample(size=10)
 
@@ -150,7 +144,6 @@ def test_enable_buffered_stream(tempdir):
     assert table_read.equals(table)
 
 
-@pytest.mark.dataset
 def test_special_chars_filename(tempdir):
     table = pa.Table.from_arrays([pa.array([42])], ["ints"])
     filename = "foo # bar"
@@ -162,11 +155,9 @@ def test_special_chars_filename(tempdir):
     assert table_read.equals(table)
 
 
-@pytest.mark.dataset
 def test_invalid_source():
     # Test that we provide an helpful error message pointing out
     # that None wasn't expected when trying to open a Parquet None file.
-    #
     with pytest.raises(TypeError, match="None"):
         pq.read_table(None)
 
@@ -186,7 +177,6 @@ def test_file_with_over_int16_max_row_groups():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_empty_table_roundtrip():
     df = alltypes_sample(size=10)
 
@@ -203,14 +193,12 @@ def test_empty_table_roundtrip():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_empty_table_no_columns():
     df = pd.DataFrame()
     empty = pa.Table.from_pandas(df, preserve_index=False)
     _check_roundtrip(empty)
 
 
-@pytest.mark.dataset
 def test_write_nested_zero_length_array_chunk_failure():
     # Bug report in ARROW-3792
     cols = OrderedDict(
@@ -240,7 +228,6 @@ def test_write_nested_zero_length_array_chunk_failure():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_multiple_path_types(tempdir):
     # Test compatibility with PEP 519 path-like objects
     path = tempdir / 'zzz.parquet'
@@ -259,7 +246,6 @@ def test_multiple_path_types(tempdir):
     tm.assert_frame_equal(df, df_read)
 
 
-@pytest.mark.dataset
 def test_fspath(tempdir):
     # ARROW-12472 support __fspath__ objects without using str()
     path = tempdir / "test.parquet"
@@ -276,7 +262,6 @@ def test_fspath(tempdir):
         _read_table(fs_protocol_obj, filesystem=FileSystem())
 
 
-@pytest.mark.dataset
 @pytest.mark.parametrize("filesystem", [
     None, fs.LocalFileSystem(), LocalFileSystem._get_instance()
 ])
@@ -302,14 +287,12 @@ def test_relative_paths(tempdir, filesystem, name):
     assert result.equals(table)
 
 
-@pytest.mark.dataset
 def test_read_non_existing_file():
     # ensure we have a proper error message
     with pytest.raises(FileNotFoundError):
         pq.read_table('i-am-not-existing.parquet')
 
 
-@pytest.mark.dataset
 def test_file_error_python_exception():
     class BogusFile(io.BytesIO):
         def read(self, *args):
@@ -323,7 +306,6 @@ def test_file_error_python_exception():
         pq.read_table(BogusFile(b""))
 
 
-@pytest.mark.dataset
 def test_parquet_read_from_buffer(tempdir):
     # reading from a buffer from python's open()
     table = pa.table({"a": [1, 2, 3]})
@@ -338,7 +320,6 @@ def test_parquet_read_from_buffer(tempdir):
     assert result.equals(table)
 
 
-@pytest.mark.dataset
 def test_byte_stream_split():
     # This is only a smoke test.
     arr_float = pa.array(list(map(float, range(100))))
@@ -376,7 +357,6 @@ def test_byte_stream_split():
                          use_dictionary=False)
 
 
-@pytest.mark.dataset
 def test_column_encoding():
     arr_float = pa.array(list(map(float, range(100))))
     arr_int = pa.array(list(map(int, range(100))))
@@ -502,7 +482,6 @@ def test_column_encoding():
                          column_encoding=True)
 
 
-@pytest.mark.dataset
 def test_compression_level():
     arr = pa.array(list(map(int, range(1000))))
     data = [arr, arr]
@@ -560,7 +539,6 @@ def test_sanitized_spark_field_names():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_multithreaded_read():
     df = alltypes_sample(size=10000)
 
@@ -579,7 +557,6 @@ def test_multithreaded_read():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_min_chunksize():
     data = pd.DataFrame([np.arange(4)], columns=['A', 'B', 'C', 'D'])
     table = pa.Table.from_pandas(data.reset_index())
@@ -623,7 +600,6 @@ def test_write_error_deletes_incomplete_file(tempdir):
     assert not filename.exists()
 
 
-@pytest.mark.dataset
 def test_read_non_existent_file(tempdir):
     path = 'nonexistent-file.parquet'
     try:
@@ -632,7 +608,6 @@ def test_read_non_existent_file(tempdir):
         assert path in e.args[0]
 
 
-@pytest.mark.dataset
 def test_read_table_doesnt_warn(datadir):
     with warnings.catch_warnings():
         warnings.simplefilter(action="error")
@@ -640,7 +615,6 @@ def test_read_table_doesnt_warn(datadir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_zlib_compression_bug():
     # ARROW-3514: "zlib deflate failed, output buffer too small"
     table = pa.Table.from_arrays([pa.array(['abc', 'def'])], ['some_col'])
@@ -652,7 +626,6 @@ def test_zlib_compression_bug():
     tm.assert_frame_equal(roundtrip.to_pandas(), table.to_pandas())
 
 
-@pytest.mark.dataset
 def test_parquet_file_too_small(tempdir):
     path = str(tempdir / "test.parquet")
     # TODO(dataset) with datasets API it raises OSError instead
@@ -709,17 +682,15 @@ def test_fastparquet_cross_compatibility(tempdir):
     tm.assert_frame_equal(table_fp.to_pandas(), df)
 
 
-@pytest.mark.dataset
 @pytest.mark.parametrize('array_factory', [
     lambda: pa.array([0, None] * 10),
     lambda: pa.array([0, None] * 10).dictionary_encode(),
     lambda: pa.array(["", None] * 10),
     lambda: pa.array(["", None] * 10).dictionary_encode(),
 ])
-@pytest.mark.parametrize('use_dictionary', [False, True])
 @pytest.mark.parametrize('read_dictionary', [False, True])
 def test_buffer_contents(
-        array_factory, use_dictionary, read_dictionary
+        array_factory, read_dictionary
 ):
     # Test that null values are deterministically initialized to zero
     # after a roundtrip through Parquet.
@@ -782,7 +753,6 @@ def test_reads_over_batch(tempdir):
     assert table == table2
 
 
-@pytest.mark.dataset
 def test_permutation_of_column_order(tempdir):
     # ARROW-2366
     case = tempdir / "dataset_column_order_permutation"
@@ -940,6 +910,7 @@ def test_checksum_write_to_dataset(tempdir):
         _ = pq.read_table(corrupted_file_path, page_checksum_verification=True)
 
 
+@pytest.mark.dataset
 def test_deprecated_use_legacy_dataset(tempdir):
     # Test that specifying use_legacy_dataset in ParquetDataset, write_to_dataset
     # and read_table doesn't raise an error but gives a warning.

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -57,7 +57,6 @@ parametrize_test_data = pytest.mark.parametrize(
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 @parametrize_test_data
 def test_write_compliant_nested_type_enable(tempdir, test_data):
     # prepare dataframe for testing

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -18,7 +18,6 @@
 import pytest
 
 import pyarrow as pa
-from pyarrow.tests.parquet.common import parametrize_legacy_dataset
 
 try:
     import pyarrow.parquet as pq
@@ -58,16 +57,14 @@ parametrize_test_data = pytest.mark.parametrize(
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @parametrize_test_data
-def test_write_compliant_nested_type_enable(tempdir,
-                                            use_legacy_dataset, test_data):
+def test_write_compliant_nested_type_enable(tempdir, test_data):
     # prepare dataframe for testing
     df = pd.DataFrame(data=test_data)
     # verify that we can read/write pandas df with new flag (default behaviour)
     _roundtrip_pandas_dataframe(df,
-                                write_kwargs={},
-                                use_legacy_dataset=use_legacy_dataset)
+                                write_kwargs={})
 
     # Write to a parquet file with compliant nested type
     table = pa.Table.from_pandas(df, preserve_index=False)
@@ -83,21 +80,18 @@ def test_write_compliant_nested_type_enable(tempdir,
     assert new_table.schema.types[0].value_field.name == 'element'
 
     # Verify that the new table can be read/written correctly
-    _check_roundtrip(new_table,
-                     use_legacy_dataset=use_legacy_dataset)
+    _check_roundtrip(new_table)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @parametrize_test_data
-def test_write_compliant_nested_type_disable(tempdir,
-                                             use_legacy_dataset, test_data):
+def test_write_compliant_nested_type_disable(tempdir,test_data):
     # prepare dataframe for testing
     df = pd.DataFrame(data=test_data)
     # verify that we can read/write with new flag disabled
     _roundtrip_pandas_dataframe(df, write_kwargs={
-        'use_compliant_nested_type': False},
-        use_legacy_dataset=use_legacy_dataset)
+        'use_compliant_nested_type': False})
 
     # Write to a parquet file while disabling compliant nested type
     table = pa.Table.from_pandas(df, preserve_index=False)
@@ -114,5 +108,4 @@ def test_write_compliant_nested_type_disable(tempdir,
 
     # Verify that the new table can be read/written correctly
     _check_roundtrip(new_table,
-                     use_legacy_dataset=use_legacy_dataset,
                      use_compliant_nested_type=False)

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -86,7 +86,7 @@ def test_write_compliant_nested_type_enable(tempdir, test_data):
 @pytest.mark.pandas
 @pytest.mark.dataset
 @parametrize_test_data
-def test_write_compliant_nested_type_disable(tempdir,test_data):
+def test_write_compliant_nested_type_disable(tempdir, test_data):
     # prepare dataframe for testing
     df = pd.DataFrame(data=test_data)
     # verify that we can read/write with new flag disabled

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -83,7 +83,6 @@ def test_write_compliant_nested_type_enable(tempdir, test_data):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 @parametrize_test_data
 def test_write_compliant_nested_type_disable(tempdir, test_data):
     # prepare dataframe for testing

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -23,8 +23,7 @@ import pytest
 
 import pyarrow as pa
 from pyarrow.tests import util
-from pyarrow.tests.parquet.common import (_check_roundtrip,
-                                          parametrize_legacy_dataset)
+from pyarrow.tests.parquet.common import _check_roundtrip
 
 try:
     import pyarrow.parquet as pq
@@ -54,9 +53,9 @@ pytestmark = pytest.mark.parquet
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @pytest.mark.parametrize('chunk_size', [None, 1000])
-def test_parquet_2_0_roundtrip(tempdir, chunk_size, use_legacy_dataset):
+def test_parquet_2_0_roundtrip(tempdir, chunk_size):
     df = alltypes_sample(size=10000, categorical=True)
 
     filename = tempdir / 'pandas_roundtrip.parquet'
@@ -65,8 +64,7 @@ def test_parquet_2_0_roundtrip(tempdir, chunk_size, use_legacy_dataset):
 
     _write_table(arrow_table, filename, version='2.6',
                  chunk_size=chunk_size)
-    table_read = pq.read_pandas(
-        filename, use_legacy_dataset=use_legacy_dataset)
+    table_read = pq.read_pandas(filename)
     assert table_read.schema.pandas_metadata is not None
 
     read_metadata = table_read.schema.metadata
@@ -77,8 +75,8 @@ def test_parquet_2_0_roundtrip(tempdir, chunk_size, use_legacy_dataset):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_parquet_1_0_roundtrip(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_parquet_1_0_roundtrip(tempdir):
     size = 10000
     np.random.seed(0)
     df = pd.DataFrame({
@@ -100,7 +98,7 @@ def test_parquet_1_0_roundtrip(tempdir, use_legacy_dataset):
     filename = tempdir / 'pandas_roundtrip.parquet'
     arrow_table = pa.Table.from_pandas(df)
     _write_table(arrow_table, filename, version='1.0')
-    table_read = _read_table(filename, use_legacy_dataset=use_legacy_dataset)
+    table_read = _read_table(filename)
     df_read = table_read.to_pandas()
 
     # We pass uint32_t as int64_t if we write Parquet version 1.0
@@ -113,18 +111,18 @@ def test_parquet_1_0_roundtrip(tempdir, use_legacy_dataset):
 # -----------------------------------------------------------------------------
 
 
-def _simple_table_write_read(table, use_legacy_dataset):
+def _simple_table_write_read(table):
     bio = pa.BufferOutputStream()
     pq.write_table(table, bio)
     contents = bio.getvalue()
     return pq.read_table(
-        pa.BufferReader(contents), use_legacy_dataset=use_legacy_dataset
+        pa.BufferReader(contents)
     )
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_direct_read_dictionary(use_legacy_dataset):
+@pytest.mark.dataset
+def test_direct_read_dictionary():
     # ARROW-3325
     repeats = 10
     nunique = 5
@@ -140,8 +138,7 @@ def test_direct_read_dictionary(use_legacy_dataset):
     contents = bio.getvalue()
 
     result = pq.read_table(pa.BufferReader(contents),
-                           read_dictionary=['f0'],
-                           use_legacy_dataset=use_legacy_dataset)
+                           read_dictionary=['f0'])
 
     # Compute dictionary-encoded subfield
     expected = pa.table([table[0].dictionary_encode()], names=['f0'])
@@ -149,8 +146,8 @@ def test_direct_read_dictionary(use_legacy_dataset):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_direct_read_dictionary_subfield(use_legacy_dataset):
+@pytest.mark.dataset
+def test_direct_read_dictionary_subfield():
     repeats = 10
     nunique = 5
 
@@ -163,8 +160,7 @@ def test_direct_read_dictionary_subfield(use_legacy_dataset):
     pq.write_table(table, bio)
     contents = bio.getvalue()
     result = pq.read_table(pa.BufferReader(contents),
-                           read_dictionary=['f0.list.element'],
-                           use_legacy_dataset=use_legacy_dataset)
+                           read_dictionary=['f0.list.element'])
 
     arr = pa.array(data[0])
     values_as_dict = arr.values.dictionary_encode()
@@ -181,8 +177,8 @@ def test_direct_read_dictionary_subfield(use_legacy_dataset):
     assert result[0].num_chunks == 1
 
 
-@parametrize_legacy_dataset
-def test_dictionary_array_automatically_read(use_legacy_dataset):
+@pytest.mark.dataset
+def test_dictionary_array_automatically_read():
     # ARROW-3246
 
     # Make a large dictionary, a little over 4MB of data
@@ -200,7 +196,7 @@ def test_dictionary_array_automatically_read(use_legacy_dataset):
                                                      dict_values))
 
     table = pa.table([pa.chunked_array(chunks)], names=['f0'])
-    result = _simple_table_write_read(table, use_legacy_dataset)
+    result = _simple_table_write_read(table)
 
     assert result.equals(table)
 
@@ -213,8 +209,8 @@ def test_dictionary_array_automatically_read(use_legacy_dataset):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_decimal_roundtrip(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_decimal_roundtrip(tempdir):
     num_values = 10
 
     columns = {}
@@ -234,8 +230,7 @@ def test_decimal_roundtrip(tempdir, use_legacy_dataset):
     string_filename = str(filename)
     table = pa.Table.from_pandas(expected)
     _write_table(table, string_filename)
-    result_table = _read_table(
-        string_filename, use_legacy_dataset=use_legacy_dataset)
+    result_table = _read_table(string_filename)
     result = result_table.to_pandas()
     tm.assert_frame_equal(result, expected)
 
@@ -259,14 +254,14 @@ def test_decimal_roundtrip_negative_scale(tempdir):
 # -----------------------------------------------------------------------------
 
 
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @pytest.mark.parametrize('dtype', [int, float])
-def test_single_pylist_column_roundtrip(tempdir, dtype, use_legacy_dataset):
+def test_single_pylist_column_roundtrip(tempdir, dtype,):
     filename = tempdir / 'single_{}_column.parquet'.format(dtype.__name__)
     data = [pa.array(list(map(dtype, range(5))))]
     table = pa.Table.from_arrays(data, names=['a'])
     _write_table(table, filename)
-    table_read = _read_table(filename, use_legacy_dataset=use_legacy_dataset)
+    table_read = _read_table(filename)
     for i in range(table.num_columns):
         col_written = table[i]
         col_read = table_read[i]
@@ -277,16 +272,16 @@ def test_single_pylist_column_roundtrip(tempdir, dtype, use_legacy_dataset):
         assert data_written.equals(data_read)
 
 
-@parametrize_legacy_dataset
-def test_empty_lists_table_roundtrip(use_legacy_dataset):
+@pytest.mark.dataset
+def test_empty_lists_table_roundtrip():
     # ARROW-2744: Shouldn't crash when writing an array of empty lists
     arr = pa.array([[], []], type=pa.list_(pa.int32()))
     table = pa.Table.from_arrays([arr], ["A"])
-    _check_roundtrip(table, use_legacy_dataset=use_legacy_dataset)
+    _check_roundtrip(table)
 
 
-@parametrize_legacy_dataset
-def test_nested_list_nonnullable_roundtrip_bug(use_legacy_dataset):
+@pytest.mark.dataset
+def test_nested_list_nonnullable_roundtrip_bug():
     # Reproduce failure in ARROW-5630
     typ = pa.list_(pa.field("item", pa.float32(), False))
     num_rows = 10000
@@ -295,26 +290,23 @@ def test_nested_list_nonnullable_roundtrip_bug(use_legacy_dataset):
                   (num_rows // 10)), type=typ)
     ], ['a'])
     _check_roundtrip(
-        t, data_page_size=4096, use_legacy_dataset=use_legacy_dataset)
+        t, data_page_size=4096)
 
 
-@parametrize_legacy_dataset
-def test_nested_list_struct_multiple_batches_roundtrip(
-    tempdir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_nested_list_struct_multiple_batches_roundtrip(tempdir):
     # Reproduce failure in ARROW-11024
     data = [[{'x': 'abc', 'y': 'abc'}]]*100 + [[{'x': 'abc', 'y': 'gcb'}]]*100
     table = pa.table([pa.array(data)], names=['column'])
     _check_roundtrip(
-        table, row_group_size=20, use_legacy_dataset=use_legacy_dataset)
+        table, row_group_size=20)
 
     # Reproduce failure in ARROW-11069 (plain non-nested structs with strings)
     data = pa.array(
         [{'a': '1', 'b': '2'}, {'a': '3', 'b': '4'}, {'a': '5', 'b': '6'}]*10
     )
     table = pa.table({'column': data})
-    _check_roundtrip(
-        table, row_group_size=10, use_legacy_dataset=use_legacy_dataset)
+    _check_roundtrip(table, row_group_size=10)
 
 
 def test_writing_empty_lists():
@@ -365,9 +357,9 @@ def test_large_list_records():
     _check_roundtrip(table)
 
 
+@pytest.mark.dataset
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_parquet_nested_convenience(tempdir, use_legacy_dataset):
+def test_parquet_nested_convenience(tempdir):
     # ARROW-1684
     df = pd.DataFrame({
         'a': [[1, 2, 3], None, [4, 5], []],
@@ -380,11 +372,11 @@ def test_parquet_nested_convenience(tempdir, use_legacy_dataset):
     _write_table(table, path)
 
     read = pq.read_table(
-        path, columns=['a'], use_legacy_dataset=use_legacy_dataset)
+        path, columns=['a'])
     tm.assert_frame_equal(read.to_pandas(), df[['a']])
 
     read = pq.read_table(
-        path, columns=['a', 'b'], use_legacy_dataset=use_legacy_dataset)
+        path, columns=['a', 'b'])
     tm.assert_frame_equal(read.to_pandas(), df)
 
 
@@ -420,17 +412,17 @@ def test_large_table_int32_overflow():
     _write_table(table, f)
 
 
-def _simple_table_roundtrip(table, use_legacy_dataset=False, **write_kwargs):
+def _simple_table_roundtrip(table, **write_kwargs):
     stream = pa.BufferOutputStream()
     _write_table(table, stream, **write_kwargs)
     buf = stream.getvalue()
-    return _read_table(buf, use_legacy_dataset=use_legacy_dataset)
+    return _read_table(buf)
 
 
 @pytest.mark.slow
 @pytest.mark.large_memory
-@parametrize_legacy_dataset
-def test_byte_array_exactly_2gb(use_legacy_dataset):
+@pytest.mark.dataset
+def test_byte_array_exactly_2gb():
     # Test edge case reported in ARROW-3762
     val = b'x' * (1 << 10)
 
@@ -444,15 +436,15 @@ def test_byte_array_exactly_2gb(use_legacy_dataset):
         values = pa.chunked_array([base, pa.array(case)])
         t = pa.table([values], names=['f0'])
         result = _simple_table_roundtrip(
-            t, use_legacy_dataset=use_legacy_dataset, use_dictionary=False)
+            t, use_dictionary=False)
         assert t.equals(result)
 
 
 @pytest.mark.slow
 @pytest.mark.pandas
 @pytest.mark.large_memory
-@parametrize_legacy_dataset
-def test_binary_array_overflow_to_chunked(use_legacy_dataset):
+@pytest.mark.dataset
+def test_binary_array_overflow_to_chunked():
     # ARROW-3762
 
     # 2^31 + 1 bytes
@@ -462,8 +454,7 @@ def test_binary_array_overflow_to_chunked(use_legacy_dataset):
     df = pd.DataFrame({'byte_col': values})
 
     tbl = pa.Table.from_pandas(df, preserve_index=False)
-    read_tbl = _simple_table_roundtrip(
-        tbl, use_legacy_dataset=use_legacy_dataset)
+    read_tbl = _simple_table_roundtrip(tbl)
 
     col0_data = read_tbl[0]
     assert isinstance(col0_data, pa.ChunkedArray)
@@ -477,8 +468,8 @@ def test_binary_array_overflow_to_chunked(use_legacy_dataset):
 @pytest.mark.slow
 @pytest.mark.pandas
 @pytest.mark.large_memory
-@parametrize_legacy_dataset
-def test_list_of_binary_large_cell(use_legacy_dataset):
+@pytest.mark.dataset
+def test_list_of_binary_large_cell():
     # ARROW-4688
     data = []
 
@@ -491,8 +482,7 @@ def test_list_of_binary_large_cell(use_legacy_dataset):
 
     arr = pa.array(data)
     table = pa.Table.from_arrays([arr], ['chunky_cells'])
-    read_table = _simple_table_roundtrip(
-        table, use_legacy_dataset=use_legacy_dataset)
+    read_table = _simple_table_roundtrip(table)
     assert table.equals(read_table)
 
 

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -53,7 +53,6 @@ pytestmark = pytest.mark.parquet
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 @pytest.mark.parametrize('chunk_size', [None, 1000])
 def test_parquet_2_0_roundtrip(tempdir, chunk_size):
     df = alltypes_sample(size=10000, categorical=True)
@@ -75,7 +74,6 @@ def test_parquet_2_0_roundtrip(tempdir, chunk_size):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_parquet_1_0_roundtrip(tempdir):
     size = 10000
     np.random.seed(0)
@@ -121,7 +119,6 @@ def _simple_table_write_read(table):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_direct_read_dictionary():
     # ARROW-3325
     repeats = 10
@@ -146,7 +143,6 @@ def test_direct_read_dictionary():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_direct_read_dictionary_subfield():
     repeats = 10
     nunique = 5
@@ -177,7 +173,6 @@ def test_direct_read_dictionary_subfield():
     assert result[0].num_chunks == 1
 
 
-@pytest.mark.dataset
 def test_dictionary_array_automatically_read():
     # ARROW-3246
 
@@ -209,7 +204,6 @@ def test_dictionary_array_automatically_read():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_decimal_roundtrip(tempdir):
     num_values = 10
 
@@ -254,7 +248,6 @@ def test_decimal_roundtrip_negative_scale(tempdir):
 # -----------------------------------------------------------------------------
 
 
-@pytest.mark.dataset
 @pytest.mark.parametrize('dtype', [int, float])
 def test_single_pylist_column_roundtrip(tempdir, dtype,):
     filename = tempdir / 'single_{}_column.parquet'.format(dtype.__name__)
@@ -272,7 +265,6 @@ def test_single_pylist_column_roundtrip(tempdir, dtype,):
         assert data_written.equals(data_read)
 
 
-@pytest.mark.dataset
 def test_empty_lists_table_roundtrip():
     # ARROW-2744: Shouldn't crash when writing an array of empty lists
     arr = pa.array([[], []], type=pa.list_(pa.int32()))
@@ -280,7 +272,6 @@ def test_empty_lists_table_roundtrip():
     _check_roundtrip(table)
 
 
-@pytest.mark.dataset
 def test_nested_list_nonnullable_roundtrip_bug():
     # Reproduce failure in ARROW-5630
     typ = pa.list_(pa.field("item", pa.float32(), False))
@@ -293,7 +284,6 @@ def test_nested_list_nonnullable_roundtrip_bug():
         t, data_page_size=4096)
 
 
-@pytest.mark.dataset
 def test_nested_list_struct_multiple_batches_roundtrip(tempdir):
     # Reproduce failure in ARROW-11024
     data = [[{'x': 'abc', 'y': 'abc'}]]*100 + [[{'x': 'abc', 'y': 'gcb'}]]*100
@@ -357,7 +347,6 @@ def test_large_list_records():
     _check_roundtrip(table)
 
 
-@pytest.mark.dataset
 @pytest.mark.pandas
 def test_parquet_nested_convenience(tempdir):
     # ARROW-1684
@@ -421,7 +410,6 @@ def _simple_table_roundtrip(table, **write_kwargs):
 
 @pytest.mark.slow
 @pytest.mark.large_memory
-@pytest.mark.dataset
 def test_byte_array_exactly_2gb():
     # Test edge case reported in ARROW-3762
     val = b'x' * (1 << 10)
@@ -443,7 +431,6 @@ def test_byte_array_exactly_2gb():
 @pytest.mark.slow
 @pytest.mark.pandas
 @pytest.mark.large_memory
-@pytest.mark.dataset
 def test_binary_array_overflow_to_chunked():
     # ARROW-3762
 
@@ -468,7 +455,6 @@ def test_binary_array_overflow_to_chunked():
 @pytest.mark.slow
 @pytest.mark.pandas
 @pytest.mark.large_memory
-@pytest.mark.dataset
 def test_list_of_binary_large_cell():
     # ARROW-4688
     data = []

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1145,6 +1145,7 @@ def test_pickle_dataset(tempdir, pickle_module):
     assert is_pickleable(dataset)
 
 
+@pytest.mark.pandas
 def test_partitioned_dataset(tempdir):
     # ARROW-3208: Segmentation fault when reading a Parquet partitioned dataset
     # to a Parquet file

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -920,6 +920,7 @@ def test_ignore_custom_prefixes(tempdir):
 
 
 def test_empty_directory(tempdir):
+    # ARROW-5310
     empty_dir = tempdir / 'dataset'
     empty_dir.mkdir()
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -969,11 +969,8 @@ def _test_write_to_dataset_with_partitions(base_path,
     else:
         pq.write_metadata(output_table.schema, metadata_path)
 
-    # ARROW-2891: Ensure the output_schema is preserved when writing a
-    # partitioned dataset
     dataset = pq.ParquetDataset(base_path,
-                                filesystem=filesystem,
-                                validate_schema=True)
+                                filesystem=filesystem)
     # ARROW-2209: Ensure the dataset schema also includes the partition columns
     # NB schema property is an arrow and not parquet schema
     dataset_cols = set(dataset.schema.names)

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -821,7 +821,7 @@ def _make_example_multifile_dataset(base_path, nfiles=10, file_nrows=5):
 
 def _assert_dataset_paths(dataset, paths):
     paths = [str(path.as_posix()) for path in paths]
-    assert set(paths) == set(dataset._dataset.files)
+    assert set(paths) == set(dataset.files)
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1219,24 +1219,6 @@ def test_read_table_schema(tempdir):
     assert result.read().equals(expected)
 
 
-def test_dataset_unsupported_keywords():
-
-    with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", metadata=pa.schema([]))
-
-    with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", validate_schema=False)
-
-    with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", split_row_groups=True)
-
-    with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", metadata_nthreads=4)
-
-    with pytest.raises(ValueError, match="no longer supported"):
-        pq.read_table("", metadata=pa.schema([]))
-
-
 def test_dataset_partitioning(tempdir):
     import pyarrow.dataset as ds
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -53,18 +53,6 @@ except ImportError:
 pytestmark = pytest.mark.parquet
 
 
-def test_partition_set_dictionary_type():
-    set1 = pq.PartitionSet('key1', ['foo', 'bar', 'baz'])
-    set2 = pq.PartitionSet('key2', [2007, 2008, 2009])
-
-    assert isinstance(set1.dictionary, pa.StringArray)
-    assert isinstance(set2.dictionary, pa.IntegerArray)
-
-    set3 = pq.PartitionSet('key2', [datetime.datetime(2007, 1, 1)])
-    with pytest.raises(TypeError):
-        set3.dictionary
-
-
 @pytest.mark.dataset
 def test_filesystem_uri(tempdir):
     table = pa.table({"a": [1, 2, 3]})

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -679,12 +679,6 @@ def test_read_multiple_files(tempdir):
 
     assert result.equals(expected)
 
-    # Read with provided metadata
-    # TODO specifying metadata not yet supported
-    metadata = pq.read_metadata(paths[0])
-    with pytest.raises(ValueError, match="no longer supported"):
-        pq.read_table(paths, metadata=metadata)
-
     # Read column subset
     to_read = [0, 2, 6, result.num_columns - 1]
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -29,9 +29,6 @@ import pyarrow.compute as pc
 from pyarrow import fs
 from pyarrow.filesystem import LocalFileSystem
 from pyarrow.tests import util
-from pyarrow.tests.parquet.common import (
-    parametrize_legacy_dataset, parametrize_legacy_dataset_fixed,
-    parametrize_legacy_dataset_not_supported)
 from pyarrow.util import guid
 from pyarrow.vendored.version import Version
 
@@ -56,59 +53,6 @@ except ImportError:
 pytestmark = pytest.mark.parquet
 
 
-@pytest.mark.pandas
-def test_parquet_piece_read(tempdir):
-    df = _test_dataframe(1000)
-    table = pa.Table.from_pandas(df)
-
-    path = tempdir / 'parquet_piece_read.parquet'
-    _write_table(table, path, version='2.6')
-
-    with pytest.warns(FutureWarning):
-        piece1 = pq.ParquetDatasetPiece(path)
-
-    result = piece1.read()
-    assert result.equals(table)
-
-
-@pytest.mark.pandas
-def test_parquet_piece_open_and_get_metadata(tempdir):
-    df = _test_dataframe(100)
-    table = pa.Table.from_pandas(df)
-
-    path = tempdir / 'parquet_piece_read.parquet'
-    _write_table(table, path, version='2.6')
-
-    with pytest.warns(FutureWarning):
-        piece = pq.ParquetDatasetPiece(path)
-
-    table1 = piece.read()
-    assert isinstance(table1, pa.Table)
-    meta1 = piece.get_metadata()
-    assert isinstance(meta1, pq.FileMetaData)
-
-    assert table.equals(table1)
-
-
-@pytest.mark.filterwarnings("ignore:ParquetDatasetPiece:FutureWarning")
-def test_parquet_piece_basics():
-    path = '/baz.parq'
-
-    piece1 = pq.ParquetDatasetPiece(path)
-    piece2 = pq.ParquetDatasetPiece(path, row_group=1)
-    piece3 = pq.ParquetDatasetPiece(
-        path, row_group=1, partition_keys=[('foo', 0), ('bar', 1)])
-
-    assert str(piece1) == path
-    assert str(piece2) == '/baz.parq | row_group=1'
-    assert str(piece3) == 'partition[foo=0, bar=1] /baz.parq | row_group=1'
-
-    assert piece1 == piece1
-    assert piece2 == piece2
-    assert piece3 == piece3
-    assert piece1 != piece3
-
-
 def test_partition_set_dictionary_type():
     set1 = pq.PartitionSet('key1', ['foo', 'bar', 'baz'])
     set2 = pq.PartitionSet('key2', [2007, 2008, 2009])
@@ -121,8 +65,8 @@ def test_partition_set_dictionary_type():
         set3.dictionary
 
 
-@parametrize_legacy_dataset_fixed
-def test_filesystem_uri(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filesystem_uri(tempdir):
     table = pa.table({"a": [1, 2, 3]})
 
     directory = tempdir / "data_dir"
@@ -132,72 +76,39 @@ def test_filesystem_uri(tempdir, use_legacy_dataset):
 
     # filesystem object
     result = pq.read_table(
-        path, filesystem=fs.LocalFileSystem(),
-        use_legacy_dataset=use_legacy_dataset)
+        path, filesystem=fs.LocalFileSystem())
     assert result.equals(table)
 
     # filesystem URI
     result = pq.read_table(
-        "data_dir/data.parquet", filesystem=util._filesystem_uri(tempdir),
-        use_legacy_dataset=use_legacy_dataset)
+        "data_dir/data.parquet", filesystem=util._filesystem_uri(tempdir))
     assert result.equals(table)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_read_partitioned_directory(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_partitioned_directory(tempdir):
     fs = LocalFileSystem._get_instance()
-    _partition_test_for_filesystem(fs, tempdir, use_legacy_dataset)
-
-
-@pytest.mark.filterwarnings("ignore:'ParquetDataset:FutureWarning")
-@pytest.mark.pandas
-def test_create_parquet_dataset_multi_threaded(tempdir):
-    fs = LocalFileSystem._get_instance()
-    base_path = tempdir
-
-    _partition_test_for_filesystem(fs, base_path)
-
-    manifest = pq.ParquetManifest(base_path, filesystem=fs,
-                                  metadata_nthreads=1)
-    with pytest.warns(
-        FutureWarning, match="Specifying the 'metadata_nthreads'"
-    ):
-        dataset = pq.ParquetDataset(
-            base_path, filesystem=fs, metadata_nthreads=16,
-            use_legacy_dataset=True
-        )
-    assert len(dataset.pieces) > 0
-    partitions = dataset.partitions
-    assert len(partitions.partition_names) > 0
-    assert partitions.partition_names == manifest.partitions.partition_names
-    assert len(partitions.levels) == len(manifest.partitions.levels)
+    _partition_test_for_filesystem(fs, tempdir)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_read_partitioned_columns_selection(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_partitioned_columns_selection(tempdir):
     # ARROW-3861 - do not include partition columns in resulting table when
     # `columns` keyword was passed without those columns
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
     _partition_test_for_filesystem(fs, base_path)
 
-    dataset = pq.ParquetDataset(
-        base_path, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(base_path)
     result = dataset.read(columns=["values"])
-    if use_legacy_dataset:
-        # ParquetDataset implementation always includes the partition columns
-        # automatically, and we can't easily "fix" this since dask relies on
-        # this behaviour (ARROW-8644)
-        assert result.column_names == ["values", "foo", "bar"]
-    else:
-        assert result.column_names == ["values"]
+    assert result.column_names == ["values"]
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_filters_equivalency(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filters_equivalency(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -225,7 +136,6 @@ def test_filters_equivalency(tempdir, use_legacy_dataset):
         base_path, filesystem=fs,
         filters=[('integer', '=', 1), ('string', '!=', 'b'),
                  ('boolean', '==', 'True')],
-        use_legacy_dataset=use_legacy_dataset,
     )
     table = dataset.read()
     result_df = (table.to_pandas().reset_index(drop=True))
@@ -247,8 +157,7 @@ def test_filters_equivalency(tempdir, use_legacy_dataset):
         [('integer', '=', 0), ('boolean', '==', 'False')]
     ]
     dataset = pq.ParquetDataset(
-        base_path, filesystem=fs, filters=filters,
-        use_legacy_dataset=use_legacy_dataset)
+        base_path, filesystem=fs, filters=filters)
     table = dataset.read()
     result_df = table.to_pandas().reset_index(drop=True)
 
@@ -262,30 +171,16 @@ def test_filters_equivalency(tempdir, use_legacy_dataset):
     assert df_filter_2.sum() > 0
     assert result_df.shape[0] == (df_filter_1.sum() + df_filter_2.sum())
 
-    if use_legacy_dataset:
-        # Check for \0 in predicate values. Until they are correctly
-        # implemented in ARROW-3391, they would otherwise lead to weird
-        # results with the current code.
-        with pytest.raises(NotImplementedError):
-            filters = [[('string', '==', b'1\0a')]]
-            pq.ParquetDataset(base_path, filesystem=fs, filters=filters,
-                              use_legacy_dataset=True)
-        with pytest.raises(NotImplementedError):
-            filters = [[('string', '==', '1\0a')]]
-            pq.ParquetDataset(base_path, filesystem=fs, filters=filters,
-                              use_legacy_dataset=True)
-    else:
-        for filters in [[[('string', '==', b'1\0a')]],
-                        [[('string', '==', '1\0a')]]]:
-            dataset = pq.ParquetDataset(
-                base_path, filesystem=fs, filters=filters,
-                use_legacy_dataset=False)
-            assert dataset.read().num_rows == 0
+    for filters in [[[('string', '==', b'1\0a')]],
+                    [[('string', '==', '1\0a')]]]:
+        dataset = pq.ParquetDataset(
+            base_path, filesystem=fs, filters=filters)
+        assert dataset.read().num_rows == 0
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_filters_cutoff_exclusive_integer(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filters_cutoff_exclusive_integer(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -308,7 +203,6 @@ def test_filters_cutoff_exclusive_integer(tempdir, use_legacy_dataset):
             ('integers', '<', 4),
             ('integers', '>', 1),
         ],
-        use_legacy_dataset=use_legacy_dataset
     )
     table = dataset.read()
     result_df = (table.to_pandas()
@@ -319,15 +213,15 @@ def test_filters_cutoff_exclusive_integer(tempdir, use_legacy_dataset):
     assert result_list == [2, 3]
 
 
-@pytest.mark.pandas
-@parametrize_legacy_dataset
 @pytest.mark.xfail(
     # different error with use_legacy_datasets because result_df is no longer
     # categorical
     raises=(TypeError, AssertionError),
     reason='Loss of type information in creation of categoricals.'
 )
-def test_filters_cutoff_exclusive_datetime(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+@pytest.mark.pandas
+def test_filters_cutoff_exclusive_datetime(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -356,7 +250,6 @@ def test_filters_cutoff_exclusive_datetime(tempdir, use_legacy_dataset):
             ('dates', '<', "2018-04-12"),
             ('dates', '>', "2018-04-10")
         ],
-        use_legacy_dataset=use_legacy_dataset
     )
     table = dataset.read()
     result_df = (table.to_pandas()
@@ -389,8 +282,8 @@ def test_filters_inclusive_datetime(tempdir):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_filters_inclusive_integer(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filters_inclusive_integer(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -413,7 +306,6 @@ def test_filters_inclusive_integer(tempdir, use_legacy_dataset):
             ('integers', '<=', 3),
             ('integers', '>=', 2),
         ],
-        use_legacy_dataset=use_legacy_dataset
     )
     table = dataset.read()
     result_df = (table.to_pandas()
@@ -425,8 +317,8 @@ def test_filters_inclusive_integer(tempdir, use_legacy_dataset):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_filters_inclusive_set(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filters_inclusive_set(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -451,7 +343,6 @@ def test_filters_inclusive_set(tempdir, use_legacy_dataset):
     dataset = pq.ParquetDataset(
         base_path, filesystem=fs,
         filters=[('string', 'in', 'ab')],
-        use_legacy_dataset=use_legacy_dataset
     )
     table = dataset.read()
     result_df = (table.to_pandas().reset_index(drop=True))
@@ -464,7 +355,6 @@ def test_filters_inclusive_set(tempdir, use_legacy_dataset):
         base_path, filesystem=fs,
         filters=[('integer', 'in', [1]), ('string', 'in', ('a', 'b')),
                  ('boolean', 'not in', {'False'})],
-        use_legacy_dataset=use_legacy_dataset
     )
     table = dataset.read()
     result_df = (table.to_pandas().reset_index(drop=True))
@@ -475,8 +365,8 @@ def test_filters_inclusive_set(tempdir, use_legacy_dataset):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_filters_invalid_pred_op(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filters_invalid_pred_op(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -496,49 +386,31 @@ def test_filters_invalid_pred_op(tempdir, use_legacy_dataset):
     with pytest.raises(TypeError):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
-                          filters=[('integers', 'in', 3), ],
-                          use_legacy_dataset=use_legacy_dataset)
+                          filters=[('integers', 'in', 3), ])
 
     with pytest.raises(ValueError):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
-                          filters=[('integers', '=<', 3), ],
-                          use_legacy_dataset=use_legacy_dataset)
+                          filters=[('integers', '=<', 3), ])
 
-    if use_legacy_dataset:
-        with pytest.raises(ValueError):
-            pq.ParquetDataset(base_path,
-                              filesystem=fs,
-                              filters=[('integers', 'in', set()), ],
-                              use_legacy_dataset=use_legacy_dataset)
-    else:
-        # Dataset API returns empty table instead
-        dataset = pq.ParquetDataset(base_path,
-                                    filesystem=fs,
-                                    filters=[('integers', 'in', set()), ],
-                                    use_legacy_dataset=use_legacy_dataset)
+    # Dataset API returns empty table
+    dataset = pq.ParquetDataset(base_path,
+                                filesystem=fs,
+                                filters=[('integers', 'in', set()), ])
+    assert dataset.read().num_rows == 0
+
+    dataset = pq.ParquetDataset(base_path,
+                                filesystem=fs,
+                                filters=[('integers', '!=', {3})])
+    with pytest.raises(NotImplementedError):
         assert dataset.read().num_rows == 0
-
-    if use_legacy_dataset:
-        with pytest.raises(ValueError):
-            pq.ParquetDataset(base_path,
-                              filesystem=fs,
-                              filters=[('integers', '!=', {3})],
-                              use_legacy_dataset=use_legacy_dataset)
-    else:
-        dataset = pq.ParquetDataset(base_path,
-                                    filesystem=fs,
-                                    filters=[('integers', '!=', {3})],
-                                    use_legacy_dataset=use_legacy_dataset)
-        with pytest.raises(NotImplementedError):
-            assert dataset.read().num_rows == 0
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset_fixed
-def test_filters_invalid_column(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filters_invalid_column(tempdir):
     # ARROW-5572 - raise error on invalid name in filter specification
-    # works with new dataset / xfail with legacy implementation
+    # works with new dataset
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -556,12 +428,11 @@ def test_filters_invalid_column(tempdir, use_legacy_dataset):
     msg = r"No match for FieldRef.Name\(non_existent_column\)"
     with pytest.raises(ValueError, match=msg):
         pq.ParquetDataset(base_path, filesystem=fs,
-                          filters=[('non_existent_column', '<', 3), ],
-                          use_legacy_dataset=use_legacy_dataset).read()
+                          filters=[('non_existent_column', '<', 3), ]).read()
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @pytest.mark.parametrize("filters",
                          ([('integers', '<', 3)],
                           [[('integers', '<', 3)]],
@@ -569,7 +440,7 @@ def test_filters_invalid_column(tempdir, use_legacy_dataset):
                           pc.field('nested', 'a') < 3,
                           pc.field('nested', 'b').cast(pa.int64()) < 3))
 @pytest.mark.parametrize("read_method", ("read_table", "read_pandas"))
-def test_filters_read_table(tempdir, use_legacy_dataset, filters, read_method):
+def test_filters_read_table(tempdir, filters, read_method):
     read = getattr(pq, read_method)
     # test that filters keyword is passed through in read_table
     fs = LocalFileSystem._get_instance()
@@ -589,24 +460,16 @@ def test_filters_read_table(tempdir, use_legacy_dataset, filters, read_method):
 
     _generate_partition_directories(fs, base_path, partition_spec, df)
 
-    kwargs = dict(filesystem=fs, filters=filters,
-                  use_legacy_dataset=use_legacy_dataset)
+    kwargs = dict(filesystem=fs, filters=filters)
 
-    # Using Expression in legacy dataset not supported
-    if use_legacy_dataset and isinstance(filters, pc.Expression):
-        msg = "Expressions as filter not supported for legacy dataset"
-        with pytest.raises(TypeError, match=msg):
-            read(base_path, **kwargs)
-    else:
-        table = read(base_path, **kwargs)
-        assert table.num_rows == 3
+    table = read(base_path, **kwargs)
+    assert table.num_rows == 3
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset_fixed
-def test_partition_keys_with_underscores(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_partition_keys_with_underscores(tempdir):
     # ARROW-5666 - partition field values with underscores preserve underscores
-    # xfail with legacy dataset -> they get interpreted as integers
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
 
@@ -623,60 +486,51 @@ def test_partition_keys_with_underscores(tempdir, use_legacy_dataset):
 
     _generate_partition_directories(fs, base_path, partition_spec, df)
 
-    dataset = pq.ParquetDataset(
-        base_path, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(base_path)
     result = dataset.read()
     assert result.column("year_week").to_pylist() == string_keys
 
 
 @pytest.mark.s3
-@parametrize_legacy_dataset
-def test_read_s3fs(s3_example_s3fs, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_s3fs(s3_example_s3fs, ):
     fs, path = s3_example_s3fs
     path = path + "/test.parquet"
     table = pa.table({"a": [1, 2, 3]})
     _write_table(table, path, filesystem=fs)
 
-    result = _read_table(
-        path, filesystem=fs, use_legacy_dataset=use_legacy_dataset
-    )
+    result = _read_table(path, filesystem=fs)
     assert result.equals(table)
 
 
 @pytest.mark.s3
-@parametrize_legacy_dataset
-def test_read_directory_s3fs(s3_example_s3fs, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_directory_s3fs(s3_example_s3fs):
     fs, directory = s3_example_s3fs
     path = directory + "/test.parquet"
     table = pa.table({"a": [1, 2, 3]})
     _write_table(table, path, filesystem=fs)
 
-    result = _read_table(
-        directory, filesystem=fs, use_legacy_dataset=use_legacy_dataset
-    )
+    result = _read_table(directory, filesystem=fs)
     assert result.equals(table)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_read_single_file_list(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_single_file_list(tempdir):
     data_path = str(tempdir / 'data.parquet')
 
     table = pa.table({"a": [1, 2, 3]})
     _write_table(table, data_path)
 
-    result = pq.ParquetDataset(
-        [data_path], use_legacy_dataset=use_legacy_dataset
-    ).read()
+    result = pq.ParquetDataset([data_path]).read()
     assert result.equals(table)
 
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@parametrize_legacy_dataset
-def test_read_partitioned_directory_s3fs_wrapper(
-    s3_example_s3fs, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_read_partitioned_directory_s3fs_wrapper(s3_example_s3fs):
     import s3fs
 
     from pyarrow.filesystem import S3FSWrapper
@@ -690,23 +544,19 @@ def test_read_partitioned_directory_s3fs_wrapper(
     _partition_test_for_filesystem(wrapper, path)
 
     # Check that we can auto-wrap
-    dataset = pq.ParquetDataset(
-        path, filesystem=fs, use_legacy_dataset=use_legacy_dataset
-    )
+    dataset = pq.ParquetDataset(path, filesystem=fs)
     dataset.read()
 
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@parametrize_legacy_dataset
-def test_read_partitioned_directory_s3fs(s3_example_s3fs, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_partitioned_directory_s3fs(s3_example_s3fs):
     fs, path = s3_example_s3fs
-    _partition_test_for_filesystem(
-        fs, path, use_legacy_dataset=use_legacy_dataset
-    )
+    _partition_test_for_filesystem(fs, path)
 
 
-def _partition_test_for_filesystem(fs, base_path, use_legacy_dataset=True):
+def _partition_test_for_filesystem(fs, base_path):
     foo_keys = [0, 1]
     bar_keys = ['a', 'b', 'c']
     partition_spec = [
@@ -724,8 +574,7 @@ def _partition_test_for_filesystem(fs, base_path, use_legacy_dataset=True):
 
     _generate_partition_directories(fs, base_path, partition_spec, df)
 
-    dataset = pq.ParquetDataset(
-        base_path, filesystem=fs, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(base_path, filesystem=fs)
     table = dataset.read()
     result_df = (table.to_pandas()
                  .sort_values(by='index')
@@ -735,15 +584,12 @@ def _partition_test_for_filesystem(fs, base_path, use_legacy_dataset=True):
                    .reset_index(drop=True)
                    .reindex(columns=result_df.columns))
 
-    if use_legacy_dataset or Version(pd.__version__) < Version("2.0.0"):
-        expected_df['foo'] = pd.Categorical(df['foo'], categories=foo_keys)
-        expected_df['bar'] = pd.Categorical(df['bar'], categories=bar_keys)
-    else:
-        # With pandas 2.0.0 Index can store all numeric dtypes (not just
-        # int64/uint64/float64). Using astype() to create a categorical
-        # column preserves original dtype (int32)
-        expected_df['foo'] = expected_df['foo'].astype("category")
-        expected_df['bar'] = expected_df['bar'].astype("category")
+
+    # With pandas 2.0.0 Index can store all numeric dtypes (not just
+    # int64/uint64/float64). Using astype() to create a categorical
+    # column preserves original dtype (int32)
+    expected_df['foo'] = expected_df['foo'].astype("category")
+    expected_df['bar'] = expected_df['bar'].astype("category")
 
     assert (result_df.columns == ['index', 'values', 'foo', 'bar']).all()
 
@@ -790,83 +636,6 @@ def _generate_partition_directories(fs, base_dir, partition_spec, df):
     _visit_level(base_dir, 0, [])
 
 
-def _test_read_common_metadata_files(fs, base_path):
-    import pandas as pd
-
-    import pyarrow.parquet as pq
-
-    N = 100
-    df = pd.DataFrame({
-        'index': np.arange(N),
-        'values': np.random.randn(N)
-    }, columns=['index', 'values'])
-
-    base_path = str(base_path)
-    data_path = os.path.join(base_path, 'data.parquet')
-
-    table = pa.Table.from_pandas(df)
-
-    with fs.open(data_path, 'wb') as f:
-        _write_table(table, f)
-
-    metadata_path = os.path.join(base_path, '_common_metadata')
-    with fs.open(metadata_path, 'wb') as f:
-        pq.write_metadata(table.schema, f)
-
-    dataset = pq.ParquetDataset(base_path, filesystem=fs,
-                                use_legacy_dataset=True)
-    with pytest.warns(FutureWarning):
-        assert dataset.common_metadata_path == str(metadata_path)
-
-    with fs.open(data_path) as f:
-        common_schema = pq.read_metadata(f).schema
-    assert dataset.schema.equals(common_schema)
-
-    # handle list of one directory
-    dataset2 = pq.ParquetDataset([base_path], filesystem=fs,
-                                 use_legacy_dataset=True)
-    assert dataset2.schema.equals(dataset.schema)
-
-
-@pytest.mark.pandas
-@pytest.mark.filterwarnings("ignore:'ParquetDataset.schema:FutureWarning")
-def test_read_common_metadata_files(tempdir):
-    fs = LocalFileSystem._get_instance()
-    _test_read_common_metadata_files(fs, tempdir)
-
-
-@pytest.mark.pandas
-@pytest.mark.filterwarnings("ignore:'ParquetDataset.schema:FutureWarning")
-def test_read_metadata_files(tempdir):
-    fs = LocalFileSystem._get_instance()
-
-    N = 100
-    df = pd.DataFrame({
-        'index': np.arange(N),
-        'values': np.random.randn(N)
-    }, columns=['index', 'values'])
-
-    data_path = tempdir / 'data.parquet'
-
-    table = pa.Table.from_pandas(df)
-
-    with fs.open(data_path, 'wb') as f:
-        _write_table(table, f)
-
-    metadata_path = tempdir / '_metadata'
-    with fs.open(metadata_path, 'wb') as f:
-        pq.write_metadata(table.schema, f)
-
-    dataset = pq.ParquetDataset(tempdir, filesystem=fs,
-                                use_legacy_dataset=True)
-    with pytest.warns(FutureWarning):
-        assert dataset.metadata_path == str(metadata_path)
-
-    with fs.open(data_path) as f:
-        metadata_schema = pq.read_metadata(f).schema
-    assert dataset.schema.equals(metadata_schema)
-
-
 def _filter_partition(df, part_keys):
     predicate = np.ones(len(df), dtype=bool)
 
@@ -883,9 +652,9 @@ def _filter_partition(df, part_keys):
     return df[predicate].drop(to_drop, axis=1)
 
 
-@parametrize_legacy_dataset
 @pytest.mark.pandas
-def test_filter_before_validate_schema(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_filter_before_validate_schema(tempdir):
     # ARROW-4076 apply filter before schema validation
     # to avoid checking unneeded schemas
 
@@ -902,16 +671,13 @@ def test_filter_before_validate_schema(tempdir, use_legacy_dataset):
     pq.write_table(table2, dir2 / 'data.parquet')
 
     # read single file using filter
-    table = pq.read_table(tempdir, filters=[[('A', '==', 0)]],
-                          use_legacy_dataset=use_legacy_dataset)
+    table = pq.read_table(tempdir, filters=[[('A', '==', 0)]])
     assert table.column('B').equals(pa.chunked_array([[1, 2, 3]]))
 
 
 @pytest.mark.pandas
-@pytest.mark.filterwarnings(
-    "ignore:Specifying the 'metadata':FutureWarning")
-@parametrize_legacy_dataset
-def test_read_multiple_files(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_multiple_files(tempdir):
     nfiles = 10
     size = 5
 
@@ -938,8 +704,7 @@ def test_read_multiple_files(tempdir, use_legacy_dataset):
     (dirpath / '_SUCCESS.crc').touch()
 
     def read_multiple_files(paths, columns=None, use_threads=True, **kwargs):
-        dataset = pq.ParquetDataset(
-            paths, use_legacy_dataset=use_legacy_dataset, **kwargs)
+        dataset = pq.ParquetDataset(paths, **kwargs)
         return dataset.read(columns=columns, use_threads=use_threads)
 
     result = read_multiple_files(paths)
@@ -948,36 +713,23 @@ def test_read_multiple_files(tempdir, use_legacy_dataset):
     assert result.equals(expected)
 
     # Read with provided metadata
-    # TODO(dataset) specifying metadata not yet supported
+    # TODO specifying metadata not yet supported
     metadata = pq.read_metadata(paths[0])
-    if use_legacy_dataset:
-        result2 = read_multiple_files(paths, metadata=metadata)
-        assert result2.equals(expected)
-
-        with pytest.warns(FutureWarning, match="Specifying the 'schema'"):
-            result3 = pq.ParquetDataset(dirpath, schema=metadata.schema,
-                                        use_legacy_dataset=True).read()
-        assert result3.equals(expected)
-    else:
-        with pytest.raises(ValueError, match="no longer supported"):
-            pq.read_table(paths, metadata=metadata, use_legacy_dataset=False)
+    with pytest.raises(ValueError, match="no longer supported"):
+        pq.read_table(paths, metadata=metadata)
 
     # Read column subset
     to_read = [0, 2, 6, result.num_columns - 1]
 
     col_names = [result.field(i).name for i in to_read]
-    out = pq.read_table(
-        dirpath, columns=col_names, use_legacy_dataset=use_legacy_dataset
-    )
+    out = pq.read_table(dirpath, columns=col_names)
     expected = pa.Table.from_arrays([result.column(i) for i in to_read],
                                     names=col_names,
                                     metadata=result.schema.metadata)
     assert out.equals(expected)
 
     # Read with multiple threads
-    pq.read_table(
-        dirpath, use_threads=True, use_legacy_dataset=use_legacy_dataset
-    )
+    pq.read_table(dirpath, use_threads=True)
 
     # Test failure modes with non-uniform metadata
     bad_apple = _test_dataframe(size, seed=i).iloc[:, :4]
@@ -986,31 +738,25 @@ def test_read_multiple_files(tempdir, use_legacy_dataset):
     t = pa.Table.from_pandas(bad_apple)
     _write_table(t, bad_apple_path)
 
-    if not use_legacy_dataset:
-        # TODO(dataset) Dataset API skips bad files
-        return
+    # TODO(dataset) Dataset API skips bad files
 
-    bad_meta = pq.read_metadata(bad_apple_path)
+    # bad_meta = pq.read_metadata(bad_apple_path)
 
-    with pytest.raises(ValueError):
-        read_multiple_files(paths + [bad_apple_path])
+    # with pytest.raises(ValueError):
+    #     read_multiple_files(paths + [bad_apple_path])
 
-    with pytest.raises(ValueError):
-        read_multiple_files(paths, metadata=bad_meta)
+    # with pytest.raises(ValueError):
+    #     read_multiple_files(paths, metadata=bad_meta)
 
-    mixed_paths = [bad_apple_path, paths[0]]
+    # mixed_paths = [bad_apple_path, paths[0]]
 
-    with pytest.raises(ValueError):
-        with pytest.warns(FutureWarning, match="Specifying the 'schema'"):
-            read_multiple_files(mixed_paths, schema=bad_meta.schema)
-
-    with pytest.raises(ValueError):
-        read_multiple_files(mixed_paths)
+    # with pytest.raises(ValueError):
+    #     read_multiple_files(mixed_paths)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_dataset_read_pandas(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_dataset_read_pandas(tempdir):
     nfiles = 5
     size = 5
 
@@ -1033,7 +779,7 @@ def test_dataset_read_pandas(tempdir, use_legacy_dataset):
         frames.append(df)
         paths.append(path)
 
-    dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(dirpath)
     columns = ['uint8', 'strings']
     result = dataset.read_pandas(columns=columns).to_pandas()
     expected = pd.concat([x[columns] for x in frames])
@@ -1047,10 +793,9 @@ def test_dataset_read_pandas(tempdir, use_legacy_dataset):
     tm.assert_frame_equal(result.reindex(columns=expected.columns), expected)
 
 
-@pytest.mark.filterwarnings("ignore:'ParquetDataset:FutureWarning")
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_dataset_memory_map(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_dataset_memory_map(tempdir):
     # ARROW-2627: Check that we can use ParquetDataset with memory-mapping
     dirpath = tempdir / guid()
     dirpath.mkdir()
@@ -1061,15 +806,13 @@ def test_dataset_memory_map(tempdir, use_legacy_dataset):
     _write_table(table, path, version='2.6')
 
     dataset = pq.ParquetDataset(
-        dirpath, memory_map=True, use_legacy_dataset=use_legacy_dataset)
+        dirpath, memory_map=True)
     assert dataset.read().equals(table)
-    if use_legacy_dataset:
-        assert dataset.pieces[0].read().equals(table)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_dataset_enable_buffered_stream(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_dataset_enable_buffered_stream(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
 
@@ -1080,19 +823,17 @@ def test_dataset_enable_buffered_stream(tempdir, use_legacy_dataset):
 
     with pytest.raises(ValueError):
         pq.ParquetDataset(
-            dirpath, buffer_size=-64,
-            use_legacy_dataset=use_legacy_dataset)
+            dirpath, buffer_size=-64)
 
     for buffer_size in [128, 1024]:
         dataset = pq.ParquetDataset(
-            dirpath, buffer_size=buffer_size,
-            use_legacy_dataset=use_legacy_dataset)
+            dirpath, buffer_size=buffer_size)
         assert dataset.read().equals(table)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_dataset_enable_pre_buffer(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_dataset_enable_pre_buffer(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
 
@@ -1103,11 +844,9 @@ def test_dataset_enable_pre_buffer(tempdir, use_legacy_dataset):
 
     for pre_buffer in (True, False):
         dataset = pq.ParquetDataset(
-            dirpath, pre_buffer=pre_buffer,
-            use_legacy_dataset=use_legacy_dataset)
+            dirpath, pre_buffer=pre_buffer)
         assert dataset.read().equals(table)
-        actual = pq.read_table(dirpath, pre_buffer=pre_buffer,
-                               use_legacy_dataset=use_legacy_dataset)
+        actual = pq.read_table(dirpath, pre_buffer=pre_buffer)
         assert actual.equals(table)
 
 
@@ -1123,18 +862,15 @@ def _make_example_multifile_dataset(base_path, nfiles=10, file_nrows=5):
     return paths
 
 
-def _assert_dataset_paths(dataset, paths, use_legacy_dataset):
-    if use_legacy_dataset:
-        assert set(map(str, paths)) == {x.path for x in dataset._pieces}
-    else:
-        paths = [str(path.as_posix()) for path in paths]
-        assert set(paths) == set(dataset._dataset.files)
+def _assert_dataset_paths(dataset, paths):
+    paths = [str(path.as_posix()) for path in paths]
+    assert set(paths) == set(dataset._dataset.files)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @pytest.mark.parametrize('dir_prefix', ['_', '.'])
-def test_ignore_private_directories(tempdir, dir_prefix, use_legacy_dataset):
+def test_ignore_private_directories(tempdir, dir_prefix):
     dirpath = tempdir / guid()
     dirpath.mkdir()
 
@@ -1144,14 +880,14 @@ def test_ignore_private_directories(tempdir, dir_prefix, use_legacy_dataset):
     # private directory
     (dirpath / '{}staging'.format(dir_prefix)).mkdir()
 
-    dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(dirpath)
 
-    _assert_dataset_paths(dataset, paths, use_legacy_dataset)
+    _assert_dataset_paths(dataset, paths)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_ignore_hidden_files_dot(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_ignore_hidden_files_dot(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
 
@@ -1164,14 +900,14 @@ def test_ignore_hidden_files_dot(tempdir, use_legacy_dataset):
     with (dirpath / '.private').open('wb') as f:
         f.write(b'gibberish')
 
-    dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(dirpath)
 
-    _assert_dataset_paths(dataset, paths, use_legacy_dataset)
+    _assert_dataset_paths(dataset, paths)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_ignore_hidden_files_underscore(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_ignore_hidden_files_underscore(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
 
@@ -1184,17 +920,15 @@ def test_ignore_hidden_files_underscore(tempdir, use_legacy_dataset):
     with (dirpath / '_started_321').open('wb') as f:
         f.write(b'abcd')
 
-    dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(dirpath)
 
-    _assert_dataset_paths(dataset, paths, use_legacy_dataset)
+    _assert_dataset_paths(dataset, paths)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @pytest.mark.parametrize('dir_prefix', ['_', '.'])
-def test_ignore_no_private_directories_in_base_path(
-    tempdir, dir_prefix, use_legacy_dataset
-):
+def test_ignore_no_private_directories_in_base_path(tempdir, dir_prefix):
     # ARROW-8427 - don't ignore explicitly listed files if parent directory
     # is a private directory
     dirpath = tempdir / "{0}data".format(dir_prefix) / guid()
@@ -1203,17 +937,17 @@ def test_ignore_no_private_directories_in_base_path(
     paths = _make_example_multifile_dataset(dirpath, nfiles=10,
                                             file_nrows=5)
 
-    dataset = pq.ParquetDataset(paths, use_legacy_dataset=use_legacy_dataset)
-    _assert_dataset_paths(dataset, paths, use_legacy_dataset)
+    dataset = pq.ParquetDataset(paths)
+    _assert_dataset_paths(dataset, paths)
 
     # ARROW-9644 - don't ignore full directory with underscore in base path
-    dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
-    _assert_dataset_paths(dataset, paths, use_legacy_dataset)
+    dataset = pq.ParquetDataset(dirpath)
+    _assert_dataset_paths(dataset, paths)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset_fixed
-def test_ignore_custom_prefixes(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_ignore_custom_prefixes(tempdir):
     # ARROW-9573 - allow override of default ignore_prefixes
     part = ["xxx"] * 3 + ["yyy"] * 3
     table = pa.table([
@@ -1221,7 +955,6 @@ def test_ignore_custom_prefixes(tempdir, use_legacy_dataset):
         pa.array(part).dictionary_encode(),
     ], names=['index', '_part'])
 
-    # TODO use_legacy_dataset ARROW-10247
     pq.write_to_dataset(table, str(tempdir), partition_cols=['_part'])
 
     private_duplicate = tempdir / '_private_duplicate'
@@ -1230,32 +963,26 @@ def test_ignore_custom_prefixes(tempdir, use_legacy_dataset):
                         partition_cols=['_part'])
 
     read = pq.read_table(
-        tempdir, use_legacy_dataset=use_legacy_dataset,
-        ignore_prefixes=['_private'])
+        tempdir, ignore_prefixes=['_private'])
 
     assert read.equals(table)
 
 
-@parametrize_legacy_dataset_fixed
-def test_empty_directory(tempdir, use_legacy_dataset):
-    # ARROW-5310 - reading empty directory
-    # fails with legacy implementation
+@pytest.mark.dataset
+def test_empty_directory(tempdir):
     empty_dir = tempdir / 'dataset'
     empty_dir.mkdir()
 
-    dataset = pq.ParquetDataset(
-        empty_dir, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(empty_dir)
     result = dataset.read()
     assert result.num_rows == 0
     assert result.num_columns == 0
 
 
-@pytest.mark.filterwarnings("ignore:'ParquetDataset.schema:FutureWarning")
 def _test_write_to_dataset_with_partitions(base_path,
-                                           use_legacy_dataset=True,
                                            filesystem=None,
                                            schema=None,
-                                           index_name=None):
+                                                                                      index_name=None):
     import pandas as pd
     import pandas.testing as tm
 
@@ -1275,8 +1002,7 @@ def _test_write_to_dataset_with_partitions(base_path,
     output_table = pa.Table.from_pandas(output_df, schema=schema, safe=False,
                                         preserve_index=False)
     pq.write_to_dataset(output_table, base_path, partition_by,
-                        filesystem=filesystem,
-                        use_legacy_dataset=use_legacy_dataset)
+                        filesystem=filesystem)
 
     metadata_path = os.path.join(str(base_path), '_common_metadata')
 
@@ -1290,15 +1016,10 @@ def _test_write_to_dataset_with_partitions(base_path,
     # partitioned dataset
     dataset = pq.ParquetDataset(base_path,
                                 filesystem=filesystem,
-                                validate_schema=True,
-                                use_legacy_dataset=use_legacy_dataset)
+                                validate_schema=True)
     # ARROW-2209: Ensure the dataset schema also includes the partition columns
-    if use_legacy_dataset:
-        with pytest.warns(FutureWarning, match="'ParquetDataset.schema'"):
-            dataset_cols = set(dataset.schema.to_arrow_schema().names)
-    else:
-        # NB schema property is an arrow and not parquet schema
-        dataset_cols = set(dataset.schema.names)
+    # NB schema property is an arrow and not parquet schema
+    dataset_cols = set(dataset.schema.names)
 
     assert dataset_cols == set(output_table.schema.names)
 
@@ -1323,7 +1044,6 @@ def _test_write_to_dataset_with_partitions(base_path,
 
 
 def _test_write_to_dataset_no_partitions(base_path,
-                                         use_legacy_dataset=True,
                                          filesystem=None):
     import pandas as pd
 
@@ -1347,7 +1067,6 @@ def _test_write_to_dataset_no_partitions(base_path,
     n = 5
     for i in range(n):
         pq.write_to_dataset(output_table, base_path,
-                            use_legacy_dataset=use_legacy_dataset,
                             filesystem=filesystem)
     output_files = [file for file in filesystem.ls(str(base_path))
                     if file.endswith(".parquet")]
@@ -1356,8 +1075,7 @@ def _test_write_to_dataset_no_partitions(base_path,
     # Deduplicated incoming DataFrame should match
     # original outgoing Dataframe
     input_table = pq.ParquetDataset(
-        base_path, filesystem=filesystem,
-        use_legacy_dataset=use_legacy_dataset
+        base_path, filesystem=filesystem
     ).read()
     input_df = input_table.to_pandas()
     input_df = input_df.drop_duplicates()
@@ -1366,128 +1084,77 @@ def _test_write_to_dataset_no_partitions(base_path,
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_with_partitions(tempdir, use_legacy_dataset):
-    _test_write_to_dataset_with_partitions(str(tempdir), use_legacy_dataset)
+@pytest.mark.dataset
+def test_write_to_dataset_with_partitions(tempdir):
+    _test_write_to_dataset_with_partitions(str(tempdir))
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_with_partitions_and_schema(
-    tempdir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_write_to_dataset_with_partitions_and_schema(tempdir):
     schema = pa.schema([pa.field('group1', type=pa.string()),
                         pa.field('group2', type=pa.string()),
                         pa.field('num', type=pa.int64()),
                         pa.field('nan', type=pa.int32()),
                         pa.field('date', type=pa.timestamp(unit='us'))])
     _test_write_to_dataset_with_partitions(
-        str(tempdir), use_legacy_dataset, schema=schema)
+        str(tempdir), schema=schema)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_with_partitions_and_index_name(
-    tempdir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_write_to_dataset_with_partitions_and_index_name(tempdir):
     _test_write_to_dataset_with_partitions(
-        str(tempdir), use_legacy_dataset, index_name='index_name')
+        str(tempdir), index_name='index_name')
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_no_partitions(tempdir, use_legacy_dataset):
-    _test_write_to_dataset_no_partitions(str(tempdir), use_legacy_dataset)
+@pytest.mark.dataset
+def test_write_to_dataset_no_partitions(tempdir):
+    _test_write_to_dataset_no_partitions(str(tempdir))
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_pathlib(tempdir, use_legacy_dataset):
-    _test_write_to_dataset_with_partitions(
-        tempdir / "test1", use_legacy_dataset)
-    _test_write_to_dataset_no_partitions(
-        tempdir / "test2", use_legacy_dataset)
+@pytest.mark.dataset
+def test_write_to_dataset_pathlib(tempdir):
+    _test_write_to_dataset_with_partitions(tempdir / "test1")
+    _test_write_to_dataset_no_partitions(tempdir / "test2")
 
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@parametrize_legacy_dataset
-def test_write_to_dataset_pathlib_nonlocal(
-    tempdir, s3_example_s3fs, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_write_to_dataset_pathlib_nonlocal(tempdir, s3_example_s3fs):
     # pathlib paths are only accepted for local files
     fs, _ = s3_example_s3fs
 
     with pytest.raises(TypeError, match="path-like objects are only allowed"):
         _test_write_to_dataset_with_partitions(
-            tempdir / "test1", use_legacy_dataset, filesystem=fs)
+            tempdir / "test1", filesystem=fs)
 
     with pytest.raises(TypeError, match="path-like objects are only allowed"):
         _test_write_to_dataset_no_partitions(
-            tempdir / "test2", use_legacy_dataset, filesystem=fs)
+            tempdir / "test2", filesystem=fs)
 
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@parametrize_legacy_dataset
-def test_write_to_dataset_with_partitions_s3fs(
-    s3_example_s3fs, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_write_to_dataset_with_partitions_s3fs(s3_example_s3fs):
     fs, path = s3_example_s3fs
 
     _test_write_to_dataset_with_partitions(
-        path, use_legacy_dataset, filesystem=fs)
+        path, filesystem=fs)
 
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@parametrize_legacy_dataset
-def test_write_to_dataset_no_partitions_s3fs(
-    s3_example_s3fs, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_write_to_dataset_no_partitions_s3fs(s3_example_s3fs):
     fs, path = s3_example_s3fs
 
     _test_write_to_dataset_no_partitions(
-        path, use_legacy_dataset, filesystem=fs)
-
-
-@pytest.mark.filterwarnings(
-    "ignore:'ParquetDataset:FutureWarning",
-    "ignore:'partition_filename_cb':FutureWarning")
-@pytest.mark.pandas
-@parametrize_legacy_dataset_not_supported
-def test_write_to_dataset_with_partitions_and_custom_filenames(
-    tempdir, use_legacy_dataset
-):
-    output_df = pd.DataFrame({'group1': list('aaabbbbccc'),
-                              'group2': list('eefeffgeee'),
-                              'num': list(range(10)),
-                              'nan': [np.nan] * 10,
-                              'date': np.arange('2017-01-01', '2017-01-11',
-                                                dtype='datetime64[D]')})
-    partition_by = ['group1', 'group2']
-    output_table = pa.Table.from_pandas(output_df)
-    path = str(tempdir)
-
-    def partition_filename_callback(keys):
-        return "{}-{}.parquet".format(*keys)
-
-    pq.write_to_dataset(output_table, path,
-                        partition_by, partition_filename_callback,
-                        use_legacy_dataset=use_legacy_dataset)
-
-    dataset = pq.ParquetDataset(path, use_legacy_dataset=use_legacy_dataset)
-
-    # ARROW-3538: Ensure partition filenames match the given pattern
-    # defined in the local function partition_filename_callback
-    expected_basenames = [
-        'a-e.parquet', 'a-f.parquet',
-        'b-e.parquet', 'b-f.parquet',
-        'b-g.parquet', 'c-e.parquet'
-    ]
-    output_basenames = [os.path.basename(p.path) for p in dataset.pieces]
-
-    assert sorted(expected_basenames) == sorted(output_basenames)
+        path, filesystem=fs)
 
 
 @pytest.mark.dataset
@@ -1502,7 +1169,7 @@ def test_write_to_dataset_filesystem(tempdir):
     assert result.equals(table)
 
 
-def _make_dataset_for_pickling(tempdir, use_legacy_dataset=False, N=100):
+def _make_dataset_for_pickling(tempdir, N=100):
     path = tempdir / 'data.parquet'
     fs = LocalFileSystem._get_instance()
 
@@ -1525,42 +1192,24 @@ def _make_dataset_for_pickling(tempdir, use_legacy_dataset=False, N=100):
         pq.write_metadata(table.schema, f)
 
     dataset = pq.ParquetDataset(
-        tempdir, filesystem=fs, use_legacy_dataset=use_legacy_dataset)
-    if use_legacy_dataset:
-        with pytest.warns(FutureWarning):
-            assert dataset.metadata_path == str(metadata_path)
+        tempdir, filesystem=fs)
 
     return dataset
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pickle_dataset(tempdir, datadir, use_legacy_dataset, pickle_module):
+@pytest.mark.dataset
+def test_pickle_dataset(tempdir, pickle_module):
     def is_pickleable(obj):
         return obj == pickle_module.loads(pickle_module.dumps(obj))
 
-    dataset = _make_dataset_for_pickling(tempdir, use_legacy_dataset)
+    dataset = _make_dataset_for_pickling(tempdir)
     assert is_pickleable(dataset)
-    if use_legacy_dataset:
-        with pytest.warns(FutureWarning):
-            metadata = dataset.metadata
-        assert is_pickleable(metadata)
-        assert is_pickleable(metadata.schema)
-        assert len(metadata.schema)
-        for column in metadata.schema:
-            assert is_pickleable(column)
-
-        for piece in dataset._pieces:
-            assert is_pickleable(piece)
-            metadata = piece.get_metadata()
-            assert metadata.num_row_groups
-            for i in range(metadata.num_row_groups):
-                assert is_pickleable(metadata.row_group(i))
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_partitioned_dataset(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_partitioned_dataset(tempdir):
     # ARROW-3208: Segmentation fault when reading a Parquet partitioned dataset
     # to a Parquet file
     path = tempdir / "ARROW-3208"
@@ -1571,27 +1220,22 @@ def test_partitioned_dataset(tempdir, use_legacy_dataset):
     })
     table = pa.Table.from_pandas(df)
     pq.write_to_dataset(table, root_path=str(path),
-                        partition_cols=['one', 'two'],
-                        use_legacy_dataset=use_legacy_dataset)
-    table = pq.ParquetDataset(
-        path, use_legacy_dataset=use_legacy_dataset).read()
+                        partition_cols=['one', 'two'])
+    table = pq.ParquetDataset(path).read()
     pq.write_table(table, path / "output.parquet")
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_dataset_read_dictionary(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_dataset_read_dictionary(tempdir):
     path = tempdir / "ARROW-3325-dataset"
     t1 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
     t2 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
-    pq.write_to_dataset(t1, root_path=str(path),
-                        use_legacy_dataset=use_legacy_dataset)
-    pq.write_to_dataset(t2, root_path=str(path),
-                        use_legacy_dataset=use_legacy_dataset)
+    pq.write_to_dataset(t1, root_path=str(path))
+    pq.write_to_dataset(t2, root_path=str(path))
 
     result = pq.ParquetDataset(
-        path, read_dictionary=['f0'],
-        use_legacy_dataset=use_legacy_dataset).read()
+        path, read_dictionary=['f0']).read()
 
     # The order of the chunks is non-deterministic
     ex_chunks = [t1[0].chunk(0).dictionary_encode(),
@@ -1608,7 +1252,6 @@ def test_dataset_read_dictionary(tempdir, use_legacy_dataset):
 
 @pytest.mark.dataset
 @pytest.mark.pandas
-@pytest.mark.filterwarnings("ignore:Passing 'use_legacy:FutureWarning")
 def test_read_table_schema(tempdir):
     # test that schema keyword is passed through in read_table
     table = pa.table({'a': pa.array([1, 2, 3], pa.int32())})
@@ -1627,17 +1270,7 @@ def test_read_table_schema(tempdir):
     expected = pa.table({'a': [1, 2, 3, 1, 2, 3]}, schema=schema)
     assert result.equals(expected)
 
-    # don't allow it with the legacy reader
-    with pytest.raises(
-        ValueError, match="The 'schema' argument is only supported"
-    ):
-        pq.read_table(tempdir / "data.parquet", schema=schema,
-                      use_legacy_dataset=True)
-
-    # using ParquetDataset directory with non-legacy implementation
-    result = pq.ParquetDataset(
-        tempdir, schema=schema, use_legacy_dataset=False
-    )
+    result = pq.ParquetDataset(tempdir, schema=schema)
     expected = pa.table({'a': [1, 2, 3, 1, 2, 3]}, schema=schema)
     assert result.read().equals(expected)
 
@@ -1646,23 +1279,22 @@ def test_read_table_schema(tempdir):
 def test_dataset_unsupported_keywords():
 
     with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", use_legacy_dataset=False, metadata=pa.schema([]))
+        pq.ParquetDataset("", metadata=pa.schema([]))
 
     with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", use_legacy_dataset=False, validate_schema=False)
+        pq.ParquetDataset("", validate_schema=False)
 
     with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", use_legacy_dataset=False, split_row_groups=True)
+        pq.ParquetDataset("", split_row_groups=True)
 
     with pytest.raises(ValueError, match="not yet supported with the new"):
-        pq.ParquetDataset("", use_legacy_dataset=False, metadata_nthreads=4)
+        pq.ParquetDataset("", metadata_nthreads=4)
 
     with pytest.raises(ValueError, match="no longer supported"):
-        pq.read_table("", use_legacy_dataset=False, metadata=pa.schema([]))
+        pq.read_table("", metadata=pa.schema([]))
 
 
 @pytest.mark.dataset
-@pytest.mark.filterwarnings("ignore:Passing 'use_legacy:FutureWarning")
 def test_dataset_partitioning(tempdir):
     import pyarrow.dataset as ds
 
@@ -1679,42 +1311,27 @@ def test_dataset_partitioning(tempdir):
     # read_table
     part = ds.partitioning(field_names=["year", "month", "day"])
     result = pq.read_table(
-        str(root_path), partitioning=part, use_legacy_dataset=False)
+        str(root_path), partitioning=part)
     assert result.column_names == ["a", "year", "month", "day"]
 
     result = pq.ParquetDataset(
-        str(root_path), partitioning=part, use_legacy_dataset=False).read()
+        str(root_path), partitioning=part).read()
     assert result.column_names == ["a", "year", "month", "day"]
-
-    # This raises an error for legacy dataset
-    with pytest.raises(ValueError):
-        pq.read_table(
-            str(root_path), partitioning=part, use_legacy_dataset=True)
-
-    with pytest.raises(ValueError):
-        pq.ParquetDataset(
-            str(root_path), partitioning=part, use_legacy_dataset=True)
 
 
 @pytest.mark.dataset
 def test_parquet_dataset_new_filesystem(tempdir):
     # Ensure we can pass new FileSystem object to ParquetDataset
-    # (use new implementation automatically without specifying
-    #  use_legacy_dataset=False)
     table = pa.table({'a': [1, 2, 3]})
     pq.write_table(table, tempdir / 'data.parquet')
-    # don't use simple LocalFileSystem (as that gets mapped to legacy one)
     filesystem = fs.SubTreeFileSystem(str(tempdir), fs.LocalFileSystem())
     dataset = pq.ParquetDataset('.', filesystem=filesystem)
     result = dataset.read()
     assert result.equals(table)
 
 
-@pytest.mark.filterwarnings("ignore:'ParquetDataset:FutureWarning")
-@parametrize_legacy_dataset
-def test_parquet_dataset_partitions_piece_path_with_fsspec(
-    tempdir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_parquet_dataset_partitions_piece_path_with_fsspec(tempdir):
     # ARROW-10462 ensure that on Windows we properly use posix-style paths
     # as used by fsspec
     fsspec = pytest.importorskip("fsspec")
@@ -1725,106 +1342,10 @@ def test_parquet_dataset_partitions_piece_path_with_fsspec(
     # pass a posix-style path (using "/" also on Windows)
     path = str(tempdir).replace("\\", "/")
     dataset = pq.ParquetDataset(
-        path, filesystem=filesystem, use_legacy_dataset=use_legacy_dataset)
+        path, filesystem=filesystem)
     # ensure the piece path is also posix-style
     expected = path + "/data.parquet"
     assert dataset.pieces[0].path == expected
-
-
-@pytest.mark.dataset
-def test_parquet_dataset_deprecated_properties(tempdir):
-    table = pa.table({'a': [1, 2, 3]})
-    path = tempdir / 'data.parquet'
-    pq.write_table(table, path)
-    dataset = pq.ParquetDataset(path, use_legacy_dataset=True)
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.pieces"):
-        dataset.pieces
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.partitions"):
-        dataset.partitions
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.memory_map"):
-        dataset.memory_map
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.read_dictio"):
-        dataset.read_dictionary
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.buffer_size"):
-        dataset.buffer_size
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.fs"):
-        dataset.fs
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.schema'"):
-        dataset.schema
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.common_metadata'"):
-        dataset.common_metadata
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.metadata"):
-        dataset.metadata
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.metadata_path"):
-        dataset.metadata_path
-
-    with pytest.warns(FutureWarning,
-                      match="'ParquetDataset.common_metadata_path"):
-        dataset.common_metadata_path
-
-    dataset2 = pq.ParquetDataset(path, use_legacy_dataset=False)
-
-    with pytest.warns(FutureWarning, match="'ParquetDataset.pieces"):
-        dataset2.pieces
-
-
-@pytest.mark.dataset
-def test_parquet_write_to_dataset_deprecated_properties(tempdir):
-    table = pa.table({'a': [1, 2, 3]})
-    path = tempdir / 'data.parquet'
-
-    with pytest.warns(FutureWarning,
-                      match="Passing 'use_legacy_dataset=True'"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True)
-
-    # check also that legacy implementation is set when
-    # partition_filename_cb is specified
-    with pytest.warns(FutureWarning,
-                      match="Passing 'use_legacy_dataset=True'"):
-        pq.write_to_dataset(table, path,
-                            partition_filename_cb=lambda x: 'filename.parquet')
-
-
-@pytest.mark.dataset
-def test_parquet_write_to_dataset_unsupported_keywords_in_legacy(tempdir):
-    table = pa.table({'a': [1, 2, 3]})
-    path = tempdir / 'data.parquet'
-
-    with pytest.raises(ValueError, match="schema"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            schema=pa.schema([
-                                ('a', pa.int32())
-                            ]))
-
-    with pytest.raises(ValueError, match="partitioning"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            partitioning=["a"])
-
-    with pytest.raises(ValueError, match="use_threads"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            use_threads=False)
-
-    with pytest.raises(ValueError, match="file_visitor"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            file_visitor=lambda x: x)
-
-    with pytest.raises(ValueError, match="existing_data_behavior"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            existing_data_behavior='error')
-
-    with pytest.raises(ValueError, match="basename_template"):
-        pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                            basename_template='part-{i}.parquet')
 
 
 @pytest.mark.dataset
@@ -1841,8 +1362,7 @@ def test_parquet_write_to_dataset_exposed_keywords(tempdir):
 
     pq.write_to_dataset(table, path, partitioning=["a"],
                         file_visitor=file_visitor,
-                        basename_template=basename_template,
-                        use_legacy_dataset=False)
+                        basename_template=basename_template)
 
     expected_paths = {
         path / '1' / 'part-0.parquet',
@@ -1851,52 +1371,6 @@ def test_parquet_write_to_dataset_exposed_keywords(tempdir):
     }
     paths_written_set = set(map(pathlib.Path, paths_written))
     assert paths_written_set == expected_paths
-
-
-@pytest.mark.dataset
-def test_write_to_dataset_conflicting_keywords(tempdir):
-    table = pa.table({'a': [1, 2, 3]})
-    path = tempdir / 'data.parquet'
-
-    with pytest.raises(ValueError, match="'basename_template' argument "
-                       "is not supported by use_legacy_dataset=True"):
-        pq.write_to_dataset(table, path,
-                            use_legacy_dataset=True,
-                            partition_filename_cb=lambda x: 'filename.parquet',
-                            basename_template='file-{i}.parquet')
-    with pytest.raises(ValueError, match="'partition_filename_cb' argument "
-                       "is not supported by use_legacy_dataset=False"):
-        pq.write_to_dataset(table, path,
-                            use_legacy_dataset=False,
-                            partition_filename_cb=lambda x: 'filename.parquet',
-                            basename_template='file-{i}.parquet')
-
-    with pytest.raises(ValueError, match="'partitioning' argument "
-                       "is not supported by use_legacy_dataset=True"):
-        pq.write_to_dataset(table, path,
-                            use_legacy_dataset=True,
-                            partition_cols=["a"],
-                            partitioning=["a"])
-
-    with pytest.raises(ValueError, match="'partition_cols' argument "
-                       "is not supported by use_legacy_dataset=False"):
-        pq.write_to_dataset(table, path,
-                            use_legacy_dataset=False,
-                            partition_cols=["a"],
-                            partitioning=["a"])
-
-    with pytest.raises(ValueError, match="'file_visitor' argument "
-                       "is not supported by use_legacy_dataset=True"):
-        pq.write_to_dataset(table, path,
-                            use_legacy_dataset=True,
-                            metadata_collector=[],
-                            file_visitor=lambda x: x)
-    with pytest.raises(ValueError, match="'metadata_collector' argument "
-                       "is not supported by use_legacy_dataset=False"):
-        pq.write_to_dataset(table, path,
-                            use_legacy_dataset=False,
-                            metadata_collector=[],
-                            file_visitor=lambda x: x)
 
 
 @pytest.mark.dataset
@@ -1926,8 +1400,8 @@ def test_write_to_dataset_kwargs_passed(tempdir, write_dataset_kwarg):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_category_observed(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_write_to_dataset_category_observed(tempdir):
     # if we partition on a categorical variable with "unobserved" categories
     # (values present in the dictionary, but not in the actual data)
     # ensure those are not creating empty files/directories
@@ -1938,8 +1412,7 @@ def test_write_to_dataset_category_observed(tempdir, use_legacy_dataset):
     table = pa.table(df)
     path = tempdir / "dataset"
     pq.write_to_dataset(
-        table, tempdir / "dataset", partition_cols=["cat"],
-        use_legacy_dataset=use_legacy_dataset
+        table, tempdir / "dataset", partition_cols=["cat"]
     )
     subdirs = [f.name for f in path.iterdir() if f.is_dir()]
     assert len(subdirs) == 2

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -50,10 +50,9 @@ except ImportError:
 
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not parquet'
-pytestmark = pytest.mark.parquet
+pytestmark = [pytest.mark.parquet, pytest.mark.dataset]
 
 
-@pytest.mark.dataset
 def test_filesystem_uri(tempdir):
     table = pa.table({"a": [1, 2, 3]})
 
@@ -74,14 +73,12 @@ def test_filesystem_uri(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_read_partitioned_directory(tempdir):
     fs = LocalFileSystem._get_instance()
     _partition_test_for_filesystem(fs, tempdir)
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_read_partitioned_columns_selection(tempdir):
     # ARROW-3861 - do not include partition columns in resulting table when
     # `columns` keyword was passed without those columns
@@ -95,7 +92,6 @@ def test_read_partitioned_columns_selection(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filters_equivalency(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
@@ -167,7 +163,6 @@ def test_filters_equivalency(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filters_cutoff_exclusive_integer(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
@@ -207,7 +202,6 @@ def test_filters_cutoff_exclusive_integer(tempdir):
     raises=(TypeError, AssertionError),
     reason='Loss of type information in creation of categoricals.'
 )
-@pytest.mark.dataset
 @pytest.mark.pandas
 def test_filters_cutoff_exclusive_datetime(tempdir):
     fs = LocalFileSystem._get_instance()
@@ -252,7 +246,6 @@ def test_filters_cutoff_exclusive_datetime(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filters_inclusive_datetime(tempdir):
     # ARROW-11480
     path = tempdir / 'timestamps.parquet'
@@ -270,7 +263,6 @@ def test_filters_inclusive_datetime(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filters_inclusive_integer(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
@@ -305,7 +297,6 @@ def test_filters_inclusive_integer(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filters_inclusive_set(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
@@ -353,7 +344,6 @@ def test_filters_inclusive_set(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filters_invalid_pred_op(tempdir):
     fs = LocalFileSystem._get_instance()
     base_path = tempdir
@@ -395,7 +385,6 @@ def test_filters_invalid_pred_op(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filters_invalid_column(tempdir):
     # ARROW-5572 - raise error on invalid name in filter specification
     # works with new dataset
@@ -420,7 +409,6 @@ def test_filters_invalid_column(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 @pytest.mark.parametrize("filters",
                          ([('integers', '<', 3)],
                           [[('integers', '<', 3)]],
@@ -455,7 +443,6 @@ def test_filters_read_table(tempdir, filters, read_method):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_partition_keys_with_underscores(tempdir):
     # ARROW-5666 - partition field values with underscores preserve underscores
     fs = LocalFileSystem._get_instance()
@@ -480,7 +467,6 @@ def test_partition_keys_with_underscores(tempdir):
 
 
 @pytest.mark.s3
-@pytest.mark.dataset
 def test_read_s3fs(s3_example_s3fs, ):
     fs, path = s3_example_s3fs
     path = path + "/test.parquet"
@@ -492,7 +478,6 @@ def test_read_s3fs(s3_example_s3fs, ):
 
 
 @pytest.mark.s3
-@pytest.mark.dataset
 def test_read_directory_s3fs(s3_example_s3fs):
     fs, directory = s3_example_s3fs
     path = directory + "/test.parquet"
@@ -504,7 +489,6 @@ def test_read_directory_s3fs(s3_example_s3fs):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_read_single_file_list(tempdir):
     data_path = str(tempdir / 'data.parquet')
 
@@ -517,7 +501,6 @@ def test_read_single_file_list(tempdir):
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@pytest.mark.dataset
 def test_read_partitioned_directory_s3fs_wrapper(s3_example_s3fs):
     import s3fs
 
@@ -538,7 +521,6 @@ def test_read_partitioned_directory_s3fs_wrapper(s3_example_s3fs):
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@pytest.mark.dataset
 def test_read_partitioned_directory_s3fs(s3_example_s3fs):
     fs, path = s3_example_s3fs
     _partition_test_for_filesystem(fs, path)
@@ -640,7 +622,6 @@ def _filter_partition(df, part_keys):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_filter_before_validate_schema(tempdir):
     # ARROW-4076 apply filter before schema validation
     # to avoid checking unneeded schemas
@@ -663,7 +644,6 @@ def test_filter_before_validate_schema(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_read_multiple_files(tempdir):
     nfiles = 10
     size = 5
@@ -742,7 +722,6 @@ def test_read_multiple_files(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_dataset_read_pandas(tempdir):
     nfiles = 5
     size = 5
@@ -781,7 +760,6 @@ def test_dataset_read_pandas(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_dataset_memory_map(tempdir):
     # ARROW-2627: Check that we can use ParquetDataset with memory-mapping
     dirpath = tempdir / guid()
@@ -798,7 +776,6 @@ def test_dataset_memory_map(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_dataset_enable_buffered_stream(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
@@ -819,7 +796,6 @@ def test_dataset_enable_buffered_stream(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_dataset_enable_pre_buffer(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
@@ -855,7 +831,6 @@ def _assert_dataset_paths(dataset, paths):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 @pytest.mark.parametrize('dir_prefix', ['_', '.'])
 def test_ignore_private_directories(tempdir, dir_prefix):
     dirpath = tempdir / guid()
@@ -873,7 +848,6 @@ def test_ignore_private_directories(tempdir, dir_prefix):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_ignore_hidden_files_dot(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
@@ -893,7 +867,6 @@ def test_ignore_hidden_files_dot(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_ignore_hidden_files_underscore(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
@@ -913,7 +886,6 @@ def test_ignore_hidden_files_underscore(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 @pytest.mark.parametrize('dir_prefix', ['_', '.'])
 def test_ignore_no_private_directories_in_base_path(tempdir, dir_prefix):
     # ARROW-8427 - don't ignore explicitly listed files if parent directory
@@ -933,7 +905,6 @@ def test_ignore_no_private_directories_in_base_path(tempdir, dir_prefix):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_ignore_custom_prefixes(tempdir):
     # ARROW-9573 - allow override of default ignore_prefixes
     part = ["xxx"] * 3 + ["yyy"] * 3
@@ -955,7 +926,6 @@ def test_ignore_custom_prefixes(tempdir):
     assert read.equals(table)
 
 
-@pytest.mark.dataset
 def test_empty_directory(tempdir):
     empty_dir = tempdir / 'dataset'
     empty_dir.mkdir()
@@ -1071,13 +1041,11 @@ def _test_write_to_dataset_no_partitions(base_path,
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_with_partitions(tempdir):
     _test_write_to_dataset_with_partitions(str(tempdir))
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_with_partitions_and_schema(tempdir):
     schema = pa.schema([pa.field('group1', type=pa.string()),
                         pa.field('group2', type=pa.string()),
@@ -1089,20 +1057,17 @@ def test_write_to_dataset_with_partitions_and_schema(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_with_partitions_and_index_name(tempdir):
     _test_write_to_dataset_with_partitions(
         str(tempdir), index_name='index_name')
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_no_partitions(tempdir):
     _test_write_to_dataset_no_partitions(str(tempdir))
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_pathlib(tempdir):
     _test_write_to_dataset_with_partitions(tempdir / "test1")
     _test_write_to_dataset_no_partitions(tempdir / "test2")
@@ -1110,7 +1075,6 @@ def test_write_to_dataset_pathlib(tempdir):
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@pytest.mark.dataset
 def test_write_to_dataset_pathlib_nonlocal(tempdir, s3_example_s3fs):
     # pathlib paths are only accepted for local files
     fs, _ = s3_example_s3fs
@@ -1126,7 +1090,6 @@ def test_write_to_dataset_pathlib_nonlocal(tempdir, s3_example_s3fs):
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@pytest.mark.dataset
 def test_write_to_dataset_with_partitions_s3fs(s3_example_s3fs):
     fs, path = s3_example_s3fs
 
@@ -1136,7 +1099,6 @@ def test_write_to_dataset_with_partitions_s3fs(s3_example_s3fs):
 
 @pytest.mark.pandas
 @pytest.mark.s3
-@pytest.mark.dataset
 def test_write_to_dataset_no_partitions_s3fs(s3_example_s3fs):
     fs, path = s3_example_s3fs
 
@@ -1144,7 +1106,6 @@ def test_write_to_dataset_no_partitions_s3fs(s3_example_s3fs):
         path, filesystem=fs)
 
 
-@pytest.mark.dataset
 @pytest.mark.pandas
 def test_write_to_dataset_filesystem(tempdir):
     df = pd.DataFrame({'A': [1, 2, 3]})
@@ -1185,7 +1146,6 @@ def _make_dataset_for_pickling(tempdir, N=100):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pickle_dataset(tempdir, pickle_module):
     def is_pickleable(obj):
         return obj == pickle_module.loads(pickle_module.dumps(obj))
@@ -1195,7 +1155,6 @@ def test_pickle_dataset(tempdir, pickle_module):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_partitioned_dataset(tempdir):
     # ARROW-3208: Segmentation fault when reading a Parquet partitioned dataset
     # to a Parquet file
@@ -1213,7 +1172,6 @@ def test_partitioned_dataset(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_dataset_read_dictionary(tempdir):
     path = tempdir / "ARROW-3325-dataset"
     t1 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
@@ -1237,7 +1195,6 @@ def test_dataset_read_dictionary(tempdir):
         assert c1.equals(ex_chunks[0])
 
 
-@pytest.mark.dataset
 @pytest.mark.pandas
 def test_read_table_schema(tempdir):
     # test that schema keyword is passed through in read_table
@@ -1262,7 +1219,6 @@ def test_read_table_schema(tempdir):
     assert result.read().equals(expected)
 
 
-@pytest.mark.dataset
 def test_dataset_unsupported_keywords():
 
     with pytest.raises(ValueError, match="not yet supported with the new"):
@@ -1281,7 +1237,6 @@ def test_dataset_unsupported_keywords():
         pq.read_table("", metadata=pa.schema([]))
 
 
-@pytest.mark.dataset
 def test_dataset_partitioning(tempdir):
     import pyarrow.dataset as ds
 
@@ -1306,7 +1261,6 @@ def test_dataset_partitioning(tempdir):
     assert result.column_names == ["a", "year", "month", "day"]
 
 
-@pytest.mark.dataset
 def test_parquet_dataset_new_filesystem(tempdir):
     # Ensure we can pass new FileSystem object to ParquetDataset
     table = pa.table({'a': [1, 2, 3]})
@@ -1317,7 +1271,6 @@ def test_parquet_dataset_new_filesystem(tempdir):
     assert result.equals(table)
 
 
-@pytest.mark.dataset
 def test_parquet_dataset_partitions_piece_path_with_fsspec(tempdir):
     # ARROW-10462 ensure that on Windows we properly use posix-style paths
     # as used by fsspec
@@ -1335,7 +1288,6 @@ def test_parquet_dataset_partitions_piece_path_with_fsspec(tempdir):
     assert dataset.fragments[0].path == expected
 
 
-@pytest.mark.dataset
 def test_parquet_write_to_dataset_exposed_keywords(tempdir):
     table = pa.table({'a': [1, 2, 3]})
     path = tempdir / 'partitioning'
@@ -1360,7 +1312,6 @@ def test_parquet_write_to_dataset_exposed_keywords(tempdir):
     assert paths_written_set == expected_paths
 
 
-@pytest.mark.dataset
 @pytest.mark.parametrize("write_dataset_kwarg", (
     ("create_dir", True),
     ("create_dir", False),
@@ -1387,7 +1338,6 @@ def test_write_to_dataset_kwargs_passed(tempdir, write_dataset_kwarg):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_category_observed(tempdir):
     # if we partition on a categorical variable with "unobserved" categories
     # (values present in the dictionary, but not in the actual data)

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -584,7 +584,6 @@ def _partition_test_for_filesystem(fs, base_path):
                    .reset_index(drop=True)
                    .reindex(columns=result_df.columns))
 
-
     # With pandas 2.0.0 Index can store all numeric dtypes (not just
     # int64/uint64/float64). Using astype() to create a categorical
     # column preserves original dtype (int32)
@@ -982,7 +981,7 @@ def test_empty_directory(tempdir):
 def _test_write_to_dataset_with_partitions(base_path,
                                            filesystem=None,
                                            schema=None,
-                                                                                      index_name=None):
+                                           index_name=None):
     import pandas as pd
     import pandas.testing as tm
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1345,7 +1345,7 @@ def test_parquet_dataset_partitions_piece_path_with_fsspec(tempdir):
         path, filesystem=filesystem)
     # ensure the piece path is also posix-style
     expected = path + "/data.parquet"
-    assert dataset.pieces[0].path == expected
+    assert dataset.fragments[0].path == expected
 
 
 @pytest.mark.dataset

--- a/python/pyarrow/tests/parquet/test_datetime.py
+++ b/python/pyarrow/tests/parquet/test_datetime.py
@@ -47,7 +47,6 @@ pytestmark = pytest.mark.parquet
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pandas_parquet_datetime_tz():
     # Pandas v2 defaults to [ns], but Arrow defaults to [us] time units
     # so we need to cast the pandas dtype. Pandas v1 will always silently
@@ -75,7 +74,6 @@ def test_pandas_parquet_datetime_tz():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_datetime_timezone_tzinfo():
     value = datetime.datetime(2018, 1, 1, 1, 23, 45,
                               tzinfo=datetime.timezone.utc)

--- a/python/pyarrow/tests/parquet/test_datetime.py
+++ b/python/pyarrow/tests/parquet/test_datetime.py
@@ -23,8 +23,7 @@ import numpy as np
 import pytest
 
 import pyarrow as pa
-from pyarrow.tests.parquet.common import (
-    _check_roundtrip, parametrize_legacy_dataset)
+from pyarrow.tests.parquet.common import _check_roundtrip
 
 try:
     import pyarrow.parquet as pq
@@ -48,8 +47,8 @@ pytestmark = pytest.mark.parquet
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_parquet_datetime_tz(use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_parquet_datetime_tz():
     # Pandas v2 defaults to [ns], but Arrow defaults to [us] time units
     # so we need to cast the pandas dtype. Pandas v1 will always silently
     # coerce to [ns] due to lack of non-[ns] support.
@@ -69,21 +68,20 @@ def test_pandas_parquet_datetime_tz(use_legacy_dataset):
     _write_table(arrow_table, f)
     f.seek(0)
 
-    table_read = pq.read_pandas(f, use_legacy_dataset=use_legacy_dataset)
+    table_read = pq.read_pandas(f)
 
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_datetime_timezone_tzinfo(use_legacy_dataset):
+@pytest.mark.dataset
+def test_datetime_timezone_tzinfo():
     value = datetime.datetime(2018, 1, 1, 1, 23, 45,
                               tzinfo=datetime.timezone.utc)
     df = pd.DataFrame({'foo': [value]})
 
-    _roundtrip_pandas_dataframe(
-        df, write_kwargs={}, use_legacy_dataset=use_legacy_dataset)
+    _roundtrip_pandas_dataframe(df, write_kwargs={})
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -23,8 +23,6 @@ import pytest
 
 import pyarrow as pa
 from pyarrow.fs import LocalFileSystem, SubTreeFileSystem
-from pyarrow.tests.parquet.common import (
-    parametrize_legacy_dataset, parametrize_legacy_dataset_not_supported)
 from pyarrow.util import guid
 from pyarrow.vendored.version import Version
 
@@ -101,8 +99,8 @@ def test_merging_parquet_tables_with_different_pandas_metadata(tempdir):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_parquet_column_multiindex(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_parquet_column_multiindex(tempdir):
     df = alltypes_sample(size=10)
     df.columns = pd.MultiIndex.from_tuples(
         list(zip(df.columns, df.columns[::-1])),
@@ -115,17 +113,14 @@ def test_pandas_parquet_column_multiindex(tempdir, use_legacy_dataset):
 
     _write_table(arrow_table, filename)
 
-    table_read = pq.read_pandas(
-        filename, use_legacy_dataset=use_legacy_dataset)
+    table_read = pq.read_pandas(filename)
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(
-    tempdir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(tempdir):
     df = alltypes_sample(size=10000)
 
     filename = tempdir / 'pandas_roundtrip.parquet'
@@ -137,8 +132,7 @@ def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(
     assert js['columns']
 
     _write_table(arrow_table, filename)
-    table_read = pq.read_pandas(
-        filename, use_legacy_dataset=use_legacy_dataset)
+    table_read = pq.read_pandas(filename)
 
     js = table_read.schema.pandas_metadata
     assert not js['index_columns']
@@ -150,52 +144,22 @@ def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(
     tm.assert_frame_equal(df, df_read)
 
 
-# TODO(dataset) duplicate column selection actually gives duplicate columns now
 @pytest.mark.pandas
-@parametrize_legacy_dataset_not_supported
-def test_pandas_column_selection(tempdir, use_legacy_dataset):
-    size = 10000
-    np.random.seed(0)
-    df = pd.DataFrame({
-        'uint8': np.arange(size, dtype=np.uint8),
-        'uint16': np.arange(size, dtype=np.uint16)
-    })
-    filename = tempdir / 'pandas_roundtrip.parquet'
-    arrow_table = pa.Table.from_pandas(df)
-    _write_table(arrow_table, filename)
-    table_read = _read_table(
-        filename, columns=['uint8'], use_legacy_dataset=use_legacy_dataset)
-    df_read = table_read.to_pandas()
-
-    tm.assert_frame_equal(df[['uint8']], df_read)
-
-    # ARROW-4267: Selection of duplicate columns still leads to these columns
-    # being read uniquely.
-    table_read = _read_table(
-        filename, columns=['uint8', 'uint8'],
-        use_legacy_dataset=use_legacy_dataset)
-    df_read = table_read.to_pandas()
-
-    tm.assert_frame_equal(df[['uint8']], df_read)
-
-
-@pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_parquet_native_file_roundtrip(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_parquet_native_file_roundtrip(tempdir):
     df = _test_dataframe(10000)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
     _write_table(arrow_table, imos, version='2.6')
     buf = imos.getvalue()
     reader = pa.BufferReader(buf)
-    df_read = _read_table(
-        reader, use_legacy_dataset=use_legacy_dataset).to_pandas()
+    df_read = _read_table(reader).to_pandas()
     tm.assert_frame_equal(df, df_read)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_read_pandas_column_subset(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_read_pandas_column_subset(tempdir):
     df = _test_dataframe(10000)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
@@ -204,22 +168,20 @@ def test_read_pandas_column_subset(tempdir, use_legacy_dataset):
     reader = pa.BufferReader(buf)
     df_read = pq.read_pandas(
         reader, columns=['strings', 'uint8'],
-        use_legacy_dataset=use_legacy_dataset
     ).to_pandas()
     tm.assert_frame_equal(df[['strings', 'uint8']], df_read)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_parquet_empty_roundtrip(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_parquet_empty_roundtrip(tempdir):
     df = _test_dataframe(0)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
     _write_table(arrow_table, imos, version='2.6')
     buf = imos.getvalue()
     reader = pa.BufferReader(buf)
-    df_read = _read_table(
-        reader, use_legacy_dataset=use_legacy_dataset).to_pandas()
+    df_read = _read_table(reader).to_pandas()
     tm.assert_frame_equal(df, df_read)
 
 
@@ -241,8 +203,8 @@ def test_pandas_can_write_nested_data(tempdir):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_parquet_pyfile_roundtrip(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_parquet_pyfile_roundtrip(tempdir):
     filename = tempdir / 'pandas_pyfile_roundtrip.parquet'
     size = 5
     df = pd.DataFrame({
@@ -260,14 +222,14 @@ def test_pandas_parquet_pyfile_roundtrip(tempdir, use_legacy_dataset):
 
     data = io.BytesIO(filename.read_bytes())
 
-    table_read = _read_table(data, use_legacy_dataset=use_legacy_dataset)
+    table_read = _read_table(data)
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_parquet_configuration_options(tempdir):
     size = 10000
     np.random.seed(0)
     df = pd.DataFrame({
@@ -289,16 +251,14 @@ def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
     for use_dictionary in [True, False]:
         _write_table(arrow_table, filename, version='2.6',
                      use_dictionary=use_dictionary)
-        table_read = _read_table(
-            filename, use_legacy_dataset=use_legacy_dataset)
+        table_read = _read_table(filename)
         df_read = table_read.to_pandas()
         tm.assert_frame_equal(df, df_read)
 
     for write_statistics in [True, False]:
         _write_table(arrow_table, filename, version='2.6',
                      write_statistics=write_statistics)
-        table_read = _read_table(filename,
-                                 use_legacy_dataset=use_legacy_dataset)
+        table_read = _read_table(filename)
         df_read = table_read.to_pandas()
         tm.assert_frame_equal(df, df_read)
 
@@ -308,8 +268,7 @@ def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
             continue
         _write_table(arrow_table, filename, version='2.6',
                      compression=compression)
-        table_read = _read_table(
-            filename, use_legacy_dataset=use_legacy_dataset)
+        table_read = _read_table(filename)
         df_read = table_read.to_pandas()
         tm.assert_frame_equal(df, df_read)
 
@@ -327,8 +286,8 @@ def test_spark_flavor_preserves_pandas_metadata():
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_index_column_name_duplicate(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_index_column_name_duplicate(tempdir):
     data = {
         'close': {
             pd.Timestamp('2017-06-30 01:31:00'): 154.99958999999998,
@@ -352,14 +311,14 @@ def test_index_column_name_duplicate(tempdir, use_legacy_dataset):
 
     tdfx = pa.Table.from_pandas(dfx)
     _write_table(tdfx, path)
-    arrow_table = _read_table(path, use_legacy_dataset=use_legacy_dataset)
+    arrow_table = _read_table(path)
     result_df = arrow_table.to_pandas()
     tm.assert_frame_equal(result_df, dfx)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_multiindex_duplicate_values(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_multiindex_duplicate_values(tempdir):
     num_rows = 3
     numbers = list(range(num_rows))
     index = pd.MultiIndex.from_arrays(
@@ -373,7 +332,7 @@ def test_multiindex_duplicate_values(tempdir, use_legacy_dataset):
     filename = tempdir / 'dup_multi_index_levels.parquet'
 
     _write_table(table, filename)
-    result_table = _read_table(filename, use_legacy_dataset=use_legacy_dataset)
+    result_table = _read_table(filename)
     assert table.equals(result_table)
 
     result_df = result_table.to_pandas()
@@ -381,8 +340,8 @@ def test_multiindex_duplicate_values(tempdir, use_legacy_dataset):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_backwards_compatible_index_naming(datadir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_backwards_compatible_index_naming(datadir):
     expected_string = b"""\
 carat        cut  color  clarity  depth  table  price     x     y     z
  0.23      Ideal      E      SI2   61.5   55.0    326  3.95  3.98  2.43
@@ -397,17 +356,14 @@ carat        cut  color  clarity  depth  table  price     x     y     z
  0.23  Very Good      H      VS1   59.4   61.0    338  4.00  4.05  2.39"""
     expected = pd.read_csv(io.BytesIO(expected_string), sep=r'\s{2,}',
                            index_col=None, header=0, engine='python')
-    table = _read_table(
-        datadir / 'v0.7.1.parquet', use_legacy_dataset=use_legacy_dataset)
+    table = _read_table(datadir / 'v0.7.1.parquet')
     result = table.to_pandas()
     tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_backwards_compatible_index_multi_level_named(
-    datadir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_backwards_compatible_index_multi_level_named(datadir):
     expected_string = b"""\
 carat        cut  color  clarity  depth  table  price     x     y     z
  0.23      Ideal      E      SI2   61.5   55.0    326  3.95  3.98  2.43
@@ -426,17 +382,14 @@ carat        cut  color  clarity  depth  table  price     x     y     z
         header=0, engine='python'
     ).sort_index()
 
-    table = _read_table(datadir / 'v0.7.1.all-named-index.parquet',
-                        use_legacy_dataset=use_legacy_dataset)
+    table = _read_table(datadir / 'v0.7.1.all-named-index.parquet')
     result = table.to_pandas()
     tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_backwards_compatible_index_multi_level_some_named(
-        datadir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_backwards_compatible_index_multi_level_some_named(datadir):
     expected_string = b"""\
 carat        cut  color  clarity  depth  table  price     x     y     z
  0.23      Ideal      E      SI2   61.5   55.0    326  3.95  3.98  2.43
@@ -456,17 +409,14 @@ carat        cut  color  clarity  depth  table  price     x     y     z
     ).sort_index()
     expected.index = expected.index.set_names(['cut', None, 'clarity'])
 
-    table = _read_table(datadir / 'v0.7.1.some-named-index.parquet',
-                        use_legacy_dataset=use_legacy_dataset)
+    table = _read_table(datadir / 'v0.7.1.some-named-index.parquet')
     result = table.to_pandas()
     tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_backwards_compatible_column_metadata_handling(
-    datadir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_backwards_compatible_column_metadata_handling(datadir):
     expected = pd.DataFrame(
         {'a': [1, 2, 3], 'b': [.1, .2, .3],
          'c': pd.date_range("2017-01-01", periods=3, tz='Europe/Brussels')})
@@ -476,19 +426,19 @@ def test_backwards_compatible_column_metadata_handling(
         names=['index', None])
 
     path = datadir / 'v0.7.1.column-metadata-handling.parquet'
-    table = _read_table(path, use_legacy_dataset=use_legacy_dataset)
+    table = _read_table(path)
     result = table.to_pandas()
     tm.assert_frame_equal(result, expected)
 
     table = _read_table(
-        path, columns=['a'], use_legacy_dataset=use_legacy_dataset)
+        path, columns=['a'])
     result = table.to_pandas()
     tm.assert_frame_equal(result, expected[['a']].reset_index(drop=True))
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_categorical_index_survives_roundtrip(use_legacy_dataset):
+@pytest.mark.dataset
+def test_categorical_index_survives_roundtrip():
     # ARROW-3652, addressed by ARROW-3246
     df = pd.DataFrame([['a', 'b'], ['c', 'd']], columns=['c1', 'c2'])
     df['c1'] = df['c1'].astype('category')
@@ -497,15 +447,14 @@ def test_categorical_index_survives_roundtrip(use_legacy_dataset):
     table = pa.Table.from_pandas(df)
     bos = pa.BufferOutputStream()
     pq.write_table(table, bos)
-    ref_df = pq.read_pandas(
-        bos.getvalue(), use_legacy_dataset=use_legacy_dataset).to_pandas()
+    ref_df = pq.read_pandas(bos.getvalue()).to_pandas()
     assert isinstance(ref_df.index, pd.CategoricalIndex)
     assert ref_df.index.equals(df.index)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_categorical_order_survives_roundtrip(use_legacy_dataset):
+@pytest.mark.dataset
+def test_categorical_order_survives_roundtrip():
     # ARROW-6302
     df = pd.DataFrame({"a": pd.Categorical(
         ["a", "b", "c", "a"], categories=["b", "c", "d"], ordered=True)})
@@ -515,15 +464,14 @@ def test_categorical_order_survives_roundtrip(use_legacy_dataset):
     pq.write_table(table, bos)
 
     contents = bos.getvalue()
-    result = pq.read_pandas(
-        contents, use_legacy_dataset=use_legacy_dataset).to_pandas()
+    result = pq.read_pandas(contents).to_pandas()
 
     tm.assert_frame_equal(result, df)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_categorical_na_type_row_groups(use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_categorical_na_type_row_groups():
     # ARROW-5085
     df = pd.DataFrame({"col": [None] * 100, "int": [1.0] * 100})
     df_category = df.astype({"col": "category", "int": "category"})
@@ -533,8 +481,7 @@ def test_pandas_categorical_na_type_row_groups(use_legacy_dataset):
 
     # it works
     pq.write_table(table_cat, buf, version='2.6', chunk_size=10)
-    result = pq.read_table(
-        buf.getvalue(), use_legacy_dataset=use_legacy_dataset)
+    result = pq.read_table(buf.getvalue())
 
     # Result is non-categorical
     assert result[0].equals(table[0])
@@ -542,8 +489,8 @@ def test_pandas_categorical_na_type_row_groups(use_legacy_dataset):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_pandas_categorical_roundtrip(use_legacy_dataset):
+@pytest.mark.dataset
+def test_pandas_categorical_roundtrip():
     # ARROW-5480, this was enabled by ARROW-3246
 
     # Have one of the categories unobserved and include a null (-1)
@@ -555,8 +502,7 @@ def test_pandas_categorical_roundtrip(use_legacy_dataset):
     buf = pa.BufferOutputStream()
     pq.write_table(pa.table(df), buf)
 
-    result = pq.read_table(
-        buf.getvalue(), use_legacy_dataset=use_legacy_dataset).to_pandas()
+    result = pq.read_table(buf.getvalue()).to_pandas()
     assert result.x.dtype == 'category'
     assert (result.x.cat.categories == categories).all()
     tm.assert_frame_equal(result, df)
@@ -587,41 +533,30 @@ def test_categories_with_string_pyarrow_dtype(tempdir):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_pandas_preserve_extensiondtypes(
-    tempdir, use_legacy_dataset
-):
+@pytest.mark.dataset
+def test_write_to_dataset_pandas_preserve_extensiondtypes(tempdir):
     df = pd.DataFrame({'part': 'a', "col": [1, 2, 3]})
     df['col'] = df['col'].astype("Int64")
     table = pa.table(df)
 
     pq.write_to_dataset(
         table, str(tempdir / "case1"), partition_cols=['part'],
-        use_legacy_dataset=use_legacy_dataset
     )
-    result = pq.read_table(
-        str(tempdir / "case1"), use_legacy_dataset=use_legacy_dataset
-    ).to_pandas()
+    result = pq.read_table(str(tempdir / "case1")).to_pandas()
     tm.assert_frame_equal(result[["col"]], df[["col"]])
 
-    pq.write_to_dataset(
-        table, str(tempdir / "case2"), use_legacy_dataset=use_legacy_dataset
-    )
-    result = pq.read_table(
-        str(tempdir / "case2"), use_legacy_dataset=use_legacy_dataset
-    ).to_pandas()
+    pq.write_to_dataset(table, str(tempdir / "case2"))
+    result = pq.read_table(str(tempdir / "case2")).to_pandas()
     tm.assert_frame_equal(result[["col"]], df[["col"]])
 
     pq.write_table(table, str(tempdir / "data.parquet"))
-    result = pq.read_table(
-        str(tempdir / "data.parquet"), use_legacy_dataset=use_legacy_dataset
-    ).to_pandas()
+    result = pq.read_table(str(tempdir / "data.parquet")).to_pandas()
     tm.assert_frame_equal(result[["col"]], df[["col"]])
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_write_to_dataset_pandas_preserve_index(tempdir, use_legacy_dataset):
+@pytest.mark.dataset
+def test_write_to_dataset_pandas_preserve_index(tempdir):
     # ARROW-8251 - preserve pandas index in roundtrip
 
     df = pd.DataFrame({'part': ['a', 'a', 'b'], "col": [1, 2, 3]})
@@ -632,34 +567,25 @@ def test_write_to_dataset_pandas_preserve_index(tempdir, use_legacy_dataset):
 
     pq.write_to_dataset(
         table, str(tempdir / "case1"), partition_cols=['part'],
-        use_legacy_dataset=use_legacy_dataset
     )
-    result = pq.read_table(
-        str(tempdir / "case1"), use_legacy_dataset=use_legacy_dataset
-    ).to_pandas()
+    result = pq.read_table(str(tempdir / "case1")).to_pandas()
     tm.assert_frame_equal(result, df_cat)
 
-    pq.write_to_dataset(
-        table, str(tempdir / "case2"), use_legacy_dataset=use_legacy_dataset
-    )
-    result = pq.read_table(
-        str(tempdir / "case2"), use_legacy_dataset=use_legacy_dataset
-    ).to_pandas()
+    pq.write_to_dataset(table, str(tempdir / "case2"))
+    result = pq.read_table(str(tempdir / "case2")).to_pandas()
     tm.assert_frame_equal(result, df)
 
     pq.write_table(table, str(tempdir / "data.parquet"))
-    result = pq.read_table(
-        str(tempdir / "data.parquet"), use_legacy_dataset=use_legacy_dataset
-    ).to_pandas()
+    result = pq.read_table(str(tempdir / "data.parquet")).to_pandas()
     tm.assert_frame_equal(result, df)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
+@pytest.mark.dataset
 @pytest.mark.parametrize('preserve_index', [True, False, None])
 @pytest.mark.parametrize('metadata_fname', ["_metadata", "_common_metadata"])
 def test_dataset_read_pandas_common_metadata(
-    tempdir, use_legacy_dataset, preserve_index, metadata_fname
+    tempdir, preserve_index, metadata_fname
 ):
     # ARROW-1103
     nfiles = 5
@@ -696,7 +622,7 @@ def test_dataset_read_pandas_common_metadata(
     )
     pq.write_metadata(table_for_metadata.schema, dirpath / metadata_fname)
 
-    dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+    dataset = pq.ParquetDataset(dirpath)
     columns = ['uint8', 'strings']
     result = dataset.read_pandas(columns=columns).to_pandas()
     expected = pd.concat([x[columns] for x in frames])

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -99,7 +99,6 @@ def test_merging_parquet_tables_with_different_pandas_metadata(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pandas_parquet_column_multiindex(tempdir):
     df = alltypes_sample(size=10)
     df.columns = pd.MultiIndex.from_tuples(
@@ -119,7 +118,6 @@ def test_pandas_parquet_column_multiindex(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(tempdir):
     df = alltypes_sample(size=10000)
 
@@ -145,8 +143,7 @@ def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
-def test_pandas_parquet_native_file_roundtrip(tempdir):
+def test_pandas_parquet_native_file_roundtrip():
     df = _test_dataframe(10000)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
@@ -158,8 +155,7 @@ def test_pandas_parquet_native_file_roundtrip(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
-def test_read_pandas_column_subset(tempdir):
+def test_read_pandas_column_subset():
     df = _test_dataframe(10000)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
@@ -173,8 +169,7 @@ def test_read_pandas_column_subset(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
-def test_pandas_parquet_empty_roundtrip(tempdir):
+def test_pandas_parquet_empty_roundtrip():
     df = _test_dataframe(0)
     arrow_table = pa.Table.from_pandas(df)
     imos = pa.BufferOutputStream()
@@ -186,7 +181,7 @@ def test_pandas_parquet_empty_roundtrip(tempdir):
 
 
 @pytest.mark.pandas
-def test_pandas_can_write_nested_data(tempdir):
+def test_pandas_can_write_nested_data():
     data = {
         "agg_col": [
             {"page_type": 1},
@@ -203,7 +198,6 @@ def test_pandas_can_write_nested_data(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pandas_parquet_pyfile_roundtrip(tempdir):
     filename = tempdir / 'pandas_pyfile_roundtrip.parquet'
     size = 5
@@ -228,7 +222,6 @@ def test_pandas_parquet_pyfile_roundtrip(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pandas_parquet_configuration_options(tempdir):
     size = 10000
     np.random.seed(0)
@@ -286,7 +279,6 @@ def test_spark_flavor_preserves_pandas_metadata():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_index_column_name_duplicate(tempdir):
     data = {
         'close': {
@@ -317,7 +309,6 @@ def test_index_column_name_duplicate(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_multiindex_duplicate_values(tempdir):
     num_rows = 3
     numbers = list(range(num_rows))
@@ -340,7 +331,6 @@ def test_multiindex_duplicate_values(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_backwards_compatible_index_naming(datadir):
     expected_string = b"""\
 carat        cut  color  clarity  depth  table  price     x     y     z
@@ -362,7 +352,6 @@ carat        cut  color  clarity  depth  table  price     x     y     z
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_backwards_compatible_index_multi_level_named(datadir):
     expected_string = b"""\
 carat        cut  color  clarity  depth  table  price     x     y     z
@@ -388,7 +377,6 @@ carat        cut  color  clarity  depth  table  price     x     y     z
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_backwards_compatible_index_multi_level_some_named(datadir):
     expected_string = b"""\
 carat        cut  color  clarity  depth  table  price     x     y     z
@@ -415,7 +403,6 @@ carat        cut  color  clarity  depth  table  price     x     y     z
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_backwards_compatible_column_metadata_handling(datadir):
     expected = pd.DataFrame(
         {'a': [1, 2, 3], 'b': [.1, .2, .3],
@@ -437,7 +424,6 @@ def test_backwards_compatible_column_metadata_handling(datadir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_categorical_index_survives_roundtrip():
     # ARROW-3652, addressed by ARROW-3246
     df = pd.DataFrame([['a', 'b'], ['c', 'd']], columns=['c1', 'c2'])
@@ -453,7 +439,6 @@ def test_categorical_index_survives_roundtrip():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_categorical_order_survives_roundtrip():
     # ARROW-6302
     df = pd.DataFrame({"a": pd.Categorical(
@@ -470,7 +455,6 @@ def test_categorical_order_survives_roundtrip():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pandas_categorical_na_type_row_groups():
     # ARROW-5085
     df = pd.DataFrame({"col": [None] * 100, "int": [1.0] * 100})
@@ -489,7 +473,6 @@ def test_pandas_categorical_na_type_row_groups():
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_pandas_categorical_roundtrip():
     # ARROW-5480, this was enabled by ARROW-3246
 
@@ -533,7 +516,6 @@ def test_categories_with_string_pyarrow_dtype(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_pandas_preserve_extensiondtypes(tempdir):
     df = pd.DataFrame({'part': 'a', "col": [1, 2, 3]})
     df['col'] = df['col'].astype("Int64")
@@ -555,7 +537,6 @@ def test_write_to_dataset_pandas_preserve_extensiondtypes(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 def test_write_to_dataset_pandas_preserve_index(tempdir):
     # ARROW-8251 - preserve pandas index in roundtrip
 
@@ -581,7 +562,6 @@ def test_write_to_dataset_pandas_preserve_index(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.dataset
 @pytest.mark.parametrize('preserve_index', [True, False, None])
 @pytest.mark.parametrize('metadata_fname', ["_metadata", "_common_metadata"])
 def test_dataset_read_pandas_common_metadata(

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -296,28 +296,6 @@ def test_parquet_file_explicitly_closed(tempdir):
     table = pa.table({'col1': [0, 1], 'col2': [0, 1]})
     pq.write_table(table, fn)
 
-    # read_table (legacy) with opened file (will leave open)
-    with open(fn, 'rb') as f:
-        pq.read_table(f, use_legacy_dataset=True)
-        assert not f.closed  # Didn't close it internally after read_table
-
-    # read_table (legacy) with unopened file (will close)
-    with mock.patch.object(pq.ParquetFile, "close") as mock_close:
-        pq.read_table(fn, use_legacy_dataset=True)
-        mock_close.assert_called()
-
-    # ParquetDataset test (legacy) with unopened file (will close)
-    with mock.patch.object(pq.ParquetFile, "close") as mock_close:
-        pq.ParquetDataset(fn, use_legacy_dataset=True).read()
-        mock_close.assert_called()
-
-    # ParquetDataset test (legacy) with opened file (will leave open)
-    with open(fn, 'rb') as f:
-        # ARROW-8075: support ParquetDataset from file-like, not just path-like
-        with pytest.raises(TypeError, match='not a path-like object'):
-            pq.ParquetDataset(f, use_legacy_dataset=True).read()
-            assert not f.closed
-
     # ParquetFile with opened file (will leave open)
     with open(fn, 'rb') as f:
         with pq.ParquetFile(f) as p:
@@ -338,7 +316,7 @@ def test_parquet_file_explicitly_closed(tempdir):
 
 @pytest.mark.s3
 @pytest.mark.parametrize("use_uri", (True, False))
-def test_parquet_file_with_filesystem(tempdir, s3_example_fs, use_uri):
+def test_parquet_file_with_filesystem(s3_example_fs, use_uri):
     s3_fs, s3_uri, s3_path = s3_example_fs
 
     args = (s3_uri if use_uri else s3_path,)

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -18,7 +18,6 @@
 import io
 import os
 import sys
-from unittest import mock
 
 import pytest
 

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -20,7 +20,6 @@ import pytest
 import pyarrow as pa
 from pyarrow import fs
 from pyarrow.filesystem import FileSystem, LocalFileSystem
-from pyarrow.tests.parquet.common import parametrize_legacy_dataset
 
 try:
     import pyarrow.parquet as pq
@@ -44,8 +43,7 @@ pytestmark = pytest.mark.parquet
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_parquet_incremental_file_build(tempdir, use_legacy_dataset):
+def test_parquet_incremental_file_build(tempdir):
     df = _test_dataframe(100)
     df['unique_id'] = 0
 
@@ -65,8 +63,7 @@ def test_parquet_incremental_file_build(tempdir, use_legacy_dataset):
     writer.close()
 
     buf = out.getvalue()
-    result = _read_table(
-        pa.BufferReader(buf), use_legacy_dataset=use_legacy_dataset)
+    result = _read_table(pa.BufferReader(buf))
 
     expected = pd.concat(frames, ignore_index=True)
     tm.assert_frame_equal(result.to_pandas(), expected)
@@ -105,8 +102,7 @@ def test_parquet_invalid_writer(tempdir):
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_parquet_writer_context_obj(tempdir, use_legacy_dataset):
+def test_parquet_writer_context_obj(tempdir):
     df = _test_dataframe(100)
     df['unique_id'] = 0
 
@@ -124,18 +120,14 @@ def test_parquet_writer_context_obj(tempdir, use_legacy_dataset):
             frames.append(df.copy())
 
     buf = out.getvalue()
-    result = _read_table(
-        pa.BufferReader(buf), use_legacy_dataset=use_legacy_dataset)
+    result = _read_table(pa.BufferReader(buf))
 
     expected = pd.concat(frames, ignore_index=True)
     tm.assert_frame_equal(result.to_pandas(), expected)
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_parquet_writer_context_obj_with_exception(
-    tempdir, use_legacy_dataset
-):
+def test_parquet_writer_context_obj_with_exception(tempdir):
     df = _test_dataframe(100)
     df['unique_id'] = 0
 
@@ -160,8 +152,7 @@ def test_parquet_writer_context_obj_with_exception(
         assert str(e) == error_text
 
     buf = out.getvalue()
-    result = _read_table(
-        pa.BufferReader(buf), use_legacy_dataset=use_legacy_dataset)
+    result = _read_table(pa.BufferReader(buf))
 
     expected = pd.concat(frames, ignore_index=True)
     tm.assert_frame_equal(result.to_pandas(), expected)
@@ -340,8 +331,7 @@ def test_parquet_writer_filesystem_buffer_raises():
 
 
 @pytest.mark.pandas
-@parametrize_legacy_dataset
-def test_parquet_writer_with_caller_provided_filesystem(use_legacy_dataset):
+def test_parquet_writer_with_caller_provided_filesystem():
     out = pa.BufferOutputStream()
 
     class CustomFS(FileSystem):
@@ -368,8 +358,7 @@ def test_parquet_writer_with_caller_provided_filesystem(use_legacy_dataset):
     assert out.closed
 
     buf = out.getvalue()
-    table_read = _read_table(
-        pa.BufferReader(buf), use_legacy_dataset=use_legacy_dataset)
+    table_read = _read_table(pa.BufferReader(buf))
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df_read, df)
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1082,7 +1082,6 @@ def _create_dataset_for_fragments(tempdir, chunk_size=None, filesystem=None):
 
     path = str(tempdir / "test_parquet_dataset")
 
-    # write_to_dataset currently requires pandas
     pq.write_to_dataset(table, path,
                         partition_cols=["part"], chunk_size=chunk_size)
     dataset = ds.dataset(
@@ -1092,7 +1091,6 @@ def _create_dataset_for_fragments(tempdir, chunk_size=None, filesystem=None):
     return table, dataset
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments(tempdir, dataset_reader):
     table, dataset = _create_dataset_for_fragments(tempdir)
@@ -1140,7 +1138,6 @@ def test_fragments_implicit_cast(tempdir):
     assert len(list(fragments)) == 1
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_reconstruct(tempdir, dataset_reader, pickle_module):
     table, dataset = _create_dataset_for_fragments(tempdir)
@@ -1202,7 +1199,6 @@ def test_fragments_reconstruct(tempdir, dataset_reader, pickle_module):
         dataset_reader.to_table(new_fragment, filter=ds.field('part') == 'a')
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_row_groups(tempdir, dataset_reader):
     table, dataset = _create_dataset_for_fragments(tempdir, chunk_size=2)
@@ -1254,8 +1250,6 @@ def test_fragments_parquet_num_row_groups(tempdir):
 @pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_row_groups_dictionary(tempdir, dataset_reader):
-    import pandas as pd
-
     df = pd.DataFrame(dict(col1=['a', 'b'], col2=[1, 2]))
     df['col1'] = df['col1'].astype("category")
 
@@ -1268,7 +1262,6 @@ def test_fragments_parquet_row_groups_dictionary(tempdir, dataset_reader):
     assert (df.iloc[0] == result.to_pandas()).all().all()
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_ensure_metadata(tempdir, open_logging_fs, pickle_module):
     fs, assert_opens = open_logging_fs
@@ -1310,7 +1303,6 @@ def test_fragments_parquet_ensure_metadata(tempdir, open_logging_fs, pickle_modu
         assert row_group.statistics is not None
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_pickle_no_metadata(tempdir, open_logging_fs, pickle_module):
     # https://issues.apache.org/jira/browse/ARROW-15796
@@ -1452,7 +1444,6 @@ def test_parquet_empty_row_group_statistics(tempdir):
     assert fragments[0].row_groups[0].statistics == {}
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_row_groups_predicate(tempdir):
     table, dataset = _create_dataset_for_fragments(tempdir, chunk_size=2)
@@ -1476,7 +1467,6 @@ def test_fragments_parquet_row_groups_predicate(tempdir):
     assert len(row_group_fragments) == 0
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_row_groups_reconstruct(tempdir, dataset_reader,
                                                   pickle_module):
@@ -1519,7 +1509,6 @@ def test_fragments_parquet_row_groups_reconstruct(tempdir, dataset_reader,
         dataset_reader.to_table(new_fragment)
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_subset_ids(tempdir, open_logging_fs,
                                       dataset_reader):
@@ -1548,7 +1537,6 @@ def test_fragments_parquet_subset_ids(tempdir, open_logging_fs,
     assert result.equals(table[:0])
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_subset_filter(tempdir, open_logging_fs,
                                          dataset_reader):
@@ -1581,7 +1569,6 @@ def test_fragments_parquet_subset_filter(tempdir, open_logging_fs,
     assert subfrag.num_row_groups == 4
 
 
-@pytest.mark.pandas
 @pytest.mark.parquet
 def test_fragments_parquet_subset_invalid(tempdir):
     _, dataset = _create_dataset_for_fragments(tempdir, chunk_size=1)
@@ -3729,7 +3716,6 @@ def test_dataset_project_only_partition_columns(tempdir, dataset_reader):
 @pytest.mark.parquet
 @pytest.mark.pandas
 def test_dataset_project_null_column(tempdir, dataset_reader):
-    import pandas as pd
     df = pd.DataFrame({"col": np.array([None, None, None], dtype='object')})
 
     f = tempdir / "test_dataset_project_null_column.parquet"

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1094,8 +1094,6 @@ def _create_dataset_for_fragments(tempdir, chunk_size=None, filesystem=None):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments(tempdir, dataset_reader):
     table, dataset = _create_dataset_for_fragments(tempdir)
 
@@ -1144,8 +1142,6 @@ def test_fragments_implicit_cast(tempdir):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_reconstruct(tempdir, dataset_reader, pickle_module):
     table, dataset = _create_dataset_for_fragments(tempdir)
 
@@ -1208,8 +1204,6 @@ def test_fragments_reconstruct(tempdir, dataset_reader, pickle_module):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_parquet_row_groups(tempdir, dataset_reader):
     table, dataset = _create_dataset_for_fragments(tempdir, chunk_size=2)
 
@@ -1276,8 +1270,6 @@ def test_fragments_parquet_row_groups_dictionary(tempdir, dataset_reader):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_parquet_ensure_metadata(tempdir, open_logging_fs, pickle_module):
     fs, assert_opens = open_logging_fs
     _, dataset = _create_dataset_for_fragments(
@@ -1388,16 +1380,13 @@ def _create_dataset_all_types(tempdir, chunk_size=None):
     path = str(tempdir / "test_parquet_dataset_all_types")
 
     # write_to_dataset currently requires pandas
-    pq.write_to_dataset(table, path, use_legacy_dataset=True,
-                        chunk_size=chunk_size)
+    pq.write_to_dataset(table, path, chunk_size=chunk_size)
 
     return table, ds.dataset(path, format="parquet", partitioning="hive")
 
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_parquet_fragment_statistics(tempdir):
     table, dataset = _create_dataset_all_types(tempdir)
 
@@ -1465,8 +1454,6 @@ def test_parquet_empty_row_group_statistics(tempdir):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_parquet_row_groups_predicate(tempdir):
     table, dataset = _create_dataset_for_fragments(tempdir, chunk_size=2)
 
@@ -1491,8 +1478,6 @@ def test_fragments_parquet_row_groups_predicate(tempdir):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_parquet_row_groups_reconstruct(tempdir, dataset_reader,
                                                   pickle_module):
     table, dataset = _create_dataset_for_fragments(tempdir, chunk_size=2)
@@ -1536,8 +1521,6 @@ def test_fragments_parquet_row_groups_reconstruct(tempdir, dataset_reader,
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_parquet_subset_ids(tempdir, open_logging_fs,
                                       dataset_reader):
     fs, assert_opens = open_logging_fs
@@ -1567,8 +1550,6 @@ def test_fragments_parquet_subset_ids(tempdir, open_logging_fs,
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_parquet_subset_filter(tempdir, open_logging_fs,
                                          dataset_reader):
     fs, assert_opens = open_logging_fs
@@ -1602,8 +1583,6 @@ def test_fragments_parquet_subset_filter(tempdir, open_logging_fs,
 
 @pytest.mark.pandas
 @pytest.mark.parquet
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
 def test_fragments_parquet_subset_invalid(tempdir):
     _, dataset = _create_dataset_for_fragments(tempdir, chunk_size=1)
     fragment = list(dataset.get_fragments())[0]
@@ -3525,10 +3504,7 @@ def test_parquet_dataset_factory_fsspec(tempdir):
 
 @pytest.mark.parquet
 @pytest.mark.pandas  # write_to_dataset currently requires pandas
-@pytest.mark.parametrize('use_legacy_dataset', [False, True])
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
-def test_parquet_dataset_factory_roundtrip(tempdir, use_legacy_dataset):
+def test_parquet_dataset_factory_roundtrip(tempdir):
     # Simple test to ensure we can roundtrip dataset to
     # _metadata/common_metadata and back.  A more complex test
     # using partitioning will have to wait for ARROW-13269.  The
@@ -3540,7 +3516,6 @@ def test_parquet_dataset_factory_roundtrip(tempdir, use_legacy_dataset):
     metadata_collector = []
     pq.write_to_dataset(
         table, str(root_path), metadata_collector=metadata_collector,
-        use_legacy_dataset=use_legacy_dataset
     )
     metadata_path = str(root_path / '_metadata')
     # write _metadata file
@@ -3864,8 +3839,7 @@ def test_write_to_dataset_given_null_just_works(tempdir):
                       'col': list(range(4))}, schema=schema)
 
     path = str(tempdir / 'test_dataset')
-    pq.write_to_dataset(table, path, partition_cols=[
-                        'part'], use_legacy_dataset=False)
+    pq.write_to_dataset(table, path, partition_cols=['part'])
 
     actual_table = pq.read_table(tempdir / 'test_dataset')
     # column.equals can handle the difference in chunking but not the fact
@@ -3873,28 +3847,6 @@ def test_write_to_dataset_given_null_just_works(tempdir):
     assert actual_table.column('part').to_pylist(
     ) == table.column('part').to_pylist()
     assert actual_table.column('col').equals(table.column('col'))
-
-
-@pytest.mark.parquet
-@pytest.mark.pandas
-@pytest.mark.filterwarnings(
-    "ignore:Passing 'use_legacy_dataset=True':FutureWarning")
-def test_legacy_write_to_dataset_drops_null(tempdir):
-    schema = pa.schema([
-        pa.field('col', pa.int64()),
-        pa.field('part', pa.dictionary(pa.int32(), pa.string()))
-    ])
-    table = pa.table({'part': ['a', 'a', None, None],
-                      'col': list(range(4))}, schema=schema)
-    expected = pa.table(
-        {'part': ['a', 'a'], 'col': list(range(2))}, schema=schema)
-
-    path = str(tempdir / 'test_dataset')
-    pq.write_to_dataset(table, path, partition_cols=[
-                        'part'], use_legacy_dataset=True)
-
-    actual = pq.read_table(tempdir / 'test_dataset')
-    assert actual == expected
 
 
 def _sort_table(tab, sort_col):

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -309,6 +309,8 @@ class HdfsTestCases:
         expected = pa.concat_tables(test_data)
         return expected
 
+    @pytest.mark.xfail(reason="legacy.FileSystem.read_parquet used legacy ParquetDataset "
+                       "that has been removed in PyArrow 15.0.0.", raises=TypeError)
     @pytest.mark.pandas
     @pytest.mark.parquet
     def test_read_multiple_parquet_files(self):

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -309,10 +309,9 @@ class HdfsTestCases:
         expected = pa.concat_tables(test_data)
         return expected
 
-    @pytest.mark.xfail(reason="legacy.FileSystem.read_parquet used legacy ParquetDataset "
-                       "that has been removed in PyArrow 15.0.0.", raises=TypeError)
-    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
-                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset "
+                       "due to legacy path being removed in PyArrow 15.0.0.",
+                       raises=TypeError)
     @pytest.mark.pandas
     @pytest.mark.parquet
     def test_read_multiple_parquet_files(self):
@@ -347,8 +346,9 @@ class HdfsTestCases:
             expected.to_pandas()
         )
 
-    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
-                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset "
+                       "due to legacy path being removed in PyArrow 15.0.0.",
+                       raises=TypeError)
     @pytest.mark.pandas
     @pytest.mark.parquet
     def test_read_write_parquet_files_with_uri(self):
@@ -370,8 +370,9 @@ class HdfsTestCases:
 
         assert_frame_equal(result, df)
 
-    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
-                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset "
+                       "due to legacy path being removed in PyArrow 15.0.0.",
+                       raises=TypeError)
     @pytest.mark.parquet
     @pytest.mark.pandas
     def test_write_to_dataset_with_partitions(self):
@@ -380,8 +381,9 @@ class HdfsTestCases:
         _test_write_to_dataset_with_partitions(
             tmpdir, filesystem=self.hdfs)
 
-    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
-                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset "
+                       "due to legacy path being removed in PyArrow 15.0.0.",
+                       raises=TypeError)
     @pytest.mark.parquet
     @pytest.mark.pandas
     def test_write_to_dataset_no_partitions(self):

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -27,7 +27,7 @@ import pyarrow as pa
 from pyarrow.tests import util
 from pyarrow.tests.parquet.common import _test_dataframe
 from pyarrow.tests.parquet.test_dataset import (
-    _test_read_common_metadata_files, _test_write_to_dataset_with_partitions,
+    _test_write_to_dataset_with_partitions,
     _test_write_to_dataset_no_partitions
 )
 from pyarrow.util import guid
@@ -360,18 +360,9 @@ class HdfsTestCases:
 
         pq.write_table(table, path, filesystem=self.hdfs)
 
-        result = pq.read_table(
-            path, filesystem=self.hdfs, use_legacy_dataset=True
-        ).to_pandas()
+        result = pq.read_table(path, filesystem=self.hdfs).to_pandas()
 
         assert_frame_equal(result, df)
-
-    @pytest.mark.parquet
-    @pytest.mark.pandas
-    def test_read_common_metadata_files(self):
-        tmpdir = pjoin(self.tmp_path, 'common-metadata-' + guid())
-        self.hdfs.mkdir(tmpdir)
-        _test_read_common_metadata_files(self.hdfs, tmpdir)
 
     @pytest.mark.parquet
     @pytest.mark.pandas

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -311,6 +311,8 @@ class HdfsTestCases:
 
     @pytest.mark.xfail(reason="legacy.FileSystem.read_parquet used legacy ParquetDataset "
                        "that has been removed in PyArrow 15.0.0.", raises=TypeError)
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
+                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
     @pytest.mark.pandas
     @pytest.mark.parquet
     def test_read_multiple_parquet_files(self):
@@ -345,6 +347,8 @@ class HdfsTestCases:
             expected.to_pandas()
         )
 
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
+                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
     @pytest.mark.pandas
     @pytest.mark.parquet
     def test_read_write_parquet_files_with_uri(self):
@@ -366,6 +370,8 @@ class HdfsTestCases:
 
         assert_frame_equal(result, df)
 
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
+                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
     @pytest.mark.parquet
     @pytest.mark.pandas
     def test_write_to_dataset_with_partitions(self):
@@ -374,6 +380,8 @@ class HdfsTestCases:
         _test_write_to_dataset_with_partitions(
             tmpdir, filesystem=self.hdfs)
 
+    @pytest.mark.xfail(reason="legacy.FileSystem not supported with ParquetDataset due to "
+                       "legacy path being removed in PyArrow 15.0.0.", raises=TypeError)
     @pytest.mark.parquet
     @pytest.mark.pandas
     def test_write_to_dataset_no_partitions(self):


### PR DESCRIPTION
### Rationale for this change

Legacy ParquetDataset has been deprecated for a while now, see https://github.com/apache/arrow/issues/31529. This PR is removing the legacy implementation from the code.

### What changes are included in this PR?

The PR is removing:
- `ParquetDatasetPiece `
-  `ParquetManifest`
-  `_ParquetDatasetMetadata `
-  `ParquetDataset`

The PR is renaming `_ParquetDatasetV2` to `ParquetDataset` which was removed. It is also updating the docstrings.

The PR is updating:
- `read_table`
-  `write_to_dataset`

The PR is updating all the tests to not use `use_legacy_dataset` keyword or legacy parametrisation.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Deprecated code is removed.
* Closes: #31303