### PR TITLE
GH-37164: [Python] Attach Python stacktrace to errors in `ConvertPyError`

### DIFF
--- a/python/pyarrow/src/arrow/python/common.cc
+++ b/python/pyarrow/src/arrow/python/common.cc
@@ -158,6 +158,8 @@ class PythonErrorDetail : public StatusDetail {
     std::stringstream ss;
     ss << "Python exception: ";
     Py_ssize_t num_lines = PySequence_Length(formatted.obj());
+    RETURN_IF_PYERROR();
+
     for (Py_ssize_t i = 0; i < num_lines; ++i) {
       Py_ssize_t line_size;
 

--- a/python/pyarrow/src/arrow/python/common.cc
+++ b/python/pyarrow/src/arrow/python/common.cc
@@ -161,7 +161,7 @@ class PythonErrorDetail : public StatusDetail {
     for (Py_ssize_t i = 0; i < num_lines; ++i) {
       Py_ssize_t line_size;
 
-      PyObject* line = PyList_GET_ITEM(formatted.obj(), i);
+      PyObject* line = PySequence_GetItem(formatted.obj(), i);
       RETURN_IF_PYERROR();
 
       const char* data = PyUnicode_AsUTF8AndSize(line, &line_size);

--- a/python/pyarrow/src/arrow/python/python_test.cc
+++ b/python/pyarrow/src/arrow/python/python_test.cc
@@ -174,10 +174,14 @@ Status TestOwnedRefNoGILMoves() {
   }
 }
 
-std::string FormatPythonException(const std::string& exc_class_name) {
+std::string FormatPythonException(const std::string& exc_class_name,
+                                  const std::string& exc_value) {
   std::stringstream ss;
   ss << "Python exception: ";
   ss << exc_class_name;
+  ss << ": ";
+  ss << exc_value;
+  ss << "\n";
   return ss.str();
 }
 
@@ -205,7 +209,8 @@ Status TestCheckPyErrorStatus() {
   }
 
   PyErr_SetString(PyExc_TypeError, "some error");
-  ASSERT_OK(check_error(st, "some error", FormatPythonException("TypeError")));
+  ASSERT_OK(
+      check_error(st, "some error", FormatPythonException("TypeError", "some error")));
   ASSERT_TRUE(st.IsTypeError());
 
   PyErr_SetString(PyExc_ValueError, "some error");
@@ -223,7 +228,8 @@ Status TestCheckPyErrorStatus() {
   }
 
   PyErr_SetString(PyExc_NotImplementedError, "some error");
-  ASSERT_OK(check_error(st, "some error", FormatPythonException("NotImplementedError")));
+  ASSERT_OK(check_error(st, "some error",
+                        FormatPythonException("NotImplementedError", "some error")));
   ASSERT_TRUE(st.IsNotImplemented());
 
   // No override if a specific status code is given
@@ -246,7 +252,8 @@ Status TestCheckPyErrorStatusNoGIL() {
     lock.release();
     ASSERT_TRUE(st.IsUnknownError());
     ASSERT_EQ(st.message(), "zzzt");
-    ASSERT_EQ(st.detail()->ToString(), FormatPythonException("ZeroDivisionError"));
+    ASSERT_EQ(st.detail()->ToString(),
+              FormatPythonException("ZeroDivisionError", "zzzt"));
     return Status::OK();
   }
 }
@@ -257,7 +264,7 @@ Status TestRestorePyErrorBasics() {
   ASSERT_FALSE(PyErr_Occurred());
   ASSERT_TRUE(st.IsUnknownError());
   ASSERT_EQ(st.message(), "zzzt");
-  ASSERT_EQ(st.detail()->ToString(), FormatPythonException("ZeroDivisionError"));
+  ASSERT_EQ(st.detail()->ToString(), FormatPythonException("ZeroDivisionError", "zzzt"));
 
   RestorePyError(st);
   ASSERT_TRUE(PyErr_Occurred());

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -416,6 +416,7 @@ def test_export_import_batch_reader(reader_factory):
 
 @needs_cffi
 def test_export_import_exception_reader():
+    # See: https://github.com/apache/arrow/issues/37164
     c_stream = ffi.new("struct ArrowArrayStream*")
     ptr_stream = int(ffi.cast("uintptr_t", c_stream))
 
@@ -441,6 +442,8 @@ def test_export_import_exception_reader():
     # inner *and* outer exception should be present
     assert 'ValueError: foo' in str(exc_info.value)
     assert 'NotImplementedError: bar' in str(exc_info.value)
+    # Stacktrace containing line of the raise statement
+    assert 'raise ValueError(\'foo\')' in str(exc_info.value)
 
     assert pa.total_allocated_bytes() == old_allocated
 

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -415,6 +415,37 @@ def test_export_import_batch_reader(reader_factory):
 
 
 @needs_cffi
+def test_export_import_exception_reader():
+    c_stream = ffi.new("struct ArrowArrayStream*")
+    ptr_stream = int(ffi.cast("uintptr_t", c_stream))
+
+    gc.collect()  # Make sure no Arrow data dangles in a ref cycle
+    old_allocated = pa.total_allocated_bytes()
+
+    def gen():
+        if True:
+            try:
+                raise ValueError('foo')
+            except ValueError as e:
+                raise NotImplementedError('bar') from e
+        else:
+            yield from make_batches()
+
+    original = pa.RecordBatchReader.from_batches(make_schema(), gen())
+    original._export_to_c(ptr_stream)
+
+    reader = pa.RecordBatchReader._import_from_c(ptr_stream)
+    with pytest.raises(OSError) as exc_info:
+        reader.read_next_batch()
+
+    # inner *and* outer exception should be present
+    assert 'ValueError: foo' in str(exc_info.value)
+    assert 'NotImplementedError: bar' in str(exc_info.value)
+
+    assert pa.total_allocated_bytes() == old_allocated
+
+
+@needs_cffi
 def test_imported_batch_reader_error():
     c_stream = ffi.new("struct ArrowArrayStream*")
     ptr_stream = int(ffi.cast("uintptr_t", c_stream))


### PR DESCRIPTION
### Rationale for this change

Users might define Python generators that are used in RecordBatchReaders and then exported through the C Data Interface. However, if an error occurs in their generator, the stacktrace and message are currently swallowed in the current `ConvertPyError` implementation, which only provides the type of error. This makes debugging code that passed RBRs difficult.

### What changes are included in this PR?

Changes `ConvertPyError` to provide the fully formatted traceback in the error message.

### Are these changes tested?

Yes, added one test to validate the errors messages are propagated.

### Are there any user-facing changes?

This is a minor change in the error reporting behavior, which will provide more information.
* Closes: #37164