### PR TITLE
GH-39564: [CI][Java] Set correct version on Java BOM

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -236,6 +236,8 @@ jobs:
           set -e
           pushd arrow/java
           mvn versions:set -DnewVersion={{ arrow.no_rc_snapshot_version }}
+          mvn versions:set -DnewVersion={{ arrow.no_rc_snapshot_version }} -f bom
+          mvn versions:set -DnewVersion={{ arrow.no_rc_snapshot_version }} -f maven
           popd
           arrow/ci/scripts/java_full_build.sh \
             $GITHUB_WORKSPACE/arrow \


### PR DESCRIPTION
### Rationale for this change

The version set currently on the maintenance branch is incorrect for Java BOM.

### What changes are included in this PR?

Suggested changes to set specifically version for BOM and maven.

### Are these changes tested?

I will trigger java-jars via archery but I think this is currently only reproducible on the maintenance branch. So we will have to merge and validate there.

### Are there any user-facing changes?
No
* Closes: #39564