### PR TITLE
GH-38535: [Python] Fix S3FileSystem equals None segfault

### DIFF
--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -505,7 +505,7 @@ cdef class FileSystem(_Weakrefable):
     cdef inline shared_ptr[CFileSystem] unwrap(self) nogil:
         return self.wrapped
 
-    def equals(self, FileSystem other):
+    def equals(self, FileSystem other not None):
         """
         Parameters
         ----------

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -542,6 +542,13 @@ def test_filesystem_equals():
     assert SubTreeFileSystem('/base', fs0) != SubTreeFileSystem('/other', fs0)
 
 
+def test_filesystem_equals_none(fs):
+    with pytest.raises(TypeError, match="got NoneType"):
+        fs.equals(None)
+
+    assert fs != None
+
+
 def test_subtree_filesystem():
     localfs = LocalFileSystem()
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -546,7 +546,7 @@ def test_filesystem_equals_none(fs):
     with pytest.raises(TypeError, match="got NoneType"):
         fs.equals(None)
 
-    assert fs != None
+    assert fs is not None
 
 
 def test_subtree_filesystem():


### PR DESCRIPTION
### Rationale for this change

`S3FileSystem` equals `None` currently causes bus error.

### What changes are included in this PR?

Add `not None` to `FileSystem.equals` signature.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #38535