### PR TITLE
GH-39859: [R] Remove macOS from the allow list

### DIFF
--- a/r/tools/nixlibs-allowlist.txt
+++ b/r/tools/nixlibs-allowlist.txt
@@ -2,4 +2,3 @@ ubuntu
 centos
 redhat
 rhel
-darwin

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -222,7 +222,7 @@ check_allowlist <- function(os, allowed = "https://raw.githubusercontent.com/apa
     # Try a remote allowlist so that we can add/remove without a release
     suppressWarnings(readLines(allowed)),
     # Fallback to default: allowed only on Ubuntu and CentOS/RHEL
-    error = function(e) c("ubuntu", "centos", "redhat", "rhel", "darwin")
+    error = function(e) c("ubuntu", "centos", "redhat", "rhel")
   )
   # allowlist should contain valid regular expressions (plain strings ok too)
   any(grepl(paste(allowlist, collapse = "|"), os))


### PR DESCRIPTION
Originally this was going to also bundle all of our dependencies to send to CRAN, but their webforms don't allow source tars that large (I tried down to 80MB which removed a large number of our dependencies, and that was still rejected by the macbuilder).

This means that on CRAN, if there is no internet, the macOS binary will be minimal. But it means that we build on CRAN using source always.

We should definitely submit this to macbuilder after this merges to main and confirm we get source build by default (since we look to the repo for our allowlist)
* Closes: #39859