### PR TITLE
GH-39645: [Python] Fix read_table for encrypted parquet

### DIFF
--- a/python/pyarrow/_dataset_parquet.pxd
+++ b/python/pyarrow/_dataset_parquet.pxd
@@ -29,6 +29,7 @@ cdef class ParquetFragmentScanOptions(FragmentScanOptions):
     cdef:
         CParquetFragmentScanOptions* parquet_options
         object _parquet_decryption_config
+        object _decryption_properties
 
     cdef void init(self, const shared_ptr[CFragmentScanOptions]& sp)
     cdef CReaderProperties* reader_properties(self)

--- a/python/pyarrow/_dataset_parquet_encryption.pyx
+++ b/python/pyarrow/_dataset_parquet_encryption.pyx
@@ -162,6 +162,14 @@ def set_encryption_config(
     opts.parquet_options.parquet_encryption_config = c_config
 
 
+def set_decryption_properties(
+    ParquetFragmentScanOptions opts not None,
+    FileDecryptionProperties config not None
+):
+    cdef CReaderProperties* reader_props = opts.reader_properties()
+    reader_props.file_decryption_properties(config.unwrap())
+
+
 def set_decryption_config(
     ParquetFragmentScanOptions opts not None,
     ParquetDecryptionConfig config not None

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1299,8 +1299,8 @@ Examples
                 f"local file systems, not {type(filesystem)}"
             )
 
-        # check for BufferReader object
-        buffer_reader = None
+        # check for single fragment dataset or dataset directory
+        single_file = None
         self._base_dir = None
         if not isinstance(path_or_paths, list):
             if _is_path_like(path_or_paths):
@@ -1316,12 +1316,12 @@ Examples
                 if finfo.type == FileType.Directory:
                     self._base_dir = path_or_paths
             else:
-                buffer_reader = path_or_paths
+                single_file = path_or_paths
 
         parquet_format = ds.ParquetFileFormat(**read_options)
 
-        if buffer_reader is not None:
-            fragment = parquet_format.make_fragment(buffer_reader, filesystem)
+        if single_file is not None:
+            fragment = parquet_format.make_fragment(single_file, filesystem)
 
             self._dataset = ds.FileSystemDataset(
                 [fragment], schema=schema or fragment.physical_schema,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1300,7 +1300,7 @@ Examples
             )
 
         # check for single fragment dataset
-        single_file = None
+        buffer_reader = None
         self._base_dir = None
         if not isinstance(path_or_paths, list):
             if _is_path_like(path_or_paths):
@@ -1313,17 +1313,15 @@ Examples
                     except ValueError:
                         filesystem = LocalFileSystem(use_mmap=memory_map)
                 finfo = filesystem.get_file_info(path_or_paths)
-                if finfo.is_file:
-                    single_file = path_or_paths
                 if finfo.type == FileType.Directory:
                     self._base_dir = path_or_paths
             else:
-                single_file = path_or_paths
+                buffer_reader = path_or_paths
 
         parquet_format = ds.ParquetFileFormat(**read_options)
 
-        if single_file is not None:
-            fragment = parquet_format.make_fragment(single_file, filesystem)
+        if buffer_reader is not None:
+            fragment = parquet_format.make_fragment(buffer_reader, filesystem)
 
             self._dataset = ds.FileSystemDataset(
                 [fragment], schema=schema or fragment.physical_schema,
@@ -1771,6 +1769,7 @@ def read_table(source, *, columns=None, use_threads=True,
             ignore_prefixes=ignore_prefixes,
             pre_buffer=pre_buffer,
             coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
+            decryption_properties=decryption_properties,
             thrift_string_size_limit=thrift_string_size_limit,
             thrift_container_size_limit=thrift_container_size_limit,
             page_checksum_verification=page_checksum_verification,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1299,7 +1299,7 @@ Examples
                 f"local file systems, not {type(filesystem)}"
             )
 
-        # check for single fragment dataset
+        # check for BufferReader object
         buffer_reader = None
         self._base_dir = None
         if not isinstance(path_or_paths, list):

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -101,6 +101,42 @@ def write_encrypted_file(path, data_table, footer_key_name, col_key_name,
                             kms_connection_config, crypto_factory)
 
 
+def setup_encryption_environment(custom_kms_conf):
+    """
+    Sets up and returns the KMS connection configuration and crypto factory
+    based on provided KMS configuration parameters.
+    """
+    kms_connection_config = pe.KmsConnectionConfig(custom_kms_conf=custom_kms_conf)
+
+    def kms_factory(kms_connection_configuration):
+        return InMemoryKmsClient(kms_connection_configuration)
+
+    # Create our CryptoFactory
+    crypto_factory = pe.CryptoFactory(kms_factory)
+
+    return kms_connection_config, crypto_factory
+
+
+def write_encrypted_file(path, data_table, footer_key_name, col_key_name,
+                         footer_key, col_key, encryption_config):
+    """
+    Writes an encrypted parquet file based on the provided parameters.
+    """
+    # Setup the custom KMS configuration with provided keys
+    custom_kms_conf = {
+        footer_key_name: footer_key.decode("UTF-8"),
+        col_key_name: col_key.decode("UTF-8"),
+    }
+
+    # Setup encryption environment
+    kms_connection_config, crypto_factory = setup_encryption_environment(
+        custom_kms_conf)
+
+    # Write the encrypted parquet file
+    write_encrypted_parquet(path, data_table, encryption_config,
+                            kms_connection_config, crypto_factory)
+
+
 def test_encrypted_parquet_write_read(tempdir, data_table):
     """Write an encrypted parquet, verify it's encrypted, and then read it."""
     path = tempdir / PARQUET_NAME
@@ -120,7 +156,16 @@ def test_encrypted_parquet_write_read(tempdir, data_table):
     write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
                          FOOTER_KEY, COL_KEY, encryption_config)
 
+    write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
+                         FOOTER_KEY, COL_KEY, encryption_config)
+
     verify_file_encrypted(path)
