### PR TITLE
GH-38772: [C++] Implement directory semantics even when the storage account doesn't support HNS

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1480,6 +1480,8 @@ class AzureFileSystem::Impl {
   /// depending on the value of preserve_dir_marker_blob.
   ///
   /// \pre location.container is not empty.
+  /// \pre preserve_dir_marker_blob=false implies location.path is not empty
+  /// because we can't *not preserve* the root directory of a container.
   ///
   /// \param require_dir_to_exist Require the directory to exist *before* this
   /// operation, otherwise return PathNotFound.
@@ -1493,6 +1495,9 @@ class AzureFileSystem::Impl {
                                       bool preserve_dir_marker_blob) {
     using DeleteBlobResponse = Storage::DeferredResponse<Blobs::Models::DeleteBlobResult>;
     DCHECK(!location.container.empty());
+    DCHECK(preserve_dir_marker_blob || !location.path.empty())
+        << "Must pass preserve_dir_marker_blob=true when location.path is empty "
+           "(i.e. deleting the contents of a container).";
     Blobs::ListBlobsOptions options;
     if (!location.path.empty()) {
       options.Prefix = internal::EnsureTrailingSlash(location.path);

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1781,13 +1781,13 @@ Status AzureFileSystem::CreateDir(const std::string& path, bool recursive) {
     RETURN_NOT_OK(CreateContainerIfNotExists(location.container, container_client));
     // Perform a second check for HNS support after creating the container.
     ARROW_ASSIGN_OR_RAISE(hns_support, impl_->HierarchicalNamespaceSupport(adlfs_client));
-  }
-  if (hns_support == HNSSupport::kContainerNotFound) {
-    // We only get kContainerNotFound if we are unable to read the properties of the
-    // container we just created. This is very unlikely, but theoretically possible in
-    // a concurrent system, so the error is handled to avoid infinite recursion.
-    return Status::IOError("Unable to read properties of a newly created container: ",
-                           location.container, ": " + container_client.GetUrl());
+    if (hns_support == HNSSupport::kContainerNotFound) {
+      // We only get kContainerNotFound if we are unable to read the properties of the
+      // container we just created. This is very unlikely, but theoretically possible in
+      // a concurrent system, so the error is handled to avoid infinite recursion.
+      return Status::IOError("Unable to read properties of a newly created container: ",
+                             location.container, ": " + container_client.GetUrl());
+    }
   }
   // CreateDirOnFileSystem and CreateDirOnContainer can handle the container
   // not existing which is useful and necessary here since the only reason

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1494,7 +1494,7 @@ class AzureFileSystem::Impl {
     }
   }
 
-  /// Deletes and contents of a directory and possibly the directory itself
+  /// Deletes contents of a directory and possibly the directory itself
   /// depending on the value of preserve_dir_marker_blob.
   ///
   /// \pre location.container is not empty.

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1443,7 +1443,12 @@ class AzureFileSystem::Impl {
     auto dir_marker_blob_path = internal::EnsureTrailingSlash(path_within_container);
     auto block_blob_client =
         container_client.GetBlobClient(dir_marker_blob_path).AsBlockBlobClient();
-    block_blob_client.UploadFrom(nullptr, 0);
+    // Attach metadata that other filesystem implementations expect to be present
+    // on directory marker blobs.
+    // https://github.com/fsspec/adlfs/blob/32132c4094350fca2680155a5c236f2e9f991ba5/adlfs/spec.py#L855-L870
+    Blobs::UploadBlockBlobFromOptions blob_options;
+    blob_options.Metadata.emplace("is_directory", "true");
+    block_blob_client.UploadFrom(nullptr, 0, blob_options);
   }
 
  public:

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -819,7 +819,7 @@ bool IsDfsEmulator(const AzureOptions& options) {
 namespace internal {
 
 Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
-    DataLake::DataLakeFileSystemClient& adlfs_client, const AzureOptions& options) {
+    const DataLake::DataLakeFileSystemClient& adlfs_client, const AzureOptions& options) {
   try {
     auto directory_client = adlfs_client.GetDirectoryClient("");
     // GetAccessControlList will fail on storage accounts
@@ -885,7 +885,7 @@ const char kDelimiter[] = {internal::kSep, '\0'};
 /// \pre location.container is not empty.
 template <class ContainerClient>
 Result<FileInfo> GetContainerPropsAsFileInfo(const AzureLocation& location,
-                                             ContainerClient& container_client) {
+                                             const ContainerClient& container_client) {
   DCHECK(!location.container.empty());
   FileInfo info{location.path.empty() ? location.all : location.container};
   try {
@@ -905,7 +905,7 @@ Result<FileInfo> GetContainerPropsAsFileInfo(const AzureLocation& location,
 
 template <class ContainerClient>
 Status CreateContainerIfNotExists(const std::string& container_name,
-                                  ContainerClient& container_client) {
+                                  const ContainerClient& container_client) {
   try {
     container_client.CreateIfNotExists();
     return Status::OK();
@@ -974,7 +974,7 @@ class AzureFileSystem::Impl {
   ///
   /// \return kEnabled/kDisabled/kContainerNotFound (kUnknown is never returned).
   Result<HNSSupport> HierarchicalNamespaceSupport(
-      DataLake::DataLakeFileSystemClient& adlfs_client) {
+      const DataLake::DataLakeFileSystemClient& adlfs_client) {
     switch (cached_hns_support_) {
       case HNSSupport::kEnabled:
       case HNSSupport::kDisabled:
@@ -1018,7 +1018,7 @@ class AzureFileSystem::Impl {
   }
 
   /// \pre location.path is not empty.
-  Result<FileInfo> GetFileInfo(DataLake::DataLakeFileSystemClient& adlfs_client,
+  Result<FileInfo> GetFileInfo(const DataLake::DataLakeFileSystemClient& adlfs_client,
                                const AzureLocation& location) {
     auto file_client = adlfs_client.GetFileClient(location.path);
     try {
@@ -1055,7 +1055,7 @@ class AzureFileSystem::Impl {
   /// being blobs with names starting with the directory path.
   ///
   /// \pre location.path is not empty.
-  Result<FileInfo> GetFileInfo(Blobs::BlobContainerClient& container_client,
+  Result<FileInfo> GetFileInfo(const Blobs::BlobContainerClient& container_client,
                                const AzureLocation& location) {
     DCHECK(!location.path.empty());
     Blobs::ListBlobsOptions options;
@@ -1097,7 +1097,7 @@ class AzureFileSystem::Impl {
  private:
   /// \pref location.container is not empty.
   template <typename ContainerClient>
-  Status CheckDirExists(ContainerClient& container_client,
+  Status CheckDirExists(const ContainerClient& container_client,
                         const AzureLocation& location) {
     DCHECK(!location.container.empty());
     FileInfo info;
@@ -1334,7 +1334,7 @@ class AzureFileSystem::Impl {
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
   template <class ContainerClient, class GetDirectoryClient, class CreateDirIfNotExists>
-  Status CreateDirTemplate(ContainerClient& container_client,
+  Status CreateDirTemplate(const ContainerClient& container_client,
                            GetDirectoryClient&& get_directory_client,
                            CreateDirIfNotExists&& create_if_not_exists,
                            const AzureLocation& location, bool recursive) {
@@ -1378,7 +1378,7 @@ class AzureFileSystem::Impl {
   ///
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
-  Status CreateDirOnFileSystem(DataLake::DataLakeFileSystemClient& adlfs_client,
+  Status CreateDirOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
                                const AzureLocation& location, bool recursive) {
     return CreateDirTemplate(
         adlfs_client,
@@ -1393,7 +1393,7 @@ class AzureFileSystem::Impl {
   ///
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
-  Status CreateDirOnContainer(Blobs::BlobContainerClient& container_client,
+  Status CreateDirOnContainer(const Blobs::BlobContainerClient& container_client,
                               const AzureLocation& location, bool recursive) {
     return CreateDirTemplate(
         container_client,
@@ -1453,7 +1453,7 @@ class AzureFileSystem::Impl {
 
   /// \pre location.container is not empty.
   /// \pre location.path is empty.
-  Status DeleteContainer(Blobs::BlobContainerClient& container_client,
+  Status DeleteContainer(const Blobs::BlobContainerClient& container_client,
                          const AzureLocation& location) {
     DCHECK(!location.container.empty());
     DCHECK(location.path.empty());
@@ -1589,7 +1589,7 @@ class AzureFileSystem::Impl {
 
   /// \pre location.container is not empty.
   /// \pre location.path is not empty.
-  Status DeleteDirOnFileSystem(DataLake::DataLakeFileSystemClient& adlfs_client,
+  Status DeleteDirOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
                                const AzureLocation& location) {
     DCHECK(!location.container.empty());
     DCHECK(!location.path.empty());

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1480,6 +1480,7 @@ class AzureFileSystem::Impl {
   std::pair<int, Status> DeleteDirContentsOnContainer(
       const Blobs::BlobContainerClient& container_client, const AzureLocation& location,
       bool require_dir_to_exist) {
+    using DeleteBlobResponse = Storage::DeferredResponse<Blobs::Models::DeleteBlobResult>;
     DCHECK(!location.container.empty());
     Blobs::ListBlobsOptions options;
     if (!location.path.empty()) {
@@ -1502,8 +1503,7 @@ class AzureFileSystem::Impl {
           continue;
         }
         auto batch = container_client.CreateBatch();
-        std::vector<Storage::DeferredResponse<Blobs::Models::DeleteBlobResult>>
-            deferred_responses;
+        std::vector<DeleteBlobResponse> deferred_responses;
         for (const auto& blob_item : list_response.Blobs) {
           num_potentially_deleted_blobs += 1;
           deferred_responses.push_back(batch.DeleteBlob(blob_item.Name));

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -71,7 +71,7 @@ enum class HierarchicalNamespaceSupport {
 /// \return kEnabled/kDisabled/kContainerNotFound (kUnknown is never
 /// returned).
 Result<HierarchicalNamespaceSupport> CheckIfHierarchicalNamespaceIsEnabled(
-    Azure::Storage::Files::DataLake::DataLakeFileSystemClient& adlfs_client,
+    const Azure::Storage::Files::DataLake::DataLakeFileSystemClient& adlfs_client,
     const arrow::fs::AzureOptions& options);
 
 }  // namespace internal

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -575,7 +575,7 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   constexpr static const char* const kSubmitBatchBugMessage =
-      "This test is affected by an Azurite isse: "
+      "This test is affected by an Azurite issue: "
       "https://github.com/Azure/Azurite/pull/2302";
 
   /// Azurite has a bug that causes BlobContainerClient::SubmitBatch to fail on macOS.

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -583,8 +583,8 @@ class TestAzureFileSystem : public ::testing::Test {
   ///  - AzureFileSystem::DeleteDir
   ///  - AzureFileSystem::DeleteDirContents
   bool HasSubmitBatchBug() const {
-    EXPECT_OK_AND_ASSIGN(auto env, GetAzureEnv());
 #ifdef __APPLE__
+    EXPECT_OK_AND_ASSIGN(auto env, GetAzureEnv());
     return env->backend() == AzureBackend::kAzurite;
 #else
     return false;

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -760,15 +760,17 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestDeleteDirSuccessEmpty() {
+    if (HasSubmitBatchBug()) {
+      GTEST_SKIP() << kSubmitBatchBugMessage;
+    }
     auto data = SetUpPreexistingData();
     const auto directory_path = data.RandomDirectoryPath(rng_);
 
     AssertFileInfo(fs(), directory_path, FileType::NotFound);
     ASSERT_OK(fs()->CreateDir(directory_path, true));
     AssertFileInfo(fs(), directory_path, FileType::Directory);
-    // XXX: implement DeleteDir on flat namespace storage accounts
-    // ASSERT_OK(fs()->DeleteDir(directory_path));
-    // AssertFileInfo(fs(), directory_path, FileType::NotFound);
+    ASSERT_OK(fs()->DeleteDir(directory_path));
+    AssertFileInfo(fs(), directory_path, FileType::NotFound);
   }
 
   void TestDeleteDirFailureNonexistent() {
@@ -778,6 +780,9 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestDeleteDirSuccessHaveBlob() {
+    if (HasSubmitBatchBug()) {
+      GTEST_SKIP() << kSubmitBatchBugMessage;
+    }
     auto data = SetUpPreexistingData();
     const auto directory_path = data.RandomDirectoryPath(rng_);
     const auto blob_path = ConcatAbstractPath(directory_path, "hello.txt");
@@ -790,6 +795,9 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestDeleteDirSuccessHaveDirectory() {
+    if (HasSubmitBatchBug()) {
+      GTEST_SKIP() << kSubmitBatchBugMessage;
+    }
     auto data = SetUpPreexistingData();
     const auto parent = data.RandomDirectoryPath(rng_);
     const auto path = ConcatAbstractPath(parent, "new-sub");
@@ -802,6 +810,9 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestDeleteDirContentsSuccessExist() {
+    if (HasSubmitBatchBug()) {
+      GTEST_SKIP() << kSubmitBatchBugMessage;
+    }
     auto preexisting_data = SetUpPreexistingData();
     HierarchicalPaths paths;
     CreateHierarchicalData(&paths);
@@ -813,6 +824,9 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestDeleteDirContentsSuccessNonexistent() {
+    if (HasSubmitBatchBug()) {
+      GTEST_SKIP() << kSubmitBatchBugMessage;
+    }
     auto data = SetUpPreexistingData();
     const auto directory_path = data.RandomDirectoryPath(rng_);
     ASSERT_OK(fs()->DeleteDirContents(directory_path, true));
@@ -1277,6 +1291,9 @@ TEST_F(TestAzuriteFileSystem, DeleteDirSuccessContainer) {
 }
 
 TEST_F(TestAzuriteFileSystem, DeleteDirSuccessNonexistent) {
+  if (HasSubmitBatchBug()) {
+    GTEST_SKIP() << kSubmitBatchBugMessage;
+  }
   auto data = SetUpPreexistingData();
   const auto directory_path = data.RandomDirectoryPath(rng_);
   // There is only virtual directory without hierarchical namespace

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -574,6 +574,23 @@ class TestAzureFileSystem : public ::testing::Test {
     return env->WithHierarchicalNamespace();
   }
 
+  constexpr static const char* const kSubmitBatchBugMessage =
+      "This test is affected by an Azurite isse: "
+      "https://github.com/Azure/Azurite/pull/2302";
+
+  /// Azurite has a bug that causes BlobContainerClient::SubmitBatch to fail on macOS.
+  /// SubmitBatch is used by:
+  ///  - AzureFileSystem::DeleteDir
+  ///  - AzureFileSystem::DeleteDirContents
+  bool HasSubmitBatchBug() const {
+    EXPECT_OK_AND_ASSIGN(auto env, GetAzureEnv());
+#ifdef __APPLE__
+    return env->backend() == AzureBackend::kAzurite;
+#else
+    return false;
+#endif
+  }
+
   // Tests that are called from more than one implementation of TestAzureFileSystem
 
   void TestDetectHierarchicalNamespace(bool trip_up_azurite);
@@ -1255,10 +1272,9 @@ TEST_F(TestAzuriteFileSystem, DeleteDirSuccessNonexistent) {
 }
 
 TEST_F(TestAzuriteFileSystem, DeleteDirSuccessHaveBlobs) {
-#ifdef __APPLE__
-  GTEST_SKIP() << "This test fails by an Azurite problem: "
-                  "https://github.com/Azure/Azurite/pull/2302";
-#endif
+  if (HasSubmitBatchBug()) {
+    GTEST_SKIP() << kSubmitBatchBugMessage;
+  }
   auto data = SetUpPreexistingData();
   const auto directory_path = data.RandomDirectoryPath(rng_);
   // We must use 257 or more blobs here to test pagination of ListBlobs().
@@ -1284,10 +1300,9 @@ TEST_F(TestAzuriteFileSystem, DeleteDirUri) {
 }
 
 TEST_F(TestAzuriteFileSystem, DeleteDirContentsSuccessContainer) {
-#ifdef __APPLE__
-  GTEST_SKIP() << "This test fails by an Azurite problem: "
-                  "https://github.com/Azure/Azurite/pull/2302";
-#endif
+  if (HasSubmitBatchBug()) {
+    GTEST_SKIP() << kSubmitBatchBugMessage;
+  }
   auto data = SetUpPreexistingData();
   HierarchicalPaths paths;
   CreateHierarchicalData(&paths);
@@ -1300,10 +1315,9 @@ TEST_F(TestAzuriteFileSystem, DeleteDirContentsSuccessContainer) {
 }
 
 TEST_F(TestAzuriteFileSystem, DeleteDirContentsSuccessDirectory) {
-#ifdef __APPLE__
-  GTEST_SKIP() << "This test fails by an Azurite problem: "
-                  "https://github.com/Azure/Azurite/pull/2302";
-#endif
+  if (HasSubmitBatchBug()) {
+    GTEST_SKIP() << kSubmitBatchBugMessage;
+  }
   auto data = SetUpPreexistingData();
   HierarchicalPaths paths;
   CreateHierarchicalData(&paths);

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -662,7 +662,7 @@ class TestAzureFileSystem : public ::testing::Test {
 void TestAzureFileSystem::TestDetectHierarchicalNamespace(bool trip_up_azurite) {
   EXPECT_OK_AND_ASSIGN(auto env, GetAzureEnv());
   if (trip_up_azurite && env->backend() != AzureBackend::kAzurite) {
-    GTEST_SKIP() << "trip_up_azurite=true is only for Azurite.";
+    return;
   }
 
   auto data = SetUpPreexistingData();

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1296,9 +1296,8 @@ TEST_F(TestAzuriteFileSystem, DeleteDirSuccessNonexistent) {
   }
   auto data = SetUpPreexistingData();
   const auto directory_path = data.RandomDirectoryPath(rng_);
-  // There is only virtual directory without hierarchical namespace
-  // support. So the DeleteDir() for nonexistent directory does nothing.
-  ASSERT_OK(fs()->DeleteDir(directory_path));
+  // DeleteDir() fails if the directory doesn't exist.
+  ASSERT_RAISES(IOError, fs()->DeleteDir(directory_path));
   AssertFileInfo(fs(), directory_path, FileType::NotFound);
 }
 
@@ -1353,8 +1352,7 @@ TEST_F(TestAzuriteFileSystem, DeleteDirContentsSuccessDirectory) {
   HierarchicalPaths paths;
   CreateHierarchicalData(&paths);
   ASSERT_OK(fs()->DeleteDirContents(paths.directory));
-  // GH-38772: We may change this to FileType::Directory.
-  AssertFileInfo(fs(), paths.directory, FileType::NotFound);
+  AssertFileInfo(fs(), paths.directory, FileType::Directory);
   for (const auto& sub_path : paths.sub_paths) {
     AssertFileInfo(fs(), sub_path, FileType::NotFound);
   }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -617,32 +617,20 @@ class TestAzureFileSystem : public ::testing::Test {
     auto data = SetUpPreexistingData();
     const auto directory_path = data.RandomDirectoryPath(rng_);
 
-    if (WithHierarchicalNamespace()) {
-      ASSERT_OK(fs()->CreateDir(directory_path, true));
-      AssertFileInfo(fs(), directory_path, FileType::Directory);
-      ASSERT_OK(fs()->DeleteDir(directory_path));
-      AssertFileInfo(fs(), directory_path, FileType::NotFound);
-    } else {
-      // There is only virtual directory without hierarchical namespace
-      // support. So the CreateDir() and DeleteDir() do nothing.
-      ASSERT_OK(fs()->CreateDir(directory_path));
-      AssertFileInfo(fs(), directory_path, FileType::NotFound);
-      ASSERT_OK(fs()->DeleteDir(directory_path));
-      AssertFileInfo(fs(), directory_path, FileType::NotFound);
-    }
+    AssertFileInfo(fs(), directory_path, FileType::NotFound);
+    ASSERT_OK(fs()->CreateDir(directory_path, true));
+    AssertFileInfo(fs(), directory_path, FileType::Directory);
+    // XXX: implement DeleteDir on flat namespace storage accounts
+    // ASSERT_OK(fs()->DeleteDir(directory_path));
+    // AssertFileInfo(fs(), directory_path, FileType::NotFound);
   }
 
   void TestCreateDirSuccessContainerAndDirectory() {
     auto data = SetUpPreexistingData();
     const auto path = data.RandomDirectoryPath(rng_);
+    AssertFileInfo(fs(), path, FileType::NotFound);
     ASSERT_OK(fs()->CreateDir(path, false));
-    if (WithHierarchicalNamespace()) {
-      AssertFileInfo(fs(), path, FileType::Directory);
-    } else {
-      // There is only virtual directory without hierarchical namespace
-      // support. So the CreateDir() does nothing.
-      AssertFileInfo(fs(), path, FileType::NotFound);
-    }
+    AssertFileInfo(fs(), path, FileType::Directory);
   }
 
   void TestCreateDirRecursiveSuccessContainerOnly() {
@@ -656,15 +644,8 @@ class TestAzureFileSystem : public ::testing::Test {
     const auto parent = data.RandomDirectoryPath(rng_);
     const auto path = ConcatAbstractPath(parent, "new-sub");
     ASSERT_OK(fs()->CreateDir(path, true));
-    if (WithHierarchicalNamespace()) {
-      AssertFileInfo(fs(), path, FileType::Directory);
-      AssertFileInfo(fs(), parent, FileType::Directory);
-    } else {
-      // There is only virtual directory without hierarchical namespace
-      // support. So the CreateDir() does nothing.
-      AssertFileInfo(fs(), path, FileType::NotFound);
-      AssertFileInfo(fs(), parent, FileType::NotFound);
-    }
+    AssertFileInfo(fs(), path, FileType::Directory);
+    AssertFileInfo(fs(), parent, FileType::Directory);
   }
 
   void TestCreateDirRecursiveSuccessContainerAndDirectory() {
@@ -672,17 +653,9 @@ class TestAzureFileSystem : public ::testing::Test {
     const auto parent = data.RandomDirectoryPath(rng_);
     const auto path = ConcatAbstractPath(parent, "new-sub");
     ASSERT_OK(fs()->CreateDir(path, true));
-    if (WithHierarchicalNamespace()) {
-      AssertFileInfo(fs(), path, FileType::Directory);
-      AssertFileInfo(fs(), parent, FileType::Directory);
-      AssertFileInfo(fs(), data.container_name, FileType::Directory);
-    } else {
-      // There is only virtual directory without hierarchical namespace
-      // support. So the CreateDir() does nothing.
-      AssertFileInfo(fs(), path, FileType::NotFound);
-      AssertFileInfo(fs(), parent, FileType::NotFound);
-      AssertFileInfo(fs(), data.container_name, FileType::Directory);
-    }
+    AssertFileInfo(fs(), path, FileType::Directory);
+    AssertFileInfo(fs(), parent, FileType::Directory);
+    AssertFileInfo(fs(), data.container_name, FileType::Directory);
   }
 
   void TestDeleteDirContentsSuccessNonexistent() {


### PR DESCRIPTION
### Rationale for this change

The `FileSystem` implementation based on Azure Blob Storage should implement directory operations according to filesystem semantics. When Hierarchical Namespace (HNS) is enabled, we can rely on Azure Data Lake Storage Gen 2 APIs implementing the filesystem semantics for us, but when all we have is the Blobs API, we should emulate it.

### What changes are included in this PR?

 - Skip fewer tests
 - Re-implement `GetFileInfo` using `ListBlobsByHierarchy` instead of `ListBlobs`
 - Re-implement `CreateDir` with an upfront HNS support check instead of falling back to Blobs API after an error
 - Add comprehensive tests to `CreateDir`
 - Add `HasSubmitBatchBug` to check if a test inside any scenario is affected by a certain Azurite issue
 - Implement `DeleteDir` to work properly on flat namespace storage accounts (non-HNS accounts)
 - 

### Are these changes tested?

Yes. By existing and new tests added by this PR itself.
* Closes: #38772