### PR TITLE
GH-39500: [Docs] Pin pydata-sphinx-theme to 0.14

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -20,7 +20,7 @@ breathe
 doxygen
 ipython
 numpydoc
-pydata-sphinx-theme
+pydata-sphinx-theme=0.14
 sphinx-autobuild
 sphinx-design
 sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@
 breathe
 ipython
 numpydoc
-pydata-sphinx-pydata-sphinx-theme==0.14
+pydata-sphinx-theme==0.14
 sphinx-autobuild
 sphinx-design
 sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@
 breathe
 ipython
 numpydoc
-pydata-sphinx-theme
+pydata-sphinx-pydata-sphinx-theme==0.14
 sphinx-autobuild
 sphinx-design
 sphinx-copybutton


### PR DESCRIPTION
### Rationale for this change

The latest pydata-sphinx-theme release 0.15 of a few days ago had some breakages. So let's pin to 0.14.x until 0.15 has stabilized.

* Closes: #39500