### PR TITLE
GH-39223: [C#] Support IReadOnlyList<T?> on remaining scalar types

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal128Array.cs
@@ -14,18 +14,16 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
-#if !NETSTANDARD1_3
 using System.Data.SqlTypes;
-#endif
 using System.Diagnostics;
-using System.Numerics;
 using Apache.Arrow.Arrays;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {
-    public class Decimal128Array : FixedSizeBinaryArray
+    public class Decimal128Array : FixedSizeBinaryArray, IReadOnlyList<SqlDecimal?>
     {
         public class Builder : BuilderBase<Decimal128Array, Builder>
         {
@@ -95,7 +93,6 @@ namespace Apache.Arrow
                 return Instance;
             }
 
-#if !NETSTANDARD1_3
             public Builder Append(SqlDecimal value)
             {
                 Span<byte> bytes = stackalloc byte[DataType.ByteWidth];
@@ -118,7 +115,6 @@ namespace Apache.Arrow
 
                 return Instance;
             }
-#endif
 
             public Builder Set(int index, decimal value)
             {
@@ -184,7 +180,6 @@ namespace Apache.Arrow
             return DecimalUtility.GetString(ValueBuffer, index, Precision, Scale, ByteWidth);
         }
 
-#if !NETSTANDARD1_3
         public SqlDecimal? GetSqlDecimal(int index)
         {
             if (IsNull(index))
@@ -194,6 +189,18 @@ namespace Apache.Arrow
 
             return DecimalUtility.GetSqlDecimal128(ValueBuffer, index, Precision, Scale);
         }
-#endif
+
+        int IReadOnlyCollection<SqlDecimal?>.Count => Length;
+        SqlDecimal? IReadOnlyList<SqlDecimal?>.this[int index] => GetSqlDecimal(index);
+
+        IEnumerator<SqlDecimal?> IEnumerable<SqlDecimal?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetSqlDecimal(index);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<SqlDecimal>)this).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Decimal256Array.cs
@@ -14,17 +14,16 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
-#if !NETSTANDARD1_3
 using System.Data.SqlTypes;
-#endif
 using System.Diagnostics;
 using Apache.Arrow.Arrays;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {
-    public class Decimal256Array : FixedSizeBinaryArray
+    public class Decimal256Array : FixedSizeBinaryArray, IReadOnlyList<SqlDecimal?>, IReadOnlyList<string>
     {
         public class Builder : BuilderBase<Decimal256Array, Builder>
         {
@@ -94,7 +93,6 @@ namespace Apache.Arrow
                 return Instance;
             }
 
-#if !NETSTANDARD1_3
             public Builder Append(SqlDecimal value)
             {
                 Span<byte> bytes = stackalloc byte[DataType.ByteWidth];
@@ -123,7 +121,6 @@ namespace Apache.Arrow
 
                 return Instance;
             }
-#endif
 
             public Builder Set(int index, decimal value)
             {
@@ -190,7 +187,6 @@ namespace Apache.Arrow
             return DecimalUtility.GetString(ValueBuffer, index, Precision, Scale, ByteWidth);
         }
 
-#if !NETSTANDARD1_3
         public bool TryGetSqlDecimal(int index, out SqlDecimal? value)
         {
             if (IsNull(index))
@@ -211,6 +207,40 @@ namespace Apache.Arrow
             value = null;
             return false;
         }
-#endif
+
+        private SqlDecimal? GetSqlDecimal(int index)
+        {
+            SqlDecimal? value;
+            if (TryGetSqlDecimal(index, out value))
+            {
+                return value;
+            }
+
+            throw new OverflowException("decimal256 value out of range of SqlDecimal");
+        }
+
+        int IReadOnlyCollection<SqlDecimal?>.Count => Length;
+        SqlDecimal? IReadOnlyList<SqlDecimal?>.this[int index] => GetSqlDecimal(index);
+
+        IEnumerator<SqlDecimal?> IEnumerable<SqlDecimal?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetSqlDecimal(index);
+            }
+        }
+
+        int IReadOnlyCollection<string>.Count => Length;
+        string? IReadOnlyList<string>.this[int index] => GetString(index);
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetString(index);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<string>)this).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/DurationArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/DurationArray.cs
@@ -14,11 +14,13 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {
-    public class DurationArray : PrimitiveArray<long>
+    public class DurationArray : PrimitiveArray<long>, IReadOnlyList<TimeSpan?>
     {
         public class Builder : PrimitiveArrayBuilder<long, DurationArray, Builder>
         {
@@ -80,5 +82,18 @@ namespace Apache.Arrow
         }
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
+
+        int IReadOnlyCollection<TimeSpan?>.Count => Length;
+        TimeSpan? IReadOnlyList<TimeSpan?>.this[int index] => GetTimeSpan(index);
+
+        IEnumerator<TimeSpan?> IEnumerable<TimeSpan?>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetTimeSpan(index);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<TimeSpan?>)this).GetEnumerator();
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/FixedSizeBinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/FixedSizeBinaryArray.cs
@@ -14,13 +14,14 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Apache.Arrow.Memory;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow.Arrays
 {
-    public class FixedSizeBinaryArray : Array
+    public class FixedSizeBinaryArray : Array, IReadOnlyList<byte[]>
     {
         public FixedSizeBinaryArray(ArrayData data)
             : base(data)
@@ -69,6 +70,19 @@ namespace Apache.Arrow.Arrays
             int size = ((FixedSizeBinaryType)Data.DataType).ByteWidth;
             return ValueBuffer.Span.Slice(index * size, size);
         }
+
+        int IReadOnlyCollection<byte[]>.Count => Length;
+        byte[] IReadOnlyList<byte[]>.this[int index] => GetBytes(index).ToArray();
+
+        IEnumerator<byte[]> IEnumerable<byte[]>.GetEnumerator()
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                yield return GetBytes(index).ToArray();
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<byte[]>)this).GetEnumerator();
 
         public abstract class BuilderBase<TArray, TBuilder> : IArrowArrayBuilder<byte[], TArray, TBuilder>
             where TArray : IArrowArray
