### PR TITLE
GH-39051: [C++] Use Cast() instead of CastTo() for List Scalar in test

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -317,8 +317,8 @@ struct CastFixedList {
 
     if (in_size != out_size) {
       return Status::TypeError("Size of FixedSizeList is not the same.",
-                               " input list: ", in_type.ToString(),
-                               " output list: ", out_type.ToString());
+                               " input type: ", in_type.ToString(),
+                               " output type: ", out_type.ToString());
     }
 
     const ArraySpan& in_array = batch[0].array;
@@ -428,6 +428,19 @@ struct CastMap {
     out_array->buffers[1] = in_array.GetBuffer(1);
 
     std::shared_ptr<ArrayData> entries = in_array.child_data[0].ToArrayData();
+
+    // Validate if output is fixed size list
+    if (out->type()->id() == Type::FIXED_SIZE_LIST) {
+      const auto& in_type = checked_cast<const MapType&>(*batch[0].type());
+      const auto& out_type = checked_cast<const FixedSizeListType&>(*out->type());
+      const auto in_size = entries->length;
+      const auto out_size = out_type.list_size();
+      if (in_size != out_size) {
+        return Status::TypeError("Size of FixedSizeList is not the same.",
+                                 " input type: ", in_type.ToString(),
+                                 " output type: ", out_type.ToString());
+      }
+    }
 
     // Shift bitmap in case the source offset is non-zero
     if (in_array.offset != 0 && in_array.buffers[0].data != nullptr) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -436,7 +436,8 @@ struct CastMap {
     const ArraySpan& in_array = batch[0].array;
 
     ArrayData* out_array = out->array_data().get();
-    out_array->buffers[0] = in_array.GetBuffer(0);
+    ARROW_ASSIGN_OR_RAISE(out_array->buffers[0],
+                          GetNullBitmapBuffer(in_array, ctx->memory_pool()));
     out_array->buffers[1] = in_array.GetBuffer(1);
 
     std::shared_ptr<ArrayData> entries = in_array.child_data[0].ToArrayData();

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -480,14 +480,18 @@ std::vector<std::shared_ptr<CastFunction>> GetNestedCasts() {
   auto cast_list = std::make_shared<CastFunction>("cast_list", Type::LIST);
   AddCommonCasts(Type::LIST, kOutputTargetType, cast_list.get());
   AddListCast<ListType, ListType>(cast_list.get());
+  AddListCast<ListViewType, ListType>(cast_list.get());
   AddListCast<LargeListType, ListType>(cast_list.get());
+  AddListCast<LargeListViewType, ListType>(cast_list.get());
   AddTypeToTypeCast<CastFixedToVarList<ListType>, FixedSizeListType>(cast_list.get());
 
   auto cast_large_list =
       std::make_shared<CastFunction>("cast_large_list", Type::LARGE_LIST);
   AddCommonCasts(Type::LARGE_LIST, kOutputTargetType, cast_large_list.get());
   AddListCast<ListType, LargeListType>(cast_large_list.get());
+  AddListCast<ListViewType, LargeListType>(cast_large_list.get());
   AddListCast<LargeListType, LargeListType>(cast_large_list.get());
+  AddListCast<LargeListViewType, LargeListType>(cast_large_list.get());
   AddTypeToTypeCast<CastFixedToVarList<LargeListType>, FixedSizeListType>(
       cast_large_list.get());
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -438,7 +438,9 @@ struct CastMap {
     ArrayData* out_array = out->array_data().get();
     ARROW_ASSIGN_OR_RAISE(out_array->buffers[0],
                           GetNullBitmapBuffer(in_array, ctx->memory_pool()));
-    out_array->buffers[1] = in_array.GetBuffer(1);
+    if (in_array.GetBuffer(1) != nullptr) {
+      out_array->buffers[1] = in_array.GetBuffer(1);
+    }
 
     std::shared_ptr<ArrayData> entries = in_array.child_data[0].ToArrayData();
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -401,7 +401,7 @@ void AddTypeToTypeCast(CastFunction* func) {
   kernel.exec = CastFunctor::Exec;
   kernel.signature = KernelSignature::Make({InputType(SrcT::type_id)}, kOutputTargetType);
   kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
-  DCHECK_OK(func->AddKernel(StructType::type_id, std::move(kernel)));
+  DCHECK_OK(func->AddKernel(SrcT::type_id, std::move(kernel)));
 }
 
 template <typename DestType>
@@ -507,7 +507,10 @@ std::vector<std::shared_ptr<CastFunction>> GetNestedCasts() {
   AddCommonCasts(Type::FIXED_SIZE_LIST, kOutputTargetType, cast_fsl.get());
   AddTypeToTypeCast<CastFixedList, FixedSizeListType>(cast_fsl.get());
   AddTypeToTypeCast<CastVarToFixedList<ListType>, ListType>(cast_fsl.get());
+  AddTypeToTypeCast<CastVarToFixedList<ListViewType>, ListViewType>(cast_fsl.get());
   AddTypeToTypeCast<CastVarToFixedList<LargeListType>, LargeListType>(cast_fsl.get());
+  AddTypeToTypeCast<CastVarToFixedList<LargeListViewType>, LargeListViewType>(
+      cast_fsl.get());
 
   // So is struct
   auto cast_struct = std::make_shared<CastFunction>("cast_struct", Type::STRUCT);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -317,8 +317,8 @@ struct CastFixedList {
 
     if (in_size != out_size) {
       return Status::TypeError("Size of FixedSizeList is not the same.",
-                               " input type: ", in_type.ToString(),
-                               " output type: ", out_type.ToString());
+                               " input list: ", in_type.ToString(),
+                               " output list: ", out_type.ToString());
     }
 
     const ArraySpan& in_array = batch[0].array;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -410,6 +410,18 @@ struct CastMap {
 
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const CastOptions& options = CastState::Get(ctx);
+    // Validate if output is fixed size list
+    if (out->type()->id() == Type::FIXED_SIZE_LIST) {
+      const auto& in_type = checked_cast<const MapType&>(*batch[0].type());
+      const auto& out_type = checked_cast<const FixedSizeListType&>(*out->type());
+      const auto in_size = batch[0].array.child_data[0].ToArrayData()->length;
+      const auto out_size = out_type.list_size();
+      if (in_size != out_size) {
+        return Status::TypeError("Size of FixedSizeList is not the same.",
+                                 " input type: ", in_type.ToString(),
+                                 " output type: ", out_type.ToString());
+      }
+    }
 
     std::shared_ptr<DataType> entry_type =
         checked_cast<const DestType&>(*out->type()).value_type();
@@ -428,19 +440,6 @@ struct CastMap {
     out_array->buffers[1] = in_array.GetBuffer(1);
 
     std::shared_ptr<ArrayData> entries = in_array.child_data[0].ToArrayData();
-
-    // Validate if output is fixed size list
-    if (out->type()->id() == Type::FIXED_SIZE_LIST) {
-      const auto& in_type = checked_cast<const MapType&>(*batch[0].type());
-      const auto& out_type = checked_cast<const FixedSizeListType&>(*out->type());
-      const auto in_size = entries->length;
-      const auto out_size = out_type.list_size();
-      if (in_size != out_size) {
-        return Status::TypeError("Size of FixedSizeList is not the same.",
-                                 " input type: ", in_type.ToString(),
-                                 " output type: ", out_type.ToString());
-      }
-    }
 
     // Shift bitmap in case the source offset is non-zero
     if (in_array.offset != 0 && in_array.buffers[0].data != nullptr) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -511,6 +511,7 @@ std::vector<std::shared_ptr<CastFunction>> GetNestedCasts() {
   AddTypeToTypeCast<CastVarToFixedList<LargeListType>, LargeListType>(cast_fsl.get());
   AddTypeToTypeCast<CastVarToFixedList<LargeListViewType>, LargeListViewType>(
       cast_fsl.get());
+  AddMapCast<FixedSizeListType>(cast_fsl.get());
 
   // So is struct
   auto cast_struct = std::make_shared<CastFunction>("cast_struct", Type::STRUCT);

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1090,11 +1090,11 @@ void CheckListCast(const ScalarType& scalar, const std::shared_ptr<DataType>& to
 std::tuple<StatusCode, std::string> GetExpectedError(
     const std::shared_ptr<DataType>& type,
     const std::shared_ptr<DataType>& invalidCastType) {
-  if (type->id() == Type::FIXED_SIZE_LIST) {
+  if (type->id() == Type::FIXED_SIZE_LIST || type->id() == Type::MAP) {
     return std::make_tuple(
         StatusCode::TypeError,
-        "Size of FixedSizeList is not the same. input list: " + type->ToString() +
-            " output list: " + invalidCastType->ToString());
+        "Size of FixedSizeList is not the same. input type: " + type->ToString() +
+            " output type: " + invalidCastType->ToString());
   } else {
     return std::make_tuple(
         StatusCode::Invalid,
@@ -1255,10 +1255,10 @@ TEST(TestMapScalar, Cast) {
   CheckListCast(scalar, large_list(key_value_type));
   CheckListCast(scalar, fixed_size_list(key_value_type, 2));
 
-  //  CheckInvalidListCast(scalar, fixed_size_list(key_value_type, 5),
-  //                       "Cannot cast " + scalar.type->ToString() + " of length " +
-  //                           std::to_string(value->length()) +
-  //                           " to fixed size list of length 5");
+  auto invalidCastType = fixed_size_list(key_value_type, 5);
+  auto [expectedCode, expectedMessage] = GetExpectedError(scalar.type, invalidCastType);
+
+  CheckInvalidListCast(scalar, invalidCastType, expectedCode, expectedMessage);
 }
 
 TEST(TestStructScalar, FieldAccess) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1255,10 +1255,10 @@ TEST(TestMapScalar, Cast) {
   CheckListCast(scalar, large_list(key_value_type));
   CheckListCast(scalar, fixed_size_list(key_value_type, 2));
 
-//  CheckInvalidListCast(scalar, fixed_size_list(key_value_type, 5),
-//                       "Cannot cast " + scalar.type->ToString() + " of length " +
-//                           std::to_string(value->length()) +
-//                           " to fixed size list of length 5");
+  //  CheckInvalidListCast(scalar, fixed_size_list(key_value_type, 5),
+  //                       "Cannot cast " + scalar.type->ToString() + " of length " +
+  //                           std::to_string(value->length()) +
+  //                           " to fixed size list of length 5");
 }
 
 TEST(TestStructScalar, FieldAccess) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1105,9 +1105,9 @@ std::tuple<StatusCode, std::string> GetExpectedError(
 }
 
 template <typename ScalarType>
-void CheckInvalidListCast(const ScalarType& scalar,
-                          const std::shared_ptr<DataType>& to_type, const StatusCode code,
-                          const std::string& expected_message) {
+void CheckListCastError(const ScalarType& scalar,
+                        const std::shared_ptr<DataType>& to_type, const StatusCode code,
+                        const std::string& expected_message) {
   EXPECT_RAISES_WITH_CODE_AND_MESSAGE_THAT(code, ::testing::HasSubstr(expected_message),
                                            Cast(scalar, to_type));
 }
@@ -1199,7 +1199,7 @@ class TestListLikeScalar : public ::testing::Test {
     auto invalidCastType = fixed_size_list(value_->type(), 5);
     auto [expectedCode, expectedMessage] = GetExpectedError(type_, invalidCastType);
 
-    CheckInvalidListCast(scalar, invalidCastType, expectedCode, expectedMessage);
+    CheckListCastError(scalar, invalidCastType, expectedCode, expectedMessage);
   }
 
  protected:
@@ -1259,7 +1259,7 @@ TEST(TestMapScalar, Cast) {
   auto invalidCastType = fixed_size_list(key_value_type, 5);
   auto [expectedCode, expectedMessage] = GetExpectedError(scalar.type, invalidCastType);
 
-  CheckInvalidListCast(scalar, invalidCastType, expectedCode, expectedMessage);
+  CheckListCastError(scalar, invalidCastType, expectedCode, expectedMessage);
 }
 
 TEST(TestStructScalar, FieldAccess) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1077,14 +1077,15 @@ std::shared_ptr<DataType> MakeListType<FixedSizeListType>(
 
 template <typename ScalarType>
 void CheckListCast(const ScalarType& scalar, const std::shared_ptr<DataType>& to_type) {
-  EXPECT_OK_AND_ASSIGN(auto cast_scalar, Cast(scalar, to_type));
-  ASSERT_OK(cast_scalar.scalar()->ValidateFull());
-  ASSERT_EQ(*cast_scalar.scalar()->type, *to_type);
+  EXPECT_OK_AND_ASSIGN(auto cast_scalar_datum, Cast(scalar, to_type));
+  const auto& cast_scalar = cast_scalar_datum.scalar();
+  ASSERT_OK(cast_scalar->ValidateFull());
+  ASSERT_EQ(*cast_scalar->type, *to_type);
 
-  ASSERT_EQ(scalar.is_valid, cast_scalar.scalar()->is_valid);
+  ASSERT_EQ(scalar.is_valid, cast_scalar->is_valid);
   ASSERT_TRUE(scalar.is_valid);
   ASSERT_ARRAYS_EQUAL(*scalar.value,
-                      *checked_cast<const BaseListScalar&>(*cast_scalar.scalar()).value);
+                      *checked_cast<const BaseListScalar&>(*cast_scalar).value);
 }
 
 std::tuple<StatusCode, std::string> GetExpectedError(

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1090,14 +1090,13 @@ void CheckListCast(const ScalarType& scalar, const std::shared_ptr<DataType>& to
 
 template <typename ScalarType>
 void CheckListCastError(const ScalarType& scalar,
-                        const std::shared_ptr<DataType>& from_type,
                         const std::shared_ptr<DataType>& to_type) {
   StatusCode code;
   std::string expected_message;
-  if (from_type->id() == Type::FIXED_SIZE_LIST) {
+  if (scalar.type->id() == Type::FIXED_SIZE_LIST) {
     code = StatusCode::TypeError;
     expected_message =
-        "Size of FixedSizeList is not the same. input list: " + from_type->ToString() +
+        "Size of FixedSizeList is not the same. input list: " + scalar.type->ToString() +
         " output list: " + to_type->ToString();
   } else {
     code = StatusCode::Invalid;
@@ -1195,7 +1194,7 @@ class TestListLikeScalar : public ::testing::Test {
         scalar, fixed_size_list(value_->type(), static_cast<int32_t>(value_->length())));
 
     auto invalid_cast_type = fixed_size_list(value_->type(), 5);
-    CheckListCastError(scalar, type_, invalid_cast_type);
+    CheckListCastError(scalar, invalid_cast_type);
   }
 
  protected:
@@ -1253,7 +1252,7 @@ TEST(TestMapScalar, Cast) {
   CheckListCast(scalar, fixed_size_list(key_value_type, 2));
 
   auto invalid_cast_type = fixed_size_list(key_value_type, 5);
-  CheckListCastError(scalar, scalar.type, invalid_cast_type);
+  CheckListCastError(scalar, invalid_cast_type);
 }
 
 TEST(TestStructScalar, FieldAccess) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1093,8 +1093,8 @@ std::tuple<StatusCode, std::string> GetExpectedError(
   if (type->id() == Type::FIXED_SIZE_LIST) {
     return std::make_tuple(
         StatusCode::TypeError,
-        "Size of FixedSizeList is not the same. input type: " + type->ToString() +
-            " output type: " + invalidCastType->ToString());
+        "Size of FixedSizeList is not the same. input list: " + type->ToString() +
+            " output list: " + invalidCastType->ToString());
   } else {
     return std::make_tuple(
         StatusCode::Invalid,

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1090,12 +1090,12 @@ void CheckListCast(const ScalarType& scalar, const std::shared_ptr<DataType>& to
 
 std::tuple<StatusCode, std::string> GetExpectedError(
     const std::shared_ptr<DataType>& type,
-    const std::shared_ptr<DataType>& invalidCastType) {
+    const std::shared_ptr<DataType>& invalid_cast_type) {
   if (type->id() == Type::FIXED_SIZE_LIST) {
     return std::make_tuple(
         StatusCode::TypeError,
         "Size of FixedSizeList is not the same. input list: " + type->ToString() +
-            " output list: " + invalidCastType->ToString());
+            " output list: " + invalid_cast_type->ToString());
   } else {
     return std::make_tuple(
         StatusCode::Invalid,
@@ -1196,10 +1196,10 @@ class TestListLikeScalar : public ::testing::Test {
     CheckListCast(
         scalar, fixed_size_list(value_->type(), static_cast<int32_t>(value_->length())));
 
-    auto invalidCastType = fixed_size_list(value_->type(), 5);
-    auto [expectedCode, expectedMessage] = GetExpectedError(type_, invalidCastType);
+    auto invalid_cast_type = fixed_size_list(value_->type(), 5);
+    auto [expectedCode, expectedMessage] = GetExpectedError(type_, invalid_cast_type);
 
-    CheckListCastError(scalar, invalidCastType, expectedCode, expectedMessage);
+    CheckListCastError(scalar, invalid_cast_type, expectedCode, expectedMessage);
   }
 
  protected:
@@ -1256,10 +1256,10 @@ TEST(TestMapScalar, Cast) {
   CheckListCast(scalar, large_list(key_value_type));
   CheckListCast(scalar, fixed_size_list(key_value_type, 2));
 
-  auto invalidCastType = fixed_size_list(key_value_type, 5);
-  auto [expectedCode, expectedMessage] = GetExpectedError(scalar.type, invalidCastType);
+  auto invalid_cast_type = fixed_size_list(key_value_type, 5);
+  auto [expectedCode, expectedMessage] = GetExpectedError(scalar.type, invalid_cast_type);
 
-  CheckListCastError(scalar, invalidCastType, expectedCode, expectedMessage);
+  CheckListCastError(scalar, invalid_cast_type, expectedCode, expectedMessage);
 }
 
 TEST(TestStructScalar, FieldAccess) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1090,7 +1090,7 @@ void CheckListCast(const ScalarType& scalar, const std::shared_ptr<DataType>& to
 std::tuple<StatusCode, std::string> GetExpectedError(
     const std::shared_ptr<DataType>& type,
     const std::shared_ptr<DataType>& invalidCastType) {
-  if (type->id() == Type::FIXED_SIZE_LIST || type->id() == Type::MAP) {
+  if (type->id() == Type::FIXED_SIZE_LIST) {
     return std::make_tuple(
         StatusCode::TypeError,
         "Size of FixedSizeList is not the same. input type: " + type->ToString() +


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Remove legacy code

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Replace the legacy scalar CastTo implementation for List Scalar in test.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. It is passed by existing test cases.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39051