### PR TITLE
GH-39333: [C++] Don't use "if constexpr" in lambda

### DIFF
--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -267,7 +267,6 @@ template <typename ListViewArrayT, bool HasNulls>
 Result<std::shared_ptr<Array>> FlattenListViewArray(const ListViewArrayT& list_view_array,
                                                     MemoryPool* memory_pool) {
   using offset_type = typename ListViewArrayT::offset_type;
-  const int64_t list_view_array_offset = list_view_array.offset();
   const int64_t list_view_array_length = list_view_array.length();
   std::shared_ptr<arrow::Array> value_array = list_view_array.values();
 
@@ -282,18 +281,24 @@ Result<std::shared_ptr<Array>> FlattenListViewArray(const ListViewArrayT& list_v
     }
   }
 
-  const auto* validity = list_view_array.data()->template GetValues<uint8_t>(0, 0);
   const auto* offsets = list_view_array.data()->template GetValues<offset_type>(1);
   const auto* sizes = list_view_array.data()->template GetValues<offset_type>(2);
 
-  auto is_null_or_empty = [&](int64_t i) {
-    if constexpr (HasNulls) {
+  std::function<bool(int64_t)> is_null_or_empty;
+  const auto* validity = list_view_array.data()->template GetValues<uint8_t>(0, 0);
+  const int64_t list_view_array_offset = list_view_array.offset();
+  if constexpr (HasNulls) {
+    is_null_or_empty = [&](int64_t i) {
       if (!bit_util::GetBit(validity, list_view_array_offset + i)) {
         return true;
       }
-    }
-    return sizes[i] == 0;
-  };
+      return sizes[i] == 0;
+    };
+  } else {
+    ARROW_UNUSED(validity);
+    ARROW_UNUSED(list_view_array_offset);
+    is_null_or_empty = [&](int64_t i) { return sizes[i] == 0; };
+  }
 
   // Index of the first valid, non-empty list-view.
   int64_t first_i = 0;


### PR DESCRIPTION
### Rationale for this change

It seems that it's not portable. At least it doesn't work as expected with Visual Studio 2017:

    C:/arrow/cpp/src/arrow/array/array_nested.cc(291): error C2065: 'validity': undeclared identifier (compiling source file C:\arrow-build\src\arrow\CMakeFiles\arrow_shared.dir\Unity\unity_0_cxx.cxx) [C:\arrow-build\src\arrow\arrow_shared.vcxproj]
      C:/arrow/cpp/src/arrow/array/array_nested.cc(660): note: see reference to function template instantiation 'arrow::Result<std::shared_ptr<arrow::Array>> arrow::`anonymous-namespace'::FlattenListViewArray<arrow::ListViewArray,false>(const ListViewArrayT &,arrow::MemoryPool *)' being compiled
              with
              [
                  ListViewArrayT=arrow::ListViewArray
              ] (compiling source file C:\arrow-build\src\arrow\CMakeFiles\arrow_shared.dir\Unity\unity_0_cxx.cxx)
      memory_pool.cc
    C:/arrow/cpp/src/arrow/array/array_nested.cc(291): error C2065: 'list_view_array_offset': undeclared identifier (compiling source file C:\arrow-build\src\arrow\CMakeFiles\arrow_shared.dir\Unity\unity_0_cxx.cxx) [C:\arrow-build\src\arrow\arrow_shared.vcxproj]
### What changes are included in this PR?

Avoid "if constexpr" in lambda.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39333