### PR TITLE
GH-39014: [Java] Add default truststore along with KeychainStore when on Mac system

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtils.java
@@ -115,6 +115,16 @@ public final class ClientAuthenticationUtils {
     return keyStore;
   }
 
+  @VisibleForTesting
+  static KeyStore getDefaultKeyStoreInstance(String password)
+      throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+    try (InputStream fileInputStream = getKeystoreInputStream()) {
+      KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keyStore.load(fileInputStream, password == null ? null : password.toCharArray());
+      return keyStore;
+    }
+  }
+
   static String getOperatingSystem() {
     return System.getProperty("os.name");
   }
@@ -156,16 +166,9 @@ public final class ClientAuthenticationUtils {
       keyStoreList.add(getKeyStoreInstance("Windows-MY"));
     } else if (isMac()) {
       keyStoreList.add(getKeyStoreInstance("KeychainStore"));
+      keyStoreList.add(getDefaultKeyStoreInstance(password));
     } else {
-      try (InputStream fileInputStream = getKeystoreInputStream()) {
-        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        if (password == null) {
-          keyStore.load(fileInputStream, null);
-        } else {
-          keyStore.load(fileInputStream, password.toCharArray());
-        }
-        keyStoreList.add(keyStore);
-      }
+      keyStoreList.add(getDefaultKeyStoreInstance(password));
     }
 
     return getCertificatesInputStream(keyStoreList);

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
@@ -83,8 +83,8 @@ public class ClientAuthenticationUtilsTest {
     try (MockedStatic<KeyStore> keyStoreMockedStatic = Mockito.mockStatic(KeyStore.class)) {
 
       keyStoreMockedStatic
-              .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit"))
-              .thenReturn(keyStoreMock);
+         .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit"))
+         .thenReturn(keyStoreMock);
       KeyStore receiveKeyStore = ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit");
       Assert.assertEquals(receiveKeyStore, keyStoreMock);
     }
@@ -96,8 +96,8 @@ public class ClientAuthenticationUtilsTest {
     try (MockedStatic<KeyStore> keyStoreMockedStatic = Mockito.mockStatic(KeyStore.class)) {
 
       keyStoreMockedStatic
-              .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance(null))
-              .thenReturn(keyStoreMock);
+          .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance(null))
+          .thenReturn(keyStoreMock);
       KeyStore receiveKeyStore = ClientAuthenticationUtils.getDefaultKeyStoreInstance(null);
       Assert.assertEquals(receiveKeyStore, keyStoreMock);
     }
@@ -121,8 +121,8 @@ public class ClientAuthenticationUtilsTest {
           .getDefaultKeyStoreInstance("changeit"))
           .thenReturn(keyStoreMock);
       clientAuthenticationUtilsMockedStatic
-              .when(ClientAuthenticationUtils::getKeystoreInputStream)
-              .thenCallRealMethod();
+          .when(ClientAuthenticationUtils::getKeystoreInputStream)
+          .thenCallRealMethod();
       keyStoreMockedStatic.when(KeyStore::getDefaultType).thenCallRealMethod();
       keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
           .getCertificatesInputStream(Mockito.any()))
@@ -170,14 +170,14 @@ public class ClientAuthenticationUtilsTest {
 
       setOperatingSystemMock(clientAuthenticationUtilsMockedStatic, false, false);
       keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
-              .getCertificatesInputStream(Mockito.any()))
+          .getCertificatesInputStream(Mockito.any()))
           .thenReturn(mock);
       keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
-              .getDefaultKeyStoreInstance(Mockito.any()))
-              .thenReturn(keyStoreMock);
+          .getDefaultKeyStoreInstance(Mockito.any()))
+          .thenReturn(keyStoreMock);
       clientAuthenticationUtilsMockedStatic
-              .when(ClientAuthenticationUtils::getKeystoreInputStream)
-              .thenCallRealMethod();
+          .when(ClientAuthenticationUtils::getKeystoreInputStream)
+          thenCallRealMethod();
       keyStoreMockedStatic.when(KeyStore::getDefaultType).thenCallRealMethod();
 
       InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
