### PR TITLE
GH-39301: [Archery][CI][Integration] Add nanoarrow to archery + integration setup

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: apache/arrow-nanoarrow
+          repository: paleolimbot/arrow-nanoarrow
+          ref: more-integration
           path: nanoarrow
       - name: Free up disk space
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -102,8 +102,8 @@ jobs:
         run: >
           archery docker run \
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
-            -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
+            -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             conda-integration
       - name: Docker Push
         if: >-

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,8 +78,7 @@ jobs:
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paleolimbot/arrow-nanoarrow
-          ref: more-integration
+          repository: apache/arrow-nanoarrow
           path: nanoarrow
       - name: Free up disk space
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: apache/arrow-nanoarrow
+          repository: paleolimbot/arrow-nanoarrow
+          ref: integration-fixes
           path: nanoarrow
       - name: Free up disk space
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,6 +75,11 @@ jobs:
         with:
           repository: apache/arrow-rs
           path: rust
+      - name: Checkout Arrow Rust
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          repository: apache/arrow-nanoarrow
+          path: nanoarrow
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,7 +81,6 @@ jobs:
           repository: paleolimbot/arrow-nanoarrow
           ref: integration-fixes
           path: nanoarrow
-
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           repository: apache/arrow-rs
           path: rust
-      - name: Checkout Arrow Rust
+      - name: Checkout Arrow nanoarrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           repository: apache/arrow-nanoarrow

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,8 +78,7 @@ jobs:
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
-          repository: paleolimbot/arrow-nanoarrow
-          ref: integration-fixes
+          repository: apache/arrow-nanoarrow
           path: nanoarrow
       - name: Free up disk space
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,6 +98,7 @@ jobs:
           archery docker run \
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
             -e ARCHERY_INTEGRATION_WITH_RUST=1 \
+            -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
             conda-integration
       - name: Docker Push
         if: >-

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,6 +81,7 @@ jobs:
           repository: paleolimbot/arrow-nanoarrow
           ref: integration-fixes
           path: nanoarrow
+
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh

--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -30,6 +30,8 @@ build_dir=${2}
 
 ${arrow_dir}/ci/scripts/rust_build.sh ${arrow_dir} ${build_dir}
 
+${arrow_dir}/ci/scripts/nanoarrow_build.sh ${arrow_dir} ${build_dir}
+
 if [ "${ARROW_INTEGRATION_CPP}" == "ON" ]; then
     ${arrow_dir}/ci/scripts/cpp_build.sh ${arrow_dir} ${build_dir}
 fi

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+arrow_dir=${1}
+source_dir=${1}/nanoarrow
+build_dir=${2}/nanoarrow
+
+# This file is used to build the nanoarrow binaries needed for the archery
+# integration tests. Testing of the nanoarrow implementation in normal CI is handled
+# by github workflows in the arrow-nanoarrow repository.
+
+if [ "${ARCHERY_INTEGRATION_WITH_NANOARROW}" -eq "0" ]; then
+  echo "====================================================================="
+  echo "Not building nanoarrow"
+  echo "====================================================================="
+  exit 0;
+elif [ ! -d "${source_dir}" ]; then
+  echo "====================================================================="
+  echo "The nanoarrow source is missing. Please clone the arrow-rs repository"
+  echo "to arrow/nanoarrow before running the integration tests:"
+  echo "  git clone https://github.com/apache/arrow-nanoarrow.git path/to/arrow/nanoarrow"
+  echo "====================================================================="
+  exit 1;
+fi
+
+set -x
+
+pushd ${build_dir}
+
+# Build nanoarrow C Data integration tests
+mkdir -p cdata && pushd cdata
+cmake ${source_dir} -DNANOARROW_BUILD_INTEGRATION_TESTS=ON
+popd
+
+# Build nanoarrow IPC integration tests
+pushd
+mkdir -p ipc && pushd ipc
+cmake ${source_dir}/extensions/nanoarrow_ipc -DNANOARROW_BUILD_APPS=ON
+popd
+
+popd

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -43,6 +43,7 @@ fi
 
 set -x
 
