### PR TITLE
GH-38655: [C++] "iso_calendar" kernel returns incorrect results for array length > 32

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
@@ -1503,14 +1503,13 @@ struct ISOCalendar {
     std::unique_ptr<ArrayBuilder> array_builder;
     RETURN_NOT_OK(MakeBuilder(ctx->memory_pool(), IsoCalendarType(), &array_builder));
     StructBuilder* struct_builder = checked_cast<StructBuilder*>(array_builder.get());
-    RETURN_NOT_OK(struct_builder->Reserve(in.length));
 
     std::vector<BuilderType*> field_builders;
     field_builders.reserve(3);
     for (int i = 0; i < 3; i++) {
       field_builders.push_back(
           checked_cast<BuilderType*>(struct_builder->field_builder(i)));
-      RETURN_NOT_OK(field_builders[i]->Reserve(1));
+      RETURN_NOT_OK(field_builders[i]->Reserve(in.length));
     }
     auto visit_null = [&]() { return struct_builder->AppendNull(); };
     std::function<Status(typename InType::c_type arg)> visit_value;

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
@@ -1503,6 +1503,7 @@ struct ISOCalendar {
     std::unique_ptr<ArrayBuilder> array_builder;
     RETURN_NOT_OK(MakeBuilder(ctx->memory_pool(), IsoCalendarType(), &array_builder));
     StructBuilder* struct_builder = checked_cast<StructBuilder*>(array_builder.get());
+    RETURN_NOT_OK(struct_builder->Reserve(in.length));
 
     std::vector<BuilderType*> field_builders;
     field_builders.reserve(3);

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2223,8 +2223,19 @@ def _check_datetime_components(timestamps, timezone=None):
         first_week_is_fully_in_year=False)
     assert pc.week(tsa, options=week_options).equals(pa.array(iso_week))
 
+
+def _test_iso_calendar_regression(timezone=None):
     # Test for iso_calendar regression
     # https://github.com/apache/arrow/issues/38655
+
+    from pyarrow.vendored.version import Version
+
+    iso_calendar_fields = [
+        pa.field('iso_year', pa.int64()),
+        pa.field('iso_week', pa.int64()),
+        pa.field('iso_day_of_week', pa.int64())
+    ]
+
     ts = (pd.date_range("2019-01-01", periods=33, freq="21D")
             .tz_localize("UTC")
             .tz_convert(timezone).to_series())
@@ -2269,6 +2280,7 @@ def test_extract_datetime_components():
 
     # Test timezone naive timestamp array
     _check_datetime_components(timestamps)
+    _test_iso_calendar_regression()
 
     # Test timezone aware timestamp array
     if sys.platform == "win32" and not util.windows_has_tzdata():
@@ -2276,6 +2288,7 @@ def test_extract_datetime_components():
     else:
         for timezone in timezones:
             _check_datetime_components(timestamps, timezone)
+            _test_iso_calendar_regression(timezone)
 
 
 @pytest.mark.pandas


### PR DESCRIPTION
### Rationale for this change

When defining `StructArray`'s field builders for `ISOCalendar` we don't pre-allocate memory and then use unsafe append. This causes the resulting array to be at most 32 rows long.

### What changes are included in this PR?

This introduces required memory pre-allocation in the `ISOCalendar` c++ kernel.

### Are these changes tested?

This adds a test for the Python wrapper.

### Are there any user-facing changes?

Fixes the behavior of `iso_calendar` kernel.
* Closes: #38655