### PR TITLE
GH-39946: [Java] Bump com.puppycrawl.tools:checkstyle from 8.19 to 8.29

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
@@ -21,7 +21,8 @@ package org.apache.arrow.adapter.jdbc;
  * String constants used for metadata returned on Vectors.
  */
 public class Constants {
-  private Constants() {}
+  private Constants() {
+  }
 
   public static final String SQL_CATALOG_NAME_KEY = "SQL_CATALOG_NAME";
   public static final String SQL_SCHEMA_NAME_KEY = "SQL_SCHEMA_NAME";

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/MockPreparedStatement.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/MockPreparedStatement.java
@@ -231,7 +231,8 @@ public final class MockPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {}
+  public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+  }
 
   @Override
   public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
@@ -241,7 +242,8 @@ public final class MockPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {}
+  public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+  }
 
   @Override
   public void setURL(int parameterIndex, URL x) throws SQLException {
@@ -259,62 +261,80 @@ public final class MockPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public void setNString(int parameterIndex, String value) throws SQLException {}
+  public void setNString(int parameterIndex, String value) throws SQLException {
+  }
 
   @Override
   public void setNCharacterStream(int parameterIndex, Reader value, long length)
-      throws SQLException {}
+      throws SQLException {
+  }
 
   @Override
-  public void setNClob(int parameterIndex, NClob value) throws SQLException {}
+  public void setNClob(int parameterIndex, NClob value) throws SQLException {
+  }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {}
+  public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  }
 
   @Override
   public void setBlob(int parameterIndex, InputStream inputStream, long length)
-      throws SQLException {}
+      throws SQLException {
+  }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {}
+  public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+  }
 
   @Override
-  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {}
+  public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+  }
 
   @Override
   public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength)
-      throws SQLException {}
+      throws SQLException {
+  }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {}
+  public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {}
+  public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+  }
 
   @Override
   public void setCharacterStream(int parameterIndex, Reader reader, long length)
-      throws SQLException {}
+      throws SQLException {
+  }
 
   @Override
-  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {}
+  public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+  }
 
   @Override
-  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {}
+  public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+  }
 
   @Override
-  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {}
+  public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+  }
 
   @Override
-  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {}
+  public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+  }
 
   @Override
-  public void setClob(int parameterIndex, Reader reader) throws SQLException {}
+  public void setClob(int parameterIndex, Reader reader) throws SQLException {
+  }
 
   @Override
-  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {}
+  public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+  }
 
   @Override
