### PR TITLE
GH-39433: [Ruby] Add support for Table.load(format: json) options

### DIFF
--- a/ruby/red-arrow/lib/arrow/table-loader.rb
+++ b/ruby/red-arrow/lib/arrow/table-loader.rb
@@ -252,7 +252,13 @@ module Arrow
 
     def load_as_json
       open_input_stream do |input|
-        reader = JSONReader.new(input)
+        options = JSONReadOptions.new
+        @options.each do |key, value|
+          next if value.nil?
+          setter = :"#{key}="
+          options.__send__(setter, value) if options.respond_to?(setter)
+        end
+        reader = JSONReader.new(input, options)
         table = reader.read
         table.refer_input(input)
         table

--- a/ruby/red-arrow/test/helper.rb
+++ b/ruby/red-arrow/test/helper.rb
@@ -18,6 +18,7 @@
 require "arrow"
 
 require "fiddle"
+require "json"
 require "pathname"
 require "tempfile"
 require "timeout"

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -677,6 +677,31 @@ class TableTest < Test::Unit::TestCase
                                        format: :tsv,
                                        schema: @table.schema))
       end
+
+      def test_json
+        output = create_output(".json")
+        # TODO: Implement this.
+        # @table.save(output, format: :json)
+        columns = ""
+        @table.each_record.each do |record|
+          column = {
+            "count" => record.count,
+            "visible" => record.visible,
+          }
+          columns << column.to_json
+          columns << "\n"
+        end
+        if output.is_a?(String)
+          File.write(output, columns)
+        else
+          output.resize(columns.bytesize)
+          output.set_data(0, columns)
+        end
+        assert_equal(@table,
+                     Arrow::Table.load(output,
+                                       format: :json,
+                                       schema: @table.schema))
+      end
     end
 
     sub_test_case("path") do


### PR DESCRIPTION
### Rationale for this change

Other `format:` such as `format: :csv` accepts custom options. `format: :json` should also accept them.

### What changes are included in this PR?

Use `Arrow::JSONReadOptions` for `Table::Load(format: :json)`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #39433