### PR TITLE
GH-38470: [CI][Integration] Install jpype and build JNI c-data to run integration tests

### DIFF
--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -649,7 +649,7 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
                 consumer.name, "consuming")
             if exc_info:
                 exc_type, exc_value, exc_tb = exc_info
-                log(f'{exc_type}: {exc_value} \n{exc_tb}')
+                log(f'{exc_type}: {exc_value}')
             log()
 
     log(f"{fail_count} failures, {len(runner.skips)} skips")

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -649,7 +649,7 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
                 consumer.name, "consuming")
             if exc_info:
                 exc_type, exc_value, exc_tb = exc_info
-                log(f'{exc_type}: {exc_value}')
+                log(f'{exc_type}: {exc_value} \n{exc_tb}')
             log()
 
     log(f"{fail_count} failures, {len(runner.skips)} skips")

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -95,14 +95,18 @@ def setup_jpype():
 class _CDataBase:
 
     def __init__(self, debug, args):
-        import jpype
         self.debug = debug
         self.args = args
         self.ffi = cdata.ffi()
-        setup_jpype()
-        # JPype pointers to java.io, org.apache.arrow...
-        self.java_io = jpype.JPackage("java").io
-        self.java_arrow = jpype.JPackage("org").apache.arrow
+        try:
+            import jpype
+        except ImportError:
+            log("jpype is not installed. Skipping setup.")
+        else:
+            setup_jpype()
+            # JPype pointers to java.io, org.apache.arrow...
+            self.java_io = jpype.JPackage("java").io
+            self.java_arrow = jpype.JPackage("org").apache.arrow
         self.java_allocator = self._make_java_allocator()
 
     def _pointer_to_int(self, c_ptr):

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -107,7 +107,7 @@ class _CDataBase:
             # JPype pointers to java.io, org.apache.arrow...
             self.java_io = jpype.JPackage("java").io
             self.java_arrow = jpype.JPackage("org").apache.arrow
-        self.java_allocator = self._make_java_allocator()
+            self.java_allocator = self._make_java_allocator()
 
     def _pointer_to_int(self, c_ptr):
         return int(self.ffi.cast('uintptr_t', c_ptr))

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -105,7 +105,7 @@ def setup_jpype():
 @functools.lru_cache
 def _enable_c_data_tests():
     try:
-        import jpype
+        import jpype      # noqa: F401  # ignore unused
     except ImportError as error:
         log(f"Skipping C data tests, jpype is not available: {error}")
         return False

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -92,7 +92,7 @@ def setup_jpype():
                    *_JAVA_OPTS)
 
 
-functools.lru_cache
+@functools.lru_cache
 def _enable_c_data_tests():
     try:
         import jpype

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -102,16 +102,6 @@ def setup_jpype():
                    *java_opts)
 
 
-@functools.lru_cache
-def _enable_c_data_tests():
-    try:
-        import jpype      # noqa: F401  # ignore unused
-    except ImportError as error:
-        log(f"Skipping C data tests, jpype is not available: {error}")
-        return False
-    return True
-
-
 class _CDataBase:
 
     def __init__(self, debug, args):
@@ -248,10 +238,10 @@ class JavaTester(Tester):
     CONSUMER = True
     FLIGHT_SERVER = True
     FLIGHT_CLIENT = True
-    C_DATA_SCHEMA_EXPORTER = _enable_c_data_tests()
-    C_DATA_SCHEMA_IMPORTER = _enable_c_data_tests()
-    C_DATA_ARRAY_EXPORTER = _enable_c_data_tests()
-    C_DATA_ARRAY_IMPORTER = _enable_c_data_tests()
+    C_DATA_SCHEMA_EXPORTER = True
+    C_DATA_SCHEMA_IMPORTER = True
+    C_DATA_ARRAY_EXPORTER = True
+    C_DATA_ARRAY_IMPORTER = True
 
     name = 'Java'
 

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -40,7 +40,6 @@ def load_version_from_pom():
 _JAVA_OPTS = [
     "-Dio.netty.tryReflectionSetAccessible=true",
     "-Darrow.struct.conflict.policy=CONFLICT_APPEND",
-    "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED",
     # GH-39113: avoid failures accessing files in `/tmp/hsperfdata_...`
     "-XX:-UsePerfData",
 ]
