### PR TITLE
GH-39113: [Integration][Flight][Java] Fix occasional failure starting Java server

### DIFF
--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -41,6 +41,8 @@ _JAVA_OPTS = [
     "-Dio.netty.tryReflectionSetAccessible=true",
     "-Darrow.struct.conflict.policy=CONFLICT_APPEND",
     "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    # GH-39113: avoid failures accessing files in `/tmp/hsperfdata_...`
+    "-XX:-UsePerfData",
 ]
 
 _arrow_version = load_version_from_pom()


### PR DESCRIPTION
### Rationale for this change

The "perfdata" feature in the JVM can sometimes cause spurious warnings or failures trying to start the Integration Flight server:
```
################# FAILURES #################
FAILED TEST: decimal Java producing,  Java consuming
<class 'RuntimeError'>: Flight-Java server did not start properly, stdout:
Warning: [0.002s][warning][perf,memops] Cannot use file /tmp/hsperfdata_root/55221 because it is locked by another process (errno = 11)


stderr:
```

### What changes are included in this PR?

Disable the perfdata feature when starting the JVM for integration tests.

### Are these changes tested?

By construction, yes.

### Are there any user-facing changes?

No.
* Closes: #39113