### PR TITLE
GH-39185: [C++] Remove compiler warnings with `-Wconversion -Wno-sign-conversion` in public headers

### DIFF
--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -335,7 +335,9 @@ void ClearBitmap(uint8_t* data, int64_t offset, int64_t length);
 /// ref: https://stackoverflow.com/a/59523400
 template <typename Word>
 constexpr Word PrecedingWordBitmask(unsigned int const i) {
-  return (static_cast<Word>(i < sizeof(Word) * 8) << (i & (sizeof(Word) * 8 - 1))) - 1;
+  return static_cast<Word>(static_cast<Word>(i < sizeof(Word) * 8)
+                           << (i & (sizeof(Word) * 8 - 1))) -
+         1;
 }
 static_assert(PrecedingWordBitmask<uint8_t>(0) == 0x00, "");
 static_assert(PrecedingWordBitmask<uint8_t>(4) == 0x0f, "");
@@ -357,8 +359,9 @@ constexpr Word SpliceWord(int n, Word low, Word high) {
 template <int batch_size>
 void PackBits(const uint32_t* values, uint8_t* out) {
   for (int i = 0; i < batch_size / 8; ++i) {
-    *out++ = (values[0] | values[1] << 1 | values[2] << 2 | values[3] << 3 |
-              values[4] << 4 | values[5] << 5 | values[6] << 6 | values[7] << 7);
+    *out++ = static_cast<uint8_t>(values[0] | values[1] << 1 | values[2] << 2 |
+                                  values[3] << 3 | values[4] << 4 | values[5] << 5 |
+                                  values[6] << 6 | values[7] << 7);
     values += 8;
   }
 }

--- a/cpp/src/arrow/util/bitmap_generate.h
+++ b/cpp/src/arrow/util/bitmap_generate.h
@@ -90,9 +90,10 @@ void GenerateBitsUnrolled(uint8_t* bitmap, int64_t start_offset, int64_t length,
     for (int i = 0; i < 8; ++i) {
       out_results[i] = g();
     }
-    *cur++ = (out_results[0] | out_results[1] << 1 | out_results[2] << 2 |
-              out_results[3] << 3 | out_results[4] << 4 | out_results[5] << 5 |
-              out_results[6] << 6 | out_results[7] << 7);
+    *cur++ = static_cast<uint8_t>(out_results[0] | out_results[1] << 1 |
+                                  out_results[2] << 2 | out_results[3] << 3 |
+                                  out_results[4] << 4 | out_results[5] << 5 |
+                                  out_results[6] << 6 | out_results[7] << 7);
   }
 
   int64_t remaining_bits = remaining % 8;


### PR DESCRIPTION
### Rationale for this change

The R package has a warning from CRAN to fix a failure to compile with `-Wconversion -Wno-sign-conversion -Werror`. Some of these errors we control and can patch easily; however, the ones in the Arrow C++ portion are more difficult to work around (hence the separate PR). See #39138 for all reported errors (including those in just the R package).

### What changes are included in this PR?

The requisite `static_cast<>()`s were added to silence the warnings.

### Are these changes tested?

By existing tests. We may add a future R nightly job that runs with these warning flags.

### Are there any user-facing changes?

No
* Closes: #39185