### PR TITLE
GH-39335: [C#] Support creating FlightClient with Grpc.Core.Channel

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
+++ b/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
@@ -16,10 +16,8 @@
 using System.Threading.Tasks;
 using Apache.Arrow.Flight.Internal;
 using Apache.Arrow.Flight.Protocol;
-using Apache.Arrow.Flight.Server;
 using Apache.Arrow.Flight.Server.Internal;
 using Grpc.Core;
-using Grpc.Net.Client;
 
 namespace Apache.Arrow.Flight.Client
 {
@@ -29,7 +27,7 @@ namespace Apache.Arrow.Flight.Client
 
         private readonly FlightService.FlightServiceClient _client;
 
-        public FlightClient(GrpcChannel grpcChannel)
+        public FlightClient(ChannelBase grpcChannel)
         {
             _client = new FlightService.FlightServiceClient(grpcChannel);
         }


### PR DESCRIPTION
as well as Grpc.Net.Client.GrpcChannel by changing our constructor arg to Grpc.Core.ChannelBase which both classes inherit from.

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Changing the constructor of C#'s Flight Client to take in a ChannelBase which allows for multiple implementations of gRPC channels to be passed in.

### Are these changes tested?

Existing tests already cover the use but have also manually tested in a separate app (

### Are there any user-facing changes?

No as we're just changing the constructor to take in a parent/base class instead.
* Closes: #39335