### PR TITLE
GH-39385: [C++] Use more permissable return code for rename

### DIFF
--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -595,7 +595,7 @@ Status LocalFileSystem::Move(const std::string& src, const std::string& dest) {
                                "' to '", dfn.ToString(), "'");
   }
 #else
-  if (rename(sfn.ToNative().c_str(), dfn.ToNative().c_str()) == -1) {
+  if (rename(sfn.ToNative().c_str(), dfn.ToNative().c_str()) != 0) {
     return IOErrorFromErrno(errno, "Failed renaming '", sfn.ToString(), "' to '",
                             dfn.ToString(), "'");
   }


### PR DESCRIPTION
### Rationale for this change

While the `rename` [system call](https://man7.org/linux/man-pages/man2/rename.2.html) and [Posix standard](https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html) do specify that a return value of -1 is expected for error calls, the [C++ reference](https://en.cppreference.com/w/cpp/io/c/rename) specifies that a "non-zero" is returned upon error.

This PR proposes changing to the more encompassing "non-zero" check for `std::rename`.

### Are these changes tested?

There are existing tests: https://github.com/apache/arrow/blob/afb40a9f5a33802897e1d5bae8305c81da7beee1/cpp/src/arrow/filesystem/filesystem_test.cc#L701C3-L701C3
* Closes: #39385