### PR TITLE
MINOR: [C#] Remove launchSettings.json

### DIFF
--- a/csharp/test/Apache.Arrow.IntegrationTest/Properties/launchSettings.json
+++ b/csharp/test/Apache.Arrow.IntegrationTest/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Apache.Arrow.IntegrationTest": {
-      "commandName": "Project",
-      "commandLineArgs": "--mode validate -j C:\\Users\\curt\\AppData\\Local\\Temp\\arrow-integration-9_cov7dz\\generated_binary_view.json -a C:\\Users\\curt\\AppData\\Local\\Temp\\tmpxicbzqpn\\460a151e_generated_binary_view.json_as_file"
-    }
-  }
-}


### PR DESCRIPTION
### Rationale for this change

A previous commit accidentally included a version of launchSettings.json used for local debugging. This file is not helpful to anyone.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No.