### PR TITLE
GH-39444: [C++][Parquet] Fix crash in Modular Encryption

### DIFF
--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -55,12 +55,7 @@ class AesEncryptor::AesEncryptorImpl {
   explicit AesEncryptorImpl(ParquetCipher::type alg_id, int key_len, bool metadata,
                             bool write_length);
 
-  ~AesEncryptorImpl() {
-    if (nullptr != ctx_) {
-      EVP_CIPHER_CTX_free(ctx_);
-      ctx_ = nullptr;
-    }
-  }
+  ~AesEncryptorImpl() { WipeOut(); }
 
   int Encrypt(const uint8_t* plaintext, int plaintext_len, const uint8_t* key,
               int key_len, const uint8_t* aad, int aad_len, uint8_t* ciphertext);
@@ -318,12 +313,7 @@ class AesDecryptor::AesDecryptorImpl {
   explicit AesDecryptorImpl(ParquetCipher::type alg_id, int key_len, bool metadata,
                             bool contains_length);
 
-  ~AesDecryptorImpl() {
-    if (nullptr != ctx_) {
-      EVP_CIPHER_CTX_free(ctx_);
-      ctx_ = nullptr;
-    }
-  }
+  ~AesDecryptorImpl() { WipeOut(); }
 
   int Decrypt(const uint8_t* ciphertext, int ciphertext_len, const uint8_t* key,
               int key_len, const uint8_t* aad, int aad_len, uint8_t* plaintext);

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -61,6 +61,7 @@ InternalFileDecryptor::InternalFileDecryptor(FileDecryptionProperties* propertie
 }
 
 void InternalFileDecryptor::WipeOutDecryptionKeys() {
+  std::lock_guard<std::mutex> lock(mutex_);
   properties_->WipeOutDecryptionKeys();
   for (auto const& i : all_decryptors_) {
     if (auto aes_decryptor = i.lock()) {
@@ -139,10 +140,16 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetFooterDecryptor(
   // Create both data and metadata decryptors to avoid redundant retrieval of key
   // from the key_retriever.
   int key_len = static_cast<int>(footer_key.size());
-  auto aes_metadata_decryptor = encryption::AesDecryptor::Make(
-      algorithm_, key_len, /*metadata=*/true, &all_decryptors_);
-  auto aes_data_decryptor = encryption::AesDecryptor::Make(
-      algorithm_, key_len, /*metadata=*/false, &all_decryptors_);
+  std::shared_ptr<encryption::AesDecryptor> aes_metadata_decryptor;
+  std::shared_ptr<encryption::AesDecryptor> aes_data_decryptor;
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    aes_metadata_decryptor = encryption::AesDecryptor::Make(
+        algorithm_, key_len, /*metadata=*/true, &all_decryptors_);
+    aes_data_decryptor = encryption::AesDecryptor::Make(
+        algorithm_, key_len, /*metadata=*/false, &all_decryptors_);
+  }
 
   footer_metadata_decryptor_ = std::make_shared<Decryptor>(
       aes_metadata_decryptor, footer_key, file_aad_, aad, pool_);
@@ -168,21 +175,7 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDataDecryptor(
 std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
     const std::string& column_path, const std::string& column_key_metadata,
     const std::string& aad, bool metadata) {
-  std::string column_key;
-  // first look if we already got the decryptor from before
-  if (metadata) {
-    if (column_metadata_map_.find(column_path) != column_metadata_map_.end()) {
-      auto res(column_metadata_map_.at(column_path));
-      res->UpdateAad(aad);
-      return res;
-    }
-  } else {
-    if (column_data_map_.find(column_path) != column_data_map_.end()) {
-      auto res(column_data_map_.at(column_path));
-      res->UpdateAad(aad);
-      return res;
-    }
-  }
+  std::string column_key = properties_->column_key(column_path);
 
   column_key = properties_->column_key(column_path);
   // No explicit column key given via API. Retrieve via key metadata.
@@ -200,21 +193,12 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
     throw HiddenColumnException("HiddenColumnException, path=" + column_path);
   }
 
-  // Create both data and metadata decryptors to avoid redundant retrieval of key
-  // using the key_retriever.
   int key_len = static_cast<int>(column_key.size());
-  auto aes_metadata_decryptor = encryption::AesDecryptor::Make(
-      algorithm_, key_len, /*metadata=*/true, &all_decryptors_);
-  auto aes_data_decryptor = encryption::AesDecryptor::Make(
-      algorithm_, key_len, /*metadata=*/false, &all_decryptors_);
-
-  column_metadata_map_[column_path] = std::make_shared<Decryptor>(
-      aes_metadata_decryptor, column_key, file_aad_, aad, pool_);
-  column_data_map_[column_path] =
-      std::make_shared<Decryptor>(aes_data_decryptor, column_key, file_aad_, aad, pool_);
-
-  if (metadata) return column_metadata_map_[column_path];
-  return column_data_map_[column_path];
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto aes_decryptor =
+      encryption::AesDecryptor::Make(algorithm_, key_len, metadata, &all_decryptors_);
+  return std::make_shared<Decryptor>(std::move(aes_decryptor), column_key, file_aad_, aad,
+                                     pool_);
 }
 
 namespace {

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -91,15 +92,15 @@ class InternalFileDecryptor {
   FileDecryptionProperties* properties_;
   // Concatenation of aad_prefix (if exists) and aad_file_unique
   std::string file_aad_;
-  std::map<std::string, std::shared_ptr<Decryptor>> column_data_map_;
-  std::map<std::string, std::shared_ptr<Decryptor>> column_metadata_map_;
 
   std::shared_ptr<Decryptor> footer_metadata_decryptor_;
   std::shared_ptr<Decryptor> footer_data_decryptor_;
   ParquetCipher::type algorithm_;
   std::string footer_key_metadata_;
+  // Mutex to guard access to all_decryptors_
+  mutable std::mutex mutex_;
   // A weak reference to all decryptors that need to be wiped out when decryption is
-  // finished
+  // finished, guarded by mutex_ for thread safety
   std::vector<std::weak_ptr<encryption::AesDecryptor>> all_decryptors_;
 
   ::arrow::MemoryPool* pool_;

--- a/python/pyarrow/tests/test_dataset_encryption.py
+++ b/python/pyarrow/tests/test_dataset_encryption.py
@@ -15,10 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import base64
 from datetime import timedelta
+import numpy as np
 import pyarrow.fs as fs
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
+import tempfile
 
 encryption_unavailable = False
 
@@ -151,3 +155,58 @@ def test_write_dataset_parquet_without_encryption():
 
     with pytest.raises(NotImplementedError):
         _ = pformat.make_write_options(encryption_config="some value")
+
+
+@pytest.mark.skipif(
+    encryption_unavailable, reason="Parquet Encryption is not currently enabled"
+)
+def test_large_row_encryption_decryption():
+    """Test encryption and decryption of a large number of rows."""
+
+    class NoOpKmsClient(pe.KmsClient):
+        def wrap_key(self, key_bytes: bytes, _: str) -> bytes:
+            b = base64.b64encode(key_bytes)
+            return b
+
+        def unwrap_key(self, wrapped_key: bytes, _: str) -> bytes:
+            b = base64.b64decode(wrapped_key)
+            return b
+
+    row_count = 2**15 + 1
+    table = pa.Table.from_arrays(
+        [pa.array(np.random.rand(row_count), type=pa.float32())], names=["foo"]
+    )
+
+    kms_config = pe.KmsConnectionConfig()
+    crypto_factory = pe.CryptoFactory(lambda _: NoOpKmsClient())
+    encryption_config = pe.EncryptionConfiguration(
+        footer_key="UNIMPORTANT_KEY",
+        column_keys={"UNIMPORTANT_KEY": ["foo"]},
+        double_wrapping=True,
+        plaintext_footer=False,
+        data_key_length_bits=128,
+    )
+    pqe_config = ds.ParquetEncryptionConfig(
+        crypto_factory, kms_config, encryption_config
+    )
+    pqd_config = ds.ParquetDecryptionConfig(
+        crypto_factory, kms_config, pe.DecryptionConfiguration()
+    )
+    scan_options = ds.ParquetFragmentScanOptions(decryption_config=pqd_config)
+    file_format = ds.ParquetFileFormat(default_fragment_scan_options=scan_options)
+    write_options = file_format.make_write_options(encryption_config=pqe_config)
+    file_decryption_properties = crypto_factory.file_decryption_properties(kms_config)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        path = tempdir + "/test-dataset"
+        ds.write_dataset(table, path, format=file_format, file_options=write_options)
+
+        file_path = path + "/part-0.parquet"
+        new_table = pq.ParquetFile(
+            file_path, decryption_properties=file_decryption_properties
+        ).read()
+        assert table == new_table
+
+        dataset = ds.dataset(path, format=file_format)
+        new_table = dataset.to_table()
+        assert table == new_table


### PR DESCRIPTION
**Rationale for this change:**

This pull request addresses a critical issue (GH-39444) in the C++/Python components of Parquet, specifically a segmentation fault occurring when processing encrypted datasets over 2^15 rows. The fix involves modifications in `cpp/src/parquet/encryption/internal_file_decryptor.cc`, particularly in `InternalFileDecryptor::GetColumnDecryptor`. The caching of the `Decryptor` object was removed to resolve the multithreading issue causing the segmentation fault and encryption failures.

**What changes are included in this PR?**

- Removal of `Decryptor` object caching in `InternalFileDecryptor::GetColumnDecryptor`.
- Addition of two unit tests: `large_row_parquet_encrypt_test.cc` for C++ and an update to `test_dataset_encryption.py` with `test_large_row_encryption_decryption` for Python.

**Are these changes tested?**

Yes, the unit tests (`large_row_parquet_encrypt_test.cc` and `test_large_row_encryption_decryption` in `test_dataset_encryption.py`) have been added to ensure the reliability and effectiveness of these changes.

**Are there any user-facing changes?**

No significant user-facing changes, but the update significantly improves the backend stability and reliability of Parquet file handling.  Calling DecryptionKeyRetriever::GetKey could be an expensive operation potentially involving network calls to key management servers. 

* Closes: #39444
* GitHub Issue: #39444