### PR TITLE
GH-39738: [R] Support build against the last three released versions of Arrow

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         config:
-        - cpp_version: ["15.0.0"]
+        - cpp_version: "15.0.0"
     env:
       ARROW_HOME: arrow
 

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -53,14 +53,11 @@ env:
 
 jobs:
   ubuntu-cpp-versions:
-    name: Arrow C++ Versions (${{ matrix.config.cpp_version }})
+    name: Arrow C++ Versions (${{ matrix.cpp_version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        config:
-        - { cpp_version: "15.0.0" }
-        - { cpp_version: "14.0.2" }
-        - { cpp_version: "13.0.0" }
+        cpp_version: ["15.0.0" , "14.0.2",  "13.0.0"]
 
     env:
       ARROW_HOME: "${{ github.workspace }}/arrow"
@@ -76,15 +73,15 @@ jobs:
       uses: actions/cache@v4
       with:
         path: arrow
-        key: arrow-r-cpp-release-${{ matrix.config.cpp_version }}-1
+        key: arrow-r-cpp-release-${{ matrix.cpp_version }}-1
 
-    - name: Build Arrow C++ (${{ matrix.config.cpp_version }})
+    - name: Build Arrow C++ (${{ matrix.cpp_version }})
       if: steps.cache-arrow-build.outputs.cache-hit != 'true'
       run: |
-        curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.config.cpp_version }}.tar.gz | \
+        curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.cpp_version }}.tar.gz | \
           tar -zxf -
         mkdir arrow-build
-        export SOURCE_DIR="$(pwd)/arrow-apache-arrow-${{ matrix.config.cpp_version }}/cpp"
+        export SOURCE_DIR="$(pwd)/arrow-apache-arrow-${{ matrix.cpp_version }}/cpp"
         export DEST_DIR="$(pwd)/arrow"
 
         src/r/inst/build_arrow_static.sh

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -52,6 +52,54 @@ env:
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
+  ubuntu-cpp-versions:
+    name: R / Arrow C++ (${{ matrix.config.cpp_version }})
+    strategy:
+      matrix:
+        config:
+        - cpp_version: ["15.0.0"]
+    env:
+      ARROW_HOME: arrow
+
+    steps:
+    - name: Checkout Arrow
+      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+      with:
+        path: src
+
+    - name: Cache Arrow C++ Build
+      id: cache-arrow-build
+      uses: actions/cache@v3
+      with:
+        path: arrow
+        key: arrow-r-cpp-release-${{ matrix.config.cpp_version }}-0
+
+    - name: Build Arrow C++ (${{ matrix.config.cpp_version }})
+      if: steps.cache-arrow-build.outputs.cache-hit != 'true'
+      run: |
+        curl https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.config.cpp_version }}.tar.gz | \
+          tar -zxf -
+        mkdir arrow-build
+        export SOURCE_DIR="$(pwd)/arrow-build"
+        export DEST_DIR="$(pwd)/arrow"
+
+        src/r/inst/build_arrow_static.sh
+
+    - uses: r-lib/actions/setup-pandoc@v2
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
+        install-r: false
+    - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+          working-directory: src/r
+
+    - uses: r-lib/actions/check-r-package@v2
+      with:
+        working-directory: src/r
+
   ubuntu:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} R ${{ matrix.r }} Force-Tests ${{ matrix.force-tests }}
     runs-on: ubuntu-latest

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -80,9 +80,8 @@ jobs:
       run: |
         curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.config.cpp_version }}.tar.gz | \
           tar -zxf -
-        ls -a
         mkdir arrow-build
-        export SOURCE_DIR="$(pwd)/apache-arrow-${{ matrix.config.cpp_version }}/cpp"
+        export SOURCE_DIR="$(pwd)/arrow-apache-arrow-${{ matrix.config.cpp_version }}/cpp"
         export DEST_DIR="$(pwd)/arrow"
 
         src/r/inst/build_arrow_static.sh

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -86,10 +86,16 @@ jobs:
 
         src/r/inst/build_arrow_static.sh
 
+    - name: Install checkbashisms
+      run: |
+        sudo apt-get update
+        sudo apt-get install devscripts
+
     - uses: r-lib/actions/setup-r@v2
       with:
         use-public-rspm: true
         install-r: false
+
     - uses: r-lib/actions/setup-r-dependencies@v2
       with:
         extra-packages: any::rcmdcheck
