### PR TITLE
GH-39320: [C++][FS][Azure] Add managed identity auth configuration

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -146,6 +146,9 @@ Status AzureOptions::ConfigureWorkloadIdentityCredential(
 
 Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceClient()
     const {
+  if (account_name_.empty()) {
+    return Status::Invalid("AzureOptions doesn't contain a valid account name");
+  }
   switch (credential_kind_) {
     case CredentialKind::kAnonymous:
       break;
@@ -161,6 +164,9 @@ Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceC
 
 Result<std::unique_ptr<DataLake::DataLakeServiceClient>>
 AzureOptions::MakeDataLakeServiceClient() const {
+  if (account_name_.empty()) {
+    return Status::Invalid("AzureOptions doesn't contain a valid account name");
+  }
   switch (credential_kind_) {
     case CredentialKind::kAnonymous:
       break;

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -132,11 +132,11 @@ Status AzureOptions::ConfigureDefaultCredential(const std::string& account_name)
 }
 
 Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& account_name,
-                                                        std::string const& clientId) {
+                                                        const std::string& client_id) {
   account_name_ = account_name;
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ =
-      std::make_shared<Azure::Identity::ManagedIdentityCredential>(clientId);
+      std::make_shared<Azure::Identity::ManagedIdentityCredential>(client_id);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -117,6 +117,7 @@ Status AzureOptions::ConfigureClientSecretCredential(const std::string& account_
                                                      const std::string& tenant_id,
                                                      const std::string& client_id,
                                                      const std::string& client_secret) {
+  account_name_ = account_name;
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ = std::make_shared<Azure::Identity::ClientSecretCredential>(
       tenant_id, client_id, client_secret);
@@ -124,6 +125,7 @@ Status AzureOptions::ConfigureClientSecretCredential(const std::string& account_
 }
 
 Status AzureOptions::ConfigureDefaultCredential(const std::string& account_name) {
+  account_name_ = account_name;
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ = std::make_shared<Azure::Identity::DefaultAzureCredential>();
   return Status::OK();
@@ -131,6 +133,7 @@ Status AzureOptions::ConfigureDefaultCredential(const std::string& account_name)
 
 Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& account_name,
                                                         std::string const& clientId) {
+  account_name_ = account_name;
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ =
       std::make_shared<Azure::Identity::ManagedIdentityCredential>(clientId);
@@ -139,6 +142,7 @@ Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& accou
 
 Status AzureOptions::ConfigureWorkloadIdentityCredential(
     const std::string& account_name) {
+  account_name_ = account_name;
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
   return Status::OK();

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -47,7 +47,9 @@ using HNSSupport = internal::HierarchicalNamespaceSupport;
 // -----------------------------------------------------------------------
 // AzureOptions Implementation
 
-AzureOptions::AzureOptions() = default;
+// AzureOptions::AzureOptions(const std::string& account_name) = default;
+AzureOptions::AzureOptions(const std::string& account_name)
+      : account_name_(account_name) {}
 
 AzureOptions::~AzureOptions() = default;
 
@@ -104,45 +106,36 @@ std::string AzureOptions::AccountDfsUrl(const std::string& account_name) const {
   return BuildBaseUrl(dfs_storage_scheme, dfs_storage_authority, account_name);
 }
 
-Status AzureOptions::ConfigureAccountKeyCredential(const std::string& account_name,
-                                                   const std::string& account_key) {
+Status AzureOptions::ConfigureAccountKeyCredential(const std::string& account_key) {
   credential_kind_ = CredentialKind::kStorageSharedKeyCredential;
-  account_name_ = account_name;
   storage_shared_key_credential_ =
-      std::make_shared<Storage::StorageSharedKeyCredential>(account_name, account_key);
+      std::make_shared<Storage::StorageSharedKeyCredential>(account_name_, account_key);
   return Status::OK();
 }
 
-Status AzureOptions::ConfigureClientSecretCredential(const std::string& account_name,
-                                                     const std::string& tenant_id,
+Status AzureOptions::ConfigureClientSecretCredential(const std::string& tenant_id,
                                                      const std::string& client_id,
                                                      const std::string& client_secret) {
-  account_name_ = account_name;
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ = std::make_shared<Azure::Identity::ClientSecretCredential>(
       tenant_id, client_id, client_secret);
   return Status::OK();
 }
 
-Status AzureOptions::ConfigureDefaultCredential(const std::string& account_name) {
-  account_name_ = account_name;
+Status AzureOptions::ConfigureDefaultCredential() {
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ = std::make_shared<Azure::Identity::DefaultAzureCredential>();
   return Status::OK();
 }
 
-Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& account_name,
-                                                        const std::string& client_id) {
-  account_name_ = account_name;
+Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& client_id) {
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ =
       std::make_shared<Azure::Identity::ManagedIdentityCredential>(client_id);
   return Status::OK();
 }
 
-Status AzureOptions::ConfigureWorkloadIdentityCredential(
-    const std::string& account_name) {
-  account_name_ = account_name;
+Status AzureOptions::ConfigureWorkloadIdentityCredential() {
   credential_kind_ = CredentialKind::kTokenCredential;
   token_credential_ = std::make_shared<Azure::Identity::WorkloadIdentityCredential>();
   return Status::OK();

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -129,6 +129,14 @@ Status AzureOptions::ConfigureDefaultCredential(const std::string& account_name)
   return Status::OK();
 }
 
+Status AzureOptions::ConfigureManagedIdentityCredential(const std::string& account_name,
+                                                        std::string const& clientId) {
+  credential_kind_ = CredentialKind::kTokenCredential;
+  token_credential_ =
+      std::make_shared<Azure::Identity::ManagedIdentityCredential>(clientId);
+  return Status::OK();
+}
+
 Status AzureOptions::ConfigureWorkloadIdentityCredential(
     const std::string& account_name) {
   credential_kind_ = CredentialKind::kTokenCredential;

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -105,6 +105,9 @@ struct ARROW_EXPORT AzureOptions {
 
   Status ConfigureDefaultCredential(const std::string& account_name);
 
+  Status ConfigureManagedIdentityCredential(const std::string& account_name,
+                                            std::string const& clientId = std::string());
+
   Status ConfigureWorkloadIdentityCredential(const std::string& account_name);
 
   Status ConfigureAccountKeyCredential(const std::string& account_name,

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -100,21 +100,18 @@ struct ARROW_EXPORT AzureOptions {
       storage_shared_key_credential_;
 
  public:
-  AzureOptions();
+  AzureOptions(const std::string& account_name);
   ~AzureOptions();
 
-  Status ConfigureDefaultCredential(const std::string& account_name);
+  Status ConfigureDefaultCredential();
 
-  Status ConfigureManagedIdentityCredential(const std::string& account_name,
-                                            const std::string& client_id = std::string());
+  Status ConfigureManagedIdentityCredential(const std::string& client_id = std::string());
 
-  Status ConfigureWorkloadIdentityCredential(const std::string& account_name);
+  Status ConfigureWorkloadIdentityCredential();
 
-  Status ConfigureAccountKeyCredential(const std::string& account_name,
-                                       const std::string& account_key);
+  Status ConfigureAccountKeyCredential(const std::string& account_key);
 
-  Status ConfigureClientSecretCredential(const std::string& account_name,
-                                         const std::string& tenant_id,
+  Status ConfigureClientSecretCredential(const std::string& tenant_id,
                                          const std::string& client_id,
                                          const std::string& client_secret);
 

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -106,7 +106,7 @@ struct ARROW_EXPORT AzureOptions {
   Status ConfigureDefaultCredential(const std::string& account_name);
 
   Status ConfigureManagedIdentityCredential(const std::string& account_name,
-                                            std::string const& clientId = std::string());
+                                            const std::string& client_id = std::string());
 
   Status ConfigureWorkloadIdentityCredential(const std::string& account_name);
 

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -48,6 +48,9 @@ class TestAzureFileSystem;
 
 /// Options for the AzureFileSystem implementation.
 struct ARROW_EXPORT AzureOptions {
+  /// \brief account name of the Azure Storage account.
+  std::string account_name;
+
   /// \brief hostname[:port] of the Azure Blob Storage Service.
   ///
   /// If the hostname is a relative domain name (one that starts with a '.'), then storage
@@ -94,13 +97,12 @@ struct ARROW_EXPORT AzureOptions {
     kStorageSharedKeyCredential,
   } credential_kind_ = CredentialKind::kAnonymous;
 
-  std::string account_name_;
   std::shared_ptr<Azure::Core::Credentials::TokenCredential> token_credential_;
   std::shared_ptr<Azure::Storage::StorageSharedKeyCredential>
       storage_shared_key_credential_;
 
  public:
-  AzureOptions(const std::string& account_name);
+  AzureOptions();
   ~AzureOptions();
 
   Status ConfigureDefaultCredential();

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -271,6 +271,15 @@ class AzureHierarchicalNSEnv : public AzureEnvImpl<AzureHierarchicalNSEnv> {
   bool WithHierarchicalNamespace() const final { return true; }
 };
 
+TEST(AzureFileSystem, InitializingFilesystemWithoutAccountNameFails) {
+  AzureOptions options;
+  ASSERT_RAISES(Invalid, options.ConfigureAccountKeyCredential("account_key"));
+
+  ARROW_EXPECT_OK(
+      options.ConfigureClientSecretCredential("tenant_id", "client_id", "client_secret"));
+  ASSERT_RAISES(Invalid, AzureFileSystem::Make(options));
+}
+
 TEST(AzureFileSystem, InitializeFilesystemWithClientSecretCredential) {
   AzureOptions options;
   options.account_name = "dummy-account-name";

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -284,6 +284,16 @@ TEST(AzureFileSystem, InitializeFilesystemWithDefaultCredential) {
   EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 }
 
+TEST(AzureFileSystem, InitializeFilesystemWithManagedIdentityCredential) {
+  AzureOptions options;
+  ARROW_EXPECT_OK(options.ConfigureManagedIdentityCredential("dummy-account-name"));
+  EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
+
+  ARROW_EXPECT_OK(options.ConfigureManagedIdentityCredential("dummy-account-name",
+                                                             "specific-client-id"));
+  EXPECT_OK_AND_ASSIGN(fs, AzureFileSystem::Make(options));
+}
+
 TEST(AzureFileSystem, InitializeFilesystemWithWorkloadIdentityCredential) {
   AzureOptions options;
   ARROW_EXPECT_OK(options.ConfigureWorkloadIdentityCredential("dummy-account-name"));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -272,20 +272,23 @@ class AzureHierarchicalNSEnv : public AzureEnvImpl<AzureHierarchicalNSEnv> {
 };
 
 TEST(AzureFileSystem, InitializeFilesystemWithClientSecretCredential) {
-  AzureOptions options("dummy-account-name");
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(
       options.ConfigureClientSecretCredential("tenant_id", "client_id", "client_secret"));
   EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 }
 
 TEST(AzureFileSystem, InitializeFilesystemWithDefaultCredential) {
-  AzureOptions options("dummy-account-name");
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(options.ConfigureDefaultCredential());
   EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 }
 
 TEST(AzureFileSystem, InitializeFilesystemWithManagedIdentityCredential) {
-  AzureOptions options("dummy-account-name");
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(options.ConfigureManagedIdentityCredential());
   EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 
@@ -294,13 +297,14 @@ TEST(AzureFileSystem, InitializeFilesystemWithManagedIdentityCredential) {
 }
 
 TEST(AzureFileSystem, InitializeFilesystemWithWorkloadIdentityCredential) {
-  AzureOptions options("dummy-account-name");
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(options.ConfigureWorkloadIdentityCredential());
   EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 }
 
 TEST(AzureFileSystem, OptionsCompare) {
-  AzureOptions options("account-name");
+  AzureOptions options;
   EXPECT_TRUE(options.Equals(options));
 }
 
@@ -374,7 +378,7 @@ class TestAzureFileSystem : public ::testing::Test {
   std::unique_ptr<DataLake::DataLakeServiceClient> datalake_service_client_;
 
  public:
-  TestAzureFileSystem() : rng_(std::random_device()()), options_("temp") {}
+  TestAzureFileSystem() : rng_(std::random_device()()) {}
 
   virtual Result<BaseAzureEnv*> GetAzureEnv() const = 0;
   virtual HNSSupport CachedHNSSupport(const BaseAzureEnv& env) const = 0;
@@ -391,7 +395,8 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   static Result<AzureOptions> MakeOptions(BaseAzureEnv* env) {
-    AzureOptions options(env->account_name());
+    AzureOptions options;
+    options.account_name = env->account_name();
     switch (env->backend()) {
       case AzureBackend::kAzurite:
         options.blob_storage_authority = "127.0.0.1:10000";


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Workload identity is a useful Azure authentication method. Also I failed to set the account_name correctly for a bunch of auths (I think this got lost in a rebase then I copy pasted the broken code). 

### What changes are included in this PR?
- Make filesystem initialisation fail if `account_name_.empty()`. This prevents the account name configuration bug we had. Also added a test asserting that filesystem initialization fails in this case. 
- Remove account name configuration on all auth configs, in favour of setting in separately from the auth configuration. 
- Implement `AzureOptions::ConfigureManagedIdentityCredential`

### Are these changes tested?
Added a simple test initialising a filesystem using `ConfigureManagedIdentityCredential`. This is not the most comprehensive test but its the same as what we agreed on for https://github.com/apache/arrow/pull/39263. 

### Are there any user-facing changes?
Managed identity authentication is now supported. 

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39320