### PR TITLE
GH-39683: [Release] Use temporary directory with TEST_BINARY=1

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -173,7 +173,7 @@ test_binary() {
   show_header "Testing binary artifacts"
   maybe_setup_conda
 
-  local download_dir=binaries
+  local download_dir=${ARROW_TMPDIR}/binaries
   mkdir -p ${download_dir}
 
   ${PYTHON:-python3} $SOURCE_DIR/download_rc_binaries.py $VERSION $RC_NUMBER \


### PR DESCRIPTION
### Rationale for this change

We should use temporary directory to verify in clean environment.

### What changes are included in this PR?

Use `ARROW_TMPDIR` for prefix of download directory.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39683