### PR TITLE
GH-39666: [C++] Ensure CSV and JSON benchmarks present a bytes/s or items/s metric

### DIFF
--- a/cpp/src/arrow/csv/writer_benchmark.cc
+++ b/cpp/src/arrow/csv/writer_benchmark.cc
@@ -97,7 +97,7 @@ void BenchmarkWriteCsv(benchmark::State& state, const WriteOptions& options,
                        const RecordBatch& batch) {
   int64_t total_size = 0;
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto out = io::BufferOutputStream::Create().ValueOrDie();
     ABORT_NOT_OK(WriteCSV(batch, options, out.get()));
     auto buffer = out->Finish().ValueOrDie();
@@ -106,6 +106,7 @@ void BenchmarkWriteCsv(benchmark::State& state, const WriteOptions& options,
 
   // byte size of the generated csv dataset
   state.SetBytesProcessed(total_size);
+  state.SetItemsProcessed(state.iterations() * batch.num_columns() * batch.num_rows());
   state.counters["null_percent"] = static_cast<double>(state.range(0));
 }
 


### PR DESCRIPTION
### Rationale for this change

Some of our microbenchmarks only present an iteration time in (nano,micro...)seconds. That is usually tedious to read and difficult to interpret.

### What changes are included in this PR?

Ensure that benchmarks present a items/seconds and/or a bytes/seconds metric where that makes sense.

### Are these changes tested?

Manually.

### Are there any user-facing changes?

No.
* Closes: #39666