+
+    # Setup for reading
+    kms_connection_config, crypto_factory = setup_encryption_environment({
+        FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
+        COL_KEY_NAME: COL_KEY.decode("UTF-8"),
+    })
 
     # Setup for reading
     kms_connection_config, crypto_factory = setup_encryption_environment({
@@ -132,8 +177,10 @@ def test_encrypted_parquet_write_read(tempdir, data_table):
     decryption_config = pe.DecryptionConfiguration(
         cache_lifetime=timedelta(minutes=5.0))
 
+
     result_table = read_encrypted_parquet(
         path, decryption_config, kms_connection_config, crypto_factory)
+
 
     assert data_table.equals(result_table)
 
@@ -539,6 +586,12 @@ def test_read_with_deleted_crypto_factory(tempdir, data_table, basic_encryption_
                             kms_connection_config, encryption_crypto_factory)
     verify_file_encrypted(path)
 
+    # Setup for reading with decryption properties
+    kms_connection_config, crypto_factory = setup_encryption_environment({
+        FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
+        COL_KEY_NAME: COL_KEY.decode("UTF-8"),
+    })
+
     # Use a local function to get decryption properties, so the crypto factory that
     # creates the properties will be deleted after it returns.
     def get_decryption_properties():
@@ -556,38 +609,22 @@ def test_read_with_deleted_crypto_factory(tempdir, data_table, basic_encryption_
 
 def test_encrypted_parquet_read_table(tempdir, data_table, basic_encryption_config):
     """Write an encrypted parquet then read it back using read_table."""
-    path = tempdir / 'encrypted_table_read_table.parquet'
+    path = tempdir / PARQUET_NAME
 
-    # Encryption configuration
-    encryption_config = basic_encryption_config
+    # Write the encrypted parquet file using the utility function
+    write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
+                         FOOTER_KEY, COL_KEY, basic_encryption_config)
 
-    # KMS Connection Configuration
-    kms_connection_config = pe.KmsConnectionConfig(
-        custom_kms_conf={
-            FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
-            COL_KEY_NAME: COL_KEY.decode("UTF-8"),
-        }
-    )
+    # Setup for reading with decryption properties
+    kms_connection_config, crypto_factory = setup_encryption_environment({
+        FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
+        COL_KEY_NAME: COL_KEY.decode("UTF-8"),
+    })
 
-    def kms_factory(kms_connection_configuration):
-        return InMemoryKmsClient(kms_connection_configuration)
-
-    # create our CryptoFactory
-    crypto_factory = pe.CryptoFactory(kms_factory)
-
-    # Write the encrypted parquet file
-    write_encrypted_parquet(path, data_table, encryption_config,
-                            kms_connection_config, crypto_factory)
-
-    # Setup decryption configuration
     decryption_config = pe.DecryptionConfiguration(
         cache_lifetime=timedelta(minutes=5.0))
-
-    # Setup file decryption properties
     file_decryption_properties = crypto_factory.file_decryption_properties(
         kms_connection_config, decryption_config)
-
-    assert file_decryption_properties is not None
 
     # Read the encrypted parquet file using read_table
     result_table = pq.read_table(path, decryption_properties=file_decryption_properties)

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -65,6 +65,42 @@ def basic_encryption_config():
     return basic_encryption_config
 
 
+def setup_encryption_environment(custom_kms_conf):
+    """
+    Sets up and returns the KMS connection configuration and crypto factory
+    based on provided KMS configuration parameters.
+    """
+    kms_connection_config = pe.KmsConnectionConfig(custom_kms_conf=custom_kms_conf)
+
+    def kms_factory(kms_connection_configuration):
+        return InMemoryKmsClient(kms_connection_configuration)
+
+    # Create our CryptoFactory
+    crypto_factory = pe.CryptoFactory(kms_factory)
+
+    return kms_connection_config, crypto_factory
+
+
+def write_encrypted_file(path, data_table, footer_key_name, col_key_name,
+                         footer_key, col_key, encryption_config):
+    """
+    Writes an encrypted parquet file based on the provided parameters.
+    """
+    # Setup the custom KMS configuration with provided keys
+    custom_kms_conf = {
+        footer_key_name: footer_key.decode("UTF-8"),
+        col_key_name: col_key.decode("UTF-8"),
+    }
+
+    # Setup encryption environment
+    kms_connection_config, crypto_factory = setup_encryption_environment(
+        custom_kms_conf)
+
+    # Write the encrypted parquet file
+    write_encrypted_parquet(path, data_table, encryption_config,
+                            kms_connection_config, crypto_factory)
+
+
 def test_encrypted_parquet_write_read(tempdir, data_table):
     """Write an encrypted parquet, verify it's encrypted, and then read it."""
     path = tempdir / PARQUET_NAME
@@ -81,27 +117,24 @@ def test_encrypted_parquet_write_read(tempdir, data_table):
         cache_lifetime=timedelta(minutes=5.0),
         data_key_length_bits=256)
 
-    kms_connection_config = pe.KmsConnectionConfig(
-        custom_kms_conf={
-            FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
-            COL_KEY_NAME: COL_KEY.decode("UTF-8"),
-        }
-    )
+    write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
+                         FOOTER_KEY, COL_KEY, encryption_config)
 
