### PR TITLE
GH-39675: [C++][FlightRPC] Expose additional RPC call info to middleware

### DIFF
--- a/cpp/src/arrow/flight/server_middleware.h
+++ b/cpp/src/arrow/flight/server_middleware.h
@@ -49,6 +49,12 @@ class ARROW_FLIGHT_EXPORT ServerMiddleware {
 
   /// \brief A callback after the call has completed.
   virtual void CallCompleted(const Status& status) = 0;
+
+  /// \brief Callbacks before forwarding a request to its transport-specific server
+  virtual void HandlingRequest(FlightMethod method, const Criteria& criteria) {}
+  virtual void HandlingRequest(FlightMethod method, const FlightDescriptor& descriptor) {}
+  virtual void HandlingRequest(FlightMethod method, const Ticket& ticket) {}
+  virtual void HandlingRequest(FlightMethod method, const Action& action) {}
 };
 
 /// \brief A factory for new middleware instances.

--- a/cpp/src/arrow/flight/server_tracing_middleware.h
+++ b/cpp/src/arrow/flight/server_tracing_middleware.h
@@ -49,6 +49,8 @@ class ARROW_FLIGHT_EXPORT TracingServerMiddleware : public ServerMiddleware {
   void SendingHeaders(AddCallHeaders*) override;
   void CallCompleted(const Status&) override;
 
+  void HandlingRequest(FlightMethod, const Action&) override;
+
   struct TraceKey {
     std::string key;
     std::string value;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Exposes more gRPC call information to middleware APIs for better traces and debugging

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- [x] Adds more virtual callbacks to `ServerMiddleware` to be invoked after protobuf messsages are received
- [x] Sets `code.function` span attribute in `TracingServerMiddleware` for `DoAction` methods (based on [OTel semantic conventions doc](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/rpc/rpc-spans.md), but warrants double-checking)
- [ ] Tests for middleware

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Ad hoc only. Proper tests are WIP

### Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39675