### PR TITLE
GH-35239: [MATLAB] Report error when building the MATLAB Interface to Arrow in Debug mode on Windows

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 if(WIN32)
   string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
   if(CMAKE_BUILD_TYPE_UPPER STREQUAL DEBUG)
-    message(FATAL_ERROR "You can't build this with Debug because MATLAB is built with Release. You must use Release")
+    message(FATAL_ERROR "Building the MATLAB interface in Debug mode is not supported.")
   endif()
 endif()
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -131,10 +131,10 @@ if(NOT Arrow_FOUND)
   build_arrow()
 endif()
 
-# Identify MATLAB build mode (Debug or Release)
+# Check the Build mode on Windows
 if(WIN32)
-  execute_process(COMMAND dumpbin /dependents ${Matlab_MAIN_PROGRAM} OUTPUT_VARIABLE DEPENDENTS)
-  if(DEPENDENTS MATCHES "MSVCP\\d+.dll")
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
+  if(CMAKE_BUILD_TYPE_UPPER STREQUAL DEBUG)
     message(FATAL_ERROR "You can't build this with Debug because MATLAB is built with Release. You must use Release")
   endif()
 endif()

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 if(WIN32)
   execute_process(COMMAND dumpbin /dependents ${Matlab_MAIN_PROGRAM} OUTPUT_VARIABLE DEPENDENTS)
   if(DEPENDENTS MATCHES "MSVCP\\d+.dll")
-    message(FATAL_ERROR "Error: Building in Debug mode is not allowed because MATLAB is built with Release mode. Please switch to Release mode.")
+    message(FATAL_ERROR "You can't build this with Debug because MATLAB is built with Release. You must use Release")
   endif()
 endif()
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -131,6 +131,14 @@ if(NOT Arrow_FOUND)
   build_arrow()
 endif()
 
+# Identify MATLAB build mode (Debug or Release)
+if(WIN32)
+  execute_process(COMMAND dumpbin /dependents ${Matlab_MAIN_PROGRAM} OUTPUT_VARIABLE DEPENDENTS)
+  if(DEPENDENTS MATCHES "MSVCP\\d+.dll")
+    message(FATAL_ERROR "Error: Building in Debug mode is not allowed because MATLAB is built with Release mode. Please switch to Release mode.")
+  endif()
+endif()
+
 # MATLAB is Required
 find_package(Matlab REQUIRED COMPONENTS MAIN_PROGRAM)
 

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -133,8 +133,13 @@ endif()
 
 # Check the Build mode on Windows
 if(WIN32)
-  string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
-  if(CMAKE_BUILD_TYPE_UPPER STREQUAL DEBUG)
+  if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
+    set(is_debug "$<CONFIG:Debug>")
+  else()
+    set(is_debug "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+  endif()
+  
+  if (is_debug)
     message(FATAL_ERROR "Building the MATLAB interface in Debug mode is not supported.")
   endif()
 endif()


### PR DESCRIPTION
### Rationale for this change
The changes aim to identify the build mode (Debug or Release) of MATLAB by checking the MSVC Runtime library it is linked against. If MATLAB is built with a non-debug version, building in Debug mode is disallowed, and an error message is displayed, guiding the user to switch to Release mode.

### What changes are included in this PR?
Added a block of code to check the dependencies of the MATLAB executable, specifically looking for references to MSVCP\d+.dll. If such references are found, it indicates a non-debug version of the MSVC Runtime, and an error message is displayed.

### Are these changes tested?
Yes, the changes have been manually tested

### Are there any user-facing changes?
No, these changes focus on improving the build process for compatibility with MATLAB. Users will not observe any differences in the functionality or usage of the MATLAB Interface to Arrow. 
* Closes: #35239