### PR TITLE
GH-39421: [CI][Ruby] Update to using Ubuntu 22.04 on test-ruby and test-c-glib nightly jobs

### DIFF
--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -53,7 +53,7 @@ RUN luarocks install lgi
 # ERROR: Command errored out with exit status 1: /usr/bin/python3 /usr/share/python-wheels/pep517-0.7.0-py2.py3-none-any.whl/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpsk4jveay Check the logs for full command output.
 RUN (python3 -m pip install meson || \
          python3 -m pip install --no-use-pep517 meson) && \
-    gem install --no-document bundler -v 2.4.22
+    gem install --no-document bundler
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN bundle install --gemfile /arrow/c_glib/Gemfile

--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -53,7 +53,7 @@ RUN luarocks install lgi
 # ERROR: Command errored out with exit status 1: /usr/bin/python3 /usr/share/python-wheels/pep517-0.7.0-py2.py3-none-any.whl/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpsk4jveay Check the logs for full command output.
 RUN (python3 -m pip install meson || \
          python3 -m pip install --no-use-pep517 meson) && \
-    gem install --no-document bundler
+    gem install --no-document bundler -v 2.4.22
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN bundle install --gemfile /arrow/c_glib/Gemfile

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1032,6 +1032,8 @@ tasks:
     ci: github
     template: docker-tests/github.linux.yml
     params:
+      env:
+        UBUNTU: 22.04
       image: {{ image }}
 {% endfor %}
 


### PR DESCRIPTION
### Rationale for this change
CI Jobs for Ruby and c-glib are failing on Ubuntu due to bundler failing to install on old Ruby.

### What changes are included in this PR?

Use Ubuntu 22.04 on those jobs.

### Are these changes tested?

Via Archery

### Are there any user-facing changes?
No
* Closes: #39421