### PR TITLE
GH-39392: [C++][Parquet] Support page pruning

### DIFF
--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string_view>
 
+#include "arrow/buffer.h"
 #include "arrow/io/concurrency.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/util/visibility.h"
@@ -161,6 +162,157 @@ class ARROW_EXPORT BufferedInputStream
 
   class ARROW_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;
+};
+
+/// \class ChunkBufferedInputStream
+/// \brief An ChunkBufferedInputStream that performs buffered reads from an
+/// unbuffered InputStream, which can mitigate the overhead of many small
+/// reads in some cases.
+///
+/// When an actual io request occurs, read ranges will be coalesced if the
+/// distance between them is less than io_merge_threshold, and the actual size
+/// in one io request will be limited by the buffer_size.
+///
+/// \attention It is important to note that since the data returned by the Read
+/// interface is a reference to the Buffer, the caller must ensure that the data
+/// returned by the Read interface is processed completely before calling the
+/// Read interface again. Otherwise, fatal errors may occur due to data in the
+/// Buffer being overwritten.
+class ARROW_EXPORT ChunkBufferedInputStream : public InputStream {
+ public:
+  static Result<std::shared_ptr<ChunkBufferedInputStream>> Create(
+      int64_t start, int64_t length, std::shared_ptr<RandomAccessFile> impl,
+      std::vector<ReadRange> read_ranges, int64_t buffer_size, int32_t io_merge_threshold,
+      MemoryPool* pool_ = ::arrow::default_memory_pool());
+
+  // InputStream interface
+  Status Advance(int64_t nbytes) override;
+
+  /// \brief Peek some data without advancing the read position.
+  Result<std::string_view> Peek(int64_t nbytes) override;
+
+  // Readable interface
+  Result<int64_t> Read(int64_t nbytes, void* out) override;
+
+  Result<std::shared_ptr<Buffer>> Read(int64_t nbytes) override;
+
+  // FileInterface
+  Status Close() override;
+
+  Result<int64_t> Tell() const override;
+
+  bool closed() const override;
+
+ private:
+  explicit ChunkBufferedInputStream(int64_t start, int64_t length,
+                                    std::shared_ptr<RandomAccessFile> impl,
+                                    std::vector<ReadRange> read_ranges,
+                                    int64_t buffer_size, int32_t io_merge_threshold,
+                                    std::shared_ptr<ResizableBuffer> buffer);
+
+  inline Status CheckClosed() const {
+    if (ARROW_PREDICT_TRUE(is_open_)) {
+      return Status::OK();
+    }
+
+    return Status::IOError("Operation forbidden on closed file input stream");
+  }
+
+  inline Status CheckReadRange(int64_t nbytes) {
+    // Upon reaching the end of the current read range, if there is a next read
+    // range, current_range_available_bytes_ will be set to the length of the
+    // next read range, and this will be ensured by ConsumeBuffer;
+    if (ARROW_PREDICT_TRUE(current_range_available_bytes_ >= nbytes)) {
+      return Status::OK();
+    }
+
+    if (current_range_available_bytes_ > 0 && current_range_available_bytes_ < nbytes) {
+      if (read_ranges_[read_ranges_idx_].length > nbytes) {
+        return Status::IOError("Read length is illegal");
+      }
+
+      // At the beginning of a new read range and required bytes is more than
+      // read range length, we think it's ok because there are some tentative
+      // read requests when getting next page data.
+      return Status::OK();
+    }
+
+    if (read_ranges_idx_ != read_ranges_.size()) {
+      // Should not be here
+      return Status::IOError("Unexpected status");
+    }
+    return Status::OK();
+  }
+
+  inline Status CheckPosition(int64_t length) const {
+    if (ARROW_PREDICT_TRUE(raw_pos_ + length <= raw_end_)) {
+      return Status::OK();
+    }
+
+    return Status::IOError("Read position is out of range");
+  }
+
+  inline Status EnsureBufferCapacity(int64_t size) const {
+    if (ARROW_PREDICT_FALSE(size > buffer_->size())) {
+      RETURN_NOT_OK(buffer_->Resize(size));
+    }
+
+    return Status::OK();
+  }
+
+  inline void ConsumeBuffer(int64_t nbytes) {
+    current_range_available_bytes_ -= nbytes;
+    buffer_pos_ += nbytes;
+    bytes_buffered_ -= nbytes;
+    if (current_range_available_bytes_ == 0) {
+      if (++read_gaps_idx_ != read_gaps_.size()) {
+        buffer_pos_ += read_gaps_[read_gaps_idx_];
+        bytes_buffered_ -= read_gaps_[read_gaps_idx_];
+      }
+      if (++read_ranges_idx_ != read_ranges_.size()) {
+        current_range_available_bytes_ = read_ranges_[read_ranges_idx_].length;
+      }
+    }
+  }
+
+  /// \brief Prefetch data from the underlying file if remaining data in buffer
+  /// is less than the required nbytes. Return the number of bytes that can be
+  /// read from the buffer.
+  Status BufferIfNeeded(int64_t nbytes);
+
+  bool is_open_;
+
+  // Every instance of FileInputStream should keep its own position
+  // info to make sure the owner can acquire data on demand, in
+  // consideration of other readers may change the position of
+  // the impl_.
+  int64_t raw_pos_{0};
+  int64_t raw_end_{0};
+  std::shared_ptr<RandomAccessFile> raw_;
+
+  std::vector<ReadRange> read_ranges_;
+  size_t read_ranges_idx_{0};
+
+  // Keep the distance between two read ranges when coalescing them
+  std::vector<int32_t> read_gaps_;
+  size_t read_gaps_idx_{0};
+
+  int64_t buffer_pos_{0};
+  int64_t bytes_buffered_{0};
+
+  // Buffer may contain multiple read ranges, this value keeps the
+  // remaining bytes for current range being read.
+  int64_t current_range_available_bytes_{0};
+
+  // Threshold to limit prefetch data size.
+  int64_t buffer_size_{0};
+  // Coalesce two read ranges if the distance between them is less
+  // then the threshold.
+  int32_t io_merge_threshold_{0};
+
+  // Used for saving the data when invoking Peek to make data can
+  // be accessed safely outside.
+  std::shared_ptr<ResizableBuffer> buffer_;
 };
 
 }  // namespace io

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -210,7 +210,7 @@ class ARROW_EXPORT InputStream : virtual public FileInterface, virtual public Re
   /// \brief Advance or skip stream indicated number of bytes
   /// \param[in] nbytes the number to move forward
   /// \return Status
-  Status Advance(int64_t nbytes);
+  virtual Status Advance(int64_t nbytes);
 
   /// \brief Return zero-copy string_view to upcoming bytes.
   ///

--- a/cpp/src/arrow/io/metrics.h
+++ b/cpp/src/arrow/io/metrics.h
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/metrics.h"
+
+namespace arrow::io {
+
+struct IoMetrics {
+  Metric io_time;
+  Counter io_size{Unit::SIZE_BYTE, 0};
+
+  inline void Update(int64_t time, int64_t size) {
+    io_time.Update(time);
+    io_size.Update(size);
+  }
+
+  inline void Merge(const IoMetrics& other) {
+    io_time.Merge(other.io_time);
+    io_size.Merge(other.io_size);
+  }
+};
+
+}  // namespace arrow::io

--- a/cpp/src/arrow/metrics.h
+++ b/cpp/src/arrow/metrics.h
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+enum ARROW_EXPORT Unit {
+  NONE,
+  TIME_NANO,
+  TIME_MICRO,
+  TIME_MILLI,
+  TIME_SECOND,
+  SIZE_BYTE,
+  SIZE_KB,
+  SIZE_MB,
+  UNIT_MAX
+};
+
+struct ARROW_EXPORT Counter {
+  Unit unit{NONE};
+  int64_t value{0};
+
+  inline void Update(int64_t v) { value += v; }
+
+  inline void Merge(const Counter& other) { value += other.value; }
+
+  inline void Reset(int64_t v, Unit u = NONE) {
+    value = v;
+    unit = u;
+  }
+};
+
+struct ARROW_EXPORT Metric {
+  Unit unit{TIME_NANO};
+
+  int64_t sum{0};
+  int32_t count{0};
+  int64_t min{std::numeric_limits<int64_t>::max()};
+  int64_t max{std::numeric_limits<int64_t>::min()};
+
+  inline void Update(int64_t value) {
+    sum += value;
+    count++;
+
+    if (min > value) {
+      min = value;
+    }
+    if (max < value) {
+      max = value;
+    }
+  };
+
+  inline void Merge(const Metric& other) {
+    sum += other.sum;
+    count += other.count;
+    if (min > other.min) {
+      min = other.min;
+    }
+    if (max < other.max) {
+      max = other.max;
+    }
+  }
+
+  inline void Reset(int64_t o_sum, int32_t o_count, int64_t o_min, int64_t o_max,
+                    Unit o_unit) {
+    unit = o_unit;
+    sum = o_sum;
+    count = o_count;
+    min = o_min;
+    max = o_max;
+  }
+};
+
+}  // namespace arrow

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -424,6 +424,7 @@ add_parquet_benchmark(encoding_benchmark)
 add_parquet_benchmark(level_conversion_benchmark)
 add_parquet_benchmark(page_index_benchmark SOURCES page_index_benchmark.cc
                       benchmark_util.cc)
