### PR TITLE
GH-39359: [CI][C++] Remove MinGW MINGW32 C++ job

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -340,8 +340,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - msystem_lower: mingw32
-            msystem_upper: MINGW32
           - msystem_lower: mingw64
             msystem_upper: MINGW64
           - msystem_lower: clang64


### PR DESCRIPTION
### Rationale for this change

MSYS2 stopped providing MINGW32 packages:

* https://github.com/msys2/MINGW-packages/pull/19517
* https://github.com/msys2/MINGW-packages/commit/f68162d5827fce41e7c2d4eb65cab6fcd8b9dd60

### What changes are included in this PR?

Remove the job.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39359