### PR TITLE
GH-39527: [C++][Parquet] Validate page sizes before truncating to int32

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -274,7 +274,7 @@ class SerializedPageWriter : public PageWriter {
     int64_t uncompressed_size = page.buffer()->size();
     if (uncompressed_size > std::numeric_limits<int32_t>::max()) {
       throw ParquetException(
-          "Uncompressed dictionary page size overflows to INT32_MAX. Size:",
+          "Uncompressed dictionary page size overflows INT32_MAX. Size:",
           uncompressed_size);
     }
     std::shared_ptr<Buffer> compressed_data;

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -295,7 +295,7 @@ class SerializedPageWriter : public PageWriter {
     const uint8_t* output_data_buffer = compressed_data->data();
     if (compressed_data->size() > std::numeric_limits<int32_t>::max()) {
       throw ParquetException(
-          "Compressed dictionary page size overflows to INT32_MAX. Size: ",
+          "Compressed dictionary page size overflows INT32_MAX. Size: ",
           uncompressed_size);
     }
     int32_t output_data_len = static_cast<int32_t>(compressed_data->size());
@@ -384,7 +384,7 @@ class SerializedPageWriter : public PageWriter {
     int64_t output_data_len = compressed_data->size();
 
     if (output_data_len > std::numeric_limits<int32_t>::max()) {
-      throw ParquetException("Compressed data page size overflows to INT32_MAX. Size:",
+      throw ParquetException("Compressed data page size overflows INT32_MAX. Size:",
                              output_data_len);
     }
 
@@ -401,7 +401,7 @@ class SerializedPageWriter : public PageWriter {
     format::PageHeader page_header;
 
     if (uncompressed_size > std::numeric_limits<int32_t>::max()) {
-      throw ParquetException("Uncompressed data page size overflows to INT32_MAX. Size:",
+      throw ParquetException("Uncompressed data page size overflows INT32_MAX. Size:",
                              uncompressed_size);
     }
     page_header.__set_uncompressed_page_size(static_cast<int32_t>(uncompressed_size));
@@ -442,7 +442,7 @@ class SerializedPageWriter : public PageWriter {
     if (offset_index_builder_ != nullptr) {
       const int64_t compressed_size = output_data_len + header_size;
       if (compressed_size > std::numeric_limits<int32_t>::max()) {
-        throw ParquetException("Compressed page size overflows to INT32_MAX.");
+        throw ParquetException("Compressed page size overflows INT32_MAX.");
       }
       if (!page.first_row_index().has_value()) {
         throw ParquetException("First row index is not set in data page.");

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -273,7 +273,9 @@ class SerializedPageWriter : public PageWriter {
   int64_t WriteDictionaryPage(const DictionaryPage& page) override {
     int64_t uncompressed_size = page.buffer()->size();
     if (uncompressed_size > std::numeric_limits<int32_t>::max()) {
-      throw ParquetException("Uncompressed page size overflows to INT32_MAX.");
+      throw ParquetException(
+          "Uncompressed dictionary page size overflows to INT32_MAX. Size:",
+          uncompressed_size);
     }
     std::shared_ptr<Buffer> compressed_data;
     if (has_compressor()) {
@@ -292,7 +294,9 @@ class SerializedPageWriter : public PageWriter {
 
     const uint8_t* output_data_buffer = compressed_data->data();
     if (compressed_data->size() > std::numeric_limits<int32_t>::max()) {
-      throw ParquetException("Compressed page size overflows to INT32_MAX.");
+      throw ParquetException(
+          "Compressed dictionary page size overflows to INT32_MAX. Size: ",
+          uncompressed_size);
     }
     int32_t output_data_len = static_cast<int32_t>(compressed_data->size());
 
@@ -380,7 +384,8 @@ class SerializedPageWriter : public PageWriter {
     int64_t output_data_len = compressed_data->size();
 
     if (output_data_len > std::numeric_limits<int32_t>::max()) {
-      throw ParquetException("Compressed page size overflows to INT32_MAX.");
+      throw ParquetException("Compressed data page size overflows to INT32_MAX. Size:",
+                             output_data_len);
     }
 
     if (data_encryptor_.get()) {
@@ -396,7 +401,8 @@ class SerializedPageWriter : public PageWriter {
     format::PageHeader page_header;
 
     if (uncompressed_size > std::numeric_limits<int32_t>::max()) {
-      throw ParquetException("Uncompressed page size overflows to INT32_MAX.");
+      throw ParquetException("Uncompressed data page size overflows to INT32_MAX. Size:",
+                             uncompressed_size);
     }
     page_header.__set_uncompressed_page_size(static_cast<int32_t>(uncompressed_size));
     page_header.__set_compressed_page_size(static_cast<int32_t>(output_data_len));

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -922,8 +922,8 @@ TEST(TestPageWriter, ThrowsOnPagesTooLarge) {
               ThrowsMessage<ParquetException>(HasSubstr("overflows INT32_MAX")));
   DictionaryPage dictionary_over_compressed_limit(buffer, /*num_values=*/100,
                                                   Encoding::PLAIN);
-  EXPECT_THROW(pager->WriteDictionaryPage(dictionary_over_compressed_limit),
-               ParquetException);
+  EXPECT_THAT([&]() { pager->WriteDictionaryPage(dictionary_over_compressed_limit); },
+              ThrowsMessage<ParquetException>(HasSubstr("overflows INT32_MAX")));
 
   buffer = std::make_shared<Buffer>(&data, 1);
   DataPageV1 over_uncompressed_limit(

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -919,7 +919,7 @@ TEST(TestPageWriter, ThrowsOnPagesTooLarge) {
                                    Encoding::BIT_PACKED, Encoding::BIT_PACKED,
                                    /*uncompressed_size=*/100);
   EXPECT_THAT([&]() { pager->WriteDataPage(over_compressed_limit); },
-              ThrowsMessage<ParquetException>(HasSubstr("overflows to INT32_MAX")));
+              ThrowsMessage<ParquetException>(HasSubstr("overflows INT32_MAX")));
   DictionaryPage dictionary_over_compressed_limit(buffer, /*num_values=*/100,
                                                   Encoding::PLAIN);
   EXPECT_THROW(pager->WriteDictionaryPage(dictionary_over_compressed_limit),
@@ -931,7 +931,7 @@ TEST(TestPageWriter, ThrowsOnPagesTooLarge) {
       Encoding::BIT_PACKED,
       /*uncompressed_size=*/std::numeric_limits<int32_t>::max() + int64_t{1});
   EXPECT_THAT([&]() { pager->WriteDataPage(over_compressed_limit); },
-              ThrowsMessage<ParquetException>(HasSubstr("overflows to INT32_MAX")));
+              ThrowsMessage<ParquetException>(HasSubstr("overflows INT32_MAX")));
 }
 
 TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -26,6 +26,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_builders.h"
 
+#include "parquet/column_page.h"
 #include "parquet/column_reader.h"
 #include "parquet/column_writer.h"
 #include "parquet/file_reader.h"
@@ -37,7 +38,6 @@
 #include "parquet/test_util.h"
 #include "parquet/thrift_internal.h"
 #include "parquet/types.h"
-#include "third_party/parquet_cpp/src2/parquet/column_page.h"
 
 namespace bit_util = arrow::bit_util;
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -891,7 +891,7 @@ TEST_F(TestByteArrayValuesWriter, CheckDefaultStats) {
   ASSERT_TRUE(this->metadata_is_stats_set());
 }
 
-TEST(TestPageWriter, ThrowsOnPagesToLarge) {
+TEST(TestPageWriter, ThrowsOnPagesTooLarge) {
   NodePtr item = schema::Int32("item");  // optional item
   NodePtr list(GroupNode::Make("b", Repetition::REPEATED, {item}, ConvertedType::LIST));
   NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));  // optional list


### PR DESCRIPTION
Be defensive instead of writing invalid data.

### Rationale for this change

Users can provide this API pages that are large to validly write and we silently truncate lengths before writing.

### What changes are included in this PR?

Add validations and throw an exception if sizes are too large (this was previously checked only if page indexes are being build).

### Are these changes tested?

Unit tested

### Are there any user-facing changes?

This might start raising exceptions instead of writing out invalid parquet files.

Closes #39527 

**This PR contains a "Critical Fix".** 
* Closes: #39527