### PR TITLE
MINOR: [CI] Update allowed_roles for crossbow submission

### DIFF
--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -280,7 +280,7 @@ class CommentBot:
             # https://developer.github.com/v4/enum/commentauthorassociation/
             # Checking  privileges here enables the bot to respond
             # without relying on the handler.
-            allowed_roles = {'OWNER', 'MEMBER', 'CONTRIBUTOR', 'COLLABORATOR'}
+            allowed_roles = {'OWNER', 'MEMBER', 'COLLABORATOR'}
             if payload['comment']['author_association'] not in allowed_roles:
                 raise EventError(
                     "Only contributors can submit requests to this bot. "


### PR DESCRIPTION
### Rationale for this change

Improved security, this aligns the permissions with the current default repo setting of required approval for all contributors.

### What changes are included in this PR?

Only committers (members,owner and collaborator of ASF org) can submit a crossbow job.

### Are these changes tested?
Not possible.