### PR TITLE
GH-39119: [C++] Refactor the Azure FS tests and filesystem class instantiation

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -757,9 +757,9 @@ class AzureFileSystem::Impl {
   io::IOContext io_context_;
   AzureOptions options_;
 
-  internal::HierarchicalNamespaceDetector hns_detector_;
   std::unique_ptr<DataLake::DataLakeServiceClient> datalake_service_client_;
   std::unique_ptr<Blobs::BlobServiceClient> blob_service_client_;
+  internal::HierarchicalNamespaceDetector hns_detector_;
 
   Impl(AzureOptions options, io::IOContext io_context)
       : io_context_(std::move(io_context)), options_(std::move(options)) {}

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -49,12 +49,12 @@ AzureOptions::~AzureOptions() = default;
 
 bool AzureOptions::Equals(const AzureOptions& other) const {
   // TODO(GH-38598): update here when more auth methods are added.
-  const bool ret = backend == other.backend &&
-                   default_metadata == other.default_metadata &&
-                   account_blob_url_ == other.account_blob_url_ &&
-                   account_dfs_url_ == other.account_dfs_url_ &&
-                   credential_kind_ == other.credential_kind_;
-  if (!ret) {
+  const bool equals = backend == other.backend &&
+                      default_metadata == other.default_metadata &&
+                      account_blob_url_ == other.account_blob_url_ &&
+                      account_dfs_url_ == other.account_dfs_url_ &&
+                      credential_kind_ == other.credential_kind_;
+  if (!equals) {
     return false;
   }
   switch (credential_kind_) {

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -88,7 +88,8 @@ struct ARROW_EXPORT AzureOptions {
   const std::string& AccountBlobUrl() const { return account_blob_url_; }
   const std::string& AccountDfsUrl() const { return account_dfs_url_; }
 
-  Result<std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient>> MakeBlobServiceClient() const;
+  Result<std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient>>
+  MakeBlobServiceClient() const;
 
   Result<std::unique_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>>
   MakeDataLakeServiceClient() const;

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -125,8 +125,17 @@ struct ARROW_EXPORT AzureOptions {
 /// [3]:
 /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-known-issues
 class ARROW_EXPORT AzureFileSystem : public FileSystem {
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+
+  explicit AzureFileSystem(std::unique_ptr<Impl>&& impl);
+
  public:
   ~AzureFileSystem() override = default;
+
+  static Result<std::shared_ptr<AzureFileSystem>> Make(
+      const AzureOptions& options, const io::IOContext& = io::default_io_context());
 
   std::string type_name() const override { return "abfs"; }
 
@@ -171,15 +180,6 @@ class ARROW_EXPORT AzureFileSystem : public FileSystem {
   Result<std::shared_ptr<io::OutputStream>> OpenAppendStream(
       const std::string& path,
       const std::shared_ptr<const KeyValueMetadata>& metadata = {}) override;
-
-  static Result<std::shared_ptr<AzureFileSystem>> Make(
-      const AzureOptions& options, const io::IOContext& = io::default_io_context());
-
- private:
-  AzureFileSystem(const AzureOptions& options, const io::IOContext& io_context);
-
-  class Impl;
-  std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace arrow::fs

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -88,9 +88,9 @@ struct ARROW_EXPORT AzureOptions {
   const std::string& AccountBlobUrl() const { return account_blob_url_; }
   const std::string& AccountDfsUrl() const { return account_dfs_url_; }
 
-  std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> MakeBlobServiceClient() const;
+  Result<std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient>> MakeBlobServiceClient() const;
 
-  std::unique_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>
+  Result<std::unique_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>>
   MakeDataLakeServiceClient() const;
 };
 

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -43,7 +43,7 @@ class DataLakeServiceClient;
 
 namespace arrow::fs {
 
-enum class AzureBackend : bool {
+enum class AzureBackend {
   /// \brief Official Azure Remote Backend
   kAzure,
   /// \brief Local Simulated Storage

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -23,10 +23,16 @@
 
 namespace arrow::fs::internal {
 
+namespace {
+
+// TODO(GH-38772): Remote azurefs_internal.h/.cc by moving the detector to
+// azurefs.cc (which contains a private copy of this helper function already).
 Status ExceptionToStatus(const std::string& prefix,
                          const Azure::Storage::StorageException& exception) {
   return Status::IOError(prefix, " Azure Error: ", exception.what());
 }
+
+}  // namespace
 
 Status HierarchicalNamespaceDetector::Init(
     Azure::Storage::Files::DataLake::DataLakeServiceClient* datalake_service_client) {

--- a/cpp/src/arrow/filesystem/azurefs_internal.cc
+++ b/cpp/src/arrow/filesystem/azurefs_internal.cc
@@ -25,7 +25,7 @@ namespace arrow::fs::internal {
 
 namespace {
 
-// TODO(GH-38772): Remote azurefs_internal.h/.cc by moving the detector to
+// TODO(GH-38772): Remove azurefs_internal.h/.cc by moving the detector to
 // azurefs.cc (which contains a private copy of this helper function already).
 Status ExceptionToStatus(const std::string& prefix,
                          const Azure::Storage::StorageException& exception) {

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -25,9 +25,6 @@
 
 namespace arrow::fs::internal {
 
-Status ExceptionToStatus(const std::string& prefix,
-                         const Azure::Storage::StorageException& exception);
-
 class HierarchicalNamespaceDetector {
  public:
   Status Init(

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -217,10 +217,8 @@ class AzureFileSystemTest : public ::testing::Test {
     }
     // Stop-gap solution before GH-39119 is fixed.
     container_name_ = "z" + RandomChars(31);
-    blob_service_client_ = std::make_unique<Blobs::BlobServiceClient>(
-        options_.account_blob_url, options_.storage_credentials_provider);
-    datalake_service_client_ = std::make_unique<Files::DataLake::DataLakeServiceClient>(
-        options_.account_dfs_url, options_.storage_credentials_provider);
+    blob_service_client_ = options_.MakeBlobServiceClient();
+    datalake_service_client_ = options_.MakeDataLakeServiceClient();
     ASSERT_OK_AND_ASSIGN(fs_, AzureFileSystem::Make(options_));
     auto container_client = CreateContainer(container_name_);
 
@@ -388,8 +386,8 @@ class AzuriteFileSystemTest : public AzureFileSystemTest {
     ARROW_EXPECT_OK(GetAzuriteEnv()->status());
     ARROW_ASSIGN_OR_RAISE(debug_log_start_, GetAzuriteEnv()->GetDebugLogSize());
     AzureOptions options;
-    options.backend = AzureBackend::Azurite;
-    ARROW_EXPECT_OK(options.ConfigureAccountKeyCredentials(
+    options.backend = AzureBackend::kAzurite;
+    ARROW_EXPECT_OK(options.ConfigureAccountKeyCredential(
         GetAzuriteEnv()->account_name(), GetAzuriteEnv()->account_key()));
     return options;
   }
@@ -413,7 +411,7 @@ class AzureFlatNamespaceFileSystemTest : public AzureFileSystemTest {
     const auto account_key = std::getenv("AZURE_FLAT_NAMESPACE_ACCOUNT_KEY");
     const auto account_name = std::getenv("AZURE_FLAT_NAMESPACE_ACCOUNT_NAME");
     if (account_key && account_name) {
-      RETURN_NOT_OK(options.ConfigureAccountKeyCredentials(account_name, account_key));
+      RETURN_NOT_OK(options.ConfigureAccountKeyCredential(account_name, account_key));
       return options;
     }
     return Status::Cancelled(
@@ -444,7 +442,7 @@ class AzureHierarchicalNamespaceFileSystemTest : public AzureFileSystemTest {
     const auto account_key = std::getenv("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_KEY");
     const auto account_name = std::getenv("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_NAME");
     if (account_key && account_name) {
-      RETURN_NOT_OK(options.ConfigureAccountKeyCredentials(account_name, account_key));
+      RETURN_NOT_OK(options.ConfigureAccountKeyCredential(account_name, account_key));
       return options;
     }
     return Status::Cancelled(

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -132,11 +132,19 @@ class AzureEnvImpl : public BaseAzureEnv {
       const std::string& account_name_var, const std::string& account_key_var) {
     const auto account_name = std::getenv(account_name_var.c_str());
     const auto account_key = std::getenv(account_key_var.c_str());
+    if (!account_name && !account_key) {
+      return Status::Cancelled(account_name_var + " and " + account_key_var +
+                               " are not set. Skipping tests.");
+    }
+    // If only one of the variables is set. Don't cancel tests,
+    // fail with a Status::Invalid.
     if (!account_name) {
-      return Status::Cancelled(account_name_var + " not set.");
+      return Status::Invalid(account_name_var + " not set while " + account_key_var +
+                             " is set.");
     }
     if (!account_key) {
-      return Status::Cancelled(account_key_var + " not set.");
+      return Status::Invalid(account_key_var + " not set while " + account_name_var +
+                             " is set.");
     }
     return std::unique_ptr<AzureEnvClass>{new AzureEnvClass(account_name, account_key)};
   }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -71,7 +71,8 @@ using ::testing::Not;
 using ::testing::NotNull;
 
 namespace Blobs = Azure::Storage::Blobs;
-namespace Files = Azure::Storage::Files;
+namespace Core = Azure::Core;
+namespace DataLake = Azure::Storage::Files::DataLake;
 
 auto const* kLoremIpsum = R"""(
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -87,8 +88,8 @@ class AzuriteEnv : public ::testing::Environment {
   AzuriteEnv() {
     account_name_ = "devstoreaccount1";
     account_key_ =
-        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/"
-        "KBHBeksoGMGw==";
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+        "K1SZFPTOtr/KBHBeksoGMGw==";
     auto exe_path = bp::search_path("azurite");
     if (exe_path.empty()) {
       auto error = std::string("Could not find Azurite emulator.");
@@ -197,7 +198,7 @@ class AzureFileSystemTest : public ::testing::Test {
  public:
   std::shared_ptr<FileSystem> fs_;
   std::unique_ptr<Blobs::BlobServiceClient> blob_service_client_;
-  std::unique_ptr<Files::DataLake::DataLakeServiceClient> datalake_service_client_;
+  std::unique_ptr<DataLake::DataLakeServiceClient> datalake_service_client_;
   AzureOptions options_;
   std::mt19937_64 generator_;
   std::string container_name_;
@@ -1200,7 +1201,7 @@ TEST_F(AzuriteFileSystemTest, TestWriteMetadata) {
           .GetBlockBlobClient(path)
           .GetProperties()
           .Value.Metadata;
-  EXPECT_EQ(Azure::Core::CaseInsensitiveMap{std::make_pair("foo", "bar")}, blob_metadata);
+  EXPECT_EQ(Core::CaseInsensitiveMap{std::make_pair("foo", "bar")}, blob_metadata);
 
   // Check that explicit metadata overrides the defaults.
   ASSERT_OK_AND_ASSIGN(
@@ -1213,7 +1214,7 @@ TEST_F(AzuriteFileSystemTest, TestWriteMetadata) {
                       .GetProperties()
                       .Value.Metadata;
   // Defaults are overwritten and not merged.
-  EXPECT_EQ(Azure::Core::CaseInsensitiveMap{std::make_pair("bar", "foo")}, blob_metadata);
+  EXPECT_EQ(Core::CaseInsensitiveMap{std::make_pair("bar", "foo")}, blob_metadata);
 }
 
 TEST_F(AzuriteFileSystemTest, OpenOutputStreamSmall) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -383,7 +383,7 @@ class AzureFileSystemTest : public ::testing::Test {
     if (options_res.status().IsCancelled()) {
       GTEST_SKIP() << options_res.status().message();
     } else {
-      EXPECT_OK_AND_ASSIGN(options_, std::move(options_res));
+      EXPECT_OK_AND_ASSIGN(options_, options_res);
     }
 
     ASSERT_OK_AND_ASSIGN(fs_, AzureFileSystem::Make(options_));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -387,8 +387,8 @@ class AzureFileSystemTest : public ::testing::Test {
     }
 
     ASSERT_OK_AND_ASSIGN(fs_, AzureFileSystem::Make(options_));
-    blob_service_client_ = options_.MakeBlobServiceClient();
-    datalake_service_client_ = options_.MakeDataLakeServiceClient();
+    EXPECT_OK_AND_ASSIGN(blob_service_client_, options_.MakeBlobServiceClient());
+    EXPECT_OK_AND_ASSIGN(datalake_service_client_, options_.MakeDataLakeServiceClient());
     set_up_succeeded_ = true;
   }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -819,7 +819,7 @@ TEST_F(AzureHierarchicalNSFileSystemTest, DeleteDirContentsFailureNonexistent) {
 TEST_F(AzuriteFileSystemTest, DetectHierarchicalNamespaceFailsWithMissingContainer) {
   auto hierarchical_namespace = internal::HierarchicalNamespaceDetector();
   ASSERT_OK(hierarchical_namespace.Init(datalake_service_client_.get()));
-  ASSERT_NOT_OK(hierarchical_namespace.Enabled("nonexistent-container"));
+  ASSERT_RAISES(IOError, hierarchical_namespace.Enabled("nonexistent-container"));
 }
 
 TEST_F(AzuriteFileSystemTest, GetFileInfoAccount) {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -85,8 +85,6 @@ class BaseAzureEnv : public ::testing::Environment {
       : account_name_(std::move(account_name)), account_key_(std::move(account_key)) {}
 
  public:
-  ~BaseAzureEnv() override = default;
-
   const std::string& account_name() const { return account_name_; }
   const std::string& account_key() const { return account_key_; }
 
@@ -151,8 +149,6 @@ class AzureEnvImpl : public BaseAzureEnv {
   }
 
  public:
-  ~AzureEnvImpl() override = default;
-
   static Result<BaseAzureEnv*> GetInstance() {
     // Ensure MakeAndAddToGlobalTestEnvironment() is called only once by storing the
     // Result<BaseAzureEnv*> in a static variable.
@@ -249,8 +245,6 @@ class AzureFlatNSEnv : public AzureEnvImpl<AzureFlatNSEnv> {
  public:
   static const AzureBackend kBackend = AzureBackend::kAzure;
 
-  ~AzureFlatNSEnv() override = default;
-
   static Result<std::unique_ptr<AzureFlatNSEnv>> Make() {
     return MakeFromEnvVars("AZURE_FLAT_NAMESPACE_ACCOUNT_NAME",
                            "AZURE_FLAT_NAMESPACE_ACCOUNT_KEY");
@@ -263,8 +257,6 @@ class AzureHierarchicalNSEnv : public AzureEnvImpl<AzureHierarchicalNSEnv> {
 
  public:
   static const AzureBackend kBackend = AzureBackend::kAzure;
-
-  ~AzureHierarchicalNSEnv() override = default;
 
   static Result<std::unique_ptr<AzureHierarchicalNSEnv>> Make() {
     return MakeFromEnvVars("AZURE_HIERARCHICAL_NAMESPACE_ACCOUNT_NAME",

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -380,7 +380,7 @@ class AzureFileSystemTest : public ::testing::Test {
       return MakeOptions(env);
     };
     auto options_res = make_options();
-    if (!options_res.ok() && options_res.status().IsCancelled()) {
+    if (options_res.status().IsCancelled()) {
       GTEST_SKIP() << options_res.status().message();
     } else {
       EXPECT_OK_AND_ASSIGN(options_, std::move(options_res));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -677,15 +677,12 @@ class AzureFileSystemTestImpl : public AzureFileSystemTest {
 // You need an Azure account. You should be able to create a free account [1].
 // Through the portal Web UI, you should create a storage account [2].
 //
-//
 // A few suggestions on configuration:
 //
 // * Use Standard general-purpose v2 not premium
 // * Use LRS redundancy
 // * Set the default access tier to hot
 // * SFTP, NFS and file shares are not required.
-//
-// You need to enable Hierarchical Namespace on the storage account
 //
 // You must not enable Hierarchical Namespace on the storage account used for
 // AzureFlatNSFileSystemTest, but you must enable it on the storage account

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -315,20 +315,20 @@ culpa qui officia deserunt mollit anim id est laborum.
   static std::string RandomContainerName(RNG& rng) { return RandomChars(32, rng); }
   static std::string RandomDirectoryName(RNG& rng) { return RandomChars(32, rng); }
 
-  static std::string RandomLine(int lineno, std::size_t width, RNG& rng) {
+  static std::string RandomLine(int lineno, int width, RNG& rng) {
     auto line = std::to_string(lineno) + ":    ";
-    line += RandomChars(width - line.size() - 1, rng);
+    line += RandomChars(width - static_cast<int>(line.size()) - 1, rng);
     line += '\n';
     return line;
   }
 
-  static std::size_t RandomIndex(std::size_t end, RNG& rng) {
-    return std::uniform_int_distribution<std::size_t>(0, end - 1)(rng);
+  static int RandomIndex(int end, RNG& rng) {
+    return std::uniform_int_distribution<int>(0, end - 1)(rng);
   }
 
-  static std::string RandomChars(std::size_t count, RNG& rng) {
+  static std::string RandomChars(int count, RNG& rng) {
     auto const fillers = std::string("abcdefghijlkmnopqrstuvwxyz0123456789");
-    std::uniform_int_distribution<std::size_t> d(0, fillers.size() - 1);
+    std::uniform_int_distribution<int> d(0, static_cast<int>(fillers.size()) - 1);
     std::string s;
     std::generate_n(std::back_inserter(s), count, [&] { return fillers[d(rng)]; });
     return s;


### PR DESCRIPTION
### Rationale for this change

This PR contains some unrelated improvements (like better docs) and some nitpicky fixes. The test refactoring makes it easier to see on which environments tests run and make them able to be instantiated with different options in the future once we extend the `AzureOptions`.

### What changes are included in this PR?

 - Random cleanups
 - Short namespace aliases
 - Refactoring of the tests (multiple environments, TYPED_TEST_SUITE, explicit preexisting data setup)
 - Cleanup of the `AzureOptions` class

### Are these changes tested?

Yes. I created Azure Storage accounts to test with and without Hierarchical Namespace support. I also ran the tests in a shell without my environment variables to ensure the test-skipping behavior is correct.

### Are there any user-facing changes?

Changes to `AzureOptions`, but since `AzureFileSystem` is not really used yet, these breaking changes won't be a problem.
* Closes: #39119