### PR TITLE
GH-39628: [C++] Use -j1 for cmake >= 3.28

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2639,7 +2639,7 @@ macro(build_bzip2)
                       BUILD_IN_SOURCE 1
                       BUILD_COMMAND ${MAKE} libbz2.a ${MAKE_BUILD_ARGS}
                                     ${BZIP2_EXTRA_ARGS}
-                      INSTALL_COMMAND ${MAKE} install PREFIX=${BZIP2_PREFIX}
+                      INSTALL_COMMAND ${MAKE} install -j1 PREFIX=${BZIP2_PREFIX}
                                       ${BZIP2_EXTRA_ARGS}
                       INSTALL_DIR ${BZIP2_PREFIX}
                       URL ${ARROW_BZIP2_SOURCE_URL}

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1005,8 +1005,13 @@ if("${MAKE}" STREQUAL "")
   endif()
 endif()
 
-# Args for external projects using make.
-set(MAKE_BUILD_ARGS "-j${NPROC}")
+# Args for external projects using make
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
+  #Prevent 'bad file descriptor' error
+  set(MAKE_BUILD_ARGS "-j1")
+else()
+  set(MAKE_BUILD_ARGS "-j${NPROC}")
+endif()
 
 include(FetchContent)
 set(FC_DECLARE_COMMON_OPTIONS)

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1007,7 +1007,7 @@ endif()
 
 # Args for external projects using make
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.28")
-  #Prevent 'bad file descriptor' error
+  # Prevent 'bad file descriptor' error see #39517 #39628
   set(MAKE_BUILD_ARGS "-j1")
 else()
   set(MAKE_BUILD_ARGS "-j${NPROC}")


### PR DESCRIPTION
### Rationale for this change

Prevent 'bad file descriptor' issue.

### What changes are included in this PR?

Use -j1 for make on CMake >= 3.28

### Are these changes tested?
Crossbow
* Closes: #39628