+mkdir -p ${build_dir}
 pushd ${build_dir}
 
 # Build nanoarrow C Data integration tests

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -54,7 +54,7 @@ popd
 # Build nanoarrow IPC integration tests
 pushd
 mkdir -p ipc && pushd ipc
-cmake ${source_dir}/extensions/nanoarrow_ipc -DNANOARROW_BUILD_APPS=ON
+cmake ${source_dir}/extensions/nanoarrow_ipc -DNANOARROW_IPC_BUILD_APPS=ON
 popd
 
 popd

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -34,7 +34,7 @@ if [ "${ARCHERY_INTEGRATION_WITH_NANOARROW}" -eq "0" ]; then
   exit 0;
 elif [ ! -d "${source_dir}" ]; then
   echo "====================================================================="
-  echo "The nanoarrow source is missing. Please clone the arrow-rs repository"
+  echo "The nanoarrow source is missing. Please clone the arrow-nanoarrow repository"
   echo "to arrow/nanoarrow before running the integration tests:"
   echo "  git clone https://github.com/apache/arrow-nanoarrow.git path/to/arrow/nanoarrow"
   echo "====================================================================="
@@ -49,12 +49,14 @@ pushd ${build_dir}
 # Build nanoarrow C Data integration tests
 mkdir -p cdata && pushd cdata
 cmake ${source_dir} -DNANOARROW_BUILD_INTEGRATION_TESTS=ON
+echo "Contents of build directory:"
+ls -lha .
 popd
 
 # Build nanoarrow IPC integration tests
-pushd
 mkdir -p ipc && pushd ipc
 cmake ${source_dir}/extensions/nanoarrow_ipc -DNANOARROW_IPC_BUILD_APPS=ON
+ls -lha .
 popd
 
 popd

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -46,16 +46,7 @@ set -x
 mkdir -p ${build_dir}
 pushd ${build_dir}
 
-# Build nanoarrow C Data integration tests
-mkdir -p cdata && pushd cdata
 cmake ${source_dir} -DNANOARROW_BUILD_INTEGRATION_TESTS=ON
 cmake --build .
-popd
-
-# Build nanoarrow IPC integration tests
-mkdir -p ipc && pushd ipc
-cmake ${source_dir}/extensions/nanoarrow_ipc -DNANOARROW_IPC_BUILD_APPS=ON
-cmake --build .
-popd
 
 popd

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -49,14 +49,13 @@ pushd ${build_dir}
 # Build nanoarrow C Data integration tests
 mkdir -p cdata && pushd cdata
 cmake ${source_dir} -DNANOARROW_BUILD_INTEGRATION_TESTS=ON
-echo "Contents of build directory:"
-ls -lha .
+cmake --build .
 popd
 
 # Build nanoarrow IPC integration tests
 mkdir -p ipc && pushd ipc
 cmake ${source_dir}/extensions/nanoarrow_ipc -DNANOARROW_IPC_BUILD_APPS=ON
-ls -lha .
+cmake --build .
 popd
 
 popd

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -738,12 +738,12 @@ def _set_default(opt, default):
               help='Include JavaScript in integration tests')
 @click.option('--with-go', type=bool, default=False,
               help='Include Go in integration tests')
