### PR TITLE
GH-39737: [Release][Docs] Update post release documentation task

### DIFF
--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -86,10 +86,10 @@ if [ "$is_major_release" = "yes" ] ; then
 fi
 # Update DOCUMENTATION_OPTIONS.theme_switcher_version_match and
 # DOCUMENTATION_OPTIONS.show_version_warning_banner
-cd docs/${previous_version}
+pushd docs/${previous_version}
 find ./ -type f -exec sed -i "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_version}';/g" {} \;
 find ./ -type f -exec sed -i "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" {} \;
-cd ../..
+popd
 git add docs
 git commit -m "[Website] Update documentations for ${version}"
 git clean -d -f -x

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -87,8 +87,13 @@ fi
 # Update DOCUMENTATION_OPTIONS.theme_switcher_version_match and
 # DOCUMENTATION_OPTIONS.show_version_warning_banner
 pushd docs/${previous_version}
-find ./ -type f -exec sed -i "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_version}';/g" {} \;
-find ./ -type f -exec sed -i "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" {} \;
+find ./ \
+  -type f \
+  -exec \
+    sed -i \
+      -e "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_version}';/g" \
+      -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" \
+      {} \;
 popd
 git add docs
 git commit -m "[Website] Update documentations for ${version}"

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -90,10 +90,11 @@ pushd docs/${previous_version}
 find ./ \
   -type f \
   -exec \
-    sed -i \
+    sed -i.bak \
       -e "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_version}';/g" \
       -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" \
       {} \;
+find ./ -name '*.bak' -delete
 popd
 git add docs
 git commit -m "[Website] Update documentations for ${version}"

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -84,6 +84,12 @@ if [ "$is_major_release" = "yes" ] ; then
   previous_series=${previous_version%.*}
   mv docs_temp docs/${previous_series}
 fi
+# Update DOCUMENTATION_OPTIONS.theme_switcher_version_match and
+# DOCUMENTATION_OPTIONS.show_version_warning_banner
+cd docs/${previous_version}
+find ./ -type f -exec sed -i "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_version}';/g" {} \;
+find ./ -type f -exec sed -i "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" {} \;
+cd ../..
 git add docs
 git commit -m "[Website] Update documentations for ${version}"
 git clean -d -f -x

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -84,9 +84,12 @@ if [ "$is_major_release" = "yes" ] ; then
   previous_series=${previous_version%.*}
   mv docs_temp docs/${previous_series}
 fi
+git add docs
+git commit -m "[Website] Update documentations for ${version}"
+
 # Update DOCUMENTATION_OPTIONS.theme_switcher_version_match and
 # DOCUMENTATION_OPTIONS.show_version_warning_banner
-pushd docs/${previous_version}
+pushd docs/${previous_series}
 find ./ \
   -type f \
   -exec \
@@ -96,8 +99,8 @@ find ./ \
       {} \;
 find ./ -name '*.bak' -delete
 popd
-git add docs
-git commit -m "[Website] Update documentations for ${version}"
+git add docs/${previous_series}
+git commit -m "[Website] Update warning banner for ${previous_series}"
 git clean -d -f -x
 popd
 


### PR DESCRIPTION
This PR updates the `dev/release/post-08-docs.sh` task so that

- `DOCUMENTATION_OPTIONS.theme_switcher_version_match` changes from `""` to `"{previous_version}"` 
- `DOCUMENTATION_OPTIONS.show_version_warning_banner` changes from `false` to `true`

for the documentation that is moved to a subfolder when a new major release is done.
* Closes: #39737