@@ -220,7 +234,6 @@ namespace Apache.Arrow.Arrays
                 ValidityBuffer.Set(index, false);
                 return Instance;
             }
-
         }
     }
 }

--- a/csharp/src/Apache.Arrow/DecimalUtility.cs
+++ b/csharp/src/Apache.Arrow/DecimalUtility.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 
 using System;
-#if !NETSTANDARD1_3
 using System.Data.SqlTypes;
-#endif
 using System.Numerics;
 
 namespace Apache.Arrow
@@ -183,7 +181,6 @@ namespace Apache.Arrow
         }
 #endif
 
-#if !NETSTANDARD1_3
         internal static SqlDecimal GetSqlDecimal128(in ArrowBuffer valueBuffer, int index, int precision, int scale)
         {
             const int byteWidth = 16;
@@ -207,7 +204,6 @@ namespace Apache.Arrow
                 return new SqlDecimal((byte)precision, (byte)scale, false, (int)(data1 & 0xffffffff), (int)(data1 >> 32), (int)(data2 & 0xffffffff), (int)(data2 >> 32));
             }
         }
-#endif
 
         private static decimal DivideByScale(BigInteger integerValue, int scale)
         {
@@ -428,7 +424,6 @@ namespace Apache.Arrow
             }
         }
 
-#if !NETSTANDARD1_3
         internal static void GetBytes(SqlDecimal value, int precision, int scale, Span<byte> bytes)
         {
             if (value.Precision != precision || value.Scale != scale)
@@ -446,6 +441,5 @@ namespace Apache.Arrow
                 longSpan[1] = (longSpan[0] == 0) ? -longSpan[1] : ~longSpan[1];
             }
         }
-#endif
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Decimal128ArrayTests.cs
@@ -14,10 +14,9 @@
 // limitations under the License.
 
 using System;
-#if !NETSTANDARD1_3
+using System.Collections.Generic;
 using System.Data.SqlTypes;
 using System.Linq;
-#endif
 using Apache.Arrow.Types;
 using Xunit;
 
@@ -25,7 +24,6 @@ namespace Apache.Arrow.Tests
 {
     public class Decimal128ArrayTests
     {
-#if !NETSTANDARD1_3
         static SqlDecimal? Convert(decimal? value)
         {
             return value == null ? null : new SqlDecimal(value.Value);
@@ -35,7 +33,6 @@ namespace Apache.Arrow.Tests
         {
             return value == null ? null : value.Value.Value;
         }
-#endif
 
         public class Builder
         {
@@ -61,11 +58,9 @@ namespace Apache.Arrow.Tests
                     Assert.Null(array.GetValue(1));
                     Assert.Null(array.GetValue(2));
 
-#if !NETSTANDARD1_3
                     Assert.Null(array.GetSqlDecimal(0));
                     Assert.Null(array.GetSqlDecimal(1));
                     Assert.Null(array.GetSqlDecimal(2));
-#endif
                 }
             }
 
@@ -99,9 +94,7 @@ namespace Apache.Arrow.Tests
                     for (int i = 0; i < count; i++)
                     {
                         Assert.Equal(testData[i], array.GetValue(i));
-#if !NETSTANDARD1_3
                         Assert.Equal(Convert(testData[i]), array.GetSqlDecimal(i));
-#endif
                     }
                 }
 
@@ -120,10 +113,8 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(large, array.GetValue(0));
                     Assert.Equal(-large, array.GetValue(1));
 
-#if !NETSTANDARD1_3
                     Assert.Equal(Convert(large), array.GetSqlDecimal(0));
                     Assert.Equal(Convert(-large), array.GetSqlDecimal(1));
-#endif
                 }
 
                 [Fact]
