### PR TITLE
GH-39761: [Docs] Link to Go documentation references outdated documentation from 2018

### DIFF
--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -200,8 +200,10 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         {
           path: "docs/source/index.rst",
           hunks: [
-            "-   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}>",
-            "+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}>",
+            [
+              "-   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}>",
+              "+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}>",
+            ],
           ],
         },
         {
@@ -222,8 +224,10 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         {
           path: "r/_pkgdown.yml",
           hunks: [
-            "-          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}) <br>",
-            "+          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}) <br>",
+            [
+              "-          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}) <br>",
+              "+          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}) <br>",
+            ],
           ],
         },
       ]

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -198,6 +198,13 @@ class PostBumpVersionsTest < Test::Unit::TestCase
     if release_type == :major
       expected_changes += [
         {
+          path: "docs/source/index.rst",
+          hunks: [
+            "-   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}>",
+            "+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}>",
+          ],
+        },
+        {
           path: "r/pkgdown/assets/versions.json",
           hunks: [
             [
@@ -210,6 +217,13 @@ class PostBumpVersionsTest < Test::Unit::TestCase
               "+        \"version\": \"#{@previous_compatible_version}/\"",
               "+    },",
             ],
+          ],
+        },
+        {
+          path: "r/_pkgdown.yml",
+          hunks: [
+            "-          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}) <br>",
+            "+          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}) <br>",
           ],
         },
       ]

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -164,6 +164,15 @@ update_versions() {
   git add .
   popd
 
+  pushd "${ARROW_DIR}/docs/source"
+  # godoc link must include current version, and will reference v0.0.0 (2018) otherwise; see GH-39761
+  find . -name "index.rst" -exec sed -i.bak -E -e \
+    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" {} \;
+
+  rm -f index.rst.bak
+  git add .
+  popd
+
   pushd "${ARROW_DIR}"
   ${PYTHON:-python3} "dev/release/utils-update-docs-versions.py" \
                      . \

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -141,9 +141,10 @@ update_versions() {
   rm -f NEWS.md.bak
   git add NEWS.md
 
-  find . -name "_pkgdown.yml" -exec sed -i.bak -E -e \
-    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" {} \;
-
+  # godoc link must reference current version, will reference v0.0.0 (2018) otherwise
+  sed -i.bak -E -e \
+    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" \
+    _pkgdown.yml
   rm -f _pkgdown.yml.bak
   git add _pkgdown.yml
   popd
@@ -173,9 +174,9 @@ update_versions() {
 
   pushd "${ARROW_DIR}/docs/source"
   # godoc link must reference current version, will reference v0.0.0 (2018) otherwise
-  find . -name "index.rst" -exec sed -i.bak -E -e \
-    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" {} \;
-
+  sed -i.bak -E -e \
+    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" \
+    index.rst
   rm -f index.rst.bak
   git add index.rst
   popd

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -127,6 +127,7 @@ update_versions() {
     DESCRIPTION
   rm -f DESCRIPTION.bak
   git add DESCRIPTION
+  
   # Replace dev version with release version
   sed -i.bak -E -e \
     "/^<!--/,/^# arrow /s/^# arrow .+/# arrow ${base_version}/" \
@@ -139,6 +140,12 @@ update_versions() {
   fi
   rm -f NEWS.md.bak
   git add NEWS.md
+
+  find . -name "_pkgdown.yml" -exec sed -i.bak -E -e \
+    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" {} \;
+
+  rm -f _pkgdown.yml.bak
+  git add _pkgdown.yml
   popd
 
   pushd "${ARROW_DIR}/ruby"
@@ -165,12 +172,12 @@ update_versions() {
   popd
 
   pushd "${ARROW_DIR}/docs/source"
-  # godoc link must include current version, and will reference v0.0.0 (2018) otherwise; see GH-39761
+  # godoc link must reference current version, will reference v0.0.0 (2018) otherwise
   find . -name "index.rst" -exec sed -i.bak -E -e \
     "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" {} \;
 
   rm -f index.rst.bak
-  git add .
+  git add index.rst
   popd
 
   pushd "${ARROW_DIR}"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,7 @@ Implementations
    C/GLib <c_glib/index>
    C++ <cpp/index>
    C# <https://github.com/apache/arrow/blob/main/csharp/README.md>
-   Go <https://pkg.go.dev/github.com/apache/arrow/go>
+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v15>
    Java <java/index>
    JavaScript <js/index>
    Julia <https://arrow.apache.org/julia/>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,7 @@ Implementations
    C/GLib <c_glib/index>
    C++ <cpp/index>
    C# <https://github.com/apache/arrow/blob/main/csharp/README.md>
-   Go <https://pkg.go.dev/github.com/apache/arrow/go/v15>
+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v16>
    Java <java/index>
    JavaScript <js/index>
    Julia <https://arrow.apache.org/julia/>

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -76,7 +76,7 @@ home:
           [C GLib](https://arrow.apache.org/docs/c_glib) <br>
           [C++](https://arrow.apache.org/docs/cpp) <br>
           [C#](https://github.com/apache/arrow/blob/main/csharp/README.md) <br>
-          [Go](https://pkg.go.dev/github.com/apache/arrow/go) <br>
+          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v15) <br>
           [Java](https://arrow.apache.org/docs/java) <br>
           [JavaScript](https://arrow.apache.org/docs/js) <br>
           [Julia](https://github.com/apache/arrow-julia/blob/main/README.md) <br>

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -76,7 +76,7 @@ home:
           [C GLib](https://arrow.apache.org/docs/c_glib) <br>
           [C++](https://arrow.apache.org/docs/cpp) <br>
           [C#](https://github.com/apache/arrow/blob/main/csharp/README.md) <br>
-          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v15) <br>
+          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v16) <br>
           [Java](https://arrow.apache.org/docs/java) <br>
           [JavaScript](https://arrow.apache.org/docs/js) <br>
           [Julia](https://github.com/apache/arrow-julia/blob/main/README.md) <br>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)
-->

### Rationale for this change

The godoc format shows docs in a versioned fashion, making the ["basic" link](https://pkg.go.dev/github.com/apache/arrow/go) reference v0.0.0 from 2018, and godoc doesn't warn you when docs are outdated. Accordingly, for people to find "real" documentation, they have to manually search for the latest docs.

Otherwise, it gives the impression that the package is abandoned / makes devs waste considerable time — e.g., I work with Go professionally and wasted 15 minutes on the 2018 docs until I realized they were wrong.

### What changes are included in this PR?

* Reference the latest version (v16) in the list of supported implementations of the Arrow website & R package.
* Add step to release process that automatically updates the version on release

### Are these changes tested?

Yes, I've added tests for this to `dev/release/post-11-bump-versions-test.rb`.

### Are there any user-facing changes?

Yes, the link to Implementations > Go on the website will change.
* Closes: #39761