### PR TITLE
GH-39720: [Swift] Switch reader to use arrow field instead of proto for building arrays

### DIFF
--- a/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
@@ -36,12 +36,12 @@ public class ArrowArrayBuilder<T: ArrowBufferBuilder, U: ArrowArray<T.ItemType>>
 
     public func finish() throws -> ArrowArray<T.ItemType> {
         let buffers = self.bufferBuilder.finish()
-        let arrowData = try ArrowData(self.type, buffers: buffers, nullCount: self.nullCount, stride: self.getStride())
+        let arrowData = try ArrowData(self.type, buffers: buffers, nullCount: self.nullCount)
         return U(arrowData)
     }
 
     public func getStride() -> Int {
-        MemoryLayout<T.ItemType>.stride
+        return self.type.getStride()
     }
 }
 
@@ -73,19 +73,11 @@ public class Date32ArrayBuilder: ArrowArrayBuilder<Date32BufferBuilder, Date32Ar
     fileprivate convenience init() throws {
         try self.init(ArrowType(ArrowType.ArrowDate32))
     }
-
-    public override func getStride() -> Int {
-        MemoryLayout<Int32>.stride
-    }
 }
 
 public class Date64ArrayBuilder: ArrowArrayBuilder<Date64BufferBuilder, Date64Array> {
     fileprivate convenience init() throws {
         try self.init(ArrowType(ArrowType.ArrowDate64))
-    }
-
-    public override func getStride() -> Int {
-        MemoryLayout<Int64>.stride
     }
 }
 

--- a/swift/Arrow/Sources/Arrow/ArrowData.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowData.swift
@@ -24,7 +24,7 @@ public class ArrowData {
     public let length: UInt
     public let stride: Int
 
-    init(_ arrowType: ArrowType, buffers: [ArrowBuffer], nullCount: UInt, stride: Int) throws {
+    init(_ arrowType: ArrowType, buffers: [ArrowBuffer], nullCount: UInt) throws {
         let infoType = arrowType.info
         switch infoType {
         case let .primitiveInfo(typeId):
@@ -45,7 +45,7 @@ public class ArrowData {
         self.buffers = buffers
         self.nullCount = nullCount
         self.length = buffers[1].length
-        self.stride = stride
+        self.stride = arrowType.getStride()
     }
 
     public func isNull(_ at: UInt) -> Bool {

--- a/swift/Arrow/Sources/Arrow/ArrowType.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowType.swift
@@ -19,6 +19,8 @@ import Foundation
 
 public typealias Time32 = Int32
 public typealias Time64 = Int64
+public typealias Date32 = Int32
+public typealias Date64 = Int64
 
 func FlatBuffersVersion_23_1_4() { // swiftlint:disable:this identifier_name
 }
@@ -163,6 +165,48 @@ public class ArrowType {
             return ArrowType.ArrowDouble
         } else {
             return ArrowType.ArrowUnknown
+        }
+    }
+
+    public func getStride( // swiftlint:disable:this cyclomatic_complexity
+    ) -> Int {
+        switch self.id {
+        case .int8:
+            return MemoryLayout<Int8>.stride
+        case .int16:
+            return MemoryLayout<Int16>.stride
+        case .int32:
+            return MemoryLayout<Int32>.stride
+        case .int64:
+            return MemoryLayout<Int64>.stride
+        case .uint8:
+            return MemoryLayout<UInt8>.stride
+        case .uint16:
+            return MemoryLayout<UInt16>.stride
+        case .uint32:
+            return MemoryLayout<UInt32>.stride
+        case .uint64:
+            return MemoryLayout<UInt64>.stride
+        case .float:
+            return MemoryLayout<Float>.stride
+        case .double:
+            return MemoryLayout<Double>.stride
+        case .boolean:
+            return MemoryLayout<Bool>.stride
+        case .date32:
+            return MemoryLayout<Date32>.stride
+        case .date64:
+            return MemoryLayout<Date64>.stride
+        case .time32:
+            return MemoryLayout<Time32>.stride
+        case .time64:
+            return MemoryLayout<Time64>.stride
+        case .binary:
+            return MemoryLayout<Int8>.stride
+        case .string:
+            return MemoryLayout<Int8>.stride
+        default:
+            fatalError("Stride requested for unknown type: \(self)")
         }
     }
 }

--- a/swift/Arrow/Sources/Arrow/ProtoUtil.swift
+++ b/swift/Arrow/Sources/Arrow/ProtoUtil.swift
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+func fromProto( // swiftlint:disable:this cyclomatic_complexity
+    field: org_apache_arrow_flatbuf_Field
+) -> ArrowField {
+    let type = field.typeType
+    var arrowType = ArrowType(ArrowType.ArrowUnknown)
+    switch type {
+    case .int:
+        let intType = field.type(type: org_apache_arrow_flatbuf_Int.self)!
+        let bitWidth = intType.bitWidth
+        if bitWidth == 8 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt8 : ArrowType.ArrowUInt8)
+        } else if bitWidth == 16 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt16 : ArrowType.ArrowUInt16)
+        } else if bitWidth == 32 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt32 : ArrowType.ArrowUInt32)
+        } else if bitWidth == 64 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt64 : ArrowType.ArrowUInt64)
+        }
+    case .bool:
+        arrowType = ArrowType(ArrowType.ArrowBool)
+    case .floatingpoint:
+        let floatType = field.type(type: org_apache_arrow_flatbuf_FloatingPoint.self)!
+        if floatType.precision == .single {
+            arrowType = ArrowType(ArrowType.ArrowFloat)
+        } else if floatType.precision == .double {
+            arrowType = ArrowType(ArrowType.ArrowDouble)
+        }
+    case .utf8:
+        arrowType = ArrowType(ArrowType.ArrowString)
+    case .binary:
+        arrowType = ArrowType(ArrowType.ArrowBinary)
+    case .date:
+        let dateType = field.type(type: org_apache_arrow_flatbuf_Date.self)!
+        if dateType.unit == .day {
+            arrowType = ArrowType(ArrowType.ArrowDate32)
+        } else {
+            arrowType = ArrowType(ArrowType.ArrowDate64)
+        }
+    case .time:
+        let timeType = field.type(type: org_apache_arrow_flatbuf_Time.self)!
+        if timeType.unit == .second || timeType.unit == .millisecond {
+            let arrowUnit: ArrowTime32Unit = timeType.unit == .second ? .seconds : .milliseconds
+            arrowType = ArrowTypeTime32(arrowUnit)
+        } else {
+            let arrowUnit: ArrowTime64Unit = timeType.unit == .microsecond ? .microseconds : .nanoseconds
+            arrowType = ArrowTypeTime64(arrowUnit)
+        }
+    default:
+        arrowType = ArrowType(ArrowType.ArrowUnknown)
+    }
+
+    return ArrowField(field.name ?? "", type: arrowType, isNullable: field.nullable)
+}

