### PR TITLE
GH-39246: [CI][GLib][Ruby] Use Ubuntu 22.04 not 20.04

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu:
-          - 20.04
+          - 22.04
     env:
       UBUNTU: ${{ matrix.ubuntu }}
     steps:


### PR DESCRIPTION
### Rationale for this change

Ubuntu 20.04 ships Ruby 2.7 but it reached EOL.
Bundler 2.5.0 or later requires Ruby 3.0 or later.

### What changes are included in this PR?

Use Ubuntu 22.04 that ships Ruby 3.0.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39246