### PR TITLE
GH-37577: [MATLAB] Create a superclass for DateType-related MATLAB tests

### DIFF
--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -86,7 +86,6 @@ classdef hDateType < hFixedWidthType
 
     methods (Access = protected, Abstract)
         DefaultDateUnit;
-        end
     end
 
 end

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -15,8 +15,6 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-
-
 classdef tDate32Type < tDateTypeTest
 
     properties
@@ -99,4 +97,3 @@ classdef tDate32Type < tDateTypeTest
         end
     end
 end
-

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -15,9 +15,9 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-% Modified test class for arrow.type.Date32Type and arrow.date32
 
-classdef tDate32Type < tDataTypeTest
+
+classdef tDate32Type < tDateTypeTest
 
     properties
         ConstructionFcn = @arrow.date32

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -15,7 +15,9 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tDate32Type < hFixedWidthType
+% Modified test class for arrow.type.Date32Type and arrow.date32
+
+classdef tDate32Type < tDataTypeTest
 
     properties
         ConstructionFcn = @arrow.date32
@@ -23,6 +25,13 @@ classdef tDate32Type < hFixedWidthType
         TypeID = arrow.type.ID.Date32
         BitWidth = int32(32)
         ClassName = "arrow.type.Date32Type"
+    end
+
+    methods (Access = private)
+        function defaultUnit = getDefaultDateUnit(~)
+            % Define the default DateUnit for Date32Type
+            defaultUnit = arrow.type.DateUnit.Day;
+        end
     end
 
     methods(Test)
@@ -88,7 +97,6 @@ classdef tDate32Type < hFixedWidthType
             typeArray2 = [date32Type date32Type]';
             testCase.verifyFalse(isequal(typeArray1, typeArray2));
         end
-    
     end
-
 end
+

--- a/matlab/test/arrow/type/tDate64Type.m
+++ b/matlab/test/arrow/type/tDate64Type.m
@@ -15,9 +15,9 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-% Modified test class for arrow.type.Date64Type and arrow.date64
 
-classdef tDate64Type < tDataTypeTest
+
+classdef tDate64Type < tDateTypeTest
 
     properties
         ConstructionFcn = @arrow.date64

--- a/matlab/test/arrow/type/tDate64Type.m
+++ b/matlab/test/arrow/type/tDate64Type.m
@@ -15,8 +15,6 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-
-
 classdef tDate64Type < tDateTypeTest
 
     properties

--- a/matlab/test/arrow/type/tDate64Type.m
+++ b/matlab/test/arrow/type/tDate64Type.m
@@ -15,7 +15,9 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tDate64Type < hFixedWidthType
+% Modified test class for arrow.type.Date64Type and arrow.date64
+
+classdef tDate64Type < tDataTypeTest
 
     properties
         ConstructionFcn = @arrow.date64
@@ -23,6 +25,13 @@ classdef tDate64Type < hFixedWidthType
         TypeID = arrow.type.ID.Date64
         BitWidth = int32(64)
         ClassName = "arrow.type.Date64Type"
+    end
+
+    methods (Access = private)
+        function defaultUnit = getDefaultDateUnit(~)
+            % Define the default DateUnit for Date64Type
+            defaultUnit = arrow.type.DateUnit.Millisecond;
+        end
     end
 
     methods(Test)

--- a/matlab/test/arrow/type/tDateTypeTest.m
+++ b/matlab/test/arrow/type/tDateTypeTest.m
@@ -1,12 +1,25 @@
-% Shared superclass for DateType-related tests for Date32Type and Date64Type
-classdef tDateType < matlab.unittest.TestCase
+% Shared superclass for DateType-related tests
+
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef hDateTypeTest < hFixedWidthType
     
-    properties
+    properties (Abstract)
         ConstructionFcn
-        ArrowType
-        TypeID
-        BitWidth
-        ClassName
     end
     
     methods (Test)
@@ -19,7 +32,7 @@ classdef tDateType < matlab.unittest.TestCase
         function DefaultDateUnit(testCase)
             type = testCase.ConstructionFcn();
             actualUnit = type.DateUnit;
-            expectedUnit = testCase.getDefaultDateUnit();
+            expectedUnit = testCase.retrieveDefaultDateUnit();
             testCase.verifyEqual(actualUnit, expectedUnit);
         end
 
@@ -71,9 +84,8 @@ classdef tDateType < matlab.unittest.TestCase
         end
     end
 
-    methods (Access = private)
-        function defaultUnit = retrieveDefaultDateUnit(~)
-            defaultUnit = arrow.type.DateUnit.Millisecond;
+    methods (Access = protected, Abstract)
+        retrieveDefaultDateUnit(obj)
         end
     end
 

