### PR TITLE
GH-35718: [Go][Parquet] Fix for null-only encoding panic

### DIFF
--- a/go/parquet/internal/encoding/delta_bit_packing.go
+++ b/go/parquet/internal/encoding/delta_bit_packing.go
@@ -466,7 +466,11 @@ func (enc *deltaBitPackEncoder) FlushValues() (Buffer, error) {
 
 // EstimatedDataEncodedSize returns the current amount of data actually flushed out and written
 func (enc *deltaBitPackEncoder) EstimatedDataEncodedSize() int64 {
-	return int64(enc.bitWriter.Written())
+	if enc.bitWriter != nil {
+		return int64(enc.bitWriter.Written())
+	} else {
+		return 0
+	}
 }
 
 // DeltaBitPackInt32Encoder is an encoder for the delta bitpacking encoding for int32 data.

--- a/go/parquet/internal/encoding/delta_byte_array.go
+++ b/go/parquet/internal/encoding/delta_byte_array.go
@@ -40,7 +40,15 @@ type DeltaByteArrayEncoder struct {
 }
 
 func (enc *DeltaByteArrayEncoder) EstimatedDataEncodedSize() int64 {
-	return enc.prefixEncoder.EstimatedDataEncodedSize() + enc.suffixEncoder.EstimatedDataEncodedSize()
+	prefixEstimatedSize := int64(0)
+	if enc.prefixEncoder != nil {
+		prefixEstimatedSize = enc.prefixEncoder.EstimatedDataEncodedSize()
+	}
+	suffixEstimatedSize := int64(0)
+	if enc.suffixEncoder != nil {
+		suffixEstimatedSize = enc.suffixEncoder.EstimatedDataEncodedSize()
+	}
+	return prefixEstimatedSize + suffixEstimatedSize
 }
 
 func (enc *DeltaByteArrayEncoder) initEncoders() {

--- a/go/parquet/pqarrow/encode_arrow_test.go
+++ b/go/parquet/pqarrow/encode_arrow_test.go
@@ -427,6 +427,64 @@ func TestWriteEmptyLists(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWriteAllNullsWithDeltaEncoding(t *testing.T) {
+	sc := arrow.NewSchema([]arrow.Field{
+		{Name: "f1", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+		{Name: "f2", Type: arrow.ListOf(arrow.FixedWidthTypes.Date32)},
+		{Name: "f3", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "f4", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+		{Name: "f5", Type: arrow.BinaryTypes.LargeString, Nullable: true},
+		{Name: "f6", Type: arrow.ListOf(arrow.BinaryTypes.LargeString)},
+		{Name: "f7", Type: arrow.PrimitiveTypes.Float64, Nullable: true},
+		{Name: "f8", Type: arrow.ListOf(arrow.FixedWidthTypes.Date64)},
+		{Name: "f9", Type: arrow.BinaryTypes.String, Nullable: true},
+		{Name: "f10", Type: arrow.ListOf(arrow.BinaryTypes.LargeString)},
+		{Name: "f11", Type: arrow.FixedWidthTypes.Boolean, Nullable: true},
+		{Name: "f12", Type: arrow.ListOf(arrow.FixedWidthTypes.Boolean)},
+		{Name: "f13", Type: arrow.PrimitiveTypes.Int32, Nullable: true},
+		{Name: "f14", Type: arrow.ListOf(arrow.PrimitiveTypes.Float32)},
+	}, nil)
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, sc)
+	defer bldr.Release()
+	for _, b := range bldr.Fields() {
+		b.AppendNull()
+	}
+
+	rec := bldr.NewRecord()
+	defer rec.Release()
+
+	props := parquet.NewWriterProperties(
+		parquet.WithVersion(parquet.V1_0),
+		parquet.WithDictionaryDefault(false),
+		parquet.WithDictionaryFor("f9", true),
+		parquet.WithDictionaryFor("f10", true),
+		parquet.WithDictionaryFor("f13", true),
+		parquet.WithDictionaryFor("f14", true),
+		parquet.WithEncodingFor("f1", parquet.Encodings.DeltaBinaryPacked),
+		parquet.WithEncodingFor("f2", parquet.Encodings.DeltaBinaryPacked),
+		parquet.WithEncodingFor("f3", parquet.Encodings.DeltaByteArray),
+		parquet.WithEncodingFor("f4", parquet.Encodings.DeltaByteArray),
+		parquet.WithEncodingFor("f5", parquet.Encodings.DeltaLengthByteArray),
+		parquet.WithEncodingFor("f6", parquet.Encodings.DeltaLengthByteArray),
+		parquet.WithEncodingFor("f7", parquet.Encodings.Plain),
+		parquet.WithEncodingFor("f8", parquet.Encodings.Plain),
+		parquet.WithEncodingFor("f9", parquet.Encodings.Plain),
+		parquet.WithEncodingFor("f10", parquet.Encodings.Plain),
+		parquet.WithEncodingFor("f11", parquet.Encodings.RLE),
+		parquet.WithEncodingFor("f12", parquet.Encodings.RLE),
+		parquet.WithEncodingFor("f13", parquet.Encodings.RLE),
+		parquet.WithEncodingFor("f14", parquet.Encodings.RLE),
+	)
+	arrprops := pqarrow.DefaultWriterProps()
+	var buf bytes.Buffer
+	fw, err := pqarrow.NewFileWriter(sc, &buf, props, arrprops)
+	require.NoError(t, err)
+	err = fw.Write(rec)
+	require.NoError(t, err)
+	err = fw.Close()
+	require.NoError(t, err)
+}
+
 func TestArrowReadWriteTableChunkedCols(t *testing.T) {
 	chunkSizes := []int{2, 4, 10, 2}
 	const totalLen = int64(18)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

closes: #35718 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Fix painc writing with DeltaBinaryPacked or DeltaByteArray when column only has nulls

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

- add a test writing nulls to columns with DeltaBinaryPacked / DeltaByteArray / DeltaLengthByteArray encodings

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #35718