@@ -99,6 +105,13 @@ jobs:
     - uses: r-lib/actions/check-r-package@v2
       with:
         working-directory: src/r
+      env:
+        ARROW_R_VERBOSE_TEST: "true"
+
+    - name: Show install output
+      if: always()
+      run: find check -name '00install.out*' -exec cat '{}' \; || true
+      shell: bash
 
 
   ubuntu:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -78,10 +78,10 @@ jobs:
     - name: Build Arrow C++ (${{ matrix.config.cpp_version }})
       if: steps.cache-arrow-build.outputs.cache-hit != 'true'
       run: |
-        curl https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.config.cpp_version }}.tar.gz | \
+        curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.config.cpp_version }}.tar.gz | \
           tar -zxf -
         mkdir arrow-build
-        export SOURCE_DIR="$(pwd)/arrow-build"
+        export SOURCE_DIR="$(pwd)/apache-arrow-${{ matrix.config.cpp_version }}/cpp"
         export DEST_DIR="$(pwd)/arrow"
 
         src/r/inst/build_arrow_static.sh

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -85,7 +85,6 @@ jobs:
 
         src/r/inst/build_arrow_static.sh
 
-    - uses: r-lib/actions/setup-pandoc@v2
     - uses: r-lib/actions/setup-r@v2
       with:
         use-public-rspm: true
@@ -99,6 +98,7 @@ jobs:
     - uses: r-lib/actions/check-r-package@v2
       with:
         working-directory: src/r
