### PR TITLE
GH-39523: [R] Don't override explicitly set NOT_CRAN=false when on dev version

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -861,7 +861,7 @@ if (is_release) {
   arrow_repo <- paste0(getOption("arrow.repo", sprintf("https://apache.jfrog.io/artifactory/arrow/r/%s", VERSION)), "/libarrow/")
 } else {
   # Don't override explictily set NOT_CRAN env var, as it is used in CI.
-  not_cran <- TRUE || !env_is("NOT_CRAN", "false")
+  not_cran <- TRUE && !env_is("NOT_CRAN", "false")
   arrow_repo <- paste0(getOption("arrow.dev_repo", "https://nightlies.apache.org/arrow/r"), "/libarrow/")
 }
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -861,7 +861,7 @@ if (is_release) {
   arrow_repo <- paste0(getOption("arrow.repo", sprintf("https://apache.jfrog.io/artifactory/arrow/r/%s", VERSION)), "/libarrow/")
 } else {
   # Don't override explictily set NOT_CRAN env var, as it is used in CI.
-  not_cran <- TRUE && !env_is("NOT_CRAN", "false")
+  not_cran <- !env_is("NOT_CRAN", "false")
   arrow_repo <- paste0(getOption("arrow.dev_repo", "https://nightlies.apache.org/arrow/r"), "/libarrow/")
 }
 

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -860,7 +860,8 @@ if (is_release) {
   VERSION <- VERSION[1, 1:3]
   arrow_repo <- paste0(getOption("arrow.repo", sprintf("https://apache.jfrog.io/artifactory/arrow/r/%s", VERSION)), "/libarrow/")
 } else {
-  not_cran <- TRUE
+  # Don't override explictily set NOT_CRAN env var, as it is used in CI.
+  not_cran <- TRUE || !env_is("NOT_CRAN", "false")
   arrow_repo <- paste0(getOption("arrow.dev_repo", "https://nightlies.apache.org/arrow/r"), "/libarrow/")
 }
 


### PR DESCRIPTION
### Rationale for this change

The default linux build used in the lto job should not build with aws/gcs. A change in the build system changed this.

### What changes are included in this PR?

Revert to old behavior by not overriding explicitly set `NOT_CRAN=false`.

### Are these changes tested?

CI

### Are there any user-facing changes?

No
* Closes: #39523