### PR TITLE
GH-39225: [GLib] Use Cast() instaed of CastTo

### DIFF
--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -387,7 +387,7 @@ garrow_scalar_cast(GArrowScalar *scalar,
 {
   const auto arrow_scalar = garrow_scalar_get_raw(scalar);
   const auto arrow_data_type = garrow_data_type_get_raw(data_type);
-  auto arrow_casted_scalar_result = arrow::compute::Cast(*arrow_scalar, arrow_data_type);
+  auto arrow_casted_scalar_result = arrow::compute::Cast(arrow_scalar, arrow_data_type);
   if (garrow::check(error, arrow_casted_scalar_result, "[scalar][cast]")) {
     auto arrow_casted_scalar = (*arrow_casted_scalar_result).scalar();
     return garrow_scalar_new_raw(&arrow_casted_scalar,

--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -26,6 +26,8 @@
 #include <arrow-glib/interval.hpp>
 #include <arrow-glib/scalar.hpp>
 
+#include <arrow/compute/cast.h>
+
 G_BEGIN_DECLS
 
 /**
@@ -385,9 +387,9 @@ garrow_scalar_cast(GArrowScalar *scalar,
 {
   const auto arrow_scalar = garrow_scalar_get_raw(scalar);
   const auto arrow_data_type = garrow_data_type_get_raw(data_type);
-  auto arrow_casted_scalar_result = arrow_scalar->CastTo(arrow_data_type);
+  auto arrow_casted_scalar_result = arrow::compute::Cast(*arrow_scalar, arrow_data_type);
   if (garrow::check(error, arrow_casted_scalar_result, "[scalar][cast]")) {
-    auto arrow_casted_scalar = *arrow_casted_scalar_result;
+    auto arrow_casted_scalar = (*arrow_casted_scalar_result).scalar();
     return garrow_scalar_new_raw(&arrow_casted_scalar,
                                  "scalar", &arrow_casted_scalar,
                                  "data-type", data_type,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Remove legacy code

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

* Replace the legacy scalar CastTo implementation for GLib. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

No.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39225