+
 
   ubuntu:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} R ${{ matrix.r }} Force-Tests ${{ matrix.force-tests }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -73,10 +73,10 @@ jobs:
 
     - name: Cache Arrow C++ Build
       id: cache-arrow-build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: arrow
-        key: arrow-r-cpp-release-${{ matrix.config.cpp_version }}-0
+        key: arrow-r-cpp-release-${{ matrix.config.cpp_version }}-1
 
     - name: Build Arrow C++ (${{ matrix.config.cpp_version }})
       if: steps.cache-arrow-build.outputs.cache-hit != 'true'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -63,7 +63,7 @@ jobs:
         - { cpp_version: "13.0.0" }
 
     env:
-      ARROW_HOME: arrow
+      ARROW_HOME: "${{ github.workspace }}/arrow"
 
     steps:
     - name: Checkout Arrow

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -53,7 +53,7 @@ env:
 
 jobs:
   ubuntu-cpp-versions:
-    name: R / Arrow C++ (${{ matrix.config.cpp_version }})
+    name: Arrow C++ Versions (${{ matrix.config.cpp_version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -80,6 +80,7 @@ jobs:
       run: |
         curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.config.cpp_version }}.tar.gz | \
           tar -zxf -
+        ls -a
         mkdir arrow-build
         export SOURCE_DIR="$(pwd)/apache-arrow-${{ matrix.config.cpp_version }}/cpp"
         export DEST_DIR="$(pwd)/arrow"

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -58,7 +58,10 @@ jobs:
     strategy:
       matrix:
         config:
-        - cpp_version: "15.0.0"
+        - { cpp_version: "15.0.0" }
+        - { cpp_version: "14.0.2" }
+        - { cpp_version: "13.0.0" }
+
     env:
       ARROW_HOME: arrow
 
@@ -110,7 +113,7 @@ jobs:
 
     - name: Show install output
       if: always()
-      run: find check -name '00install.out*' -exec cat '{}' \; || true
+      run: find src/r/check -name '00install.out*' -exec cat '{}' \; || true
       shell: bash
 
 

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -54,6 +54,7 @@ env:
 jobs:
   ubuntu-cpp-versions:
     name: R / Arrow C++ (${{ matrix.config.cpp_version }})
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         config:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -57,7 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cpp_version: ["15.0.0" , "14.0.2",  "13.0.0"]
+        # 14.0.2 apt binaries are missing but contain only minor changes
+        cpp_version: ["15.0.0" , "14.0.1",  "13.0.0"]
 
     env:
       ARROW_HOME: "${{ github.workspace }}/arrow"
@@ -68,27 +69,21 @@ jobs:
       with:
         path: src
 
-    - name: Cache Arrow C++ Build
-      id: cache-arrow-build
-      uses: actions/cache@v4
-      with:
-        path: arrow
-        key: arrow-r-cpp-release-${{ matrix.cpp_version }}-1
-
-    - name: Build Arrow C++ (${{ matrix.cpp_version }})
-      if: steps.cache-arrow-build.outputs.cache-hit != 'true'
+    - name: Install Arrow C++ (${{ matrix.cpp_version }})
       run: |
-        curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-${{ matrix.cpp_version }}.tar.gz | \
-          tar -zxf -
-        mkdir arrow-build
-        export SOURCE_DIR="$(pwd)/arrow-apache-arrow-${{ matrix.cpp_version }}/cpp"
-        export DEST_DIR="$(pwd)/arrow"
-
-        src/r/inst/build_arrow_static.sh
+        sudo apt update
+        sudo apt install -y -V ca-certificates lsb-release wget
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+        sudo apt update
+        # We have to list all packages to avoid version conflicts.
+        sudo apt install -y -V libarrow-dev=${{ matrix.cpp_version }}-1 \
+                               libarrow-acero-dev=${{ matrix.cpp_version }}-1 \
+                               libparquet-dev=${{ matrix.cpp_version }}-1 \
+                               libarrow-dataset-dev=${{ matrix.cpp_version }}-1
 
     - name: Install checkbashisms
       run: |
-        sudo apt-get update
         sudo apt-get install devscripts
 
     - uses: r-lib/actions/setup-r@v2
@@ -106,6 +101,8 @@ jobs:
       with:
         working-directory: src/r
       env:
+        LIBARROW_BINARY: "false"
+        LIBARROW_BUILD: "false"
         ARROW_R_VERBOSE_TEST: "true"
 
     - name: Show install output

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -62,6 +62,7 @@ jobs:
 
     env:
       ARROW_HOME: "${{ github.workspace }}/arrow"
+      ARROW_R_ALLOW_CPP_VERSION_MISMATCH: "true"
 
     steps:
     - name: Checkout Arrow

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -90,10 +90,10 @@ jobs:
         use-public-rspm: true
         install-r: false
     - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
-          working-directory: src/r
+      with:
+        extra-packages: any::rcmdcheck
+        needs: check
+        working-directory: src/r
 
     - uses: r-lib/actions/check-r-package@v2
       with:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -68,6 +68,7 @@ jobs:
       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
       with:
         path: src
+        submodules: recursive
 
     - name: Install Arrow C++ (${{ matrix.cpp_version }})
       run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -52,18 +52,13 @@ env:
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
-  ubuntu-cpp-versions:
-    name: Arrow C++ Versions (${{ matrix.cpp_version }})
+  ubuntu-minimum-cpp-version:
+    name: Check minimum supported Arrow C++ Version (${{ matrix.cpp_version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 14.0.2 apt binaries are missing but contain only minor changes
-        cpp_version: ["15.0.0" , "14.0.1",  "13.0.0"]
-
-    env:
-      ARROW_HOME: "${{ github.workspace }}/arrow"
-      ARROW_R_ALLOW_CPP_VERSION_MISMATCH: "true"
-
+        include:
+          - cpp_version: "13.0.0"
     steps:
     - name: Checkout Arrow
       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
@@ -106,6 +101,7 @@ jobs:
         LIBARROW_BINARY: "false"
         LIBARROW_BUILD: "false"
         ARROW_R_VERBOSE_TEST: "true"
+        ARROW_R_ALLOW_CPP_VERSION_MISMATCH: "true"
 
     - name: Show install output
       if: always()

--- a/r/PACKAGING.md
+++ b/r/PACKAGING.md
@@ -26,6 +26,7 @@ For a high-level overview of the release process see the
 ## Before the release candidate is cut
 
 - [ ] [Create a GitHub issue](https://github.com/apache/arrow/issues/new/) entitled `[R] CRAN packaging checklist for version X.X.X` and copy this checklist to the issue.
+- [ ] Review deprecated functions to advance their deprecation status, including removing preprocessor directives that no longer apply (e.g., oudated R versions, Arrow C++ versions older than the last three major versions).
 - [ ] Evaluate the status of any failing [nightly tests and nightly packaging builds](http://crossbow.voltrondata.com). These checks replicate most of the checks that CRAN runs, so we need them all to be passing or to understand that the failures may (though won't necessarily) result in a rejection from CRAN.
 - [ ] Check [current CRAN check results](https://cran.rstudio.org/web/checks/check_results_arrow.html)
 - [ ] Ensure the contents of the README are accurate and up to date.

--- a/r/PACKAGING.md
+++ b/r/PACKAGING.md
@@ -26,7 +26,7 @@ For a high-level overview of the release process see the
 ## Before the release candidate is cut
 
 - [ ] [Create a GitHub issue](https://github.com/apache/arrow/issues/new/) entitled `[R] CRAN packaging checklist for version X.X.X` and copy this checklist to the issue.
-- [ ] Review deprecated functions to advance their deprecation status, including removing preprocessor directives that no longer apply (e.g., oudated R versions, Arrow C++ versions older than the last three major versions).
+- [ ] Review deprecated functions to advance their deprecation status, including removing preprocessor directives that no longer apply (search for `ARROW_VERSION_MAJOR` in r/src).
 - [ ] Evaluate the status of any failing [nightly tests and nightly packaging builds](http://crossbow.voltrondata.com). These checks replicate most of the checks that CRAN runs, so we need them all to be passing or to understand that the failures may (though won't necessarily) result in a rejection from CRAN.
 - [ ] Check [current CRAN check results](https://cran.rstudio.org/web/checks/check_results_arrow.html)
 - [ ] Ensure the contents of the README are accurate and up to date.

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -1050,6 +1050,7 @@ class RDictionaryConverter<ValueType, enable_if_has_string_view<ValueType>>
 template <typename T, typename Enable = void>
 struct RConverterTrait;
 
+#if ARROW_VERSION_MAJOR >= 15
 template <typename T>
 struct RConverterTrait<
     T, enable_if_t<!is_nested_type<T>::value && !is_interval_type<T>::value &&
@@ -1061,6 +1062,14 @@ template <typename T>
 struct RConverterTrait<T, enable_if_binary_view_like<T>> {
   // not implemented
 };
+#else
+template <typename T>
+struct RConverterTrait<
+    T, enable_if_t<!is_nested_type<T>::value && !is_interval_type<T>::value &&
+                   !is_extension_type<T>::value>> {
+  using type = RPrimitiveConverter<T>;
+};
+#endif
 
 template <typename T>
 struct RConverterTrait<T, enable_if_list_like<T>> {

--- a/r/tools/check-versions.R
+++ b/r/tools/check-versions.R
@@ -25,9 +25,8 @@ release_version_supported <- function(r_version, cpp_version) {
   cpp_version <- package_version(cpp_version)
   major <- function(x) as.numeric(x[1, 1])
 
-  # Currently the last three released versions of Arrow C++
-  # (>= 13.0.0 at the time this check was added)
-  major(cpp_version) %in% (major(r_version) - 0:2)
+  allow_mismatch <- tolower(Sys.getenv("ARROW_R_ALLOW_CPP_VERSION_MISMATCH", "false"))
+  identical(allow_mismatch, "true") || major(r_version) == major(cpp_version)
 }
 
 check_versions <- function(r_version, cpp_version) {

--- a/r/tools/check-versions.R
+++ b/r/tools/check-versions.R
@@ -25,8 +25,9 @@ release_version_supported <- function(r_version, cpp_version) {
   cpp_version <- package_version(cpp_version)
   major <- function(x) as.numeric(x[1, 1])
 
-  # Last four released versions of Arrow C++
-  major(cpp_version) %in% (major(r_version) - 0:3)
+  # Currently the last three released versions of Arrow C++
+  # (>= 13.0.0 at the time this check was added)
+  major(cpp_version) %in% (major(r_version) - 0:2)
 }
 
 check_versions <- function(r_version, cpp_version) {

--- a/r/tools/check-versions.R
+++ b/r/tools/check-versions.R
@@ -24,9 +24,14 @@ release_version_supported <- function(r_version, cpp_version) {
   r_version <- package_version(r_version)
   cpp_version <- package_version(cpp_version)
   major <- function(x) as.numeric(x[1, 1])
+  minimum_cpp_version <- package_version("13.0.0")
 
-  allow_mismatch <- tolower(Sys.getenv("ARROW_R_ALLOW_CPP_VERSION_MISMATCH", "false"))
-  identical(allow_mismatch, "true") || major(r_version) == major(cpp_version)
+  allow_mismatch <- identical(tolower(Sys.getenv("ARROW_R_ALLOW_CPP_VERSION_MISMATCH", "false")), "true")
+  # If we allow a version mismatch we still need to cover the minimum version (13.0.0 for now)
+  # we don't allow newer C++ versions as new features without additional feature gates are likely to
+  # break the R package
+  version_valid <- cpp_version >= minimum_cpp_version && major(cpp_version) <= major(r_version)
+  allow_mismatch && version_valid || major(r_version) == major(cpp_version)
 }
 
 check_versions <- function(r_version, cpp_version) {

--- a/r/tools/test-check-versions.R
+++ b/r/tools/test-check-versions.R
@@ -27,7 +27,7 @@ source("check-versions.R", local = TRUE)
 test_that("check_versions", {
   expect_output(
     check_versions("10.0.0", "10.0.0"),
-    "**** C++ and R library versions match: 10.0.0",
+    "**** C++ library version 10.0.0 is supported by R version 10.0.0",
     fixed = TRUE
   )
   expect_output(
@@ -35,7 +35,7 @@ test_that("check_versions", {
       check_versions("10.0.0", "10.0.0-SNAPSHOT"),
       "version mismatch"
     ),
-    "**** Not using: C++ library version (10.0.0-SNAPSHOT) does not match R package (10.0.0)",
+    "**** Not using: C++ library version (10.0.0-SNAPSHOT): not supported by R package version 10.0.0",
     fixed = TRUE
   )
   expect_output(
@@ -43,20 +43,12 @@ test_that("check_versions", {
       check_versions("10.0.0.9000", "10.0.0-SNAPSHOT"),
       "version mismatch"
     ),
-    "**** Not using: C++ library version (10.0.0-SNAPSHOT) does not match R package (10.0.0.9000)",
-    fixed = TRUE
-  )
-  expect_output(
-    expect_error(
-      check_versions("10.0.0.9000", "10.0.0"),
-      "version mismatch"
-    ),
-    "**** Not using: C++ library version (10.0.0) does not match R package (10.0.0.9000)",
+    "**** Not using: C++ library version (10.0.0-SNAPSHOT): not supported by R package version 10.0.0.9000",
     fixed = TRUE
   )
   expect_output(
     check_versions("10.0.0.3", "10.0.0"),
-    "*** > Using C++ library version 10.0.0 with R package 10.0.0.3",
+    "**** C++ library version 10.0.0 is supported by R version 10.0.0.3",
     fixed = TRUE
   )
   expect_output(

--- a/r/tools/test-check-versions.R
+++ b/r/tools/test-check-versions.R
@@ -24,7 +24,7 @@ TESTING <- TRUE
 
 source("check-versions.R", local = TRUE)
 
-test_that("check_versions", {
+test_that("check_versions without mismatch", {
   expect_output(
     check_versions("10.0.0", "10.0.0"),
     "**** C++ library version 10.0.0 is supported by R version 10.0.0",
@@ -55,5 +55,27 @@ test_that("check_versions", {
     check_versions("10.0.0.9000", "11.0.0-SNAPSHOT"),
     "*** > Packages are both on development versions (11.0.0-SNAPSHOT, 10.0.0.9000)\n",
     fixed = TRUE
+  )
+})
+
+test_that("check_versions with mismatch", {
+  withr::local_envvar(.new = c(ARROW_R_ALLOW_CPP_VERSION_MISMATCH = "false"))
+
+  expect_false(
+    release_version_supported("15.0.0", "13.0.0")
+  )
+
+  withr::local_envvar(.new = c(ARROW_R_ALLOW_CPP_VERSION_MISMATCH = "true"))
+
+  expect_true(
+    release_version_supported("15.0.0", "13.0.0")
+  )
+
+  expect_false(
+    release_version_supported("15.0.0", "16.0.0")
+  )
+
+  expect_false(
+    release_version_supported("15.0.0", "12.0.0")
   )
 })


### PR DESCRIPTION
### Rationale for this change

Development velocity of the R package has slowed considerably since early versions of Arrow such that the commit-level integration that we once relied on is no longer necessary. The ability to build against older versions of Arrow also opens up more options for our CRAN submissions, since we may be able to work with CRAN to build a version of Arrow C++ they are happy with.

This change doesn't require us to *do* anything about it...it just adds a check so that we are aware of the first PR that breaks the ability to build against a previous version.

There is a possibility that an accidentally but previously installed version will end up being used via pkg-config, which I believe is how the version checking came into existence in the first place.

### What changes are included in this PR?

- An `#if` to guard code that was added to support the string view/binary view
- Changes to the version checker script to not error for supported Arrow C++ versions
- CI job that checks build against supported Arrow versions

### Are these changes tested?

Yes, a CI job was added

### Are there any user-facing changes?

Yes, but I'll wait until there's consensus on this before documenting what our intended support policy will be.

* Closes: #39738