@@ -145,12 +136,10 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(Decimal.MaxValue - 10, array.GetValue(2));
                     Assert.Equal(Decimal.MinValue + 10, array.GetValue(3));
 
-#if !NETSTANDARD1_3
                     Assert.Equal(Convert(Decimal.MaxValue), array.GetSqlDecimal(0));
                     Assert.Equal(Convert(Decimal.MinValue), array.GetSqlDecimal(1));
                     Assert.Equal(Convert(Decimal.MaxValue) - 10, array.GetSqlDecimal(2));
                     Assert.Equal(Convert(Decimal.MinValue) + 10, array.GetSqlDecimal(3));
-#endif
                 }
 
                 [Fact]
@@ -168,10 +157,8 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(fraction, array.GetValue(0));
                     Assert.Equal(-fraction, array.GetValue(1));
 
-#if !NETSTANDARD1_3
                     Assert.Equal(Convert(fraction), array.GetSqlDecimal(0));
                     Assert.Equal(Convert(-fraction), array.GetSqlDecimal(1));
-#endif
                 }
 
                 [Fact]
@@ -190,9 +177,7 @@ namespace Apache.Arrow.Tests
                     for (int i = 0; i < range.Length; i++)
                     {
                         Assert.Equal(range[i], array.GetValue(i));
-#if !NETSTANDARD1_3
                         Assert.Equal(Convert(range[i]), array.GetSqlDecimal(i));
-#endif
                     }
 
                     Assert.Null(array.GetValue(range.Length));
@@ -301,7 +286,6 @@ namespace Apache.Arrow.Tests
                 }
             }
 
-#if !NETSTANDARD1_3
             public class SqlDecimals
             {
                 [Theory]
@@ -334,6 +318,12 @@ namespace Apache.Arrow.Tests
                     {
                         Assert.Equal(testData[i], array.GetSqlDecimal(i));
                         Assert.Equal(Convert(testData[i]), array.GetValue(i));
+                    }
+
+                    IReadOnlyList<SqlDecimal?> asList = array;
+                    for (int i = 0; i < asList.Count; i++)
+                    {
+                        Assert.Equal(testData[i], asList[i]);
                     }
                 }
 
@@ -467,7 +457,6 @@ namespace Apache.Arrow.Tests
                     Assert.Null(array.GetValue(range.Length));
                 }
             }
-#endif
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Decimal256ArrayTests.cs
@@ -14,10 +14,9 @@
 // limitations under the License.
 
 using System;
-#if !NETSTANDARD1_3
+using System.Collections.Generic;
 using System.Data.SqlTypes;
 using System.Linq;
-#endif
 using Apache.Arrow.Types;
 using Xunit;
 
@@ -25,7 +24,6 @@ namespace Apache.Arrow.Tests
 {
     public class Decimal256ArrayTests
     {
-#if !NETSTANDARD1_3
         static SqlDecimal? GetSqlDecimal(Decimal256Array array, int index)
         {
             SqlDecimal? result;
@@ -42,7 +40,11 @@ namespace Apache.Arrow.Tests
         {
             return value == null ? null : value.Value.Value;
         }
-#endif
+
+        static decimal? Convert(string value)
+        {
+            return value == null ? null : decimal.Parse(value);
+        }
 
         public class Builder
         {
@@ -68,11 +70,9 @@ namespace Apache.Arrow.Tests
                     Assert.Null(array.GetValue(1));
                     Assert.Null(array.GetValue(2));
 
-#if !NETSTANDARD1_3
                     Assert.Null(GetSqlDecimal(array, 0));
                     Assert.Null(GetSqlDecimal(array, 1));
                     Assert.Null(GetSqlDecimal(array, 2));
-#endif
                 }
             }
 
@@ -106,9 +106,7 @@ namespace Apache.Arrow.Tests
                     for (int i = 0; i < count; i++)
                     {
                         Assert.Equal(testData[i], array.GetValue(i));
-#if !NETSTANDARD1_3
                         Assert.Equal(Convert(testData[i]), GetSqlDecimal(array, i));
-#endif
                     }
                 }
 
@@ -127,10 +125,8 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(large, array.GetValue(0));
                     Assert.Equal(-large, array.GetValue(1));
 
-#if !NETSTANDARD1_3
                     Assert.Equal(Convert(large), GetSqlDecimal(array, 0));
                     Assert.Equal(Convert(-large), GetSqlDecimal(array, 1));
-#endif
                 }
 
                 [Fact]
