### PR TITLE
GH-39387: [C++] Fix compile warning

### DIFF
--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -449,7 +449,8 @@ struct ARROW_EXPORT ArraySpan {
   /// \return A span<const T> of the requested length
   template <typename T>
   util::span<const T> GetSpan(int i, int64_t length) const {
-    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
+    [[maybe_unused]] const int64_t buffer_length =
+        buffers[i].size / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
     return util::span<const T>(buffers[i].data_as<T>() + this->offset, length);
   }
@@ -464,7 +465,8 @@ struct ARROW_EXPORT ArraySpan {
   /// \return A span<T> of the requested length
   template <typename T>
   util::span<T> GetSpan(int i, int64_t length) {
-    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
+    [[maybe_unused]] const int64_t buffer_length =
+        buffers[i].size / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
     return util::span<T>(buffers[i].mutable_data_as<T>() + this->offset, length);
   }

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -449,9 +449,9 @@ struct ARROW_EXPORT ArraySpan {
   /// \return A span<const T> of the requested length
   template <typename T>
   util::span<const T> GetSpan(int i, int64_t length) const {
-    [[maybe_unused]] const int64_t buffer_length =
-        buffers[i].size / static_cast<int64_t>(sizeof(T));
+    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
+    ARROW_UNUSED(buffer_length);
     return util::span<const T>(buffers[i].data_as<T>() + this->offset, length);
   }
 
@@ -465,9 +465,9 @@ struct ARROW_EXPORT ArraySpan {
   /// \return A span<T> of the requested length
   template <typename T>
   util::span<T> GetSpan(int i, int64_t length) {
-    [[maybe_unused]] const int64_t buffer_length =
-        buffers[i].size / static_cast<int64_t>(sizeof(T));
+    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
+    ARROW_UNUSED(buffer_length);
     return util::span<T>(buffers[i].mutable_data_as<T>() + this->offset, length);
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Fix compile warning:
```bash
In file included from /workspace/arrow/cpp/src/arrow/array/array_base.h:26:
/workspace/arrow/cpp/src/arrow/array/data.h:452:19: warning: unused variable 'buffer_length' [-Wunused-variable]
    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
                  ^
/workspace/arrow/cpp/src/arrow/array/data.h:467:19: warning: unused variable 'buffer_length' [-Wunused-variable]
    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
                  ^
2 warnings generated.
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39387