### PR TITLE
GH-39394: [Python] pa.array correctly convert nans from an array with from_pandas=True

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -240,8 +240,13 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         c_from_pandas = from_pandas
 
     if isinstance(obj, Array):
+        from pyarrow.types import is_floating
         if type is not None and not obj.type.equals(type):
             obj = obj.cast(type, safe=safe, memory_pool=memory_pool)
+        if is_floating(obj.type):
+            mask_nulls_and_nans = obj.is_null(nan_is_null=True)
+            obj = _pc().replace_with_mask(obj, mask_nulls_and_nans, nulls(
+                mask_nulls_and_nans.sum().as_py(), type=obj.type))
         return obj
 
     if hasattr(obj, '__arrow_array__'):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2183,6 +2183,12 @@ def test_pandas_null_sentinels_index():
     assert result.equals(expected)
 
 
+def test_array_from_array_with_pandas_nans():
+    result = pa.array(pa.array([np.nan, None]), from_pandas=True)
+    expected = pa.nulls(2, type=pa.float64())
+    assert result.equals(expected)
+
+
 def test_array_roundtrip_from_numpy_datetimeD():
     arr = np.array([None, datetime.date(2017, 4, 4)], dtype='datetime64[D]')
 


### PR DESCRIPTION
### What changes are included in this PR?

Replace nans by nulls when `from_pandas=True` and input object in an `Array`. I am not sure if there is a faster/cleaner way to do it.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

A minor bug fix.

* Closes: #39394