### PR TITLE
GH-39656: [Release] Update platform tags for macOS wheels to macosx_10_15

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1136,7 +1136,7 @@ test_macos_wheels() {
     local check_flight=OFF
   else
     local python_versions="3.8 3.9 3.10 3.11 3.12"
-    local platform_tags="macosx_10_14_x86_64"
+    local platform_tags="macosx_10_15_x86_64"
   fi
 
   # verify arch-native wheels inside an arch-native conda environment


### PR DESCRIPTION
### Rationale for this change

Currently the binary verification for releases fails due to wrong macOS platform version.

### What changes are included in this PR?

Update to the current generated platform tag.

### Are these changes tested?

No, but I've validated this is the corrected generated platform tag for the wheels on the Release Candidate: https://apache.jfrog.io/ui/native/arrow/python-rc/15.0.0-rc1/

### Are there any user-facing changes?

Not because of this change but there was a minimum version of macOS as part of the PR that caused this issue.
* Closes: #39656