### PR TITLE
GH-39469: [CI][JS] Force node 20 on JS build on arm64 to fix build issues

### DIFF
--- a/dev/tasks/verify-rc/github.macos.arm64.yml
+++ b/dev/tasks/verify-rc/github.macos.arm64.yml
@@ -45,7 +45,9 @@ jobs:
         run: |
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile
-          export PATH="$(brew --prefix node@18)/bin:$PATH"
+          # Force node v20 due to GH-39469
+          brew install node@20
+          export PATH="$(brew --prefix node@20)/bin:$PATH"
           export PATH="$(brew --prefix ruby)/bin:$PATH"
           export PKG_CONFIG_PATH="$(brew --prefix ruby)/lib/pkgconfig"
           arrow/dev/release/verify-release-candidate.sh \


### PR DESCRIPTION
### Rationale for this change

The nightly jobs are currently failing when using node v21 on macOS arm64.

### What changes are included in this PR?

Install and use node v20 for macOS arm64 jobs.

### Are these changes tested?

Yes via archery.

### Are there any user-facing changes?
No
* Closes: #39469