-  public void setNClob(int parameterIndex, Reader reader) throws SQLException {}
+  public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+  }
 
   @Override
   public ResultSet executeQuery(String sql) throws SQLException {
@@ -327,7 +347,8 @@ public final class MockPreparedStatement implements PreparedStatement {
   }
 
   @Override
-  public void close() throws SQLException {}
+  public void close() throws SQLException {
+  }
 
   @Override
   public int getMaxFieldSize() throws SQLException {

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtility.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtility.java
@@ -348,7 +348,8 @@ public class ResultSetUtility {
       private int displaySize;
 
 
-      private MockColumnMetaData() {}
+      private MockColumnMetaData() {
+      }
 
       private String getLabel() {
         return label;

--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcJniUtils.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcJniUtils.java
@@ -32,7 +32,8 @@ class OrcJniUtils {
   private static final String LIBRARY_NAME = "arrow_orc_jni";
   private static boolean isLoaded = false;
 
-  private OrcJniUtils() {}
+  private OrcJniUtils() {
+  }
 
   static void loadOrcAdapterLibraryFromJar()
           throws IOException, IllegalAccessException {

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -60,6 +60,11 @@
       <property name="eachLine" value="true"/>
     </module>
 
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -71,10 +76,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap"/>
@@ -223,14 +224,14 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
+<!--            <property name="allowMissingThrowsTags" value="true"/>-->
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
+<!--            <property name="minLineCount" value="2"/>-->
             <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
+<!--            <property name="allowThrowsTagsForSubclasses" value="true"/>-->
             <!-- This seems partially broken under JDK >= 9. -->
-            <property name="suppressLoadErrors" value="true"/>
-            <property name="ignoreMethodNamesRegex" value="main"/>
+<!--            <property name="suppressLoadErrors" value="true"/>-->
+<!--            <property name="ignoreMethodNamesRegex" value="main"/>-->
         </module>
         <module name="JavadocType">
             <property name="scope" value="public"/>

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -224,14 +224,8 @@
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
-<!--            <property name="allowMissingThrowsTags" value="true"/>-->
             <property name="allowMissingReturnTag" value="true"/>
-<!--            <property name="minLineCount" value="2"/>-->
             <property name="allowedAnnotations" value="Override, Test"/>
-<!--            <property name="allowThrowsTagsForSubclasses" value="true"/>-->
-            <!-- This seems partially broken under JDK >= 9. -->
-<!--            <property name="suppressLoadErrors" value="true"/>-->
-<!--            <property name="ignoreMethodNamesRegex" value="main"/>-->
         </module>
         <module name="JavadocType">
             <property name="scope" value="public"/>

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -227,6 +227,11 @@
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>
         </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="minLineCount" value="2"/>
+            <property name="ignoreMethodNamesRegex" value="main"/>
+        </module>
         <module name="JavadocType">
             <property name="scope" value="public"/>
         </module>

--- a/java/dev/checkstyle/suppressions.xml
+++ b/java/dev/checkstyle/suppressions.xml
@@ -40,5 +40,5 @@
   <suppress checks="NoFinalizer|OverloadMethodsDeclarationOrder|VariableDeclarationUsageDistance" files=".*" />
 
   <!-- No license header in generated file -->
-  <suppress checks="header" files="flight.properties"/>
+  <suppress checks="header|LineLength" files="flight.properties"/>
 </suppressions>

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -437,7 +437,8 @@ public class FlightClient implements AutoCloseable {
      */
     public void getResult() {
       // After exchange is complete, make sure stream is drained to propagate errors through reader
-      while (reader.next()) { };
+      while (reader.next()) {
+      }
     }
 
     /** Shut down the streams in this call. */

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
@@ -125,7 +125,8 @@ public class FlightGrpcUtils {
     }
   }
 
-  private FlightGrpcUtils() {}
+  private FlightGrpcUtils() {
+  }
 
   /**
    * Creates a Flight service.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
@@ -194,7 +194,8 @@ public class FlightStream implements AutoCloseable {
           }
         }
         // Drain the stream without the lock (as next() implicitly needs the lock)
-        while (next()) { }
+        while (next()) {
+        }
       } catch (FlightRuntimeException e) {
         suppressor = e;
       }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
@@ -119,5 +119,6 @@ public interface OutboundStreamListener {
    * <p>The default value can be toggled globally by setting the JVM property arrow.flight.enable_zero_copy_write
    * or the environment variable ARROW_FLIGHT_ENABLE_ZERO_COPY_WRITE.
    */
-  default void setUseZeroCopy(boolean enabled) {}
+  default void setUseZeroCopy(boolean enabled) {
+  }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
@@ -47,5 +47,6 @@ public final class AuthConstants {
 
   public static final Context.Key<String> PEER_IDENTITY_KEY = Context.keyWithDefault("arrow-flight-peer-identity", "");
 
-  private AuthConstants() {}
+  private AuthConstants() {
+  }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthWrapper.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthWrapper.java
@@ -115,7 +115,9 @@ public class ServerAuthWrapper {
     @Override
     public void onError(Throwable t) {
       completed = true;
-      while (future == null) {/* busy wait */}
+      while (future == null) {
+        /* busy wait */
+      }
       future.cancel(true);
     }
 

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestClientMiddleware.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestClientMiddleware.java
@@ -303,10 +303,12 @@ public class TestClientMiddleware {
     }
 
     @Override
-    public void onCallCompleted(CallStatus status) {}
+    public void onCallCompleted(CallStatus status) {
+    }
 
     @Override
-    public void onCallErrored(Throwable err) {}
+    public void onCallErrored(Throwable err) {
+    }
   }
 
   static class MultiHeaderClientMiddlewareFactory implements FlightClientMiddleware.Factory {
@@ -356,6 +358,7 @@ public class TestClientMiddleware {
     }
 
     @Override
-    public void onCallCompleted(CallStatus status) {}
+    public void onCallCompleted(CallStatus status) {
+    }
   }
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/OrderedScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/OrderedScenario.java
@@ -55,7 +55,8 @@ public class OrderedScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) throws Exception {}
+  public void buildServer(FlightServer.Builder builder) throws Exception {
+  }
 
   @Override
   public void client(BufferAllocator allocator, Location location, FlightClient client)

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/IntervalStringUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/IntervalStringUtils.java
@@ -31,7 +31,8 @@ public final class IntervalStringUtils {
   /**
    * Constructor Method of class.
    */
-  private IntervalStringUtils( ) {}
+  private IntervalStringUtils( ) {
+  }
 
   /**
    * Formats a period similar to Oracle INTERVAL YEAR TO MONTH data type<br>.

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
@@ -84,7 +84,7 @@ public class ClientAuthenticationUtilsTest {
 
       keyStoreMockedStatic
          .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit"))
-         .thenReturn(keyStoreMock);
+          .thenReturn(keyStoreMock);
       KeyStore receiveKeyStore = ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit");
       Assert.assertEquals(receiveKeyStore, keyStoreMock);
     }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
@@ -43,7 +43,8 @@ public class ConfigurationBuilder {
       return new ConfigOptions();
     }
 
-    public ConfigOptions() {}
+    public ConfigOptions() {
+    }
 
     public ConfigOptions withOptimize(boolean optimize) {
       this.optimize = optimize;

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/DecimalTypeUtil.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/DecimalTypeUtil.java
@@ -23,7 +23,8 @@ import org.apache.arrow.vector.types.pojo.ArrowType.Decimal;
  * Utility methods for working with {@link Decimal} values.
  */
 public class DecimalTypeUtil {
-  private DecimalTypeUtil() {}
+  private DecimalTypeUtil() {
+  }
 
   /**
    * Enum for supported mathematical operations.

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.types.pojo.Schema;
  * Utility methods to convert between Arrow and Gandiva types.
  */
 public class ArrowTypeHelper {
-  private ArrowTypeHelper() {}
+  private ArrowTypeHelper() {
+  }
 
   static final int WIDTH_8 = 8;
   static final int WIDTH_16 = 16;

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/TreeBuilder.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/TreeBuilder.java
@@ -29,7 +29,8 @@ import org.apache.arrow.vector.types.pojo.Field;
  * Contains helper functions for constructing expression trees.
  */
 public class TreeBuilder {
-  private TreeBuilder() {}
+  private TreeBuilder() {
+  }
 
   /**
    * Helper functions to create literal constants.

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -235,7 +235,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.19</version>
+            <version>8.29</version>
           </dependency>
           <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationListener.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationListener.java
@@ -34,7 +34,8 @@ public interface AllocationListener {
    *
    * @param size the buffer size being allocated
    */
-  default void onPreAllocation(long size) {}
+  default void onPreAllocation(long size) {
+  }
 
   /**
    * Called each time a new buffer has been allocated.
@@ -43,7 +44,8 @@ public interface AllocationListener {
    *
    * @param size the buffer size being allocated
    */
-  default void onAllocation(long size) {}
+  default void onAllocation(long size) {
+  }
 
   /**
    * Informed each time a buffer is released from allocation.
@@ -51,7 +53,8 @@ public interface AllocationListener {
    * <p>An exception cannot be thrown by this method.
    * @param size The size of the buffer being released.
    */
-  default void onRelease(long size) {}
+  default void onRelease(long size) {
+  }
 
 
   /**
@@ -73,7 +76,8 @@ public interface AllocationListener {
    * @param parentAllocator The parent allocator to which a child was added
    * @param childAllocator  The child allocator that was just added
    */
-  default void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {}
+  default void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
+  }
 
   /**
    * Called immediately after a child allocator was removed from the parent allocator.
@@ -81,5 +85,6 @@ public interface AllocationListener {
    * @param parentAllocator The parent allocator from which a child was removed
    * @param childAllocator The child allocator that was just removed
    */
-  default void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {}
+  default void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
+  }
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -702,18 +702,18 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   void print(StringBuilder sb, int level, Verbosity verbosity) {
 
     CommonUtil.indent(sb, level)
-      .append("Allocator(")
-      .append(name)
-      .append(") ")
-      .append(reservation)
-      .append('/')
-      .append(getAllocatedMemory())
-      .append('/')
-      .append(getPeakMemoryAllocation())
-      .append('/')
-      .append(getLimit())
-      .append(" (res/actual/peak/limit)")
-      .append('\n');
+        .append("Allocator(")
+        .append(name)
+        .append(") ")
+        .append(reservation)
+        .append('/')
+        .append(getAllocatedMemory())
+        .append('/')
+        .append(getPeakMemoryAllocation())
+        .append('/')
+        .append(getLimit())
+        .append(" (res/actual/peak/limit)")
+        .append('\n');
 
     if (DEBUG) {
       CommonUtil.indent(sb, level + 1).append(String.format("child allocators: %d\n", childAllocators.size()));

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -478,20 +478,20 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
    */
   void print(StringBuilder sb, int indent, BaseAllocator.Verbosity verbosity) {
     CommonUtil.indent(sb, indent)
-      .append("ledger[")
-      .append(ledgerId)
-      .append("] allocator: ")
-      .append(allocator.getName())
-      .append("), isOwning: ")
-      .append(", size: ")
-      .append(", references: ")
-      .append(bufRefCnt.get())
-      .append(", life: ")
-      .append(lCreationTime)
-      .append("..")
-      .append(lDestructionTime)
-      .append(", allocatorManager: [")
-      .append(", life: ");
+        .append("ledger[")
+        .append(ledgerId)
+        .append("] allocator: ")
+        .append(allocator.getName())
+        .append("), isOwning: ")
+        .append(", size: ")
+        .append(", references: ")
+        .append(bufRefCnt.get())
+        .append(", life: ")
+        .append(lCreationTime)
+        .append("..")
+        .append(lDestructionTime)
+        .append(", allocatorManager: [")
+        .append(", life: ");
 
     if (!BaseAllocator.DEBUG) {
       sb.append("]\n");
@@ -499,8 +499,8 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
       Preconditions.checkArgument(buffers != null, "IdentityHashMap of buffers must not be null");
       synchronized (buffers) {
         sb.append("] holds ")
-          .append(buffers.size())
-          .append(" buffers. \n");
+            .append(buffers.size())
+            .append(" buffers. \n");
         for (ArrowBuf buf : buffers.keySet()) {
           buf.print(sb, indent + 2, verbosity);
           sb.append('\n');

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ReferenceManager.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ReferenceManager.java
@@ -141,10 +141,12 @@ public interface ReferenceManager {
     }
 
     @Override
-    public void retain() { }
+    public void retain() {
+    }
 
     @Override
-    public void retain(int increment) { }
+    public void retain(int increment) {
+    }
 
     @Override
     public ArrowBuf retain(ArrowBuf srcBuffer, BufferAllocator targetAllocator) {

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -32,7 +32,8 @@ public class ByteFunctionHelpers {
 
   private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
-  private ByteFunctionHelpers() {}
+  private ByteFunctionHelpers() {
+  }
 
   /**
    * Helper function to check for equality of bytes in two ArrowBufs.

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/CommonUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/CommonUtil.java
@@ -24,7 +24,8 @@ import java.util.Arrays;
  */
 public final class CommonUtil {
 
-  private CommonUtil() { }
+  private CommonUtil() {
+  }
 
   /**
    * Rounds up the provided value to the nearest power of two.

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
@@ -22,7 +22,8 @@ import org.apache.arrow.memory.BoundsChecking;
 /** Contains utilities for dealing with a 64-bit address base. */
 public final class LargeMemoryUtil {
 
-  private LargeMemoryUtil() {}
+  private LargeMemoryUtil() {
+  }
 
   /**
    * Casts length to an int, but raises an exception the value is outside

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/util/Collections2.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/util/Collections2.java
@@ -34,7 +34,8 @@ import java.util.stream.StreamSupport;
  * Utility methods for manipulating {@link java.util.Collections} and their subclasses/implementations.
  */
 public final class Collections2 {
-  private Collections2() {}
+  private Collections2() {
+  }
 
   /**
    * Creates a {@link List} from the elements remaining in iterator.

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/util/Preconditions.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/util/Preconditions.java
@@ -111,7 +111,8 @@ import org.checkerframework.dataflow.qual.AssertMethod;
  * @since 2.0
  */
 public final class Preconditions {
-  private Preconditions() {}
+  private Preconditions() {
+  }
 
   /**
    * Ensures the truth of an expression involving one or more parameters to the calling method.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -304,7 +304,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.19</version>
+            <version>8.29</version>
           </dependency>
           <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.ipc.ArrowStreamWriter;
  * first argument and the output is written to standard out.
  */
 public class FileToStream {
-  private FileToStream() {}
+  private FileToStream() {
+  }
 
   /**
    * Reads an Arrow file from in and writes it back to out.

--- a/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
@@ -22,7 +22,8 @@ import org.apache.arrow.vector.complex.RepeatedVariableWidthVectorLike;
 
 /** Helper utility methods for allocating storage for Vectors. */
 public class AllocationHelper {
-  private AllocationHelper() {}
+  private AllocationHelper() {
+  }
 
   /**
    * Allocates the vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.DataSizeRoundingUtil;
  */
 public class BitVectorHelper {
 
-  private BitVectorHelper() {}
+  private BitVectorHelper() {
+  }
 
   /**
    * Get the index of byte corresponding to bit index in validity buffer.

--- a/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
@@ -27,7 +27,8 @@ import java.nio.charset.Charset;
  * with sample data. This class should be used for that purpose.
  */
 public class GenerateSampleData {
-  private GenerateSampleData() {}
+  private GenerateSampleData() {
+  }
 
   /** Populates <code>vector</code> with <code>valueCount</code> random values. */
   public static void generateTestData(final ValueVector vector, final int valueCount) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -300,7 +300,8 @@ public class NullVector implements FieldVector {
    * @param index position of element
    */
   @Override
-  public void setNull(int index) {}
+  public void setNull(int index) {
+  }
 
   @Override
   public boolean isNull(int index) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/Range.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/Range.java
@@ -41,7 +41,8 @@ public class Range {
   /**
    * Constructs a new instance.
    */
-  public Range() {}
+  public Range() {
+  }
 
   /**
    * Constructs a new instance.

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
@@ -23,7 +23,8 @@ import java.util.Arrays;
  * Utility methods for state machines based on enums.
  */
 public class StateTool {
-  private StateTool() {}
+  private StateTool() {
+  }
 
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StateTool.class);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowMagic.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowMagic.java
@@ -25,7 +25,8 @@ import java.util.Arrays;
  * Magic header/footer helpers for {@link ArrowFileWriter} and {@link ArrowFileReader} formatted files.
  */
 class ArrowMagic {
-  private ArrowMagic(){}
+  private ArrowMagic(){
+  }
 
   private static final byte[] MAGIC = "ARROW1".getBytes(StandardCharsets.UTF_8);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializables.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializables.java
@@ -31,7 +31,8 @@ import com.google.flatbuffers.FlatBufferBuilder;
  * Utility methods for {@linkplain org.apache.arrow.vector.ipc.message.FBSerializable}s.
  */
 public class FBSerializables {
-  private FBSerializables() {}
+  private FBSerializables() {
+  }
 
   /**
    * Writes every element of all to builder and calls {@link FlatBufferBuilder#endVector()} afterwards.

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DateUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DateUtility.java
@@ -26,7 +26,8 @@ import java.util.TimeZone;
 
 /** Utility class for Date, DateTime, TimeStamp, Interval data types. */
 public class DateUtility {
-  private DateUtility() {}
+  private DateUtility() {
+  }
 
   private static final String UTC = "UTC";
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
@@ -29,7 +29,8 @@ import org.apache.arrow.memory.util.MemoryUtil;
  * Utility methods for configurable precision Decimal values (e.g. {@link BigDecimal}).
  */
 public class DecimalUtility {
-  private DecimalUtility() {}
+  private DecimalUtility() {
+  }
 
   public static final byte [] zeroes = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DictionaryUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DictionaryUtility.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.types.pojo.FieldType;
  * Utility methods for working with Dictionaries used in Dictionary encodings.
  */
 public class DictionaryUtility {
-  private DictionaryUtility() {}
+  private DictionaryUtility() {
+  }
 
   /**
    * Convert field and child fields that have a dictionary encoding to message format, so fields

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ObjectMapperFactory.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ObjectMapperFactory.java
@@ -26,7 +26,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
  */
 public final class ObjectMapperFactory {
 
-  private ObjectMapperFactory() {}
+  private ObjectMapperFactory() {
+  }
 
   /**
    * Creates a new {@link ObjectMapper} instance.

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/SchemaUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/SchemaUtility.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.types.pojo.Schema;
  * Schema utility class including serialization and deserialization.
  */
 public class SchemaUtility {
-  private SchemaUtility() {}
+  private SchemaUtility() {
+  }
 
   /**
    * Deserialize Arrow schema from byte array.

--- a/java/vector/src/test/java/org/apache/arrow/vector/testing/ValueVectorDataPopulator.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/testing/ValueVectorDataPopulator.java
@@ -75,7 +75,8 @@ import org.apache.arrow.vector.types.pojo.FieldType;
  */
 public class ValueVectorDataPopulator {
 
-  private ValueVectorDataPopulator(){}
+  private ValueVectorDataPopulator() {
+  }
 
   /**
    * Populate values for BigIntVector.


### PR DESCRIPTION
### Rationale for this change

This PR was created in place of https://github.com/apache/arrow/pull/39202 to integrate the `puppycrawl.tools.checkstyle` upgrade. 

### What changes are included in this PR?

Style changes in Java classes and core changes to the style format itself. 
Some unsupported attributes have been removed. And some attributes have
been reorganized upon the provided guidelines in the documentation. 

### Are these changes tested?

N/A 
Tested by existing checkstyle guideline. 

### Are there any user-facing changes?

No

* Closes: #39946