--- a/swift/Arrow/Tests/ArrowTests/ArrayTests.swift
+++ b/swift/Arrow/Tests/ArrowTests/ArrayTests.swift
@@ -211,4 +211,38 @@ final class ArrayTests: XCTestCase {
         XCTAssertEqual(microArray[1], 20000)
         XCTAssertEqual(microArray[2], 987654321)
     }
+
+    func checkHolderForType(_ checkType: ArrowType) throws {
+        let buffers = [ArrowBuffer(length: 0, capacity: 0,
+                                rawPointer: UnsafeMutableRawPointer.allocate(byteCount: 0, alignment: .zero)),
+                       ArrowBuffer(length: 0, capacity: 0,
+                               rawPointer: UnsafeMutableRawPointer.allocate(byteCount: 0, alignment: .zero))]
+        let field = ArrowField("", type: checkType, isNullable: true)
+        switch makeArrayHolder(field, buffers: buffers, nullCount: 0) {
+        case .success(let holder):
+            XCTAssertEqual(holder.type.id, checkType.id)
+        case .failure(let err):
+            throw err
+        }
+    }
+
+    func testArrayHolders() throws {
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt8))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt8))
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt16))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt16))
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt32))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt32))
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt64))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt64))
+        try checkHolderForType(ArrowTypeTime32(.seconds))
+        try checkHolderForType(ArrowTypeTime32(.milliseconds))
+        try checkHolderForType(ArrowTypeTime64(.microseconds))
+        try checkHolderForType(ArrowTypeTime64(.nanoseconds))
+        try checkHolderForType(ArrowType(ArrowType.ArrowBinary))
+        try checkHolderForType(ArrowType(ArrowType.ArrowFloat))
+        try checkHolderForType(ArrowType(ArrowType.ArrowDouble))
+        try checkHolderForType(ArrowType(ArrowType.ArrowBool))
+        try checkHolderForType(ArrowType(ArrowType.ArrowString))
+    }
 }


### PR DESCRIPTION
This PR updates the ArrowReaderHelper to use an ArrowField object for building an Array instead of a protobuf field obj.  This removes leveraging protobuf from building out the Arrays and makes the code easier to reuse (like for the C Data Interface)
* Closes: #39720