### PR TITLE
MINOR: [Docs] local_timestamp kernel docs are not linked in python docs

### DIFF
--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -468,6 +468,7 @@ Timezone Handling
    :toctree: ../generated/
 
    assume_timezone
+   local_timestamp
 
 Associative Transforms
 ----------------------


### PR DESCRIPTION
### Rationale for this change

local_timestamp kernel docs are linked in [cpp](https://arrow.apache.org/docs/cpp/compute.html#timezone-handling) but not in [python docs](https://arrow.apache.org/docs/python/api/compute.html#timezone-handling).

### What changes are included in this PR?

This adds a rst link in python docs

### Are these changes tested?

No

### Are there any user-facing changes?

Change will be visible in the docs