--- a/matlab/test/arrow/type/tDateTypeTest.m
+++ b/matlab/test/arrow/type/tDateTypeTest.m
@@ -16,7 +16,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef hDateTypeTest < hFixedWidthType
+classdef hDateType < hFixedWidthType
     
     properties (Abstract)
         ConstructionFcn
@@ -30,7 +30,7 @@ classdef hDateTypeTest < hFixedWidthType
         end
 
         function DefaultDateUnit(testCase)
-            type = testCase.ConstructionFcn();
+            type = testCase.ConstructionFcn;
             actualUnit = type.DateUnit;
             expectedUnit = testCase.retrieveDefaultDateUnit();
             testCase.verifyEqual(actualUnit, expectedUnit);
@@ -85,7 +85,7 @@ classdef hDateTypeTest < hFixedWidthType
     end
 
     methods (Access = protected, Abstract)
-        retrieveDefaultDateUnit(obj)
+        DefaultDateUnit;
         end
     end
 

--- a/matlab/test/arrow/type/tDateTypeTest.m
+++ b/matlab/test/arrow/type/tDateTypeTest.m
@@ -1,0 +1,80 @@
+% Shared superclass for DateType-related tests for Date32Type and Date64Type
+classdef tDateType < matlab.unittest.TestCase
+    
+    properties
+        ConstructionFcn
+        ArrowType
+        TypeID
+        BitWidth
+        ClassName
+    end
+    
+    methods (Test)
+        function TestClass(testCase)
+            % Verify ArrowType is an object of the expected class type.
+            name = string(class(testCase.ArrowType));
+            testCase.verifyEqual(name, testCase.ClassName);
+        end
+
+        function DefaultDateUnit(testCase)
+            type = testCase.ConstructionFcn();
+            actualUnit = type.DateUnit;
+            expectedUnit = testCase.getDefaultDateUnit();
+            testCase.verifyEqual(actualUnit, expectedUnit);
+        end
+
+        function DateUnitNoSetter(testCase)
+            % Verify that an error is thrown when trying to set the value
+            % of the DateUnit property.
+            type = testCase.ConstructionFcn();
+            testCase.verifyError(@() setfield(type, "DateUnit", "Millisecond"), "MATLAB:class:SetProhibited");
+        end
+
+        function InvalidProxy(testCase)
+            % Verify that an error is thrown when a Proxy of an unexpected
+            % type is passed to the DateType constructor.
+            array = arrow.array([1, 2, 3]);
+            proxy = array.Proxy;
+            testCase.verifyError(@() testCase.ConstructionFcn(proxy), "arrow:proxy:ProxyNameMismatch");
+        end
+
+        function IsEqualTrue(testCase)
+            % Verifies isequal method of DateType returns true if
+            % conditions are met:
+            %
+            % 1. All input arguments have a class type DateType
+            % 2. All inputs have the same size
+
+            % Scalar DateType arrays
+            dateType1 = testCase.ConstructionFcn();
+            dateType2 = testCase.ConstructionFcn();
+            testCase.verifyTrue(isequal(dateType1, dateType2));
+
+            % Non-scalar DateType arrays
+            typeArray1 = [dateType1 dateType1];
+            typeArray2 = [dateType2 dateType2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
+        end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method of DateType returns false when expected.
+            % Pass a different arrow.type.Type subclass to isequal
+            dateType = testCase.ConstructionFcn();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(dateType, int32Type));
+            testCase.verifyFalse(isequal([dateType dateType], [int32Type int32Type]));
+
+            % DateType arrays have different sizes
+            typeArray1 = [dateType dateType];
+            typeArray2 = [dateType dateType]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+    end
+
+    methods (Access = private)
+        function defaultUnit = retrieveDefaultDateUnit(~)
+            defaultUnit = arrow.type.DateUnit.Millisecond;
+        end
+    end
+
+end


### PR DESCRIPTION
### Rationale for this change
We introduced a shared superclass, DateTypeTest, to tackle code duplication issues for Date32Type and Date64Type. This aims to make our code more reusable and easier to maintain.

### What changes are included in this PR?
 * Introduction of the shared superclass DateTypeTest for DateType-related tests.
 * Modification of individual test classes (tDate32Type and tDate64Type) to inherit from DateTypeTest.
 * Updates method names, comments, and code structure to improve clarity.

### Are these changes tested?
Yes
 * The new shared superclass successfully reduces code duplication.

### Are there any user-facing changes?
No


* Closes: #37577