### PR TITLE
GH-39493: [C++][Gandiva] Add PreEvalInExpr

### DIFF
--- a/cpp/src/gandiva/dex.h
+++ b/cpp/src/gandiva/dex.h
@@ -409,4 +409,31 @@ class InExprDex<std::string> : public InExprDexBase<std::string> {
   }
 };
 
+class PreEvalInExprDex : public Dex {
+ public:
+  PreEvalInExprDex(const ValueValidityPairPtr& eval_expr_vv,
+                   const ValueValidityPairPtr& condition_eval_expr_vv)
+      : eval_expr_vv_(eval_expr_vv), condition_eval_expr_vv_(condition_eval_expr_vv){};
+  const ValueValidityPairPtr& eval_expr_vv() const { return eval_expr_vv_; }
+  const ValueValidityPairPtr& condition_eval_expr_vv() const {
+    return condition_eval_expr_vv_;
+  }
+
+  void Accept(DexVisitor& visitor) override { visitor.Visit(*this); }
+
+ private:
+  ValueValidityPairPtr eval_expr_vv_;
+  ValueValidityPairPtr condition_eval_expr_vv_;
+};
+
+class ReadProxyDex : public Dex {
+ public:
+  ReadProxyDex(DataTypePtr type) : type_(type){};
+  void Accept(DexVisitor& visitor) override { visitor.Visit(*this); }
+  const DataTypePtr& type() const { return type_; }
+
+ private:
+  DataTypePtr type_;
+};
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/dex_visitor.h
+++ b/cpp/src/gandiva/dex_visitor.h
@@ -41,6 +41,8 @@ class BooleanAndDex;
 class BooleanOrDex;
 template <typename Type>
 class InExprDexBase;
