### PR TITLE
GH-39138: [R] Fix implicit conversion warnings

### DIFF
--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -53,6 +53,10 @@ jobs:
             ARROW_SOURCE_HOME=arrow \
             arrow/ci/scripts/r_install_system_dependencies.sh
           arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin
+      - name: Configure extra warning flags (macos)
+        if: contains(matrix.os, 'macOS')
+        run: |
+          echo "PKG_CXXFLAGS='-Wconversion -Wno-sign-conversion -Wsign-compare -Werror'" >> $GITHUB_ENV
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
@@ -71,7 +75,6 @@ jobs:
           FORCE_BUNDLED_BUILD: true
           LIBARROW_MINIMAL: false
           ARROW_R_DEV: TRUE
-          PKG_CXXFLAGS: "-Wconversion -Wno-sign-conversion -Wsign-compare -Werror"
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
           sccache --start-server || echo 'sccache not found'

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -71,6 +71,7 @@ jobs:
           FORCE_BUNDLED_BUILD: true
           LIBARROW_MINIMAL: false
           ARROW_R_DEV: TRUE
+          PKG_CXXFLAGS: "-Wconversion -Wno-sign-conversion"
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
           sccache --start-server || echo 'sccache not found'

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -71,7 +71,7 @@ jobs:
           FORCE_BUNDLED_BUILD: true
           LIBARROW_MINIMAL: false
           ARROW_R_DEV: TRUE
-          PKG_CXXFLAGS: "-Wconversion -Wno-sign-conversion"
+          PKG_CXXFLAGS: "-Wconversion -Wno-sign-conversion -Wsign-compare -Werror"
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
           sccache --start-server || echo 'sccache not found'

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -53,10 +53,6 @@ jobs:
             ARROW_SOURCE_HOME=arrow \
             arrow/ci/scripts/r_install_system_dependencies.sh
           arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin
-      - name: Configure extra warning flags (macos)
-        if: contains(matrix.os, 'macOS')
-        run: |
-          echo "PKG_CXXFLAGS='-Wconversion -Wno-sign-conversion -Wsign-compare -Werror'" >> $GITHUB_ENV
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -275,7 +275,7 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     auto altrep_data =
         reinterpret_cast<ArrowAltrepData*>(R_ExternalPtrAddr(R_altrep_data1(alt)));
     auto resolve = altrep_data->locate(i);
-    const auto& array = altrep_data->chunked_array()->chunk(resolve.chunk_index);
+    const auto& array = altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
     auto j = resolve.index_in_chunk;
 
     return array->IsNull(j) ? cpp11::na<c_type>()
@@ -768,7 +768,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
       bool no_nul = std::find(view_.begin(), view_.end(), '\0') == view_.end();
 
       if (no_nul) {
-        return Rf_mkCharLenCE(view_.data(), view_.size(), CE_UTF8);
+        return Rf_mkCharLenCE(view_.data(), static_cast<int>(view_.size()), CE_UTF8);
       } else if (strip_out_nuls_) {
         return ConvertStripNul();
       } else {
@@ -805,7 +805,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
       }
 
       nul_was_stripped_ = true;
-      return Rf_mkCharLenCE(stripped_string_.data(), stripped_len, CE_UTF8);
+      return Rf_mkCharLenCE(stripped_string_.data(), static_cast<int>(stripped_len), CE_UTF8);
     }
 
     bool nul_was_stripped() const { return nul_was_stripped_; }
@@ -850,7 +850,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     auto altrep_data =
         reinterpret_cast<ArrowAltrepData*>(R_ExternalPtrAddr(R_altrep_data1(alt)));
     auto resolve = altrep_data->locate(i);
-    const auto& array = altrep_data->chunked_array()->chunk(resolve.chunk_index);
+    const auto& array = altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
     auto j = resolve.index_in_chunk;
 
     SEXP s = NA_STRING;

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -569,7 +569,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
         reinterpret_cast<ArrowAltrepData*>(R_ExternalPtrAddr(R_altrep_data1(alt)));
     auto resolve = altrep_data->locate(i);
 
