### PR TITLE
GH-39439 [C++][Gandiva] Add regexp_like

### DIFF
--- a/cpp/src/gandiva/function_holder_maker_registry.cc
+++ b/cpp/src/gandiva/function_holder_maker_registry.cc
@@ -63,6 +63,7 @@ FunctionHolderMakerRegistry::MakerMap FunctionHolderMakerRegistry::DefaultHolder
       {"rand", HolderMaker<RandomGeneratorHolder>},
       {"regexp_replace", HolderMaker<ReplaceHolder>},
       {"regexp_extract", HolderMaker<ExtractHolder>},
+      {"regexp_like", HolderMaker<RegexpLikeHolder>},
       {"castintervalday", HolderMaker<IntervalDaysHolder>},
       {"castintervalyear", HolderMaker<IntervalYearsHolder>}};
   return maker_map;

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -541,7 +541,13 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      kResultNullIfNull, "mask_utf8_utf8", NativeFunction::kNeedsContext),
 
       NativeFunction("mask", {}, DataTypeVector{utf8()}, utf8(), kResultNullIfNull,
-                     "mask_utf8", NativeFunction::kNeedsContext)};
+                     "mask_utf8", NativeFunction::kNeedsContext),
+      NativeFunction("regexp_like", {}, DataTypeVector{utf8(), utf8()}, boolean(),
+                     kResultNullIfNull, "gdv_fn_regexp_like_utf8_utf8",
+                     NativeFunction::kNeedsFunctionHolder),
+      NativeFunction("regexp_like", {}, DataTypeVector{utf8(), utf8(), utf8()}, boolean(),
+                     kResultNullIfNull, "gdv_fn_regexp_like_utf8_utf8_utf8",
+                     NativeFunction::kNeedsFunctionHolder)};
   return string_fn_registry_;
 }
 

--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -384,4 +384,15 @@ const char* mask_utf8_utf8(int64_t context, const char* in, int32_t length,
 
 GANDIVA_EXPORT
 const char* mask_utf8(int64_t context, const char* in, int32_t length, int32_t* out_len);
+
+GANDIVA_EXPORT
+bool gdv_fn_regexp_like_utf8_uft8(int64_t holder_ptr, const char* source_string,
+                                  int32_t source_len, const char* pattern,
+                                  int32_t pattern_len);
+
+GANDIVA_EXPORT
+bool gdv_fn_regexp_like_utf8_uft8_utf8(int64_t holder_ptr, const char* source_string,
+                                       int32_t source_len, const char* pattern,
+                                       int32_t pattern_len, const char* match_parameter,
+                                       int32_t parameter_len);
 }

--- a/cpp/src/gandiva/gdv_string_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_string_function_stubs.cc
@@ -755,6 +755,23 @@ const char* translate_utf8_utf8_utf8(int64_t context, const char* in, int32_t in
   *out_len = result_len;
   return result;
 }