@@ -83,13 +82,24 @@ def setup_jpype():
     import jpype
     jar_path = f"{_ARROW_TOOLS_JAR}:{_ARROW_C_DATA_JAR}"
     # XXX Didn't manage to tone down the logging level here (DEBUG -> INFO)
+    java_opts = _JAVA_OPTS[:]
+    proc = subprocess.run(
+            ['java', '--add-opens'],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True)
+    if 'Unrecognized option: --add-opens' not in proc.stderr:
+        # Java 9+
+        java_opts.append(
+            '--add-opens=java.base/java.nio='
+            'org.apache.arrow.memory.core,ALL-UNNAMED')
     jpype.startJVM(jpype.getDefaultJVMPath(),
                    "-Djava.class.path=" + jar_path,
                    # This flag is too heavy for IPC and Flight tests
                    "-Darrow.memory.debug.allocator=true",
                    # Reduce internal use of signals by the JVM
                    "-Xrs",
-                   *_JAVA_OPTS)
+                   *java_opts)
 
 
 @functools.lru_cache

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -92,22 +92,27 @@ def setup_jpype():
                    *_JAVA_OPTS)
 
 
+functools.lru_cache
+def _enable_c_data_tests():
+    try:
+        import jpype
+    except ImportError as error:
+        log(f"Skipping C data tests, jpype is not available: {error}")
+        return False
+    return True
+
 class _CDataBase:
 
     def __init__(self, debug, args):
+        import jpype
         self.debug = debug
         self.args = args
         self.ffi = cdata.ffi()
-        try:
-            import jpype
-        except ImportError:
-            log("jpype is not installed. Skipping setup.")
-        else:
-            setup_jpype()
-            # JPype pointers to java.io, org.apache.arrow...
-            self.java_io = jpype.JPackage("java").io
-            self.java_arrow = jpype.JPackage("org").apache.arrow
-            self.java_allocator = self._make_java_allocator()
+        setup_jpype()
+        # JPype pointers to java.io, org.apache.arrow...
+        self.java_io = jpype.JPackage("java").io
+        self.java_arrow = jpype.JPackage("org").apache.arrow
+        self.java_allocator = self._make_java_allocator()
 
     def _pointer_to_int(self, c_ptr):
         return int(self.ffi.cast('uintptr_t', c_ptr))
@@ -232,10 +237,10 @@ class JavaTester(Tester):
     CONSUMER = True
     FLIGHT_SERVER = True
     FLIGHT_CLIENT = True
-    C_DATA_SCHEMA_EXPORTER = True
-    C_DATA_SCHEMA_IMPORTER = True
-    C_DATA_ARRAY_EXPORTER = True
-    C_DATA_ARRAY_IMPORTER = True
+    C_DATA_SCHEMA_EXPORTER = _enable_c_data_tests()
+    C_DATA_SCHEMA_IMPORTER = _enable_c_data_tests()
+    C_DATA_ARRAY_EXPORTER = _enable_c_data_tests()
+    C_DATA_ARRAY_IMPORTER = _enable_c_data_tests()
 
     name = 'Java'
 

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -101,6 +101,7 @@ def _enable_c_data_tests():
         return False
     return True
 
