### PR TITLE
GH-39449: [C++] Use default Azure credentials implicitly and support anonymous credentials explicitly

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -92,11 +92,13 @@ struct ARROW_EXPORT AzureOptions {
 
  private:
   enum class CredentialKind {
-    kDefaultCredential,
-    kAnonymousCredential,
-    kStorageSharedKeyCredential,
-    kTokenCredential,
-  } credential_kind_ = CredentialKind::kDefaultCredential;
+    kDefault,
+    kAnonymous,
+    kStorageSharedKey,
+    kClientSecret,
+    kManagedIdentity,
+    kWorkloadIdentity,
+  } credential_kind_ = CredentialKind::kDefault;
 
   std::shared_ptr<Azure::Storage::StorageSharedKeyCredential>
       storage_shared_key_credential_;

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -47,6 +47,17 @@ namespace arrow::fs {
 class TestAzureFileSystem;
 
 /// Options for the AzureFileSystem implementation.
+///
+/// By default, authentication is handled by the Azure SDK's credential chain
+/// which may read from multiple environment variables, such as:
+/// - `AZURE_TENANT_ID`
+/// - `AZURE_CLIENT_ID`
+/// - `AZURE_CLIENT_SECRET`
+/// - `AZURE_AUTHORITY_HOST`
+/// - `AZURE_CLIENT_CERTIFICATE_PATH`
+/// - `AZURE_FEDERATED_TOKEN_FILE`
+///
+/// Functions are provided for explicit configuration of credentials if that is preferred.
 struct ARROW_EXPORT AzureOptions {
   /// \brief The name of the Azure Storage Account being accessed.
   ///

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -48,7 +48,7 @@ class TestAzureFileSystem;
 
 /// Options for the AzureFileSystem implementation.
 struct ARROW_EXPORT AzureOptions {
-  /// \brief account name of the Azure Storage account.
+  /// \brief Name of the Azure Storage Account.
   std::string account_name;
 
   /// \brief hostname[:port] of the Azure Blob Storage Service.
@@ -92,30 +92,28 @@ struct ARROW_EXPORT AzureOptions {
 
  private:
   enum class CredentialKind {
-    kAnonymous,
-    kTokenCredential,
+    kDefaultCredential,
+    kAnonymousCredential,
     kStorageSharedKeyCredential,
-  } credential_kind_ = CredentialKind::kAnonymous;
+    kTokenCredential,
+  } credential_kind_ = CredentialKind::kDefaultCredential;
 
-  std::shared_ptr<Azure::Core::Credentials::TokenCredential> token_credential_;
   std::shared_ptr<Azure::Storage::StorageSharedKeyCredential>
       storage_shared_key_credential_;
+  mutable std::shared_ptr<Azure::Core::Credentials::TokenCredential> token_credential_;
 
  public:
   AzureOptions();
   ~AzureOptions();
 
   Status ConfigureDefaultCredential();
-
-  Status ConfigureManagedIdentityCredential(const std::string& client_id = std::string());
-
-  Status ConfigureWorkloadIdentityCredential();
-
+  Status ConfigureAnonymousCredential();
   Status ConfigureAccountKeyCredential(const std::string& account_key);
-
   Status ConfigureClientSecretCredential(const std::string& tenant_id,
                                          const std::string& client_id,
                                          const std::string& client_secret);
+  Status ConfigureManagedIdentityCredential(const std::string& client_id = std::string());
+  Status ConfigureWorkloadIdentityCredential();
 
   bool Equals(const AzureOptions& other) const;
 

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -48,7 +48,11 @@ class TestAzureFileSystem;
 
 /// Options for the AzureFileSystem implementation.
 struct ARROW_EXPORT AzureOptions {
-  /// \brief Name of the Azure Storage Account.
+  /// \brief The name of the Azure Storage Account being accessed.
+  ///
+  /// All service URLs will be constructed using this storage account name.
+  /// `ConfigureAccountKeyCredential` assumes the user wants to authenticate
+  /// this account.
   std::string account_name;
 
   /// \brief hostname[:port] of the Azure Blob Storage Service.

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -299,6 +299,13 @@ TEST(AzureFileSystem, InitializeWithDefaultCredentialImplicitly) {
   ASSERT_TRUE(options.Equals(explictly_default_options));
 }
 
+TEST(AzureFileSystem, InitializeWithAnonymousCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ARROW_EXPECT_OK(options.ConfigureAnonymousCredential());
+  EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
+}
+
 TEST(AzureFileSystem, InitializeWithClientSecretCredential) {
   AzureOptions options;
   options.account_name = "dummy-account-name";

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -290,9 +290,6 @@ TEST(AzureFileSystem, InitializeWithDefaultCredential) {
 TEST(AzureFileSystem, InitializeWithDefaultCredentialImplicitly) {
   AzureOptions options;
   options.account_name = "dummy-account-name";
-  ARROW_EXPECT_OK(options.ConfigureDefaultCredential());
-  EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
-
   AzureOptions explictly_default_options;
   explictly_default_options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(explictly_default_options.ConfigureDefaultCredential());

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -280,7 +280,26 @@ TEST(AzureFileSystem, InitializingFilesystemWithoutAccountNameFails) {
   ASSERT_RAISES(Invalid, AzureFileSystem::Make(options));
 }
 
-TEST(AzureFileSystem, InitializeFilesystemWithClientSecretCredential) {
+TEST(AzureFileSystem, InitializeWithDefaultCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ARROW_EXPECT_OK(options.ConfigureDefaultCredential());
+  EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
+}
+
+TEST(AzureFileSystem, InitializeWithDefaultCredentialImplicitly) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  ARROW_EXPECT_OK(options.ConfigureDefaultCredential());
+  EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
+
+  AzureOptions explictly_default_options;
+  explictly_default_options.account_name = "dummy-account-name";
+  ARROW_EXPECT_OK(explictly_default_options.ConfigureDefaultCredential());
+  ASSERT_TRUE(options.Equals(explictly_default_options));
+}
+
+TEST(AzureFileSystem, InitializeWithClientSecretCredential) {
   AzureOptions options;
   options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(
@@ -288,14 +307,7 @@ TEST(AzureFileSystem, InitializeFilesystemWithClientSecretCredential) {
   EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 }
 
-TEST(AzureFileSystem, InitializeFilesystemWithDefaultCredential) {
-  AzureOptions options;
-  options.account_name = "dummy-account-name";
-  ARROW_EXPECT_OK(options.ConfigureDefaultCredential());
-  EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
-}
-
-TEST(AzureFileSystem, InitializeFilesystemWithManagedIdentityCredential) {
+TEST(AzureFileSystem, InitializeWithManagedIdentityCredential) {
   AzureOptions options;
   options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(options.ConfigureManagedIdentityCredential());
@@ -305,7 +317,7 @@ TEST(AzureFileSystem, InitializeFilesystemWithManagedIdentityCredential) {
   EXPECT_OK_AND_ASSIGN(fs, AzureFileSystem::Make(options));
 }
 
-TEST(AzureFileSystem, InitializeFilesystemWithWorkloadIdentityCredential) {
+TEST(AzureFileSystem, InitializeWithWorkloadIdentityCredential) {
   AzureOptions options;
   options.account_name = "dummy-account-name";
   ARROW_EXPECT_OK(options.ConfigureWorkloadIdentityCredential());


### PR DESCRIPTION
### Rationale for this change

 - Default credentials should be used by default.
 - There should be a way to connect to public containers without credentials (aka "anonymous credential").

### What changes are included in this PR?

 - Sync ordering of declarations and definitions in the `AzureOptions` classs
 - Use default credentials even when `ConfigureDefaultCredential()` isn't explicitly called
 - Create clients when `credential_kind_` is "anonymous" instead of returning an error
 
### Are these changes tested?

By new and existing tests.
* Closes: #39449