### PR TITLE
GH-39191: [R] throw error when `string_replace` is passed vector of values in `pattern`

### DIFF
--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -352,8 +352,8 @@ register_bindings_string_regex <- function() {
   # Encapsulate some common logic for sub/gsub/str_replace/str_replace_all
   arrow_r_string_replace_function <- function(max_replacements) {
     function(pattern, replacement, x, ignore.case = FALSE, fixed = FALSE) {
-      if(length(pattern) !=1 || length(replacement) != 1){
-        stop("`pattern` and `replacement` must be a length 1 character vector")
+      if(length(pattern) !=1){
+        stop("`pattern` must be a length 1 character vector")
       }
       Expression$create(
         ifelse(fixed && !ignore.case, "replace_substring", "replace_substring_regex"),

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -352,6 +352,9 @@ register_bindings_string_regex <- function() {
   # Encapsulate some common logic for sub/gsub/str_replace/str_replace_all
   arrow_r_string_replace_function <- function(max_replacements) {
     function(pattern, replacement, x, ignore.case = FALSE, fixed = FALSE) {
+      if(length(pattern) !=1 || length(replacement) != 1){
+        stop("`pattern` must be a length 1 character vector")
+      }
       Expression$create(
         ifelse(fixed && !ignore.case, "replace_substring", "replace_substring_regex"),
         x,

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -58,7 +58,6 @@ get_stringr_pattern_options <- function(pattern) {
   }
 
   ensure_opts <- function(opts) {
-
     # default options for the simple cases
     if (is.character(opts)) {
       opts <- list(pattern = opts, fixed = FALSE, ignore_case = FALSE)
@@ -352,8 +351,11 @@ register_bindings_string_regex <- function() {
   # Encapsulate some common logic for sub/gsub/str_replace/str_replace_all
   arrow_r_string_replace_function <- function(max_replacements) {
     function(pattern, replacement, x, ignore.case = FALSE, fixed = FALSE) {
-      if(length(pattern) !=1){
+      if (length(pattern) != 1) {
         stop("`pattern` must be a length 1 character vector")
+      }
+      if (length(replacement) != 1) {
+        stop("`replacement` must be a length 1 character vector")
       }
       Expression$create(
         ifelse(fixed && !ignore.case, "replace_substring", "replace_substring_regex"),

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -353,7 +353,7 @@ register_bindings_string_regex <- function() {
   arrow_r_string_replace_function <- function(max_replacements) {
     function(pattern, replacement, x, ignore.case = FALSE, fixed = FALSE) {
       if(length(pattern) !=1 || length(replacement) != 1){
-        stop("`pattern` must be a length 1 character vector")
+        stop("`pattern` and `replacement` must be a length 1 character vector")
       }
       Expression$create(
         ifelse(fixed && !ignore.case, "replace_substring", "replace_substring_regex"),

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -433,7 +433,21 @@ test_that("str_replace and str_replace_all", {
       collect(),
     df
   )
-
+  # TODO str_replace_all should throw error now but doesn't, throws a message
+  # about pulling data into R instead?
+  expect_error(
+    arrow_table(df) %>%
+      transmute(x = str_replace_all(x, c("F"="_", "b"=""))) %>%
+      collect(),
+    regexp = "`pattern` must be a length 1 character vector",
+  )
+  # TODO: This test fails as expected (probably remove)
+  compare_dplyr_binding(
+    .input %>%
+      transmute(x = str_replace_all(x, c("F"="f", "b"="B"))) %>%
+      collect(),
+    df
+  )
   compare_dplyr_binding(
     .input %>%
       transmute(x = str_replace_all(x, regex("^F"), "baz")) %>%

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -437,16 +437,9 @@ test_that("str_replace and str_replace_all", {
   # about pulling data into R instead?
   expect_error(
     arrow_table(df) %>%
-      transmute(x = str_replace_all(x, c("F"="_", "b"=""))) %>%
+      transmute(x = call_binding("str_replace_all", x, c("F"="_", "b"=""))) %>%
       collect(),
-    regexp = "`pattern` must be a length 1 character vector",
-  )
-  # TODO: This test fails as expected (probably remove)
-  compare_dplyr_binding(
-    .input %>%
-      transmute(x = str_replace_all(x, c("F"="f", "b"="B"))) %>%
-      collect(),
-    df
+    regexp = "`pattern` and `replacement` must be a length 1 character vector",
   )
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -425,6 +425,23 @@ test_that("sub and gsub with namespacing", {
 })
 
 test_that("str_replace and str_replace_all", {
+  x <- Expression$field_ref("x")
+
+  expect_error(
+    call_binding("str_replace_all", x, c("F" = "_", "b" = "")),
+    regexp = "`pattern` must be a length 1 character vector"
+  )
+
+  expect_error(
+    call_binding("str_replace_all", x, c("F", "b"), c("_", "")),
+    regexp = "`pattern` must be a length 1 character vector"
+  )
+
+  expect_error(
+    call_binding("str_replace_all", x, c("F"), c("_", "")),
+    regexp = "`replacement` must be a length 1 character vector"
+  )
+
   df <- tibble(x = c("Foo", "bar"))
 
   compare_dplyr_binding(
@@ -433,24 +450,7 @@ test_that("str_replace and str_replace_all", {
       collect(),
     df
   )
-  expect_error(
-    arrow_table(df) %>%
-      transmute(x = call_binding("str_replace_all", x, c("F" = "_", "b" = ""))) %>%
-      collect(),
-    regexp = "`pattern` must be a length 1 character vector",
-  )
-  expect_error(
-    arrow_table(df) %>%
-      transmute(x = call_binding("str_replace_all", x, c("F", "b"), c("_", ""))) %>%
-      collect(),
-    regexp = "`pattern` must be a length 1 character vector",
-  )
-  expect_error(
-    arrow_table(df) %>%
-      transmute(x = call_binding("str_replace_all", x, c("F"), c("_", ""))) %>%
-      collect(),
-    regexp = "`replacement` must be a length 1 character vector",
-  )
+
   compare_dplyr_binding(
     .input %>%
       transmute(x = str_replace_all(x, regex("^F"), "baz")) %>%

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -433,11 +433,15 @@ test_that("str_replace and str_replace_all", {
       collect(),
     df
   )
-  # TODO str_replace_all should throw error now but doesn't, throws a message
-  # about pulling data into R instead?
   expect_error(
     arrow_table(df) %>%
       transmute(x = call_binding("str_replace_all", x, c("F"="_", "b"=""))) %>%
+      collect(),
+    regexp = "`pattern` and `replacement` must be a length 1 character vector",
+  )
+  expect_error(
+    arrow_table(df) %>%
+      transmute(x = call_binding("str_replace_all", x, c("F", "b"), c("_", ""))) %>%
       collect(),
     regexp = "`pattern` and `replacement` must be a length 1 character vector",
   )

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -435,7 +435,7 @@ test_that("str_replace and str_replace_all", {
   )
   expect_error(
     arrow_table(df) %>%
-      transmute(x = call_binding("str_replace_all", x, c("F"="_", "b"=""))) %>%
+      transmute(x = call_binding("str_replace_all", x, c("F" = "_", "b" = ""))) %>%
       collect(),
     regexp = "`pattern` must be a length 1 character vector",
   )

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -445,6 +445,12 @@ test_that("str_replace and str_replace_all", {
       collect(),
     regexp = "`pattern` must be a length 1 character vector",
   )
+  expect_error(
+    arrow_table(df) %>%
+      transmute(x = call_binding("str_replace_all", x, c("F"), c("_", ""))) %>%
+      collect(),
+    regexp = "`replacement` must be a length 1 character vector",
+  )
   compare_dplyr_binding(
     .input %>%
       transmute(x = str_replace_all(x, regex("^F"), "baz")) %>%

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -437,13 +437,13 @@ test_that("str_replace and str_replace_all", {
     arrow_table(df) %>%
       transmute(x = call_binding("str_replace_all", x, c("F"="_", "b"=""))) %>%
       collect(),
-    regexp = "`pattern` and `replacement` must be a length 1 character vector",
+    regexp = "`pattern` must be a length 1 character vector",
   )
   expect_error(
     arrow_table(df) %>%
       transmute(x = call_binding("str_replace_all", x, c("F", "b"), c("_", ""))) %>%
       collect(),
-    regexp = "`pattern` and `replacement` must be a length 1 character vector",
+    regexp = "`pattern` must be a length 1 character vector",
   )
   compare_dplyr_binding(
     .input %>%


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
See #39191 This PR will hopefully throw an informative error message to let the user know that while the stringr::str_replace_all function can handle a named vector of values as the pattern argument, the arrow R package implementation cannot.  
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
- [ ] add tests for passing vector to the pattern argument
- [ ] add check for length > 1 to the string replace bindings

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
yes (though I need help!)
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
 yes. Hopefully the user will be alerted by an informative error message that they cannot pass a vector to the pattern argument. No breaking changes are expected.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39191