### PR TITLE
MINOR: [Java] Bump maven.version from 3.3.9 to 3.9.6 in /java

### DIFF
--- a/.env
+++ b/.env
@@ -65,7 +65,7 @@ JDK=8
 KARTOTHEK=latest
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=14
-MAVEN=3.5.4
+MAVEN=3.9.6
 NODE=18
 NUMBA=latest
 NUMPY=latest

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -140,6 +140,12 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
+      - name: Set up Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          maven-version: ${{ matrix.maven }}
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -141,10 +141,9 @@ jobs:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
       - name: Set up Maven
-        uses: actions/setup-java@v4
+        uses: s4u/setup-maven-action@1.9.0
         with:
           java-version: ${{ matrix.jdk }}
-          distribution: 'temurin'
           maven-version: ${{ matrix.maven }}
       - name: Checkout Arrow
         uses: actions/checkout@v4

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [8, 11, 17, 21]
-        maven: [3.9.5]
+        maven: [3.9.6]
         image: [java]
     env:
       JDK: ${{ matrix.jdk }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -133,6 +133,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [11]
+        maven: [3.9.6]
     steps:
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -20,7 +20,7 @@ ARG arch=amd64
 FROM ${repo}:${arch}-conda-cpp
 
 ARG arch=amd64
-ARG maven=3.5
+ARG maven=3.9.6
 ARG node=16
 ARG yarn=1.22
 ARG jdk=8

--- a/ci/docker/conda-python-hdfs.dockerfile
+++ b/ci/docker/conda-python-hdfs.dockerfile
@@ -21,7 +21,7 @@ ARG python=3.8
 FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=8
-ARG maven=3.5
+ARG maven=3.9.6
 RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \

--- a/ci/docker/conda-python-jpype.dockerfile
+++ b/ci/docker/conda-python-jpype.dockerfile
@@ -21,7 +21,7 @@ ARG python=3.8
 FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=11
-ARG maven=3.6
+ARG maven=3.9.6
 RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \

--- a/ci/docker/conda-python-spark.dockerfile
+++ b/ci/docker/conda-python-spark.dockerfile
@@ -21,7 +21,7 @@ ARG python=3.8
 FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=8
-ARG maven=3.5
+ARG maven=3.9.6
 
 ARG numpy=latest
 COPY ci/scripts/install_numpy.sh /arrow/ci/scripts/

--- a/ci/docker/java-jni-manylinux-201x.dockerfile
+++ b/ci/docker/java-jni-manylinux-201x.dockerfile
@@ -34,7 +34,7 @@ RUN vcpkg install \
 
 # Install Java
 ARG java=1.8.0
-ARG maven=3.9.3
+ARG maven=3.9.6
 RUN yum install -y java-$java-openjdk-devel && \
       yum clean all && \
       curl \

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update -y && \
 
 ENV JAVA_HOME=/usr/lib/jvm/java-${jdk}-openjdk-amd64
 
-ARG maven=3.5.4
+ARG maven=3.9.6
 COPY ci/scripts/util_download_apache.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/util_download_apache.sh \
     "maven/maven-3/${maven}/binaries/apache-maven-${maven}-bin.tar.gz" /opt

--- a/dev/conbench_envs/README.md
+++ b/dev/conbench_envs/README.md
@@ -111,7 +111,7 @@ Verify that you have at least these versions of `java`, `javac` and `maven`:
     javac 1.8.0_292
     ...
     # mvn -version
-    Apache Maven 3.6.3
+    Apache Maven 3.9.6
     ...
 
 ### 3. Install Arrow dependencies for Java Script

--- a/dev/tasks/verify-rc/github.linux.amd64.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.yml
@@ -54,7 +54,8 @@ jobs:
         with:
           ruby-version: 3.1
 
-      - uses: actions/setup-java@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1707,7 +1707,7 @@ services:
         repo: ${REPO}
         arch: ${ARCH}
         # Use a newer JDK as it seems to improve stability
-        jdk: ${JDK}
+        jdk: 11
         # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
         # be set to ${MAVEN}
         maven: 3.9.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1707,7 +1707,7 @@ services:
         repo: ${REPO}
         arch: ${ARCH}
         # Use a newer JDK as it seems to improve stability
-        jdk: 17
+        jdk: ${JDK}
         # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
         # be set to ${MAVEN}
         maven: 3.9.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1678,7 +1678,7 @@ services:
     #   docker-compose build java
     #   docker-compose run java
     # Parameters:
-    #   MAVEN: 3.9.5
+    #   MAVEN: 3.9.6
     #   JDK: 8, 11, 17, 21
     image: ${ARCH}/maven:${MAVEN}-eclipse-temurin-${JDK}
     shm_size: *shm-size
@@ -1710,7 +1710,7 @@ services:
         jdk: 17
         # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
         # be set to ${MAVEN}
-        maven: 3.5
+        maven: 3.9.6
         node: ${NODE}
         go: ${GO}
     volumes: *conda-volumes
@@ -1844,7 +1844,7 @@ services:
         jdk: ${JDK}
         # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
         # be set to ${MAVEN}
-        maven: 3.5
+        maven: 3.9.6
         hdfs: ${HDFS}
     links:
       - impala:impala
@@ -1887,7 +1887,7 @@ services:
         jdk: ${JDK}
         # conda-forge doesn't have 3.5.4 so pinning explicitly, but this should
         # be set to ${MAVEN}
-        maven: 3.5
+        maven: 3.9.6
         spark: ${SPARK}
         numpy: ${NUMPY}
     shm_size: *shm-size

--- a/java/maven/module-info-compiler-maven-plugin/pom.xml
+++ b/java/maven/module-info-compiler-maven-plugin/pom.xml
@@ -30,7 +30,7 @@
   </prerequisites>
 
   <properties>
-    <maven.version>3.3.9</maven.version>
+    <maven.version>3.9.6</maven.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### Rationale for this change

This is a draft PR to evaluate the maven bump done by the dependabot https://github.com/apache/arrow/pull/39371

### What changes are included in this PR?

Change the maven version to `3.9.6`

### Are these changes tested?

N/A

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

The CI's itself will test the change

### Are there any user-facing changes?

No