### PR TITLE
GH-39387: [C++] Mark debug-only variables as unused

### DIFF
--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -449,7 +449,8 @@ struct ARROW_EXPORT ArraySpan {
   /// \return A span<const T> of the requested length
   template <typename T>
   util::span<const T> GetSpan(int i, int64_t length) const {
-    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
+    [[maybe_unused]] const int64_t buffer_length =
+        buffers[i].size / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
     return util::span<const T>(buffers[i].data_as<T>() + this->offset, length);
   }
@@ -464,7 +465,8 @@ struct ARROW_EXPORT ArraySpan {
   /// \return A span<T> of the requested length
   template <typename T>
   util::span<T> GetSpan(int i, int64_t length) {
-    const int64_t buffer_length = buffers[i].size / static_cast<int64_t>(sizeof(T));
+    [[maybe_unused]] const int64_t buffer_length =
+        buffers[i].size / static_cast<int64_t>(sizeof(T));
     assert(i > 0 && length + offset <= buffer_length);
     return util::span<T>(buffers[i].mutable_data_as<T>() + this->offset, length);
   }


### PR DESCRIPTION
### Rationale for this change

The variables is used for a debug-build-only assertion.

### What changes are included in this PR?

Adding an annotation that makes the compiler OK with the variable being unused in builds without asserts.

### Are these changes tested?

N/A.

* Closes: #39387