### PR TITLE
GH-38988: [Go] Expose dictionary size from DictionaryBuilder

### DIFF
--- a/go/arrow/array/dictionary.go
+++ b/go/arrow/array/dictionary.go
@@ -1004,6 +1004,10 @@ func (b *dictionaryBuilder) AppendIndices(indices []int, valid []bool) {
 	}
 }
 
+func (b *dictionaryBuilder) DictionarySize() int {
+	return b.memoTable.Size()
+}
+
 type NullDictionaryBuilder struct {
 	dictionaryBuilder
 }

--- a/go/arrow/array/dictionary.go
+++ b/go/arrow/array/dictionary.go
@@ -412,6 +412,7 @@ type DictionaryBuilder interface {
 	AppendArray(arrow.Array) error
 	AppendIndices([]int, []bool)
 	ResetFull()
+	DictionarySize() int
 }
 
 type dictionaryBuilder struct {

--- a/go/arrow/array/dictionary_test.go
+++ b/go/arrow/array/dictionary_test.go
@@ -92,8 +92,7 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderBasic() {
 	p.EqualValues(4, bldr.Len())
 	p.EqualValues(1, bldr.NullN())
 
-	dictionarySizeFn := builder.MethodByName("DictionarySize")
-	p.EqualValues(2, dictionarySizeFn.Call([]reflect.Value{})[0].Int())
+	p.EqualValues(2, bldr.DictionarySize())
 
 	arr := bldr.NewArray().(*array.Dictionary)
 	defer arr.Release()

--- a/go/arrow/array/dictionary_test.go
+++ b/go/arrow/array/dictionary_test.go
@@ -92,6 +92,9 @@ func (p *PrimitiveDictionaryTestSuite) TestDictionaryBuilderBasic() {
 	p.EqualValues(4, bldr.Len())
 	p.EqualValues(1, bldr.NullN())
 
+	dictionarySizeFn := builder.MethodByName("DictionarySize")
+	p.EqualValues(2, dictionarySizeFn.Call([]reflect.Value{})[0].Int())
+
 	arr := bldr.NewArray().(*array.Dictionary)
 	defer arr.Release()
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Details are in https://github.com/apache/arrow/issues/38988

### What changes are included in this PR?

This adds a method to `DictionaryBuilder` that returns the current dictionary size.

### Are these changes tested?

Updated an existing test to account for this new method.

### Are there any user-facing changes?

Yes, a new method is added to `DictionaryBuilder`.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38988