+add_parquet_benchmark(arrow/page_pruning_benchmark PREFIX "parquet-arrow")
 add_parquet_benchmark(arrow/reader_writer_benchmark PREFIX "parquet-arrow")
 
 if(ARROW_WITH_BROTLI)

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -182,6 +182,7 @@ set(PARQUET_SRCS
     platform.cc
     printer.cc
     properties.cc
+    row_ranges.cc
     schema.cc
     statistics.cc
     stream_reader.cc
@@ -367,7 +368,8 @@ add_parquet_test(reader-test
                  column_scanner_test.cc
                  reader_test.cc
                  stream_reader_test.cc
-                 test_util.cc)
+                 test_util.cc
+                 row_ranges_test.cc)
 
 add_parquet_test(writer-test
                  SOURCES
@@ -381,7 +383,8 @@ add_parquet_test(arrow-test
                  arrow/arrow_reader_writer_test.cc
                  arrow/arrow_schema_test.cc
                  arrow/arrow_statistics_test.cc
-                 test_util.cc)
+                 test_util.cc
+                 arrow/read_by_row_ranges_test.cc)
 
 add_parquet_test(arrow-internals-test
                  SOURCES

--- a/cpp/src/parquet/arrow/page_pruning_benchmark.cc
+++ b/cpp/src/parquet/arrow/page_pruning_benchmark.cc
@@ -1,0 +1,706 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <vector>
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/io/memory.h"
+#include "arrow/table.h"
+#include "arrow/testing/util.h"
+#include "arrow/util/range.h"
+
+#include "parquet/arrow/reader.h"
+#include "parquet/arrow/schema.h"
+#include "parquet/arrow/test_util.h"
+#include "parquet/arrow/writer.h"
+#include "parquet/platform.h"
+
+using arrow::Result;
+using arrow::TimeUnit;
+using arrow::internal::Iota;
+using arrow::io::BufferReader;
+
+/// Benchmarks primarily aim to explore the impact of the number of pages hit and the
+/// number of row sets hit within a single page on scan performance in page pruning.
+namespace parquet::benchmark {
+
+const int64_t num_rows = 2000000;
+
+static void InitReader(std::shared_ptr<::arrow::Table> table,
+                       std::unique_ptr<arrow::FileReader>* reader) {
+  auto sink = CreateOutputStream();
+
+  WriterProperties::Builder builder;
+  auto writer_properties = builder.max_row_group_length(num_rows)
+                               ->enable_write_page_index()
+                               ->disable_dictionary()
+                               ->build();
+  ASSERT_OK_NO_THROW(arrow::WriteTable(*table, ::arrow::default_memory_pool(), sink,
+                                       num_rows, std::move(writer_properties)));
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+
+  auto arrow_reader_properties = ::parquet::default_arrow_reader_properties();
+  arrow_reader_properties.set_batch_size(num_rows);
+  arrow_reader_properties.set_pre_buffer(false);
+
+  auto reader_properties = default_reader_properties();
+  reader_properties.set_buffer_size(1024 * 1024);
+  arrow::FileReaderBuilder file_reader_builder;
+  ASSERT_OK_NO_THROW(file_reader_builder.Open(
+      std::make_shared<BufferReader>(std::move(buffer)), std::move(reader_properties)));
+  ASSERT_OK_NO_THROW(
+      file_reader_builder.properties(arrow_reader_properties)->Build(reader));
+  ASSERT_EQ(1, (*reader)->num_row_groups());
+}
+
+template <bool nullable, typename ArrowType>
+static void PrepareDataAndReader(std::unique_ptr<arrow::FileReader>* reader) {
+  std::shared_ptr<::arrow::Array> values;
+  std::shared_ptr<::arrow::Table> table;
+  if (nullable) {
+    ASSERT_OK(arrow::NullableArray<ArrowType>(num_rows, num_rows / 2, 0, &values));
+    table = arrow::MakeSimpleTable(values, true);
+  } else {
+    ASSERT_OK(arrow::NonNullArray<ArrowType>(num_rows, &values));
+    table = arrow::MakeSimpleTable(values, false);
+  }
+
+  InitReader(std::move(table), reader);
+}
+
+struct PageInfo {
+  int num_pages;      // Total page num for all columns
+  int min_num_pages;  // The min page num between all columns
+  int max_num_pages;  // The max page num between all columns
+};
+
+/// \breif Build page read info based on  hit page percent.
+///
+/// @param reader File reader to get page index
+/// @param hit_page_percent How many pages should be hit
+/// \return The tuple of PageInfo, the index of column which has the max page num
+/// and the indices of hit pages.
+static std::tuple<PageInfo, int, std::vector<int>> BuildPageReadInfo(
+    const std::unique_ptr<arrow::FileReader>& reader, int hit_page_percent) {
+  int num_pages = 0;
+  int min_num_pages = std::numeric_limits<int>::max();
+  int max_num_pages = std::numeric_limits<int>::min();
+  int column_index = 0;
+
+  // Find out the column which has max page num and calculate the total page num
+  auto rg_pi_reader = reader->parquet_reader()->GetPageIndexReader()->RowGroup(0);
+  for (int i = 0; i < reader->parquet_reader()->metadata()->num_columns(); i++) {
+    int col_num_pages =
+        static_cast<int>(rg_pi_reader->GetOffsetIndex(i)->page_locations().size());
+    if (col_num_pages < min_num_pages) {
+      min_num_pages = col_num_pages;
+    }
+    if (col_num_pages > max_num_pages) {
+      column_index = i;
+      max_num_pages = col_num_pages;
+    }
+
+    num_pages += col_num_pages;
+  }
+
+  int hit_page_num = std::ceil(max_num_pages * hit_page_percent / 100.0);
+
+  // Random generate the hit page indices
+  std::vector<int> page_indices;
+  if (hit_page_percent == 100) {
+    page_indices.resize(hit_page_num);
+    std::iota(page_indices.begin(), page_indices.end(), 0);
+  } else {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> d(0, max_num_pages - 1);
+
+    for (int i = 0; i < hit_page_num; i++) {
+      auto page_index = d(gen);
+      auto it = std::find(page_indices.begin(), page_indices.end(), page_index);
+      while (it != page_indices.end()) {
+        page_index = d(gen);
+        it = std::find(page_indices.begin(), page_indices.end(), page_index);
+      }
+      page_indices.push_back(page_index);
+    }
+    std::sort(page_indices.begin(), page_indices.end());
+  }
+
+  return std::make_tuple(PageInfo{num_pages, min_num_pages, max_num_pages}, column_index,
+                         std::move(page_indices));
+}
+
+static inline int64_t GetLastRowIndex(const std::vector<PageLocation>& page_locations,
+                                      size_t page_index) {
+  const size_t next_page_index = page_index + 1;
+  if (next_page_index >= page_locations.size()) {
+    return num_rows - 1;
+  } else {
+    return page_locations[next_page_index].first_row_index - 1;
+  }
+}
+
+/// \brief Build read info with given hit page percent.
+///
+/// \param reader  File reader to get page index
+/// \param hit_page_percent How many pages should be hit
+/// \param page_hit_rows How many rows should be hit in each page
+/// \return  The tuple of PageInfo and the final read row ranges.
+static std::tuple<PageInfo, std::optional<std::unordered_map<int, RowRanges>>>
+BuildReadInfoWithPageHitPercent(const std::unique_ptr<arrow::FileReader>& reader,
+                                int hit_page_percent, int page_hit_rows) {
+  auto info = BuildPageReadInfo(reader, hit_page_percent);
+  auto page_info = std::get<0>(info);
+  auto column_index = std::get<1>(info);
+  auto page_indices = std::get<2>(info);
+  auto hit_page_num = static_cast<int>(page_indices.size());
+
+  auto rg_pi_reader = reader->parquet_reader()->GetPageIndexReader()->RowGroup(0);
+  const auto page_locations =
+      rg_pi_reader->GetOffsetIndex(column_index)->page_locations();
+
+  std::vector<RowRanges::Range> ranges;
+  bool read_all_rows = page_hit_rows == std::numeric_limits<int>::max();
+  if (read_all_rows) {
+    for (int i = 0; i < hit_page_num; i++) {
+      const int page_ordinal = page_indices[i];
+      const int64_t first_row_index = page_locations[page_ordinal].first_row_index;
+      ranges.push_back({first_row_index, GetLastRowIndex(page_locations, page_ordinal)});
+    }
+  } else {
+    std::random_device rd1;
+    std::mt19937_64 gen1(rd1());
+
+    for (int i = 0; i < hit_page_num; i++) {
+      const int page_ordinal = page_indices[i];
+      const int64_t first_row_index = page_locations[page_ordinal].first_row_index;
+      std::uniform_int_distribution<int64_t> d1(
+          first_row_index,
+          GetLastRowIndex(page_locations, page_ordinal) - page_hit_rows + 1);
+      const int64_t start = d1(gen1);
+      ranges.push_back({start, start + page_hit_rows - 1});
+    }
+  }
+
+  std::unordered_map<int, RowRanges> row_ranges = {{0, RowRanges(std::move(ranges))}};
+  return std::make_tuple(page_info, std::make_optional(std::move(row_ranges)));
+}
+
+static std::vector<RowRanges::Range> GenerateRanges(int num_ranges, int64_t start_index,
+                                                    int64_t end_index) {
+  const int64_t total_rows = end_index - start_index + 1;
+  int64_t step;
+  if (num_ranges * 2 > total_rows) {
+    num_ranges = static_cast<int>(total_rows / 2);
+    step = 1;
+  } else {
+    step = total_rows / (num_ranges * 2);
+  }
+  std::vector<RowRanges::Range> ranges;
+  for (int i = 1; i <= num_ranges; i++) {
+    auto start = start_index + (2 * i - 1) * step;
+    auto end = start_index + 2 * i * step - 1;
+    ranges.push_back(RowRanges::Range{start, end});
+  }
+  return ranges;
+}
+
+/// \brief Build read info with given hit page percent and range num.
+///
+/// \param reader File reader to get page index
+/// \param hit_page_percent How many pages should be hit
+/// \param num_ranges How many row ranges in each page should be generate
+/// \return The tuple of PageInfo and the final read row ranges.
+static std::tuple<PageInfo, std::unordered_map<int, RowRanges>>
+BuildReadInfoWithPageHitRanges(const std::unique_ptr<arrow::FileReader>& reader,
+                               int hit_page_percent, int num_ranges) {
+  auto info = BuildPageReadInfo(reader, hit_page_percent);
+  auto page_info = std::get<0>(info);
+  auto column_index = std::get<1>(info);
+  auto page_indices = std::get<2>(info);
+  auto hit_page_num = static_cast<int>(page_indices.size());
+
+  auto rg_pi_reader = reader->parquet_reader()->GetPageIndexReader()->RowGroup(0);
+  const auto page_locations =
+      rg_pi_reader->GetOffsetIndex(column_index)->page_locations();
+
+  std::vector<RowRanges::Range> ranges;
+  for (int i = 0; i < hit_page_num; i++) {
+    const int page_ordinal = page_indices[i];
+    const int64_t first_row_index = page_locations[page_ordinal].first_row_index;
+    const int64_t end_index = GetLastRowIndex(page_locations, page_ordinal);
+    const auto page_row_ranges = GenerateRanges(num_ranges, first_row_index, end_index);
+    ranges.insert(ranges.end(), page_row_ranges.begin(), page_row_ranges.end());
+  }
+
+  std::unordered_map<int, RowRanges> row_ranges = {{0, RowRanges(std::move(ranges))}};
+  return std::make_tuple(page_info, std::move(row_ranges));
+}
+
+static void RegisterCounters(::benchmark::State& state, int num_pages,
+                             int64_t rows_read) {
+  auto iterations = state.iterations();
+
+  state.counters["TotalPage"] = num_pages;
+  state.counters["HitRows"] = rows_read;
+}
+
+static void RunBenchmark(
+    ::benchmark::State& state, std::unique_ptr<arrow::FileReader> reader,
+    const std::vector<int>& column_indices,
+    std::tuple<PageInfo, std::optional<std::unordered_map<int, RowRanges>>> info) {
+  auto page_info = std::get<0>(info);
+  auto row_ranges = std::get<1>(info);
+  auto rows_read = row_ranges.has_value()
+                       ? row_ranges.value()[0].GetRowCount()
+                       : reader->parquet_reader()->metadata()->num_rows();
+
+  for (auto _ : state) {
+    std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+    ASSERT_OK(
+        reader->GetRecordBatchReader({0}, column_indices, row_ranges, &batch_reader));
+    std::shared_ptr<::arrow::RecordBatch> record_batch;
+    ASSERT_OK(batch_reader->ReadNext(&record_batch));
+    ASSERT_EQ(rows_read, record_batch->num_rows());
+    ::benchmark::DoNotOptimize(record_batch);
+    ::benchmark::ClobberMemory();
+  }
+
+  state.SetItemsProcessed(state.iterations() * rows_read);
+
+  RegisterCounters(state, page_info.num_pages, rows_read);
+}
+
+template <bool nullable, typename ArrowType>
+static inline void ReadRowGroup(::benchmark::State& state) {
+  std::unique_ptr<arrow::FileReader> reader;
+  PrepareDataAndReader<nullable, ArrowType>(&reader);
+
+  const auto page_locations = reader->parquet_reader()
+                                  ->GetPageIndexReader()
+                                  ->RowGroup(0)
+                                  ->GetOffsetIndex(0)
+                                  ->page_locations();
+  auto num_pages = static_cast<int>(page_locations.size());
+  auto info = std::make_tuple(PageInfo{num_pages, num_pages, num_pages}, std::nullopt);
+  RunBenchmark(state, std::move(reader), {0}, std::move(info));
+}
+
+/// \brief Read hit rows in all hit pages for single column using page pruning.
+///
+/// All hit pages are random generated according to hit page percent, and hit
+/// rows are also random generated according to page hit rows param.
+template <bool nullable, typename ArrowType>
+static void BM_SingleColumn_NumPages_PagePruning(::benchmark::State& state) {
+  const int hit_page_percent = static_cast<int>(state.range(0));
+  const int page_hit_rows = static_cast<int>(state.range(1));
+
+  std::unique_ptr<arrow::FileReader> reader;
+  PrepareDataAndReader<nullable, ArrowType>(&reader);
+
+  auto info = BuildReadInfoWithPageHitPercent(reader, hit_page_percent, page_hit_rows);
+  RunBenchmark(state, std::move(reader), {0}, std::move(info));
+}
+
+/// \brief Read all rows in all pages for single column using page pruning.
+template <bool nullable, typename ArrowType>
+static void BM_SingleColumn_NumPages_PagePruningWithHitAll(::benchmark::State& state) {
+  const int hit_page_percent = 100;
+  const int page_hit_rows = std::numeric_limits<int>::max();
+
+  std::unique_ptr<arrow::FileReader> reader;
+  PrepareDataAndReader<nullable, ArrowType>(&reader);
+
+  auto info = BuildReadInfoWithPageHitPercent(reader, hit_page_percent, page_hit_rows);
+  RunBenchmark(state, std::move(reader), {0}, std::move(info));
+}
+
+/// \brief Read all data in row group for single column without page pruning.
+template <bool nullable, typename ArrowType>
+static void BM_SingleColumn_NumPages_ReadRowGroup(::benchmark::State& state) {
+  ReadRowGroup<nullable, ArrowType>(state);
+}
+
+/// \brief Generate row ranges and read hit data for single column with page pruning.
+template <bool nullable, typename ArrowType>
+static void BM_SingleColumn_NumRanges_PagePruning(::benchmark::State& state) {
+  const int hit_page_percent = static_cast<int>(state.range(0));
+  const int page_hit_ranges = static_cast<int>(state.range(1));
+
+  std::unique_ptr<arrow::FileReader> reader;
+  PrepareDataAndReader<nullable, ArrowType>(&reader);
+
+  auto info = BuildReadInfoWithPageHitRanges(reader, hit_page_percent, page_hit_ranges);
+  RunBenchmark(state, std::move(reader), {0}, std::move(info));
+}
+
+/// \brief Read all data in row group for single column without page pruning.
+template <bool nullable, typename ArrowType>
+static void BM_SingleColumn_NumRanges_ReadRowGroup(::benchmark::State& state) {
+  ReadRowGroup<nullable, ArrowType>(state);
+}
+
+// ----------------------------------------------------------------------
+// The following benchmarks aim to assess the influence of the number of hit pages on scan
+// performance for different types. In contrast, the comparative test for each type
+// involves scanning the entire row group.
+
+const int64_t hit_rows_val = 1;
+
+// ----------------------------------------------------------------------
+// Int32
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, false, ::arrow::Int32Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, false,
+                    ::arrow::Int32Type)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, false, ::arrow::Int32Type)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, true, ::arrow::Int32Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, true,
+                    ::arrow::Int32Type)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, true, ::arrow::Int32Type)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// Int64
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, false, ::arrow::Int64Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, false,
+                    ::arrow::Int64Type)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, false, ::arrow::Int64Type)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, true, ::arrow::Int64Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, true,
+                    ::arrow::Int64Type)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, true, ::arrow::Int64Type)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// Float
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, false, ::arrow::FloatType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, false,
+                    ::arrow::FloatType)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, false, ::arrow::FloatType)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, true, ::arrow::FloatType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, true,
+                    ::arrow::FloatType)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, true, ::arrow::FloatType)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// Double
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, false, ::arrow::DoubleType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, false,
+                    ::arrow::DoubleType)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, false, ::arrow::DoubleType)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, true, ::arrow::DoubleType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, true,
+                    ::arrow::DoubleType)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, true, ::arrow::DoubleType)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// String
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, false, ::arrow::StringType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, false,
+                    ::arrow::StringType)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, false, ::arrow::StringType)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumPages_PagePruning, true, ::arrow::StringType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_PagePruningWithHitAll, true,
+                    ::arrow::StringType)
+    ->Iterations(50);
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumPages_ReadRowGroup, true, ::arrow::StringType)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// The following benchmarks are designed to evaluate the effect of the number of hit row
+// ranges within each page on scan performance for different types. Additionally, the
+// comparative test for each type involves scanning the entire row group.
+
+const int hit_page_val = 100;
+
+// ----------------------------------------------------------------------
+// Int32
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, false, ::arrow::Int32Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, false, ::arrow::Int32Type)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, true, ::arrow::Int32Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, true, ::arrow::Int32Type)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// Int64
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, false, ::arrow::Int64Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, false, ::arrow::Int64Type)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, true, ::arrow::Int64Type)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, true, ::arrow::Int64Type)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// Float
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, false, ::arrow::FloatType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, false, ::arrow::FloatType)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, true, ::arrow::FloatType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, true, ::arrow::FloatType)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// Double
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, false, ::arrow::DoubleType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, false, ::arrow::DoubleType)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, true, ::arrow::DoubleType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, true, ::arrow::DoubleType)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// String
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, false, ::arrow::StringType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, false, ::arrow::StringType)
+    ->Iterations(50);
+
+BENCHMARK_TEMPLATE(BM_SingleColumn_NumRanges_PagePruning, true, ::arrow::StringType)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_ranges"})
+    ->Args({hit_page_val, 500})
+    ->Args({hit_page_val, 1000})
+    ->Args({hit_page_val, 10000})
+    ->Args({hit_page_val, 100000})
+    ->Args({hit_page_val, 1000000});
+BENCHMARK_TEMPLATE2(BM_SingleColumn_NumRanges_ReadRowGroup, true, ::arrow::StringType)
+    ->Iterations(50);
+
+// ----------------------------------------------------------------------
+// The following benchmarks are designed to test the impact of the number of hit pages on
+// scan performance for different types, while the comparative test scans the entire row
+// group for all columns. Different from above benchmarks, following benchmarks execute
+// with 25 columns with different types, which is closer to real-world usage scenarios.
+
+static const std::shared_ptr<::arrow::Table> table_with_multiple_columns =
+    arrow::MakeSimpleTable(num_rows);
+
+static void BM_MultipleColumns_PagePruning(::benchmark::State& state) {
+  const int hit_page_percent = static_cast<int>(state.range(0));
+  const int page_hit_rows = static_cast<int>(state.range(1));
+
+  std::unique_ptr<arrow::FileReader> reader;
+  InitReader(table_with_multiple_columns, &reader);
+
+  const int num_columns = reader->parquet_reader()->metadata()->num_columns();
+  auto column_indices = Iota(num_columns);
+  auto info = BuildReadInfoWithPageHitPercent(reader, hit_page_percent, page_hit_rows);
+  RunBenchmark(state, std::move(reader), column_indices, info);
+  auto page_info = std::get<0>(info);
+  state.counters["MinPageNum"] = page_info.min_num_pages;
+  state.counters["MaxPageNum"] = page_info.max_num_pages;
+}
+
+static void BM_MultipleColumns_ReadRowGroup(::benchmark::State& state) {
+  std::unique_ptr<arrow::FileReader> reader;
+  InitReader(table_with_multiple_columns, &reader);
+  const int num_columns = reader->parquet_reader()->metadata()->num_columns();
+  auto column_indices = Iota(num_columns);
+
+  int num_pages = 0, min_page_num = std::numeric_limits<int>::max(),
+      max_page_num = std::numeric_limits<int>::min();
+  auto rg_pi_reader = reader->parquet_reader()->GetPageIndexReader()->RowGroup(0);
+  for (int column_index : column_indices) {
+    auto col_num_pages = static_cast<int>(
+        rg_pi_reader->GetOffsetIndex(column_index)->page_locations().size());
+    num_pages += col_num_pages;
+    if (col_num_pages < min_page_num) {
+      min_page_num = col_num_pages;
+    }
+    if (col_num_pages > max_page_num) {
+      max_page_num = col_num_pages;
+    }
+  }
+  auto info =
+      std::make_tuple(PageInfo{num_pages, min_page_num, max_page_num}, std::nullopt);
+  RunBenchmark(state, std::move(reader), column_indices, std::move(info));
+  state.counters["MinPageNum"] = min_page_num;
+  state.counters["MaxPageNum"] = max_page_num;
+}
+
+BENCHMARK(BM_MultipleColumns_PagePruning)
+    ->Iterations(50)
+    ->ArgNames({"hit_page(%)", "hit_rows"})
+    ->Args({5, hit_rows_val})
+    ->Args({10, hit_rows_val})
+    ->Args({30, hit_rows_val})
+    ->Args({50, hit_rows_val})
+    ->Args({70, hit_rows_val})
+    ->Args({100, hit_rows_val});
+BENCHMARK(BM_MultipleColumns_ReadRowGroup)->Iterations(50);
+
+}  // namespace parquet::benchmark