+
+bool gdv_fn_regexp_like_utf8_uft8(int64_t holder_ptr, const char* source_string,
+                                  int32_t source_len, const char* pattern,
+                                  int32_t pattern_len) {
+  gandiva::RegexpLikeHolder* holder =
+      reinterpret_cast<gandiva::RegexpLikeHolder*>(holder_ptr);
+  return (*holder)(source_string, source_len);
+}
+
+bool gdv_fn_regexp_like_utf8_uft8_utf8(int64_t holder_ptr, const char* source_string,
+                                       int32_t source_len, const char* pattern,
+                                       int32_t pattern_len, const char* match_parameter,
+                                       int32_t parameter_len) {
+  gandiva::RegexpLikeHolder* holder =
+      reinterpret_cast<gandiva::RegexpLikeHolder*>(holder_ptr);
+  return (*holder)(source_string, source_len);
+}
 }
 
 namespace gandiva {
@@ -986,6 +1003,32 @@ arrow::Status ExportedStringFunctions::AddMappings(Engine* engine) const {
   engine->AddGlobalMappingForFunc("translate_utf8_utf8_utf8",
                                   types->i8_ptr_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(translate_utf8_utf8_utf8));
+
+  // gdv_fn_regexp_like_utf8_utf8
+  args = {
+      types->i64_type(),     // int64_t holder_ptr
+      types->i8_ptr_type(),  // const char* source_string
+      types->i32_type(),     // int source_string_len
+      types->i8_ptr_type(),  // const char* pattern
+      types->i32_type()      // int pattern_len
+  };
+  engine->AddGlobalMappingForFunc("gdv_fn_regexp_like_utf8_utf8",
+                                  types->i1_type() /*return_type*/, args,
+                                  reinterpret_cast<void*>(gdv_fn_regexp_like_utf8_uft8));
+
+  // gdv_fn_regexp_like_utf8_utf8_utf8
+  args = {
+      types->i64_type(),     // int64_t holder_ptr
+      types->i8_ptr_type(),  // const char* source_string
+      types->i32_type(),     // int source_string_len
+      types->i8_ptr_type(),  // const char* pattern
+      types->i32_type(),     // int pattern_len
+      types->i8_ptr_type(),  // const char* match_parameter
+      types->i32_type()      // int pattern_len
+  };
+  engine->AddGlobalMappingForFunc(
+      "gdv_fn_regexp_like_utf8_utf8_utf8", types->i1_type() /*return_type*/, args,
+      reinterpret_cast<void*>(gdv_fn_regexp_like_utf8_uft8_utf8));
   return arrow::Status::OK();
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/regex_functions_holder.h
+++ b/cpp/src/gandiva/regex_functions_holder.h
@@ -150,4 +150,27 @@ class GANDIVA_EXPORT ExtractHolder : public FunctionHolder {
   int32_t num_groups_pattern_;  // number of groups that user defined inside the regex
 };
 
+class GANDIVA_EXPORT RegexpLikeHolder : public FunctionHolder {
+ public:
+  ~RegexpLikeHolder() override = default;
+
+  static Result<std::shared_ptr<RegexpLikeHolder>> Make(const FunctionNode& node);
+
+  static Result<std::shared_ptr<RegexpLikeHolder>> Make(
+      const std::string& regex_pattern, bool used_match_parameter,
+      const std::string& match_parameter);
+
+  bool operator()(const char* source_string, int32_t source_string_len) {
+    std::string source_str(source_string, source_string_len);
+    return RE2::PartialMatch(source_str, regexp_);
+  }
+
+ private:
+  explicit RegexpLikeHolder(const std::string& pattern, RE2::Options regex_op)
+      : regex_pattern_(pattern), regexp_(pattern, regex_op) {}
+
+  std::string regex_pattern_;
+  RE2 regexp_;
+};
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -449,4 +449,82 @@ TEST_F(TestFilter, TestLike) {
   EXPECT_ARROW_ARRAY_EQUALS(exp, selection_vector->ToArray());
 }
 
+TEST_F(TestFilter, TestRegexpLike) {
+  // schema for input fields
+  auto field0 = field("f0", utf8());
+  auto schema = arrow::schema({field0});
+
+  auto node_f0 = TreeExprBuilder::MakeField(field0);
+  auto literal_pattern = TreeExprBuilder::MakeStringLiteral("abc");
+  auto like_func =
+      TreeExprBuilder::MakeFunction("regexp_like", {node_f0, literal_pattern}, boolean());
+
+  auto condition = TreeExprBuilder::MakeCondition(like_func);
+
+  std::shared_ptr<Filter> filter;
+  auto status = Filter::Make(schema, condition, TestConfiguration(), &filter);
+  EXPECT_TRUE(status.ok());
+
+  // Create a row-batch with some sample data
+  int num_records = 5;
+  auto array0 = MakeArrowArrayUtf8({"abc-xyz", "hello", "bye", "abc-x", "abc-xyzw"},
+                                   {true, true, true, true, true});
+
+  // expected output (indices for which condition matches)
+  auto exp = MakeArrowArrayUint16({0, 3, 4});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});
+
+  std::shared_ptr<SelectionVector> selection_vector;
+  status = SelectionVector::MakeInt16(num_records, pool_, &selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Evaluate expression
+  status = filter->Evaluate(*in_batch, selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp, selection_vector->ToArray());
+}
+
+TEST_F(TestFilter, TestRegexpLikeUseParameter) {
+  auto field0 = field("f0", utf8());
+  auto schema = arrow::schema({field0});
+
+  auto node_f0 = TreeExprBuilder::MakeField(field0);
+  auto literal_pattern = TreeExprBuilder::MakeStringLiteral("ABC");
+  auto literal_parameter = TreeExprBuilder::MakeStringLiteral("i");
+  auto like_func = TreeExprBuilder::MakeFunction(
+      "regexp_like", {node_f0, literal_pattern, literal_parameter}, boolean());
+
+  auto condition = TreeExprBuilder::MakeCondition(like_func);
+
+  std::shared_ptr<Filter> filter;
+  auto status = Filter::Make(schema, condition, TestConfiguration(), &filter);
+  EXPECT_TRUE(status.ok());
+
+  // Create a row-batch with some sample data
+  int num_records = 5;
+  auto array0 = MakeArrowArrayUtf8({"abc-xyz", "hello", "bye", "abc-x", "abc-xyzw"},
+                                   {true, true, true, true, true});
+
+  // expected output (indices for which condition matches)
+  auto exp = MakeArrowArrayUint16({0, 3, 4});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});
+
+  std::shared_ptr<SelectionVector> selection_vector;
+  status = SelectionVector::MakeInt16(num_records, pool_, &selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Evaluate expression
+  status = filter->Evaluate(*in_batch, selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp, selection_vector->ToArray());
+}
+
 }  // namespace gandiva


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Add a regexp_like function.
 https://github.com/apache/arrow/issues/39439

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

REGEXP_LIKE is similar to the LIKE condition, except REGEXP_LIKE performs regular expression matching instead of the simple pattern matching performed by LIKE. This condition evaluates strings using characters as defined by the input character set.
This PR is try to give gandiva a regexp_like  function as regexp_like in oracle [https://docs.oracle.com/cd/B12037_01/server.101/b10759/conditions018.htm]()
source_string is a character expression that serves as the search value.

pattern is the regular expression. 

match_parameter is a text literal that lets you change the default matching behavior of the function. You can specify one or more of the following values for match_parameter:

'i' specifies case-insensitive matching.

'c' specifies case-sensitive matching.

'n' allows the period (.), which is the match-any-character wildcard character, to match the newline character. If you omit this parameter, the period does not match the newline character.

'm' treats the source string as multiple lines.

And the regexp_like only supports POSIX Basic Regular Expression syntax.


### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes. It tested.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39439