### PR TITLE
MINOR: [Java] Bump ch.qos.logback:logback-classic from 1.2.13 to 1.3.14 in /java

### DIFF
--- a/java/memory/memory-netty/pom.xml
+++ b/java/memory/memory-netty/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -308,7 +308,7 @@
           <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.5</version>
+            <version>${dep.slf4j.version}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -31,7 +31,7 @@
     <target.gen.source.path>${project.build.directory}/generated-sources</target.gen.source.path>
     <dep.junit.platform.version>1.9.0</dep.junit.platform.version>
     <dep.junit.jupiter.version>5.10.1</dep.junit.jupiter.version>
-    <dep.slf4j.version>1.7.25</dep.slf4j.version>
+    <dep.slf4j.version>2.0.7</dep.slf4j.version>
     <dep.guava-bom.version>32.1.3-jre</dep.guava-bom.version>
     <dep.netty-bom.version>4.1.100.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.59.0</dep.grpc-bom.version>
@@ -698,7 +698,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
-          <version>1.2.13</version>
+          <version>1.3.14</version>
           <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Rationale for this change

Raised by dependabot, but dependabot didn't upgrade to the correct version for Arrow Java and did not upgrade the dependency.

### What changes are included in this PR?

* logback 1.2.13 -> 1.3.14
* slf4j 1.7.25 -> 2.0.7 (required by logback 1.3.14)

### Are these changes tested?

CI

### Are there any user-facing changes?

No