--- a/cpp/src/parquet/arrow/read_by_row_ranges_test.cc
+++ b/cpp/src/parquet/arrow/read_by_row_ranges_test.cc
@@ -1,0 +1,1485 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <optional>
+#include <random>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/io/memory.h"
+#include "arrow/record_batch.h"
+#include "arrow/table.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/type_fwd.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/range.h"
+
+#include "parquet/arrow/reader.h"
+#include "parquet/arrow/schema.h"
+#include "parquet/arrow/test_util.h"
+#include "parquet/arrow/writer.h"
+#include "parquet/file_writer.h"
+#include "parquet/platform.h"
+#include "parquet/properties.h"
+#include "parquet/row_ranges.h"
+
+using arrow::TimeUnit;
+using arrow::internal::Iota;
+using arrow::io::BufferReader;
+using parquet::schema::GroupNode;
+
+namespace parquet::arrow::relyt {
+
+struct ReadStatesParam {
+  ReadStatesParam() = default;
+
+  ReadStatesParam(RowRanges ranges, std::shared_ptr<PageReadStates> states)
+      : row_ranges(std::move(ranges)), read_states(std::move(states)){};
+
+  RowRanges row_ranges;
+  std::shared_ptr<PageReadStates> read_states;
+};
+
+class TestBuildPageReadStates : public ::testing::TestWithParam<ReadStatesParam> {
+ protected:
+  void SetUp() override {
+    // clang-format off
+    //
+    // Column chunk data layout:
+    //  |-----------------------------------------------------------------------------------------|
+    //  | dict_page | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+    //      -            215K         300K         512K         268K         435K         355K
+    //      -           [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+    //
+    // clang-format on
+    page_locations_.push_back(PageLocation{1048626, 220160, 0});     // page0
+    page_locations_.push_back(PageLocation{1268786, 307200, 440});   // page1
+    page_locations_.push_back(PageLocation{1575986, 524288, 998});   // page2
+    page_locations_.push_back(PageLocation{2100274, 274432, 1346});  // page3
+    page_locations_.push_back(PageLocation{2374706, 445440, 1835});  // page4
+    page_locations_.push_back(PageLocation{2820146, 363520, 2177});  // page5
+
+    param_ = GetParam();
+  }
+
+  void BuildAndVerifyPageReadStates() {
+    ASSERT_OK_AND_ASSIGN(
+        auto read_states,
+        BuildPageReadStates(num_rows_, chunk_range_, page_locations_, param_.row_ranges));
+    ASSERT_TRUE((read_states == nullptr && param_.read_states == nullptr) ||
+                (*param_.read_states == *read_states));
+  }
+
+ private:
+  const int64_t num_rows_ = 2704;
+  const ::arrow::io::ReadRange chunk_range_{50, 3183666};
+  std::vector<PageLocation> page_locations_;
+
+  ReadStatesParam param_;
+};
+
+std::vector<ReadStatesParam> GenerateTestCases() {
+  std::vector<ReadStatesParam> params;
+
+  // clang-format off
+  //
+  //  0         350
+  //  |<--read-->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{0, 350}}};
+
+    ReadRanges read_ranges =
+        ReadRanges{{{50, 1048576} /*dict page*/, {1048626, 220160} /*data_page0*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{0, 350}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{350}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //  0           439
+  //  |<-- read -->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{0, 439}}};
+
+    ReadRanges read_ranges =
+        ReadRanges{{{50, 1048576} /*dict page*/, {1048626, 220160} /*data_page0*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{0, 439}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{439}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //  0             503
+  //  |<--- read --->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{0, 503}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{0, 439}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{439}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{440, 503}},
+                                      std::vector<int64_t>{0}, std::vector<int64_t>{63}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //  0                        997
+  //  |<--------- read -------->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{0, 997}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{0, 439}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{439}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{440, 997}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{557}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //  0                          1105
+  //  |<---------- read ---------->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{0, 1105}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/,
+                                         {1575986, 524288} /*data_page2*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{0, 439}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{439}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{440, 997}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{557}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{998, 1105}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{107}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //   57       402
+  //    |<-read->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{57, 402}}};
+
+    ReadRanges read_ranges =
+        ReadRanges{{{50, 1048576} /*dict page*/, {1048626, 220160} /*data_page0*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{57, 402}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{402}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //   57         439
+  //    |<--read-->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{57, 439}}};
+
+    ReadRanges read_ranges =
+        ReadRanges{{{50, 1048576} /*dict page*/, {1048626, 220160} /*data_page0*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{57, 439}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{439}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //   57               637
+  //    |<---- read ---->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{57, 637}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{57, 439}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{439}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{440, 637}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{197}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //   57                      997
+  //    |<-------- read ------->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{57, 997}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{57, 439}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{439}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{440, 997}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{557}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //   57                        1104
+  //    |<--------- read --------->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{57, 1104}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/,
+                                         {1575986, 524288} /*data_page2*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{57, 439}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{439}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{440, 997}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{557}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{998, 1104}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{106}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //                                1197 1246
+  //   57                       1104 |   | 1311 1450
+  //    |<--------- read --------->| |<->| |<-->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{57, 1104}, {1197, 1246}, {1311, 1450}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/,
+                                         {1575986, 524288} /*data_page2*/,
+                                         {2100274, 274432} /*data_page3*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{57, 439}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{439}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{440, 997}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{557}});
+    skip_infos.push_back(PageSkipInfo{
+        std::vector<RowRanges::Range>{{998, 1104}, {1197, 1246}, {1311, 1345}},
+        std::vector<int64_t>{0, 92, 64}, std::vector<int64_t>{106, 248, 347}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{1346, 1450}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{104}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //   57       403 475 763 859        1259  1403    1679
+  //    |<-read->|   |<-->|  |<---read-->|     |<----->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{57, 403}, {475, 763}, {859, 1259}, {1403, 1679}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/,
+                                         {1575986, 524288} /*data_page2*/,
+                                         {2100274, 274432} /*data_page3*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{57, 403}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{403}});
+    skip_infos.push_back(
+        PageSkipInfo{std::vector<RowRanges::Range>{{475, 763}, {859, 997}},
+                     std::vector<int64_t>{35, 95}, std::vector<int64_t>{323, 557}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{998, 1259}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{261}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{1403, 1679}},
+                                      std::vector<int64_t>{57},
+                                      std::vector<int64_t>{333}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //       257         666     1004  1117 1289   1599      2001           2433
+  //        |           |        |<--->|  |<------>|         |              |
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{
+        {{257, 257}, {666, 666}, {1004, 1117}, {1289, 1599}, {2001, 2001}, {2433, 2433}}};
+
+    ReadRanges read_ranges = ReadRanges{{{50, 1048576} /*dict page*/,
+                                         {1048626, 220160} /*data_page0*/,
+                                         {1268786, 307200} /*data_page1*/,
+                                         {1575986, 524288} /*data_page2*/,
+                                         {2100274, 274432} /*data_page3*/,
+                                         {2374706, 445440} /*data_page4*/,
+                                         {2820146, 363520} /*data_page5*/}};
+    std::vector<PageSkipInfo> skip_infos;
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{257, 257}},
+                                      std::vector<int64_t>{257},
+                                      std::vector<int64_t>{257}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{666, 666}},
+                                      std::vector<int64_t>{226},
+                                      std::vector<int64_t>{226}});
+    skip_infos.push_back(
+        PageSkipInfo{std::vector<RowRanges::Range>{{1004, 1117}, {1289, 1345}},
+                     std::vector<int64_t>{6, 171}, std::vector<int64_t>{119, 347}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{1346, 1599}},
+                                      std::vector<int64_t>{0},
+                                      std::vector<int64_t>{253}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{2001, 2001}},
+                                      std::vector<int64_t>{166},
+                                      std::vector<int64_t>{166}});
+    skip_infos.push_back(PageSkipInfo{std::vector<RowRanges::Range>{{2433, 2433}},
+                                      std::vector<int64_t>{256},
+                                      std::vector<int64_t>{256}});
+    auto read_states = std::make_shared<PageReadStates>(ranges, read_ranges, skip_infos);
+
+    params.emplace_back(ranges, std::move(read_states));
+  }
+
+  // clang-format off
+  //
+  //  0                                                                           2703
+  //  |<--------------------------------------------------------------------------->|
+  //  |-----------------------------------------------------------------------------|
+  //  | data_page0 | data_page1 | data_page2 | data_page3 | data_page4 | data_page5 |
+  //       215K         300K         512K         268K         435K         355K
+  //      [0,439]    [440,997]    [998,1345]   [1346,1834]  [1835,2176]  [2177,2703]
+  //
+  // clang-format on
+  {
+    RowRanges ranges = RowRanges{{{0, 2703}}};
+
+    params.emplace_back(ranges, nullptr);
+  }
+
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(BuildPageReadStates, TestBuildPageReadStates,
+                         ::testing::ValuesIn(GenerateTestCases()));
+
+TEST_P(TestBuildPageReadStates, BuildPageReadStates) { BuildAndVerifyPageReadStates(); }
+
+void CompareResult(const std::shared_ptr<::arrow::Table>& table_expected,
+                   const std::shared_ptr<::arrow::Table>& table_read,
+                   const std::unordered_map<int, RowRanges>& row_ranges,
+                   int64_t max_row_group_length) {
+  std::vector<::arrow::io::ReadRange> expected_rows;
+  std::vector<::arrow::io::ReadRange> actually_rows;
+
+  std::vector<int> row_group_indices;
+  for (const auto& kv : row_ranges) {
+    row_group_indices.push_back(kv.first);
+  }
+  ASSERT_EQ(row_group_indices.size(), row_ranges.size());
+
+  // Calculate expected row ranges in original table and corresponding
+  // ranges in read result table.
+  std::sort(row_group_indices.begin(), row_group_indices.end());
+  int64_t cumulative_rows = 0;
+  for (int row_group : row_group_indices) {
+    auto it = row_ranges.find(row_group);
+    if (it == row_ranges.end()) {
+      ASSERT_TRUE(false);
+    }
+    const auto& ranges = it->second.GetRanges();
+    int64_t base = max_row_group_length * row_group;
+    for (const auto& range : ranges) {
+      expected_rows.emplace_back(
+          ::arrow::io::ReadRange{base + range.from, (range.to - range.from + 1)});
+      actually_rows.emplace_back(
+          ::arrow::io::ReadRange{cumulative_rows, (range.to - range.from + 1)});
+      cumulative_rows += (range.to - range.from + 1);
+    }
+  }
+  ASSERT_EQ(expected_rows.size(), actually_rows.size());
+
+  // Check total row num
+  int64_t total_rows_expected = 0;
+  int64_t total_rows_actually = 0;
+  for (const auto& range : expected_rows) {
+    total_rows_expected += range.length;
+  }
+  for (const auto& range : actually_rows) {
+    total_rows_actually += range.length;
+  }
+  ASSERT_EQ(total_rows_expected, total_rows_actually);
+  ASSERT_EQ(total_rows_expected, table_read->num_rows());
+
+  // Check data is consistent for every row range
+  for (size_t i = 0; i < expected_rows.size(); i++) {
+    auto expected =
+        table_expected->Slice(expected_rows[i].offset, expected_rows[i].length);
+    auto actually = table_read->Slice(actually_rows[i].offset, actually_rows[i].length);
+    EXPECT_TRUE(expected->Equals(*actually));
+  }
+}
+
+void CompareResult(const std::shared_ptr<::arrow::Schema>& schema,
+                   const std::shared_ptr<::arrow::RecordBatch>& record_batch_expected,
+                   const std::shared_ptr<::arrow::RecordBatch>& record_batch_read,
+                   const std::unordered_map<int, RowRanges>& row_ranges,
+                   int64_t max_row_group_length) {
+  ASSERT_OK_AND_ASSIGN(auto table_read,
+                       ::arrow::Table::FromRecordBatches(schema, {record_batch_read}));
+  ASSERT_OK_AND_ASSIGN(auto table_expected, ::arrow::Table::FromRecordBatches(
+                                                schema, {record_batch_expected}));
+  CompareResult(std::move(table_expected), std::move(table_read), row_ranges,
+                max_row_group_length);
+}
+
+class TestReadByRowRangesSimple : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = ::arrow::default_memory_pool();
+    auto sink = CreateOutputStream();
+    max_row_group_length_ = 10;
+    // Limit the max number of rows in a row group to 10
+    auto writer_properties = WriterProperties::Builder()
+                                 .max_row_group_length(max_row_group_length_)
+                                 ->enable_write_page_index()
+                                 ->build();
+    auto arrow_writer_properties = default_arrow_writer_properties();
+
+    // Prepare schema
+    schema_ = ::arrow::schema(
+        {::arrow::field("a", ::arrow::int64()),
+         ::arrow::field("b", ::arrow::struct_({::arrow::field("b1", ::arrow::int64()),
+                                               ::arrow::field("b2", ::arrow::utf8())})),
+         ::arrow::field("c", ::arrow::utf8())});
+    std::shared_ptr<SchemaDescriptor> parquet_schema;
+    ASSERT_OK_NO_THROW(ToParquetSchema(schema_.get(), *writer_properties,
+                                       *arrow_writer_properties, &parquet_schema));
+    auto schema_node = std::static_pointer_cast<GroupNode>(parquet_schema->schema_root());
+
+    // Prepare data
+    record_batch_ = ::arrow::RecordBatchFromJSON(schema_, R"([
+      [1,    {"b1": -3,   "b2": "1"   }, "alfa"],
+      [null, {"b1": null, "b2": "22"  }, "alfa"],
+      [3,    {"b1": -2,   "b2": "333" }, "beta"],
+      [null, {"b1": null, "b2": null  }, "gama"],
+      [5,    {"b1": -1,   "b2": "-333"}, null  ],
+      [6,    {"b1": null, "b2": "-22" }, "alfa"],
+      [7,    {"b1": 0,    "b2": "-1"  }, "beta"],
+      [8,    {"b1": null, "b2": null  }, "beta"],
+      [9,    {"b1": 1,    "b2": "0"   }, null  ],
+      [null, {"b1": null, "b2": ""    }, "gama"],
+      [11,   {"b1": 2,    "b2": "1234"}, "foo" ],
+      [12,   {"b1": null, "b2": "4321"}, "bar" ]
+    ])");
+    num_rows_ = record_batch_->num_rows();
+
+    // Create writer to write data via RecordBatch.
+    auto writer = ParquetFileWriter::Open(sink, schema_node, writer_properties);
+    std::unique_ptr<FileWriter> arrow_writer;
+    ASSERT_OK(FileWriter::Make(pool_, std::move(writer), schema_, arrow_writer_properties,
+                               &arrow_writer));
+    // NewBufferedRowGroup() is not called explicitly and it will be called
+    // inside WriteRecordBatch().
+    ASSERT_OK_NO_THROW(arrow_writer->WriteRecordBatch(*record_batch_));
+    ASSERT_OK_NO_THROW(arrow_writer->Close());
+    ASSERT_OK_AND_ASSIGN(buffer_, sink->Finish());
+  }
+
+  void ReadAllData(int64_t batch_size) {
+    std::vector<RowRanges::Range> rg0_row_ranges;
+    std::vector<RowRanges::Range> rg1_row_ranges;
+    rg0_row_ranges.push_back({0, 9});
+    rg1_row_ranges.push_back({0, 1});
+
+    std::unordered_map<int, RowRanges> row_ranges;
+    row_ranges[0] = RowRanges(std::move(rg0_row_ranges));
+    row_ranges[1] = RowRanges(std::move(rg1_row_ranges));
+
+    reader_properties_.set_batch_size(batch_size);
+    auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+    std::unique_ptr<FileReader> arrow_reader;
+    ASSERT_OK(
+        FileReader::Make(pool_, std::move(reader), reader_properties_, &arrow_reader));
+    const int num_row_groups =
+        arrow_reader->parquet_reader()->metadata()->num_row_groups();
+    std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+    ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(
+        Iota(num_row_groups), column_vectors_, std::make_optional(row_ranges),
+        &batch_reader));
+
+    const int iterate_num = static_cast<int>((num_rows_ + batch_size - 1) / batch_size);
+    const int64_t last_batch_size =
+        num_rows_ % batch_size == 0 ? batch_size : num_rows_ % batch_size;
+    std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+    for (int i = 0; i < iterate_num; i++) {
+      ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+      if (i != iterate_num - 1) {
+        const auto& expected = record_batch_->Slice(i * batch_size, batch_size);
+        EXPECT_TRUE(expected->Equals(*record_batch_read));
+      } else {
+        const auto& expected = record_batch_->Slice(i * batch_size, last_batch_size);
+        EXPECT_TRUE(expected->Equals(*record_batch_read));
+      }
+    }
+    ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+    ASSERT_TRUE(record_batch_read == nullptr);
+  }
+
+  void ReadPartialDataWithOneRangeEachPage(int64_t offset) {
+    auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+    const int64_t row_group_length = reader->metadata()->RowGroup(0)->num_rows();
+    for (int row_num = 1; row_num < num_rows_ - offset; row_num++) {
+      std::vector<int> row_group_indices;
+      std::unordered_map<int, RowRanges> row_ranges;
+      if (offset + row_num <= row_group_length) {
+        row_group_indices.push_back(0);
+
+        row_ranges[0] = RowRanges({RowRanges::Range{offset, offset + row_num - 1}});
+      } else {
+        row_group_indices.push_back(0);
+        row_group_indices.push_back(1);
+
+        row_ranges[0] = RowRanges({RowRanges::Range{offset, row_group_length - 1}});
+        row_ranges[1] =
+            RowRanges({RowRanges::Range{0, row_num - (row_group_length - offset + 1)}});
+      }
+
+      reader_properties_.set_batch_size(15);
+      reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+      std::unique_ptr<FileReader> arrow_reader;
+      ASSERT_OK(
+          FileReader::Make(pool_, std::move(reader), reader_properties_, &arrow_reader));
+      std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+      ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(
+          row_group_indices, column_vectors_, std::make_optional(row_ranges),
+          &batch_reader));
+
+      std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+      ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+      EXPECT_TRUE(record_batch_->Slice(offset, row_num)->Equals(*record_batch_read));
+      ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+      ASSERT_TRUE(record_batch_read == nullptr);
+    }
+  }
+
+  std::vector<RowRanges::Range> SplitRanges(int64_t from, int64_t to) {
+    std::vector<RowRanges::Range> splits;
+    if (from == to) {
+      splits.push_back(RowRanges::Range{from, to});
+    } else {
+      std::random_device rd;
+      std::mt19937_64 gen(rd());
+      std::uniform_int_distribution<int64_t> d(from, to);
+      const int64_t point0 = d(gen);
+      const int64_t point1 = d(gen);
+
+      RowRanges::Range first_part, second_part;
+      if (point0 < point1) {
+        first_part = {from, point0};
+        second_part = {point1, to};
+      } else if (point0 == point1) {
+        if (from < point0) {
+          first_part = {from, point0 - 1};
+          second_part = {point1, to};
+        } else {
+          first_part = {from, point0};
+          second_part = {point1 + 1, to};
+        }
+      } else {
+        first_part = {from, point1};
+        second_part = {point0, to};
+      }
+      splits.push_back(std::move(first_part));
+      splits.push_back(std::move(second_part));
+    }
+
+    return splits;
+  }
+
+  void ReadPartialDataWithMultiRangesEachPage(int64_t offset) {
+    auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+    const int64_t row_group_length = reader->metadata()->RowGroup(0)->num_rows();
+    for (int row_num = 1; row_num < num_rows_ - offset; row_num++) {
+      std::vector<int> row_group_indices;
+      std::unordered_map<int, RowRanges> row_ranges;
+      if (offset + row_num <= row_group_length) {
+        row_group_indices.push_back(0);
+
+        row_ranges[0] = RowRanges(SplitRanges(offset, offset + row_num - 1));
+      } else {
+        row_group_indices.push_back(0);
+        row_group_indices.push_back(1);
+
+        row_ranges[0] = RowRanges(SplitRanges(offset, row_group_length - 1));
+        row_ranges[1] =
+            RowRanges(SplitRanges(0, row_num - (row_group_length - offset + 1)));
+      }
+
+      reader_properties_.set_batch_size(15);
+      reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+      std::unique_ptr<FileReader> arrow_reader;
+      ASSERT_OK(
+          FileReader::Make(pool_, std::move(reader), reader_properties_, &arrow_reader));
+      std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+      ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(
+          row_group_indices, column_vectors_, std::make_optional(row_ranges),
+          &batch_reader));
+
+      std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+      ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+      CompareResult(schema_, record_batch_, record_batch_read, row_ranges,
+                    max_row_group_length_);
+      ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+      ASSERT_TRUE(record_batch_read == nullptr);
+    }
+  }
+
+  void RandomReadOneRow() {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<int64_t> d(0, num_rows_ - 1);
+    const int64_t row_offset = d(gen);
+
+    auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+    const int64_t row_group_length = reader->metadata()->RowGroup(0)->num_rows();
+    std::vector<int> row_group_indices;
+    const int row_group_index = static_cast<int>(row_offset / row_group_length);
+    row_group_indices.push_back(row_group_index);
+    int64_t row_offset_in_rg = row_offset % row_group_length;
+    std::unordered_map<int, RowRanges> row_ranges;
+    row_ranges[row_group_index] =
+        RowRanges({RowRanges::Range{row_offset_in_rg, row_offset_in_rg}});
+
+    std::unique_ptr<FileReader> arrow_reader;
+    ASSERT_OK(
+        FileReader::Make(pool_, std::move(reader), reader_properties_, &arrow_reader));
+    std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+    ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(
+        row_group_indices, column_vectors_, std::make_optional(row_ranges),
+        &batch_reader));
+
+    std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+    ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+    CompareResult(schema_, record_batch_, record_batch_read, row_ranges,
+                  max_row_group_length_);
+  }
+
+  void DynamicReadAsDict() {
+    reader_properties_.set_batch_size(num_rows_);
+
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<int64_t> d(0, num_rows_ - 1);
+    const int64_t point0 = d(gen);
+    const int64_t point1 = d(gen);
+
+    int64_t from, to;
+    if (point0 <= point1) {
+      from = point0;
+      to = point1;
+    } else {
+      from = point1;
+      to = point0;
+    }
+
+    std::vector<int> row_group_indices;
+    std::unordered_map<int, RowRanges> row_ranges;
+    if (to >= max_row_group_length_) {
+      if (from >= max_row_group_length_) {
+        row_group_indices.push_back(1);
+        row_ranges[1] =
+            RowRanges({{from - max_row_group_length_, to - max_row_group_length_}});
+      } else {
+        row_group_indices.push_back(0);
+        row_group_indices.push_back(1);
+
+        row_ranges[0] = RowRanges({{from, max_row_group_length_ - 1}});
+        row_ranges[1] = RowRanges({{0, to - max_row_group_length_}});
+      }
+    } else {
+      row_group_indices.push_back(0);
+      row_ranges[0] = RowRanges({{from, to}});
+    }
+
+    int64_t num_rows_expected = 0;
+    for (const auto& kv : row_ranges) {
+      num_rows_expected += kv.second.GetRowCount();
+    }
+
+    auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+    ASSERT_EQ(2, reader->metadata()->num_row_groups());
+    for (int i = 0; i < reader->metadata()->num_columns(); i++) {
+      reader_properties_.set_read_dictionary(i, true);
+    }
+
+    std::unique_ptr<FileReader> arrow_reader;
+    ASSERT_OK(
+        FileReader::Make(pool_, std::move(reader), reader_properties_, &arrow_reader));
+    std::unique_ptr<::arrow::RecordBatchReader> batch_reader_raw;
+    std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+
+    // Primitive types support read multiple dicts in one batch and cache result in
+    // iterator to make sure return only one dict in each invocation
+    {
+      ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(row_group_indices, {0, 3},
+                                                            &batch_reader_raw));
+      ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(
+          row_group_indices, {0, 3}, std::make_optional(row_ranges), &batch_reader));
+
+      int64_t num_rows_read = 0;
+      std::shared_ptr<::arrow::RecordBatch> record_batch_raw;
+      std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+      for (int row_group_index : row_group_indices) {
+        ASSERT_OK(batch_reader_raw->ReadNext(&record_batch_raw));
+        ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+
+        ASSERT_TRUE(record_batch_raw != nullptr);
+        ASSERT_TRUE(record_batch_read != nullptr);
+
+        EXPECT_TRUE(record_batch_read->column(0)->type_id() == ::arrow::Type::INT64);
+        EXPECT_TRUE(record_batch_read->column(1)->type_id() == ::arrow::Type::DICTIONARY);
+        auto dict2 = std::dynamic_pointer_cast<::arrow::DictionaryArray>(
+            record_batch_read->column(1));
+        EXPECT_TRUE(dict2->dictionary() != nullptr);
+
+        // Compare read result
+        const auto& ranges = row_ranges[row_group_index].GetRanges();
+        auto record_batch_expected =
+            record_batch_raw->Slice(ranges[0].from, (ranges[0].to - ranges[0].from + 1));
+        ASSERT_TRUE(record_batch_expected->Equals(*record_batch_read));
+
+        num_rows_read += record_batch_read->num_rows();
+      }
+
+      ASSERT_EQ(num_rows_expected, num_rows_read);
+    }
+
+    // Nested types do not support read multiple dicts in one batch
+    {
+      ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(
+          row_group_indices, column_vectors_, &batch_reader_raw));
+      ASSERT_OK_NO_THROW(arrow_reader->GetRecordBatchReader(
+          row_group_indices, column_vectors_, std::make_optional(row_ranges),
+          &batch_reader));
+
+      if (row_ranges.size() == 1) {
+        // Read only one dict in this invocation
+        std::shared_ptr<::arrow::RecordBatch> record_batch_raw;
+        std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+        ASSERT_OK(batch_reader_raw->ReadNext(&record_batch_raw));
+        ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+
+        ASSERT_TRUE(record_batch_raw != nullptr);
+        ASSERT_TRUE(record_batch_read != nullptr);
+
+        EXPECT_TRUE(record_batch_read->column(0)->type_id() == ::arrow::Type::INT64);
+        EXPECT_TRUE(record_batch_read->column(1)->type_id() == ::arrow::Type::STRUCT);
+        const auto array =
+            std::dynamic_pointer_cast<::arrow::StructArray>(record_batch_read->column(1));
+        EXPECT_TRUE(array->field(0)->type_id() == ::arrow::Type::INT64);
+        EXPECT_TRUE(array->field(1)->type_id() == ::arrow::Type::DICTIONARY);
+        auto dict1 = std::dynamic_pointer_cast<::arrow::DictionaryArray>(array->field(1));
+        EXPECT_TRUE(dict1->dictionary() != nullptr);
+        EXPECT_TRUE(record_batch_read->column(2)->type_id() == ::arrow::Type::DICTIONARY);
+        auto dict2 = std::dynamic_pointer_cast<::arrow::DictionaryArray>(
+            record_batch_read->column(2));
+        EXPECT_TRUE(dict2->dictionary() != nullptr);
+
+        // Compare read result
+        const int row_group_index = row_group_indices[0];
+        const auto& ranges = row_ranges[row_group_index].GetRanges();
+        auto record_batch_expected =
+            record_batch_raw->Slice(ranges[0].from, (ranges[0].to - ranges[0].from + 1));
+        ASSERT_TRUE(record_batch_expected->Equals(*record_batch_read));
+
+        ASSERT_EQ(num_rows_expected, record_batch_read->num_rows());
+
+        record_batch_read.reset();
+        ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+        ASSERT_TRUE(record_batch_read == nullptr);
+      } else {
+        // Read multiple dicts in this invocation
+        std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+        ASSERT_RAISES_WITH_MESSAGE(NotImplemented,
+                                   "NotImplemented: Nested data conversions not "
+                                   "implemented for chunked array outputs",
+                                   batch_reader->ReadNext(&record_batch_read));
+      }
+    }
+  }
+
+  void ReadWithInvalidRowRange() {
+    auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer_));
+    const int num_row_groups = reader->metadata()->num_row_groups();
+    std::unique_ptr<FileReader> arrow_reader;
+    ASSERT_OK(
+        FileReader::Make(pool_, std::move(reader), reader_properties_, &arrow_reader));
+
+    // Random generate a point within file row range
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<int64_t> d(0, num_rows_ - 1);
+    const int64_t row_offset = d(gen);
+
+    std::vector<int> row_group_indices;
+    const int row_group_index = static_cast<int>(row_offset / max_row_group_length_);
+    row_group_indices.push_back(row_group_index);
+
+    // First row index is too small
+    {
+      int64_t end_row_offset;
+      RowRanges::Range allowable_range;
+
+      if (row_group_index == num_row_groups - 1) {
+        end_row_offset = num_rows_ - max_row_group_length_ - 1;
+        allowable_range = {0, num_rows_ % max_row_group_length_ - 1};
+      } else {
+        end_row_offset = max_row_group_length_ - 1;
+        allowable_range = {0, max_row_group_length_ - 1};
+      }
+
+      std::unordered_map<int, RowRanges> row_ranges;
+      row_ranges[row_group_index] = RowRanges({RowRanges::Range{-1, end_row_offset}});
+
+      std::stringstream ss;
+      ss << "Invalid: Row range exceeded, allowable: " << allowable_range.ToString()
+         << ", actually: " << row_ranges[row_group_index].ToString();
+      std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+
+      ASSERT_RAISES_WITH_MESSAGE(Invalid, ss.str(),
+                                 arrow_reader->GetRecordBatchReader(
+                                     row_group_indices, column_vectors_,
+                                     std::make_optional(row_ranges), &batch_reader));
+    }
+
+    // Last row index is too big
+    {
+      int64_t start_row_offset = row_offset % max_row_group_length_;
+      int64_t end_row_offset;
+      RowRanges::Range allowable_range;
+
+      if (row_group_index == num_row_groups - 1) {
+        end_row_offset = num_rows_ - max_row_group_length_;
+        allowable_range = {0, num_rows_ % max_row_group_length_ - 1};
+      } else {
+        end_row_offset = max_row_group_length_;
+        allowable_range = {0, max_row_group_length_ - 1};
+      }
+
+      std::unordered_map<int, RowRanges> row_ranges;
+      row_ranges[row_group_index] =
+          RowRanges({RowRanges::Range{start_row_offset, end_row_offset}});
+
+      std::stringstream ss;
+      ss << "Invalid: Row range exceeded, allowable: " << allowable_range.ToString()
+         << ", actually: " << row_ranges[row_group_index].ToString();
+      std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+
+      ASSERT_RAISES_WITH_MESSAGE(Invalid, ss.str(),
+                                 arrow_reader->GetRecordBatchReader(
+                                     row_group_indices, column_vectors_,
+                                     std::make_optional(row_ranges), &batch_reader));
+    }
+
+    // First row index and last row index are illegal
+    {
+      int64_t end_row_offset;
+      RowRanges::Range allowable_range;
+
+      if (row_group_index == num_row_groups - 1) {
+        end_row_offset = num_rows_ - max_row_group_length_;
+        allowable_range = {0, num_rows_ % max_row_group_length_ - 1};
+      } else {
+        end_row_offset = max_row_group_length_;
+        allowable_range = {0, max_row_group_length_ - 1};
+      }
+
+      std::unordered_map<int, RowRanges> row_ranges;
+      row_ranges[row_group_index] = RowRanges({RowRanges::Range{-1, end_row_offset}});
+
+      std::stringstream ss;
+      ss << "Invalid: Row range exceeded, allowable: " << allowable_range.ToString()
+         << ", actually: " << row_ranges[row_group_index].ToString();
+      std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+
+      ASSERT_RAISES_WITH_MESSAGE(Invalid, ss.str(),
+                                 arrow_reader->GetRecordBatchReader(
+                                     row_group_indices, column_vectors_,
+                                     std::make_optional(row_ranges), &batch_reader));
+    }
+  }
+
+  // @formatter:off
+  const std::vector<int> column_vectors_ = {0, 1, 2, 3};
+  // @formatter:on
+
+  MemoryPool* pool_;
+
+  int64_t max_row_group_length_{-1};
+  std::shared_ptr<::arrow::Schema> schema_;
+
+  std::shared_ptr<Buffer> buffer_;
+  std::shared_ptr<::arrow::RecordBatch> record_batch_;
+  int64_t num_rows_;
+
+  ArrowReaderProperties reader_properties_;
+};
+
+TEST_F(TestReadByRowRangesSimple, ReadAllData) {
+  // Test cases:
+  //   1. Batch size bigger than row group size
+  //   2. Batch size equals to row group size
+  //   3. Batch size smaller than row group size
+  //   4. Read all data into 4 record batches,
+  for (int64_t batch_size : {15, 10, 7, 3}) {
+    ReadAllData(batch_size);
+  }
+}
+
+TEST_F(TestReadByRowRangesSimple, ReadPartialDataWithOneRangeEachPage) {
+  for (int64_t offset : Iota(9)) {
+    ReadPartialDataWithOneRangeEachPage(offset);
+  }
+}
+
+TEST_F(TestReadByRowRangesSimple, ReadPartialDataWithMultiRangesEachPage) {
+  for (int64_t offset : Iota(9)) {
+    ReadPartialDataWithMultiRangesEachPage(offset);
+  }
+}
+
+TEST_F(TestReadByRowRangesSimple, RandomReadOneRow) {
+  for (int i = 0; i < 10; i++) {
+    RandomReadOneRow();
+  }
+}
+
+TEST_F(TestReadByRowRangesSimple, DynamicReadAsDict) {
+  for (int i = 0; i < 10; i++) {
+    DynamicReadAsDict();
+  }
+}
+
+TEST_F(TestReadByRowRangesSimple, ReadWithInvalidRowRanges) { ReadWithInvalidRowRange(); }
+
+class TestReadByRowRangesBase {
+ protected:
+  virtual void PrepareDataAndReader(bool nullable = false) = 0;
+
+  void ReadNonNullData() {
+    PrepareDataAndReader(false);
+    for (int i = 0; i < 10; i++) {
+      RandomReadOneRow();
+    }
+    for (int num_ranges : {1, 5, 10, 20}) {
+      ReadDataWithRandomRanges(num_ranges);
+    }
+  }
+
+  void ReadNullableData() {
+    PrepareDataAndReader(true);
+    for (int i = 0; i < 10; i++) {
+      RandomReadOneRow();
+    }
+    for (int num_ranges : {1, 5, 10, 20}) {
+      ReadDataWithRandomRanges(num_ranges);
+    }
+  }
+
+  MemoryPool* pool_ = ::arrow::default_memory_pool();
+
+  int64_t max_data_page_size_{-1};
+  int64_t write_batch_size_{-1};
+  int64_t max_row_group_length_{-1};
+  std::shared_ptr<WriterProperties> writer_properties_;
+
+  std::shared_ptr<::arrow::Schema> schema_;
+  std::shared_ptr<::arrow::Table> table_;
+
+  int64_t num_rows_{-1};
+  std::unique_ptr<FileReader> reader_;
+
+  std::vector<int> column_vectors_;
+
+ private:
+  void CheckPrepared() const {
+    ASSERT_TRUE(num_rows_ > 0);
+    ASSERT_TRUE(schema_ != nullptr);
+    ASSERT_TRUE(table_ != nullptr);
+    ASSERT_TRUE(reader_ != nullptr);
+  }
+
+  std::vector<RowRanges::Range> GenerateRowRanges(int num_ranges) const {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<int64_t> d(0, num_rows_ - 1);
+
+    std::vector<int64_t> points;
+    for (int i = 0; i < num_ranges * 2; i++) {
+      int64_t point = d(gen);
+      auto it = std::find(points.begin(), points.end(), point);
+
+      // Try to generate a value that is not in the points vector
+      if (it != points.end()) {
+        while (true) {
+          point = d(gen);
+          it = std::find(points.begin(), points.end(), point);
+          if (it == points.end()) {
+            break;
+          }
+        }
+      }
+      points.push_back(d(gen));
+    }
+    std::sort(points.begin(), points.end());
+
+    std::vector<RowRanges::Range> ranges;
+    for (int i = 0; i < num_ranges; i++) {
+      ranges.push_back(RowRanges::Range{points[2 * i], points[2 * i + 1]});
+    }
+    return ranges;
+  }
+
+  std::unordered_map<int, RowRanges> SplitRowRangesByRowGroup(
+      const std::vector<RowRanges::Range>& ranges) const {
+    const auto metadata = reader_->parquet_reader()->metadata();
+    const auto num_row_groups = metadata->num_row_groups();
+
+    int64_t from = 0;
+    int64_t cumulative_row = 0;
+    std::vector<int64_t> row_nums;
+    std::vector<int64_t> cumulative_rows;
+    std::vector<RowRanges::Range> rg_row_ranges;
+    for (int i = 0; i < num_row_groups; i++) {
+      const int64_t row_num = metadata->RowGroup(i)->num_rows();
+      row_nums.push_back(row_num);
+      cumulative_rows.push_back(cumulative_row);
+      cumulative_row += row_num;
+      rg_row_ranges.push_back(RowRanges::Range{from, cumulative_row - 1});
+      from = cumulative_row;
+    }
+
+    std::unordered_map<int, RowRanges> row_ranges;
+    std::vector<RowRanges::Range> rg_ranges;
+
+    int i = 0;
+    for (auto range : ranges) {
+      while (i < num_row_groups) {
+        auto res = RowRanges::Range::Intersection(rg_row_ranges[i], range);
+        if (res == RowRanges::EMPTY_RANGE) {
+          if (range.from > rg_row_ranges[i].to) {
+            if (!rg_ranges.empty()) {
+              row_ranges[i] = RowRanges(rg_ranges);
+              rg_ranges.clear();
+            }
+            // move to next i
+            i++;
+          } else {
+            // range.to < rg_row_ranges[i].from
+            // move to next range
+            break;
+          }
+        } else {
+          RowRanges::Range rg_range{res.from - cumulative_rows[i],
+                                    res.to - cumulative_rows[i]};
+          rg_ranges.push_back(std::move(rg_range));
+          if (range.to > rg_row_ranges[i].to) {
+            row_ranges[i] = RowRanges(rg_ranges);
+            rg_ranges.clear();
+            // move to next i
+            i++;
+          } else {
+            // range.to <= rg_row_ranges[i].to
+            // move to next range
+            break;
+          }
+        }
+      }
+    }
+
+    if (!rg_ranges.empty()) {
+      row_ranges[i] = RowRanges(rg_ranges);
+      rg_ranges.clear();
+    }
+
+    return row_ranges;
+  }
+
+  void ReadDataWithRandomRanges(int num_ranges) {
+    CheckPrepared();
+
+    const std::vector<RowRanges::Range> ranges = GenerateRowRanges(num_ranges);
+    const std::unordered_map<int, RowRanges> row_ranges =
+        SplitRowRangesByRowGroup(ranges);
+
+    std::vector<int> row_group_indices;
+    for (const auto& kv : row_ranges) {
+      row_group_indices.push_back(kv.first);
+    }
+
+    // Although file reader doesn't care whether passed-in row group indices
+    // are in asc order, we sort it to make easier to compare read result
+    // with original data table.
+    std::sort(row_group_indices.begin(), row_group_indices.end());
+
+    std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+    ASSERT_OK_NO_THROW(reader_->GetRecordBatchReader(row_group_indices, column_vectors_,
+                                                     std::make_optional(row_ranges),
+                                                     &batch_reader));
+    std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+    ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+    ASSERT_OK_AND_ASSIGN(auto table_read,
+                         ::arrow::Table::FromRecordBatches(schema_, {record_batch_read}));
+    CompareResult(table_, table_read, row_ranges, max_row_group_length_);
+    ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+    ASSERT_TRUE(record_batch_read == nullptr);
+  }
+
+  void RandomReadOneRow() {
+    CheckPrepared();
+
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<int64_t> d(0, num_rows_ - 1);
+    const int64_t row_offset = d(gen);
+
+    std::vector<int> row_group_indices;
+    const int row_group_index = static_cast<int>(row_offset / max_row_group_length_);
+    row_group_indices.push_back(row_group_index);
+    int64_t row_offset_in_rg = row_offset % max_row_group_length_;
+    std::unordered_map<int, RowRanges> row_ranges;
+    row_ranges[row_group_index] =
+        RowRanges({RowRanges::Range{row_offset_in_rg, row_offset_in_rg}});
+
+    std::unique_ptr<::arrow::RecordBatchReader> batch_reader;
+    ASSERT_OK_NO_THROW(reader_->GetRecordBatchReader(row_group_indices, column_vectors_,
+                                                     std::make_optional(row_ranges),
+                                                     &batch_reader));
+
+    std::shared_ptr<::arrow::RecordBatch> record_batch_read;
+    ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+    ASSERT_OK_AND_ASSIGN(auto table_read,
+                         ::arrow::Table::FromRecordBatches(schema_, {record_batch_read}));
+    CompareResult(table_, table_read, row_ranges, max_row_group_length_);
+    ASSERT_OK(batch_reader->ReadNext(&record_batch_read));
+    ASSERT_TRUE(record_batch_read == nullptr);
+  }
+};
+
+template <typename TestType>
+class TestReadSingleColumnByRowRanges : public TestReadByRowRangesBase,
+                                        public ::testing::Test {
+ protected:
+  void SetUp() override {
+    max_data_page_size_ = 1;
+    write_batch_size_ = 256;
+    max_row_group_length_ = 1024;
+
+    WriterProperties::Builder builder;
+    writer_properties_ = builder.max_row_group_length(max_row_group_length_)
+                             ->data_pagesize(max_data_page_size_)
+                             ->write_batch_size(write_batch_size_)
+                             ->enable_write_page_index()
+                             ->build();
+  }
+
+  void PrepareDataAndReader(bool nullable) override {
+    auto sink = CreateOutputStream();
+
+    std::shared_ptr<::arrow::Array> values;
+    const int64_t total_rows = 10240;
+    if (nullable) {
+      ASSERT_OK(NullableArray<TestType>(total_rows, total_rows / 2, 0, &values));
+      table_ = MakeSimpleTable(values, true);
+    } else {
+      ASSERT_OK(NonNullArray<TestType>(total_rows, &values));
+      table_ = MakeSimpleTable(values, false);
+    }
+    schema_ = table_->schema();
+    num_rows_ = table_->num_rows();
+    column_vectors_.push_back(0);
+
+    ASSERT_OK_NO_THROW(WriteTable(*table_, ::arrow::default_memory_pool(), sink,
+                                  max_row_group_length_, writer_properties_));
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+
+    auto arrow_reader_properties = ::parquet::default_arrow_reader_properties();
+    arrow_reader_properties.set_batch_size(num_rows_);
+
+    FileReaderBuilder file_reader_builder;
+    ASSERT_OK_NO_THROW(
+        file_reader_builder.Open(std::make_shared<BufferReader>(std::move(buffer))));
+    ASSERT_OK_NO_THROW(file_reader_builder.memory_pool(pool_)
+                           ->properties(arrow_reader_properties)
+                           ->Build(&reader_));
+  }
+};
+
+using TestTypes = ::testing::Types<
+    ::arrow::BooleanType, ::arrow::UInt8Type, ::arrow::Int8Type, ::arrow::UInt16Type,
+    ::arrow::Int16Type, ::arrow::Int32Type, ::arrow::UInt64Type, ::arrow::Int64Type,
+    ::arrow::Date32Type, ::arrow::FloatType, ::arrow::DoubleType, ::arrow::StringType,
+    ::arrow::BinaryType, ::arrow::FixedSizeBinaryType, DecimalWithPrecisionAndScale<19>,
+    DecimalWithPrecisionAndScale<20>, DecimalWithPrecisionAndScale<25>,
+    DecimalWithPrecisionAndScale<27>, DecimalWithPrecisionAndScale<29>,
+    DecimalWithPrecisionAndScale<33>, DecimalWithPrecisionAndScale<38>>;
+
+TYPED_TEST_SUITE(TestReadSingleColumnByRowRanges, TestTypes);
+
+TYPED_TEST(TestReadSingleColumnByRowRanges, ReadNonNullColumn) {
+  this->ReadNonNullData();
+}
+
+TYPED_TEST(TestReadSingleColumnByRowRanges, ReadNullableColumn) {
+  this->ReadNullableData();
+}
+
+class TestReadTableByRowRanges : public TestReadByRowRangesBase, public ::testing::Test {
+ protected:
+  void SetUp() override {
+    max_data_page_size_ = 32 * 1024;  // 32KB
+    max_row_group_length_ = 150000;
+
+    WriterProperties::Builder builder;
+    writer_properties_ = builder.max_row_group_length(max_row_group_length_)
+                             ->data_pagesize(max_data_page_size_)
+                             ->enable_write_page_index()
+                             ->build();
+
+    num_rows_ = 1000000;
+  }
+
+  void PrepareDataAndReader(bool) override {
+    auto sink = CreateOutputStream();
+
+    using ColumnTypes =
+        TypeList<::arrow::BooleanType, ::arrow::UInt8Type, ::arrow::Int8Type,
+                 ::arrow::UInt16Type, ::arrow::Int16Type, ::arrow::Int32Type,
+                 ::arrow::UInt64Type, ::arrow::Int64Type, ::arrow::Date32Type,
+                 ::arrow::FloatType, ::arrow::DoubleType, ::arrow::StringType,
+                 ::arrow::BinaryType, ::arrow::FixedSizeBinaryType,
+                 DecimalWithPrecisionAndScale<19>, DecimalWithPrecisionAndScale<20>,
+                 DecimalWithPrecisionAndScale<25>, DecimalWithPrecisionAndScale<27>,
+                 DecimalWithPrecisionAndScale<29>, DecimalWithPrecisionAndScale<33>,
+                 DecimalWithPrecisionAndScale<38>>;
+
+    // Prepare data and schema
+    columns_.clear();
+    MakeColumns(ColumnTypes{});
+    ASSERT_EQ(21, columns_.size());
+
+    std::vector<std::shared_ptr<::arrow::Field>> fields;
+    for (size_t i = 0; i < columns_.size(); i++) {
+      const bool nullable = columns_[i]->null_count() > 0;
+      fields.push_back(
+          ::arrow::field("col" + std::to_string(i), columns_[i]->type(), nullable));
+    }
+    schema_ = ::arrow::schema(std::move(fields));
+    table_ = ::arrow::Table::Make(schema_, columns_, num_rows_);
+
+    // Write data to sink
+    ASSERT_OK_NO_THROW(WriteTable(*table_, ::arrow::default_memory_pool(), sink,
+                                  max_row_group_length_, writer_properties_));
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+
+    // Prepare relyt schema and missing values
+    auto arrow_reader_properties = ::parquet::default_arrow_reader_properties();
+    std::vector<std::shared_ptr<::arrow::Field>> relyt_fields;
+    for (int i = 0; i < schema_->num_fields(); i++) {
+      column_vectors_.push_back({i});
+    }
+
+    arrow_reader_properties.set_batch_size(num_rows_);
+
+    FileReaderBuilder file_reader_builder;
+    ASSERT_OK_NO_THROW(
+        file_reader_builder.Open(std::make_shared<BufferReader>(std::move(buffer))));
+    ASSERT_OK_NO_THROW(file_reader_builder.memory_pool(pool_)
+                           ->properties(arrow_reader_properties)
+                           ->Build(&reader_));
+  }
+
+ private:
+  template <typename... Types>
+  struct TypeList {};
+
+  template <typename T>
+  void MakeColumn() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> d(0, 1);
+    bool nullable = d(gen) == 1;
+
+    std::shared_ptr<::arrow::Array> values;
+    if (nullable) {
+      ASSERT_OK(NullableArray<T>(num_rows_, num_rows_ / 2, 0, &values));
+    } else {
+      ASSERT_OK(NonNullArray<T>(num_rows_, &values));
+    }
+
+    columns_.push_back(std::move(values));
+  }
+
+  template <typename... Types>
+  void MakeColumns(TypeList<Types...>) {}
+
+  template <typename T, typename... Types>
+  void MakeColumns(TypeList<T, Types...>) {
+    MakeColumn<T>();
+    MakeColumns(TypeList<Types...>{});
+  }
+
+  void MakeColumns() {}
+
+  std::vector<std::shared_ptr<::arrow::Array>> columns_;
+};
+
+TEST_F(TestReadTableByRowRanges, RandomReadByRowRanges) { this->ReadNullableData(); }
+
+}  // namespace parquet::arrow::relyt

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -26,6 +26,7 @@
 #include "parquet/file_reader.h"
 #include "parquet/platform.h"
 #include "parquet/properties.h"
