### PR TITLE
GH-39531: [Python][CI] Skip failing dask tests: test_describe_empty and test_view

### DIFF
--- a/ci/scripts/integration_dask.sh
+++ b/ci/scripts/integration_dask.sh
@@ -34,7 +34,12 @@ python -c "import dask.dataframe"
 # The "skip_with_pyarrow_strings" marker is meant to skip automatically, but that doesn't work with --pyargs, so de-selecting manually
 # - The 'test_categorize_info' test is failing because of change in StringArray's nbytes and
 #   an upstream fix (https://github.com/apache/arrow/issues/39028)
-pytest -v --pyargs dask.dataframe.tests.test_dataframe -m "not skip_with_pyarrow_strings" -k "not test_categorize_info"
+# - The 'test_describe_empty' test is flakey
+#   upstream issue: https://github.com/dask/dask/issues/10672
+# - The 'test_view' fails because we are not using the dev version of pandas
+#   where pd.Series.view is deprecated (https://pandas.pydata.org/docs/dev/reference/api/pandas.Series.view.html)
+pytest -v --pyargs dask.dataframe.tests.test_dataframe -m "not skip_with_pyarrow_strings" \
+  -k "not test_categorize_info and not test_describe_empty and not test_view"
 pytest -v --pyargs dask.dataframe.io.tests.test_orc
 pytest -v --pyargs dask.dataframe.io.tests.test_parquet \
   -m "not skip_with_pyarrow_strings and not xfail_with_pyarrow_strings"


### PR DESCRIPTION
Skipping dask tests `test_dataframe.py::test_describe_empty` and `test_dataframe.py::test_view` on our CI to stop the nightly dask test jobs to fail. 
* Closes: #39531