### PR TITLE
GH-39815: [C++] Document and micro-optimize ChunkResolver::Resolve()

### DIFF
--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -18,25 +18,46 @@
 #pragma once
 
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <vector>
 
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
 struct ChunkLocation {
-  int64_t chunk_index, index_in_chunk;
+  /// \brief Index of the chunk in the array of chunks
+  ///
+  /// The value is always in the range `[0, chunks.size()]`. `chunks.size()` is used
+  /// to represent out-of-bounds locations.
+  int64_t chunk_index;
+
+  /// \brief Index of the value in the chunk
+  ///
+  /// The value is undefined if chunk_index >= chunks.size()
+  int64_t index_in_chunk;
 };
 
-// An object that resolves an array chunk depending on a logical index
+/// \brief An utility that incrementally resolves logical indices into
+/// physical indices in a chunked array.
 struct ARROW_EXPORT ChunkResolver {
+ private:
+  /// \brief Array containing `chunks.size() + 1` offsets.
+  ///
+  /// `offsets_[i]` is the starting logical index of chunk `i`. `offsets_[0]` is always 0
+  /// and `offsets_[chunks.size()]` is the logical length of the chunked array.
+  std::vector<int64_t> offsets_;
+
+  /// \brief Cache of the index of the last resolved chunk.
+  ///
+  /// \invariant `cached_chunk_ in [0, chunks.size()]`
+  mutable std::atomic<int64_t> cached_chunk_;
+
+ public:
   explicit ChunkResolver(const ArrayVector& chunks);
-
   explicit ChunkResolver(const std::vector<const Array*>& chunks);
-
   explicit ChunkResolver(const RecordBatchVector& batches);
 
   ChunkResolver(ChunkResolver&& other) noexcept
@@ -48,31 +69,49 @@ struct ARROW_EXPORT ChunkResolver {
     return *this;
   }
 
-  /// \brief Return a ChunkLocation containing the chunk index and in-chunk value index of
-  /// the chunked array at logical index
+  /// \brief Resolve a logical index to a ChunkLocation.
+  ///
+  /// The returned ChunkLocation contains the chunk index and the within-chunk index
+  /// equivalent to the logical index.
+  ///
+  /// \pre index >= 0
+  /// \post location.chunk_index in [0, chunks.size()]
+  /// \param index The logical index to resolve
+  /// \return ChunkLocation with a valid chunk_index if index is within
+  ///         bounds, or with chunk_index == chunks.size() if logical index is
+  ///         `>= chunked_array.length()`.
   inline ChunkLocation Resolve(const int64_t index) const {
-    // It is common for the algorithms below to make consecutive accesses at
-    // a relatively small distance from each other, hence often falling in
-    // the same chunk.
-    // This is trivial when merging (assuming each side of the merge uses
-    // its own resolver), but also in the inner recursive invocations of
+    // It is common for algorithms sequentially processing arrays to make consecutive
+    // accesses at a relatively small distance from each other, hence often falling in the
+    // same chunk.
+    //
+    // This is guaranteed when merging (assuming each side of the merge uses its
+    // own resolver), and is the most common case in recursive invocations of
     // partitioning.
     if (offsets_.size() <= 1) {
       return {0, index};
     }
     const auto cached_chunk = cached_chunk_.load();
+    // XXX: the access below is unsafe because cached_chunk+1 can be out-of-bounds
     const bool cache_hit =
         (index >= offsets_[cached_chunk] && index < offsets_[cached_chunk + 1]);
     if (ARROW_PREDICT_TRUE(cache_hit)) {
       return {cached_chunk, index - offsets_[cached_chunk]};
     }
     auto chunk_index = Bisect(index);
+    assert(chunk_index < static_cast<int64_t>(offsets_.size()));
     cached_chunk_.store(chunk_index);
     return {chunk_index, index - offsets_[chunk_index]};
   }
 
  protected:
-  // Find the chunk index corresponding to a value index using binary search
+  /// \brief Find the index of the chunk that contains the logical index.
+  ///
+  /// Any non-negative index is accepted.
+  ///
+  /// \pre index >= 0
+  /// \return Chunk index in `[0, chunks.size())` or `chunks.size()` if the logical index
+  /// is out-of-bounds.
   inline int64_t Bisect(const int64_t index) const {
     // Like std::upper_bound(), but hand-written as it can help the compiler.
     // Search [lo, lo + n)
@@ -90,15 +129,6 @@ struct ARROW_EXPORT ChunkResolver {
     }
     return lo;
   }
-
- private:
-  // Collection of starting offsets used for binary search
-  std::vector<int64_t> offsets_;
-
-  // Tracks the most recently used chunk index to allow fast
-  // access for consecutive indices corresponding to the same chunk
-  mutable std::atomic<int64_t> cached_chunk_;
 };
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -95,10 +95,8 @@ struct ARROW_EXPORT ChunkResolver {
       return {0, index};
     }
     const int64_t* offsets = offsets_.data();
