### PR TITLE
GH-39718: [C++][FS][Azure] Remove StatusFromErrorResponse as it's not necessary

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -306,6 +306,8 @@ Status ValidateFileLocation(const AzureLocation& location) {
 }
 
 bool IsContainerNotFound(const Storage::StorageException& e) {
+  // In some situations, only the ReasonPhrase is set and the
+  // ErrorCode is empty, so we check both.
   if (e.ErrorCode == "ContainerNotFound" ||
       e.ReasonPhrase == "The specified container does not exist." ||
       e.ReasonPhrase == "The specified filesystem does not exist.") {


### PR DESCRIPTION
### Rationale for this change

Only the "*IfExists" functions from the Azure SDK ever set `response.Value.Deleted` to `false` to indicate that a resource wasn't found and the request succeeded without deleting anything. 

It's better that we use the `Delete()` versions of these functions instead of `DeleteIfExists` and check the `ErrorCode` ourselves to return an appropriate `Status` instead of something generic.

### What changes are included in this PR?

 - Removing `StatusFromErrorResponse`
 - Comments explaining the error handling decisions
 - Addition of a boolean parameter to `DeleteDirOnFileSystem` that controls how it fails when the directory being deleted doesn't exist
 
### Are these changes tested?

 - Yes, by the existing tests in `azurefs_test.cc`.
* Closes: #39718