+
 class _CDataBase:
 
     def __init__(self, debug, args):

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -84,10 +84,10 @@ def setup_jpype():
     # XXX Didn't manage to tone down the logging level here (DEBUG -> INFO)
     java_opts = _JAVA_OPTS[:]
     proc = subprocess.run(
-            ['java', '--add-opens'],
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            text=True)
+        ['java', '--add-opens'],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True)
     if 'Unrecognized option: --add-opens' not in proc.stderr:
         # Java 9+
         java_opts.append(

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -35,6 +35,7 @@ extras = {
                         'setuptools_scm'],
     'docker': ['ruamel.yaml', 'python-dotenv'],
     'integration': ['cffi'],
+    'integration-java': ['jpype1'],
     'lint': ['numpydoc==1.1.0', 'autopep8', 'flake8==6.1.0', 'cython-lint',
              'cmake_format==0.6.13'],
     'numpydoc': ['numpydoc==1.1.0'],

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -567,6 +567,14 @@ test_package_java() {
 
   maybe_setup_conda maven openjdk
 
+  # Build Java JNI
+  pushd java/c
+  mkdir -p build
+  pushd build
+  cmake ..
+  cmake --build .
+  popd
+
   pushd java
   if [ ${TEST_JAVA} -gt 0 ]; then
     mvn test

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -904,6 +904,7 @@ test_integration() {
   maybe_setup_virtualenv
 
   pip install -e dev/archery[integration]
+  pip install jpype1 || :
 
   JAVA_DIR=$ARROW_SOURCE_DIR/java
   CPP_BUILD_DIR=$ARROW_TMPDIR/cpp-build

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -950,7 +950,7 @@ test_integration() {
   maybe_setup_virtualenv
 
   pip install -e dev/archery[integration]
-  pip install jpype1
+  pip install -e dev/archery[integration-java]
 
   JAVA_DIR=$ARROW_SOURCE_DIR/java
   CPP_BUILD_DIR=$ARROW_TMPDIR/cpp-build

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -567,15 +567,21 @@ test_package_java() {
 
   maybe_setup_conda maven openjdk
 
+  pushd java
+
   # Build Java JNI
-  pushd java/c
   mkdir -p build
   pushd build
-  cmake ..
+  # Disable Testing because GTest might not be present
+  # Disable JNI Gandiva because Protobuf might not be present
+  cmake \
+    -DBUILD_TESTING=OFF \
+    -DARROW_JAVA_JNI_ENABLE_GANDIVA=OFF \
+    ..
   cmake --build .
   popd
 
-  pushd java
+  # Build Java JARs
   if [ ${TEST_JAVA} -gt 0 ]; then
     mvn test
   fi
@@ -640,6 +646,7 @@ test_and_install_cpp() {
     -DARROW_JSON=ON \
     -DARROW_ORC=ON \
     -DARROW_PARQUET=ON \
+    -DARROW_SUBSTRAIT=ON \
     -DARROW_S3=${ARROW_S3} \
     -DARROW_USE_CCACHE=${ARROW_USE_CCACHE:-ON} \
     -DARROW_VERBOSE_THIRDPARTY_BUILD=ON \

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -904,7 +904,7 @@ test_integration() {
   maybe_setup_virtualenv
 
   pip install -e dev/archery[integration]
-  pip install jpype1 || :
+  pip install jpype1
 
   JAVA_DIR=$ARROW_SOURCE_DIR/java
   CPP_BUILD_DIR=$ARROW_TMPDIR/cpp-build

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -578,7 +578,7 @@ test_package_java() {
     -DBUILD_TESTING=OFF \
     -DARROW_JAVA_JNI_ENABLE_GANDIVA=OFF \
     ..
-  cmake --build .
+  cmake --build . --target install
   popd
 
   # Build Java JARs

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -580,9 +580,9 @@ test_package_java() {
     if [ ! -z "${CMAKE_GENERATOR}" ]; then
       cmake_options+=(-G "${CMAKE_GENERATOR}")
     fi
-    local build_dir="${ARROW_TMPDIR/java-jni-build}"
-    local install_dir="${ARROW_TMPDIR/java-jni-install}"
-    local dist_dir="${ARROW_TMPDIR/java-jni-dist}"
+    local build_dir="${ARROW_TMPDIR}/java-jni-build"
+    local install_dir="${ARROW_TMPDIR}/java-jni-install"
+    local dist_dir="${ARROW_TMPDIR}/java-jni-dist"
     cmake \
       -S . \
       -B "${build_dir}" \


### PR DESCRIPTION
### Rationale for this change

Integration verification tasks are currently failing on CI.

### What changes are included in this PR?

Install jpype and build JNI c-data to run integration tests

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?
No

* Closes: #38470