-    // XXX: the access below is unsafe because cached_chunk+1 can be out-of-bounds
-    const bool cache_hit =
-        (index >= offsets[cached_chunk] && index < offsets[cached_chunk + 1]);
-    if (ARROW_PREDICT_TRUE(cache_hit)) {
+    if (ARROW_PREDICT_TRUE(index >= offsets[cached_chunk]) &&
+        (cached_chunk + 1 == num_offsets || index < offsets[cached_chunk + 1])) {
       return {cached_chunk, index - offsets[cached_chunk]};
     }
     const auto chunk_index = Bisect(index, offsets, /*lo=*/0, /*hi=*/num_offsets);

--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -89,12 +89,12 @@ struct ARROW_EXPORT ChunkResolver {
     // This is guaranteed when merging (assuming each side of the merge uses its
     // own resolver), and is the most common case in recursive invocations of
     // partitioning.
+    const auto cached_chunk = cached_chunk_.load(std::memory_order_relaxed);
     const auto num_offsets = static_cast<int64_t>(offsets_.size());
     if (num_offsets <= 1) {
       return {0, index};
     }
     const int64_t* offsets = offsets_.data();
-    const auto cached_chunk = cached_chunk_.load(std::memory_order_relaxed);
     // XXX: the access below is unsafe because cached_chunk+1 can be out-of-bounds
     const bool cache_hit =
         (index >= offsets[cached_chunk] && index < offsets[cached_chunk + 1]);

--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -91,9 +91,6 @@ struct ARROW_EXPORT ChunkResolver {
     // partitioning.
     const auto cached_chunk = cached_chunk_.load(std::memory_order_relaxed);
     const auto num_offsets = static_cast<int64_t>(offsets_.size());
-    if (num_offsets <= 1) {
-      return {0, index};
-    }
     const int64_t* offsets = offsets_.data();
     if (ARROW_PREDICT_TRUE(index >= offsets[cached_chunk]) &&
         (cached_chunk + 1 == num_offsets || index < offsets[cached_chunk + 1])) {


### PR DESCRIPTION
### Rationale for this change

There has been interest in improving operations on chunked-arrays and even though `ChunkResolver::Resolve()` is not a big contributor in most kernels, the fact that it can be used from tight loops warrants careful attention to branch prediction and memory effects of its implementation.

### What changes are included in this PR?

 - Documentation of invariants and behavior of functions
 - Multiple optimizations justified by microbenchmarks
 - Addition of a variation of `Resolve` that takes a hint as parameter
 - Fix of an out-of-bounds memory access that doesn't affect correctness (it can only reduce effectiveness of cache in very rare situations, but is nevertheless an issue)

### Are these changes tested?

Yes, by existing tests.

### Are there any user-facing changes?

 - The `arrow::internal::ChunkResolver::Bisect()` function was `protected` and is now `private` with a different signature
* Closes: #39815