### PR TITLE
GH-38811: [R] Actually use fetched cmake on macos

### DIFF
--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -44,6 +44,8 @@ jobs:
           # disable sccache on macos as it times out for unknown reasons
           # see GH-33721
           # brew install sccache
+          # remove cmake so that we can test our cmake downloading abilities
+          brew uninstall cmake
       - name: Configure dependencies (linux)
         if: contains(matrix.os, 'ubuntu')
         run: |

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -71,6 +71,7 @@ jobs:
           FORCE_BUNDLED_BUILD: true
           LIBARROW_MINIMAL: false
           ARROW_R_DEV: TRUE
+          LIBARROW_BINARY: false
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
           sccache --start-server || echo 'sccache not found'

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -629,10 +629,18 @@ ensure_cmake <- function(cmake_minimum_required = "3.16") {
     untar(cmake_tar, exdir = cmake_dir)
     unlink(cmake_tar)
     cleanup(cmake_dir)
+    # the bin dir is slightly different on macos
+    if (on_macos) {
+      bin_dir <- "CMake.app/Contents/bin"
+    } else {
+      bin_dir <- "bin"
+    }
     cmake <- paste0(
       cmake_dir,
       "/cmake-", CMAKE_VERSION, sub(".tar.gz", "", postfix, fixed = TRUE),
-      "/bin/cmake"
+      "/",
+      bin_dir,
+      "/cmake"
     )
   } else {
     # Show which one we found


### PR DESCRIPTION
### Rationale for this change

We sometimes need to use a more modern cmake, before this change although we downloaded a functioning cmake on macos, we didn't have the correct path for it. 

### What changes are included in this PR?

Resolves #38811 so that cmake is useable when downloaded on macos. This also restores the local source build jobs to be testing that source builds work (which is what the Ci jobs say they are doing). I believe these jobs started using binaries when we overhauled the build system last release.

### Are these changes tested?

Yes, in CI with the local (source) install jobs in crossbow)

### Are there any user-facing changes?

* Closes: #38811