### PR TITLE
GH-39437: [CI][Python] Update pandas tests failing on pandas nightly CI build

### DIFF
--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -504,11 +504,9 @@ def test_categories_with_string_pyarrow_dtype(tempdir):
     df2 = df2.astype("category")
 
     # categories should be converted to pa.Array
-    assert pa.array(df1["x"]) == pa.array(df2["x"],
-                                          type=pa.dictionary(pa.int8(),
-                                                             pa.large_string()))
-    assert pa.array(df1["x"].cat.categories.values) == pa.array(
-        df2["x"].cat.categories.values, type=pa.large_string())
+    assert pa.array(df1["x"]).to_pylist() == pa.array(df2["x"]).to_pylist()
+    assert pa.array(df1["x"].cat.categories.values).to_pylist() == pa.array(
+        df2["x"].cat.categories.values).to_pylist()
 
     path = str(tempdir / 'cat.parquet')
     pq.write_table(pa.table(df1), path)

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -504,9 +504,11 @@ def test_categories_with_string_pyarrow_dtype(tempdir):
     df2 = df2.astype("category")
 
     # categories should be converted to pa.Array
-    assert pa.array(df1["x"]) == pa.array(df2["x"])
+    assert pa.array(df1["x"]) == pa.array(df2["x"],
+                                          type=pa.dictionary(pa.int8(),
+                                                             pa.large_string()))
     assert pa.array(df1["x"].cat.categories.values) == pa.array(
-        df2["x"].cat.categories.values)
+        df2["x"].cat.categories.values, type=pa.large_string())
 
     path = str(tempdir / 'cat.parquet')
     pq.write_table(pa.table(df1), path)

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -406,7 +406,7 @@ carat        cut  color  clarity  depth  table  price     x     y     z
 def test_backwards_compatible_column_metadata_handling(datadir):
     if Version("2.2.0") <= Version(pd.__version__):
         # TODO: regression in pandas
