### PR TITLE
GH-30117:  [C++][Python] Add "Z" to the end of timestamp print string when tz defined

### DIFF
--- a/cpp/src/arrow/pretty_print_test.cc
+++ b/cpp/src/arrow/pretty_print_test.cc
@@ -350,10 +350,10 @@ TEST_F(TestPrettyPrint, DateTimeTypes) {
     std::vector<int64_t> values = {
         0, 1, 2, 678 + 1000000 * (5 + 60 * (4 + 60 * (3 + 24 * int64_t(1)))), 4};
     static const char* expected = R"expected([
-  1970-01-01 00:00:00.000000,
-  1970-01-01 00:00:00.000001,
+  1970-01-01 00:00:00.000000Z,
+  1970-01-01 00:00:00.000001Z,
   null,
-  1970-01-02 03:04:05.000678,
+  1970-01-02 03:04:05.000678Z,
   null
 ])expected";
     CheckPrimitive<TimestampType, int64_t>(timestamp(TimeUnit::MICRO, "Transylvania"),

--- a/cpp/src/arrow/util/formatting.h
+++ b/cpp/src/arrow/util/formatting.h
@@ -470,7 +470,8 @@ class StringFormatter<TimestampType> {
   using value_type = int64_t;
 
   explicit StringFormatter(const DataType* type)
-      : unit_(checked_cast<const TimestampType&>(*type).unit()) {}
+      : unit_(checked_cast<const TimestampType&>(*type).unit()),
+        timezone_(checked_cast<const TimestampType&>(*type).timezone()) {}
 
   template <typename Duration, typename Appender>
   Return<Appender> operator()(Duration, value_type value, Appender&& append) {
@@ -503,6 +504,9 @@ class StringFormatter<TimestampType> {
     std::array<char, buffer_size> buffer;
     char* cursor = buffer.data() + buffer_size;
 
+    if (timezone_.size() > 0) {
+      detail::FormatOneChar('Z', &cursor);
+    }
     detail::FormatHH_MM_SS(arrow_vendored::date::make_time(since_midnight), &cursor);
     detail::FormatOneChar(' ', &cursor);
     detail::FormatYYYY_MM_DD(timepoint_days, &cursor);
@@ -516,6 +520,7 @@ class StringFormatter<TimestampType> {
 
  private:
   TimeUnit::type unit_;
+  std::string timezone_;
 };
 
 template <typename T>

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -522,6 +522,22 @@ TEST(Formatting, Timestamp) {
     AssertFormatting(formatter, -2203932304LL * 1000000000LL + 8,
                      "1900-02-28 12:34:56.000000008");
   }
+
+  {
+    auto ty = timestamp(TimeUnit::SECOND, "US/Eastern");
+    StringFormatter<TimestampType> formatter(ty.get());
+
+    AssertFormatting(formatter, 0, "1970-01-01 00:00:00Z");
+    AssertFormatting(formatter, 1, "1970-01-01 00:00:01Z");
+    AssertFormatting(formatter, 24 * 60 * 60, "1970-01-02 00:00:00Z");
+    AssertFormatting(formatter, 616377600, "1989-07-14 00:00:00Z");
+    AssertFormatting(formatter, 951782400, "2000-02-29 00:00:00Z");
+    AssertFormatting(formatter, 63730281600LL, "3989-07-14 00:00:00Z");
+    AssertFormatting(formatter, -2203977600LL, "1900-02-28 00:00:00Z");
+
+    AssertFormatting(formatter, 1542129070, "2018-11-13 17:11:10Z");
+    AssertFormatting(formatter, -2203932304LL, "1900-02-28 12:34:56Z");
+  }
 }
 
 TEST(Formatting, Interval) {

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -523,20 +523,28 @@ TEST(Formatting, Timestamp) {
                      "1900-02-28 12:34:56.000000008");
   }
 
+
   {
-    auto ty = timestamp(TimeUnit::SECOND, "US/Eastern");
-    StringFormatter<TimestampType> formatter(ty.get());
-
-    AssertFormatting(formatter, 0, "1970-01-01 00:00:00Z");
-    AssertFormatting(formatter, 1, "1970-01-01 00:00:01Z");
-    AssertFormatting(formatter, 24 * 60 * 60, "1970-01-02 00:00:00Z");
-    AssertFormatting(formatter, 616377600, "1989-07-14 00:00:00Z");
-    AssertFormatting(formatter, 951782400, "2000-02-29 00:00:00Z");
-    AssertFormatting(formatter, 63730281600LL, "3989-07-14 00:00:00Z");
-    AssertFormatting(formatter, -2203977600LL, "1900-02-28 00:00:00Z");
-
-    AssertFormatting(formatter, 1542129070, "2018-11-13 17:11:10Z");
-    AssertFormatting(formatter, -2203932304LL, "1900-02-28 12:34:56Z");
+    auto timestamp_types = {timestamp(TimeUnit::SECOND, "US/Eastern"),
+                          timestamp(TimeUnit::SECOND, "+01:00"),
+                          timestamp(TimeUnit::SECOND, "-42:00"),
+                          timestamp(TimeUnit::SECOND, "Pacific/Maruesas"),
+                          timestamp(TimeUnit::SECOND, "Mars/Mariner_Valley")};
+    for (auto ty : timestamp_types) {
+      auto ty = timestamp(TimeUnit::SECOND, "US/Eastern");
+      StringFormatter<TimestampType> formatter(ty.get());
+  
+      AssertFormatting(formatter, 0, "1970-01-01 00:00:00Z");
+      AssertFormatting(formatter, 1, "1970-01-01 00:00:01Z");
+      AssertFormatting(formatter, 24 * 60 * 60, "1970-01-02 00:00:00Z");
+      AssertFormatting(formatter, 616377600, "1989-07-14 00:00:00Z");
+      AssertFormatting(formatter, 951782400, "2000-02-29 00:00:00Z");
+      AssertFormatting(formatter, 63730281600LL, "3989-07-14 00:00:00Z");
+      AssertFormatting(formatter, -2203977600LL, "1900-02-28 00:00:00Z");
+  
+      AssertFormatting(formatter, 1542129070, "2018-11-13 17:11:10Z");
+      AssertFormatting(formatter, -2203932304LL, "1900-02-28 12:34:56Z");
+    }
   }
 }
 

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -526,22 +526,44 @@ TEST(Formatting, Timestamp) {
   {
     auto timestamp_types = {timestamp(TimeUnit::SECOND, "US/Eastern"),
                             timestamp(TimeUnit::SECOND, "+01:00"),
-                            timestamp(TimeUnit::SECOND, "-42:00"),
-                            timestamp(TimeUnit::SECOND, "Pacific/Maruesas"),
                             timestamp(TimeUnit::SECOND, "Mars/Mariner_Valley")};
     for (auto ty : timestamp_types) {
       StringFormatter<TimestampType> formatter(ty.get());
 
       AssertFormatting(formatter, 0, "1970-01-01 00:00:00Z");
-      AssertFormatting(formatter, 1, "1970-01-01 00:00:01Z");
-      AssertFormatting(formatter, 24 * 60 * 60, "1970-01-02 00:00:00Z");
-      AssertFormatting(formatter, 616377600, "1989-07-14 00:00:00Z");
-      AssertFormatting(formatter, 951782400, "2000-02-29 00:00:00Z");
-      AssertFormatting(formatter, 63730281600LL, "3989-07-14 00:00:00Z");
-      AssertFormatting(formatter, -2203977600LL, "1900-02-28 00:00:00Z");
+    }
+  }
 
-      AssertFormatting(formatter, 1542129070, "2018-11-13 17:11:10Z");
-      AssertFormatting(formatter, -2203932304LL, "1900-02-28 12:34:56Z");
+  {
+    auto timestamp_types = {timestamp(TimeUnit::MILLI, "US/Eastern"),
+                            timestamp(TimeUnit::MILLI, "Pacific/Maruesas"),
+                            timestamp(TimeUnit::MILLI, "Mars/Mariner_Valley")};
+    for (auto ty : timestamp_types) {
+      StringFormatter<TimestampType> formatter(ty.get());
+
+      AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000Z");
+    }
+  }
+
+  {
+    auto timestamp_types = {timestamp(TimeUnit::MICRO, "US/Eastern"),
+                            timestamp(TimeUnit::MICRO, "-42:00"),
+                            timestamp(TimeUnit::MICRO, "Pacific/Maruesas")};
+    for (auto ty : timestamp_types) {
+      StringFormatter<TimestampType> formatter(ty.get());
+
+      AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000Z");
+    }
+  }
+
+  {
+    auto timestamp_types = {timestamp(TimeUnit::NANO, "US/Eastern"),
+                            timestamp(TimeUnit::NANO, "+01:00"),
+                            timestamp(TimeUnit::NANO, "-42:00")};
+    for (auto ty : timestamp_types) {
+      StringFormatter<TimestampType> formatter(ty.get());
+
+      AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000000Z");
     }
   }
 }

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -530,7 +530,6 @@ TEST(Formatting, Timestamp) {
                             timestamp(TimeUnit::SECOND, "Pacific/Maruesas"),
                             timestamp(TimeUnit::SECOND, "Mars/Mariner_Valley")};
     for (auto ty : timestamp_types) {
-      auto ty = timestamp(TimeUnit::SECOND, "US/Eastern");
       StringFormatter<TimestampType> formatter(ty.get());
 
       AssertFormatting(formatter, 0, "1970-01-01 00:00:00Z");

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -525,8 +525,7 @@ TEST(Formatting, Timestamp) {
 
   {
     auto timestamp_types = {timestamp(TimeUnit::SECOND, "US/Eastern"),
-                            timestamp(TimeUnit::SECOND, "+01:00"),
-                            timestamp(TimeUnit::SECOND, "Mars/Mariner_Valley")};
+                            timestamp(TimeUnit::SECOND, "+01:00")};
     for (auto ty : timestamp_types) {
       StringFormatter<TimestampType> formatter(ty.get());
 
@@ -535,36 +534,21 @@ TEST(Formatting, Timestamp) {
   }
 
   {
-    auto timestamp_types = {timestamp(TimeUnit::MILLI, "US/Eastern"),
-                            timestamp(TimeUnit::MILLI, "Pacific/Maruesas"),
-                            timestamp(TimeUnit::MILLI, "Mars/Mariner_Valley")};
-    for (auto ty : timestamp_types) {
-      StringFormatter<TimestampType> formatter(ty.get());
-
-      AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000Z");
-    }
+    auto ty = timestamp(TimeUnit::MILLI, "Pacific/Maruesas");
+    StringFormatter<TimestampType> formatter(ty.get());
+    AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000Z");
   }
 
   {
-    auto timestamp_types = {timestamp(TimeUnit::MICRO, "US/Eastern"),
-                            timestamp(TimeUnit::MICRO, "-42:00"),
-                            timestamp(TimeUnit::MICRO, "Pacific/Maruesas")};
-    for (auto ty : timestamp_types) {
-      StringFormatter<TimestampType> formatter(ty.get());
-
-      AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000Z");
-    }
+    auto ty = timestamp(TimeUnit::MICRO, "-42:00");
+    StringFormatter<TimestampType> formatter(ty.get());
+    AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000Z");
   }
 
   {
-    auto timestamp_types = {timestamp(TimeUnit::NANO, "US/Eastern"),
-                            timestamp(TimeUnit::NANO, "+01:00"),
-                            timestamp(TimeUnit::NANO, "-42:00")};
-    for (auto ty : timestamp_types) {
-      StringFormatter<TimestampType> formatter(ty.get());
-
-      AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000000Z");
-    }
+    auto ty = timestamp(TimeUnit::NANO, "Mars/Mariner_Valley");
+    StringFormatter<TimestampType> formatter(ty.get());
+    AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000000Z");
   }
 }
 

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -523,17 +523,16 @@ TEST(Formatting, Timestamp) {
                      "1900-02-28 12:34:56.000000008");
   }
 
-
   {
     auto timestamp_types = {timestamp(TimeUnit::SECOND, "US/Eastern"),
-                          timestamp(TimeUnit::SECOND, "+01:00"),
-                          timestamp(TimeUnit::SECOND, "-42:00"),
-                          timestamp(TimeUnit::SECOND, "Pacific/Maruesas"),
-                          timestamp(TimeUnit::SECOND, "Mars/Mariner_Valley")};
+                            timestamp(TimeUnit::SECOND, "+01:00"),
+                            timestamp(TimeUnit::SECOND, "-42:00"),
+                            timestamp(TimeUnit::SECOND, "Pacific/Maruesas"),
+                            timestamp(TimeUnit::SECOND, "Mars/Mariner_Valley")};
     for (auto ty : timestamp_types) {
       auto ty = timestamp(TimeUnit::SECOND, "US/Eastern");
       StringFormatter<TimestampType> formatter(ty.get());
-  
+
       AssertFormatting(formatter, 0, "1970-01-01 00:00:00Z");
       AssertFormatting(formatter, 1, "1970-01-01 00:00:01Z");
       AssertFormatting(formatter, 24 * 60 * 60, "1970-01-02 00:00:00Z");
@@ -541,7 +540,7 @@ TEST(Formatting, Timestamp) {
       AssertFormatting(formatter, 951782400, "2000-02-29 00:00:00Z");
       AssertFormatting(formatter, 63730281600LL, "3989-07-14 00:00:00Z");
       AssertFormatting(formatter, -2203977600LL, "1900-02-28 00:00:00Z");
-  
+
       AssertFormatting(formatter, 1542129070, "2018-11-13 17:11:10Z");
       AssertFormatting(formatter, -2203932304LL, "1900-02-28 12:34:56Z");
     }

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -487,6 +487,16 @@ def test_timestamp():
             pa.timestamp(invalid_unit)
 
 
+def test_timestamp_print():
+    for unit in ('s', 'ms', 'us', 'ns'):
+        for tz in ('UTC', 'Europe/Paris'):
+            ty = pa.timestamp(unit, tz=tz)
+            arr = pa.array([0], ty)
+            assert "Z" in str(arr)
+        arr = pa.array([0])
+        assert "Z" not in str(arr)
+
+
 def test_time32_units():
     for valid_unit in ('s', 'ms'):
         ty = pa.time32(valid_unit)

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -494,7 +494,7 @@ def test_timestamp_print():
             ty = pa.timestamp(unit, tz=tz)
             arr = pa.array([0], ty)
             assert "Z" in str(arr)
-        arr = pa.array([0])
+        arr = pa.array([0], pa.timestamp(unit))
         assert "Z" not in str(arr)
 
 

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -489,7 +489,8 @@ def test_timestamp():
 
 def test_timestamp_print():
     for unit in ('s', 'ms', 'us', 'ns'):
-        for tz in ('UTC', 'Europe/Paris', 'Pacific/Marquesas', 'Mars/Mariner_Valley', '-00:42', '+42:00'):
+        for tz in ('UTC', 'Europe/Paris', 'Pacific/Marquesas',
+                   'Mars/Mariner_Valley', '-00:42', '+42:00'):
             ty = pa.timestamp(unit, tz=tz)
             arr = pa.array([0], ty)
             assert "Z" in str(arr)

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -489,7 +489,7 @@ def test_timestamp():
 
 def test_timestamp_print():
     for unit in ('s', 'ms', 'us', 'ns'):
-        for tz in ('UTC', 'Europe/Paris'):
+        for tz in ('UTC', 'Europe/Paris', 'Pacific/Marquesas', 'Mars/Mariner_Valley', '-00:42', '+42:00'):
             ty = pa.timestamp(unit, tz=tz)
             arr = pa.array([0], ty)
             assert "Z" in str(arr)


### PR DESCRIPTION
### What changes are included in this PR?

This PR updates the PrettyPrint for Timestamp type so that "Z" is printed at the end of the output string if the timezone has been defined. This way we add minimum information about the values being stored in UTC.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

There is a change in how `TimestampArray` prints out the data. With this change "Z" would be added to the end of the string if the timezone is defined.
* Closes: #30117