### PR TITLE
GH-39533: [Python] NumPy 2.0 compat: remove usage of np.core

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -790,7 +790,7 @@ def table_to_dataframe(
 _pandas_supported_numpy_types = {
     "int8", "int16", "int32", "int64",
     "uint8", "uint16", "uint32", "uint64",
-    "float16", "float32", "float64", "float128",
+    "float16", "float32", "float64",
     "object", "bool"
 }
 

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -30,7 +30,6 @@ import re
 import warnings
 
 import numpy as np
-from numpy.core.numerictypes import sctypes as _np_sctypes
 
 import pyarrow as pa
 from pyarrow.lib import _pandas_api, frombytes  # noqa
@@ -789,9 +788,10 @@ def table_to_dataframe(
 # Set of the string repr of all numpy dtypes that can be stored in a pandas
 # dataframe (complex not included since not supported by Arrow)
 _pandas_supported_numpy_types = {
-    str(np.dtype(typ))
-    for typ in (_np_sctypes['int'] + _np_sctypes['uint'] + _np_sctypes['float'] +
-                ['object', 'bool'])
+    "int8", "int16", "int32", "int64",
+    "uint8", "uint16", "uint32", "uint64",
+    "float16", "float32", "float64", "float128",
+    "object", "bool"
 }
 
 


### PR DESCRIPTION
### Rationale for this change

Removing usage of `np.core`, as that is deprecated and will be removed in numpy 2.0. 

For this specific case, we can just hardcode the list of data types instead of using a numpy api (this list doesn't typically change).

* Closes: #39533