### PR TITLE
GH-39147: [R] Add Bootstrap.r

### DIFF
--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -30,3 +30,4 @@ STYLE.md
 ^vignettes$
 ^PACKAGING\.md$
 ^inst/__pycache__$
+^bootstrap.R$

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -45,6 +45,7 @@ Imports:
 Roxygen: list(markdown = TRUE, r6 = FALSE, load = "source")
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3
+Config/build/bootstrap: TRUE
 Suggests:
     blob,
     curl,

--- a/r/Makefile
+++ b/r/Makefile
@@ -67,5 +67,5 @@ clean:
 	-rm src/Makevars.win
 	-rm -rf arrow.Rcheck/
 	-rm -rf libarrow/
-	-rm -rf tools/cpp/ tools/.env tools/NOTICE.txt tools/LICENSE.txt tools/checksums
+	-rm -rf tools/cpp/ tools/dotenv tools/NOTICE.txt tools/LICENSE.txt tools/checksums
 	-find . -name "*.orig" -delete

--- a/r/bootstrap.R
+++ b/r/bootstrap.R
@@ -48,6 +48,7 @@ rsync <- function(src_dir, dest_dir, exclude_patterns) {
 
 
 if (dir.exists("../cpp")) {
+  unlink("tools/cpp", recursive = TRUE)
   rsync("../cpp",
     "tools/cpp",
     exclude_patterns = c(

--- a/r/bootstrap.R
+++ b/r/bootstrap.R
@@ -52,7 +52,7 @@ if (dir.exists("../cpp")) {
     "tools/cpp",
     exclude_patterns = c(
       "^apidoc",
-      "^build$",
+      "^build/",
       "^build-support/boost-",
       "^examples",
       "^submodules",

--- a/r/bootstrap.R
+++ b/r/bootstrap.R
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+
+# exclude_patterns are regular expressions so use ^ to match top-level
+# directories only. Otherwise 'dir' will match 'src/dir' and 'dir/file'.
+rsync <- function(src_dir, dest_dir, exclude_patterns) {
+  all_files <- list.files(src_dir, recursive = TRUE)
+
+  # Filter out excluded patterns
+  for (pattern in exclude_patterns) {
+    all_files <- all_files[!grepl(pattern, all_files)]
+  }
+
+  files_to_vendor_src <- file.path(src_dir, all_files)
+  files_to_vendor_dst <- file.path(dest_dir, all_files)
+
+  # Recreate the directory structure
+  dst_dirs <- unique(dirname(files_to_vendor_dst))
+  for (dst_dir in dst_dirs) {
+    if (!dir.exists(dst_dir)) {
+      dir.create(dst_dir, recursive = TRUE)
+    }
+  }
+
+  # Copy the files
+  if (all(file.copy(files_to_vendor_src, files_to_vendor_dst, overwrite = TRUE))) {
+    cat("All files successfully copied to tools/cpp\n")
+  } else {
+    stop("Failed to vendor all files")
+  }
+}
+
+
+if (dir.exists("../cpp")) {
+  rsync("../cpp",
+    "tools/cpp",
+    exclude_patterns = c(
+      "^apidoc",
+      "^build$",
+      "^build-support/boost-",
+      "^examples",
+      "^submodules",
+      "^src/gandiva",
+      "^src/jni",
+      "^src/skyhook",
+      "_test\\.cc"
+    )
+  )
+
+  # Note: files in tools are available at build time, but not at run time. The thirdparty
+  # cmake expects .env, NOTICE.txt, and LICENSE.txt to be available one level up from cpp/
+  # we must rename .env to dotenv and then replace references to it in cpp/CMakeLists.txt
+  file.copy(from = c("../NOTICE.txt", to = "../LICENSE.txt"), "tools/", overwrite = TRUE)
+  file.copy("../.env", "tools/dotenv", overwrite = TRUE)
+
+  cmake_lists <- readLines("tools/cpp/CMakeLists.txt")
+  cmake_lists <- gsub("\\.env", "dotenv", cmake_lists)
+  writeLines(cmake_lists, "tools/cpp/CMakeLists.txt")
+} else {
+  cli::cli_alert_warning("Arrow C++ sources not found, skipping bootstrap.")
+}

--- a/r/bootstrap.R
+++ b/r/bootstrap.R
@@ -64,9 +64,9 @@ if (dir.exists("../cpp")) {
     )
   )
 
-  # Note: files in tools are available at build time, but not at run time. The thirdparty
-  # cmake expects .env, NOTICE.txt, and LICENSE.txt to be available one level up from cpp/
-  # we must rename .env to dotenv and then replace references to it in cpp/CMakeLists.txt
+  # The thirdparty cmake expects .env, NOTICE.txt, and LICENSE.txt to be available one
+  # level up from cpp/ we must rename .env to dotenv and then replace references to it
+  # in cpp/CMakeLists.txt, because R CMD will produce a Note otherwise.
   file.copy(from = c("../NOTICE.txt", to = "../LICENSE.txt"), "tools/", overwrite = TRUE)
   file.copy("../.env", "tools/dotenv", overwrite = TRUE)
 


### PR DESCRIPTION
### Rationale for this change
Currently installing via github is not possible because the vendoring of the cpp source isn't happening. We can use bootstrap.R to do it. (Does not work for `devtools::install_local()` as that copies the source folder before running bootstrap.R)
 
### What changes are included in this PR?

An R'ified version of `make sync-cpp`


### Are these changes tested?

locally

### Are there any user-facing changes?
Yes, installing via `devtools::install_github()` will now properly vendor the cpp files.

* Closes: #39147
* GitHub Issue: #39147