-    def kms_factory(kms_connection_configuration):
-        return InMemoryKmsClient(kms_connection_configuration)
-
-    crypto_factory = pe.CryptoFactory(kms_factory)
-    # Write with encryption properties
-    write_encrypted_parquet(path, data_table, encryption_config,
-                            kms_connection_config, crypto_factory)
     verify_file_encrypted(path)
+
+    # Setup for reading
+    kms_connection_config, crypto_factory = setup_encryption_environment({
+        FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
+        COL_KEY_NAME: COL_KEY.decode("UTF-8"),
+    })
 
     # Read with decryption properties
     decryption_config = pe.DecryptionConfiguration(
         cache_lifetime=timedelta(minutes=5.0))
+
     result_table = read_encrypted_parquet(
         path, decryption_config, kms_connection_config, crypto_factory)
+
     assert data_table.equals(result_table)
 
 
@@ -150,36 +183,22 @@ def test_encrypted_parquet_write_read_wrong_key(tempdir, data_table):
         cache_lifetime=timedelta(minutes=5.0),
         data_key_length_bits=256)
 
-    kms_connection_config = pe.KmsConnectionConfig(
-        custom_kms_conf={
-            FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
-            COL_KEY_NAME: COL_KEY.decode("UTF-8"),
-        }
-    )
+    write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
+                         FOOTER_KEY, COL_KEY, encryption_config)
 
-    def kms_factory(kms_connection_configuration):
-        return InMemoryKmsClient(kms_connection_configuration)
-
-    crypto_factory = pe.CryptoFactory(kms_factory)
-    # Write with encryption properties
-    write_encrypted_parquet(path, data_table, encryption_config,
-                            kms_connection_config, crypto_factory)
     verify_file_encrypted(path)
 