-        # add a link to the issue
+        # https://github.com/pandas-dev/pandas/issues/56775
         pytest.skip("Regression in pandas 2.2.0")
     expected = pd.DataFrame(
         {'a': [1, 2, 3], 'b': [.1, .2, .3],

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -404,6 +404,10 @@ carat        cut  color  clarity  depth  table  price     x     y     z
 
 @pytest.mark.pandas
 def test_backwards_compatible_column_metadata_handling(datadir):
+    if Version("2.2.0") <= Version(pd.__version__):
+        # TODO: regression in pandas
+        # add a link to the issue
+        pytest.skip("Regression in pandas 2.2.0")
     expected = pd.DataFrame(
         {'a': [1, 2, 3], 'b': [.1, .2, .3],
          'c': pd.date_range("2017-01-01", periods=3, tz='Europe/Brussels')})

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -255,6 +255,12 @@ class TestConvertMetadata:
         tm.assert_frame_equal(restored, df)
 
     def test_rangeindex_doesnt_warn(self):
+        if Version("2.2.0") <= Version(pd.__version__):
+            # make_block deprecation in pandas, still under discussion
+            # https://github.com/pandas-dev/pandas/pull/56422
+            # https://github.com/pandas-dev/pandas/issues/40226
+            pytest.skip("make_block deprecated in pandas 2.2.0")
+
         # ARROW-5606: pandas 0.25 deprecated private _start/stop/step
         # attributes -> can be removed if support < pd 0.25 is dropped
         df = pd.DataFrame(np.random.randn(4, 2), columns=['a', 'b'])
@@ -305,6 +311,12 @@ class TestConvertMetadata:
         _check_pandas_roundtrip(df, preserve_index=True)
 
     def test_multiindex_doesnt_warn(self):
+        if Version("2.2.0") <= Version(pd.__version__):
+            # make_block deprecation in pandas, still under discussion
+            # https://github.com/pandas-dev/pandas/pull/56422
+            # https://github.com/pandas-dev/pandas/issues/40226
+            pytest.skip("make_block deprecated in pandas 2.2.0")
+
         # ARROW-3953: pandas 0.24 rename of MultiIndex labels to codes
         columns = pd.MultiIndex.from_arrays([['one', 'two'], ['X', 'Y']])
         df = pd.DataFrame([(1, 'a'), (2, 'b'), (3, 'c')], columns=columns)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3095,7 +3095,7 @@ def _fully_loaded_dataframe_example():
 
 @pytest.mark.parametrize('columns', ([b'foo'], ['foo']))
 def test_roundtrip_with_bytes_unicode(columns):
-    if Version("2.0.0") <= Version(pd.__version__) < Version("2.2.0"):
+    if Version("2.0.0") <= Version(pd.__version__) < Version("2.3.0"):
         # TODO: regression in pandas, hopefully fixed in next version
         # https://issues.apache.org/jira/browse/ARROW-18394
         # https://github.com/pandas-dev/pandas/issues/50127

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -465,7 +465,7 @@ class TestConvertMetadata:
                                         preserve_index=True)
 
     def test_binary_column_name(self):
-        if Version("2.0.0") <= Version(pd.__version__) < Version("2.2.0"):
+        if Version("2.0.0") <= Version(pd.__version__) < Version("2.3.0"):
             # TODO: regression in pandas, hopefully fixed in next version
             # https://issues.apache.org/jira/browse/ARROW-18394
             # https://github.com/pandas-dev/pandas/issues/50127

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -255,18 +255,18 @@ class TestConvertMetadata:
         tm.assert_frame_equal(restored, df)
 
     def test_rangeindex_doesnt_warn(self):
-        if Version("2.2.0") <= Version(pd.__version__):
-            # make_block deprecation in pandas, still under discussion
-            # https://github.com/pandas-dev/pandas/pull/56422
-            # https://github.com/pandas-dev/pandas/issues/40226
-            pytest.skip("make_block deprecated in pandas 2.2.0")
-
         # ARROW-5606: pandas 0.25 deprecated private _start/stop/step
         # attributes -> can be removed if support < pd 0.25 is dropped
         df = pd.DataFrame(np.random.randn(4, 2), columns=['a', 'b'])
 
         with warnings.catch_warnings():
             warnings.simplefilter(action="error")
+            # make_block deprecation in pandas, still under discussion
+            # https://github.com/pandas-dev/pandas/pull/56422
+            # https://github.com/pandas-dev/pandas/issues/40226
+            warnings.filterwarnings(
+                "ignore", "make_block is deprecated", DeprecationWarning
+            )
             _check_pandas_roundtrip(df, preserve_index=True)
 
     def test_multiindex_columns(self):
@@ -311,18 +311,18 @@ class TestConvertMetadata:
         _check_pandas_roundtrip(df, preserve_index=True)
 
     def test_multiindex_doesnt_warn(self):
-        if Version("2.2.0") <= Version(pd.__version__):
-            # make_block deprecation in pandas, still under discussion
-            # https://github.com/pandas-dev/pandas/pull/56422
-            # https://github.com/pandas-dev/pandas/issues/40226
-            pytest.skip("make_block deprecated in pandas 2.2.0")
-
         # ARROW-3953: pandas 0.24 rename of MultiIndex labels to codes
         columns = pd.MultiIndex.from_arrays([['one', 'two'], ['X', 'Y']])
         df = pd.DataFrame([(1, 'a'), (2, 'b'), (3, 'c')], columns=columns)
 
         with warnings.catch_warnings():
             warnings.simplefilter(action="error")
+            # make_block deprecation in pandas, still under discussion
+            # https://github.com/pandas-dev/pandas/pull/56422
+            # https://github.com/pandas-dev/pandas/issues/40226
+            warnings.filterwarnings(
+                "ignore", "make_block is deprecated", DeprecationWarning
+            )
             _check_pandas_roundtrip(df, preserve_index=True)
 
     def test_integer_index_column(self):


### PR DESCRIPTION
Update version checks and assertions of pyarrow array equality for pandas failing tests on the CI: [test-conda-python-3.10-pandas-nightly](https://github.com/ursacomputing/crossbow/actions/runs/7391976015/job/20109720695)

* Closes: #39437