### PR TITLE
GH-39780: [Python][Parquet] Support hashing for FileMetaData and ParquetSchema

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -849,6 +849,18 @@ cdef class FileMetaData(_Weakrefable):
         cdef Buffer buffer = sink.getvalue()
         return _reconstruct_filemetadata, (buffer,)
 
+    def __hash__(self):
+        def flatten(obj):
+            if isinstance(obj, dict):
+                return tuple(
+                    (k, flatten(v))
+                    for k, v in sorted(obj.items(), key=lambda v: v[0])
+                )
+            elif isinstance(obj, list):
+                return tuple(flatten(o) for o in obj)
+            return obj
+        return hash(flatten(self.to_dict()))
+
     def __repr__(self):
         return """{0}
   created_by: {1}

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -850,16 +850,11 @@ cdef class FileMetaData(_Weakrefable):
         return _reconstruct_filemetadata, (buffer,)
 
     def __hash__(self):
-        def flatten(obj):
-            if isinstance(obj, dict):
-                return tuple(
-                    (k, flatten(v))
-                    for k, v in sorted(obj.items(), key=lambda v: v[0])
-                )
-            elif isinstance(obj, list):
-                return tuple(flatten(o) for o in obj)
-            return obj
-        return hash((self.schema, flatten(self.to_dict())))
+        return hash((self.schema,
+                     self.num_rows,
+                     self.num_row_groups,
+                     self.format_version,
+                     self.serialized_size))
 
     def __repr__(self):
         return """{0}
@@ -1084,9 +1079,7 @@ cdef class ParquetSchema(_Weakrefable):
         return self.column(i)
 
     def __hash__(self):
-        return hash(
-            (object.__hash__(self), frombytes(self.schema.ToString(), safe=True))
-        )
+        return hash(self.schema.ToString())
 
     @property
     def names(self):

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -859,7 +859,7 @@ cdef class FileMetaData(_Weakrefable):
             elif isinstance(obj, list):
                 return tuple(flatten(o) for o in obj)
             return obj
-        return hash(flatten(self.to_dict()))
+        return hash((self.schema, flatten(self.to_dict())))
 
     def __repr__(self):
         return """{0}
@@ -1082,6 +1082,11 @@ cdef class ParquetSchema(_Weakrefable):
 
     def __getitem__(self, i):
         return self.column(i)
+
+    def __hash__(self):
+        return hash(
+            (object.__hash__(self), frombytes(self.schema.ToString(), safe=True))
+        )
 
     @property
     def names(self):

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -506,7 +506,7 @@ def test_metadata_hashing(tempdir):
     parquet_meta1 = pq.read_metadata(path1)
 
     path2 = str(tempdir / "metadata2")
-    schema2 = pa.schema([("a", "int64")])
+    schema2 = pa.schema([("a", "int64"), ("b", "float32")])
     pq.write_metadata(schema2, path2)
     parquet_meta2 = pq.read_metadata(path2)
 

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -499,6 +499,24 @@ def test_multi_dataset_metadata(tempdir):
     assert md['serialized_size'] > 0
 
 
+def test_metadata_hashing(tempdir):
+    path1 = str(tempdir / "metadata1")
+    schema1 = pa.schema([("a", "int64"), ("b", "float64")])
+    pq.write_metadata(schema1, path1)
+    parquet_meta1 = pq.read_metadata(path1)
+
+    path2 = str(tempdir / "metadata2")
+    schema2 = pa.schema([("a", "int64")])
+    pq.write_metadata(schema2, path2)
+    parquet_meta2 = pq.read_metadata(path2)
+
+    # Deterministic
+    assert hash(parquet_meta1) == hash(parquet_meta1)
+
+    # Not the same as other metadata
+    assert hash(parquet_meta1) != hash(parquet_meta2)
+
+
 @pytest.mark.filterwarnings("ignore:Parquet format:FutureWarning")
 def test_write_metadata(tempdir):
     path = str(tempdir / "metadata")

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -505,16 +505,24 @@ def test_metadata_hashing(tempdir):
     pq.write_metadata(schema1, path1)
     parquet_meta1 = pq.read_metadata(path1)
 
+    # Same as 1, just different path
     path2 = str(tempdir / "metadata2")
-    schema2 = pa.schema([("a", "int64"), ("b", "float32")])
+    schema2 = pa.schema([("a", "int64"), ("b", "float64")])
     pq.write_metadata(schema2, path2)
     parquet_meta2 = pq.read_metadata(path2)
 
-    # Deterministic
-    assert hash(parquet_meta1) == hash(parquet_meta1)
+    # different schema
+    path3 = str(tempdir / "metadata3")
+    schema3 = pa.schema([("a", "int64"), ("b", "float32")])
+    pq.write_metadata(schema3, path3)
+    parquet_meta3 = pq.read_metadata(path3)
 
-    # Not the same as other metadata
-    assert hash(parquet_meta1) != hash(parquet_meta2)
+    # Deterministic
+    assert hash(parquet_meta1) == hash(parquet_meta1)  # equal w/ same instance
+    assert hash(parquet_meta1) == hash(parquet_meta2)  # equal w/ different instance
+
+    # Not the same as other metadata with different schema
+    assert hash(parquet_meta1) != hash(parquet_meta3)
 
 
 @pytest.mark.filterwarnings("ignore:Parquet format:FutureWarning")


### PR DESCRIPTION
I think the hash, especially for `FileMetaData` could be better, maybe just use return of `__repr__`, even though that won't include row group info?

### Rationale for this change

Helpful for dependent projects. 

### What changes are included in this PR?

Impl `__hash__` for `ParquetSchema` and `FileMetaData`

### Are these changes tested?

Yes

### Are there any user-facing changes?

Supports hashing metadata:

```python
In [1]: import pyarrow.parquet as pq

In [2]: f = pq.ParquetFile('test.parquet')

In [3]: hash(f.metadata)
Out[3]: 4816453453708427907

In [4]: hash(f.metadata.schema)
Out[4]: 2300988959078172540
```
* Closes: #39780