### PR TITLE
GH-39588: [CI][Go] Add CGO_ENABLED=1 to cdata_integration build to fix macOS build with conda

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -935,7 +935,7 @@ test_go() {
         go_lib="arrow_go_integration.dll"
         ;;
     esac
-    go build -buildvcs=false -tags cdata_integration,assert -buildmode=c-shared -o ${go_lib} .
+    CGO_ENABLED=1 go build -buildvcs=false -tags cdata_integration,assert -buildmode=c-shared -o ${go_lib} .
     popd
   fi
   go clean -modcache


### PR DESCRIPTION
### Rationale for this change

CI job has been failing since we added integration tests.

### What changes are included in this PR?

Add `CGO_ENABLED=1` to go build cdata_integration on the verification script.

### Are these changes tested?

Yes via archery.

### Are there any user-facing changes?

No
* Closes: #39588