### PR TITLE
GH-39488: [Ruby] Add support for ChunkedArray in Ractor

### DIFF
--- a/ruby/red-arrow/lib/arrow/chunked-array.rb
+++ b/ruby/red-arrow/lib/arrow/chunked-array.rb
@@ -24,6 +24,14 @@ module Arrow
     include GenericTakeable
     include InputReferable
 
+    def freeze
+      unless frozen?
+        # Ensure caching
+        chunks
+      end
+      super
+    end
+
     def to_arrow
       self
     end


### PR DESCRIPTION
### Rationale for this change

We can't use `@cache ||= build_cache` idiom in Ractor because Ractor requires that shared objects are immutable.

### What changes are included in this PR?

Compute caches before making ChunkedArray immutable.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* Closes: #39488