@@ -152,12 +148,10 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(Decimal.MaxValue - 10, array.GetValue(2));
                     Assert.Equal(Decimal.MinValue + 10, array.GetValue(3));
 
-#if !NETSTANDARD1_3
                     Assert.Equal(Convert(Decimal.MaxValue), GetSqlDecimal(array, 0));
                     Assert.Equal(Convert(Decimal.MinValue), GetSqlDecimal(array, 1));
                     Assert.Equal(Convert(Decimal.MaxValue) - 10, GetSqlDecimal(array, 2));
                     Assert.Equal(Convert(Decimal.MinValue) + 10, GetSqlDecimal(array, 3));
-#endif
                 }
 
                 [Fact]
@@ -175,10 +169,8 @@ namespace Apache.Arrow.Tests
                     Assert.Equal(fraction, array.GetValue(0));
                     Assert.Equal(-fraction, array.GetValue(1));
 
-#if !NETSTANDARD1_3
                     Assert.Equal(Convert(fraction), GetSqlDecimal(array, 0));
                     Assert.Equal(Convert(-fraction), GetSqlDecimal(array, 1));
-#endif
                 }
 
                 [Fact]
@@ -197,9 +189,7 @@ namespace Apache.Arrow.Tests
                     for(int i = 0; i < range.Length; i ++)
                     {
                         Assert.Equal(range[i], array.GetValue(i));
-#if !NETSTANDARD1_3
                         Assert.Equal(Convert(range[i]), GetSqlDecimal(array, i));
-#endif
                     }
 
                     Assert.Null( array.GetValue(range.Length));
@@ -308,7 +298,6 @@ namespace Apache.Arrow.Tests
                 }
             }
 
-#if !NETSTANDARD1_3
             public class SqlDecimals
             {
                 [Theory]
@@ -341,6 +330,18 @@ namespace Apache.Arrow.Tests
                     {
                         Assert.Equal(testData[i], GetSqlDecimal(array, i));
                         Assert.Equal(Convert(testData[i]), array.GetValue(i));
+                    }
+
+                    IReadOnlyList<SqlDecimal?> asDecimalList = array;
+                    for (int i = 0; i < asDecimalList.Count; i++)
+                    {
+                        Assert.Equal(testData[i], asDecimalList[i]);
+                    }
+
+                    IReadOnlyList<string> asStringList = array;
+                    for (int i = 0; i < asStringList.Count; i++)
+                    {
+                        Assert.Equal(Convert(testData[i]?.ToString()), Convert(asStringList[i]));
                     }
                 }
 
@@ -474,7 +475,6 @@ namespace Apache.Arrow.Tests
                     Assert.Null(array.GetValue(range.Length));
                 }
             }
-#endif
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/DecimalUtilityTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/DecimalUtilityTests.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 
 using System;
-#if !NETSTANDARD1_3
 using System.Data.SqlTypes;
-#endif
 using Apache.Arrow.Types;
 using Xunit;
 
@@ -72,8 +70,6 @@ namespace Apache.Arrow.Tests
 
         public class SqlDecimals
         {
-
-#if !NETSTANDARD1_3
             [Fact]
             public void NegativeSqlDecimal()
             {
@@ -119,7 +115,6 @@ namespace Apache.Arrow.Tests
                 Assert.Equal(negative, sqlNegative);
                 Assert.Equal(digits, sqlNegative.ToString());
             }
-#endif
         }
 
         public class Strings

--- a/csharp/test/Apache.Arrow.Tests/DurationArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/DurationArrayTests.cs
@@ -113,6 +113,10 @@ namespace Apache.Arrow.Tests
                 var array = builder.Build();
                 Assert.Equal(1, array.Length);
                 Assert.Equal(timeSpan, array.GetTimeSpan(0));
+
+                IReadOnlyList<TimeSpan?> asList = array;
+                Assert.Equal(1, asList.Count);
+                Assert.Equal(timeSpan, asList[0]);
             }
         }
 


### PR DESCRIPTION
### What changes are included in this PR?

Decimal128Array implements IReadOnlyList<SqlDecimal?> and IReadOnlyList<byte[]>.
Decimal256Array implements IReadOnlyList<SqlDecimal?>, IReadOnlyList<string> and IReadOnlyList<byte[]>.
FixedLengthBinaryArray implements IReadOnlyList<byte[]>.
DurationArray implements IReadOnlyList<TimeSpan?>.

Also removes #ifs which are no longer relevant now that netstandard13 isn't being built any more.

### Are these changes tested?

Yes.
* Closes: #39223