@@ -177,7 +177,7 @@ public class ClientAuthenticationUtilsTest {
           .thenReturn(keyStoreMock);
       clientAuthenticationUtilsMockedStatic
           .when(ClientAuthenticationUtils::getKeystoreInputStream)
-          thenCallRealMethod();
+          .thenCallRealMethod();
       keyStoreMockedStatic.when(KeyStore::getDefaultType).thenCallRealMethod();
 
       InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
@@ -78,6 +78,33 @@ public class ClientAuthenticationUtilsTest {
   }
 
   @Test
+  public void testGetDefaultKeyStoreInstancePassword() throws IOException,
+          KeyStoreException, CertificateException, NoSuchAlgorithmException {
+    try (MockedStatic<KeyStore> keyStoreMockedStatic = Mockito.mockStatic(KeyStore.class)) {
+
+      keyStoreMockedStatic
+              .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit"))
+              .thenReturn(keyStoreMock);
+      KeyStore receiveKeyStore = ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit");
+      Assert.assertEquals(receiveKeyStore, keyStoreMock);
+    }
+  }
+
+  @Test
+  public void testGetDefaultKeyStoreInstanceNoPassword() throws IOException,
+          KeyStoreException, CertificateException, NoSuchAlgorithmException {
+    try (MockedStatic<KeyStore> keyStoreMockedStatic = Mockito.mockStatic(KeyStore.class)) {
+
+      keyStoreMockedStatic
+              .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance(null))
+              .thenReturn(keyStoreMock);
+      KeyStore receiveKeyStore = ClientAuthenticationUtils.getDefaultKeyStoreInstance(null);
+      Assert.assertEquals(receiveKeyStore, keyStoreMock);
+    }
+  }
+
+
+  @Test
   public void testGetCertificateInputStreamFromMacSystem() throws IOException,
       KeyStoreException, CertificateException, NoSuchAlgorithmException {
     InputStream mock = mock(InputStream.class);
@@ -91,10 +118,17 @@ public class ClientAuthenticationUtilsTest {
           .getKeyStoreInstance("KeychainStore"))
           .thenReturn(keyStoreMock);
       keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
+          .getDefaultKeyStoreInstance("changeit"))
+          .thenReturn(keyStoreMock);
+      clientAuthenticationUtilsMockedStatic
+              .when(ClientAuthenticationUtils::getKeystoreInputStream)
+              .thenCallRealMethod();
+      keyStoreMockedStatic.when(KeyStore::getDefaultType).thenCallRealMethod();
+      keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
           .getCertificatesInputStream(Mockito.any()))
           .thenReturn(mock);
 
-      InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("test");
+      InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");
       Assert.assertEquals(inputStream, mock);
     }
   }
@@ -138,10 +172,12 @@ public class ClientAuthenticationUtilsTest {
       keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
               .getCertificatesInputStream(Mockito.any()))
           .thenReturn(mock);
-
+      keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
+              .getDefaultKeyStoreInstance(Mockito.any()))
+              .thenReturn(keyStoreMock);
       clientAuthenticationUtilsMockedStatic
-          .when(ClientAuthenticationUtils::getKeystoreInputStream)
-          .thenCallRealMethod();
+              .when(ClientAuthenticationUtils::getKeystoreInputStream)
+              .thenCallRealMethod();
       keyStoreMockedStatic.when(KeyStore::getDefaultType).thenCallRealMethod();
 
       InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");


### PR DESCRIPTION
### Rationale for this change
As described in #39014, when using the system TrustStore on Mac, the certificates returned do not include Root CAs trusted by the system. This change adds the default KeyStore instance along with the KeyChainStore to include trusted Root CAs. The reason we add the default KeyStore instance is because there is no easy way to get the certificates from the System Roots keychain. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

I've updated ClientAuthenticationUtils to get the default KeyStore instance when the operating system is macOS and have updated the tests to include this change. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

See changes made in ClientAuthenticationUtilsTest.java.

### Are there any user-facing changes?

No

* Closes: #39014