### PR TITLE
GH-39574: [Go] Enable PollFlightInfo in Flight RPC

### DIFF
--- a/go/arrow/flight/flightsql/client.go
+++ b/go/arrow/flight/flightsql/client.go
@@ -1038,9 +1038,14 @@ func (p *PreparedStatement) ExecutePoll(ctx context.Context, retryDescriptor *fl
 
 	cmd := &pb.CommandPreparedStatementQuery{PreparedStatementHandle: p.handle}
 
-	desc, err := descForCommand(cmd)
-	if err != nil {
-		return nil, err
+	desc := retryDescriptor
+	var err error
+
+	if desc == nil {
+		desc, err = descForCommand(cmd)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if retryDescriptor == nil {
@@ -1064,9 +1069,8 @@ func (p *PreparedStatement) ExecutePoll(ctx context.Context, retryDescriptor *fl
 				return nil, err
 			}
 		}
-		return p.client.Client.PollFlightInfo(ctx, desc, opts...)
 	}
-	return p.client.Client.PollFlightInfo(ctx, retryDescriptor, opts...)
+	return p.client.Client.PollFlightInfo(ctx, desc, opts...)
 }
 
 // ExecuteUpdate executes the prepared statement update query on the server

--- a/go/arrow/flight/flightsql/client.go
+++ b/go/arrow/flight/flightsql/client.go
@@ -82,6 +82,17 @@ func flightInfoForCommand(ctx context.Context, cl *Client, cmd proto.Message, op
 	return cl.getFlightInfo(ctx, desc, opts...)
 }
 
+func pollInfoForCommand(ctx context.Context, cl *Client, cmd proto.Message, retryDescriptor *flight.FlightDescriptor, opts ...grpc.CallOption) (*flight.PollInfo, error) {
+	if retryDescriptor != nil {
+		return cl.Client.PollFlightInfo(ctx, retryDescriptor, opts...)
+	}
+	desc, err := descForCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return cl.Client.PollFlightInfo(ctx, desc, opts...)
+}
+
 func schemaForCommand(ctx context.Context, cl *Client, cmd proto.Message, opts ...grpc.CallOption) (*flight.SchemaResult, error) {
 	desc, err := descForCommand(cmd)
 	if err != nil {
@@ -123,6 +134,14 @@ func (c *Client) Execute(ctx context.Context, query string, opts ...grpc.CallOpt
 	return flightInfoForCommand(ctx, c, &cmd, opts...)
 }
 
+// ExecutePoll idempotently starts execution of a query/checks for completion.
+// To check for completion, pass the FlightDescriptor from the previous call
+// to ExecutePoll as the retryDescriptor.
+func (c *Client) ExecutePoll(ctx context.Context, query string, retryDescriptor *flight.FlightDescriptor, opts ...grpc.CallOption) (*flight.PollInfo, error) {
+	cmd := pb.CommandStatementQuery{Query: query}
+	return pollInfoForCommand(ctx, c, &cmd, retryDescriptor, opts...)
+}
+
 // GetExecuteSchema gets the schema of the result set of a query without
 // executing the query itself.
 func (c *Client) GetExecuteSchema(ctx context.Context, query string, opts ...grpc.CallOption) (*flight.SchemaResult, error) {
@@ -134,6 +153,12 @@ func (c *Client) ExecuteSubstrait(ctx context.Context, plan SubstraitPlan, opts 
 	cmd := pb.CommandStatementSubstraitPlan{
 		Plan: &pb.SubstraitPlan{Plan: plan.Plan, Version: plan.Version}}
 	return flightInfoForCommand(ctx, c, &cmd, opts...)
+}
+
+func (c *Client) ExecuteSubstraitPoll(ctx context.Context, plan SubstraitPlan, retryDescriptor *flight.FlightDescriptor, opts ...grpc.CallOption) (*flight.PollInfo, error) {
+	cmd := pb.CommandStatementSubstraitPlan{
+		Plan: &pb.SubstraitPlan{Plan: plan.Plan, Version: plan.Version}}
+	return pollInfoForCommand(ctx, c, &cmd, retryDescriptor, opts...)
 }
 
 func (c *Client) GetExecuteSubstraitSchema(ctx context.Context, plan SubstraitPlan, opts ...grpc.CallOption) (*flight.SchemaResult, error) {
@@ -606,6 +631,15 @@ func (tx *Txn) Execute(ctx context.Context, query string, opts ...grpc.CallOptio
 	return flightInfoForCommand(ctx, tx.c, cmd, opts...)
 }
 
+func (tx *Txn) ExecutePoll(ctx context.Context, query string, retryDescriptor *flight.FlightDescriptor, opts ...grpc.CallOption) (*flight.PollInfo, error) {
+	if !tx.txn.IsValid() {
+		return nil, ErrInvalidTxn
+	}
+	// The server should encode the transaction into the retry descriptor
+	cmd := &pb.CommandStatementQuery{Query: query, TransactionId: tx.txn}
+	return pollInfoForCommand(ctx, tx.c, cmd, retryDescriptor, opts...)
+}
+
 func (tx *Txn) ExecuteSubstrait(ctx context.Context, plan SubstraitPlan, opts ...grpc.CallOption) (*flight.FlightInfo, error) {
 	if !tx.txn.IsValid() {
 		return nil, ErrInvalidTxn
@@ -614,6 +648,18 @@ func (tx *Txn) ExecuteSubstrait(ctx context.Context, plan SubstraitPlan, opts ..
 		Plan:          &pb.SubstraitPlan{Plan: plan.Plan, Version: plan.Version},
 		TransactionId: tx.txn}
 	return flightInfoForCommand(ctx, tx.c, cmd, opts...)
+}
+
+func (tx *Txn) ExecuteSubstraitPoll(ctx context.Context, plan SubstraitPlan, retryDescriptor *flight.FlightDescriptor, opts ...grpc.CallOption) (*flight.PollInfo, error) {
+	if !tx.txn.IsValid() {
+		return nil, ErrInvalidTxn
+	}
+	// The server should encode the transaction into the retry descriptor
+	cmd := &pb.CommandStatementSubstraitPlan{
+		Plan:          &pb.SubstraitPlan{Plan: plan.Plan, Version: plan.Version},
+		TransactionId: tx.txn,
+	}
+	return pollInfoForCommand(ctx, tx.c, cmd, retryDescriptor, opts...)
 }
 
 func (tx *Txn) GetExecuteSchema(ctx context.Context, query string, opts ...grpc.CallOption) (*flight.SchemaResult, error) {
@@ -979,6 +1025,48 @@ func (p *PreparedStatement) Execute(ctx context.Context, opts ...grpc.CallOption
 	}
 
 	return p.client.getFlightInfo(ctx, desc, opts...)
+}
+
+// ExecutePoll executes the prepared statement on the server and returns a PollInfo
+// indicating the progress of execution.
+//
+// Will error if already closed.
+func (p *PreparedStatement) ExecutePoll(ctx context.Context, retryDescriptor *flight.FlightDescriptor, opts ...grpc.CallOption) (*flight.PollInfo, error) {
+	if p.closed {
+		return nil, errors.New("arrow/flightsql: prepared statement already closed")
+	}
+
+	cmd := &pb.CommandPreparedStatementQuery{PreparedStatementHandle: p.handle}
+
+	desc, err := descForCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if retryDescriptor == nil {
+		if p.hasBindParameters() {
+			pstream, err := p.client.Client.DoPut(ctx, opts...)
+			if err != nil {
+				return nil, err
+			}
+
+			wr, err := p.writeBindParameters(pstream, desc)
+			if err != nil {
+				return nil, err
+			}
+			if err = wr.Close(); err != nil {
+				return nil, err
+			}
+			pstream.CloseSend()
+
+			// wait for the server to ack the result
+			if _, err = pstream.Recv(); err != nil && err != io.EOF {
+				return nil, err
+			}
+		}
+		return p.client.Client.PollFlightInfo(ctx, desc, opts...)
+	}
+	return p.client.Client.PollFlightInfo(ctx, retryDescriptor, opts...)
 }
 
 // ExecuteUpdate executes the prepared statement update query on the server

--- a/go/arrow/flight/flightsql/server_test.go
+++ b/go/arrow/flight/flightsql/server_test.go
@@ -56,6 +56,36 @@ func (*testServer) GetFlightInfoStatement(ctx context.Context, q flightsql.State
 	}, nil
 }
 
+func (*testServer) PollFlightInfo(ctx context.Context, fd *flight.FlightDescriptor) (*flight.PollInfo, error) {
+	return &flight.PollInfo{
+		Info: &flight.FlightInfo{
+			FlightDescriptor: fd,
+			Endpoint: []*flight.FlightEndpoint{{
+				Ticket: &flight.Ticket{Ticket: []byte{}},
+			}, {
+				Ticket: &flight.Ticket{Ticket: []byte{}},
+			}},
+		},
+		FlightDescriptor: nil,
+	}, nil
+}
+
+func (*testServer) PollFlightInfoStatement(ctx context.Context, q flightsql.StatementQuery, fd *flight.FlightDescriptor) (*flight.PollInfo, error) {
+	ticket, err := flightsql.CreateStatementQueryTicket([]byte(q.GetQuery()))
+	if err != nil {
+		return nil, err
+	}
+	return &flight.PollInfo{
+		Info: &flight.FlightInfo{
+			FlightDescriptor: fd,
+			Endpoint: []*flight.FlightEndpoint{{
+				Ticket: &flight.Ticket{Ticket: ticket},
+			}},
+		},
+		FlightDescriptor: &flight.FlightDescriptor{Cmd: []byte{}},
+	}, nil
+}
+
 func (*testServer) DoGetStatement(ctx context.Context, ticket flightsql.StatementQueryTicket) (sc *arrow.Schema, cc <-chan flight.StreamChunk, err error) {
 	handle := string(ticket.GetStatementHandle())
 	switch handle {
@@ -189,6 +219,20 @@ func (s *FlightSqlServerSuite) TestExecuteChunkError() {
 	}
 }
 
+func (s *FlightSqlServerSuite) TestExecutePoll() {
+	poll, err := s.cl.ExecutePoll(context.TODO(), "1", nil)
+	s.NoError(err)
+	s.NotNil(poll)
+	s.NotNil(poll.GetFlightDescriptor())
+	s.Len(poll.GetInfo().Endpoint, 1)
+
+	poll, err = s.cl.ExecutePoll(context.TODO(), "1", poll.GetFlightDescriptor())
+	s.NoError(err)
+	s.NotNil(poll)
+	s.Nil(poll.GetFlightDescriptor())
+	s.Len(poll.GetInfo().Endpoint, 2)
+}
+
 type UnimplementedFlightSqlServerSuite struct {
 	suite.Suite
 
@@ -312,6 +356,22 @@ func (s *UnimplementedFlightSqlServerSuite) TestGetTypeInfo() {
 	s.Equal(codes.Unimplemented, st.Code())
 	s.Equal(st.Message(), "GetFlightInfoXdbcTypeInfo not implemented")
 	s.Nil(info)
+}
+
+func (s *UnimplementedFlightSqlServerSuite) TestPoll() {
+	poll, err := s.cl.ExecutePoll(context.TODO(), "", nil)
+	st, ok := status.FromError(err)
+	s.True(ok)
+	s.Equal(codes.Unimplemented, st.Code())
+	s.Equal("PollFlightInfoStatement not implemented", st.Message())
+	s.Nil(poll)
+
+	poll, err = s.cl.ExecuteSubstraitPoll(context.TODO(), flightsql.SubstraitPlan{}, nil)
+	st, ok = status.FromError(err)
+	s.True(ok)
+	s.Equal(codes.Unimplemented, st.Code())
+	s.Equal("PollFlightInfoSubstraitPlan not implemented", st.Message())
+	s.Nil(poll)
 }
 
 func getTicket(cmd proto.Message) *flight.Ticket {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

It's impossible to use the current bindings with PollFlightInfo. Required for apache/arrow-adbc#1457.

### What changes are included in this PR?

Add new methods that expose PollFlightInfo.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Adds new methods.
* Closes: #39574