### PR TITLE
GH-38865 [C++][Parquet] support passing a RowRange to RecordBatchReader

### DIFF
--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -131,7 +131,8 @@ class ARROW_EXPORT ReadRangeCache {
   ///
   /// The caller must ensure that the ranges do not overlap with each other,
   /// nor with previously cached ranges.  Otherwise, behaviour will be undefined.
-  Status Cache(std::vector<ReadRange> ranges);
+  Status Cache(std::vector<ReadRange> ranges,
+               std::vector<std::vector<ReadRange>> holes_foreach_range = {});
 
   /// \brief Read a range previously given to Cache().
   Result<std::shared_ptr<Buffer>> Read(ReadRange range);

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -296,6 +296,10 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   virtual Future<std::shared_ptr<Buffer>> ReadAsync(const IOContext&, int64_t position,
                                                     int64_t nbytes);
 
+  /// EXPERIMENTAL: Read data asynchronously. The dest is provided by `out`
+  virtual Future<int64_t> ReadAsync(const IOContext& ctx, std::vector<ReadRange>& ranges,
+                                    void* out);
+
   /// EXPERIMENTAL: Read data asynchronously, using the file's IOContext.
   Future<std::shared_ptr<Buffer>> ReadAsync(int64_t position, int64_t nbytes);
 

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -360,6 +360,11 @@ add_parquet_test(internals-test
 
 set_source_files_properties(public_api_test.cc PROPERTIES SKIP_PRECOMPILE_HEADERS ON
                                                           SKIP_UNITY_BUILD_INCLUSION ON)
+add_parquet_test(rowrange-read-test
+                 SOURCES
+                 row_range_test.cc
+                 range_reader_test.cc
+)
 
 add_parquet_test(reader-test
                  SOURCES
@@ -367,8 +372,6 @@ add_parquet_test(reader-test
                  level_conversion_test.cc
                  column_scanner_test.cc
                  reader_test.cc
-                 range_reader_test.cc
-                 row_range_test.cc
                  stream_reader_test.cc
                  test_util.cc)
 

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -366,6 +366,8 @@ add_parquet_test(reader-test
                  level_conversion_test.cc
                  column_scanner_test.cc
                  reader_test.cc
+                 range_reader_test.cc
+                 row_range_test.cc
                  stream_reader_test.cc
                  test_util.cc)
 

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -162,6 +162,7 @@ set(PARQUET_SRCS
     arrow/writer.cc
     bloom_filter.cc
     bloom_filter_reader.cc
+    row_range.cc
     column_reader.cc
     column_scanner.cc
     column_writer.cc

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -184,14 +184,15 @@ class PARQUET_EXPORT FileReader {
   /// \brief Return a RecordBatchReader of row groups selected from
   /// rows_to_return, whose columns are selected by column_indices.
   ///
-  /// Notice that rows_to_return is file based, it not only decides which row groups to read,
-  /// but also which rows to read in each row group.
+  /// Notice that rows_to_return is file based, it not only decides which row groups to
+  /// read, but also which rows to read in each row group.
   ///
   ///
   /// \returns error Status if either rows_to_return or column_indices
   ///     contains an invalid index
-  virtual ::arrow::Status GetRecordBatchReader(const RowRanges& rows_to_return,
-      const std::vector<int>& column_indices, std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
+  virtual ::arrow::Status GetRecordBatchReader(
+      const RowRanges& rows_to_return, const std::vector<int>& column_indices,
+      std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
 
   /// \brief Return a RecordBatchReader of row groups selected from
   /// row_group_indices, whose columns are selected by column_indices.

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <vector>
 
+#include "parquet/column_reader.h"
 #include "parquet/file_reader.h"
 #include "parquet/platform.h"
 #include "parquet/properties.h"
@@ -179,6 +180,18 @@ class PARQUET_EXPORT FileReader {
   virtual ::arrow::Status GetRecordBatchReader(
       const std::vector<int>& row_group_indices, const std::vector<int>& column_indices,
       std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
+
+  /// \brief Return a RecordBatchReader of row groups selected from
+  /// rows_to_return, whose columns are selected by column_indices.
+  ///
+  /// Notice that rows_to_return is file based, it not only decides which row groups to read,
+  /// but also which rows to read in each row group.
+  ///
+  ///
+  /// \returns error Status if either rows_to_return or column_indices
+  ///     contains an invalid index
+  virtual ::arrow::Status GetRecordBatchReader(const RowRanges& rows_to_return,
+      const std::vector<int>& column_indices, std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
 
   /// \brief Return a RecordBatchReader of row groups selected from
   /// row_group_indices, whose columns are selected by column_indices.

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -76,6 +76,7 @@ class FileColumnIterator {
     }
 
     auto row_group_reader = reader_->RowGroup(row_groups_.front());
+    current_rg_ = row_groups_.front();
     row_groups_.pop_front();
     return row_group_reader->GetColumnPageReader(column_index_);
   }
@@ -88,11 +89,14 @@ class FileColumnIterator {
 
   int column_index() const { return column_index_; }
 
+  int current_row_group() const { return current_rg_; }
+
  protected:
   int column_index_;
   ParquetFileReader* reader_;
   const SchemaDescriptor* schema_;
   std::deque<int> row_groups_;
+  int current_rg_ = 0;
 };
 
 using FileColumnIteratorFactory =
@@ -109,6 +113,7 @@ struct ReaderContext {
   FileColumnIteratorFactory iterator_factory;
   bool filter_leaves;
   std::shared_ptr<std::unordered_set<int>> included_leaves;
+  std::shared_ptr<std::vector<std::unique_ptr<RowRanges>>> row_ranges_per_rg;
 
   bool IncludesLeaf(int leaf_index) const {
     if (this->filter_leaves) {

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -114,6 +114,7 @@ struct ReaderContext {
   bool filter_leaves;
   std::shared_ptr<std::unordered_set<int>> included_leaves;
   std::shared_ptr<std::vector<std::unique_ptr<RowRanges>>> row_ranges_per_rg;
+  bool pre_buffer_enabled;
 
   bool IncludesLeaf(int leaf_index) const {
     if (this->filter_leaves) {

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -22,12 +22,12 @@
 #include <utility>
 #include <vector>
 
-#include "page_index.h"
 #include "parquet/exception.h"
 #include "parquet/level_conversion.h"
 #include "parquet/metadata.h"
 #include "parquet/platform.h"
 #include "parquet/properties.h"
+#include "parquet/row_range.h"
 #include "parquet/schema.h"
 #include "parquet/types.h"
 
@@ -303,124 +303,6 @@ class TypedColumnReader : public ColumnReader {
                                           int32_t* dict_len) = 0;
 };
 
-// Represent a range to read. The range is inclusive on both ends.
-struct IntervalRange {
-  static IntervalRange Intersection(const IntervalRange& left,
-                                    const IntervalRange& right) {
-    if (left.start <= right.start) {
-      if (left.end >= right.start) {
-        return {right.start, std::min(left.end, right.end)};
-      }
-    } else if (right.end >= left.start) {
-      return {left.start, std::min(left.end, right.end)};
-    }
-    return {-1, -1};  // Return a default Range object if no intersection range found
-  }
-
-  IntervalRange(const int64_t start_, const int64_t end_) : start(start_), end(end_) {
-    if (start > end) {
-      throw ParquetException("Invalid range with start: " + std::to_string(start) +
-                             " and end: " + std::to_string(end));
-    }
-  }
-
-  size_t Count() const {
-    if(!IsValid()) {
-      throw ParquetException("Invalid range with start: " + std::to_string(start) +
-                             " and end: " + std::to_string(end));
-    }
-    return end - start + 1;
-  }
-
-  bool IsBefore(const IntervalRange& other) const { return end < other.start; }
-
-  bool IsAfter(const IntervalRange& other) const { return start > other.end; }
-
-  bool IsOverlap(const IntervalRange& other) const {
-    return !IsBefore(other) && !IsAfter(other);
-  }
-
-  bool IsValid() const { return start >= 0 && end >= 0 && end >= start; }
-
-  std::string ToString() const {
-    return "(" + std::to_string(start) + ", " + std::to_string(end) + ")";
-  }
-
-  // inclusive
-  int64_t start = -1;
-  // inclusive
-  int64_t end = -1;
-};
-
-struct BitmapRange {
-  int64_t offset;
-  // zero added to, if there are less than 64 elements left in the column.
-  uint64_t bitmap;
-};
-
-struct End {};
-
-// Represent a set of ranges to read. The ranges are sorted and non-overlapping.
-class RowRanges {
- public:
-  RowRanges() = default;
-  virtual ~RowRanges() = default;
-  virtual size_t RowCount() const = 0;
-  virtual int64_t LastRow() const = 0;
-  virtual bool IsValid() const = 0;
-  virtual bool IsOverlapping(const IntervalRange& searchRange) const = 0;
-  // Given a RowRanges with rows accross all RGs, split it into N RowRanges, where N = number of RGs
-  // e.g.: suppose we have 2 RGs: [0-99] and [100-199], and user is interested in RowRanges [90-110], then
-  // this function will return 2 RowRanges: [90-99] and [0-10]
-  virtual std::vector<std::unique_ptr<RowRanges>> SplitByRowGroups(const std::vector<int64_t>& rows_per_rg) const = 0;
-  virtual std::string ToString() const = 0;
-
-  // Returns a vector of PageLocations that must be read all to get values for
-  // all included in this range virtual std::vector<PageLocation>
-  // PageIndexesToInclude(const std::vector<PageLocation>&  all_pages) = 0;
-
-  class Iterator {
-  public:
-    virtual std::variant<IntervalRange, BitmapRange, End> NextRange() = 0;
-    virtual ~Iterator() = default;
-  };
-  virtual std::unique_ptr<Iterator> NewIterator() const = 0;
-
-};
-
-class IntervalRanges : public RowRanges {
- public:
-  IntervalRanges();
-  explicit IntervalRanges(const IntervalRange& range);
-  explicit IntervalRanges(const std::vector<IntervalRange>& ranges);
-  std::unique_ptr<Iterator> NewIterator() const override;
-  size_t RowCount() const override;
-  int64_t LastRow() const override;
-  bool IsValid() const override;
-  bool IsOverlapping(const IntervalRange& searchRange) const override;
-  std::string ToString() const override;
-  std::vector<std::unique_ptr<RowRanges>> SplitByRowGroups(
-      const std::vector<int64_t>& rows_per_rg) const override;
-  static IntervalRanges Intersection(const IntervalRanges& left,
-                                     const IntervalRanges& right);
-  void Add(const IntervalRange& range);
-  const std::vector<IntervalRange>& GetRanges() const;
-
- private:
-  std::vector<IntervalRange> ranges_;
-};
-
-class IntervalRowRangesIterator : public RowRanges::Iterator {
- public:
-  IntervalRowRangesIterator(const std::vector<IntervalRange>& ranges);
-  ~IntervalRowRangesIterator() override;
-  std::variant<IntervalRange, BitmapRange, End> NextRange() override;
-
- private:
-  const std::vector<IntervalRange>& ranges_;
-  size_t current_index_ = 0;
-};
-
 namespace internal {
 
 // A RecordSkipper is used to skip uncessary rows within each pages.
@@ -569,7 +451,11 @@ class PARQUET_EXPORT RecordReader {
 
   void reset_current_rg_processed_records() { current_rg_processed_records_ = 0; }
 
-  void set_record_skipper(const std::shared_ptr<RecordSkipper>& skipper) { skipper_ = skipper; }
+  void set_record_skipper(std::unique_ptr<RecordSkipper> skipper) {
+    skipper_ = std::move(skipper);
+  }
+
+  void reset_record_skipper() { skipper_.reset(); }
 
  protected:
   /// \brief Indicates if we can have nullable values. Note that repeated fields
@@ -623,7 +509,7 @@ class PARQUET_EXPORT RecordReader {
   // vector.
   bool read_dense_for_nullable_ = false;
 
-  std::shared_ptr<RecordSkipper> skipper_ = NULLPTR;
+  std::unique_ptr<RecordSkipper> skipper_ = NULLPTR;
 };
 
 class BinaryRecordReader : virtual public RecordReader {

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -29,7 +29,7 @@
 #include "parquet/properties.h"
 
 namespace parquet {
-
+class RowRanges;
 class ColumnReader;
 class FileMetaData;
 class PageIndexReader;
@@ -196,10 +196,10 @@ class PARQUET_EXPORT ParquetFileReader {
   /// only one row group at a time may be useful.
   ///
   /// This method may throw.
-  void PreBuffer(const std::vector<int>& row_groups,
-                 const std::vector<int>& column_indices,
-                 const ::arrow::io::IOContext& ctx,
-                 const ::arrow::io::CacheOptions& options);
+  void PreBuffer(
+      const std::vector<int>& row_groups, const std::vector<int>& column_indices,
+      const ::arrow::io::IOContext& ctx, const ::arrow::io::CacheOptions& options,
+      const std::shared_ptr<std::vector<std::unique_ptr<RowRanges>>>& row_ranges_per_rg);
 
   /// Wait for the specified row groups and column indices to be pre-buffered.
   ///

--- a/cpp/src/parquet/range_reader_test.cc
+++ b/cpp/src/parquet/range_reader_test.cc
@@ -1,0 +1,489 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/api.h"
+#include "arrow/io/api.h"
+#include "arrow/io/memory.h"
+#include "arrow/result.h"
+#include "arrow/util/type_fwd.h"
+#include "parquet/arrow/reader.h"
+#include "parquet/arrow/writer.h"
+
+#include <arrow/testing/builder.h>
+#include <arrow/testing/gtest_util.h>
+#include <arrow/util/range.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <iostream>
+
+#include <random>
+#include <string>
+
+using parquet::IntervalRange;
+using parquet::IntervalRanges;
+
+std::string random_string(std::string::size_type length) {
+  static auto& chrs = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  static std::mt19937 rg{std::random_device{}()};
+  static std::uniform_int_distribution<std::string::size_type> pick(0, sizeof(chrs) - 2);
+
+  std::string s;
+  s.reserve(length);
+  while (length--) s += chrs[pick(rg)];
+
+  return s;
+}
+
+/// The table looks like (with_nulls = false):
+// {
+// { a: {x: 0, y: 0}, b: {0, 0, 0}, c: "0", d: 0},
+// { a: {x: 1, y: 1}, b: {1, 1, 1}, c: "1", d: 1},
+// ...
+// { a: {x: 99, y: 99}, b: {99, 99, 99}, c: "99", d: 99}
+// }
+arrow::Result<std::shared_ptr<arrow::Table>> GetTable(bool with_nulls = false) {
+  // if with_nulls, the generated table should null values
+  // set first 10 rows and last 10 rows to null
+  std::shared_ptr<arrow::Buffer> null_bitmap;
+  std::vector flags(100, true);
+  if (with_nulls) {
+    std::fill_n(flags.begin(), 10, false);
+    std::fill_n(flags.begin() + 90, 10, false);
+
+    size_t length = flags.size();
+
+    ARROW_ASSIGN_OR_RAISE(null_bitmap, arrow::AllocateEmptyBitmap(length));
+
+    uint8_t* bitmap = null_bitmap->mutable_data();
+    for (size_t i = 0; i < length; ++i) {
+      if (flags[i]) {
+        arrow::bit_util::SetBit(bitmap, i);
+      }
+    }
+  }
+
+  auto int32_builder = arrow::Int32Builder();
+
+  // Struct col
+  std::shared_ptr<arrow::Array> arr_a_x;
+  std::shared_ptr<arrow::Array> arr_a_y;
+  ARROW_RETURN_NOT_OK(int32_builder.AppendValues(arrow::internal::Iota(0, 100)));
+  ARROW_RETURN_NOT_OK(int32_builder.Finish(&arr_a_x));
+  ARROW_RETURN_NOT_OK(int32_builder.AppendValues(arrow::internal::Iota(0, 100)));
+  ARROW_RETURN_NOT_OK(int32_builder.Finish(&arr_a_y));
+  ARROW_ASSIGN_OR_RAISE(auto arr_a, arrow::StructArray::Make(
+                                        {arr_a_x, arr_a_y},
+                                        std::vector<std::string>{"x", "y"}, null_bitmap));
+
+  // List<int> col
+  std::shared_ptr<arrow::Array> arr_b_values;
+  std::shared_ptr<arrow::Array> arr_b_offsets;
+  std::vector<int> b_values;
+  for (int i = 0; i < 100; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      b_values.push_back(i);
+    }
+  }
+  ARROW_RETURN_NOT_OK(int32_builder.AppendValues(b_values));
+  ARROW_RETURN_NOT_OK(int32_builder.Finish(&arr_b_values));
+  std::vector<int> offsets = arrow::internal::Iota(0, 101);
+  std::transform(offsets.begin(), offsets.end(), offsets.begin(),
+                 [](const int x) { return x * 3; });
+  ARROW_RETURN_NOT_OK(int32_builder.AppendValues(offsets));
+  ARROW_RETURN_NOT_OK(int32_builder.Finish(&arr_b_offsets));
+  ARROW_ASSIGN_OR_RAISE(auto arr_b, arrow::ListArray::FromArrays(
+                                        *arr_b_offsets, *arr_b_values,
+                                        arrow::default_memory_pool(), null_bitmap));
+
+  // string col
+  auto string_builder = arrow::StringBuilder();
+  std::shared_ptr<arrow::Array> arr_c;
+  std::vector<std::string> strs;
+  uint8_t valid_bytes[100];
+  for (size_t i = 0; i < 100; i++) {
+    // add more chars to make this column unaligned with other columns' page
+    strs.push_back(std::to_string(i) + random_string(20));
+    valid_bytes[i] = flags[i];
+  }
+  ARROW_RETURN_NOT_OK(string_builder.AppendValues(strs, &valid_bytes[0]));
+  ARROW_RETURN_NOT_OK(string_builder.Finish(&arr_c));
+
+  // int col
+  std::shared_ptr<arrow::Array> arr_d;
+  ARROW_RETURN_NOT_OK(int32_builder.AppendValues(arrow::internal::Iota(0, 100), flags));
+  ARROW_RETURN_NOT_OK(int32_builder.Finish(&arr_d));
+
+  auto schema = arrow::schema({
+      // complex types prior to simple types
+      field("a", arr_a->type()),
+      field("b", list(arrow::int32())),
+      field("c", arrow::utf8()),
+      field("d", arrow::int32()),
+  });
+
+  return arrow::Table::Make(schema, {arr_a, arr_b, arr_c, arr_d});
+}
+
+arrow::Result<std::shared_ptr<arrow::Buffer>> WriteFullFile(
+    const bool with_nulls = false) {
+  using parquet::ArrowWriterProperties;
+  using parquet::WriterProperties;
+
+  ARROW_ASSIGN_OR_RAISE(const auto table, GetTable(with_nulls));
+
+  const std::shared_ptr<WriterProperties> props =
+      WriterProperties::Builder()
+          .max_row_group_length(30)
+          ->enable_write_page_index()
+          ->disable_dictionary()
+          ->write_batch_size(1)
+          ->data_pagesize(30)  // small pages
+          ->compression(arrow::Compression::SNAPPY)
+          ->build();
+
+  const std::shared_ptr<ArrowWriterProperties> arrow_props =
+      ArrowWriterProperties::Builder().store_schema()->build();
+
+  ARROW_ASSIGN_OR_RAISE(const auto out_stream, ::arrow::io::BufferOutputStream::Create());
+
+  ARROW_RETURN_NOT_OK(parquet::arrow::WriteTable(*table.get(),
+                                                 arrow::default_memory_pool(), out_stream,
+                                                 /*chunk_size=*/100, props, arrow_props));
+
+  // {
+  //   // output to a local file for debugging
+  //   ARROW_ASSIGN_OR_RAISE(auto outfile, arrow::io::FileOutputStream::Open(
+  //                                           "/tmp/range_reader_test.parquet"));
+  //
+  //   ARROW_RETURN_NOT_OK(
+  //       parquet::arrow::WriteTable(*table.get(), arrow::default_memory_pool(), outfile,
+  //                                  /*chunk_size=*/100, props, arrow_props));
+  // }
+
+  return out_stream->Finish();
+}
+
+bool checking_col(const std::string& col_name,
+                  const std::vector<std::string>& column_names) {
+  return std::find(column_names.begin(), column_names.end(), col_name) !=
+         column_names.end();
+}
+
+void check_rb(std::unique_ptr<arrow::RecordBatchReader> rb_reader,
+              const size_t expected_rows, const int64_t expected_sum) {
+  const std::vector<std::string> column_names = rb_reader->schema()->field_names();
+
+  size_t total_rows = 0;
+  int64_t sum_a = 0;
+  int64_t sum_b = 0;
+  int64_t sum_c = 0;
+  int64_t sum_d = 0;
+  for (arrow::Result<std::shared_ptr<arrow::RecordBatch>> maybe_batch : *rb_reader) {
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
+    total_rows += batch->num_rows();
+
+    if (checking_col("a", column_names)) {
+      auto a_array =
+          std::dynamic_pointer_cast<arrow::StructArray>(batch->GetColumnByName("a"));
+      auto a_x_array = std::dynamic_pointer_cast<arrow::Int32Array>(a_array->field(0));
+      auto a_y_array = std::dynamic_pointer_cast<arrow::Int32Array>(a_array->field(1));
+      for (auto iter = a_x_array->begin(); iter != a_x_array->end(); ++iter) {
+        sum_a += (*iter).has_value() ? (*iter).value() : 0;
+      }
+      for (auto iter = a_y_array->begin(); iter != a_y_array->end(); ++iter) {
+        sum_a += (*iter).has_value() ? (*iter).value() : 0;
+      }
+    }
+
+    if (checking_col("b", column_names)) {
+      auto b_array =
+          std::dynamic_pointer_cast<arrow::ListArray>(batch->GetColumnByName("b"));
+      ASSERT_OK_AND_ASSIGN(auto flatten_b_array, b_array->Flatten());
+      auto b_array_values = std::dynamic_pointer_cast<arrow::Int32Array>(flatten_b_array);
+      for (auto iter = b_array_values->begin(); iter != b_array_values->end(); ++iter) {
+        sum_b += (*iter).has_value() ? (*iter).value() : 0;
+      }
+    }
+
+    if (checking_col("c", column_names)) {
+      auto c_array =
+          std::dynamic_pointer_cast<arrow::StringArray>(batch->GetColumnByName("c"));
+      for (auto iter = c_array->begin(); iter != c_array->end(); ++iter) {
+        sum_c += std::stoi(std::string(
+            (*iter).has_value() ? (*iter).value().substr(0, (*iter).value().size() - 20)
+                                : "0"));
+      }
+    }
+
+    if (checking_col("d", column_names)) {
+      auto d_array =
+          std::dynamic_pointer_cast<arrow::Int32Array>(batch->GetColumnByName("d"));
+      for (auto iter = d_array->begin(); iter != d_array->end(); ++iter) {
+        sum_d += (*iter).has_value() ? (*iter).value() : 0;
+      }
+    }
+  }
+  ASSERT_EQ(expected_rows, total_rows);
+
+  if (checking_col("a", column_names)) ASSERT_EQ(expected_sum * 2, sum_a);
+  if (checking_col("b", column_names)) ASSERT_EQ(expected_sum * 3, sum_b);
+  if (checking_col("c", column_names)) ASSERT_EQ(expected_sum, sum_c);
+  if (checking_col("d", column_names)) ASSERT_EQ(expected_sum, sum_d);
+}
+
+class TestRecordBatchReaderWithRanges : public testing::Test {
+ public:
+  void SetUp() {
+    ASSERT_OK_AND_ASSIGN(auto buffer, WriteFullFile());
+
+    arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+    auto reader_properties = parquet::ReaderProperties(pool);
+    reader_properties.set_buffer_size(4096 * 4);
+    reader_properties.enable_buffered_stream();
+
+    auto arrow_reader_props = parquet::ArrowReaderProperties();
+    arrow_reader_props.set_batch_size(10);  // default 64 * 1024
+
+    parquet::arrow::FileReaderBuilder reader_builder;
+    const auto in_file = std::make_shared<arrow::io::BufferReader>(buffer);
+    ASSERT_OK(reader_builder.Open(in_file, /*memory_map=*/reader_properties));
+    reader_builder.memory_pool(pool);
+    reader_builder.properties(arrow_reader_props);
+
+    ASSERT_OK_AND_ASSIGN(arrow_reader, reader_builder.Build());
+  }
+
+  void TearDown() {}
+
+ protected:
+  std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+};
+
+TEST_F(TestRecordBatchReaderWithRanges, TestRangesSplit) {}
+
+TEST_F(TestRecordBatchReaderWithRanges, SelectOnePageForEachRG) {
+  std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+  IntervalRanges rows{{IntervalRange{0, 9}, IntervalRange{40, 49}, IntervalRange{80, 89}, IntervalRange{90, 99}}};
+
+  const std::vector column_indices{0, 1, 2, 3, 4};
+  ASSERT_OK(arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader));
+
+  // (0+...+9) + (40+...+49) + (80+...+89) + (90+...+99) = 2280
+  check_rb(std::move(rb_reader), 40, 2280);
+}
+
+TEST_F(TestRecordBatchReaderWithRanges, SelectSomePageForOneRG) {
+  std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+  IntervalRanges rows{{IntervalRange{0, 7}, IntervalRange{16, 23}}};
+
+  const std::vector column_indices{0, 1, 2, 3, 4};
+  ASSERT_OK(arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader));
+
+  // (0+...+7) + (16+...+23) = 184
+  check_rb(std::move(rb_reader), 16, 184);
+}
+
+TEST_F(TestRecordBatchReaderWithRanges, SelectAllRange) {
+  std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+  IntervalRanges rows{{IntervalRange{0, 29}, IntervalRange{30, 59}, IntervalRange{60, 89}, IntervalRange{90, 99}}};
+
+  const std::vector column_indices{0, 1, 2, 3, 4};
+  ASSERT_OK(arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader));
+
+  // (0+...+99) = 4950
+  check_rb(std::move(rb_reader), 100, 4950);
+}
+
+TEST_F(TestRecordBatchReaderWithRanges, SelectEmptyRange) {
+  std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+  IntervalRanges rows{};
+
+  const std::vector column_indices{0, 1, 2, 3, 4};
+  const auto status =
+      arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader);
+  ASSERT_OK(status);
+  check_rb(std::move(rb_reader), 0, 0);
+}
+
+TEST_F(TestRecordBatchReaderWithRanges, SelectOneRowSkipOneRow) {
+  // case 1: only care about RG 0
+  {
+    std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+    std::vector<parquet::IntervalRange> ranges;
+    for (int64_t i = 0; i < 30; i++) {
+      if (i % 2 == 0) ranges.push_back({i, i});
+    }
+    const std::vector column_indices{0, 1, 2, 3, 4};
+    ASSERT_OK(arrow_reader->GetRecordBatchReader(IntervalRanges(ranges), column_indices,
+                                                 &rb_reader));
+
+    check_rb(std::move(rb_reader), 15, 210);  // 0 + 2 + ... + 28 = 210
+  }
+
+  // case 2: care about RG 0 and 2
+  {
+    std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+    std::vector<parquet::IntervalRange> ranges;
+    for (int64_t i = 0; i < 30; i++) {
+      if (i % 2 == 0) ranges.push_back({i, i});
+    }
+
+    for (int64_t i = 60; i < 90; i++) {
+      if (i % 2 == 0) ranges.push_back({i, i});
+    }
+    const std::vector column_indices{0, 1, 2, 3, 4};
+    ASSERT_OK(arrow_reader->GetRecordBatchReader(IntervalRanges(ranges), column_indices,
+                                                 &rb_reader));
+
+    check_rb(std::move(rb_reader), 30,
+             1320);  // (0 + 2 + ... + 28) + (60 + 62 ... + 88) = 1320
+  }
+}
+
+TEST_F(TestRecordBatchReaderWithRanges, InvalidRanges) {
+  std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+  {
+    IntervalRanges rows{{IntervalRange{-1, 5}}};
+    const std::vector column_indices{0, 1, 2, 3, 4};
+    const auto status =
+        arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader);
+    ASSERT_NOT_OK(status);
+    EXPECT_TRUE(status.message().find("The provided row range is invalid, keep it "
+                                      "monotone and non-interleaving: [(-1, 5)]") !=
+                std::string::npos);
+  }
+
+  {
+    IntervalRanges rows{{IntervalRange{0, 4}, {2, 5}}};
+    const std::vector column_indices{0, 1, 2, 3, 4};
+    const auto status =
+        arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader);
+    ASSERT_NOT_OK(status);
+    EXPECT_TRUE(
+        status.message().find("The provided row range is invalid, keep it monotone and "
+                              "non-interleaving: [(0, 4), (2, 5)]") != std::string::npos);
+  }
+  {
+    // will treat as {0,99}
+    IntervalRanges rows{{IntervalRange{0, 100}}};
+    const std::vector column_indices{0, 1, 2, 3, 4};
+    const auto status =
+        arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader);
+    ASSERT_NOT_OK(status);
+    EXPECT_TRUE(status.message().find("The provided row range [(0, 100)] exceeds the "
+                                      "number of rows in the file: 100") !=
+                std::string::npos);
+  }
+}
+
+TEST(TestRecordBatchReaderWithRangesBadCases, NoPageIndex) {
+  using parquet::ArrowWriterProperties;
+  using parquet::WriterProperties;
+
+  // write a file without page index
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::Table> table, GetTable());
+  std::shared_ptr<WriterProperties> props =
+      WriterProperties::Builder()
+          .max_row_group_length(30)
+          ->disable_write_page_index()  // NO INDEX !!!!
+          ->write_batch_size(13)
+          ->data_pagesize(1)
+          ->compression(arrow::Compression::SNAPPY)
+          ->build();
+  std::shared_ptr<ArrowWriterProperties> arrow_props =
+      ArrowWriterProperties::Builder().store_schema()->build();
+  ASSERT_OK_AND_ASSIGN(auto out_stream, ::arrow::io::BufferOutputStream::Create());
+  ASSERT_OK(parquet::arrow::WriteTable(*table.get(), arrow::default_memory_pool(),
+                                       out_stream,
+                                       /*chunk_size=*/100, props, arrow_props));
+  ASSERT_OK_AND_ASSIGN(auto buffer, out_stream->Finish());
+
+  // try to read the file with Range
+  arrow::MemoryPool* pool = arrow::default_memory_pool();
+  auto reader_properties = parquet::ReaderProperties(pool);
+  reader_properties.set_buffer_size(4096 * 4);
+  reader_properties.enable_buffered_stream();
+  auto arrow_reader_props = parquet::ArrowReaderProperties();
+  arrow_reader_props.set_batch_size(10);  // default 64 * 1024
+
+  parquet::arrow::FileReaderBuilder reader_builder;
+  auto in_file = std::make_shared<arrow::io::BufferReader>(buffer);
+  ASSERT_OK(reader_builder.Open(in_file, /*memory_map=*/reader_properties));
+  reader_builder.memory_pool(pool);
+  reader_builder.properties(arrow_reader_props);
+  ASSERT_OK_AND_ASSIGN(auto arrow_reader, reader_builder.Build());
+
+  std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+  IntervalRanges rows{{IntervalRange{0, 29}}};
+  std::vector column_indices{0, 1, 2, 3, 4};
+  auto status = arrow_reader->GetRecordBatchReader(rows, column_indices, &rb_reader);
+  ASSERT_NOT_OK(status);
+  EXPECT_TRUE(status.message().find("Attempting to read with Ranges but Page Index is "
+                                    "not found for Row Group: 0") != std::string::npos);
+}
+
+class TestRecordBatchReaderWithRangesWithNulls : public testing::Test {
+ public:
+  void SetUp() {
+    ASSERT_OK_AND_ASSIGN(auto buffer, WriteFullFile(true));
+
+    arrow::MemoryPool* pool = arrow::default_memory_pool();
+
+    auto reader_properties = parquet::ReaderProperties(pool);
+    reader_properties.set_buffer_size(4096 * 4);
+    reader_properties.enable_buffered_stream();
+
+    auto arrow_reader_props = parquet::ArrowReaderProperties();
+    arrow_reader_props.set_batch_size(10);  // default 64 * 1024
+
+    parquet::arrow::FileReaderBuilder reader_builder;
+    const auto in_file = std::make_shared<arrow::io::BufferReader>(buffer);
+    ASSERT_OK(reader_builder.Open(in_file, /*memory_map=*/reader_properties));
+    reader_builder.memory_pool(pool);
+    reader_builder.properties(arrow_reader_props);
+
+    ASSERT_OK_AND_ASSIGN(arrow_reader, reader_builder.Build());
+  }
+
+  void TearDown() {}
+
+ protected:
+  std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+};
+
+TEST_F(TestRecordBatchReaderWithRangesWithNulls, SelectOneRowSkipOneRow) {
+  {
+    std::unique_ptr<arrow::RecordBatchReader> rb_reader;
+    std::vector<parquet::IntervalRange> ranges;
+    for (int64_t i = 0; i < 30; i++) {
+      if (i % 2 == 0) ranges.push_back({i, i});
+    }
+
+    for (int64_t i = 60; i < 90; i++) {
+      if (i % 2 == 0) ranges.push_back({i, i});
+    }
+    const std::vector column_indices{0, 1, 2, 3, 4};
+    ASSERT_OK(arrow_reader->GetRecordBatchReader(IntervalRanges(ranges), column_indices,
+                                                 &rb_reader));
+
+    // 0-9 is masked as null, so the ramaining is:
+    // (10 + 12 + ... + 28) + (60 + 62 ... + 88) = 1320
+    check_rb(std::move(rb_reader), 30, 1300);
+  }
+}

--- a/cpp/src/parquet/row_range.cc
+++ b/cpp/src/parquet/row_range.cc
@@ -1,0 +1,190 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/row_range.h"
+
+#include <variant>
+
+#include "parquet/exception.h"
+
+namespace parquet {
+// ----------------------------------------------------------------------
+// RowRanges and ins implementations
+bool IsValid(const std::vector<IntervalRange>& ranges) {
+  if (ranges.size() == 0) return true;
+  if (ranges[0].start < 0) {
+    return false;
+  }
+  for (size_t i = 0; i < ranges.size(); i++) {
+    if (!IntervalRangeUtils::IsValid(ranges[i])) {
+      return false;
+    }
+  }
+  for (size_t i = 1; i < ranges.size(); i++) {
+    if (ranges[i].start <= ranges[i - 1].end) {
+      return false;
+    }
+  }
+  return true;
+}
+
+IntervalRanges::IntervalRanges() = default;
+
+IntervalRanges::IntervalRanges(const IntervalRange& range) {
+  ranges_.push_back(range);
+  if (!IsValid(ranges_)) {
+    throw ParquetException("Invalid range with start: " + std::to_string(range.start) +
+                           " and end: " + std::to_string(range.end) +
+                           ", keep it monotone and non-interleaving");
+  }
+}
+
+IntervalRanges::IntervalRanges(const std::vector<IntervalRange>& ranges) {
+  this->ranges_ = ranges;
+  if (!IsValid(ranges_)) {
+    throw ParquetException("Invalid ranges: " + this->IntervalRanges::ToString() +
+                           ", keep it monotone and non-interleaving");
+  }
+}
+
+std::unique_ptr<RowRanges::Iterator> IntervalRanges::NewIterator() const {
+  return std::make_unique<IntervalRowRangesIterator>(ranges_);
+}
+
+size_t IntervalRanges::num_rows() const {
+  size_t cnt = 0;
+  for (const IntervalRange& range : ranges_) {
+    cnt += IntervalRangeUtils::Count(range);
+  }
+  return cnt;
+}
+
+int64_t IntervalRanges::first_row() const {
+  if (ranges_.empty()) {
+    throw ParquetException("first_row() called on empty IntervalRanges");
+  }
+  return ranges_.front().start;
+}
+
+int64_t IntervalRanges::last_row() const {
+  if (ranges_.empty()) {
+    throw ParquetException("last_row() called on empty IntervalRanges");
+  }
+  return ranges_.back().end;
+}
+
+bool IntervalRanges::IsOverlapping(const int64_t start, const int64_t end) const {
+  auto searchRange = IntervalRange{start, end};
+  auto it = std::lower_bound(ranges_.begin(), ranges_.end(), searchRange,
+                             [](const IntervalRange& r1, const IntervalRange& r2) {
+                               return IntervalRangeUtils::IsBefore(r1, r2);
+                             });
+  return it != ranges_.end() && !IntervalRangeUtils::IsAfter(*it, searchRange);
+}
+
+std::string IntervalRanges::ToString() const {
+  std::string result = "[";
+  for (const IntervalRange& range : ranges_) {
+    result += IntervalRangeUtils::ToString(range) + ", ";
+  }
+  if (!ranges_.empty()) {
+    result = result.substr(0, result.size() - 2);
+  }
+  result += "]";
+  return result;
+}
+
+std::vector<std::unique_ptr<RowRanges>> IntervalRanges::SplitByRowRange(
+    const std::vector<int64_t>& num_rows_per_sub_ranges) const {
+  if (num_rows_per_sub_ranges.size() <= 1) {
+    std::unique_ptr<RowRanges> single =
+        std::make_unique<IntervalRanges>(*this);  // return a copy of itself
+    auto ret = std::vector<std::unique_ptr<RowRanges>>();
+    ret.push_back(std::move(single));
+    return ret;
+  }
+
+  std::vector<std::unique_ptr<RowRanges>> result;
+
+  IntervalRanges spaces;
+  int64_t rows_so_far = 0;
+  for (size_t i = 0; i < num_rows_per_sub_ranges.size(); ++i) {
+    auto start = rows_so_far;
+    rows_so_far += num_rows_per_sub_ranges[i];
+    auto end = rows_so_far - 1;
+    spaces.Add({start, end});
+  }
+
+  // each RG's row range forms a space, we need to adjust RowRanges in each space to
+  // zero based.
+  for (IntervalRange space : spaces.GetRanges()) {
+    auto intersection = Intersection(IntervalRanges(space), *this);
+
+    std::unique_ptr<IntervalRanges> zero_based_ranges =
+        std::make_unique<IntervalRanges>();
+    for (const IntervalRange& range : intersection.GetRanges()) {
+      zero_based_ranges->Add({range.start - space.start, range.end - space.start});
+    }
+    result.push_back(std::move(zero_based_ranges));
+  }
+
+  return result;
+}
+
+IntervalRanges IntervalRanges::Intersection(const IntervalRanges& left,
+                                            const IntervalRanges& right) {
+  IntervalRanges result;
+
+  size_t rightIndex = 0;
+  for (const IntervalRange& l : left.ranges_) {
+    for (size_t i = rightIndex, n = right.ranges_.size(); i < n; ++i) {
+      const IntervalRange& r = right.ranges_[i];
+      if (IntervalRangeUtils::IsBefore(l, r)) {
+        break;
+      } else if (IntervalRangeUtils::IsAfter(l, r)) {
+        rightIndex = i + 1;
+        continue;
+      }
+      result.Add(IntervalRangeUtils::Intersection(l, r));
+    }
+  }
+
+  return result;
+}
+
+void IntervalRanges::Add(const IntervalRange& range) {
+  const IntervalRange rangeToAdd = range;
+  if (ranges_.size() > 1 && rangeToAdd.start <= ranges_.back().end) {
+    throw ParquetException("Ranges must be added in order");
+  }
+  ranges_.push_back(rangeToAdd);
+}
+
+const std::vector<IntervalRange>& IntervalRanges::GetRanges() const { return ranges_; }
+
+IntervalRowRangesIterator::IntervalRowRangesIterator(
+    const std::vector<IntervalRange>& ranges)
+    : ranges_(ranges) {}
+
+IntervalRowRangesIterator::~IntervalRowRangesIterator() {}
+
+std::variant<IntervalRange, BitmapRange, End> IntervalRowRangesIterator::NextRange() {
+  if (current_index_ >= ranges_.size()) return End();
+
+  return ranges_[current_index_++];
+}
+}  // namespace parquet

--- a/cpp/src/parquet/row_range.h
+++ b/cpp/src/parquet/row_range.h
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This module contains the logical parquet-cpp types (independent of Thrift
+// structures), schema nodes, and related type tools
+
+#pragma once
+#include <variant>
+
+#include "parquet/exception.h"
+
+namespace parquet {
+
+// Represent a range to read. The range is inclusive on both ends.
+struct IntervalRange {
+  IntervalRange(const int64_t start_, const int64_t end_) : start(start_), end(end_) {
+    if (start > end) {
+      throw ParquetException("Invalid range with start: " + std::to_string(start) +
+                             " bigger than end: " + std::to_string(end));
+    }
+  }
+
+  // inclusive
+  int64_t start = -1;
+  // inclusive
+  int64_t end = -1;
+};
+
+class IntervalRangeUtils {
+ public:
+  static IntervalRange Intersection(const IntervalRange& left,
+                                    const IntervalRange& right) {
+    if (left.start <= right.start) {
+      if (left.end >= right.start) {
+        return {right.start, std::min(left.end, right.end)};
+      }
+    } else if (right.end >= left.start) {
+      return {left.start, std::min(left.end, right.end)};
+    }
+    return {-1, -1};  // Return a default Range object if no intersection range found
+  }
+
+  static std::string ToString(const IntervalRange& range) {
+    return "(" + std::to_string(range.start) + ", " + std::to_string(range.end) + ")";
+  }
+
+  static bool IsValid(const IntervalRange& range) {
+    return range.start >= 0 && range.end >= 0 && range.end >= range.start;
+  }
+
+  static size_t Count(const IntervalRange& range) {
+    if (!IsValid(range)) {
+      throw ParquetException("Invalid range: " + ToString(range));
+    }
+    return range.end - range.start + 1;
+  }
+
+  static bool IsBefore(const IntervalRange& self, const IntervalRange& other) {
+    return self.end < other.start;
+  }
+
+  static bool IsAfter(const IntervalRange& self, const IntervalRange& other) {
+    return self.start > other.end;
+  }
+
+  static bool IsOverlap(const IntervalRange& self, const IntervalRange& other) {
+    return !IsBefore(self, other) && !IsAfter(self, other);
+  }
+};
+
+struct BitmapRange {
+  int64_t offset;
+  // zero added to, if there are less than 64 elements left in the column.
+  uint64_t bitmap;
+};
+
+struct End {};
+
+// Represent a set of ranges to read. The ranges are sorted and non-overlapping.
+class RowRanges {
+ public:
+  virtual ~RowRanges() = default;
+  /// \brief Total number of rows in the row ranges.
+  virtual size_t num_rows() const = 0;
+  /// \brief First row in the ranges
+  virtual int64_t first_row() const = 0;
+  /// \brief Last row in the ranges
+  virtual int64_t last_row() const = 0;
+  /// \brief Whether the given range from start to end overlaps with the row ranges.
+  virtual bool IsOverlapping(int64_t start, int64_t end) const = 0;
+  /// \brief Split the row ranges into sub row ranges according to the
+  ///   specified number of rows per sub row ranges. A typical use case is
+  ///   to convert file based RowRanges to row group based RowRanges.
+  ///
+  /// \param num_rows_per_sub_ranges number of rows per sub row range.
+  virtual std::vector<std::unique_ptr<RowRanges>> SplitByRowRange(
+      const std::vector<int64_t>& num_rows_per_sub_ranges) const = 0;
+  /// \brief Readable string representation
+  virtual std::string ToString() const = 0;
+
+  class Iterator {
+   public:
+    virtual std::variant<IntervalRange, BitmapRange, End> NextRange() = 0;
+    virtual ~Iterator() = default;
+  };
+  /// \brief Create an iterator to iterate over the ranges
+  virtual std::unique_ptr<Iterator> NewIterator() const = 0;
+};
+
+class IntervalRanges : public RowRanges {
+ public:
+  IntervalRanges();
+  explicit IntervalRanges(const IntervalRange& range);
+  explicit IntervalRanges(const std::vector<IntervalRange>& ranges);
+  std::unique_ptr<Iterator> NewIterator() const override;
+  size_t num_rows() const override;
+  int64_t first_row() const override;
+  int64_t last_row() const override;
+  bool IsOverlapping(int64_t start, int64_t end) const override;
+  std::string ToString() const override;
+  std::vector<std::unique_ptr<RowRanges>> SplitByRowRange(
+      const std::vector<int64_t>& num_rows_per_sub_ranges) const override;
+  static IntervalRanges Intersection(const IntervalRanges& left,
+                                     const IntervalRanges& right);
+  void Add(const IntervalRange& range);
+  const std::vector<IntervalRange>& GetRanges() const;
+
+ private:
+  std::vector<IntervalRange> ranges_;
+};
+
+class IntervalRowRangesIterator : public RowRanges::Iterator {
+ public:
+  explicit IntervalRowRangesIterator(const std::vector<IntervalRange>& ranges);
+  ~IntervalRowRangesIterator() override;
+  std::variant<IntervalRange, BitmapRange, End> NextRange() override;
+
+ private:
+  const std::vector<IntervalRange>& ranges_;
+  size_t current_index_ = 0;
+};
+}  // namespace parquet

--- a/cpp/src/parquet/row_range_test.cc
+++ b/cpp/src/parquet/row_range_test.cc
@@ -17,7 +17,8 @@
 #include <gtest/gtest.h>
 #include "parquet/column_reader.h"
 
-using namespace parquet;
+using parquet::IntervalRange;
+using parquet::IntervalRanges;
 
 class RowRangesTest : public ::testing::Test {
  protected:
@@ -28,7 +29,7 @@ TEST_F(RowRangesTest, EmptyRG_ReturnsOriginalRowRanges) {
   row_ranges.Add(IntervalRange(0, 10));
   std::vector<int64_t> rows_per_rg;
 
-  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  auto result = row_ranges.SplitByRowRange(rows_per_rg);
   ASSERT_EQ(result.size(), 1);
 
   auto iter = result[0]->NewIterator();
@@ -42,7 +43,7 @@ TEST_F(RowRangesTest, SingleRG_ReturnsOriginalRowRanges2) {
   row_ranges.Add(IntervalRange(0, 10));
   std::vector<int64_t> rows_per_rg = {11};
 
-  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  auto result = row_ranges.SplitByRowRange(rows_per_rg);
   ASSERT_EQ(result.size(), 1);
 
   auto iter = result[0]->NewIterator();
@@ -56,7 +57,7 @@ TEST_F(RowRangesTest, ReturnsTwoRowRanges) {
   row_ranges.Add(IntervalRange(0, 10));
   std::vector<int64_t> rows_per_rg = {5, 6};
 
-  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  auto result = row_ranges.SplitByRowRange(rows_per_rg);
   ASSERT_EQ(result.size(), 2);
   {
     auto iter = result[0]->NewIterator();
@@ -78,7 +79,7 @@ TEST_F(RowRangesTest, ReturnsMultipleRowRanges) {
   row_ranges.Add(IntervalRange(0, 11));
   std::vector<int64_t> rows_per_rg = {3, 4, 100};
 
-  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  auto result = row_ranges.SplitByRowRange(rows_per_rg);
   ASSERT_EQ(result.size(), 3);
   {
     auto iter = result[0]->NewIterator();
@@ -110,7 +111,7 @@ TEST_F(RowRangesTest, MultipleInputRange) {
 
   std::vector<int64_t> rows_per_rg = {100, 100};
 
-  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  auto result = row_ranges.SplitByRowRange(rows_per_rg);
   ASSERT_EQ(result.size(), 2);
   {
     auto iter = result[0]->NewIterator();
@@ -142,7 +143,7 @@ TEST_F(RowRangesTest, MultipleSplitPoints_ReturnWithEmptyRowRanges) {
   row_ranges.Add(IntervalRange(11, 18));
   std::vector<int64_t> rows_per_rg = {5, 5, 5, 5, 5};
 
-  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  auto result = row_ranges.SplitByRowRange(rows_per_rg);
   ASSERT_EQ(result.size(), 5);
   {
     auto iter = result[0]->NewIterator();
@@ -176,7 +177,7 @@ TEST_F(RowRangesTest, RangeExceedRG) {
   row_ranges.Add(IntervalRange(0, 10));
   std::vector<int64_t> rows_per_rg = {5, 3};
 
-  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  auto result = row_ranges.SplitByRowRange(rows_per_rg);
   ASSERT_EQ(result.size(), 2);
   {
     auto iter = result[0]->NewIterator();

--- a/cpp/src/parquet/row_range_test.cc
+++ b/cpp/src/parquet/row_range_test.cc
@@ -1,0 +1,195 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#include <gtest/gtest.h>
+#include "parquet/column_reader.h"
+
+using namespace parquet;
+
+class RowRangesTest : public ::testing::Test {
+ protected:
+  IntervalRanges row_ranges;
+};
+
+TEST_F(RowRangesTest, EmptyRG_ReturnsOriginalRowRanges) {
+  row_ranges.Add(IntervalRange(0, 10));
+  std::vector<int64_t> rows_per_rg;
+
+  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  ASSERT_EQ(result.size(), 1);
+
+  auto iter = result[0]->NewIterator();
+  auto range = std::get<IntervalRange>(iter->NextRange());
+  ASSERT_EQ(range.start, 0);
+  ASSERT_EQ(range.end, 10);
+  ASSERT_EQ(iter->NextRange().index(), 2);
+}
+
+TEST_F(RowRangesTest, SingleRG_ReturnsOriginalRowRanges2) {
+  row_ranges.Add(IntervalRange(0, 10));
+  std::vector<int64_t> rows_per_rg = {11};
+
+  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  ASSERT_EQ(result.size(), 1);
+
+  auto iter = result[0]->NewIterator();
+  auto range = std::get<IntervalRange>(iter->NextRange());
+  ASSERT_EQ(range.start, 0);
+  ASSERT_EQ(range.end, 10);
+  ASSERT_EQ(iter->NextRange().index(), 2);
+}
+
+TEST_F(RowRangesTest, ReturnsTwoRowRanges) {
+  row_ranges.Add(IntervalRange(0, 10));
+  std::vector<int64_t> rows_per_rg = {5, 6};
+
+  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  ASSERT_EQ(result.size(), 2);
+  {
+    auto iter = result[0]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 4);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[1]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 5);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+}
+
+TEST_F(RowRangesTest, ReturnsMultipleRowRanges) {
+  row_ranges.Add(IntervalRange(0, 11));
+  std::vector<int64_t> rows_per_rg = {3, 4, 100};
+
+  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  ASSERT_EQ(result.size(), 3);
+  {
+    auto iter = result[0]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 2);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[1]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 3);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[2]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 4);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+}
+
+TEST_F(RowRangesTest, MultipleInputRange) {
+  row_ranges.Add(IntervalRange(0, 10));
+  row_ranges.Add(IntervalRange(90, 111));
+  row_ranges.Add(IntervalRange(191, 210));
+
+  std::vector<int64_t> rows_per_rg = {100, 100};
+
+  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  ASSERT_EQ(result.size(), 2);
+  {
+    auto iter = result[0]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 10);
+
+    range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 90);
+    ASSERT_EQ(range.end, 99);
+
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[1]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 11);
+
+    range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 91);
+    ASSERT_EQ(range.end, 99);
+
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+}
+
+TEST_F(RowRangesTest, MultipleSplitPoints_ReturnWithEmptyRowRanges) {
+  row_ranges.Add(IntervalRange(11, 18));
+  std::vector<int64_t> rows_per_rg = {5, 5, 5, 5, 5};
+
+  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  ASSERT_EQ(result.size(), 5);
+  {
+    auto iter = result[0]->NewIterator();
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[1]->NewIterator();
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[2]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 1);
+    ASSERT_EQ(range.end, 4);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[3]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 3);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[4]->NewIterator();
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+}
+
+TEST_F(RowRangesTest, RangeExceedRG) {
+  row_ranges.Add(IntervalRange(0, 10));
+  std::vector<int64_t> rows_per_rg = {5, 3};
+
+  auto result = row_ranges.SplitByRowGroups(rows_per_rg);
+  ASSERT_EQ(result.size(), 2);
+  {
+    auto iter = result[0]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 4);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+  {
+    auto iter = result[1]->NewIterator();
+    auto range = std::get<IntervalRange>(iter->NextRange());
+    ASSERT_EQ(range.start, 0);
+    ASSERT_EQ(range.end, 2);
+    ASSERT_EQ(iter->NextRange().index(), 2);
+  }
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR is a supserset of https://github.com/apache/arrow/pull/39608. 
Skipping Page IO is supported in Pre-Buffer read mode.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
In this PR, RangeCacheEntry cached in  range cache is modified:
Instead of caching the whole ReadRange, we excluded the bytes within `holes`, which is calculated by user specified RowRange.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, range_read_test.cc

### Are there any user-facing changes?
a new GetRecordBatchReader API overload is added. NO existing API is broken


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #38865