### PR TITLE
GH-39732: [Python][CI] Fix test failures with latest/nightly pandas

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5209,6 +5209,10 @@ def table(data, names=None, schema=None, metadata=None, nthreads=None):
                 "passing a pandas DataFrame")
         return Table.from_pandas(data, schema=schema, nthreads=nthreads)
     elif hasattr(data, "__arrow_c_stream__"):
+        if names is not None or metadata is not None:
+            raise ValueError(
+                "The 'names' and 'metadata' arguments are not valid when "
+                "using Arrow PyCapsule Interface")
         if schema is not None:
             requested = schema.__arrow_c_schema__()
         else:
@@ -5222,6 +5226,10 @@ def table(data, names=None, schema=None, metadata=None, nthreads=None):
             table = table.cast(schema)
         return table
     elif hasattr(data, "__arrow_c_array__"):
+        if names is not None or metadata is not None:
+            raise ValueError(
+                "The 'names' and 'metadata' arguments are not valid when "
+                "using Arrow PyCapsule Interface")
         batch = record_batch(data, schema)
         return Table.from_batches([batch])
     else:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5202,6 +5202,12 @@ def table(data, names=None, schema=None, metadata=None, nthreads=None):
             raise ValueError(
                 "The 'names' argument is not valid when passing a dictionary")
         return Table.from_pydict(data, schema=schema, metadata=metadata)
+    elif _pandas_api.is_data_frame(data):
+        if names is not None or metadata is not None:
+            raise ValueError(
+                "The 'names' and 'metadata' arguments are not valid when "
+                "passing a pandas DataFrame")
+        return Table.from_pandas(data, schema=schema, nthreads=nthreads)
     elif hasattr(data, "__arrow_c_stream__"):
         if schema is not None:
             requested = schema.__arrow_c_schema__()
@@ -5218,12 +5224,6 @@ def table(data, names=None, schema=None, metadata=None, nthreads=None):
     elif hasattr(data, "__arrow_c_array__"):
         batch = record_batch(data, schema)
         return Table.from_batches([batch])
-    elif _pandas_api.is_data_frame(data):
-        if names is not None or metadata is not None:
-            raise ValueError(
-                "The 'names' and 'metadata' arguments are not valid when "
-                "passing a pandas DataFrame")
-        return Table.from_pandas(data, schema=schema, nthreads=nthreads)
     else:
         raise TypeError(
             "Expected pandas DataFrame, python dictionary or list of arrays")


### PR DESCRIPTION
This PR rearranges if-else blocks in the `table` function (`table.pxi`) so that pandas dataframe object comes before checking for `__arrow_c_stream__` and `__arrow_c_array__`.
* Closes: #39732