### PR TITLE
GH-39212: [Release] Retry download binary subprocess in case of OpenSSL error

### DIFF
--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -121,17 +121,25 @@ class Downloader:
             dest_path,
             url,
         ]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        stdout, stderr = proc.communicate()
-        if proc.returncode != 0:
-            try:
-                # Don't leave possibly partial file around
-                os.remove(dest_path)
-            except IOError:
-                pass
-            raise Exception(f"Downloading {url} failed\n"
-                            f"stdout: {stdout}\nstderr: {stderr}")
+        # Retry subprocess in case it fails with OpenSSL Connection errors
+        # https://issues.apache.org/jira/browse/INFRA-25274
+        for _ in range(5):
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+            stdout, stderr = proc.communicate()
+            if proc.returncode != 0:
+                try:
+                    # Don't leave possibly partial file around
+                    os.remove(dest_path)
+                except IOError:
+                    pass
+                if "OpenSSL" not in stderr:
+                    # We assume curl has already retried on other errors.
+                    break
+            else:
+                return
+        raise Exception(f"Downloading {url} failed\n"
+                        f"stdout: {stdout}\nstderr: {stderr}")
 
     def _curl_version(self):
         cmd = ["curl", "--version"]

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -124,7 +124,8 @@ class Downloader:
         # Retry subprocess in case it fails with OpenSSL Connection errors
         # https://issues.apache.org/jira/browse/INFRA-25274
         for attempt in range(5):
-            if delay := attempt * 3:
+            if attempt > 0:
+                delay = attempt * 3:
                 print(f"Waiting {delay} seconds before retrying {url}")
                 time.sleep(delay)
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -123,7 +123,10 @@ class Downloader:
         ]
         # Retry subprocess in case it fails with OpenSSL Connection errors
         # https://issues.apache.org/jira/browse/INFRA-25274
-        for _ in range(5):
+        for attempt in range(5):
+            if delay := attempt * 3:
+                print(f"Waiting {delay} seconds before retrying {url}")
+                time.sleep(delay)
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
             stdout, stderr = proc.communicate()

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -125,7 +125,7 @@ class Downloader:
         # https://issues.apache.org/jira/browse/INFRA-25274
         for attempt in range(5):
             if attempt > 0:
-                delay = attempt * 3:
+                delay = attempt * 3
                 print(f"Waiting {delay} seconds before retrying {url}")
                 time.sleep(delay)
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,


### PR DESCRIPTION
### Rationale for this change

In case of OpenSSL error when trying to download RC binaries we do not retry and we are facing some issues with artifactory that after some job retries allowed us to successfully download the binaries.

### What changes are included in this PR?

Retry mechanism in case of subprocess error.

### Are these changes tested?

Tested locally verifying wheels and jars for 14.0.2 RC 3.

### Are there any user-facing changes?

No
* Closes: #39212