### PR TITLE
GH-39384: [C++] Disable -Werror=attributes for Azure SDK's identity.hpp

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -18,7 +18,16 @@
 #include "arrow/filesystem/azurefs.h"
 #include "arrow/filesystem/azurefs_internal.h"
 
+// idenfity.hpp triggers -Wattributes warnings cause -Werror builds to fail,
+// so disable it for this file with pragmas.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
 #include <azure/identity.hpp>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/files/datalake.hpp>
 


### PR DESCRIPTION
### Rationale for this change

Warnings in included headers are causing -Werror builds to fail.

### What changes are included in this PR?

Push and pop of ignore warning pragmas.

### Are these changes tested?

I'm asking @anjakefala to test the build on this branch.
* Closes: #39384