### PR TITLE
GH-17211: [C++] Add hash_64 scalar compute function

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -774,6 +774,7 @@ if(ARROW_COMPUTE)
        compute/kernels/scalar_arithmetic.cc
        compute/kernels/scalar_boolean.cc
        compute/kernels/scalar_compare.cc
+       compute/kernels/scalar_hash.cc
        compute/kernels/scalar_if_else.cc
        compute/kernels/scalar_nested.cc
        compute/kernels/scalar_random.cc

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -928,6 +928,12 @@ Result<Datum> MapLookup(const Datum& arg, MapLookupOptions options, ExecContext*
 }
 
 // ----------------------------------------------------------------------
+// Hash functions
+Result<Datum> Hash64(const Datum& input_array, ExecContext* ctx) {
+  return CallFunction("hash_64", {input_array}, ctx);
+}
+
+// ----------------------------------------------------------------------
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -1718,5 +1718,21 @@ ARROW_EXPORT Result<Datum> NanosecondsBetween(const Datum& left, const Datum& ri
 /// \note API not yet finalized
 ARROW_EXPORT Result<Datum> MapLookup(const Datum& map, MapLookupOptions options,
                                      ExecContext* ctx = NULLPTR);
+
+/// \brief Construct a hash value for each row of the input.
+///
+/// The result is an Array of length equal to the length of the input; however, the output
+/// shall be a UInt64Array, with each element being a hash constructed from each row of
+/// the input. If the input Array is a NestedArray, this means that each "attribute" or
+/// "field" of the input NestedArray corresponding to the same "row" will collectively
+/// produce a single uint64_t hash. At the moment, this function does not take options,
+/// though these may be added in the future.
+///
+/// \param[in] input_array input data to hash
+/// \param[in] ctx         function execution context, optional
+/// \return elementwise hash values
+ARROW_EXPORT
+Result<Datum> Hash64(const Datum& input_array, ExecContext* ctx = NULLPTR);
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -73,6 +73,7 @@ add_arrow_compute_test(scalar_utility_test
                        scalar_random_test.cc
                        scalar_set_lookup_test.cc
                        scalar_validity_test.cc
+                       scalar_hash_test.cc
                        EXTRA_LINK_LIBS
                        arrow_compute_kernels_testing)
 
@@ -87,6 +88,7 @@ add_arrow_benchmark(scalar_round_benchmark PREFIX "arrow-compute")
 add_arrow_benchmark(scalar_set_lookup_benchmark PREFIX "arrow-compute")
 add_arrow_benchmark(scalar_string_benchmark PREFIX "arrow-compute")
 add_arrow_benchmark(scalar_temporal_benchmark PREFIX "arrow-compute")
+add_arrow_benchmark(scalar_hash_benchmark PREFIX "arrow-compute")
 
 # ----------------------------------------------------------------------
 # Vector kernels

--- a/cpp/src/arrow/compute/kernels/scalar_hash.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_hash.cc
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * @file  scalar_hash.cc
+ * @brief Element-wise (scalar) kernels for hashing values.
+ */
+
+#include <algorithm>
+//#include <iostream>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/compute/key_hash.h"
+#include "arrow/compute/util.h"
+#include "arrow/compute/kernels/common_internal.h"
+#include "arrow/compute/light_array.h"
+#include "arrow/result.h"
+
+namespace arrow {
+namespace compute {
+namespace internal {
+
+// Define symbols visible within `arrow::compute::internal` in this file;
+// these symbols are not visible outside of this file.
+namespace {
+
+// Function documentation
+const FunctionDoc hash_64_doc{
+    "Construct a hash for every element of the input argument",
+    ("An element-wise function that uses an xxHash-like algorithm.\n"
+     "This function is not suitable for cryptographic purposes.\n"
+     "Hash results are 64-bit and emitted for each valid row.\n"
+     "Null (or invalid) rows emit a null in the output."),
+    {"hash_input"}};
+
+// ------------------------------
+// Kernel implementations
+// It is expected that HashArrowType is either UInt32Type or UInt64Type (default)
+template <typename HashArrowType = UInt64Type>
+struct FastHashScalar {
+  using OutputCType = typename TypeTraits<HashArrowType>::CType;
+  using KeyColumnArrayVec = std::vector<KeyColumnArray>;
+
+  // Internal wrapper functions to resolve Hashing32 vs Hashing64 using parameter types
+  static void FastHashMultiColumn(KeyColumnArrayVec& cols, LightContext* ctx,
+                                  uint32_t* hashes) {
+    Hashing32::HashMultiColumn(cols, ctx, hashes);
+  }
+
+  static void FastHashMultiColumn(KeyColumnArrayVec& cols, LightContext* ctx,
+                                  uint64_t* hashes) {
+    Hashing64::HashMultiColumn(cols, ctx, hashes);
+  }
+
+  static Status Exec(KernelContext* ctx, const ExecSpan& input_arg, ExecResult* out) {
+    if (input_arg.num_values() != 1 || !input_arg[0].is_array()) {
+      return Status::Invalid("FastHash currently supports a single array input");
+    }
+    ArraySpan hash_input = input_arg[0].array;
+
+    auto exec_ctx = default_exec_context();
+    if (ctx && ctx->exec_context()) {
+      exec_ctx = ctx->exec_context();
+    }
+
+    // Initialize stack-based memory allocator used by Hashing32 and Hashing64
+    util::TempVectorStack stack_memallocator;
+    ARROW_RETURN_NOT_OK(
+        stack_memallocator.Init(exec_ctx->memory_pool(),
+                                3 * sizeof(int32_t) * util::MiniBatch::kMiniBatchLength));
+
+    // Prepare context used by Hashing32 and Hashing64
+    LightContext hash_ctx;
+    hash_ctx.hardware_flags = exec_ctx->cpu_info()->hardware_flags();
+    hash_ctx.stack = &stack_memallocator;
+
+    // Construct vector<KeyColumnArray> from input ArraySpan; this essentially
+    // flattens the input array span, lifting nested Array buffers into a single level
+    ARROW_ASSIGN_OR_RAISE(KeyColumnArrayVec input_keycols,
+                          ColumnArraysFromArraySpan(hash_input, hash_input.length));
+
+    // Call the hashing function, overloaded based on OutputCType
+    ArraySpan* result_span = out->array_span_mutable();
+    FastHashMultiColumn(input_keycols, &hash_ctx, result_span->GetValues<OutputCType>(1));
+
+    return Status::OK();
+  }
+};
+
+// ------------------------------
+// Function construction and kernel registration
+std::shared_ptr<ScalarFunction> RegisterKernelsFastHash64() {
+  // Create function instance
+  auto fn_hash_64 =
+      std::make_shared<ScalarFunction>("hash_64", Arity::Unary(), hash_64_doc);
+
+  // Associate kernel with function
+  for (auto& simple_inputtype : PrimitiveTypes()) {
+    DCHECK_OK(fn_hash_64->AddKernel({InputType(simple_inputtype)}, OutputType(uint64()),
+                                    FastHashScalar<UInt64Type>::Exec));
+  }
+
+  for (const auto nested_type :
+       {Type::STRUCT, Type::DENSE_UNION, Type::SPARSE_UNION, Type::LIST,
+        Type::FIXED_SIZE_LIST, Type::MAP, Type::DICTIONARY}) {
+    DCHECK_OK(fn_hash_64->AddKernel({InputType(nested_type)}, OutputType(uint64()),
+                                    FastHashScalar<UInt64Type>::Exec));
+  }
+
+  // Return function to be registered
+  return fn_hash_64;
+}
+
+}  // namespace
+
+void RegisterScalarHash(FunctionRegistry* registry) {
+  auto fn_scalarhash64 = RegisterKernelsFastHash64();
+  DCHECK_OK(registry->AddFunction(std::move(fn_scalarhash64)));
+}
+
+}  // namespace internal
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_hash_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_hash_benchmark.cc
@@ -1,0 +1,189 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/hashing.h"
+
+#include "arrow/array/array_nested.h"
+#include "arrow/compute/exec.h"
+
+namespace arrow {
+namespace internal {
+
+// ------------------------------
+// Anonymous namespace with global params
+
+namespace {
+// copied from scalar_string_benchmark
+constexpr auto kSeed = 0x94378165;
+constexpr double null_prob = 0.2;
+
+static random::RandomArrayGenerator hashing_rng(kSeed);
+}  // namespace
+
+// ------------------------------
+// Convenience functions
+
+static Result<std::shared_ptr<StructArray>> MakeStructArray(int64_t n_values,
+                                                            int32_t min_strlen,
+                                                            int32_t max_strlen) {
+  auto vals_first = hashing_rng.Int64(n_values, 0, std::numeric_limits<int64_t>::max());
+  auto vals_second = hashing_rng.String(n_values, min_strlen, max_strlen, null_prob);
+  auto vals_third = hashing_rng.Int64(n_values, 0, std::numeric_limits<int64_t>::max());
+
+  return arrow::StructArray::Make(
+      arrow::ArrayVector{vals_first, vals_second, vals_third},
+      arrow::FieldVector{arrow::field("first", arrow::int64()),
+                         arrow::field("second", arrow::utf8()),
+                         arrow::field("third", arrow::int64())});
+}
+
+// ------------------------------
+// Benchmark implementations
+
+static void Hash64Int64(benchmark::State& state) {  // NOLINT non-const reference
+  auto test_vals = hashing_rng.Int64(10000, 0, std::numeric_limits<int64_t>::max());
+
+  while (state.KeepRunning()) {
+    ASSERT_OK_AND_ASSIGN(Datum hash_result,
+                         compute::CallFunction("hash_64", {test_vals}));
+    benchmark::DoNotOptimize(hash_result);
+  }
+
+  state.SetBytesProcessed(state.iterations() * test_vals->length() * sizeof(int64_t));
+  state.SetItemsProcessed(state.iterations() * test_vals->length());
+}
+
+static void Hash64StructSmallStrings(
+    benchmark::State& state) {  // NOLINT non-const reference
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<StructArray> values_array,
+                       MakeStructArray(10000, 2, 20));
+
+  // 2nd column (index 1) is a string column, which has offset type of int32_t
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> values_second,
+                       values_array->GetFlattenedField(1));
+  std::shared_ptr<StringArray> str_vals =
+      std::static_pointer_cast<StringArray>(values_second);
+  int32_t total_string_size = str_vals->total_values_length();
+
+  while (state.KeepRunning()) {
+    ASSERT_OK_AND_ASSIGN(Datum hash_result,
+                         compute::CallFunction("hash_64", {values_array}));
+    benchmark::DoNotOptimize(hash_result);
+  }
+
+  state.SetBytesProcessed(state.iterations() *
+                          ((values_array->length() * sizeof(int64_t)) +
+                           (total_string_size) +
+                           (values_array->length() * sizeof(int64_t))));
+  state.SetItemsProcessed(state.iterations() * 3 * values_array->length());
+}
+
+static void Hash64StructMediumStrings(
+    benchmark::State& state) {  // NOLINT non-const reference
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<StructArray> values_array,
+                       MakeStructArray(10000, 20, 120));
+
+  // 2nd column (index 1) is a string column, which has offset type of int32_t
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> values_second,
+                       values_array->GetFlattenedField(1));
+  std::shared_ptr<StringArray> str_vals =
+      std::static_pointer_cast<StringArray>(values_second);
+  int32_t total_string_size = str_vals->total_values_length();
+
+  while (state.KeepRunning()) {
+    ASSERT_OK_AND_ASSIGN(Datum hash_result,
+                         compute::CallFunction("hash_64", {values_array}));
+    benchmark::DoNotOptimize(hash_result);
+  }
+
+  state.SetBytesProcessed(state.iterations() *
+                          ((values_array->length() * sizeof(int64_t)) +
+                           (total_string_size) +
+                           (values_array->length() * sizeof(int64_t))));
+  state.SetItemsProcessed(state.iterations() * 3 * values_array->length());
+}
+
+static void Hash64StructLargeStrings(
+    benchmark::State& state) {  // NOLINT non-const reference
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<StructArray> values_array,
+                       MakeStructArray(10000, 120, 2000));
+
+  // 2nd column (index 1) is a string column, which has offset type of int32_t
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> values_second,
+                       values_array->GetFlattenedField(1));
+  std::shared_ptr<StringArray> str_vals =
+      std::static_pointer_cast<StringArray>(values_second);
+  int32_t total_string_size = str_vals->total_values_length();
+
+  while (state.KeepRunning()) {
+    ASSERT_OK_AND_ASSIGN(Datum hash_result,
+                         compute::CallFunction("hash_64", {values_array}));
+    benchmark::DoNotOptimize(hash_result);
+  }
+
+  state.SetBytesProcessed(state.iterations() *
+                          ((values_array->length() * sizeof(int64_t)) +
+                           (total_string_size) +
+                           (values_array->length() * sizeof(int64_t))));
+  state.SetItemsProcessed(state.iterations() * 3 * values_array->length());
+}
+
+static void Hash64Map(benchmark::State& state) {  // NOLINT non-const reference
+  constexpr int64_t test_size = 10000;
+  auto test_keys = hashing_rng.String(test_size, 2, 20, /*null_probability=*/0);
+  auto test_vals = hashing_rng.Int64(test_size, 0, std::numeric_limits<int64_t>::max());
+  auto test_keyvals = hashing_rng.Map(test_keys, test_vals, test_size);
+
+  auto key_arr = std::static_pointer_cast<StringArray>(test_keys);
+  int32_t total_key_size = key_arr->total_values_length();
+  int32_t total_val_size = test_size * sizeof(int64_t);
+
+  while (state.KeepRunning()) {
+    ASSERT_OK_AND_ASSIGN(Datum hash_result,
+                         compute::CallFunction("hash_64", {test_keyvals}));
+    benchmark::DoNotOptimize(hash_result);
+  }
+
+  state.SetBytesProcessed(state.iterations() * (total_key_size + total_val_size));
+  state.SetItemsProcessed(state.iterations() * 2 * test_size);
+}
+
+// ------------------------------
+// Benchmark declarations
+
+// Uses "FastHash" compute functions (wraps KeyHash functions)
+BENCHMARK(Hash64Int64);
+
+BENCHMARK(Hash64StructSmallStrings);
+BENCHMARK(Hash64StructMediumStrings);
+BENCHMARK(Hash64StructLargeStrings);
+
+BENCHMARK(Hash64Map);
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_hash_test.cc
@@ -1,0 +1,263 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "arrow/chunked_array.h"
+#include "arrow/compute/api.h"
+#include "arrow/compute/util.h"
+#include "arrow/compute/key_hash.h"
+#include "arrow/compute/kernels/test_util.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/matchers.h"
+#include "arrow/util/key_value_metadata.h"
+
+namespace arrow {
+namespace compute {
+
+/** A test helper that is a friend function for Hashing64 **/
+void TestHashVarLen(bool should_incr, uint32_t row_count,
+                    const uint32_t* var_offsets, const uint8_t* var_data,
+                    uint64_t* hash_results) {
+  Hashing64::HashVarLen(should_incr, row_count, var_offsets, var_data, hash_results);
+}
+
+namespace {
+
+// combining based on key_hash.h:CombineHashesImp (96a3af4)
+static const uint64_t combiner_const = 0x9e3779b9UL;
+static inline uint64_t hash_combine(uint64_t h1, uint64_t h2) {
+  uint64_t combiner_result = combiner_const + h2 + (h1 << 6) + (h1 >> 2);
+  return h1 ^ combiner_result;
+}
+
+// hash_int based on key_hash.cc:HashIntImp (672431b)
+template <typename T>
+uint64_t hash_int(T val) {
+  constexpr uint64_t int_const = 11400714785074694791ULL;
+  uint64_t cast_val = static_cast<uint64_t>(val);
+
+  return static_cast<uint64_t>(BYTESWAP(cast_val * int_const));
+}
+
+template <typename T>
+uint64_t hash_int_add(T val, uint64_t first_hash) {
+  return hash_combine(first_hash, hash_int(val));
+}
+
+}  // namespace
+
+TEST(TestScalarHash, Hash64Primitive) {
+  constexpr int data_bufndx{1};
+  std::vector<int32_t> test_values{3, 1, 2, 0, 127, 64};
+  std::string test_inputs_str{"[3, 1, 2, 0, 127, 64]"};
+
+  for (auto input_dtype : {int32(), uint32(), int8(), uint8()}) {
+    auto test_inputs = ArrayFromJSON(input_dtype, test_inputs_str);
+
+    ASSERT_OK_AND_ASSIGN(Datum hash_result, CallFunction("hash_64", {test_inputs}));
+    auto result_data = *(hash_result.array());
+
+    // validate each value
+    for (int val_ndx = 0; val_ndx < test_inputs->length(); ++val_ndx) {
+      uint64_t expected_hash = hash_int<int32_t>(test_values[val_ndx]);
+      uint64_t actual_hash = result_data.GetValues<uint64_t>(data_bufndx)[val_ndx];
+      ASSERT_EQ(expected_hash, actual_hash);
+    }
+  }
+}
+
+// NOTE: oddly, if int32_t or uint64_t is used for hash_int<>, this fails
+TEST(TestScalarHash, Hash64Negative) {
+  constexpr int data_bufndx{1};
+  std::vector<int32_t> test_values{-3, 1, -2, 0, -127, 64};
+
+  Int32Builder input_builder;
+  ASSERT_OK(input_builder.Reserve(test_values.size()));
+  ASSERT_OK(input_builder.AppendValues(test_values));
+  ASSERT_OK_AND_ASSIGN(auto test_inputs, input_builder.Finish());
+
+  ASSERT_OK_AND_ASSIGN(Datum hash_result, CallFunction("hash_64", {test_inputs}));
+  auto result_data = *(hash_result.array());
+
+  // validate each value
+  for (int val_ndx = 0; val_ndx < test_inputs->length(); ++val_ndx) {
+    uint64_t expected_hash = hash_int<uint32_t>(test_values[val_ndx]);
+    uint64_t actual_hash = result_data.GetValues<uint64_t>(data_bufndx)[val_ndx];
+    ASSERT_EQ(expected_hash, actual_hash);
+  }
+}
+
+TEST(TestScalarHash, Hash64IntMap) {
+  constexpr int data_bufndx{1};
+  std::vector<uint16_t> test_vals_first{7, 67, 3, 31, 17, 29};
+  std::vector<int16_t> test_vals_second{67, 7, 31, 3, 29, 17};
+
+  auto test_map = ArrayFromJSON(map(uint16(), int16()),
+                                R"([[[ 7, 67]], [[67,  7]], [[ 3, 31]],
+                                    [[31,  3]], [[17, 29]], [[29, 17]]])");
+
+  ASSERT_OK_AND_ASSIGN(Datum hash_result, CallFunction("hash_64", {test_map}));
+  auto result_data = *(hash_result.array());
+
+  // validate each value
+  for (size_t val_ndx = 0; val_ndx < test_vals_first.size(); ++val_ndx) {
+    uint64_t expected_hash = hash_combine(hash_int<uint16_t>(test_vals_first[val_ndx]),
+                                          hash_int<int16_t>(test_vals_second[val_ndx]));
+    uint64_t actual_hash = result_data.GetValues<uint64_t>(data_bufndx)[val_ndx];
+    ASSERT_EQ(expected_hash, actual_hash);
+  }
+}
+
+TEST(TestScalarHash, Hash64StringMap) {
+  constexpr int data_bufndx{1};
+  constexpr int varoffs_bufndx{1};
+  constexpr int vardata_bufndx{2};
+
+  // for expected values
+  auto test_vals_first  = ArrayFromJSON(utf8(), R"(["first-A", "second-A", "third-A"])");
+  auto test_vals_second = ArrayFromJSON(utf8(), R"(["first-B", "second-B", "third-B"])");
+  uint64_t expected_hashes[test_vals_first->length()];
+
+  TestHashVarLen(/*combine_hashes=*/false, /*num_rows=*/3,
+                 test_vals_first->data()->GetValues<uint32_t>(varoffs_bufndx),
+                 test_vals_first->data()->GetValues<uint8_t>(vardata_bufndx),
+                 expected_hashes);
+
+  TestHashVarLen(/*combine_hashes=*/true, /*num_rows=*/3,
+                 test_vals_second->data()->GetValues<uint32_t>(varoffs_bufndx),
+                 test_vals_second->data()->GetValues<uint8_t>(vardata_bufndx),
+                 expected_hashes);
+
+  // for actual values
+  auto test_map = ArrayFromJSON(map(utf8(), utf8()),
+                                R"([[["first-A", "first-B"]],
+                                    [["second-A", "second-B"]],
+                                    [["third-A", "third-B"]]])");
+
+  ASSERT_OK_AND_ASSIGN(Datum hash_result, CallFunction("hash_64", {test_map}));
+  auto result_data = *(hash_result.array());
+
+  // compare actual and expected
+  for (int64_t val_ndx = 0; val_ndx < test_vals_first->length(); ++val_ndx) {
+    uint64_t actual_hash = result_data.GetValues<uint64_t>(data_bufndx)[val_ndx];
+
+    ASSERT_EQ(expected_hashes[val_ndx], actual_hash);
+  }
+}
+
+TEST(TestScalarHash, Hash64Map) {
+  constexpr int data_bufndx{1};
+  constexpr int varoffs_bufndx{1};
+  constexpr int vardata_bufndx{2};
+
+  // For expected values
+  auto test_vals_first = ArrayFromJSON(utf8(),
+                                       R"(["first-A", "second-A", "first-B",
+                                           "second-B", "first-C", "second-C"])");
+
+  std::vector<uint8_t> test_vals_second{1, 3, 11, 23, 111, 223};
+  uint64_t expected_hashes[test_vals_first->length()];
+
+  // compute initial hashes from the string column (array)
+  TestHashVarLen(/*combine_hashes=*/false, /*num_rows=*/6,
+                 test_vals_first->data()->GetValues<uint32_t>(varoffs_bufndx),
+                 test_vals_first->data()->GetValues<uint8_t>(vardata_bufndx),
+                 expected_hashes);
+
+  // For actual values
+  auto test_map = ArrayFromJSON(map(utf8(), uint8()),
+                                R"([[["first-A", 1]], [["second-A", 3]],
+                                    [["first-B", 11]], [["second-B", 23]],
+                                    [["first-C", 111]], [["second-C", 223]]])");
+
+  ASSERT_OK_AND_ASSIGN(Datum hash_result, CallFunction("hash_64", {test_map}));
+  auto result_data = *(hash_result.array());
+
+  // compare actual and expected
+  for (int64_t val_ndx = 0; val_ndx < test_vals_first->length(); ++val_ndx) {
+    // compute final hashes by combining int hashes with initial string hashes
+    expected_hashes[val_ndx] = hash_combine(expected_hashes[val_ndx],
+                                            hash_int<uint8_t>(test_vals_second[val_ndx]));
+
+    uint64_t actual_hash = result_data.GetValues<uint64_t>(data_bufndx)[val_ndx];
+
+    ASSERT_EQ(expected_hashes[val_ndx], actual_hash);
+  }
+}
+
+TEST(TestScalarHash, Hash64List) {
+  constexpr int data_bufndx{1};
+  constexpr int varoffs_bufndx{1};
+  constexpr int vardata_bufndx{2};
+
+  // for expected values
+  auto test_vals1 = ArrayFromJSON(utf8(), R"(["first-A", "second-A", "third-A"])");
+  auto test_vals2 = ArrayFromJSON(utf8(), R"(["first-B", "second-B", "third-B"])");
+  auto test_vals3 = ArrayFromJSON(utf8(), R"(["first-A", "first-B",
+                                              "second-A", "second-B",
+                                              "third-A", "third-B"])");
+  uint64_t expected_hashes[test_vals1->length()];
+  uint64_t test_hashes[test_vals3->length()];
+
+  TestHashVarLen(/*combine_hashes=*/false, /*num_rows=*/3,
+                 test_vals1->data()->GetValues<uint32_t>(varoffs_bufndx),
+                 test_vals1->data()->GetValues<uint8_t>(vardata_bufndx),
+                 expected_hashes);
+
+  TestHashVarLen(/*combine_hashes=*/true, /*num_rows=*/3,
+                 test_vals2->data()->GetValues<uint32_t>(varoffs_bufndx),
+                 test_vals2->data()->GetValues<uint8_t>(vardata_bufndx),
+                 expected_hashes);
+
+  TestHashVarLen(/*combine_hashes=*/false, /*num_rows=*/6,
+                 test_vals3->data()->GetValues<uint32_t>(varoffs_bufndx),
+                 test_vals3->data()->GetValues<uint8_t>(vardata_bufndx),
+                 test_hashes);
+
+  // for actual values
+  auto test_list = ArrayFromJSON(list(utf8()),
+                                 R"([["first-A", "first-B"],
+                                     ["second-A", "second-B"],
+                                     ["third-A", "third-B"]])");
+
+  ARROW_LOG(INFO) << "size: " << test_list->length();
+  ARROW_LOG(INFO) << test_list->ToString();
+
+  ARROW_LOG(INFO) << "Test Hashes:";
+  for (uint64_t hash_val : test_hashes) {
+    ARROW_LOG(INFO) << "\t" << hash_val;
+  }
+
+  ASSERT_OK_AND_ASSIGN(Datum hash_result, CallFunction("hash_64", {test_list}));
+  auto result_data = *(hash_result.array());
+
+  // compare actual and expected
+  // for (int64_t val_ndx = 0; val_ndx < test_list->length(); ++val_ndx) {
+  for (int64_t val_ndx = 0; val_ndx < result_data.length; ++val_ndx) {
+    uint64_t actual_hash = result_data.GetValues<uint64_t>(data_bufndx)[val_ndx];
+    ARROW_LOG(INFO) << "actual hash: " << actual_hash;
+
+    // ASSERT_EQ(expected_hashes[val_ndx], actual_hash);
+    // ARROW_LOG(INFO) << "expected hash: " << expected_hashes[val_ndx] << "\tactual hash: " << actual_hash;
+  }
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/key_hash_internal.h
+++ b/cpp/src/arrow/compute/key_hash_internal.h
@@ -163,6 +163,9 @@ class ARROW_EXPORT Hashing64 {
   friend void TestBloomLargeHashHelper(int64_t, int64_t, const std::vector<uint64_t>&,
                                        int64_t, int, T*);
   friend void TestBloomSmall(BloomFilterBuildStrategy, int64_t, int, bool, bool);
+  friend void TestHashVarLen(bool should_incr, uint32_t row_count,
+                             const uint32_t* var_offsets, const uint8_t* var_data,
+                             uint64_t* hash_results);
 
  public:
   static void HashMultiColumn(const std::vector<KeyColumnArray>& cols, LightContext* ctx,

--- a/cpp/src/arrow/compute/light_array_internal.cc
+++ b/cpp/src/arrow/compute/light_array_internal.cc
@@ -48,16 +48,16 @@ KeyColumnArray::KeyColumnArray(const KeyColumnMetadata& metadata, int64_t length
 KeyColumnArray::KeyColumnArray(const KeyColumnMetadata& metadata, int64_t length,
                                uint8_t* validity_buffer, uint8_t* fixed_length_buffer,
                                uint8_t* var_length_buffer, int bit_offset_validity,
-                               int bit_offset_fixed) {
+                               int bit_offset_fixed,
+                               const util::TempVectorStack* alloc) {
   metadata_ = metadata;
-  length_ = length;
-  buffers_[kValidityBuffer] = mutable_buffers_[kValidityBuffer] = validity_buffer;
-  buffers_[kFixedLengthBuffer] = mutable_buffers_[kFixedLengthBuffer] =
-      fixed_length_buffer;
-  buffers_[kVariableLengthBuffer] = mutable_buffers_[kVariableLengthBuffer] =
-      var_length_buffer;
-  bit_offset_[kValidityBuffer] = bit_offset_validity;
+  length_   = length;
+  buffers_[kValidityBuffer]       = mutable_buffers_[kValidityBuffer]       = validity_buffer;
+  buffers_[kFixedLengthBuffer]    = mutable_buffers_[kFixedLengthBuffer]    = fixed_length_buffer;
+  buffers_[kVariableLengthBuffer] = mutable_buffers_[kVariableLengthBuffer] = var_length_buffer;
+  bit_offset_[kValidityBuffer]    = bit_offset_validity;
   bit_offset_[kFixedLengthBuffer] = bit_offset_fixed;
+  arena_alloc                     = alloc;
 }
 
 KeyColumnArray KeyColumnArray::WithBufferFrom(const KeyColumnArray& other,
@@ -83,6 +83,8 @@ KeyColumnArray KeyColumnArray::Slice(int64_t offset, int64_t length) const {
   sliced.metadata_ = metadata_;
   sliced.length_ = length;
   uint32_t fixed_size = metadata_.fixed_length;
+  // TODO: see if this is necessary
+  // uint32_t fixed_size = !metadata_.is_fixed_length ? sizeof(uint32_t) : metadata_.fixed_length;
 
   sliced.buffers_[0] =
       buffers_[0] ? buffers_[0] + (bit_offset_[0] + offset) / 8 : nullptr;
@@ -116,37 +118,226 @@ KeyColumnArray KeyColumnArray::Slice(int64_t offset, int64_t length) const {
 
 Result<KeyColumnMetadata> ColumnMetadataFromDataType(
     const std::shared_ptr<DataType>& type) {
-  const bool is_extension = type->id() == Type::EXTENSION;
-  const std::shared_ptr<DataType>& typ =
-      is_extension ? arrow::internal::checked_cast<const ExtensionType*>(type.get())
-                         ->storage_type()
-                   : type;
+  // "ptype" is the "physical" type
+  const DataType* ptype = type->GetSharedPtr().get();
 
-  if (typ->id() == Type::DICTIONARY) {
+  // For ExtensionType, use the backing physical type (storage_type() is a shared ptr)
+  if (ARROW_PREDICT_FALSE(type->id() == Type::EXTENSION)) {
+    const ExtensionType* ext_type = static_cast<const ExtensionType*>(type);
+    ptype = ext_type->storage_type().get();
+  }
+
+  if (ptype->id() == Type::DICTIONARY) {
     auto bit_width =
-        arrow::internal::checked_cast<const FixedWidthType&>(*typ).bit_width();
+        arrow::internal::checked_cast<const FixedWidthType&>(*ptype).bit_width();
     ARROW_DCHECK(bit_width % 8 == 0);
     return KeyColumnMetadata(true, bit_width / 8);
   }
-  if (typ->id() == Type::BOOL) {
+  if (ptype->id() == Type::BOOL) {
     return KeyColumnMetadata(true, 0);
   }
-  if (is_fixed_width(typ->id())) {
+  if (is_fixed_width(ptype->id())) {
     return KeyColumnMetadata(
-        true, arrow::internal::checked_cast<const FixedWidthType&>(*typ).bit_width() / 8);
+        true,
+        arrow::internal::checked_cast<const FixedWidthType&>(*ptype).bit_width() / 8);
   }
-  if (is_binary_like(typ->id())) {
+  if (is_binary_like(ptype->id())) {
     return KeyColumnMetadata(false, sizeof(uint32_t));
   }
-  if (is_large_binary_like(typ->id())) {
+  if (is_large_binary_like(ptype->id())) {
     return KeyColumnMetadata(false, sizeof(uint64_t));
   }
-  if (typ->id() == Type::NA) {
+  if (ptype->id() == Type::NA) {
     return KeyColumnMetadata(true, 0, true);
   }
   // Caller attempted to create a KeyColumnArray from an invalid type
-  return Status::TypeError("Unsupported column data type ", typ->name(),
+  return Status::TypeError("Unsupported column data type ", ptype->name(),
                            " used with KeyColumnMetadata");
+}
+
+Result<KeyColumnMetadata> ColumnMetadataFromDataType(
+    const std::shared_ptr<DataType>& type) {
+  return ColumnMetadataFromDataType(type.get());
+}
+
+/**
+ * Constructs metadata that tells hashing functions how to iterate over the
+ * KeyColumnArray.
+ *
+ * This function assumes ColumnMetadataFromDataType has already failed, which makes this
+ * function distinct because it should only be called when the input Array is flattened in
+ * a particular way.
+ */
+Result<KeyColumnMetadata> ColumnMetadataFromListType(const DataType* type) {
+  if (type->id() == Type::LIST || type->id() == Type::MAP) {
+    return KeyColumnMetadata(false, sizeof(uint32_t));
+  }
+  else if (type->id() == Type::LARGE_LIST) {
+    return KeyColumnMetadata(false, sizeof(uint64_t));
+  }
+  // Caller attempted to create a KeyColumnArray from an invalid type
+  return Status::TypeError("Unsupported column data type ", type->name(),
+                           " used with KeyColumnMetadata");
+}
+
+Result<KeyColumnMetadata> ColumnMetadataFromListType(
+    const std::shared_ptr<DataType>& type) {
+  return ColumnMetadataFromListType(type.get());
+}
+
+/**
+ * Coalesces children of a StructArray into a flattened list of KeyColumnArrays. When
+ * hashing a StructArray, we want to co-index a list of KeyColumnArrays so that values in
+ * the same row are combined.
+ */
+Result<KeyColumnVector> ColumnArraysFromStructArray(const ArraySpan& array_span,
+                                                    int64_t num_rows) {
+  KeyColumnVector flattened_spans;
+  flattened_spans.reserve(array_span.child_data.size());
+
+  // Recurse on each child of the ArraySpan in DFS-order
+  for (size_t child_ndx = 0; child_ndx < array_span.child_data.size(); ++child_ndx) {
+    auto child_span = array_span.child_data[child_ndx];
+    ARROW_ASSIGN_OR_RAISE(auto child_keycols,
+                          ColumnArraysFromArraySpan(child_span, num_rows));
+
+    flattened_spans.insert(flattened_spans.end(), child_keycols.begin(),
+                           child_keycols.end());
+  }
+
+  return flattened_spans;
+}
+
+/**
+ * Flattens the data in a ListArray into a list of KeyColumnArrays so that each element in
+ * the ListArray is properly treated as a row value. Due to semantics of nulls in nested
+ * arrays and their non-impact on a hash value, nulls in nested arrays are dropped when
+ * flattened. If a list is null, then that row is considered null and is preserved.
+ *
+ * The values buffer of a list type should be propagated to the caller as is, but the
+ * parent offsets and offsets of the current ArraySpan must be coalesced. Essentially, for
+ * the purposes of hashing, we don't care about internal structure of a row value so we
+ * flatten the offsets.
+ */
+
+// TODO: recurse to: (1) flatten offsets, (2) eventually bottom out and grab var data
+template <typename OffsetType>
+Result<KeyColumnArray> ColumnArraysFromListArray(const ArraySpan& array_span,
+                                                 int64_t num_rows,
+                                                 const OffsetType* parent_offsets) {
+  // Construct KeyColumnMetadata
+  ARROW_ASSIGN_OR_RAISE(KeyColumnMetadata metadata,
+                        ColumnMetadataFromListType(array_span.type));
+
+  ARROW_LOG(INFO) << "[ListArray] Child count: "
+                  << std::to_string(array_span.child_data.size());
+
+  // ListArrays have only 1 child
+  auto child_span = array_span.child_data[0];
+  uint8_t* buffer_validity = nullptr;
+  /*
+   * TODO: Currently unsupported.
+   * figure out how the validity bitmap affects flattened lists
+   *if (child_span.GetBuffer(0) != nullptr) {
+   *  buffer_validity = (uint8_t*)child_span.GetBuffer(0)->data();
+   *}
+   **/
+
+  // For simple lists or lists containing only list types, this should point to the child
+  // buffer with all of the values
+  uint8_t* buffer_varlength = nullptr;
+  if (child_span.num_buffers() > 2 && child_span.GetBuffer(2) != NULLPTR) {
+    ARROW_LOG(INFO) << "found list array data";
+    buffer_varlength = (uint8_t*)child_span.GetBuffer(2)->data();
+  }
+  else {
+    ARROW_LOG(INFO) << "child array does not have list array data";
+  }
+
+  // TODO
+  // Lists get flattened to 1 KeyColumnArray; Maps get flattened to 2 (key and value)
+  KeyColumnArray column_array =
+      KeyColumnArray(metadata, child_span.offset + num_rows, buffer_validity,
+                     child_span.GetBuffer(1)->data(), buffer_varlength);
+
+  return column_array;
+}
+
+
+Result<KeyColumnArray> ColumnArrayFromArraySpan(const ArraySpan& array_span,
+                                                int64_t num_rows) {
+  ARROW_ASSIGN_OR_RAISE(KeyColumnMetadata metadata,
+                        ColumnMetadataFromDataType(array_span.type));
+
+  uint8_t* buffer_validity = nullptr;
+  if (array_span.GetBuffer(0) != nullptr) {
+    buffer_validity = (uint8_t*)array_span.GetBuffer(0)->data();
+  }
+
+  uint8_t* buffer_varlength = nullptr;
+  if (array_span.num_buffers() > 2 && array_span.GetBuffer(2) != NULLPTR) {
+    buffer_varlength = (uint8_t*)array_span.GetBuffer(2)->data();
+  }
+
+  KeyColumnArray column_array =
+      KeyColumnArray(metadata, array_span.offset + num_rows, buffer_validity,
+                     array_span.GetBuffer(1)->data(), buffer_varlength);
+
+  return column_array.Slice(array_span.offset, num_rows);
+}
+
+Result<KeyColumnVector> ColumnArraysFromArraySpan(const ArraySpan& array_span,
+                                                  int64_t num_rows) {
+  KeyColumnVector flattened_spans;
+  flattened_spans.reserve(1 + array_span.child_data.size());
+
+  // Construct a KeyColumnArray from the given ArraySpan
+  auto keycol_result = ColumnArrayFromArraySpan(array_span, num_rows);
+  if (keycol_result.ok()) {
+    flattened_spans.push_back(*keycol_result);
+  }
+
+  // If ArraySpan data type is not supported, check for supported nested types.
+  else if (is_nested(array_span.type->id())) {
+    switch (array_span.type->id()) {
+      case Type::LIST:
+      case Type::MAP: {
+        const uint32_t* list_offsets = (const uint32_t*) array_span.GetBuffer(1)->data();
+        ARROW_ASSIGN_OR_RAISE(auto list_keycol,
+                              ColumnArraysFromListArray(array_span, num_rows,
+                                                        list_offsets));
+
+        flattened_spans.push_back(list_keycol);
+        break;
+      }
+
+      case Type::LARGE_LIST: {
+        const uint64_t* list_offsets = (const uint64_t*) array_span.GetBuffer(1)->data();
+        ARROW_ASSIGN_OR_RAISE(auto list_keycol,
+                              ColumnArraysFromListArray(array_span, num_rows,
+                                                        list_offsets));
+
+        flattened_spans.push_back(list_keycol);
+        break;
+      }
+
+      case Type::STRUCT: {
+        ARROW_ASSIGN_OR_RAISE(auto struct_keycols,
+                              ColumnArraysFromStructArray(array_span, num_rows));
+
+        flattened_spans.insert(flattened_spans.end(), struct_keycols.begin(),
+                               struct_keycols.end());
+        break;
+      }
+
+      default:
+        // unsupported types include: unions, fixed size list
+        ARROW_WARN_NOT_OK(keycol_result.status(), "Unsupported nested type for hashing");
+        break;
+    }
+  }
+
+  return flattened_spans;
 }
 
 Result<KeyColumnArray> ColumnArrayFromArrayData(
@@ -160,12 +351,14 @@ KeyColumnArray ColumnArrayFromArrayDataAndMetadata(
     const std::shared_ptr<ArrayData>& array_data, const KeyColumnMetadata& metadata,
     int64_t start_row, int64_t num_rows) {
   KeyColumnArray column_array = KeyColumnArray(
-      metadata, array_data->offset + start_row + num_rows,
-      array_data->buffers[0] != NULLPTR ? array_data->buffers[0]->data() : nullptr,
-      array_data->buffers[1]->data(),
-      (array_data->buffers.size() > 2 && array_data->buffers[2] != NULLPTR)
+       metadata
+      ,array_data->offset + start_row + num_rows
+      ,array_data->buffers[0] != NULLPTR ? array_data->buffers[0]->data() : nullptr
+      ,array_data->buffers[1]->data()
+      ,(array_data->buffers.size() > 2 && array_data->buffers[2] != NULLPTR)
           ? array_data->buffers[2]->data()
-          : nullptr);
+          : nullptr
+  );
   return column_array.Slice(array_data->offset + start_row, num_rows);
 }
 
@@ -200,8 +393,9 @@ Status ColumnArraysFromExecBatch(const ExecBatch& batch, int64_t start_row,
 
 Status ColumnArraysFromExecBatch(const ExecBatch& batch,
                                  std::vector<KeyColumnArray>* column_arrays) {
-  return ColumnArraysFromExecBatch(batch, 0, static_cast<int>(batch.length),
-                                   column_arrays);
+  return ColumnArraysFromExecBatch(
+    batch, 0, static_cast<int>(batch.length), column_arrays
+  );
 }
 
 Status ResizableArrayData::Init(const std::shared_ptr<DataType>& data_type,

--- a/cpp/src/arrow/compute/light_array_internal.cc
+++ b/cpp/src/arrow/compute/light_array_internal.cc
@@ -196,6 +196,9 @@ Result<KeyColumnArray> ColumnArrayFromListArray(const ArraySpan& array_span,
                         ColumnMetadataFromListType(array_span.type));
 
   auto child_span = array_span.child_data[0];
+  if (!is_primitive(child_span.type->id())) {
+    return Status::NotImplemented("A ListArray with non-primitive types is unsupported.");
+  }
 
   uint8_t* list_validity = nullptr;
   if (array_span.GetBuffer(0) != nullptr) {

--- a/cpp/src/arrow/compute/light_array_internal.h
+++ b/cpp/src/arrow/compute/light_array_internal.h
@@ -85,6 +85,7 @@ class ARROW_EXPORT KeyColumnArray {
  public:
   /// \brief Create an uninitialized KeyColumnArray
   KeyColumnArray() = default;
+
   /// \brief Create a read-only view from buffers
   ///
   /// This is a view only and does not take ownership of the buffers.  The lifetime
@@ -97,10 +98,14 @@ class ARROW_EXPORT KeyColumnArray {
   ///
   /// This is a view only and does not take ownership of the buffers.  The lifetime
   /// of the buffers must exceed the lifetime of this view
-  KeyColumnArray(const KeyColumnMetadata& metadata, int64_t length,
-                 uint8_t* validity_buffer, uint8_t* fixed_length_buffer,
-                 uint8_t* var_length_buffer, int bit_offset_validity = 0,
-                 int bit_offset_fixed = 0);
+  KeyColumnArray( const KeyColumnMetadata& metadata
+                 ,int64_t  length
+                 ,uint8_t* validity_buffer
+                 ,uint8_t* fixed_length_buffer
+                 ,uint8_t* var_length_buffer
+                 ,int bit_offset_validity = 0
+                 ,int bit_offset_fixed    = 0
+                 ,const util::TempVectorStack *alloc = nullptr);
   /// \brief Create a sliced view of `this`
   ///
   /// The number of rows used in offset must be divisible by 8
@@ -184,6 +189,7 @@ class ARROW_EXPORT KeyColumnArray {
   // Starting bit offset within the first byte (between 0 and 7)
   // to be used when accessing buffers that store bit vectors.
   int bit_offset_[kMaxBuffers - 1];
+  const util::TempVectorStack* arena_alloc;
 
   bool is_bool_type() const {
     return metadata_.is_fixed_length && metadata_.fixed_length == 0 &&
@@ -220,6 +226,15 @@ class ARROW_EXPORT KeyColumnArray {
 /// a non-key column will return Status::TypeError.
 ARROW_EXPORT Result<KeyColumnMetadata> ColumnMetadataFromDataType(
     const std::shared_ptr<DataType>& type);
+
+ARROW_EXPORT Result<KeyColumnMetadata> ColumnMetadataFromDataType(const DataType* type);
+
+/// \brief Create KeyColumnArray from ArraySpan
+///
+/// The caller should ensure this is only called on "key" columns.
+/// \see ColumnMetadataFromDataType for details
+ARROW_EXPORT Result<KeyColumnVector> ColumnArraysFromArraySpan(
+    const ArraySpan& array_span, int64_t num_rows);
 
 /// \brief Create KeyColumnArray from ArrayData
 ///
@@ -269,6 +284,7 @@ ARROW_EXPORT Status ColumnArraysFromExecBatch(const ExecBatch& batch, int64_t st
 /// \see ColumnArrayFromArrayData for more details
 ARROW_EXPORT Status ColumnArraysFromExecBatch(const ExecBatch& batch,
                                               std::vector<KeyColumnArray>* column_arrays);
+
 
 /// A lightweight resizable array for "key" columns
 ///

--- a/cpp/src/arrow/compute/light_array_internal.h
+++ b/cpp/src/arrow/compute/light_array_internal.h
@@ -34,6 +34,12 @@
 namespace arrow {
 namespace compute {
 
+
+// Forward declaration of KeyColumnArray for convenience of creating a type alias
+class KeyColumnArray;
+using KeyColumnVector = std::vector<KeyColumnArray>;
+
+
 /// \brief Context needed by various execution engine operations
 ///
 /// In the execution engine this context is provided by either the node or the

--- a/cpp/src/arrow/compute/light_array_internal.h
+++ b/cpp/src/arrow/compute/light_array_internal.h
@@ -34,11 +34,9 @@
 namespace arrow {
 namespace compute {
 
-
 // Forward declaration of KeyColumnArray for convenience of creating a type alias
 class KeyColumnArray;
 using KeyColumnVector = std::vector<KeyColumnArray>;
-
 
 /// \brief Context needed by various execution engine operations
 ///
@@ -104,14 +102,10 @@ class ARROW_EXPORT KeyColumnArray {
   ///
   /// This is a view only and does not take ownership of the buffers.  The lifetime
   /// of the buffers must exceed the lifetime of this view
-  KeyColumnArray( const KeyColumnMetadata& metadata
-                 ,int64_t  length
-                 ,uint8_t* validity_buffer
-                 ,uint8_t* fixed_length_buffer
-                 ,uint8_t* var_length_buffer
-                 ,int bit_offset_validity = 0
-                 ,int bit_offset_fixed    = 0
-                 ,const util::TempVectorStack *alloc = nullptr);
+  KeyColumnArray(const KeyColumnMetadata& metadata, int64_t length,
+                 uint8_t* validity_buffer, uint8_t* fixed_length_buffer,
+                 uint8_t* var_length_buffer, int bit_offset_validity = 0,
+                 int bit_offset_fixed = 0);
   /// \brief Create a sliced view of `this`
   ///
   /// The number of rows used in offset must be divisible by 8
@@ -195,7 +189,6 @@ class ARROW_EXPORT KeyColumnArray {
   // Starting bit offset within the first byte (between 0 and 7)
   // to be used when accessing buffers that store bit vectors.
   int bit_offset_[kMaxBuffers - 1];
-  const util::TempVectorStack* arena_alloc;
 
   bool is_bool_type() const {
     return metadata_.is_fixed_length && metadata_.fixed_length == 0 &&
@@ -235,9 +228,10 @@ ARROW_EXPORT Result<KeyColumnMetadata> ColumnMetadataFromDataType(
 
 ARROW_EXPORT Result<KeyColumnMetadata> ColumnMetadataFromDataType(const DataType* type);
 
-/// \brief Create KeyColumnArray from ArraySpan
+/// \brief Create KeyColumnArray instances from an ArraySpan (nested types supported)
 ///
-/// The caller should ensure this is only called on "key" columns.
+/// The caller should ensure this is only called on "key" columns. Some nested types are
+/// supported up to 1 level of nesting (e.g. List<int8> but not List<List<int8>>).
 /// \see ColumnMetadataFromDataType for details
 ARROW_EXPORT Result<KeyColumnVector> ColumnArraysFromArraySpan(
     const ArraySpan& array_span, int64_t num_rows);
@@ -290,7 +284,6 @@ ARROW_EXPORT Status ColumnArraysFromExecBatch(const ExecBatch& batch, int64_t st
 /// \see ColumnArrayFromArrayData for more details
 ARROW_EXPORT Status ColumnArraysFromExecBatch(const ExecBatch& batch,
                                               std::vector<KeyColumnArray>* column_arrays);
-
 
 /// A lightweight resizable array for "key" columns
 ///

--- a/cpp/src/arrow/compute/light_array_internal.h
+++ b/cpp/src/arrow/compute/light_array_internal.h
@@ -233,8 +233,9 @@ ARROW_EXPORT Result<KeyColumnMetadata> ColumnMetadataFromDataType(const DataType
 /// The caller should ensure this is only called on "key" columns. Some nested types are
 /// supported up to 1 level of nesting (e.g. List<int8> but not List<List<int8>>).
 /// \see ColumnMetadataFromDataType for details
-ARROW_EXPORT Result<KeyColumnVector> ColumnArraysFromArraySpan(
-    const ArraySpan& array_span, int64_t num_rows);
+ARROW_EXPORT Status ColumnArraysFromArraySpan(const ArraySpan& array_span,
+                                              int64_t start_row, int64_t num_rows,
+                                              KeyColumnVector* column_arrays);
 
 /// \brief Create KeyColumnArray from ArrayData
 ///

--- a/cpp/src/arrow/compute/light_array_test.cc
+++ b/cpp/src/arrow/compute/light_array_test.cc
@@ -287,6 +287,40 @@ TEST(KeyColumnArray, SliceBinaryTest) {
   GenericTestSlice<int64_t>(large_binary(), json_test_strings, testCases);
 }
 
+TEST(KeyColumnArray, TempAllocForHashing) {
+  std::unique_ptr<MemoryPool> pool = MemoryPool::CreateDefault();
+
+  for (const auto& type : kSampleFixedDataTypes) {
+    ARROW_SCOPED_TRACE("Type: ", type->ToString());
+    /* TODO
+    int row_count = 12;
+    int byte_width =
+        arrow::internal::checked_pointer_cast<FixedWidthType>(type)->bit_width() / 8;
+
+    {
+      KeyColumnPseudoSpan column_span {pool.get()};
+      ARROW_ASSIGN_OR_RAISE(uint8_t* buf_data,
+                            column_span.CreateBuffer(1, byte_width * row_count));
+
+      // TODO: create a test that uses a KeyColumnArray constructed from a
+      // KeyColumnPseudoSpan
+      KeyColumnMetadata metadata = ColumnMetadataFromDataType(boolean()).ValueOrDie();
+
+      KeyColumnArray column_view {
+        column_span.CreateView(
+
+      int min_bytes_needed_for_values = byte_width;
+      int min_bytes_needed_for_validity = 1;
+      int min_bytes_needed = min_bytes_needed_for_values + min_bytes_needed_for_validity;
+      ASSERT_LT(min_bytes_needed, pool->bytes_allocated());
+      ASSERT_GT(min_bytes_needed * 2, pool->bytes_allocated());
+    }
+    */
+    // After array is destroyed buffers should be freed
+    ASSERT_EQ(0, pool->bytes_allocated());
+  }
+}
+
 TEST(ResizableArrayData, Basic) {
   std::unique_ptr<MemoryPool> pool = MemoryPool::CreateDefault();
   for (const auto& type : kSampleFixedDataTypes) {

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -299,6 +299,7 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterScalarArithmetic(registry.get());
   RegisterScalarBoolean(registry.get());
   RegisterScalarComparison(registry.get());
+  RegisterScalarHash(registry.get());
   RegisterScalarIfElse(registry.get());
   RegisterScalarNested(registry.get());
   RegisterScalarRandom(registry.get());  // Nullary

--- a/cpp/src/arrow/compute/registry_internal.h
+++ b/cpp/src/arrow/compute/registry_internal.h
@@ -30,6 +30,7 @@ void RegisterScalarBoolean(FunctionRegistry* registry);
 void RegisterScalarCast(FunctionRegistry* registry);
 void RegisterDictionaryDecode(FunctionRegistry* registry);
 void RegisterScalarComparison(FunctionRegistry* registry);
+void RegisterScalarHash(FunctionRegistry* registry);
 void RegisterScalarIfElse(FunctionRegistry* registry);
 void RegisterScalarNested(FunctionRegistry* registry);
 void RegisterScalarRandom(FunctionRegistry* registry);  // Nullary

--- a/cpp/src/arrow/util/hashing_benchmark.cc
+++ b/cpp/src/arrow/util/hashing_benchmark.cc
@@ -25,10 +25,21 @@
 #include "benchmark/benchmark.h"
 
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
 #include "arrow/util/hashing.h"
+
+#include "arrow/array/builder_primitive.h"
+#include "arrow/compute/key_hash.h"
 
 namespace arrow {
 namespace internal {
+
+namespace {
+// copied from scalar_string_benchmark
+constexpr auto kSeed = 0x94378165;
+
+static random::RandomArrayGenerator hashing_rng(kSeed);
+}  // namespace
 
 template <class Integer>
 static std::vector<Integer> MakeIntegers(int32_t n_values) {
@@ -62,7 +73,22 @@ static std::vector<std::string> MakeStrings(int32_t n_values, int32_t min_length
   return values;
 }
 
-static void HashIntegers(benchmark::State& state) {  // NOLINT non-const reference
+static void HashIntegers32(benchmark::State& state) {  // NOLINT non-const reference
+  const std::vector<int32_t> values = MakeIntegers<int32_t>(10000);
+
+  while (state.KeepRunning()) {
+    hash_t total = 0;
+    for (const int32_t v : values) {
+      total += ScalarHelper<int32_t, 0>::ComputeHash(v);
+      total += ScalarHelper<int32_t, 1>::ComputeHash(v);
+    }
+    benchmark::DoNotOptimize(total);
+  }
+  state.SetBytesProcessed(2 * state.iterations() * values.size() * sizeof(int32_t));
+  state.SetItemsProcessed(2 * state.iterations() * values.size());
+}
+
+static void HashIntegers64(benchmark::State& state) {  // NOLINT non-const reference
   const std::vector<int64_t> values = MakeIntegers<int64_t>(10000);
 
   while (state.KeepRunning()) {
@@ -111,13 +137,91 @@ static void HashLargeStrings(benchmark::State& state) {  // NOLINT non-const ref
   BenchmarkStringHashing(state, values);
 }
 
+static void KeyHashIntegers32(benchmark::State& state) {  // NOLINT non-const reference
+  auto test_vals = hashing_rng.Int32(10000, 0, std::numeric_limits<int32_t>::max());
+
+  // initialize the stack allocator
+  util::TempVectorStack stack_memallocator;
+  ASSERT_OK(
+      stack_memallocator.Init(compute::default_exec_context()->memory_pool(),
+                              3 * sizeof(int32_t) * util::MiniBatch::kMiniBatchLength));
+
+  // prepare the execution context for Hashing32
+  compute::LightContext hash_ctx;
+  hash_ctx.hardware_flags = compute::default_exec_context()->cpu_info()->hardware_flags();
+  hash_ctx.stack = &stack_memallocator;
+
+  // allocate memory for results
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<Buffer> hash_buffer,
+                       AllocateBuffer(test_vals->length() * sizeof(int32_t)));
+
+  // run the benchmark
+  while (state.KeepRunning()) {
+    // Prepare input data structure for propagation to hash function
+    ASSERT_OK_AND_ASSIGN(
+        compute::KeyColumnArray input_keycol,
+        compute::ColumnArrayFromArrayData(test_vals->data(), 0, test_vals->length()));
+
+    compute::Hashing32::HashMultiColumn(
+        {input_keycol}, &hash_ctx,
+        reinterpret_cast<uint32_t*>(hash_buffer->mutable_data()));
+
+    // benchmark::DoNotOptimize(hash_buffer);
+  }
+
+  state.SetBytesProcessed(state.iterations() * test_vals->length() * sizeof(int32_t));
+  state.SetItemsProcessed(state.iterations() * test_vals->length());
+}
+
+static void KeyHashIntegers64(benchmark::State& state) {  // NOLINT non-const reference
+  auto test_vals = hashing_rng.Int64(10000, 0, std::numeric_limits<int64_t>::max());
+
+  // initialize the stack allocator
+  util::TempVectorStack stack_memallocator;
+  ASSERT_OK(
+      stack_memallocator.Init(compute::default_exec_context()->memory_pool(),
+                              3 * sizeof(int32_t) * util::MiniBatch::kMiniBatchLength));
+
+  // prepare the execution context for Hashing32
+  compute::LightContext hash_ctx;
+  hash_ctx.hardware_flags = compute::default_exec_context()->cpu_info()->hardware_flags();
+  hash_ctx.stack = &stack_memallocator;
+
+  // allocate memory for results
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<Buffer> hash_buffer,
+                       AllocateBuffer(test_vals->length() * sizeof(int64_t)));
+
+  // run the benchmark
+  while (state.KeepRunning()) {
+    // Prepare input data structure for propagation to hash function
+    ASSERT_OK_AND_ASSIGN(
+        compute::KeyColumnArray input_keycol,
+        compute::ColumnArrayFromArrayData(test_vals->data(), 0, test_vals->length()));
+
+    compute::Hashing64::HashMultiColumn(
+        {input_keycol}, &hash_ctx,
+        reinterpret_cast<uint64_t*>(hash_buffer->mutable_data()));
+
+    // benchmark::DoNotOptimize(hash_buffer);
+  }
+
+  state.SetBytesProcessed(state.iterations() * test_vals->length() * sizeof(int64_t));
+  state.SetItemsProcessed(state.iterations() * test_vals->length());
+}
+
 // ----------------------------------------------------------------------
 // Benchmark declarations
 
-BENCHMARK(HashIntegers);
+// Directly uses "Hashing" hash functions from hashing.h (xxHash)
+BENCHMARK(HashIntegers32);
+BENCHMARK(HashIntegers64);
 BENCHMARK(HashSmallStrings);
 BENCHMARK(HashMediumStrings);
 BENCHMARK(HashLargeStrings);
+
+// Directly uses "KeyHash" hash functions from key_hash.h (xxHash-like)
+BENCHMARK(KeyHashIntegers32);
+BENCHMARK(KeyHashIntegers64);
 
 }  // namespace internal
 }  // namespace arrow

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1200,6 +1200,26 @@ Containment tests
 * \(8) Output is true iff :member:`MatchSubstringOptions::pattern`
   matches the corresponding input element at any position.
 
+
+Hash Functions
+~~~~~~~~~~~~~~
+
+Not to be confused with the "group by" functions, Hash functions produce an array of hash
+values corresponding to the length of the input. Currently, these functions take a single
+array as input.
+
++-----------------------+-------+-----------------------------------+-------------+---------------+-------+
+| Function name         | Arity | Input types                       | Output type | Options class | Notes |
++=======================+=======+===================================+=============+===============+=======+
+| hash_64               | Unary | Any                               | UInt64      |               | \(1)  |
++-----------------------+-------+-----------------------------------+-------------+---------------+-------+
+
+* \(1) The hashing algorithm is "xxHash-like", making some minor trade-offs in favor of
+  performance. Arrays containing nested types are recursively walked and flattened; such
+  that each field or attribute (corresponding to the same row) are hashed and combined
+  into a single hash value.
+
+
 Categorizations
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR is a fresh continuation of https://github.com/apache/arrow/pull/13487 which was closed purely in favor of this one. The reason for this is that the other PR carried a lot of "development burden" in the form of a long commit history. This fresh version maintains the current state of the code in much fewer commits with a cleaner history. Hopefully this PR will allow others to finish what I started (if I don't finish this first).

The changes still required is to add functional mechanisms for the following:
* A TempVectorStack for local allocation within the kernel
   * This is necessary to allocate a modified structure of the input data to then be passed to the hashing functions
* Functional testing of a kernel that can handle a nested structure (e.g. a List[List[utf-8]]).

* Closes: #17211