+class PreEvalInExprDex;
+class ReadProxyDex;
 
 /// \brief Visitor for decomposed expression.
 class GANDIVA_EXPORT DexVisitor {
@@ -66,6 +68,8 @@ class GANDIVA_EXPORT DexVisitor {
   virtual void Visit(const InExprDexBase<double>& dex) = 0;
   virtual void Visit(const InExprDexBase<gandiva::DecimalScalar128>& dex) = 0;
   virtual void Visit(const InExprDexBase<std::string>& dex) = 0;
+  virtual void Visit(const PreEvalInExprDex& dex) = 0;
+  virtual void Visit(const ReadProxyDex& dex) = 0;
 };
 
 /// Default implementation with only DCHECK().
@@ -92,6 +96,8 @@ class GANDIVA_EXPORT DexDefaultVisitor : public DexVisitor {
   VISIT_DCHECK(InExprDexBase<double>)
   VISIT_DCHECK(InExprDexBase<gandiva::DecimalScalar128>)
   VISIT_DCHECK(InExprDexBase<std::string>)
+  VISIT_DCHECK(PreEvalInExprDex)
+  VISIT_DCHECK(ReadProxyDex)
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/expr_decomposer.h
+++ b/cpp/src/gandiva/expr_decomposer.h
@@ -71,6 +71,8 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
   Status Visit(const InExpressionNode<double>& node) override;
   Status Visit(const InExpressionNode<gandiva::DecimalScalar128>& node) override;
   Status Visit(const InExpressionNode<std::string>& node) override;
+  Status Visit(const PreEvalInExpressionNode& node) override;
+  Status Visit(const ReadProxyNode& node) override;
 
   template <typename ctype>
   Status VisitInGeneric(const InExpressionNode<ctype>& node);
@@ -125,6 +127,7 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
   Annotator& annotator_;
   std::stack<std::unique_ptr<IfStackEntry>> if_entries_stack_;
   ValueValidityPairPtr result_;
+  ValueValidityPairPtr read_proxy_result_;
   bool nested_if_else_;
 };
 

--- a/cpp/src/gandiva/expr_validator.cc
+++ b/cpp/src/gandiva/expr_validator.cc
@@ -195,4 +195,12 @@ Status ExprValidator::Visit(const InExpressionNode<std::string>& node) {
   return ValidateInExpression(node, arrow::utf8());
 }
 
+Status ExprValidator::Visit(const PreEvalInExpressionNode& node) {
+  ARROW_RETURN_NOT_OK(node.eval_expr()->Accept(*this));
+  ARROW_RETURN_NOT_OK(node.condition_eval_expr()->Accept(*this));
+  return Status::OK();
+}
+
+Status ExprValidator::Visit(const ReadProxyNode& node) { return Status::OK(); }
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/expr_validator.h
+++ b/cpp/src/gandiva/expr_validator.h
@@ -65,6 +65,8 @@ class ExprValidator : public NodeVisitor {
   Status Visit(const InExpressionNode<double>& node) override;
   Status Visit(const InExpressionNode<gandiva::DecimalScalar128>& node) override;
   Status Visit(const InExpressionNode<std::string>& node) override;
+  Status Visit(const PreEvalInExpressionNode& node) override;
+  Status Visit(const ReadProxyNode& node) override;
 
   LLVMTypes* types_;
 

--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -68,18 +68,23 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       UNARY_SAFE_NULL_IF_NULL(castBIGINT, {}, decimal128, int64),
 
       // cast to float32
-      UNARY_CAST_TO_FLOAT32(int32), UNARY_CAST_TO_FLOAT32(int64),
+      UNARY_CAST_TO_FLOAT32(int32),
+      UNARY_CAST_TO_FLOAT32(int64),
       UNARY_CAST_TO_FLOAT32(float64),
 
       // cast to int32
-      UNARY_CAST_TO_INT32(float32), UNARY_CAST_TO_INT32(float64),
+      UNARY_CAST_TO_INT32(float32),
+      UNARY_CAST_TO_INT32(float64),
 
       // cast to int64
-      UNARY_CAST_TO_INT64(float32), UNARY_CAST_TO_INT64(float64),
+      UNARY_CAST_TO_INT64(float32),
+      UNARY_CAST_TO_INT64(float64),
 
       // cast to float64
-      UNARY_CAST_TO_FLOAT64(int32), UNARY_CAST_TO_FLOAT64(int64),
-      UNARY_CAST_TO_FLOAT64(float32), UNARY_CAST_TO_FLOAT64(decimal128),
+      UNARY_CAST_TO_FLOAT64(int32),
+      UNARY_CAST_TO_FLOAT64(int64),
+      UNARY_CAST_TO_FLOAT64(float32),
+      UNARY_CAST_TO_FLOAT64(decimal128),
 
       // cast to decimal
       UNARY_SAFE_NULL_IF_NULL(castDECIMAL, {"decimal"}, int32, decimal128),
@@ -98,7 +103,8 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       UNARY_SAFE_NULL_IF_NULL(castDATE, {}, date32, date64),
 
       // add/sub/multiply/divide/mod
-      BINARY_SYMMETRIC_FN(add, {}), BINARY_SYMMETRIC_FN(subtract, {}),
+      BINARY_SYMMETRIC_FN(add, {}),
+      BINARY_SYMMETRIC_FN(subtract, {}),
       BINARY_SYMMETRIC_FN(multiply, {}),
       NUMERIC_TYPES(BINARY_SYMMETRIC_UNSAFE_NULL_IF_NULL, divide, {}),
       BINARY_GENERIC_SAFE_NULL_IF_NULL(mod, {"modulo"}, int64, int32, int32),
@@ -226,7 +232,10 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
 
       // binary representation of integer values
       UNARY_UNSAFE_NULL_IF_NULL(bin, {}, int32, utf8),
-      UNARY_UNSAFE_NULL_IF_NULL(bin, {}, int64, utf8)};
+      UNARY_UNSAFE_NULL_IF_NULL(bin, {}, int64, utf8),
+      NativeFunction("equal", {}, DataTypeVector{time64(), time64()}, boolean(),
+                     kResultNullIfNull, "equal_int64_int64"),
+  };
 
   return arithmetic_fn_registry_;
 }

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -127,6 +127,8 @@ class GANDIVA_EXPORT LLVMGenerator {
     void Visit(const InExprDexBase<std::string>& dex) override;
     template <typename Type>
     void VisitInExpression(const InExprDexBase<Type>& dex);
+    void Visit(const PreEvalInExprDex& dex) override;
+    void Visit(const ReadProxyDex& dex) override;
 
     LValuePtr result() { return result_; }
 
@@ -173,6 +175,7 @@ class GANDIVA_EXPORT LLVMGenerator {
 
     LLVMGenerator* generator_;
     LValuePtr result_;
+    LValuePtr read_proxy_result_;
     llvm::Function* function_;
     llvm::BasicBlock* entry_block_;
     llvm::Value* arg_addrs_;

--- a/cpp/src/gandiva/node.h
+++ b/cpp/src/gandiva/node.h
@@ -315,4 +315,51 @@ class InExpressionNode<gandiva::DecimalScalar128> : public Node {
   int32_t precision_, scale_;
 };
 
+class PreEvalInExpressionNode : public Node {
+ public:
+  PreEvalInExpressionNode(NodePtr eval_expr, NodePtr condition_eval_expr,
+                          DataTypePtr type)
+      : Node(type),
+        eval_expr_(eval_expr),
+        condition_eval_expr_(condition_eval_expr),
+        type_(type){};
+  const DataTypePtr& type() const { return type_; }
+
+  Status Accept(NodeVisitor& visitor) const override { return visitor.Visit(*this); }
+
+  std::string ToString() const override {
+    std::stringstream ss;
+    ss << "PreEvalIN expr : ( ";
+    ss << condition_eval_expr_->ToString() << " )";
+    return ss.str();
+  }
+
+  const NodePtr& eval_expr() const { return eval_expr_; }
+
+  const NodePtr& condition_eval_expr() const { return condition_eval_expr_; }
+
+ private:
+  NodePtr eval_expr_;
+  NodePtr condition_eval_expr_;
+  DataTypePtr type_;
+};
+
+class ReadProxyNode : public Node {
+ public:
+  ReadProxyNode(DataTypePtr type, std::string read_proxy_to_string)
+      : Node(type), type_(type), read_proxy_to_string_(read_proxy_to_string){};
+
+  std::string ToString() const override {
+    std::stringstream ss;
+    ss << "ReadProxyNode (" << read_proxy_to_string_ << ")";
+    return ss.str();
+  }
+
+  Status Accept(NodeVisitor& visitor) const override { return visitor.Visit(*this); }
+
+ private:
+  DataTypePtr type_;
+  std::string read_proxy_to_string_;
+};
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/node_visitor.h
+++ b/cpp/src/gandiva/node_visitor.h
@@ -34,6 +34,8 @@ class LiteralNode;
 class BooleanNode;
 template <typename Type>
 class InExpressionNode;
+class PreEvalInExpressionNode;
+class ReadProxyNode;
 
 /// \brief Visitor for nodes in the expression tree.
 class GANDIVA_EXPORT NodeVisitor {
@@ -51,6 +53,8 @@ class GANDIVA_EXPORT NodeVisitor {
   virtual Status Visit(const InExpressionNode<double>& node) = 0;
   virtual Status Visit(const InExpressionNode<gandiva::DecimalScalar128>& node) = 0;
   virtual Status Visit(const InExpressionNode<std::string>& node) = 0;
+  virtual Status Visit(const PreEvalInExpressionNode& node) = 0;
+  virtual Status Visit(const ReadProxyNode& node) = 0;
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/CMakeLists.txt
+++ b/cpp/src/gandiva/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_gandiva_test(projector-test
                  in_expr_test.cc
                  literal_test.cc
                  null_validity_test.cc
+                 pre_eval_in_expr_test.cc
                  projector_build_validation_test.cc
                  projector_test.cc
                  test_util.cc

--- a/cpp/src/gandiva/tests/test_util.cc
+++ b/cpp/src/gandiva/tests/test_util.cc
@@ -172,4 +172,18 @@ std::shared_ptr<Configuration> TestConfigWithContextFunction(
                          reinterpret_cast<void*>(multiply_by_two_formula));
   });
 }
+std::vector<Decimal128> MakeDecimalVector(std::vector<std::string> values) {
+  std::vector<arrow::Decimal128> ret;
+  for (auto str : values) {
+    Decimal128 decimal_value;
+    int32_t decimal_precision;
+    int32_t decimal_scale;
+
+    DCHECK_OK(
+        Decimal128::FromString(str, &decimal_value, &decimal_precision, &decimal_scale));
+
+    ret.push_back(decimal_value);
+  }
+  return ret;
+}
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/test_util.h
+++ b/cpp/src/gandiva/tests/test_util.h
@@ -124,5 +124,6 @@ std::shared_ptr<Configuration> TestConfigWithContextFunction(
 
 std::string GetTestFunctionLLVMIRPath();
 NativeFunction GetTestExternalFunction();
+std::vector<Decimal128> MakeDecimalVector(std::vector<std::string> values);
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/tree_expr_builder.cc
+++ b/cpp/src/gandiva/tree_expr_builder.cc
@@ -221,4 +221,19 @@ MAKE_IN(Double, double, float64());
 MAKE_IN(String, std::string, utf8());
 MAKE_IN(Binary, std::string, binary());
 
+NodePtr TreeExprBuilder::MakePreEvalInExpression(NodePtr eval_expr,
+                                                 NodeVector condition_eval_exprs) {
+  NodeVector equal_nodes;
+  equal_nodes.reserve(condition_eval_exprs.size());
+  auto read_proxy_node =
+      std::make_shared<ReadProxyNode>(eval_expr->return_type(), eval_expr->ToString());
+  for (const auto& expr : condition_eval_exprs) {
+    auto equal_func =
+        TreeExprBuilder::MakeFunction("equal", {expr, read_proxy_node}, boolean());
+    equal_nodes.push_back(equal_func);
+  }
+  auto or_expr = TreeExprBuilder::MakeOr(equal_nodes);
+  return std::make_shared<PreEvalInExpressionNode>(eval_expr, or_expr, boolean());
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/tree_expr_builder.h
+++ b/cpp/src/gandiva/tree_expr_builder.h
@@ -134,6 +134,9 @@ class GANDIVA_EXPORT TreeExprBuilder {
   /// \brief Timestamp as millis since epoch.
   static NodePtr MakeInExpressionTimeStamp(NodePtr node,
                                            const std::unordered_set<int64_t>& constants);
+
+  static NodePtr MakePreEvalInExpression(NodePtr eval_expr,
+                                         NodeVector condition_eval_exprs);
 };
 
 }  // namespace gandiva


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
see here: https://github.com/apache/arrow/issues/39492

We can introduce a new expression, PreEvalInExpr, which helps users proactively expand the IN expression in SQL into an OR expression. Simultaneously, we observe that in such cases, as shown in the diagram, performing common subexpression elimination is valuable.

In this scenario, we notice that the IN expression has a common subexpression, which will occur n times with n conditions in the IN clause. This would generate IR code for computing the common subexpression n times. Although LLVM's optimization algorithms may, with some probability, actively eliminate redundant IR code generated by the common subexpression, it still incurs a cost in terms of LLVM optimizing IR code.

Therefore, we can proactively perform common subexpression elimination as illustrated. We first compute the eval_expr for the IN expression. Then, we replace all subsequent expanded OR expression eval_expr with a read_proxy_dex. Subsequently, the llvm_generator_code will access this read_proxy_dex, which directly utilizes the previously computed value of eval_expr.

This optimization strategy aims to reduce the redundant computation of the common subexpression, enhancing the efficiency of the code generation process in LLVM.
![whiteboard_exported_image (23)](https://github.com/apache/arrow/assets/90952590/551a0534-8bb5-405a-8f46-2a6aaae350a0)


### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

add an preEvalInExpr for gandiva

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
yes,it tested!

### Are there any user-facing changes?
Add a function for TreeExprBuilder . Now user can use MakePreEvalInExpr() to codegen some sql like : select a+3 in(c-1,b*2)

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39493