+#include "parquet/row_ranges.h"
 
 namespace arrow {
 
@@ -178,6 +179,11 @@ class PARQUET_EXPORT FileReader {
   ///     contains an invalid index
   virtual ::arrow::Status GetRecordBatchReader(
       const std::vector<int>& row_group_indices, const std::vector<int>& column_indices,
+      const std::optional<std::unordered_map<int, RowRanges>>& row_ranges,
+      std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
+
+  virtual ::arrow::Status GetRecordBatchReader(
+      const std::vector<int>& row_group_indices, const std::vector<int>& column_indices,
       std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
 
   /// \brief Return a RecordBatchReader of row groups selected from
@@ -198,6 +204,10 @@ class PARQUET_EXPORT FileReader {
   ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
                                        std::shared_ptr<::arrow::RecordBatchReader>* out);
   ::arrow::Status GetRecordBatchReader(std::shared_ptr<::arrow::RecordBatchReader>* out);
+  ::arrow::Status GetRecordBatchReader(
+      const std::vector<int>& row_group_indices, const std::vector<int>& column_indices,
+      const std::optional<std::unordered_map<int, RowRanges>>& row_ranges,
+      std::shared_ptr<::arrow::RecordBatchReader>* out);
 
   /// \brief Return a generator of record batches.
   ///
@@ -241,6 +251,11 @@ class PARQUET_EXPORT FileReader {
                                        std::shared_ptr<::arrow::Table>* out) = 0;
 
   virtual ::arrow::Status ReadRowGroup(int i, std::shared_ptr<::arrow::Table>* out) = 0;
+
+  virtual ::arrow::Status ReadRowGroups(
+      const std::vector<int>& row_groups, const std::vector<int>& column_indices,
+      const std::optional<std::unordered_map<int, RowRanges>>& row_ranges,
+      std::shared_ptr<::arrow::Table>* out) = 0;
 
   virtual ::arrow::Status ReadRowGroups(const std::vector<int>& row_groups,
                                         const std::vector<int>& column_indices,

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -416,7 +416,7 @@ template <class ArrowType>
 /// Wrap an Array into a ListArray by splitting it up into size lists.
 ///
 /// This helper function only supports (size/2) nulls.
-Status MakeListArray(const std::shared_ptr<Array>& values, int64_t size,
+inline Status MakeListArray(const std::shared_ptr<Array>& values, int64_t size,
                      int64_t null_count, const std::string& item_name,
                      bool nullable_values, std::shared_ptr<::arrow::ListArray>* out) {
   // We always include an empty list
@@ -454,7 +454,7 @@ Status MakeListArray(const std::shared_ptr<Array>& values, int64_t size,
 }
 
 // Make an array containing only empty lists, with a null values array
-Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
+inline Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
   // Allocate an offsets buffer containing only zeroes
   const int64_t offsets_nbytes = (size + 1) * sizeof(int32_t);
   ARROW_ASSIGN_OR_RAISE(auto offsets_buffer, ::arrow::AllocateBuffer(offsets_nbytes));
@@ -478,13 +478,13 @@ Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
   return Status::OK();
 }
 
-std::shared_ptr<::arrow::Table> MakeSimpleTable(
+inline std::shared_ptr<::arrow::Table> MakeSimpleTable(
     const std::shared_ptr<ChunkedArray>& values, bool nullable) {
   auto schema = ::arrow::schema({::arrow::field("col", values->type(), nullable)});
   return ::arrow::Table::Make(schema, {values});
 }
 
-std::shared_ptr<::arrow::Table> MakeSimpleTable(const std::shared_ptr<Array>& values,
+inline std::shared_ptr<::arrow::Table> MakeSimpleTable(const std::shared_ptr<Array>& values,
                                                 bool nullable) {
   auto carr = std::make_shared<::arrow::ChunkedArray>(values);
   return MakeSimpleTable(carr, nullable);
@@ -499,7 +499,7 @@ void ExpectArray(T* expected, Array* result) {
 }
 
 template <typename ArrowType>
-void ExpectArrayT(void* expected, Array* result) {
+inline void ExpectArrayT(void* expected, Array* result) {
   ::arrow::PrimitiveArray* p_array = static_cast<::arrow::PrimitiveArray*>(result);
   for (int64_t i = 0; i < result->length(); i++) {
     EXPECT_EQ(reinterpret_cast<typename ArrowType::c_type*>(expected)[i],
@@ -509,7 +509,7 @@ void ExpectArrayT(void* expected, Array* result) {
 }
 
 template <>
-void ExpectArrayT<::arrow::BooleanType>(void* expected, Array* result) {
+inline void ExpectArrayT<::arrow::BooleanType>(void* expected, Array* result) {
   ::arrow::BooleanBuilder builder;
   ARROW_EXPECT_OK(
       builder.AppendValues(reinterpret_cast<uint8_t*>(expected), result->length()));

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -35,6 +35,7 @@
 #include "arrow/array/builder_dict.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/chunked_array.h"
+#include "arrow/io/buffered.h"
 #include "arrow/type.h"
 #include "arrow/util/bit_stream_utils.h"
 #include "arrow/util/bit_util.h"
@@ -55,7 +56,6 @@
 #include "parquet/statistics.h"
 #include "parquet/thrift_internal.h"  // IWYU pragma: keep
 #include "parquet/windows_fixup.h"    // for OPTIONAL
-#include "arrow/io/buffered.h"
 
 using arrow::MemoryPool;
 using arrow::internal::AddWithOverflow;

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -36,6 +36,10 @@ class PageIndexReader;
 class BloomFilterReader;
 class PageReader;
 class RowGroupMetaData;
+class RowGroupPageIndexReader;
+class RowRanges;
+
+struct PageLocation;
 
 namespace internal {
 class RecordReader;
@@ -48,7 +52,9 @@ class PARQUET_EXPORT RowGroupReader {
   // An implementation of the Contents class is defined in the .cc file
   struct Contents {
     virtual ~Contents() {}
-    virtual std::unique_ptr<PageReader> GetColumnPageReader(int i) = 0;
+    virtual std::unique_ptr<PageReader> GetColumnPageReader(
+        int i, const std::optional<RowRanges>& row_ranges,
+        const std::shared_ptr<RowGroupPageIndexReader>& index_reader) = 0;
     virtual const RowGroupMetaData* metadata() const = 0;
     virtual const ReaderProperties* properties() const = 0;
   };
@@ -81,6 +87,10 @@ class PARQUET_EXPORT RowGroupReader {
       int i, ExposedEncoding encoding_to_expose);
 
   std::unique_ptr<PageReader> GetColumnPageReader(int i);
+
+  std::unique_ptr<PageReader> GetColumnPageReader(
+      int i, const RowRanges& row_ranges,
+      const std::shared_ptr<RowGroupPageIndexReader>& index_reader);
 
  private:
   // Holds a pointer to an instance of Contents implementation

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -50,6 +50,9 @@ enum class ParquetDataPageVersion { V1, V2 };
 /// Align the default buffer size to a small multiple of a page size.
 constexpr int64_t kDefaultBufferSize = 4096 * 4;
 
+/// Merge two io blocks into one when their distance is lower then the threshold.
+constexpr int32_t kDefaultIoMergeThreshold = 4096 * 2;
+
 constexpr int32_t kDefaultThriftStringSizeLimit = 100 * 1000 * 1000;
 // Structs in the thrift definition are relatively large (at least 300 bytes).
 // This limits total memory to the same order of magnitude as
@@ -88,6 +91,11 @@ class PARQUET_EXPORT ReaderProperties {
   /// Set the size of the buffered stream buffer in bytes.
   void set_buffer_size(int64_t size) { buffer_size_ = size; }
 
+  /// Return the threshold of the merging two io blocks.
+  int32_t io_merge_threshold() const { return io_merge_threshold_; }
+  /// Set the threshold of merging two io blocks.
+  void set_io_merge_threshold(int32_t threshold) { io_merge_threshold_ = threshold; }
+
   /// \brief Return the size limit on thrift strings.
   ///
   /// This limit helps prevent space and time bombs in files, but may need to
@@ -123,6 +131,7 @@ class PARQUET_EXPORT ReaderProperties {
  private:
   MemoryPool* pool_;
   int64_t buffer_size_ = kDefaultBufferSize;
+  int32_t io_merge_threshold_ = kDefaultIoMergeThreshold;
   int32_t thrift_string_size_limit_ = kDefaultThriftStringSizeLimit;
   int32_t thrift_container_size_limit_ = kDefaultThriftContainerSizeLimit;
   bool buffered_stream_enabled_ = false;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -59,6 +59,8 @@ constexpr int32_t kDefaultThriftStringSizeLimit = 100 * 1000 * 1000;
 // kDefaultStringSizeLimit.
 constexpr int32_t kDefaultThriftContainerSizeLimit = 1000 * 1000;
 
+using ReadRanges = std::vector<::arrow::io::ReadRange>;
+
 class PARQUET_EXPORT ReaderProperties {
  public:
   explicit ReaderProperties(MemoryPool* pool = ::arrow::default_memory_pool())
@@ -67,7 +69,8 @@ class PARQUET_EXPORT ReaderProperties {
   MemoryPool* memory_pool() const { return pool_; }
 
   std::shared_ptr<ArrowInputStream> GetStream(std::shared_ptr<ArrowInputFile> source,
-                                              int64_t start, int64_t num_bytes);
+                                              int64_t start, int64_t num_bytes,
+                                              const ReadRanges* read_ranges = NULLPTR);
 
   /// Buffered stream reading allows the user to control the memory usage of
   /// parquet readers. This ensure that all `RandomAccessFile::ReadAt` calls are

--- a/cpp/src/parquet/row_ranges.cc
+++ b/cpp/src/parquet/row_ranges.cc
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "row_ranges.h"
+
+namespace parquet {
+
+bool RowRanges::IsOverlapping(int64_t from, int64_t to) const {
+  int low = 0, high = static_cast<int>(ranges_.size() - 1);
+  while (low <= high) {
+    const int mid = low + (high - low) / 2;
+    if (ranges_[mid].to < from) {
+      low = mid + 1;
+    } else if (ranges_[mid].from > to) {
+      high = mid - 1;
+    } else {
+      return true;  // Overlapping
+    }
+  }
+  return false;  // No overlap
+}
+
+} // namespace parquet

--- a/cpp/src/parquet/row_ranges.h
+++ b/cpp/src/parquet/row_ranges.h
@@ -1,0 +1,201 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "parquet/exception.h"
+
+namespace parquet {
+
+class RowRanges {
+ public:
+  /// A range of [from, to]
+  struct Range {
+    int64_t from;
+    int64_t to;
+
+    static Range Union(const Range& left, const Range& right) {
+      if (left.from <= right.from) {
+        if (left.to + 1 >= right.from) {
+          return Range{left.from, std::max(left.to, right.to)};
+        }
+      } else if (right.to + 1 >= left.from) {
+        return Range{right.from, std::max(left.to, right.to)};
+      }
+      return EMPTY_RANGE;
+    }
+
+    static Range Intersection(const Range& left, const Range& right) {
+      if (left.from <= right.from) {
+        if (left.to >= right.from) {
+          return Range{right.from, std::min(left.to, right.to)};
+        }
+      } else if (right.to >= left.from) {
+        return Range{left.from, std::min(left.to, right.to)};
+      }
+      return EMPTY_RANGE;
+    }
+
+    bool IsBefore(Range other) const { return to < other.from; }
+
+    bool IsAfter(Range other) const { return from > other.to; }
+
+    int64_t RowCount() const { return to - from + 1; }
+
+    bool operator==(const Range& other) const {
+      if (from == other.from && to == other.to) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    bool operator!=(const Range& other) const { return !(*this == other); }
+
+    std::string ToString() const {
+      std::stringstream ss;
+      ss << "[" << from << "," << to << "]";
+      return ss.str();
+    }
+  };
+
+  RowRanges() = default;
+
+  explicit RowRanges(const std::vector<Range>& ranges) {
+    if (ranges.empty()) {
+      throw ParquetException("Ranges can't be empty");
+    }
+
+    for (const auto& range : ranges) {
+      Add(range);
+    }
+  }
+
+  /*
+   * Adds a range to the end of the list of ranges. It maintains the disjunct ascending
+   * order(*) of the ranges by trying to union the specified range to the last ranges in
+   * the list. The specified range shall be larger(*) than the last one or might be
+   * overlapped with some of the last ones.
+   * (*) [a, b] < [c, d] if b < c
+   */
+  void Add(const Range& range) {
+    CheckRangeIsValid(range);
+    auto& range_to_add = const_cast<Range&>(range);
+    for (int i = static_cast<int>(ranges_.size() - 1); i >= 0; --i) {
+      Range& last = ranges_[i];
+      if (last.IsAfter(range)) {
+        throw ParquetException("Ranges should be in ascending order");
+      }
+      const Range& u = Range::Union(last, range_to_add);
+      if (u == EMPTY_RANGE) {
+        break;
+      }
+      range_to_add = u;
+      ranges_.pop_back();
+    }
+    ranges_.push_back(range_to_add);
+  }
+
+  const std::vector<Range>& GetRanges() const { return ranges_; }
+
+  const Range& GetRange(int i) const {
+    if (i >= static_cast<int>(ranges_.size())) {
+      throw ParquetException("Index overflow");
+    }
+    return ranges_[i];
+  }
+
+  int64_t GetRowCount() const {
+    int64_t row_count = 0;
+    for (const Range& range : ranges_) {
+      row_count += range.RowCount();
+    }
+    return row_count;
+  }
+
+  bool IsOverlapping(int64_t from, int64_t to) const;
+
+  /**
+   * Calculates the intersection of the two specified RowRanges object. Two ranges
+   * intersect if they have common elements otherwise the result is empty. <pre> For
+   * example: [113, 241] ∩ [221, 340] = [221, 241] while [113, 230] ∩ [231, 340] =
+   * &lt;EMPTY&gt;
+   * </pre>
+   * @param left left RowRanges
+   * @param right right RowRanges
+   * @return a mutable RowRanges contains all the row indexes that were contained in both
+   * of the specified objects
+   */
+  static RowRanges Intersection(const RowRanges& left, const RowRanges& right) {
+    const auto& left_ranges = left.GetRanges();
+    const auto& right_ranges = right.GetRanges();
+    const int num_right_ranges = static_cast<int>(right_ranges.size());
+
+    RowRanges result;
+    int right_index = 0;
+    for (const Range& l : left_ranges) {
+      for (int i = right_index, n = num_right_ranges; i < n; ++i) {
+        Range r = right_ranges[i];
+        if (l.IsBefore(r)) {
+          break;
+        } else if (l.IsAfter(r)) {
+          right_index = i + 1;
+          continue;
+        }
+        result.Add(Range::Intersection(l, r));
+      }
+    }
+
+    return result;
+  }
+
+  bool operator==(const RowRanges& other) const { return ranges_ == other.ranges_; }
+
+  bool operator!=(const RowRanges& other) const { return !(*this == other); }
+
+  std::string ToString() const {
+    std::stringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < ranges_.size(); i++) {
+      if (i == 0) {
+        ss << ranges_[i].ToString();
+      } else {
+        ss << "," << ranges_[i].ToString();
+      }
+    }
+    ss << "]";
+    return ss.str();
+  }
+
+  static constexpr Range EMPTY_RANGE{std::numeric_limits<int64_t>::max(),
+                                     std::numeric_limits<int64_t>::min()};
+
+ private:
+  inline void CheckRangeIsValid(const Range& range) {
+    if (range.from > range.to) {
+      throw ParquetException("Invalid range");
+    }
+  }
+
+  // Should be in asc order
+  std::vector<Range> ranges_;
+};
+
+}  // namespace parquet

--- a/cpp/src/parquet/row_ranges_test.cc
+++ b/cpp/src/parquet/row_ranges_test.cc
@@ -1,0 +1,323 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "gtest/gtest.h"
+
+#include "parquet/exception.h"
+#include "parquet/row_ranges.h"
+
+namespace parquet {
+
+TEST(TestRowRanges, NormalRowRanges) {
+  // Construct with given ranges and continues ranges will be merged
+  {
+    std::vector<RowRanges::Range> ranges;
+    ranges.push_back({0, 0});
+    ranges.push_back({1, 1});
+    ranges.push_back({3, 5});
+    ranges.push_back({9, 15});
+
+    RowRanges row_ranges{std::move(ranges)};
+
+    ranges.clear();
+    ranges.push_back({0, 1});
+    ranges.push_back({3, 5});
+    ranges.push_back({9, 15});
+    ASSERT_TRUE(ranges == row_ranges.GetRanges());
+    ASSERT_EQ(12, row_ranges.GetRowCount());
+  }
+
+  // Construct with add method and continues ranges will be merged
+  {
+    RowRanges row_ranges;
+    row_ranges.Add(RowRanges::Range{0, 0});
+    row_ranges.Add(RowRanges::Range{1, 1});
+    row_ranges.Add(RowRanges::Range{3, 7});
+    row_ranges.Add(RowRanges::Range{9, 11});
+
+    std::vector<RowRanges::Range> ranges;
+    ranges.push_back({0, 1});
+    ranges.push_back({3, 7});
+    ranges.push_back({9, 11});
+    ASSERT_EQ(10, row_ranges.GetRowCount());
+    ASSERT_TRUE(ranges == row_ranges.GetRanges());
+  }
+
+  // Construct with add method and continues ranges will be merged
+  {
+    RowRanges row_ranges;
+    row_ranges.Add(RowRanges::Range{0, 0});
+    row_ranges.Add(RowRanges::Range{1, 1});
+    row_ranges.Add(RowRanges::Range{3, 7});
+    row_ranges.Add(RowRanges::Range{8, 11});
+    row_ranges.Add(RowRanges::Range{12, 15});
+    row_ranges.Add(RowRanges::Range{16, 23});
+    ASSERT_EQ(23, row_ranges.GetRowCount());
+
+    std::vector<RowRanges::Range> ranges;
+    ranges.push_back({0, 1});
+    ranges.push_back({3, 23});
+    ASSERT_TRUE(ranges == row_ranges.GetRanges());
+  }
+
+  // Add same ranges
+  {
+    RowRanges row_ranges;
+
+    RowRanges::Range range = {2, 3};
+    row_ranges.Add(range);
+    row_ranges.Add(range);
+    ASSERT_EQ(1, row_ranges.GetRanges().size());
+    ASSERT_TRUE(range == row_ranges.GetRanges()[0]);
+  }
+
+  // Add overlapped ranges
+  {
+    RowRanges row_ranges;
+    row_ranges.Add(RowRanges::Range{0, 1});
+    row_ranges.Add(RowRanges::Range{9, 25});
+    row_ranges.Add(RowRanges::Range{14, 33});
+    ASSERT_EQ(2, row_ranges.GetRanges().size());
+
+    RowRanges::Range range0{0, 1};
+    RowRanges::Range range1{9, 33};
+    ASSERT_TRUE(range0 == row_ranges.GetRanges()[0]);
+    ASSERT_TRUE(range1 == row_ranges.GetRanges()[1]);
+  }
+
+  // Add overlapped ranges
+  {
+    RowRanges row_ranges;
+    row_ranges.Add(RowRanges::Range{0, 1});
+    row_ranges.Add(RowRanges::Range{9, 25});
+    row_ranges.Add(RowRanges::Range{12, 15});
+    ASSERT_EQ(2, row_ranges.GetRanges().size());
+
+    RowRanges::Range range0{0, 1};
+    RowRanges::Range range1{9, 25};
+    ASSERT_TRUE(range0 == row_ranges.GetRanges()[0]);
+    ASSERT_TRUE(range1 == row_ranges.GetRanges()[1]);
+  }
+}
+
+TEST(TestRowRanges, InvalidRowRanges) {
+  // Construct with empty ranges
+  {
+    std::vector<RowRanges::Range> ranges;
+    ASSERT_THROW(RowRanges{ranges}, ParquetException);
+  }
+
+  // Ranges are not in ascending order
+  {
+    std::vector<RowRanges::Range> ranges;
+    ranges.push_back({0, 1});
+    ranges.push_back({3, 9});
+    ranges.push_back({2, 2});
+    ASSERT_THROW(RowRanges{ranges}, ParquetException);
+  }
+
+  // Construct with illegal range
+  {
+    std::vector<RowRanges::Range> ranges;
+    ranges.push_back({7, 3});
+    ASSERT_THROW(RowRanges{ranges}, ParquetException);
+  }
+
+  // Add small range
+  {
+    RowRanges row_ranges;
+    row_ranges.Add(RowRanges::Range{1, 3});
+    row_ranges.Add(RowRanges::Range{9, 15});
+    ASSERT_THROW(row_ranges.Add(RowRanges::Range{4, 7}), ParquetException);
+  }
+
+  // Add illegal range
+  {
+    RowRanges row_ranges;
+    ASSERT_THROW(row_ranges.Add(RowRanges::Range{7, 3}), ParquetException);
+  }
+}
+
+TEST(TestRowRanges, RangeUnion) {
+  {
+    RowRanges::Range range0{10, 30};
+    RowRanges::Range range1{20, 45};
+
+    RowRanges::Range result{10, 45};
+    ASSERT_TRUE(result == RowRanges::Range::Union(range0, range1));
+  }
+
+  {
+    RowRanges::Range range0{10, 30};
+    RowRanges::Range range1{35, 45};
+
+    ASSERT_TRUE(RowRanges::EMPTY_RANGE == RowRanges::Range::Union(range0, range1));
+  }
+}
+
+TEST(TestRowRanges, RangeIntersection) {
+  {
+    RowRanges::Range range0{10, 30};
+    RowRanges::Range range1{20, 45};
+
+    RowRanges::Range result{20, 30};
+    ASSERT_TRUE(result == RowRanges::Range::Intersection(range0, range1));
+  }
+
+  {
+    RowRanges::Range range0{10, 30};
+    RowRanges::Range range1{35, 45};
+
+    ASSERT_TRUE(RowRanges::EMPTY_RANGE == RowRanges::Range::Intersection(range0, range1));
+  }
+}
+
+TEST(TestRowRanges, IsOverlapping) {
+  std::vector<RowRanges::Range> ranges;
+  ranges.push_back({1, 15});
+  ranges.push_back({23, 39});
+  ranges.push_back({29, 44});
+
+  // {1, 15}, {23, 44}
+  RowRanges row_ranges{std::move(ranges)};
+
+  ASSERT_TRUE(row_ranges.IsOverlapping(1, 1));
+  ASSERT_TRUE(row_ranges.IsOverlapping(15, 15));
+  ASSERT_TRUE(row_ranges.IsOverlapping(23, 23));
+  ASSERT_TRUE(row_ranges.IsOverlapping(44, 44));
+
+  ASSERT_TRUE(row_ranges.IsOverlapping(10, 10));
+  ASSERT_TRUE(row_ranges.IsOverlapping(30, 30));
+
+  ASSERT_TRUE(row_ranges.IsOverlapping(3, 15));
+  ASSERT_TRUE(row_ranges.IsOverlapping(15, 23));
+  ASSERT_TRUE(row_ranges.IsOverlapping(5, 20));
+  ASSERT_TRUE(row_ranges.IsOverlapping(20, 25));
+  ASSERT_TRUE(row_ranges.IsOverlapping(20, 50));
+  ASSERT_TRUE(row_ranges.IsOverlapping(10, 50));
+  ASSERT_TRUE(row_ranges.IsOverlapping(40, 56));
+  ASSERT_TRUE(row_ranges.IsOverlapping(30, 38));
+
+  ASSERT_FALSE(row_ranges.IsOverlapping(0, 0));
+  ASSERT_FALSE(row_ranges.IsOverlapping(16, 16));
+  ASSERT_FALSE(row_ranges.IsOverlapping(22, 22));
+  ASSERT_FALSE(row_ranges.IsOverlapping(45, 45));
+  ASSERT_FALSE(row_ranges.IsOverlapping(16, 22));
+  ASSERT_FALSE(row_ranges.IsOverlapping(17, 17));
+  ASSERT_FALSE(row_ranges.IsOverlapping(45, 100));
+}
+
+TEST(TestRowRanges, Intersection) {
+  RowRanges row_ranges0;
+  row_ranges0.Add({113, 241});
+  row_ranges0.Add({550, 667});
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({101, 113});
+    row_ranges1.Add({241, 333});
+
+    RowRanges result;
+    result.Add({113, 113});
+    result.Add({241, 241});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({101, 113});
+    row_ranges1.Add({309, 550});
+
+    RowRanges result;
+    result.Add({113, 113});
+    result.Add({550, 550});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({241, 289});
+    row_ranges1.Add({309, 550});
+
+    RowRanges result;
+    result.Add({241, 241});
+    result.Add({550, 550});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({309, 550});
+    row_ranges1.Add({667, 706});
+
+    RowRanges result;
+    result.Add({550, 550});
+    result.Add({667, 667});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({667, 706});
+    row_ranges1.Add({997, 1023});
+
+    RowRanges result;
+    result.Add({667, 667});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({10, 197});
+    row_ranges1.Add({278, 403});
+
+    RowRanges result;
+    result.Add({113, 197});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({10, 197});
+    row_ranges1.Add({278, 601});
+
+    RowRanges result;
+    result.Add({113, 197});
+    result.Add({550, 601});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({10, 1003});
+
+    RowRanges result;
+    result.Add({113, 241});
+    result.Add({550, 667});
+    ASSERT_TRUE(result == RowRanges::Intersection(row_ranges0, row_ranges1));
+  }
+
+  {
+    RowRanges row_ranges1;
+    row_ranges1.Add({273, 498});
+    row_ranges1.Add({703, 1021});
+    ASSERT_TRUE(
+        0 == RowRanges::Intersection(row_ranges0, row_ranges1).GetRanges().size());
+  }
+}
+
+} // namespace parquet


### PR DESCRIPTION
### Rationale for this change

FileReader supports reading data based on specified RowRanges to provide the most fundamental Filter pushdown capability to various upper-level computing engines.  More details please refer to https://github.com/apache/arrow/issues/39392.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39392