### PR TITLE
MINOR: [C#] Update copyright year on built assembly

### DIFF
--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -27,7 +27,7 @@
   <!-- AssemblyInfo properties -->
   <PropertyGroup>
     <Product>Apache Arrow library</Product>
-    <Copyright>Copyright 2016-2019 The Apache Software Foundation</Copyright>
+    <Copyright>Copyright 2016-2024 The Apache Software Foundation</Copyright>
     <Company>The Apache Software Foundation</Company>
     <Version>15.0.0-SNAPSHOT</Version>
   </PropertyGroup>


### PR DESCRIPTION
### Rationale for this change

The copyright is currently shown as "2016-2019". A lot has changed since 2019, both in the world in general and in Arrow.