-    # Read with decryption properties
-    wrong_kms_connection_config = pe.KmsConnectionConfig(
-        custom_kms_conf={
-            # Wrong keys - mixup in names
-            FOOTER_KEY_NAME: COL_KEY.decode("UTF-8"),
-            COL_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
-        }
-    )
+    wrong_kms_connection_config, wrong_crypto_factory = setup_encryption_environment({
+        FOOTER_KEY_NAME: COL_KEY.decode("UTF-8"),  # Intentionally wrong
+        COL_KEY_NAME: FOOTER_KEY.decode("UTF-8"),  # Intentionally wrong
+    })
+
     decryption_config = pe.DecryptionConfiguration(
         cache_lifetime=timedelta(minutes=5.0))
     with pytest.raises(ValueError, match=r"Incorrect master key used"):
         read_encrypted_parquet(
             path, decryption_config, wrong_kms_connection_config,
-            crypto_factory)
+            wrong_crypto_factory)
 
 
 def test_encrypted_parquet_read_no_decryption_config(tempdir, data_table):
@@ -219,23 +238,12 @@ def test_encrypted_parquet_write_no_col_key(tempdir, data_table):
     encryption_config = pe.EncryptionConfiguration(
         footer_key=FOOTER_KEY_NAME)
 
-    kms_connection_config = pe.KmsConnectionConfig(
-        custom_kms_conf={
-            FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
-            COL_KEY_NAME: COL_KEY.decode("UTF-8"),
-        }
-    )
-
-    def kms_factory(kms_connection_configuration):
-        return InMemoryKmsClient(kms_connection_configuration)
-
-    crypto_factory = pe.CryptoFactory(kms_factory)
     with pytest.raises(OSError,
                        match="Either column_keys or uniform_encryption "
                        "must be set"):
         # Write with encryption properties
-        write_encrypted_parquet(path, data_table, encryption_config,
-                                kms_connection_config, crypto_factory)
+        write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
+                             FOOTER_KEY, b"", encryption_config)
 
 
 def test_encrypted_parquet_write_kms_error(tempdir, data_table,
@@ -442,25 +450,15 @@ def test_encrypted_parquet_write_read_plain_footer_single_wrapping(
         plaintext_footer=True,
         double_wrapping=False)
 
-    kms_connection_config = pe.KmsConnectionConfig(
-        custom_kms_conf={
-            FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
-            COL_KEY_NAME: COL_KEY.decode("UTF-8"),
-        }
-    )
+    write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
+                         FOOTER_KEY, COL_KEY, encryption_config)
 
-    def kms_factory(kms_connection_configuration):
-        return InMemoryKmsClient(kms_connection_configuration)
+    verify_file_encrypted(path)
 
-    crypto_factory = pe.CryptoFactory(kms_factory)
-    # Write with encryption properties
-    write_encrypted_parquet(path, data_table, encryption_config,
-                            kms_connection_config, crypto_factory)
+    result_table = pq.read_table(path, columns=['c'])
 
-    # # Read without decryption properties only the plaintext column
-    # result = pq.ParquetFile(path)
-    # result_table = result.read(columns='c', use_threads=False)
-    # assert table.num_rows == result_table.num_rows
+    # Verify that only the plaintext column 'c' is correctly read
+    assert data_table.column('c').equals(result_table.column('c'))
 
 
 @pytest.mark.xfail(reason="External key material not supported yet")
@@ -497,37 +495,25 @@ def test_encrypted_parquet_loop(tempdir, data_table, basic_encryption_config):
 
     # Encrypt the footer with the footer key,
     # encrypt column `a` and column `b` with another key,
-    # keep `c` plaintext
-    encryption_config = basic_encryption_config
+    # keep `c` plaintext, defined in basic_encryption_config
+    write_encrypted_file(path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME,
+                         FOOTER_KEY, COL_KEY, basic_encryption_config)
 
-    kms_connection_config = pe.KmsConnectionConfig(
-        custom_kms_conf={
-            FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
-            COL_KEY_NAME: COL_KEY.decode("UTF-8"),
-        }
-    )
-
-    def kms_factory(kms_connection_configuration):
-        return InMemoryKmsClient(kms_connection_configuration)
-
-    crypto_factory = pe.CryptoFactory(kms_factory)
-
-    # Write with encryption properties
-    write_encrypted_parquet(path, data_table, encryption_config,
-                            kms_connection_config, crypto_factory)
     verify_file_encrypted(path)
