### PR TITLE
MINOR: [Python][CI] Add upper bound on pytest version

### DIFF
--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -23,7 +23,7 @@ cloudpickle
 fsspec
 hypothesis
 numpy>=1.16.6
-pytest
+pytest<8  # pytest-lazy-fixture broken on pytest 8.0.0
 pytest-faulthandler
 pytest-lazy-fixture
 s3fs>=2023.10.0

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -1,6 +1,6 @@
 cffi
 hypothesis
 pandas
-pytest
+pytest<8
 pytest-lazy-fixture
 pytz

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -1,7 +1,7 @@
 cffi
 cython
 hypothesis
-pytest
+pytest<8
 pytest-lazy-fixture
 pytz
 tzdata; sys_platform == 'win32'


### PR DESCRIPTION
### Rationale for this change

The PyArrow test suite relies on the pytest-lazy-fixture plugin, which breaks on pytest 8.0.0: https://github.com/TvoroG/pytest-lazy-fixture/issues/65

### What changes are included in this PR?

Avoid installing pytest 8 on CI builds, by putting an upper bound on the pytest version.

### Are these changes tested?

Yes, by construction.

### Are there any user-facing changes?

No.