-    const auto& array = altrep_data->chunked_array()->chunk(resolve.chunk_index);
+    const auto& array = altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
     auto j = resolve.index_in_chunk;
 
     if (!array->IsNull(j)) {
@@ -578,7 +578,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
 
       if (WasUnified(alt)) {
         const auto* transpose_data = reinterpret_cast<const int32_t*>(
-            GetArrayTransposed(alt, resolve.chunk_index)->data());
+            GetArrayTransposed(alt, static_cast<int>(resolve.chunk_index))->data());
 
         switch (indices->type_id()) {
           case Type::UINT8:

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -466,10 +466,10 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
       std::unique_ptr<arrow::DictionaryUnifier> unifier_ =
           ValueOrStop(DictionaryUnifier::Make(arr_type.value_type()));
 
-      size_t n_arrays = chunked_array->num_chunks();
+      int n_arrays = chunked_array->num_chunks();
       BufferVector arrays_transpose(n_arrays);
 
-      for (size_t i = 0; i < n_arrays; i++) {
+      for (int i = 0; i < n_arrays; i++) {
         const auto& dict_i =
             *internal::checked_cast<const DictionaryArray&>(*chunked_array->chunk(i))
                  .dictionary();
@@ -613,11 +613,14 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
           case Type::INT32:
             return indices->data()->GetValues<int32_t>(1)[j] + 1;
           case Type::UINT32:
-            return indices->data()->GetValues<uint32_t>(1)[j] + 1;
+            // TODO: check index?
+            return static_cast<int>(indices->data()->GetValues<uint32_t>(1)[j] + 1);
           case Type::INT64:
-            return indices->data()->GetValues<int64_t>(1)[j] + 1;
+            // TODO: check index?
+            return static_cast<int>(indices->data()->GetValues<int64_t>(1)[j] + 1);
           case Type::UINT64:
-            return indices->data()->GetValues<uint64_t>(1)[j] + 1;
+            // TODO: check index?
+            return static_cast<int>(indices->data()->GetValues<uint64_t>(1)[j] + 1);
           default:
             break;
         }

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -275,7 +275,8 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     auto altrep_data =
         reinterpret_cast<ArrowAltrepData*>(R_ExternalPtrAddr(R_altrep_data1(alt)));
     auto resolve = altrep_data->locate(i);
-    const auto& array = altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
+    const auto& array =
+        altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
     auto j = resolve.index_in_chunk;
 
     return array->IsNull(j) ? cpp11::na<c_type>()
@@ -569,7 +570,8 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
         reinterpret_cast<ArrowAltrepData*>(R_ExternalPtrAddr(R_altrep_data1(alt)));
     auto resolve = altrep_data->locate(i);
 
-    const auto& array = altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
+    const auto& array =
+        altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
     auto j = resolve.index_in_chunk;
 
     if (!array->IsNull(j)) {
@@ -670,7 +672,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
         // using the transpose data for this chunk
         const auto* transpose_data =
             reinterpret_cast<const int32_t*>(GetArrayTransposed(alt, j)->data());
-        auto transpose = [transpose_data](int x) { return transpose_data[x]; };
+        auto transpose = [transpose_data](int64_t x) { return transpose_data[x]; };
 
         GetRegionDispatch(array, indices, transpose, out);
 
@@ -680,7 +682,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
 
     } else {
       // simpler case, identity transpose
-      auto transpose = [](int x) { return x; };
+      auto transpose = [](int64_t x) { return static_cast<int>(x); };
 
       int* out = buf;
       for (const auto& array : slice->chunks()) {
@@ -721,7 +723,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
 
     VisitArraySpanInline<Type>(
         *array->data(),
-        /*valid_func=*/[&](index_type index) { *out++ = transpose(index) + 1; },
+        /*valid_func=*/[&](index_type index) { *out++ = static_cast<int>(transpose(index) + 1); },
         /*null_func=*/[&]() { *out++ = cpp11::na<int>(); });
   }
 
@@ -805,7 +807,8 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
       }
 
       nul_was_stripped_ = true;
-      return Rf_mkCharLenCE(stripped_string_.data(), static_cast<int>(stripped_len), CE_UTF8);
+      return Rf_mkCharLenCE(stripped_string_.data(), static_cast<int>(stripped_len),
+                            CE_UTF8);
     }
 
     bool nul_was_stripped() const { return nul_was_stripped_; }
@@ -850,7 +853,8 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     auto altrep_data =
         reinterpret_cast<ArrowAltrepData*>(R_ExternalPtrAddr(R_altrep_data1(alt)));
     auto resolve = altrep_data->locate(i);
-    const auto& array = altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
+    const auto& array =
+        altrep_data->chunked_array()->chunk(static_cast<int>(resolve.chunk_index));
     auto j = resolve.index_in_chunk;
 
     SEXP s = NA_STRING;

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -723,7 +723,8 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
 
     VisitArraySpanInline<Type>(
         *array->data(),
-        /*valid_func=*/[&](index_type index) { *out++ = static_cast<int>(transpose(index) + 1); },
+        /*valid_func=*/
+        [&](index_type index) { *out++ = static_cast<int>(transpose(index) + 1); },
         /*null_func=*/[&]() { *out++ = cpp11::na<int>(); });
   }
 

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -92,7 +92,7 @@ std::shared_ptr<arrow::Array> Array__Slice2(const std::shared_ptr<arrow::Array>&
   return array->Slice(offset, length);
 }
 
-void arrow::r::validate_index(int i, int len) {
+void arrow::r::validate_index(int64_t i, int64_t len) {
   if (i == NA_INTEGER) {
     cpp11::stop("'i' cannot be NA");
   }
@@ -119,10 +119,10 @@ r_vec_size Array__length(const std::shared_ptr<arrow::Array>& x) {
 }
 
 // [[arrow::export]]
-int Array__offset(const std::shared_ptr<arrow::Array>& x) { return x->offset(); }
+r_vec_size Array__offset(const std::shared_ptr<arrow::Array>& x) { return r_vec_size(x->offset()); }
 
 // [[arrow::export]]
-int Array__null_count(const std::shared_ptr<arrow::Array>& x) { return x->null_count(); }
+r_vec_size Array__null_count(const std::shared_ptr<arrow::Array>& x) { return r_vec_size(x->null_count()); }
 
 // [[arrow::export]]
 std::shared_ptr<arrow::DataType> Array__type(const std::shared_ptr<arrow::Array>& x) {
@@ -263,9 +263,9 @@ r_vec_size LargeListArray__value_length(
 }
 
 // [[arrow::export]]
-r_vec_size FixedSizeListArray__value_length(
+int FixedSizeListArray__value_length(
     const std::shared_ptr<arrow::FixedSizeListArray>& array, int64_t i) {
-  return r_vec_size(array->value_length(i));
+  return array->value_length(i);
 }
 
 // [[arrow::export]]

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -119,10 +119,14 @@ r_vec_size Array__length(const std::shared_ptr<arrow::Array>& x) {
 }
 
 // [[arrow::export]]
-r_vec_size Array__offset(const std::shared_ptr<arrow::Array>& x) { return r_vec_size(x->offset()); }
+r_vec_size Array__offset(const std::shared_ptr<arrow::Array>& x) {
+  return r_vec_size(x->offset());
+}
 
 // [[arrow::export]]
-r_vec_size Array__null_count(const std::shared_ptr<arrow::Array>& x) { return r_vec_size(x->null_count()); }
+r_vec_size Array__null_count(const std::shared_ptr<arrow::Array>& x) {
+  return r_vec_size(x->null_count());
+}
 
 // [[arrow::export]]
 std::shared_ptr<arrow::DataType> Array__type(const std::shared_ptr<arrow::Array>& x) {
@@ -294,10 +298,10 @@ cpp11::writable::integers ListArray__raw_value_offsets(
 }
 
 // [[arrow::export]]
-cpp11::writable::integers LargeListArray__raw_value_offsets(
+cpp11::writable::doubles LargeListArray__raw_value_offsets(
     const std::shared_ptr<arrow::LargeListArray>& array) {
   auto offsets = array->raw_value_offsets();
-  return cpp11::writable::integers(offsets, offsets + array->length());
+  return cpp11::writable::doubles(offsets, offsets + array->length());
 }
 
 // [[arrow::export]]

--- a/r/src/arraydata.cpp
+++ b/r/src/arraydata.cpp
@@ -26,18 +26,18 @@ std::shared_ptr<arrow::DataType> ArrayData__get_type(
 }
 
 // [[arrow::export]]
-int ArrayData__get_length(const std::shared_ptr<arrow::ArrayData>& x) {
-  return x->length;
+r_vec_size ArrayData__get_length(const std::shared_ptr<arrow::ArrayData>& x) {
+  return r_vec_size(x->length);
 }
 
 // [[arrow::export]]
-int ArrayData__get_null_count(const std::shared_ptr<arrow::ArrayData>& x) {
-  return x->null_count;
+r_vec_size ArrayData__get_null_count(const std::shared_ptr<arrow::ArrayData>& x) {
+  return r_vec_size(x->null_count);
 }
 
 // [[arrow::export]]
-int ArrayData__get_offset(const std::shared_ptr<arrow::ArrayData>& x) {
-  return x->offset;
+r_vec_size ArrayData__get_offset(const std::shared_ptr<arrow::ArrayData>& x) {
+  return r_vec_size(x->offset);
 }
 
 // [[arrow::export]]

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -765,7 +765,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // chunkedarray.cpp
-r_vec_size ChunkedArray__num_chunks(const std::shared_ptr<arrow::ChunkedArray>& chunked_array);
+int ChunkedArray__num_chunks(const std::shared_ptr<arrow::ChunkedArray>& chunked_array);
 extern "C" SEXP _arrow_ChunkedArray__num_chunks(SEXP chunked_array_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::ChunkedArray>&>::type chunked_array(chunked_array_sexp);

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3976,7 +3976,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // message.cpp
-r_vec_size ipc___Message__Verify(const std::unique_ptr<arrow::ipc::Message>& message);
+bool ipc___Message__Verify(const std::unique_ptr<arrow::ipc::Message>& message);
 extern "C" SEXP _arrow_ipc___Message__Verify(SEXP message_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::unique_ptr<arrow::ipc::Message>&>::type message(message_sexp);
@@ -4684,7 +4684,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // recordbatch.cpp
-r_vec_size RecordBatch__num_columns(const std::shared_ptr<arrow::RecordBatch>& x);
+int RecordBatch__num_columns(const std::shared_ptr<arrow::RecordBatch>& x);
 extern "C" SEXP _arrow_RecordBatch__num_columns(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type x(x_sexp);
@@ -4734,11 +4734,11 @@ BEGIN_CPP11
 END_CPP11
 }
 // recordbatch.cpp
-std::shared_ptr<arrow::Array> RecordBatch__column(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i);
+std::shared_ptr<arrow::Array> RecordBatch__column(const std::shared_ptr<arrow::RecordBatch>& batch, int i);
 extern "C" SEXP _arrow_RecordBatch__column(SEXP batch_sexp, SEXP i_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type batch(batch_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	return cpp11::as_sexp(RecordBatch__column(batch, i));
 END_CPP11
 }
@@ -4771,42 +4771,42 @@ BEGIN_CPP11
 END_CPP11
 }
 // recordbatch.cpp
-std::shared_ptr<arrow::RecordBatch> RecordBatch__AddColumn(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& column);
+std::shared_ptr<arrow::RecordBatch> RecordBatch__AddColumn(const std::shared_ptr<arrow::RecordBatch>& batch, int i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& column);
 extern "C" SEXP _arrow_RecordBatch__AddColumn(SEXP batch_sexp, SEXP i_sexp, SEXP field_sexp, SEXP column_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type batch(batch_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::Field>&>::type field(field_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type column(column_sexp);
 	return cpp11::as_sexp(RecordBatch__AddColumn(batch, i, field, column));
 END_CPP11
 }
 // recordbatch.cpp
-std::shared_ptr<arrow::RecordBatch> RecordBatch__SetColumn(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& column);
+std::shared_ptr<arrow::RecordBatch> RecordBatch__SetColumn(const std::shared_ptr<arrow::RecordBatch>& batch, int i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& column);
 extern "C" SEXP _arrow_RecordBatch__SetColumn(SEXP batch_sexp, SEXP i_sexp, SEXP field_sexp, SEXP column_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type batch(batch_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::Field>&>::type field(field_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type column(column_sexp);
 	return cpp11::as_sexp(RecordBatch__SetColumn(batch, i, field, column));
 END_CPP11
 }
 // recordbatch.cpp
-std::shared_ptr<arrow::RecordBatch> RecordBatch__RemoveColumn(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i);
+std::shared_ptr<arrow::RecordBatch> RecordBatch__RemoveColumn(const std::shared_ptr<arrow::RecordBatch>& batch, int i);
 extern "C" SEXP _arrow_RecordBatch__RemoveColumn(SEXP batch_sexp, SEXP i_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type batch(batch_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	return cpp11::as_sexp(RecordBatch__RemoveColumn(batch, i));
 END_CPP11
 }
 // recordbatch.cpp
-std::string RecordBatch__column_name(const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i);
+std::string RecordBatch__column_name(const std::shared_ptr<arrow::RecordBatch>& batch, int i);
 extern "C" SEXP _arrow_RecordBatch__column_name(SEXP batch_sexp, SEXP i_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::RecordBatch>&>::type batch(batch_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	return cpp11::as_sexp(RecordBatch__column_name(batch, i));
 END_CPP11
 }
@@ -5346,7 +5346,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // table.cpp
-r_vec_size Table__num_columns(const std::shared_ptr<arrow::Table>& x);
+int Table__num_columns(const std::shared_ptr<arrow::Table>& x);
 extern "C" SEXP _arrow_Table__num_columns(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Table>&>::type x(x_sexp);
@@ -5379,20 +5379,20 @@ BEGIN_CPP11
 END_CPP11
 }
 // table.cpp
-std::shared_ptr<arrow::ChunkedArray> Table__column(const std::shared_ptr<arrow::Table>& table, R_xlen_t i);
+std::shared_ptr<arrow::ChunkedArray> Table__column(const std::shared_ptr<arrow::Table>& table, int i);
 extern "C" SEXP _arrow_Table__column(SEXP table_sexp, SEXP i_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	return cpp11::as_sexp(Table__column(table, i));
 END_CPP11
 }
 // table.cpp
-std::shared_ptr<arrow::Field> Table__field(const std::shared_ptr<arrow::Table>& table, R_xlen_t i);
+std::shared_ptr<arrow::Field> Table__field(const std::shared_ptr<arrow::Table>& table, int i);
 extern "C" SEXP _arrow_Table__field(SEXP table_sexp, SEXP i_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	return cpp11::as_sexp(Table__field(table, i));
 END_CPP11
 }
@@ -5476,31 +5476,31 @@ BEGIN_CPP11
 END_CPP11
 }
 // table.cpp
-std::shared_ptr<arrow::Table> Table__RemoveColumn(const std::shared_ptr<arrow::Table>& table, R_xlen_t i);
+std::shared_ptr<arrow::Table> Table__RemoveColumn(const std::shared_ptr<arrow::Table>& table, int i);
 extern "C" SEXP _arrow_Table__RemoveColumn(SEXP table_sexp, SEXP i_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	return cpp11::as_sexp(Table__RemoveColumn(table, i));
 END_CPP11
 }
 // table.cpp
-std::shared_ptr<arrow::Table> Table__AddColumn(const std::shared_ptr<arrow::Table>& table, R_xlen_t i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::ChunkedArray>& column);
+std::shared_ptr<arrow::Table> Table__AddColumn(const std::shared_ptr<arrow::Table>& table, int i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::ChunkedArray>& column);
 extern "C" SEXP _arrow_Table__AddColumn(SEXP table_sexp, SEXP i_sexp, SEXP field_sexp, SEXP column_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::Field>&>::type field(field_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::ChunkedArray>&>::type column(column_sexp);
 	return cpp11::as_sexp(Table__AddColumn(table, i, field, column));
 END_CPP11
 }
 // table.cpp
-std::shared_ptr<arrow::Table> Table__SetColumn(const std::shared_ptr<arrow::Table>& table, R_xlen_t i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::ChunkedArray>& column);
+std::shared_ptr<arrow::Table> Table__SetColumn(const std::shared_ptr<arrow::Table>& table, int i, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::ChunkedArray>& column);
 extern "C" SEXP _arrow_Table__SetColumn(SEXP table_sexp, SEXP i_sexp, SEXP field_sexp, SEXP column_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
-	arrow::r::Input<R_xlen_t>::type i(i_sexp);
+	arrow::r::Input<int>::type i(i_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::Field>&>::type field(field_sexp);
 	arrow::r::Input<const std::shared_ptr<arrow::ChunkedArray>&>::type column(column_sexp);
 	return cpp11::as_sexp(Table__SetColumn(table, i, field, column));

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -110,7 +110,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // array.cpp
-int Array__offset(const std::shared_ptr<arrow::Array>& x);
+r_vec_size Array__offset(const std::shared_ptr<arrow::Array>& x);
 extern "C" SEXP _arrow_Array__offset(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type x(x_sexp);
@@ -118,7 +118,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // array.cpp
-int Array__null_count(const std::shared_ptr<arrow::Array>& x);
+r_vec_size Array__null_count(const std::shared_ptr<arrow::Array>& x);
 extern "C" SEXP _arrow_Array__null_count(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::Array>&>::type x(x_sexp);
@@ -315,7 +315,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // array.cpp
-r_vec_size FixedSizeListArray__value_length(const std::shared_ptr<arrow::FixedSizeListArray>& array, int64_t i);
+int FixedSizeListArray__value_length(const std::shared_ptr<arrow::FixedSizeListArray>& array, int64_t i);
 extern "C" SEXP _arrow_FixedSizeListArray__value_length(SEXP array_sexp, SEXP i_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::FixedSizeListArray>&>::type array(array_sexp);
@@ -467,7 +467,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // arraydata.cpp
-int ArrayData__get_length(const std::shared_ptr<arrow::ArrayData>& x);
+r_vec_size ArrayData__get_length(const std::shared_ptr<arrow::ArrayData>& x);
 extern "C" SEXP _arrow_ArrayData__get_length(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::ArrayData>&>::type x(x_sexp);
@@ -475,7 +475,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // arraydata.cpp
-int ArrayData__get_null_count(const std::shared_ptr<arrow::ArrayData>& x);
+r_vec_size ArrayData__get_null_count(const std::shared_ptr<arrow::ArrayData>& x);
 extern "C" SEXP _arrow_ArrayData__get_null_count(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::ArrayData>&>::type x(x_sexp);
@@ -483,7 +483,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // arraydata.cpp
-int ArrayData__get_offset(const std::shared_ptr<arrow::ArrayData>& x);
+r_vec_size ArrayData__get_offset(const std::shared_ptr<arrow::ArrayData>& x);
 extern "C" SEXP _arrow_ArrayData__get_offset(SEXP x_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::ArrayData>&>::type x(x_sexp);

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -869,11 +869,11 @@ BEGIN_CPP11
 END_CPP11
 }
 // compression.cpp
-std::shared_ptr<arrow::util::Codec> util___Codec__Create(arrow::Compression::type codec, R_xlen_t compression_level);
+std::shared_ptr<arrow::util::Codec> util___Codec__Create(arrow::Compression::type codec, int compression_level);
 extern "C" SEXP _arrow_util___Codec__Create(SEXP codec_sexp, SEXP compression_level_sexp){
 BEGIN_CPP11
 	arrow::r::Input<arrow::Compression::type>::type codec(codec_sexp);
-	arrow::r::Input<R_xlen_t>::type compression_level(compression_level_sexp);
+	arrow::r::Input<int>::type compression_level(compression_level_sexp);
 	return cpp11::as_sexp(util___Codec__Create(codec, compression_level));
 END_CPP11
 }
@@ -2024,14 +2024,14 @@ extern "C" SEXP _arrow_dataset___JsonFragmentScanOptions__Make(SEXP parse_option
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_DATASET)
-std::shared_ptr<ds::ParquetFragmentScanOptions> dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buffer_size, bool pre_buffer, int64_t thrift_string_size_limit, int64_t thrift_container_size_limit);
+std::shared_ptr<ds::ParquetFragmentScanOptions> dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buffer_size, bool pre_buffer, int32_t thrift_string_size_limit, int32_t thrift_container_size_limit);
 extern "C" SEXP _arrow_dataset___ParquetFragmentScanOptions__Make(SEXP use_buffered_stream_sexp, SEXP buffer_size_sexp, SEXP pre_buffer_sexp, SEXP thrift_string_size_limit_sexp, SEXP thrift_container_size_limit_sexp){
 BEGIN_CPP11
 	arrow::r::Input<bool>::type use_buffered_stream(use_buffered_stream_sexp);
 	arrow::r::Input<int64_t>::type buffer_size(buffer_size_sexp);
 	arrow::r::Input<bool>::type pre_buffer(pre_buffer_sexp);
-	arrow::r::Input<int64_t>::type thrift_string_size_limit(thrift_string_size_limit_sexp);
-	arrow::r::Input<int64_t>::type thrift_container_size_limit(thrift_container_size_limit_sexp);
+	arrow::r::Input<int32_t>::type thrift_string_size_limit(thrift_string_size_limit_sexp);
+	arrow::r::Input<int32_t>::type thrift_container_size_limit(thrift_container_size_limit_sexp);
 	return cpp11::as_sexp(dataset___ParquetFragmentScanOptions__Make(use_buffered_stream, buffer_size, pre_buffer, thrift_string_size_limit, thrift_container_size_limit));
 END_CPP11
 }
@@ -2567,10 +2567,10 @@ BEGIN_CPP11
 END_CPP11
 }
 // datatype.cpp
-std::shared_ptr<arrow::DataType> FixedSizeBinary__initialize(R_xlen_t byte_width);
+std::shared_ptr<arrow::DataType> FixedSizeBinary__initialize(int32_t byte_width);
 extern "C" SEXP _arrow_FixedSizeBinary__initialize(SEXP byte_width_sexp){
 BEGIN_CPP11
-	arrow::r::Input<R_xlen_t>::type byte_width(byte_width_sexp);
+	arrow::r::Input<int32_t>::type byte_width(byte_width_sexp);
 	return cpp11::as_sexp(FixedSizeBinary__initialize(byte_width));
 END_CPP11
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -359,7 +359,7 @@ BEGIN_CPP11
 END_CPP11
 }
 // array.cpp
-cpp11::writable::integers LargeListArray__raw_value_offsets(const std::shared_ptr<arrow::LargeListArray>& array);
+cpp11::writable::doubles LargeListArray__raw_value_offsets(const std::shared_ptr<arrow::LargeListArray>& array);
 extern "C" SEXP _arrow_LargeListArray__raw_value_offsets(SEXP array_sexp){
 BEGIN_CPP11
 	arrow::r::Input<const std::shared_ptr<arrow::LargeListArray>&>::type array(array_sexp);

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -435,6 +435,7 @@ cpp11::writable::list to_r_list(const std::vector<std::shared_ptr<T>>& x) {
 
 struct r_vec_size {
   explicit r_vec_size(R_xlen_t x) : value(x) {}
+  explicit r_vec_size(int64_t x): value(static_cast<R_xlen_t>(x)) {}
 
   R_xlen_t value;
 };
@@ -465,7 +466,7 @@ inline SEXP as_sexp(r_vec_size size) {
   if (x > std::numeric_limits<int>::max()) {
     return Rf_ScalarReal(x);
   } else {
-    return Rf_ScalarInteger(x);
+    return Rf_ScalarInteger(static_cast<int>(x));
   }
 }
 

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -435,7 +435,7 @@ cpp11::writable::list to_r_list(const std::vector<std::shared_ptr<T>>& x) {
 
 struct r_vec_size {
   explicit r_vec_size(R_xlen_t x) : value(x) {}
-  explicit r_vec_size(int64_t x): value(static_cast<R_xlen_t>(x)) {}
+  explicit r_vec_size(int64_t x) : value(static_cast<R_xlen_t>(x)) {}
 
   R_xlen_t value;
 };

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -27,6 +27,18 @@
 
 #include "./nameof.h"
 
+// Simple dcheck that doesn't use assert (i.e., won't crash the R session)
+// Condition this on our own debug flag to avoid this ending up in any CRAN
+// checks.
+#if defined(ARROW_R_DEBUG)
+#define ARROW_R_DCHECK(EXPR)                                              \
+  do {                                                                    \
+    if (!(EXPR)) Rf_error("Failed DCHECK: %s evaluated to false", #EXPR); \
+  } while (false)
+#else
+#define ARROW_R_DCHECK(EXPR)
+#endif
+
 // borrowed from enc package
 // because R does not make these macros available (i.e. from Defn.h)
 #define UTF8_MASK (1 << 3)

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -435,7 +435,6 @@ cpp11::writable::list to_r_list(const std::vector<std::shared_ptr<T>>& x) {
 
 struct r_vec_size {
   explicit r_vec_size(R_xlen_t x) : value(x) {}
-  explicit r_vec_size(int64_t x) : value(static_cast<R_xlen_t>(x)) {}
 
   R_xlen_t value;
 };

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -195,7 +195,7 @@ template <typename Lambda>
 void TraverseDots(cpp11::list dots, int num_fields, Lambda lambda) {
   cpp11::strings names(dots.attr(R_NamesSymbol));
 
-  for (R_xlen_t i = 0, j = 0; j < num_fields; i++) {
+  for (int i = 0, j = 0; j < num_fields; i++) {
     auto name_i = names[i];
 
     if (name_i.size() == 0) {

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -189,7 +189,7 @@ void validate_slice_offset(R_xlen_t offset, int64_t len);
 
 void validate_slice_length(R_xlen_t length, int64_t available);
 
-void validate_index(int i, int len);
+void validate_index(int64_t i, int64_t len);
 
 template <typename Lambda>
 void TraverseDots(cpp11::list dots, int num_fields, Lambda lambda) {

--- a/r/src/chunkedarray.cpp
+++ b/r/src/chunkedarray.cpp
@@ -34,8 +34,7 @@ r_vec_size ChunkedArray__null_count(
 }
 
 // [[arrow::export]]
-int ChunkedArray__num_chunks(
-    const std::shared_ptr<arrow::ChunkedArray>& chunked_array) {
+int ChunkedArray__num_chunks(const std::shared_ptr<arrow::ChunkedArray>& chunked_array) {
   return chunked_array->num_chunks();
 }
 

--- a/r/src/chunkedarray.cpp
+++ b/r/src/chunkedarray.cpp
@@ -34,9 +34,9 @@ r_vec_size ChunkedArray__null_count(
 }
 
 // [[arrow::export]]
-r_vec_size ChunkedArray__num_chunks(
+int ChunkedArray__num_chunks(
     const std::shared_ptr<arrow::ChunkedArray>& chunked_array) {
-  return r_vec_size(chunked_array->num_chunks());
+  return chunked_array->num_chunks();
 }
 
 // [[arrow::export]]

--- a/r/src/compression.cpp
+++ b/r/src/compression.cpp
@@ -22,7 +22,7 @@
 
 // [[arrow::export]]
 std::shared_ptr<arrow::util::Codec> util___Codec__Create(arrow::Compression::type codec,
-                                                         R_xlen_t compression_level) {
+                                                         int compression_level) {
   return ValueOrStop(arrow::util::Codec::Create(codec, compression_level));
 }
 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -738,8 +738,7 @@ void RegisterScalarUDF(std::string name, cpp11::list func_sexp) {
 
   // Compute the Arity from the list of input kernels. We don't currently handle
   // variable numbers of arguments in a user-defined function.
-  int n_args =
-      cpp11::as_cpp<std::shared_ptr<arrow::Schema>>(in_type_r[0])->num_fields();
+  int n_args = cpp11::as_cpp<std::shared_ptr<arrow::Schema>>(in_type_r[0])->num_fields();
   for (R_xlen_t i = 1; i < n_kernels; i++) {
     auto in_types = cpp11::as_cpp<std::shared_ptr<arrow::Schema>>(in_type_r[i]);
     if (in_types->num_fields() != n_args) {

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -241,10 +241,10 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
               interpolation);
     }
     if (!Rf_isNull(options["min_count"])) {
-      out->min_count = cpp11::as_cpp<int64_t>(options["min_count"]);
+      out->min_count = cpp11::as_cpp<uint32_t>(options["min_count"]);
     }
     if (!Rf_isNull(options["skip_nulls"])) {
-      out->skip_nulls = cpp11::as_cpp<int64_t>(options["skip_nulls"]);
+      out->skip_nulls = cpp11::as_cpp<bool>(options["skip_nulls"]);
     }
     return out;
   }
@@ -479,9 +479,9 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
       func_name == "hash_stddev") {
     using Options = arrow::compute::VarianceOptions;
     auto out = std::make_shared<Options>();
-    out->ddof = cpp11::as_cpp<int64_t>(options["ddof"]);
+    out->ddof = cpp11::as_cpp<int>(options["ddof"]);
     if (!Rf_isNull(options["min_count"])) {
-      out->min_count = cpp11::as_cpp<int64_t>(options["min_count"]);
+      out->min_count = cpp11::as_cpp<uint32_t>(options["min_count"]);
     }
     if (!Rf_isNull(options["skip_nulls"])) {
       out->skip_nulls = cpp11::as_cpp<bool>(options["skip_nulls"]);
@@ -683,7 +683,7 @@ arrow::Status CallRScalarUDF(arrow::compute::KernelContext* context,
           }
         }
 
-        cpp11::sexp batch_length_sexp = cpp11::as_sexp(span.length);
+        cpp11::sexp batch_length_sexp = cpp11::as_sexp(static_cast<double>(span.length));
 
         std::shared_ptr<arrow::DataType> output_type = result->type()->GetSharedPtr();
         cpp11::sexp output_type_sexp = cpp11::to_r6<arrow::DataType>(output_type);
@@ -738,7 +738,7 @@ void RegisterScalarUDF(std::string name, cpp11::list func_sexp) {
 
   // Compute the Arity from the list of input kernels. We don't currently handle
   // variable numbers of arguments in a user-defined function.
-  int64_t n_args =
+  int n_args =
       cpp11::as_cpp<std::shared_ptr<arrow::Schema>>(in_type_r[0])->num_fields();
   for (R_xlen_t i = 1; i < n_kernels; i++) {
     auto in_types = cpp11::as_cpp<std::shared_ptr<arrow::Schema>>(in_type_r[i]);
@@ -767,7 +767,7 @@ void RegisterScalarUDF(std::string name, cpp11::list func_sexp) {
     cpp11::sexp out_type_func = out_type_r[i];
 
     std::vector<arrow::compute::InputType> compute_in_types(in_types->num_fields());
-    for (int64_t j = 0; j < in_types->num_fields(); j++) {
+    for (int j = 0; j < in_types->num_fields(); j++) {
       compute_in_types[j] = arrow::compute::InputType(in_types->field(j)->type());
     }
 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -343,8 +343,8 @@ std::shared_ptr<ds::JsonFragmentScanOptions> dataset___JsonFragmentScanOptions__
 std::shared_ptr<ds::ParquetFragmentScanOptions>
 dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buffer_size,
                                            bool pre_buffer,
-                                           int64_t thrift_string_size_limit,
-                                           int64_t thrift_container_size_limit) {
+                                           int32_t thrift_string_size_limit,
+                                           int32_t thrift_container_size_limit) {
   auto options = std::make_shared<ds::ParquetFragmentScanOptions>();
   if (use_buffered_stream) {
     options->reader_properties->enable_buffered_stream();

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -201,7 +201,7 @@ std::shared_ptr<arrow::DataType> DayTimeInterval__initialize() {
 }
 
 // [[arrow::export]]
-std::shared_ptr<arrow::DataType> FixedSizeBinary__initialize(R_xlen_t byte_width) {
+std::shared_ptr<arrow::DataType> FixedSizeBinary__initialize(int32_t byte_width) {
   if (byte_width == NA_INTEGER) {
     cpp11::stop("'byte_width' cannot be NA");
   }

--- a/r/src/io.cpp
+++ b/r/src/io.cpp
@@ -254,7 +254,8 @@ class RConnectionFileInterface : public virtual arrow::io::FileInterface {
     }
 
     if (nbytes > std::numeric_limits<int>::max()) {
-      return arrow::Status::Invalid("Can't read more than INT_MAX bytes from an R connection");
+      return arrow::Status::Invalid(
+          "Can't read more than INT_MAX bytes from an R connection");
     }
 
     return SafeCallIntoR<int64_t>(
@@ -516,8 +517,8 @@ struct ReencodeUTF8TransformFunctionWrapper {
     // UTF-16, and UTF-32.
     while (in_bytes_left > 0) {
       // Make enough place in the output to hopefully consume all of the input.
-      RETURN_NOT_OK(
-          builder.Reserve(std::max<int64_t>(static_cast<int64_t>(in_bytes_left * kOversizeFactor), 4)));
+      RETURN_NOT_OK(builder.Reserve(
+          std::max<int64_t>(static_cast<int64_t>(in_bytes_left * kOversizeFactor), 4)));
       out_buf = builder.mutable_data() + builder.length();
       out_bytes_left = builder.capacity() - builder.length();
 

--- a/r/src/io.cpp
+++ b/r/src/io.cpp
@@ -253,11 +253,15 @@ class RConnectionFileInterface : public virtual arrow::io::FileInterface {
       return arrow::Status::IOError("R connection is closed");
     }
 
+    if (nbytes > std::numeric_limits<int>::max()) {
+      return arrow::Status::Invalid("Can't read more than INT_MAX bytes from an R connection");
+    }
+
     return SafeCallIntoR<int64_t>(
         [&] {
           cpp11::function read_bin = cpp11::package("base")["readBin"];
           cpp11::writable::raws ptype((R_xlen_t)0);
-          cpp11::integers n = cpp11::as_sexp<int>(nbytes);
+          cpp11::integers n = cpp11::as_sexp<int>(static_cast<int>(nbytes));
 
           cpp11::sexp result = read_bin(connection_sexp_, ptype, n);
 
@@ -513,7 +517,7 @@ struct ReencodeUTF8TransformFunctionWrapper {
     while (in_bytes_left > 0) {
       // Make enough place in the output to hopefully consume all of the input.
       RETURN_NOT_OK(
-          builder.Reserve(std::max<int64_t>(in_bytes_left * kOversizeFactor, 4)));
+          builder.Reserve(std::max<int64_t>(static_cast<int64_t>(in_bytes_left * kOversizeFactor), 4)));
       out_buf = builder.mutable_data() + builder.length();
       out_bytes_left = builder.capacity() - builder.length();
 

--- a/r/src/message.cpp
+++ b/r/src/message.cpp
@@ -39,8 +39,8 @@ std::shared_ptr<arrow::Buffer> ipc___Message__body(
 }
 
 // [[arrow::export]]
-r_vec_size ipc___Message__Verify(const std::unique_ptr<arrow::ipc::Message>& message) {
-  return r_vec_size(message->Verify());
+bool ipc___Message__Verify(const std::unique_ptr<arrow::ipc::Message>& message) {
+  return message->Verify();
 }
 
 // [[arrow::export]]

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -312,20 +312,12 @@ class AsArrowArrayConverter : public RConverter {
 template <typename T, typename Enable = void>
 class RPrimitiveConverter;
 
-template <typename T>
-Result<T> CIntFromRScalarImpl(int64_t value) {
+template <typename T, typename FromT>
+Result<T> CIntFromRScalarImpl(FromT value) {
   if (value < std::numeric_limits<T>::min() || value > std::numeric_limits<T>::max()) {
     return Status::Invalid("value outside of range");
   }
   return static_cast<T>(value);
-}
-
-template <>
-Result<uint64_t> CIntFromRScalarImpl<uint64_t>(int64_t value) {
-  if (value < 0) {
-    return Status::Invalid("value outside of range");
-  }
-  return static_cast<uint64_t>(value);
 }
 
 // utility to convert R single values from (int, raw, double and int64) vectors
@@ -335,7 +327,7 @@ struct RConvert {
   template <typename Type, typename From>
   static enable_if_integer<Type, Result<typename Type::c_type>> Convert(Type*,
                                                                         From from) {
-    return CIntFromRScalarImpl<typename Type::c_type>(from);
+    return CIntFromRScalarImpl<typename Type::c_type, From>(from);
   }
 
   // ---- convert R integer types to double
@@ -461,7 +453,7 @@ class RPrimitiveConverter<
 
     if (std::is_same<typename T::c_type, r_value_type>::value) {
       auto append_value = [this](r_value_type value) {
-        this->primitive_builder_->UnsafeAppend(value);
+        this->primitive_builder_->UnsafeAppend(static_cast<typename T::c_type>(value));
         return Status::OK();
       };
       return VisitVector(it, size, append_null, append_value);
@@ -595,19 +587,19 @@ class RPrimitiveConverter<T, enable_if_t<is_date_type<T>::value>>
     return VisitVector(it, size, append_null, append_value);
   }
 
-  static int FromRDate(const Date32Type*, int from) { return from; }
+  static int FromRDate(const Date32Type*, double from) { return static_cast<int>(from); }
 
-  static int64_t FromRDate(const Date64Type*, int from) {
+  static int64_t FromRDate(const Date64Type*, double from) {
     constexpr int64_t kMilliSecondsPerDay = 86400000;
-    return from * kMilliSecondsPerDay;
+    return static_cast<int64_t>(from * kMilliSecondsPerDay);
   }
 
   static int FromPosixct(const Date32Type*, double from) {
     constexpr int64_t kSecondsPerDay = 86400;
-    return from / kSecondsPerDay;
+    return static_cast<int>(from / kSecondsPerDay);
   }
 
-  static int64_t FromPosixct(const Date64Type*, double from) { return from * 1000; }
+  static int64_t FromPosixct(const Date64Type*, double from) { return static_cast<int64_t>(from * 1000); }
 };
 
 int64_t get_TimeUnit_multiplier(TimeUnit::type unit) {
@@ -1081,7 +1073,7 @@ class RListConverter : public ListConverter<T, RConverter, RConverterTrait> {
     auto append_value = [this](SEXP value) {
       // TODO: if we decide that this can be run concurrently
       //       we'll have to do vec_size() upfront
-      int n = arrow::r::vec_size(value);
+      R_xlen_t n = arrow::r::vec_size(value);
 
       RETURN_NOT_OK(this->list_builder_->ValidateOverflow(n));
       RETURN_NOT_OK(this->list_builder_->Append());

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -599,7 +599,9 @@ class RPrimitiveConverter<T, enable_if_t<is_date_type<T>::value>>
     return static_cast<int>(from / kSecondsPerDay);
   }
 
-  static int64_t FromPosixct(const Date64Type*, double from) { return static_cast<int64_t>(from * 1000); }
+  static int64_t FromPosixct(const Date64Type*, double from) {
+    return static_cast<int64_t>(from * 1000);
+  }
 };
 
 int64_t get_TimeUnit_multiplier(TimeUnit::type unit) {

--- a/r/src/recordbatch.cpp
+++ b/r/src/recordbatch.cpp
@@ -27,8 +27,8 @@
 #include <arrow/util/key_value_metadata.h>
 
 // [[arrow::export]]
-r_vec_size RecordBatch__num_columns(const std::shared_ptr<arrow::RecordBatch>& x) {
-  return r_vec_size(x->num_columns());
+int RecordBatch__num_columns(const std::shared_ptr<arrow::RecordBatch>& x) {
+  return x->num_columns();
 }
 
 // [[arrow::export]]
@@ -80,7 +80,7 @@ cpp11::list RecordBatch__columns(const std::shared_ptr<arrow::RecordBatch>& batc
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Array> RecordBatch__column(
-    const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i) {
+    const std::shared_ptr<arrow::RecordBatch>& batch, int i) {
   arrow::r::validate_index(i, batch->num_columns());
   return batch->column(i);
 }
@@ -106,7 +106,7 @@ bool RecordBatch__Equals(const std::shared_ptr<arrow::RecordBatch>& self,
 
 // [[arrow::export]]
 std::shared_ptr<arrow::RecordBatch> RecordBatch__AddColumn(
-    const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i,
+    const std::shared_ptr<arrow::RecordBatch>& batch, int i,
     const std::shared_ptr<arrow::Field>& field,
     const std::shared_ptr<arrow::Array>& column) {
   return ValueOrStop(batch->AddColumn(i, field, column));
@@ -114,7 +114,7 @@ std::shared_ptr<arrow::RecordBatch> RecordBatch__AddColumn(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::RecordBatch> RecordBatch__SetColumn(
-    const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i,
+    const std::shared_ptr<arrow::RecordBatch>& batch, int i,
     const std::shared_ptr<arrow::Field>& field,
     const std::shared_ptr<arrow::Array>& column) {
   return ValueOrStop(batch->SetColumn(i, field, column));
@@ -122,14 +122,14 @@ std::shared_ptr<arrow::RecordBatch> RecordBatch__SetColumn(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::RecordBatch> RecordBatch__RemoveColumn(
-    const std::shared_ptr<arrow::RecordBatch>& batch, R_xlen_t i) {
+    const std::shared_ptr<arrow::RecordBatch>& batch, int i) {
   arrow::r::validate_index(i, batch->num_columns());
   return ValueOrStop(batch->RemoveColumn(i));
 }
 
 // [[arrow::export]]
 std::string RecordBatch__column_name(const std::shared_ptr<arrow::RecordBatch>& batch,
-                                     R_xlen_t i) {
+                                     int i) {
   arrow::r::validate_index(i, batch->num_columns());
   return batch->column_name(i);
 }

--- a/r/src/schema.cpp
+++ b/r/src/schema.cpp
@@ -29,14 +29,14 @@ std::shared_ptr<arrow::Schema> Schema__from_fields(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Schema> Schema__from_list(cpp11::list field_list) {
-  int n = field_list.size();
+  R_xlen_t n = field_list.size();
 
   bool nullable = true;
   cpp11::strings names(field_list.attr(R_NamesSymbol));
 
   std::vector<std::shared_ptr<arrow::Field>> fields(n);
 
-  for (int i = 0; i < n; i++) {
+  for (R_xlen_t i = 0; i < n; i++) {
     fields[i] = arrow::field(
         names[i], cpp11::as_cpp<std::shared_ptr<arrow::DataType>>(field_list[i]),
         nullable);

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -23,8 +23,8 @@
 #include <arrow/util/key_value_metadata.h>
 
 // [[arrow::export]]
-r_vec_size Table__num_columns(const std::shared_ptr<arrow::Table>& x) {
-  return r_vec_size(x->num_columns());
+int Table__num_columns(const std::shared_ptr<arrow::Table>& x) {
+  return x->num_columns();
 }
 
 // [[arrow::export]]
@@ -49,14 +49,14 @@ std::shared_ptr<arrow::Table> Table__ReplaceSchemaMetadata(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::ChunkedArray> Table__column(
-    const std::shared_ptr<arrow::Table>& table, R_xlen_t i) {
+    const std::shared_ptr<arrow::Table>& table, int i) {
   arrow::r::validate_index(i, table->num_columns());
   return table->column(i);
 }
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Field> Table__field(const std::shared_ptr<arrow::Table>& table,
-                                           R_xlen_t i) {
+                                           int i) {
   arrow::r::validate_index(i, table->num_columns());
   return table->field(i);
 }
@@ -123,13 +123,13 @@ std::shared_ptr<arrow::ChunkedArray> Table__GetColumnByName(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> Table__RemoveColumn(
-    const std::shared_ptr<arrow::Table>& table, R_xlen_t i) {
+    const std::shared_ptr<arrow::Table>& table, int i) {
   return ValueOrStop(table->RemoveColumn(i));
 }
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> Table__AddColumn(
-    const std::shared_ptr<arrow::Table>& table, R_xlen_t i,
+    const std::shared_ptr<arrow::Table>& table, int i,
     const std::shared_ptr<arrow::Field>& field,
     const std::shared_ptr<arrow::ChunkedArray>& column) {
   return ValueOrStop(table->AddColumn(i, field, column));
@@ -137,7 +137,7 @@ std::shared_ptr<arrow::Table> Table__AddColumn(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> Table__SetColumn(
-    const std::shared_ptr<arrow::Table>& table, R_xlen_t i,
+    const std::shared_ptr<arrow::Table>& table, int i,
     const std::shared_ptr<arrow::Field>& field,
     const std::shared_ptr<arrow::ChunkedArray>& column) {
   return ValueOrStop(table->SetColumn(i, field, column));
@@ -241,7 +241,7 @@ arrow::Status AddMetadataFromDots(SEXP lst, int num_fields,
 
   // Remove metadata for ExtensionType columns, because these have their own mechanism for
   // preserving R type information
-  for (R_xlen_t i = 0; i < schema->num_fields(); i++) {
+  for (int i = 0; i < schema->num_fields(); i++) {
     if (schema->field(i)->type()->id() == Type::EXTENSION) {
       metadata_columns[i] = R_NilValue;
     }


### PR DESCRIPTION
### Rationale for this change

We have failing CRAN checks because this warning occurs on one check machine.

### What changes are included in this PR?

Implicit integer casts are made explicit and/or variable declarations were fixed so that fewer implicit integer casts were performed. Fully solving the warnings also requires https://github.com/r-lib/cpp11/pull/349 since some errors occur in those headers.

### Are these changes tested?

This particular test we can't do on CI because the MacOS runner we have doesn't have a new enough `clang` to support the requisite `-W` flags. I tested this locally by adding `PKG_CXXFLAGS=-Wconversion -Wno-sign-conversion -Wsign-compare -Werror` to `Makevars.in`.

### Are there any user-facing changes?

No
* Closes: #39138