### PR TITLE
GH-39765: [C++][Dataset] Fix failures in dataset-scanner-benchmark

### DIFF
--- a/cpp/src/arrow/dataset/scanner_benchmark.cc
+++ b/cpp/src/arrow/dataset/scanner_benchmark.cc
@@ -162,7 +162,11 @@ void ScanOnly(
                        acero::DeclarationToTable(std::move(scan)));
 
   ASSERT_GT(collected->num_rows(), 0);
-  ASSERT_EQ(collected->num_columns(), 2);
+  if (factory_name == "scan") {
+	ASSERT_EQ(collected->num_columns(), 6);
+  } else if (factory_name == "scan2") {
+	ASSERT_EQ(collected->num_columns(), 2);
+  }
 }
 
 static constexpr int kScanIdx = 0;

--- a/cpp/src/arrow/dataset/scanner_benchmark.cc
+++ b/cpp/src/arrow/dataset/scanner_benchmark.cc
@@ -163,9 +163,9 @@ void ScanOnly(
 
   ASSERT_GT(collected->num_rows(), 0);
   if (factory_name == "scan") {
-	ASSERT_EQ(collected->num_columns(), 6);
+    ASSERT_EQ(collected->num_columns(), 6);
   } else if (factory_name == "scan2") {
-	ASSERT_EQ(collected->num_columns(), 2);
+    ASSERT_EQ(collected->num_columns(), 2);
   }
 }
 


### PR DESCRIPTION
### Rationale for this change

`ScanOnlyBench` use 2 kind of options to scan, but ignore the function `MakeScanNode` will return 4 extra columns.

### What changes are included in this PR?

Change the expected result of bench `ScanOnlyBench`

### Are these changes tested?

They covered by existing tests.
* Closes: #39765