### PR TITLE
GH-38914: [Python] Add EncryptionConfiguration.uniform_encryption

### DIFF
--- a/cpp/src/parquet/encryption/crypto_factory.h
+++ b/cpp/src/parquet/encryption/crypto_factory.h
@@ -41,6 +41,7 @@ struct PARQUET_EXPORT EncryptionConfiguration {
       : footer_key(footer_key) {}
 
   /// ID of the master key for footer encryption/signing
+  /// If uniform_encryption is True, will use this key to encrypt all columns as well.
   std::string footer_key;
 
   /// List of columns to encrypt, with master key IDs (see HIVE-21848).
@@ -53,7 +54,7 @@ struct PARQUET_EXPORT EncryptionConfiguration {
   /// thrown.
   std::string column_keys;
 
-  /// Encrypt footer and all columns with the same encryption key.
+  /// Encrypt footer and all columns with the same encryption key (footer_key).
   bool uniform_encryption = kDefaultUniformEncryption;
 
   /// Parquet encryption algorithm. Can be "AES_GCM_V1" (default), or "AES_GCM_CTR_V1".

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -72,6 +72,7 @@ cdef extern from "parquet/encryption/crypto_factory.h" \
         CEncryptionConfiguration(const c_string& footer_key) except +
         c_string footer_key
         c_string column_keys
+        c_bool uniform_encryption
         ParquetCipher encryption_algorithm
         c_bool plaintext_footer
         c_bool double_wrapping

--- a/python/setup.py
+++ b/python/setup.py
@@ -181,8 +181,12 @@ class build_ext(_build_ext):
         self.bundle_cython_cpp = strtobool(
             os.environ.get('PYARROW_BUNDLE_CYTHON_CPP', '0'))
 
-        self.with_parquet_encryption = (self.with_parquet_encryption and
-                                        self.with_parquet)
+        if self.with_parquet_encryption and not self.with_parquet:
+            raise ValueError(
+                "Cannot build Parquet encryption without Parquet. Set PYARROW_WITH_PARQUET=1 "
+                "or use --with-parquet-encryption."
+                )
+
 
         # enforce module dependencies
         if self.with_substrait:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

I've broken the PR up into separate commits so that I can revert one if needed, especially the last one if you feel like the build process should be changed in another PR.

feat(Python/Build): raise if parquet encryption is set without parquet
test(Python): add tests using EncryptionConfiguration.uniform_encryption
feat(Python): add uniform_encryption to EncryptionConfiguration
test(C++): add a test featuring uniform_encryption using datasets
docs(C++): add more detail about uniform_encryption

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes, it adds `uniform_encryption` to the Python implementation.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38914