### PR TITLE
GH-38702 [C++]: Implement AzureFileSystem::DeleteRootDirContents

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1219,7 +1219,7 @@ Status AzureFileSystem::DeleteDirContents(const std::string& path, bool missing_
 }
 
 Status AzureFileSystem::DeleteRootDirContents() {
-  return Status::NotImplemented("The Azure FileSystem is not fully implemented");
+  return Status::NotImplemented("Cannot delete all Azure Blob Storage containers");
 }
 
 Status AzureFileSystem::DeleteFile(const std::string& path) {


### PR DESCRIPTION
### Rationale for this change

This copies the behavior implemented by S3FileSystem.

### What changes are included in this PR?

An implementation of `DeleteRootDirContent` that prevents deletion of all blob containers.

### Are these changes tested?

N/A.
* Closes: #38702