### PR TITLE
GH-38479: [C++] Avoid passing null pointer to LZ4 frame decompressor

### DIFF
--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -279,6 +279,8 @@ class CompressedInputStream::Impl {
   // Decompress some data from the compressed_ buffer.
   // Call this function only if the decompressed_ buffer is empty.
   Status DecompressData() {
+    DCHECK_NE(compressed_->data(), nullptr);
+
     int64_t decompress_size = kDecompressSize;
 
     while (true) {
@@ -329,7 +331,7 @@ class CompressedInputStream::Impl {
   // Try to feed more data into the decompressed_ buffer.
   Status RefillDecompressed(bool* has_data) {
     // First try to read data from the decompressor
-    if (compressed_) {
+    if (compressed_ && compressed_->size() != 0) {
       if (decompressor_->IsFinished()) {
         // We just went over the end of a previous compressed stream.
         RETURN_NOT_OK(decompressor_->Reset());

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -109,6 +109,7 @@ class LZ4Decompressor : public Decompressor {
     auto dst_capacity = static_cast<size_t>(output_len);
     size_t ret;
 
+    DCHECK_NE(src, nullptr);
     ret =
         LZ4F_decompress(ctx_, dst, &dst_capacity, src, &src_size, nullptr /* options */);
     if (LZ4F_isError(ret)) {


### PR DESCRIPTION
### Rationale for this change

Avoid undefined behavior in LZ4 when adding an offset to a null pointer.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38479