### PR TITLE
GH-39558: [Java] Add SQL_ALL_TABLES_ARE_SELECTABLE, SQL_NULL_ORDERING and SQL_MAX_COLUMNS_IN_TABLE support to SqlInfoBuilder

### DIFF
--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SqlInfoBuilder.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SqlInfoBuilder.java
@@ -594,6 +594,16 @@ public class SqlInfoBuilder {
   }
 
   /**
+   * Sets a value for {@link SqlInfo#SQL_MAX_COLUMNS_IN_TABLE} in the builder.
+   *
+   * @param value the value for {@link SqlInfo#SQL_MAX_COLUMNS_IN_TABLE} to be set.
+   * @return the SqlInfoBuilder itself.
+   */
+  public SqlInfoBuilder withSqlMaxColumnsInTable(final long value) {
+    return withBitIntProvider(SqlInfo.SQL_MAX_COLUMNS_IN_TABLE_VALUE, value);
+  }
+
+  /**
    * Sets a value for {@link SqlInfo#SQL_MAX_CONNECTIONS} in the builder.
    *
    * @param value the value for {@link SqlInfo#SQL_MAX_CONNECTIONS} to be set.

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SqlInfoBuilder.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SqlInfoBuilder.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import java.util.function.ObjIntConsumer;
 
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlInfo;
+import org.apache.arrow.flight.sql.impl.FlightSql.SqlNullOrdering;
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlOuterJoinsSupportLevel;
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlSupportedCaseSensitivity;
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlSupportedElementActions;
@@ -500,6 +501,26 @@ public class SqlInfoBuilder {
    */
   public SqlInfoBuilder withSqlQuotedIdentifierCase(final SqlSupportedCaseSensitivity value) {
     return withBitIntProvider(SqlInfo.SQL_QUOTED_IDENTIFIER_CASE_VALUE, value.getNumber());
+  }
+
+  /**
+   * Sets a value for {@link SqlInfo#SQL_ALL_TABLES_ARE_SELECTABLE} in the builder.
+   *
+   * @param value the value for {@link SqlInfo#SQL_ALL_TABLES_ARE_SELECTABLE} to be set.
+   * @return the SqlInfoBuilder itself.
+   */
+  public SqlInfoBuilder withSqlAllTablesAreSelectable(final boolean value) {
+    return withBooleanProvider(SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE_VALUE, value);
+  }
+
+  /**
+   * Sets a value for {@link SqlInfo#SQL_NULL_ORDERING} in the builder.
+   *
+   * @param value the value for {@link SqlInfo#SQL_NULL_ORDERING} to be set.
+   * @return the SqlInfoBuilder itself.
+   */
+  public SqlInfoBuilder withSqlNullOrdering(final SqlNullOrdering value) {
+    return withBitIntProvider(SqlInfo.SQL_NULL_ORDERING_VALUE, value.getNumber());
   }
 
   /**

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
@@ -107,6 +107,12 @@ public class TestFlightSql {
     GET_SQL_INFO_EXPECTED_RESULTS_MAP
         .put(Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY_VALUE), "false");
     GET_SQL_INFO_EXPECTED_RESULTS_MAP
+        .put(Integer.toString(FlightSql.SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE_VALUE), "true");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP
+        .put(
+            Integer.toString(FlightSql.SqlInfo.SQL_NULL_ORDERING_VALUE),
+            Integer.toString(FlightSql.SqlNullOrdering.SQL_NULLS_SORTED_AT_END_VALUE));
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP
         .put(Integer.toString(FlightSql.SqlInfo.SQL_DDL_CATALOG_VALUE), "false");
     GET_SQL_INFO_EXPECTED_RESULTS_MAP
         .put(Integer.toString(FlightSql.SqlInfo.SQL_DDL_SCHEMA_VALUE), "true");
@@ -135,6 +141,8 @@ public class TestFlightSql {
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION,
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION,
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY,
+        FlightSql.SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE,
+        FlightSql.SqlInfo.SQL_NULL_ORDERING,
         FlightSql.SqlInfo.SQL_DDL_CATALOG,
         FlightSql.SqlInfo.SQL_DDL_SCHEMA,
         FlightSql.SqlInfo.SQL_DDL_TABLE,

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/TestFlightSql.java
@@ -128,6 +128,8 @@ public class TestFlightSql {
         .put(
             Integer.toString(FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE_VALUE),
             Integer.toString(SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_CASE_INSENSITIVE_VALUE));
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP
+        .put(Integer.toString(FlightSql.SqlInfo.SQL_MAX_COLUMNS_IN_TABLE_VALUE), "42");
   }
 
   @AfterAll
@@ -148,7 +150,8 @@ public class TestFlightSql {
         FlightSql.SqlInfo.SQL_DDL_TABLE,
         FlightSql.SqlInfo.SQL_IDENTIFIER_CASE,
         FlightSql.SqlInfo.SQL_IDENTIFIER_QUOTE_CHAR,
-        FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE);
+        FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE,
+        FlightSql.SqlInfo.SQL_MAX_COLUMNS_IN_TABLE);
   }
 
   private static List<List<String>> getNonConformingResultsForGetSqlInfo(
@@ -160,6 +163,7 @@ public class TestFlightSql {
         final List<String> result = results.get(index);
         final String providedName = result.get(0);
         final String expectedName = Integer.toString(args[index].getNumber());
+        System.err.println(expectedName);
         if (!(GET_SQL_INFO_EXPECTED_RESULTS_MAP.get(providedName).equals(result.get(1)) &&
             providedName.equals(expectedName))) {
           nonConformingResults.add(result);
@@ -611,31 +615,21 @@ public class TestFlightSql {
   }
 
   @Test
-  public void testGetSqlInfoResultsWithTwoArgs() throws Exception {
-    final FlightSql.SqlInfo[] args = {
-        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME,
-        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION};
-    final FlightInfo info = sqlClient.getSqlInfo(args);
-    try (final FlightStream stream = sqlClient.getStream(info.getEndpoints().get(0).getTicket())) {
-      Assertions.assertAll(
-          () -> MatcherAssert.assertThat(
-              stream.getSchema(),
-              is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)
-          ),
-          () -> MatcherAssert.assertThat(
-              getNonConformingResultsForGetSqlInfo(getResults(stream), args),
-              is(emptyList())
-          )
-      );
-    }
-  }
-
-  @Test
-  public void testGetSqlInfoResultsWithThreeArgs() throws Exception {
+  public void testGetSqlInfoResultsWithManyArgs() throws Exception {
     final FlightSql.SqlInfo[] args = {
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME,
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION,
-        FlightSql.SqlInfo.SQL_IDENTIFIER_QUOTE_CHAR};
+        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION,
+        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY,
+        FlightSql.SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE,
+        FlightSql.SqlInfo.SQL_NULL_ORDERING,
+        FlightSql.SqlInfo.SQL_DDL_CATALOG,
+        FlightSql.SqlInfo.SQL_DDL_SCHEMA,
+        FlightSql.SqlInfo.SQL_DDL_TABLE,
+        FlightSql.SqlInfo.SQL_IDENTIFIER_CASE,
+        FlightSql.SqlInfo.SQL_IDENTIFIER_QUOTE_CHAR,
+        FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE,
+        FlightSql.SqlInfo.SQL_MAX_COLUMNS_IN_TABLE};
     final FlightInfo info = sqlClient.getSqlInfo(args);
     try (final FlightStream stream = sqlClient.getStream(info.getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -237,7 +237,10 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
                   SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UPPERCASE :
                   metaData.storesLowerCaseQuotedIdentifiers() ?
                       SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_LOWERCASE :
-                      SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UNKNOWN);
+                      SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UNKNOWN)
+          .withSqlAllTablesAreSelectable(true)
+          .withSqlNullOrdering(SqlNullOrdering.SQL_NULLS_SORTED_AT_END)
+          .withSqlMaxColumnsInTable(42);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
This PR adds ability to specify `SQL_ALL_TABLES_ARE_SELECTABLE` and `SQL_NULL_ORDERING` metadata in `org.apache.arrow.flight.sql.SqlInfoBuilder`.

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Without this change it is impossible to specify whether all tables are selectable, supported null ordering and maximum number of columns in table using `SqlInfoBuilder`.


### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In this PR two methods are added to `SqlInfoBuilder`:
- `withSqlAllTablesAreSelectable` accepting boolean parameter that specifies whether all tables are selectable
- `withSqlNullOrdering` accepting `org.apache.arrow.flight.sql.impl.FlightSql.SqlNullOrdering` value that specifies supported null ordering
- `withSqlMaxColumnsInTable` accepting long parameter that specifies maximum number of columns in table

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
To ensure correctness `org.apache.arrow.flight.TestFlightSql#testGetSqlInfoResultsWithManyArgs` test is added).

### Are there any user-facing changes?

This PR does not contain any breaking changes of user API.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39558