+
+    # Setup for reading with decryption properties
+    kms_connection_config, crypto_factory = setup_encryption_environment({
+        FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
+        COL_KEY_NAME: COL_KEY.decode("UTF-8"),
+    })
 
     decryption_config = pe.DecryptionConfiguration(
         cache_lifetime=timedelta(minutes=5.0))
+    file_decryption_properties = crypto_factory.file_decryption_properties(
+        kms_connection_config, decryption_config)
 
     for i in range(50):
-        # Read with decryption properties
-        file_decryption_properties = crypto_factory.file_decryption_properties(
-            kms_connection_config, decryption_config)
-        assert file_decryption_properties is not None
-
-        result = pq.ParquetFile(
-            path, decryption_properties=file_decryption_properties)
+        result = pq.ParquetFile(path, decryption_properties=file_decryption_properties)
         result_table = result.read(use_threads=True)
         assert data_table.equals(result_table)
 
@@ -565,4 +551,46 @@ def test_read_with_deleted_crypto_factory(tempdir, data_table, basic_encryption_
     result = pq.ParquetFile(
         path, decryption_properties=get_decryption_properties())
     result_table = result.read(use_threads=True)
+    assert data_table.equals(result_table)
+
+
+def test_encrypted_parquet_read_table(tempdir, data_table, basic_encryption_config):
+    """Write an encrypted parquet then read it back using read_table."""
+    path = tempdir / 'encrypted_table_read_table.parquet'
+
+    # Encryption configuration
+    encryption_config = basic_encryption_config
+
+    # KMS Connection Configuration
+    kms_connection_config = pe.KmsConnectionConfig(
+        custom_kms_conf={
+            FOOTER_KEY_NAME: FOOTER_KEY.decode("UTF-8"),
+            COL_KEY_NAME: COL_KEY.decode("UTF-8"),
+        }
+    )
+
+    def kms_factory(kms_connection_configuration):
+        return InMemoryKmsClient(kms_connection_configuration)
+
+    # create our CryptoFactory
+    crypto_factory = pe.CryptoFactory(kms_factory)
+
+    # Write the encrypted parquet file
+    write_encrypted_parquet(path, data_table, encryption_config,
+                            kms_connection_config, crypto_factory)
+
+    # Setup decryption configuration
+    decryption_config = pe.DecryptionConfiguration(
+        cache_lifetime=timedelta(minutes=5.0))
+
+    # Setup file decryption properties
+    file_decryption_properties = crypto_factory.file_decryption_properties(
+        kms_connection_config, decryption_config)
+
+    assert file_decryption_properties is not None
+
+    # Read the encrypted parquet file using read_table
+    result_table = pq.read_table(path, decryption_properties=file_decryption_properties)
+
+    # Assert that the read table matches the original data
     assert data_table.equals(result_table)

--- a/python/pyarrow/tests/test_dataset_encryption.py
+++ b/python/pyarrow/tests/test_dataset_encryption.py
@@ -142,6 +142,18 @@ def test_dataset_encryption_decryption():
 
     assert table.equals(dataset.to_table())
 
+    # set decryption properties for parquet fragment scan options
+    decryption_properties = crypto_factory.file_decryption_properties(
+        kms_connection_config, decryption_config)
+    pq_scan_opts = ds.ParquetFragmentScanOptions(
+        decryption_properties=decryption_properties
+    )
+
+    pformat = pa.dataset.ParquetFileFormat(default_fragment_scan_options=pq_scan_opts)
+    dataset = ds.dataset("sample_dataset", format=pformat, filesystem=mockfs)
+
+    assert table.equals(dataset.to_table())
+
 
 @pytest.mark.skipif(
     not encryption_unavailable, reason="Parquet Encryption is currently enabled"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Currently, if you try to read a decrypted parquet with read_table, passing decryption_properties - in the happy path (pyarrow.data available for import) the reading/decryption of the file fails, as the decryption properties are missing.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Pass through the argument that was intended to have been passed.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

We have tested this locally on an encrypted parquet dataset - please advise on any further testing you would like beyond that and the standard CI.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Not in any cases where their code was previously working? The intended behaviour for encrypted dataset decryption should start working.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39645