### PR TITLE
GH-39130: [CI][GLib][Windows] Use old Ruby as workaround for load error

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -196,7 +196,9 @@ jobs:
         mingw-n-bits:
           - 64
         ruby-version:
-          - ruby
+          # TODO: Use the latest Ruby again when we fix GH-39130.
+          # - ruby
+          - "3.1"
     env:
       ARROW_BUILD_STATIC: OFF
       ARROW_BUILD_TESTS: OFF
@@ -246,13 +248,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Upgrade MSYS2
-        run: |
-          ridk exec bash ci\scripts\msys2_system_upgrade.sh
-          taskkill /F /FI "MODULES eq msys-2.0.dll"
-      - name: Clean MSYS2
-        run: |
-          ridk exec bash ci\scripts\msys2_system_clean.sh
       - name: Setup MSYS2
         run: |
           ridk exec bash ci\scripts\msys2_setup.sh ruby

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -43,7 +43,6 @@ case "${target}" in
     packages+=(${MINGW_PACKAGE_PREFIX}-lz4)
     packages+=(${MINGW_PACKAGE_PREFIX}-ninja)
     packages+=(${MINGW_PACKAGE_PREFIX}-nlohmann-json)
-    packages+=(${MINGW_PACKAGE_PREFIX}-openssl)
     packages+=(${MINGW_PACKAGE_PREFIX}-protobuf)
     packages+=(${MINGW_PACKAGE_PREFIX}-rapidjson)
     packages+=(${MINGW_PACKAGE_PREFIX}-re2)
@@ -52,8 +51,17 @@ case "${target}" in
     packages+=(${MINGW_PACKAGE_PREFIX}-thrift)
     packages+=(${MINGW_PACKAGE_PREFIX}-xsimd)
     packages+=(${MINGW_PACKAGE_PREFIX}-uriparser)
-    packages+=(${MINGW_PACKAGE_PREFIX}-zlib)
     packages+=(${MINGW_PACKAGE_PREFIX}-zstd)
+
+    if [ "${target}" != "ruby" ]; then
+      # We don't update the exiting packages for Ruby because
+      # RubyInstaller for Windows bundles some DLLs such as libffi,
+      # OpenSSL and zlib separately. They should be ABI compatible
+      # with packages installed by MSYS2. If we specify packages
+      # explicitly here, the existing packages may be updated.
+      packages+=(${MINGW_PACKAGE_PREFIX}-openssl)
+      packages+=(${MINGW_PACKAGE_PREFIX}-zlib)
+    fi
   ;;
 esac
 
@@ -78,7 +86,6 @@ esac
 pacman \
   --needed \
   --noconfirm \
-  --refresh \
   --sync \
   "${packages[@]}"
 


### PR DESCRIPTION
### Rationale for this change

I don't know why the following error is happen:

    Failed to load shared library 'libarrow-glib-1500.dll' referenced
    by the typelib: 'libarrow-glib-1500.dll': The specified procedure
    could not be found.

I think that some symbols are missing but I can't identify them because:

* Windows doesn't report them...
* I can't reproduce this on my local environment.

I found that this isn't happen with a bit old Ruby. So we can use a bit old Ruby as workaround for now.

### What changes are included in this PR?

* Use Ruby 3.1
* Don't update existing packages

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39130