### PR TITLE
GH-38717: [C++] Add ImportChunkedArray and ExportChunkedArray to/from ArrowArrayStream

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1979,18 +1979,12 @@ Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
 
 namespace {
 
-template <typename T>
-static inline Status ExportStreamSchema(const std::shared_ptr<T>& src,
-                                        struct ArrowSchema* out_schema);
-
-template <>
-inline Status ExportStreamSchema(const std::shared_ptr<RecordBatchReader>& src,
+Status ExportStreamSchema(const std::shared_ptr<RecordBatchReader>& src,
                                  struct ArrowSchema* out_schema) {
   return ExportSchema(*src->schema(), out_schema);
 }
 
-template <>
-inline Status ExportStreamSchema(const std::shared_ptr<ChunkedArray>& src,
+Status ExportStreamSchema(const std::shared_ptr<ChunkedArray>& src,
                                  struct ArrowSchema* out_schema) {
   return ExportType(*src->type(), out_schema);
 }
@@ -2087,7 +2081,7 @@ class ExportedArrayStream {
     return ExportedArrayStream{stream}.GetLastError();
   }
 
-  static Status Make(const std::shared_ptr<T> reader, struct ArrowArrayStream* out) {
+  static Status Make(std::shared_ptr<T> reader, struct ArrowArrayStream* out) {
     out->get_schema = ExportedArrayStream::StaticGetSchema;
     out->get_next = ExportedArrayStream::StaticGetNext;
     out->get_last_error = ExportedArrayStream::StaticGetLastError;

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2231,12 +2231,12 @@ class ArrayStreamBatchReader : public RecordBatchReader {
     if (status.ok()) {
       status = ImportSchema(&c_schema).Value(&schema_);
     }
-    if (!status.ok()) {
+    if (!status.ok() && !ArrowArrayStreamIsReleased(&stream_)) {
       ArrowArrayStreamRelease(&stream_);
       return status;
     }
 
-    return Status::OK();
+    return status;
   }
 
   ~ArrayStreamBatchReader() override {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1989,12 +1989,8 @@ Status ExportStreamSchema(const std::shared_ptr<ChunkedArray>& src,
   return ExportType(*src->type(), out_schema);
 }
 
-template <typename T>
-static inline Status ExportStreamNext(const std::shared_ptr<T>& src, int i,
-                                      struct ArrowArray* out_array);
 
-template <>
-inline Status ExportStreamNext(const std::shared_ptr<RecordBatchReader>& src, int i,
+Status ExportStreamNext(const std::shared_ptr<RecordBatchReader>& src, int i,
                                struct ArrowArray* out_array) {
   std::shared_ptr<RecordBatch> batch;
   RETURN_NOT_OK(src->ReadNext(&batch));
@@ -2007,9 +2003,8 @@ inline Status ExportStreamNext(const std::shared_ptr<RecordBatchReader>& src, in
   }
 }
 
-template <>
-inline Status ExportStreamNext(const std::shared_ptr<ChunkedArray>& src, int i,
-                               struct ArrowArray* out_array) {
+Status ExportStreamNext(const std::shared_ptr<ChunkedArray>& src, int i,
+                        struct ArrowArray* out_array) {
   if (i >= src->num_chunks()) {
     // End of stream
     ArrowArrayMarkReleased(out_array);
@@ -2037,11 +2032,11 @@ class ExportedArrayStream {
   explicit ExportedArrayStream(struct ArrowArrayStream* stream) : stream_(stream) {}
 
   Status GetSchema(struct ArrowSchema* out_schema) {
-    return ExportStreamSchema<T>(reader(), out_schema);
+    return ExportStreamSchema(reader(), out_schema);
   }
 
   Status GetNext(struct ArrowArray* out_array) {
-    return ExportStreamNext<T>(reader(), next_batch_num(), out_array);
+    return ExportStreamNext(reader(), next_batch_num(), out_array);
   }
 
   const char* GetLastError() {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2134,6 +2134,7 @@ namespace {
 class ArrayStreamReader {
  public:
   explicit ArrayStreamReader(struct ArrowArrayStream* stream) {
+    ArrowArrayStreamMarkReleased(&stream_);
     ArrowArrayStreamMove(stream, &stream_);
     DCHECK(!ArrowArrayStreamIsReleased(&stream_));
   }
@@ -2217,6 +2218,7 @@ class ArrayStreamReader {
 class ArrayStreamBatchReader : public RecordBatchReader {
  public:
   explicit ArrayStreamBatchReader(struct ArrowArrayStream* stream) {
+    ArrowArrayStreamMarkReleased(&stream_);
     ArrowArrayStreamMove(stream, &stream_);
     DCHECK(!ArrowArrayStreamIsReleased(&stream_));
   }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -679,6 +679,11 @@ Status ExportArray(const Array& array, struct ArrowArray* out,
   return Status::OK();
 }
 
+Status ExportChunkedArray(const ChunkedArray& chunked_array,
+                          struct ArrowArrayStream* out) {
+  return Status::NotImplemented("even a little bit");
+}
+
 Status ExportRecordBatch(const RecordBatch& batch, struct ArrowArray* out,
                          struct ArrowSchema* out_schema) {
   // XXX perhaps bypass ToStructArray() for speed?
@@ -1915,6 +1920,11 @@ Result<std::shared_ptr<Array>> ImportArray(struct ArrowArray* array,
     return maybe_type.status();
   }
   return ImportArray(array, *maybe_type);
+}
+
+Result<std::shared_ptr<ChunkedArray>> ImportChunkedArray(
+    struct ArrowArrayStream* stream) {
+  return Status::NotImplemented("even a little bit");
 }
 
 Result<std::shared_ptr<RecordBatch>> ImportRecordBatch(struct ArrowArray* array,

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include "arrow/c/bridge.h"
-#include <sys/_types/_int64_t.h>
 
 #include <algorithm>
 #include <cerrno>

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -72,17 +72,6 @@ ARROW_EXPORT
 Status ExportArray(const Array& array, struct ArrowArray* out,
                    struct ArrowSchema* out_schema = NULLPTR);
 
-/// \brief Export C++ ChunkedArray using the C data interface format.
-///
-/// The resulting ArrowArray struct keeps the array data and buffers alive
-/// until its release callback is called by the consumer.
-///
-/// \param[in] chunked_array ChunkedArray object to export
-/// \param[out] out C struct where to export the chunked array
-ARROW_EXPORT
-Status ExportChunkedArray(const ChunkedArray& chunked_array,
-                          struct ArrowArrayStream* out);
-
 /// \brief Export C++ RecordBatch using the C data interface format.
 ///
 /// The record batch is exported as if it were a struct array.
@@ -312,6 +301,17 @@ Result<std::shared_ptr<RecordBatch>> ImportDeviceRecordBatch(
 ARROW_EXPORT
 Status ExportRecordBatchReader(std::shared_ptr<RecordBatchReader> reader,
                                struct ArrowArrayStream* out);
+
+/// \brief Export C++ ChunkedArray using the C data interface format.
+///
+/// The resulting ArrowArrayStream struct keeps the chunked array data and buffers alive
+/// until its release callback is called by the consumer.
+///
+/// \param[in] chunked_array ChunkedArray object to export
+/// \param[out] out C struct where to export the stream
+ARROW_EXPORT
+Status ExportChunkedArray(std::shared_ptr<ChunkedArray> chunked_array,
+                          struct ArrowArrayStream* out);
 
 /// \brief Import C++ RecordBatchReader from the C stream interface.
 ///

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -72,6 +72,17 @@ ARROW_EXPORT
 Status ExportArray(const Array& array, struct ArrowArray* out,
                    struct ArrowSchema* out_schema = NULLPTR);
 
+/// \brief Export C++ ChunkedArray using the C data interface format.
+///
+/// The resulting ArrowArray struct keeps the array data and buffers alive
+/// until its release callback is called by the consumer.
+///
+/// \param[in] chunked_array ChunkedArray object to export
+/// \param[out] out C struct where to export the chunked array
+ARROW_EXPORT
+Status ExportChunkedArray(const ChunkedArray& chunked_array,
+                          struct ArrowArrayStream* out);
+
 /// \brief Export C++ RecordBatch using the C data interface format.
 ///
 /// The record batch is exported as if it were a struct array.
@@ -139,6 +150,16 @@ Result<std::shared_ptr<Array>> ImportArray(struct ArrowArray* array,
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportArray(struct ArrowArray* array,
                                            struct ArrowSchema* type);
+
+/// \brief Import C++ array stream from the C data interface as a ChunkedArray
+///
+/// The ArrowArrayStream struct has its contents moved (as per the C stream interface
+/// specification) to a private object held alive by the resulting array.
+///
+/// \param[in,out] stream C stream interface struct holding the stream data
+/// \return Imported chunked array object
+ARROW_EXPORT
+Result<std::shared_ptr<ChunkedArray>> ImportChunkedArray(struct ArrowArrayStream* stream);
 
 /// \brief Import C++ record batch from the C data interface.
 ///

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -151,16 +151,6 @@ ARROW_EXPORT
 Result<std::shared_ptr<Array>> ImportArray(struct ArrowArray* array,
                                            struct ArrowSchema* type);
 
-/// \brief Import C++ array stream from the C data interface as a ChunkedArray
-///
-/// The ArrowArrayStream struct has its contents moved (as per the C stream interface
-/// specification) to a private object held alive by the resulting array.
-///
-/// \param[in,out] stream C stream interface struct holding the stream data
-/// \return Imported chunked array object
-ARROW_EXPORT
-Result<std::shared_ptr<ChunkedArray>> ImportChunkedArray(struct ArrowArrayStream* stream);
-
 /// \brief Import C++ record batch from the C data interface.
 ///
 /// The ArrowArray struct has its contents moved (as per the C data interface
@@ -333,6 +323,17 @@ Status ExportRecordBatchReader(std::shared_ptr<RecordBatchReader> reader,
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatchReader>> ImportRecordBatchReader(
     struct ArrowArrayStream* stream);
+
+/// \brief Import C++ ChunkedArray from the C stream interface
+///
+/// The ArrowArrayStream struct has its contents moved to a private object,
+/// is consumed in its entirity, and released before returning all chunks
+/// as a ChunkedArray.
+///
+/// \param[in,out] stream C stream interface struct
+/// \return Imported ChunkedArray object
+ARROW_EXPORT
+Result<std::shared_ptr<ChunkedArray>> ImportChunkedArray(struct ArrowArrayStream* stream);
 
 /// @}
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -4372,6 +4372,17 @@ class TestArrayStreamExport : public BaseArrayStreamTest {
     ASSERT_OK_AND_ASSIGN(auto batch, ImportRecordBatch(&c_array, expected.schema()));
     AssertBatchesEqual(expected, *batch);
   }
+
+  void AssertStreamNext(struct ArrowArrayStream* c_stream, const Array& expected) {
+    struct ArrowArray c_array;
+    ASSERT_EQ(0, c_stream->get_next(c_stream, &c_array));
+
+    ArrayExportGuard guard(&c_array);
+    ASSERT_FALSE(ArrowArrayIsReleased(&c_array));
+
+    ASSERT_OK_AND_ASSIGN(auto array, ImportArray(&c_array, expected.type()));
+    AssertArraysEqual(expected, *array);
+  }
 };
 
 TEST_F(TestArrayStreamExport, Empty) {
@@ -4467,6 +4478,43 @@ TEST_F(TestArrayStreamExport, Errors) {
   ASSERT_EQ(EINVAL, c_stream.get_next(&c_stream, &c_array));
 }
 
+TEST_F(TestArrayStreamExport, ChunkedArrayExport) {
+  ASSERT_OK_AND_ASSIGN(auto chunked_array,
+                       ChunkedArray::Make({ArrayFromJSON(int32(), "[1, 2]"),
+                                           ArrayFromJSON(int32(), "[4, 5, null]")}));
+
+  struct ArrowArrayStream c_stream;
+  struct ArrowSchema c_schema;
+  struct ArrowArray c_array0, c_array1;
+
+  ASSERT_OK(ExportChunkedArray(chunked_array, &c_stream));
+  ArrayStreamExportGuard guard(&c_stream);
+
+  {
+    ArrayStreamExportGuard guard(&c_stream);
+    ASSERT_FALSE(ArrowArrayStreamIsReleased(&c_stream));
+
+    ASSERT_EQ(0, c_stream.get_schema(&c_stream, &c_schema));
+    ASSERT_EQ(0, c_stream.get_next(&c_stream, &c_array0));
+    ASSERT_EQ(0, c_stream.get_next(&c_stream, &c_array1));
+    AssertStreamEnd(&c_stream);
+  }
+
+  ArrayExportGuard guard0(&c_array0), guard1(&c_array1);
+
+  {
+    SchemaExportGuard schema_guard(&c_schema);
+    ASSERT_OK_AND_ASSIGN(auto got_type, ImportType(&c_schema));
+    AssertTypeEqual(*chunked_array->type(), *got_type);
+  }
+
+  ASSERT_GT(pool_->bytes_allocated(), orig_allocated_);
+  ASSERT_OK_AND_ASSIGN(auto array, ImportArray(&c_array0, chunked_array->type()));
+  AssertArraysEqual(*chunked_array->chunk(0), *array);
+  ASSERT_OK_AND_ASSIGN(array, ImportArray(&c_array1, chunked_array->type()));
+  AssertArraysEqual(*chunked_array->chunk(1), *array);
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Array stream roundtrip tests
 
@@ -4504,6 +4552,29 @@ class TestArrayStreamRoundtrip : public BaseArrayStreamTest {
     }
     // Stream was released when `new_reader` was destroyed
     ASSERT_TRUE(weak_reader.expired());
+  }
+
+  void Roundtrip(std::shared_ptr<ChunkedArray> src,
+                 std::function<void(const std::shared_ptr<ChunkedArray>&)> check_func) {
+    ArrowArrayStream c_stream;
+
+    // One original copy which to compare the result, one copy held by the stream
+    std::weak_ptr<ChunkedArray> weak_src(src);
+    ASSERT_EQ(weak_src.use_count(), 2);
+
+    ASSERT_OK(ExportChunkedArray(std::move(src), &c_stream));
+    ASSERT_FALSE(ArrowArrayStreamIsReleased(&c_stream));
+
+    {
+      ASSERT_OK_AND_ASSIGN(auto dst, ImportChunkedArray(&c_stream));
+      // Stream was moved, consumed, and released
+      ASSERT_TRUE(ArrowArrayStreamIsReleased(&c_stream));
+
+      // Stream was released by ImportChunkedArray but original copy remains
+      ASSERT_EQ(weak_src.use_count(), 1);
+
+      check_func(dst);
+    }
   }
 
   void AssertReaderNext(const std::shared_ptr<RecordBatchReader>& reader,
@@ -4601,6 +4672,17 @@ TEST_F(TestArrayStreamRoundtrip, SchemaError) {
   EXPECT_RAISES_WITH_MESSAGE_THAT(IOError, ::testing::HasSubstr("Expected error"),
                                   ImportRecordBatchReader(&stream));
   ASSERT_TRUE(state.released);
+}
+
+TEST_F(TestArrayStreamRoundtrip, ChunkedArrayRoundtrip) {
+  ASSERT_OK_AND_ASSIGN(auto src,
+                       ChunkedArray::Make({ArrayFromJSON(int32(), "[1, 2]"),
+                                           ArrayFromJSON(int32(), "[4, 5, null]")}));
+
+  Roundtrip(src, [&](const std::shared_ptr<ChunkedArray>& dst) {
+    AssertTypeEqual(*dst->type(), *src->type());
+    AssertChunkedEqual(*dst, *src);
+  });
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -4590,8 +4590,8 @@ class TestArrayStreamRoundtrip : public BaseArrayStreamTest {
   }
 
   void AssertReaderClosed(const std::shared_ptr<RecordBatchReader>& reader) {
-    ASSERT_THAT(reader->Next(),
-                Raises(StatusCode::Invalid, ::testing::HasSubstr("already been released")));
+    ASSERT_THAT(reader->Next(), Raises(StatusCode::Invalid,
+                                       ::testing::HasSubstr("already been released")));
   }
 
   void AssertReaderClose(const std::shared_ptr<RecordBatchReader>& reader) {

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -4590,8 +4590,8 @@ class TestArrayStreamRoundtrip : public BaseArrayStreamTest {
   }
 
   void AssertReaderClosed(const std::shared_ptr<RecordBatchReader>& reader) {
-    ASSERT_THAT(reader->Next(), Raises(StatusCode::Invalid,
-                                       ::testing::HasSubstr("already been released")));
+    ASSERT_THAT(reader->Next(),
+                Raises(StatusCode::Invalid, ::testing::HasSubstr("already been closed")));
   }
 
   void AssertReaderClose(const std::shared_ptr<RecordBatchReader>& reader) {

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -4560,7 +4560,7 @@ class TestArrayStreamRoundtrip : public BaseArrayStreamTest {
 
     // One original copy which to compare the result, one copy held by the stream
     std::weak_ptr<ChunkedArray> weak_src(src);
-    ASSERT_EQ(weak_src.use_count(), 2);
+    int64_t initial_use_count = weak_src.use_count();
 
     ASSERT_OK(ExportChunkedArray(std::move(src), &c_stream));
     ASSERT_FALSE(ArrowArrayStreamIsReleased(&c_stream));
@@ -4571,7 +4571,7 @@ class TestArrayStreamRoundtrip : public BaseArrayStreamTest {
       ASSERT_TRUE(ArrowArrayStreamIsReleased(&c_stream));
 
       // Stream was released by ImportChunkedArray but original copy remains
-      ASSERT_EQ(weak_src.use_count(), 1);
+      ASSERT_EQ(weak_src.use_count(), initial_use_count - 1);
 
       check_func(dst);
     }

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -4591,7 +4591,7 @@ class TestArrayStreamRoundtrip : public BaseArrayStreamTest {
 
   void AssertReaderClosed(const std::shared_ptr<RecordBatchReader>& reader) {
     ASSERT_THAT(reader->Next(),
-                Raises(StatusCode::Invalid, ::testing::HasSubstr("already been closed")));
+                Raises(StatusCode::Invalid, ::testing::HasSubstr("already been released")));
   }
 
   void AssertReaderClose(const std::shared_ptr<RecordBatchReader>& reader) {


### PR DESCRIPTION
### Rationale for this change

The `ChunkedArray` has no equivalent in the C data interface; however, it is the primary array structure that higher level bindings interact with (because it is a column in a `Table`). In the Python capsule interface, this means that ChunkedArrays always require a workaround involving loops in Python.

### What changes are included in this PR?

- Added `ImportChunkedArray()` and `ExportChunkedArray()`
- Generalized the classes that support import/export to relax the assumption that every `ArrowArray` in an `ArrowArrayStream` is a `RecordBatch`.

### Are these changes tested?

TODO

### Are there any user-facing changes?

Yes, two new functions are added to bridge.h.
* Closes: #38717