### PR TITLE
GH-39159 [C++]: Try to make Buffer::device_type_ non-optional

### DIFF
--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -70,7 +70,7 @@ class ARROW_EXPORT Buffer {
 
   Buffer(const uint8_t* data, int64_t size, std::shared_ptr<MemoryManager> mm,
          std::shared_ptr<Buffer> parent = NULLPTR,
-         std::optional<DeviceAllocationType> device_type = std::nullopt)
+         std::optional<DeviceAllocationType> device_type_override = std::nullopt)
       : is_mutable_(false),
         data_(data),
         size_(size),
@@ -78,11 +78,11 @@ class ARROW_EXPORT Buffer {
         parent_(std::move(parent)) {
     // SetMemoryManager will also set device_type_
     SetMemoryManager(std::move(mm));
-    // if a device type is specified, use that instead. for example:
-    // CUDA_HOST. The CudaMemoryManager will set device_type_ to CUDA,
-    // but you can specify CUDA_HOST as the device type to override it.
-    if (device_type != std::nullopt) {
-      device_type_ = device_type;
+    // If a device type is specified, use that instead. Example of when this can be
+    // useful: the CudaMemoryManager can set device_type_ to kCUDA, but you can specify
+    // device_type_override=kCUDA_HOST as the device type to override it.
+    if (device_type_override != std::nullopt) {
+      device_type_ = *device_type_override;
     }
   }
 
@@ -296,7 +296,7 @@ class ARROW_EXPORT Buffer {
 
   const std::shared_ptr<MemoryManager>& memory_manager() const { return memory_manager_; }
 
-  std::optional<DeviceAllocationType> device_type() const { return device_type_; }
+  DeviceAllocationType device_type() const { return device_type_; }
 
   std::shared_ptr<Buffer> parent() const { return parent_; }
 
@@ -354,7 +354,7 @@ class ARROW_EXPORT Buffer {
   const uint8_t* data_;
   int64_t size_;
   int64_t capacity_;
-  std::optional<DeviceAllocationType> device_type_;
+  DeviceAllocationType device_type_;
 
   // null by default, but may be set
   std::shared_ptr<Buffer> parent_;


### PR DESCRIPTION
### Rationale for this change

Buffer should always have a device type. When unspecified, CPU can be assumed.

### What changes are included in this PR?

A change of the member variable type and some adjustments.

### Are these changes tested?

N/A.

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.**

`Buffer::device_type_` is now a `DeviceAllocationType` instead of a `std::optional<DeviceAllocationType>`.
* Closes: #39159