### PR TITLE
GH-39489: [C++][Parquet] Revert #39491 and add timestamp behavior to doc

### DIFF
--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -115,13 +115,13 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
                                                ParquetType::INT64,
                                                ConvertedType::TIMESTAMP_MILLIS));
   arrow_fields.push_back(
-      ::arrow::field("timestamp", ::arrow::timestamp(TimeUnit::MILLI, "UTC"), false));
+      ::arrow::field("timestamp", ::arrow::timestamp(TimeUnit::MILLI), false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp[us]", Repetition::REQUIRED,
                                                ParquetType::INT64,
                                                ConvertedType::TIMESTAMP_MICROS));
   arrow_fields.push_back(
-      ::arrow::field("timestamp[us]", ::arrow::timestamp(TimeUnit::MICRO, "UTC"), false));
+      ::arrow::field("timestamp[us]", ::arrow::timestamp(TimeUnit::MICRO), false));
 
   parquet_fields.push_back(PrimitiveNode::Make("date", Repetition::REQUIRED,
                                                ParquetType::INT32, ConvertedType::DATE));

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -387,7 +387,8 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
       break;
     case ArrowTypeId::TIME64: {
       type = ParquetType::INT64;
-      auto time_type = static_cast<::arrow::Time64Type*>(field->type().get());
+      const auto* time_type =
+          static_cast<const ::arrow::Time64Type*>(field->type().get());
       if (time_type->unit() == ::arrow::TimeUnit::NANO) {
         logical_type =
             LogicalType::Time(/*is_adjusted_to_utc=*/true, LogicalType::TimeUnit::NANOS);

--- a/cpp/src/parquet/arrow/schema_internal.cc
+++ b/cpp/src/parquet/arrow/schema_internal.cc
@@ -89,7 +89,11 @@ Result<std::shared_ptr<ArrowType>> MakeArrowTime64(const LogicalType& logical_ty
 
 Result<std::shared_ptr<ArrowType>> MakeArrowTimestamp(const LogicalType& logical_type) {
   const auto& timestamp = checked_cast<const TimestampLogicalType&>(logical_type);
-  const bool utc_normalized = timestamp.is_adjusted_to_utc();
+  // GH-39489: Parquet timestamps should follow the `timestamp.is_adjusted_to_utc()`,
+  //  however, arrow timestamps should not carry this information if it is from
+  //  a converted type and doesn't have `ARROW:schema` annotation set.
+  const bool utc_normalized =
+      timestamp.is_from_converted_type() ? false : timestamp.is_adjusted_to_utc();
   static const char* utc_timezone = "UTC";
   switch (timestamp.time_unit()) {
     case LogicalType::TimeUnit::MILLIS:

--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -467,12 +467,12 @@ physical type.
 +-------------------+-----------------------------+----------------------------+---------+
 | DATE              | INT32                       | Date32                     | \(3)    |
 +-------------------+-----------------------------+----------------------------+---------+
-| TIME              | INT32                       | Time32 (milliseconds)      |         |
+| TIME              | INT32                       | Time32 (milliseconds)      | \(7)    |
 +-------------------+-----------------------------+----------------------------+---------+
-| TIME              | INT64                       | Time64 (micro- or          |         |
+| TIME              | INT64                       | Time64 (micro- or          | \(7)    |
 |                   |                             | nanoseconds)               |         |
 +-------------------+-----------------------------+----------------------------+---------+
-| TIMESTAMP         | INT64                       | Timestamp (milli-, micro-  |         |
+| TIMESTAMP         | INT64                       | Timestamp (milli-, micro-  | \(8)    |
 |                   |                             | or nanoseconds)            |         |
 +-------------------+-----------------------------+----------------------------+---------+
 | STRING            | BYTE_ARRAY                  | Utf8                       | \(4)    |
@@ -498,6 +498,16 @@ physical type.
 * \(6) On the read side, a key with multiple values does not get deduplicated,
   in contradiction with the
   `Parquet specification <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps>`__.
+
+* \(7) On the writer side, an Arrow Time32/Time64 will be written as a Parquet
+  Time with LogicalType LogicalType::Time and adjustedToUTC flag set to true.
+
+* \(8) On the writer side, an Arrow Timestamp will be written as a Parquet
+  Timestamp with LogicalType LogicalType::Timestamp and adjustedToUTC flag
+  defined by the arrow timestamp type. On the reader side, the Parquet
+  Timestamp will be read as an Arrow Timestamp with the adjustedToUTC flag.
+  If the parquet file was written with a legacy TIMESTAMP ConvertedType, the
+   adjustedToUTC flag will be set to false in the Arrow Timestamp.
 
 *Unsupported logical types:* JSON, BSON, UUID.  If such a type is encountered
 when reading a Parquet file, the default physical type mapping is used (for
@@ -590,4 +600,4 @@ Miscellaneous
   data read APIs do not currently make any use of them.
 
 * \(2) APIs are provided for creating, serializing and deserializing Bloom
-  Filters, but they are not integrated into data read APIs.
+  Filters, but they are not integrated into data read/write APIs.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This patch revert change in https://github.com/apache/arrow/commit/c752bdb08b1efae467b81a026b06a92cc571497f , and update the document for timestamp casting

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

1. Revert https://github.com/apache/arrow/commit/c752bdb08b1efae467b81a026b06a92cc571497f
2. Update the timestamp document

In (1), the comment updated is not reverted.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Already

### Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39489