-@click.option('--with-rust', type=bool, default=False,
-              help='Include Rust in integration tests',
-              envvar="ARCHERY_INTEGRATION_WITH_RUST")
 @click.option('--with-nanoarrow', type=bool, default=False,
               help='Include nanoarrow in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_NANOARROW")
+@click.option('--with-rust', type=bool, default=False,
+              help='Include Rust in integration tests',
+              envvar="ARCHERY_INTEGRATION_WITH_RUST")
 @click.option('--write_generated_json', default="",
               help='Generate test JSON to indicated path')
 @click.option('--run-ipc', is_flag=True, default=False,
@@ -779,7 +779,7 @@ def integration(with_all=False, random_seed=12345, **args):
 
     gen_path = args['write_generated_json']
 
-    languages = ['cpp', 'csharp', 'java', 'js', 'go', 'rust', 'nanoarrow']
+    languages = ['cpp', 'csharp', 'java', 'js', 'go', 'nanoarrow', 'rust']
     formats = ['ipc', 'flight', 'c_data']
 
     enabled_languages = 0

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -741,6 +741,9 @@ def _set_default(opt, default):
 @click.option('--with-rust', type=bool, default=False,
               help='Include Rust in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_RUST")
+@click.option('--with-nanoarrow', type=bool, default=False,
+              help='Include nanoarrow in integration tests',
+              envvar="ARCHERY_INTEGRATION_WITH_NANOARROW")
 @click.option('--write_generated_json', default="",
               help='Generate test JSON to indicated path')
 @click.option('--run-ipc', is_flag=True, default=False,
@@ -776,7 +779,7 @@ def integration(with_all=False, random_seed=12345, **args):
 
     gen_path = args['write_generated_json']
 
-    languages = ['cpp', 'csharp', 'java', 'js', 'go', 'rust']
+    languages = ['cpp', 'csharp', 'java', 'js', 'go', 'rust', 'nanoarrow']
     formats = ['ipc', 'flight', 'c_data']
 
     enabled_languages = 0

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1934,8 +1934,7 @@ def get_generated_json_files(tempdir=None):
         generate_binary_view_case()
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('Rust')
-        ,
+        .skip_tester('Rust'),
 
         generate_list_view_case()
         .skip_tester('C#')     # Doesn't support large list views

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1934,6 +1934,7 @@ def get_generated_json_files(tempdir=None):
         generate_binary_view_case()
         .skip_tester('Java')
         .skip_tester('JS')
+        .skip_tester('nanoarrow')
         .skip_tester('Rust'),
 
         generate_list_view_case()

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1928,18 +1928,21 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('C#')
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('Rust'),
+        .skip_tester('Rust')
+        .skip_tester('nanoarrow'),
 
         generate_binary_view_case()
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('Rust'),
+        .skip_tester('Rust')
+        .skip_tester('nanoarrow'),
 
         generate_list_view_case()
         .skip_tester('C#')     # Doesn't support large list views
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('Rust'),
+        .skip_tester('Rust')
+        .skip_tester('nanoarrow'),
 
         generate_extension_case()
         # TODO: ensure the extension is registered in the C++ entrypoint

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1928,21 +1928,21 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('C#')
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('Rust')
-        .skip_tester('nanoarrow'),
+        .skip_tester('nanoarrow')
+        .skip_tester('Rust'),
 
         generate_binary_view_case()
         .skip_tester('Java')
         .skip_tester('JS')
         .skip_tester('Rust')
-        .skip_tester('nanoarrow'),
+        ,
 
         generate_list_view_case()
         .skip_tester('C#')     # Doesn't support large list views
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('Rust')
-        .skip_tester('nanoarrow'),
+        .skip_tester('nanoarrow')
+        .skip_tester('Rust'),
 
         generate_extension_case()
         # TODO: ensure the extension is registered in the C++ entrypoint

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -563,11 +563,11 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
     if with_go:
         testers.append(GoTester(**kwargs))
 
-    if with_rust:
-        testers.append(RustTester(**kwargs))
-
     if with_nanoarrow:
         testers.append(NanoarrowTester(**kwargs))
+
+    if with_rust:
+        testers.append(RustTester(**kwargs))
 
     static_json_files = get_static_json_files()
     generated_json_files = datagen.get_generated_json_files(tempdir=tempdir)

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -36,6 +36,7 @@ from .tester_rust import RustTester
 from .tester_java import JavaTester
 from .tester_js import JSTester
 from .tester_csharp import CSharpTester
+from .tester_nanoarrow import NanoarrowTester
 from .util import guid, printer
 from .util import SKIP_C_ARRAY, SKIP_C_SCHEMA, SKIP_FLIGHT, SKIP_IPC
 from ..utils.source import ARROW_ROOT_DEFAULT
@@ -541,8 +542,8 @@ def get_static_json_files():
 
 def run_all_tests(with_cpp=True, with_java=True, with_js=True,
                   with_csharp=True, with_go=True, with_rust=False,
-                  run_ipc=False, run_flight=False, run_c_data=False,
-                  tempdir=None, **kwargs):
+                  with_nanoarrow=False, run_ipc=False, run_flight=False,
+                  run_c_data=False, tempdir=None, **kwargs):
     tempdir = tempdir or tempfile.mkdtemp(prefix='arrow-integration-')
 
     testers: List[Tester] = []
@@ -564,6 +565,9 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
 
     if with_rust:
         testers.append(RustTester(**kwargs))
+
+    if with_nanoarrow:
+        testers.append(NanoarrowTester(**kwargs))
 
     static_json_files = get_static_json_files()
     generated_json_files = datagen.get_generated_json_files(tempdir=tempdir)

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -20,7 +20,6 @@ import os
 
 from . import cdata
 from .tester import Tester, CDataExporter, CDataImporter
-from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
 
 

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -1,0 +1,178 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import functools
+import os
+
+from . import cdata
+from .tester import Tester, CDataExporter, CDataImporter
+from .util import run_cmd, log
+from ..utils.source import ARROW_ROOT_DEFAULT
+
+
+_NANOARROW_PATH = os.environ.get(
+    "ARROW_NANOARROW_PATH",
+    os.path.join(ARROW_ROOT_DEFAULT, "nanoarrow"),
+)
+_INTEGRATION_EXE = os.path.join(_NANOARROW_PATH, "ipc/integration_test_util")
+_INTEGRATION_DLL = os.path.join(
+    _NANOARROW_PATH, "cdata/libnanoarrow_c_data_integration" + cdata.dll_suffix
+)
+
+
+class NanoarrowTester(Tester):
+    PRODUCER = False
+    CONSUMER = True
+    FLIGHT_SERVER = False
+    FLIGHT_CLIENT = False
+    C_DATA_SCHEMA_EXPORTER = True
+    C_DATA_ARRAY_EXPORTER = True
+    C_DATA_SCHEMA_IMPORTER = True
+    C_DATA_ARRAY_IMPORTER = True
+
+    name = "nanoarrow"
+
+    def _run(self, arrow_path=None, json_path=None, command="VALIDATE"):
+        cmd = [_INTEGRATION_EXE, "--integration"]
+
+        if arrow_path is not None:
+            cmd.append("--arrow=" + arrow_path)
+
+        if json_path is not None:
+            cmd.append("--json=" + json_path)
+
+        cmd.append("--mode=" + command)
+
+        if self.debug:
+            log(" ".join(cmd))
+
+        run_cmd(cmd)
+
+    def validate(self, json_path, arrow_path, quirks=None):
+        cmd = [
+            _INTEGRATION_EXE,
+            "--from",
+            "json",
+            json_path,
+            "--check",
+            "ipc",
+            arrow_path,
+        ]
+        if self.debug:
+            log(" ".join(cmd))
+        run_cmd(cmd)
+
+    def json_to_file(self, json_path, arrow_path):
+        raise NotImplementedError()
+
+    def stream_to_file(self, stream_path, file_path):
+        raise NotImplementedError()
+
+    def file_to_stream(self, file_path, stream_path):
+        raise NotImplementedError()
+
+    def make_c_data_exporter(self):
+        return NanoarrowCDataExporter(self.debug, self.args)
+
+    def make_c_data_importer(self):
+        return NanoarrowCDataImporter(self.debug, self.args)
+
+
+_nanoarrow_c_data_entrypoints = """
+    const char* nanoarrow_CDataIntegration_ExportSchemaFromJson(const char* json_path,
+                                                                struct ArrowSchema* out);
+
+    const char* nanoarrow_CDataIntegration_ImportSchemaAndCompareToJson(
+        const char* json_path, struct ArrowSchema* schema);
+
+    const char* nanoarrow_CDataIntegration_ExportBatchFromJson(const char* json_path,
+                                                            int num_batch,
+                                                            struct ArrowArray* out);
+
+    const char* nanoarrow_CDataIntegration_ImportBatchAndCompareToJson(
+        const char* json_path, int num_batch, struct ArrowArray* batch);
+
+    int64_t nanoarrow_BytesAllocated(void);
+    """
+
+
+@functools.lru_cache
+def _load_ffi(ffi, lib_path=_INTEGRATION_DLL):
+    ffi.cdef(_nanoarrow_c_data_entrypoints)
+    dll = ffi.dlopen(lib_path)
+    return dll
+
+
+class _CDataBase:
+    def __init__(self, debug, args):
+        self.debug = debug
+        self.args = args
+        self.ffi = cdata.ffi()
+        self.dll = _load_ffi(self.ffi)
+
+    def _check_nanoarrow_error(self, na_error):
+        """
+        Check a `const char*` error return from an integration entrypoint.
+
+        A null means success, a non-empty string is an error message.
+        The string is statically allocated on the nanoarrow side and does not
+        need to be released.
+        """
+        assert self.ffi.typeof(na_error) is self.ffi.typeof("const char*")
+        if na_error != self.ffi.NULL:
+            error = self.ffi.string(na_error).decode("utf8", errors="replace")
+            raise RuntimeError(f"nanoarrow C Data Integration call failed: {error}")
+
+
+class NanoarrowCDataExporter(CDataExporter, _CDataBase):
+    def export_schema_from_json(self, json_path, c_schema_ptr):
+        na_error = self.dll.nanoarrow_CDataIntegration_ExportSchemaFromJson(
+            str(json_path).encode(), c_schema_ptr
+        )
+        self._check_nanoarrow_error(na_error)
+
+    def export_batch_from_json(self, json_path, num_batch, c_array_ptr):
+        na_error = self.dll.nanoarrow_CDataIntegration_ExportBatchFromJson(
+            str(json_path).encode(), num_batch, c_array_ptr
+        )
+        self._check_nanoarrow_error(na_error)
+
+    @property
+    def supports_releasing_memory(self):
+        return True
+
+    def record_allocation_state(self):
+        return self.dll.nanoarrow_BytesAllocated()
+
+
+class NanoarrowCDataImporter(CDataImporter, _CDataBase):
+    def import_schema_and_compare_to_json(self, json_path, c_schema_ptr):
+        na_error = self.dll.nanoarrow_CDataIntegration_ImportSchemaAndCompareToJson(
+            str(json_path).encode(), c_schema_ptr
+        )
+        self._check_nanoarrow_error(na_error)
+
+    def import_batch_and_compare_to_json(self, json_path, num_batch, c_array_ptr):
+        na_error = self.dll.nanoarrow_CDataIntegration_ImportBatchAndCompareToJson(
+            str(json_path).encode(), num_batch, c_array_ptr
+        )
+        self._check_nanoarrow_error(na_error)
+
+    @property
+    def supports_releasing_memory(self):
+        return True

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import contextlib
 import functools
 import os
 
@@ -94,15 +93,14 @@ class NanoarrowTester(Tester):
 
 
 _nanoarrow_c_data_entrypoints = """
-    const char* nanoarrow_CDataIntegration_ExportSchemaFromJson(const char* json_path,
-                                                                struct ArrowSchema* out);
+    const char* nanoarrow_CDataIntegration_ExportSchemaFromJson(
+        const char* json_path, struct ArrowSchema* out);
 
     const char* nanoarrow_CDataIntegration_ImportSchemaAndCompareToJson(
         const char* json_path, struct ArrowSchema* schema);
 
-    const char* nanoarrow_CDataIntegration_ExportBatchFromJson(const char* json_path,
-                                                            int num_batch,
-                                                            struct ArrowArray* out);
+    const char* nanoarrow_CDataIntegration_ExportBatchFromJson(
+        const char* json_path, int num_batch, struct ArrowArray* out);
 
     const char* nanoarrow_CDataIntegration_ImportBatchAndCompareToJson(
         const char* json_path, int num_batch, struct ArrowArray* batch);

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -25,11 +25,11 @@ from ..utils.source import ARROW_ROOT_DEFAULT
 
 _NANOARROW_PATH = os.environ.get(
     "ARROW_NANOARROW_PATH",
-    os.path.join(ARROW_ROOT_DEFAULT, "nanoarrow"),
+    os.path.join(ARROW_ROOT_DEFAULT, "nanoarrow/cdata"),
 )
 
 _INTEGRATION_DLL = os.path.join(
-    _NANOARROW_PATH, "cdata/libnanoarrow_c_data_integration" + cdata.dll_suffix
+    _NANOARROW_PATH, "libnanoarrow_c_data_integration" + cdata.dll_suffix
 )
 
 
@@ -105,10 +105,8 @@ class _CDataBase:
         """
         assert self.ffi.typeof(na_error) is self.ffi.typeof("const char*")
         if na_error != self.ffi.NULL:
-            # TODO: remove these...at least one call is returning a non-null-terminated
-            # message causing a crash.
-            # error = self.ffi.string(na_error).decode("utf8", errors="replace")
-            raise RuntimeError("nanoarrow C Data Integration call failed")
+            error = self.ffi.string(na_error).decode("utf8", errors="replace")
+            raise RuntimeError(f"nanoarrow C Data Integration call failed: {error}")
 
 
 class NanoarrowCDataExporter(CDataExporter, _CDataBase):

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -105,8 +105,10 @@ class _CDataBase:
         """
         assert self.ffi.typeof(na_error) is self.ffi.typeof("const char*")
         if na_error != self.ffi.NULL:
-            error = self.ffi.string(na_error).decode("utf8", errors="replace")
-            raise RuntimeError(f"nanoarrow C Data Integration call failed: {error}")
+            # TODO: remove these...at least one call is returning a non-null-terminated
+            # message causing a crash.
+            # error = self.ffi.string(na_error).decode("utf8", errors="replace")
+            raise RuntimeError("nanoarrow C Data Integration call failed")
 
 
 class NanoarrowCDataExporter(CDataExporter, _CDataBase):

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -28,7 +28,7 @@ _NANOARROW_PATH = os.environ.get(
     "ARROW_NANOARROW_PATH",
     os.path.join(ARROW_ROOT_DEFAULT, "nanoarrow"),
 )
-_INTEGRATION_EXE = os.path.join(_NANOARROW_PATH, "ipc/integration_test_util")
+
 _INTEGRATION_DLL = os.path.join(
     _NANOARROW_PATH, "cdata/libnanoarrow_c_data_integration" + cdata.dll_suffix
 )
@@ -36,7 +36,7 @@ _INTEGRATION_DLL = os.path.join(
 
 class NanoarrowTester(Tester):
     PRODUCER = False
-    CONSUMER = True
+    CONSUMER = False
     FLIGHT_SERVER = False
     FLIGHT_CLIENT = False
     C_DATA_SCHEMA_EXPORTER = True
@@ -46,35 +46,8 @@ class NanoarrowTester(Tester):
 
     name = "nanoarrow"
 
-    def _run(self, arrow_path=None, json_path=None, command="VALIDATE"):
-        cmd = [_INTEGRATION_EXE, "--integration"]
-
-        if arrow_path is not None:
-            cmd.append("--arrow=" + arrow_path)
-
-        if json_path is not None:
-            cmd.append("--json=" + json_path)
-
-        cmd.append("--mode=" + command)
-
-        if self.debug:
-            log(" ".join(cmd))
-
-        run_cmd(cmd)
-
     def validate(self, json_path, arrow_path, quirks=None):
-        cmd = [
-            _INTEGRATION_EXE,
-            "--from",
-            "json",
-            json_path,
-            "--check",
-            "ipc",
-            arrow_path,
-        ]
-        if self.debug:
-            log(" ".join(cmd))
-        run_cmd(cmd)
+        raise NotImplementedError()
 
     def json_to_file(self, json_path, arrow_path):
         raise NotImplementedError()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1749,7 +1749,7 @@ services:
     volumes: *conda-volumes
     environment:
       <<: [*common, *ccache]
-      ARCHERY_INTEGRATION_WITH_RUST: 1
+      ARCHERY_INTEGRATION_WITH_RUST: 0
       ARCHERY_INTEGRATION_WITH_NANOARROW: 1
       # Tell Archery where Arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1754,6 +1754,7 @@ services:
       # Tell Archery where Arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug
       ARROW_RUST_EXE_PATH: /build/rust/debug
+      ARROW_NANOARROW_PATH: /build/nanoarrow
     command:
       ["/arrow/ci/scripts/integration_arrow_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_arrow.sh /arrow /build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1749,8 +1749,8 @@ services:
     volumes: *conda-volumes
     environment:
       <<: [*common, *ccache]
-      ARCHERY_INTEGRATION_WITH_RUST: 0
-      ARCHERY_INTEGRATION_WITH_NANOARROW: 0
+      ARCHERY_INTEGRATION_WITH_RUST: 1
+      ARCHERY_INTEGRATION_WITH_NANOARROW: 1
       # Tell Archery where Arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug
       ARROW_RUST_EXE_PATH: /build/rust/debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1750,6 +1750,7 @@ services:
     environment:
       <<: [*common, *ccache]
       ARCHERY_INTEGRATION_WITH_RUST: 0
+      ARCHERY_INTEGRATION_WITH_NANOARROW: 0
       # Tell Archery where Arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug
       ARROW_RUST_EXE_PATH: /build/rust/debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1749,12 +1749,12 @@ services:
     volumes: *conda-volumes
     environment:
       <<: [*common, *ccache]
-      ARCHERY_INTEGRATION_WITH_RUST: 0
       ARCHERY_INTEGRATION_WITH_NANOARROW: 1
+      ARCHERY_INTEGRATION_WITH_RUST: 0
       # Tell Archery where Arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug
-      ARROW_RUST_EXE_PATH: /build/rust/debug
       ARROW_NANOARROW_PATH: /build/nanoarrow
+      ARROW_RUST_EXE_PATH: /build/rust/debug
     command:
       ["/arrow/ci/scripts/integration_arrow_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_arrow.sh /arrow /build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1749,7 +1749,7 @@ services:
     volumes: *conda-volumes
     environment:
       <<: [*common, *ccache]
-      ARCHERY_INTEGRATION_WITH_NANOARROW: 1
+      ARCHERY_INTEGRATION_WITH_NANOARROW: 0
       ARCHERY_INTEGRATION_WITH_RUST: 0
       # Tell Archery where Arrow binaries are located
       ARROW_CPP_EXE_PATH: /build/cpp/debug


### PR DESCRIPTION
### Rationale for this change

The ability to add integration testing was added in nanoarrow however, the infrastructure for running these tests currently lives in the arrow monorepo.

### What changes are included in this PR?

- Added the relevant code to Archery such that these tests can be run
- Added the relevant scripts/environment variables to CI such that these tests run in the integration CI job

### Are these changes tested?

Yes, via the "Integration" CI job.

### Are there any user-facing changes?

No.

This PR still needs https://github.com/apache/arrow/pull/41264 for the integration tests to pass.

* Closes: #39301
* GitHub Issue: #39301