### PR TITLE
MINOR: [Java] Bump com.google.errorprone:error_prone_core from 2.4.0 to 2.24.0 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -844,7 +844,7 @@
                 <path>
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
-                  <version>2.24.0</version>
+                  <version>2.10.0</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -44,7 +44,7 @@
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
-    <error_prone_core.version>2.22.0</error_prone_core.version>
+    <error_prone_core.version>2.24.0</error_prone_core.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <mockito.core.version>5.5.0</mockito.core.version>
     <mockito.inline.version>5.2.0</mockito.inline.version>
@@ -844,7 +844,7 @@
                 <path>
                   <groupId>com.google.errorprone</groupId>
                   <artifactId>error_prone_core</artifactId>
-                  <version>2.4.0</version>
+                  <version>2.24.0</version>
                 </path>
               </annotationProcessorPaths>
             </configuration>

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -773,7 +773,7 @@ public class TestComplexWriter {
     for (int i = 0; i < COUNT; i++) {
       unionReader.setPosition(i);
       if (i % 5 == 0) {
-        Assert.assertEquals(i, i, unionReader.readInteger());
+        Assert.assertEquals(i, unionReader.readInteger().intValue());
       } else if (i % 5 == 1) {
         NullableTimeStampMilliTZHolder holder = new NullableTimeStampMilliTZHolder();
         unionReader.read(holder);


### PR DESCRIPTION
### Rationale for this change

This is a draft PR for fixing the dependabot PR https://github.com/apache/arrow/pull/39409

### What changes are included in this PR?

Upgrading `com.google.errorprone` to 2.24.0 for JDK11+ and restricting `com.google.errorprone` to 2.10 to JDK8. 

### Are these changes tested?

N/A. CIs are implicitly testing this including existing test cases. 

### Are there any user-facing changes?

No