### PR TITLE
GH-39024: [Compute] Allow implicitly casting extension to storage types in compute functions

### DIFF
--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -388,14 +388,12 @@ Result<const Kernel*> Function::DispatchWithExtensionCast(
 Result<const Kernel*> Function::DispatchBest(std::vector<TypeHolder>* values) const {
   // TODO(ARROW-11508) permit generic conversions here
   Result<const Kernel*> result;
-  result = DispatchExact(*values);
-  if (result.ok()) {
+  if (result = DispatchExact(*values); result.ok()) {
     return result;
   }
 
   // Try to cast extension types to their storage types
-  result = DispatchWithExtensionCast(values);
-  if (result.ok()) {
+  if (result = DispatchWithExtensionCast(values); result.ok()) {
     return result;
   }
 

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -284,6 +284,18 @@ class ARROW_EXPORT Function {
 
   Status CheckArity(size_t num_args) const;
 
+  /// \brief Return a best-match kernel that can execute the function that enables casting
+  /// ExtensionTypes to their storage types. If multiple kernels match, the one with the
+  /// minimum number of casts is returned. If there are multiple kernels with the minimum
+  /// number of casts, the first one is returned.
+  ///
+  ///
+  /// \param[in,out] values Argument types. An element may be modified to
+  /// indicate that the returned kernel only approximately matches the input
+  /// value descriptors; callers are responsible for casting inputs to the type
+  /// required by the kernel.
+  Result<const Kernel*> DispatchWithExtensionCast(std::vector<TypeHolder>* values) const;
+
   std::string name_;
   Function::Kind kind_;
   Arity arity_;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -138,6 +138,19 @@ void ReplaceTypes(const TypeHolder& replacement, TypeHolder* begin, size_t count
   }
 }
 
+void EnsureExtensionToStorage(std::vector<TypeHolder>* types) {
+  EnsureExtensionToStorage(types->data(), types->size());
+}
+
+void EnsureExtensionToStorage(TypeHolder* begin, size_t count) {
+  auto* end = begin + count;
+  for (auto* it = begin; it != end; it++) {
+    if (it->type->id() == Type::EXTENSION) {
+      *it = checked_cast<const ExtensionType&>(*it->type).storage_type();
+    }
+  }
+}
+
 TypeHolder CommonNumeric(const std::vector<TypeHolder>& types) {
   return CommonNumeric(types.data(), types.size());
 }

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1366,6 +1366,12 @@ ARROW_EXPORT
 void ReplaceTemporalTypes(TimeUnit::type unit, std::vector<TypeHolder>* types);
 
 ARROW_EXPORT
+void EnsureExtensionToStorage(std::vector<TypeHolder>* types);
+
+ARROW_EXPORT
+void EnsureExtensionToStorage(TypeHolder* begin, size_t count);
+
+ARROW_EXPORT
 TypeHolder CommonNumeric(const std::vector<TypeHolder>& types);
 
 ARROW_EXPORT

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -630,6 +630,7 @@ struct ArithmeticFunction : ScalarFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     // Only promote types for binary functions
     if (types->size() == 2) {
@@ -685,6 +686,7 @@ struct ArithmeticDecimalToFloatingPointFunction : public ArithmeticFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     if (types->size() == 2) {
       ReplaceNullWithOtherType(types);
@@ -717,6 +719,7 @@ struct ArithmeticIntegerToFloatingPointFunction : public ArithmeticFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     if (types->size() == 2) {
       ReplaceNullWithOtherType(types);
@@ -748,6 +751,7 @@ struct ArithmeticFloatingPointFunction : public ArithmeticFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     if (types->size() == 2) {
       ReplaceNullWithOtherType(types);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -36,6 +36,7 @@
 #include "arrow/util/string.h"
 
 #include "arrow/testing/builder.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 
@@ -2753,6 +2754,11 @@ TYPED_TEST(TestUnaryArithmeticFloating, Sign) {
   this->AssertUnaryOp(sign, this->MakeScalar(max), this->MakeScalar(1));
 }
 
+TEST(TestArithmeticExtension, Extension) {
+  // Allow extension types to be implicitly cast to their storage types
+  ASSERT_ARRAYS_EQUAL(*ArrayFromJSON(int16(), "[-32640, null, 0, 0, 0, 0, 32640]"),
+                      *Subtract(ExampleSmallint(), ExampleTinyint())->make_array());
+}
 }  // namespace
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -348,6 +348,7 @@ struct CompareFunction : ScalarFunction {
 
     EnsureDictionaryDecoded(types);
     ReplaceNullWithOtherType(types);
+    EnsureExtensionToStorage(types);
 
     if (auto type = CommonNumeric(*types)) {
       ReplaceTypes(type, types);
@@ -372,6 +373,7 @@ struct VarArgsCompareFunction : ScalarFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     if (auto type = CommonNumeric(*types)) {
       ReplaceTypes(type, types);

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -28,6 +28,7 @@
 #include "arrow/compute/api.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/testing/builder.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
 #include "arrow/testing/random.h"
@@ -2123,5 +2124,11 @@ TEST(TestMaxElementWiseMinElementWise, CommonTemporal) {
               ResultWith(ScalarFromJSON(date64(), "86400000")));
 }
 
+TEST(TestCompareExtension, Extension) {
+  // Allow extension types to be implicitly cast to their storage types
+  ASSERT_ARRAYS_EQUAL(
+      *ArrayFromJSON(int16(), "[-32768, null, 1, 2, 3, 4, 127]"),
+      *MinElementWise({ExampleSmallint(), ExampleTinyint()})->make_array());
+}
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1226,6 +1226,7 @@ struct IfElseFunction : ScalarFunction {
     }
 
     internal::EnsureDictionaryDecoded(left_arg, num_args);
+    internal::EnsureExtensionToStorage(types);
 
     if (auto type = internal::CommonNumeric(left_arg, num_args)) {
       internal::ReplaceTypes(type, left_arg, num_args);
@@ -1431,6 +1432,7 @@ struct CaseWhenFunction : ScalarFunction {
     }
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
     TypeHolder* first_arg = &(*types)[1];
     const size_t num_args = types->size() - 1;
     if (auto type = CommonNumeric(first_arg, num_args)) {
@@ -1964,6 +1966,7 @@ struct CoalesceFunction : ScalarFunction {
 
     // Do not DispatchExact here since we want to rescale decimals if necessary
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
     if (auto type = CommonNumeric(types->data(), types->size())) {
       ReplaceTypes(type, types);
     }
@@ -2663,6 +2666,7 @@ struct ChooseFunction : ScalarFunction {
     // based on the type of the rest of the arguments.
     RETURN_NOT_OK(CheckArity(types->size()));
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
     if (types->front().id() != Type::INT64) {
       (*types)[0] = int64();
     }

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -1053,6 +1053,7 @@ struct RoundFunction : ScalarFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     // for binary round functions, the second scalar must be int32
     if (types->size() == 2 && (*types)[1].id() != Type::INT32) {
@@ -1074,6 +1075,7 @@ struct RoundDecimalToFloatingPointFunction : public RoundFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     // Size of types is checked above.
     const auto originalType = (*types)[0];
@@ -1099,6 +1101,7 @@ struct RoundIntegerToFloatingPointFunction : public RoundFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     // Size of types is checked above.
     const auto originalType = (*types)[0];
@@ -1124,6 +1127,7 @@ struct RoundFloatingPointFunction : public RoundFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     // Size of types is checked above.
     const auto originalType = (*types)[0];

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -636,6 +636,7 @@ struct SetLookupFunction : ScalarFunction {
 
   Result<const Kernel*> DispatchBest(std::vector<TypeHolder>* values) const override {
     EnsureDictionaryDecoded(values);
+    EnsureExtensionToStorage(values);
     return DispatchExact(*values);
   }
 };

--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -3258,6 +3258,7 @@ struct ScalarCTypeToInt64Function : public ScalarFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
 
     EnsureDictionaryDecoded(types);
+    EnsureExtensionToStorage(types);
 
     for (auto it = types->begin(); it < types->end(); ++it) {
       if (is_integer(it->id())) {

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -317,6 +317,18 @@ static inline void SetBitTo(uint8_t* bits, int64_t i, bool bit_is_set) {
                  kBitmask[i % 8];
 }
 
+// Inputs a pattern of N bits set to 1 in an integer and outputs the next permutation of N
+// 1 bits in a lexicographical sense. For example, if N is 3 and the bit pattern is
+// 00010011, the next patterns would be 00010101, 00010110, 00011001,00011010, 00011100,
+// 00100011, and so forth. The following is a fast way to compute the next permutation.
+// https://graphics.stanford.edu/~seander/bithacks.html#NextBitPermutation
+static inline uint32_t NextBitPermutation(uint32_t v) {
+  uint32_t t = v | (v - 1);  // t gets v's least significant 0 bits set to 1
+  // Next set to 1 the most significant bit to change,
+  // set to 0 the least significant ones, and add the necessary 1 bits.
+  return (t + 1) | (((~t & -~t) - 1) >> (CountTrailingZeros(v) + 1));
+}
+
 /// \brief set or clear a range of bits quickly
 ARROW_EXPORT
 void SetBitsTo(uint8_t* bits, int64_t start_offset, int64_t length, bool bits_are_set);

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -326,7 +326,7 @@ static inline uint32_t NextBitPermutation(uint32_t v) {
   uint32_t t = v | (v - 1);  // t gets v's least significant 0 bits set to 1
   // Next set to 1 the most significant bit to change,
   // set to 0 the least significant ones, and add the necessary 1 bits.
-  return (t + 1) | (((~t & -~t) - 1) >> (CountTrailingZeros(v) + 1));
+  return (t + 1) | (((~t & (0 - ~t)) - 1) >> (CountTrailingZeros(v) + 1));
 }
 
 /// \brief set or clear a range of bits quickly


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Extension types are only logical, i.e. each extension type has a underlying native storage type. We can allow implicit casting from extension types to their storage types. I believe this can make `ExtensionType`s much easier to use.

### What changes are included in this PR?

1. In `DispatchBest`, if no matching kernels exist, allow extension types to be casted to their storage types and match again. The kernel with the minimum number of casts is selected. If there are multiple best kernels, report an error. The dispatching algo is similar to C++'s.
3. In functions that overwrite `DispatchBest`, call `EnsureExtensionToStorage` to simply replace extension types by their storage types, because these functions do not provide native kernels for extension types so we don't need to count the number of casts needed.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39024