### PR TITLE
GH-39537: [Packaging][Python] Add a numpy<2 pin to the install requirements for the 15.x release branch

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -449,7 +449,7 @@ class BinaryDistribution(Distribution):
 
 
 install_requires = (
-    'numpy >= 1.16.6',
+    'numpy >= 1.16.6, <2',
 )
 
 


### PR DESCRIPTION
### Rationale for this change

PyArrow wheels for the 15.0.0 release will not be compatible with future numpy 2.0 packages, therefore it is recommended to add this upper pin now for _releases_. We will keep the more flexible pin on the development branch (by reverting this commit on main, but so it can be cherry-picked in the release branch)

* Closes: #39537