### PR TITLE
GH-39549: [C++] Pass -jN to make in external projects

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1005,14 +1005,8 @@ if("${MAKE}" STREQUAL "")
   endif()
 endif()
 
-# Using make -j in sub-make is fragile
-# see discussion https://github.com/apache/arrow/pull/2779
-if(${CMAKE_GENERATOR} MATCHES "Makefiles")
-  set(MAKE_BUILD_ARGS "")
-else()
-  # limit the maximum number of jobs for ninja
-  set(MAKE_BUILD_ARGS "-j${NPROC}")
-endif()
+# Args for external projects using make.
+set(MAKE_BUILD_ARGS "-j${NPROC}")
 
 include(FetchContent)
 set(FC_DECLARE_COMMON_OPTIONS)
@@ -2042,10 +2036,6 @@ macro(build_jemalloc)
   endif()
 
   set(JEMALLOC_BUILD_COMMAND ${MAKE} ${MAKE_BUILD_ARGS})
-  # Paralleism for Make fails with CMake > 3.28 see #39517
-  if(${CMAKE_GENERATOR} MATCHES "Makefiles")
-    list(APPEND JEMALLOC_BUILD_COMMAND "-j1")
-  endif()
 
   if(CMAKE_OSX_SYSROOT)
     list(APPEND JEMALLOC_BUILD_COMMAND "SDKROOT=${CMAKE_OSX_SYSROOT}")


### PR DESCRIPTION
### Rationale for this change

Previous issues with sub-make fragility are no longer an issue with our new minimum CMake version 3.16.
### What changes are included in this PR?

Remove special casing from jemalloc, pass -jN to all make based eps.

### Are these changes tested?
CI
* Closes: #39549