### PR TITLE
GH-24834: [C#] Support writing compressed IPC data

### DIFF
--- a/csharp/README.md
+++ b/csharp/README.md
@@ -115,10 +115,10 @@ for currently available features.
 
 ### Compression
 
-- Buffer compression is not supported when writing IPC files or streams
-- Buffer decompression is supported, but requires installing the `Apache.Arrow.Compression` package,
-  and passing an `Apache.Arrow.Compression.CompressionCodecFactory` instance to the
-  `ArrowFileReader` or `ArrowStreamReader` constructor.
+- Buffer compression and decompression is supported, but requires installing the `Apache.Arrow.Compression` package.
+  When reading compressed data, you must pass an `Apache.Arrow.Compression.CompressionCodecFactory` instance to the
+  `ArrowFileReader` or `ArrowStreamReader` constructor, and when writing compressed data a
+  `CompressionCodecFactory` must be set in the `IpcOptions`.
   Alternatively, a custom implementation of `ICompressionCodecFactory` can be used.
 
 ## Not Implemented

--- a/csharp/src/Apache.Arrow.Compression/CompressionCodecFactory.cs
+++ b/csharp/src/Apache.Arrow.Compression/CompressionCodecFactory.cs
@@ -25,10 +25,15 @@ namespace Apache.Arrow.Compression
     {
         public ICompressionCodec CreateCodec(CompressionCodecType compressionCodecType)
         {
+            return CreateCodec(compressionCodecType, null);
+        }
+
+        public ICompressionCodec CreateCodec(CompressionCodecType compressionCodecType, int? compressionLevel)
+        {
             return compressionCodecType switch
             {
-                CompressionCodecType.Lz4Frame => Lz4CompressionCodec.Instance,
-                CompressionCodecType.Zstd => new ZstdCompressionCodec(),
+                CompressionCodecType.Lz4Frame => new Lz4CompressionCodec(compressionLevel),
+                CompressionCodecType.Zstd => new ZstdCompressionCodec(compressionLevel),
                 _ => throw new NotImplementedException($"Compression type {compressionCodecType} is not supported")
             };
         }

--- a/csharp/src/Apache.Arrow.Compression/Lz4CompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/Lz4CompressionCodec.cs
@@ -14,22 +14,46 @@
 // limitations under the License.
 
 using System;
+using System.IO;
 using Apache.Arrow.Ipc;
+using K4os.Compression.LZ4;
 using K4os.Compression.LZ4.Streams;
 
 namespace Apache.Arrow.Compression
 {
     internal sealed class Lz4CompressionCodec : ICompressionCodec
     {
-        /// <summary>
-        /// Singleton instance, used as this class doesn't need to be disposed and has no state
-        /// </summary>
-        public static readonly Lz4CompressionCodec Instance = new Lz4CompressionCodec();
+        private readonly LZ4EncoderSettings _settings = null;
+
+        public Lz4CompressionCodec(int? compressionLevel = null)
+        {
+            if (compressionLevel.HasValue)
+            {
+                if (Enum.IsDefined(typeof(LZ4Level), compressionLevel))
+                {
+                    _settings = new LZ4EncoderSettings
+                    {
+                        CompressionLevel = (LZ4Level) compressionLevel,
+                    };
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"Invalid LZ4 compression level ({compressionLevel})", nameof(compressionLevel));
+                }
+            }
+        }
 
         public int Decompress(ReadOnlyMemory<byte> source, Memory<byte> destination)
         {
             using var decoder = LZ4Frame.Decode(source);
             return decoder.ReadManyBytes(destination.Span);
+        }
+
+        public void Compress(ReadOnlyMemory<byte> source, Stream destination)
+        {
+            using var encoder = LZ4Frame.Encode(destination, _settings, leaveOpen: true);
+            encoder.WriteManyBytes(source.Span);
         }
 
         public void Dispose()

--- a/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
@@ -23,19 +23,21 @@ namespace Apache.Arrow.Compression
     internal sealed class ZstdCompressionCodec : ICompressionCodec
     {
         private readonly Decompressor _decompressor;
-        private readonly int _compressionLevel;
+        private readonly Compressor _compressor;
 
         public ZstdCompressionCodec(int? compressionLevel = null)
         {
-            _decompressor = new Decompressor();
-            _compressionLevel = compressionLevel ?? Compressor.DefaultCompressionLevel;
-            if (_compressionLevel < Compressor.MinCompressionLevel ||
-                _compressionLevel > Compressor.MaxCompressionLevel)
+            if (compressionLevel.HasValue &&
+                (compressionLevel.Value < Compressor.MinCompressionLevel ||
+                 compressionLevel.Value > Compressor.MaxCompressionLevel))
             {
                 throw new ArgumentException(
                     $"Zstd compression level must be between {Compressor.MinCompressionLevel} and {Compressor.MaxCompressionLevel}",
                     nameof(compressionLevel));
             }
+
+            _decompressor = new Decompressor();
+            _compressor = new Compressor(compressionLevel ?? Compressor.DefaultCompressionLevel);
         }
 
         public int Decompress(ReadOnlyMemory<byte> source, Memory<byte> destination)
@@ -45,13 +47,15 @@ namespace Apache.Arrow.Compression
 
         public void Compress(ReadOnlyMemory<byte> source, Stream destination)
         {
-            using var compressor = new CompressionStream(destination, level: _compressionLevel, leaveOpen: true);
+            using var compressor = new CompressionStream(
+                destination, _compressor, preserveCompressor: true, leaveOpen: true);
             compressor.Write(source.Span);
         }
 
         public void Dispose()
         {
             _decompressor.Dispose();
+            _compressor.Dispose();
         }
     }
 }

--- a/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
@@ -29,6 +29,13 @@ namespace Apache.Arrow.Compression
         {
             _decompressor = new Decompressor();
             _compressionLevel = compressionLevel ?? Compressor.DefaultCompressionLevel;
+            if (_compressionLevel < Compressor.MinCompressionLevel ||
+                _compressionLevel > Compressor.MaxCompressionLevel)
+            {
+                throw new ArgumentException(
+                    $"Zstd compression level must be between {Compressor.MinCompressionLevel} and {Compressor.MaxCompressionLevel}",
+                    nameof(compressionLevel));
+            }
         }
 
         public int Decompress(ReadOnlyMemory<byte> source, Memory<byte> destination)

--- a/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.IO;
 using Apache.Arrow.Ipc;
 using ZstdSharp;
 
@@ -22,15 +23,23 @@ namespace Apache.Arrow.Compression
     internal sealed class ZstdCompressionCodec : ICompressionCodec
     {
         private readonly Decompressor _decompressor;
+        private readonly int _compressionLevel;
 
-        public ZstdCompressionCodec()
+        public ZstdCompressionCodec(int? compressionLevel = null)
         {
             _decompressor = new Decompressor();
+            _compressionLevel = compressionLevel ?? Compressor.DefaultCompressionLevel;
         }
 
         public int Decompress(ReadOnlyMemory<byte> source, Memory<byte> destination)
         {
             return _decompressor.Unwrap(source.Span, destination.Span);
+        }
+
+        public void Compress(ReadOnlyMemory<byte> source, Stream destination)
+        {
+            using var compressor = new CompressionStream(destination, level: _compressionLevel, leaveOpen: true);
+            compressor.Write(source.Span);
         }
 
         public void Dispose()

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Apache.Arrow.Memory;
 
 namespace Apache.Arrow.Ipc
 {
@@ -37,12 +38,17 @@ namespace Apache.Arrow.Ipc
         }
 
         public ArrowFileWriter(Stream stream, Schema schema, bool leaveOpen)
-            : this(stream, schema, leaveOpen, options: null)
+            : this(stream, schema, leaveOpen, options: null, allocator: null)
         {
         }
 
         public ArrowFileWriter(Stream stream, Schema schema, bool leaveOpen, IpcOptions options)
-            : base(stream, schema, leaveOpen, options)
+            : this(stream, schema, leaveOpen, options, allocator: null)
+        {
+        }
+
+        public ArrowFileWriter(Stream stream, Schema schema, bool leaveOpen, IpcOptions options, MemoryAllocator allocator)
+            : base(stream, schema, leaveOpen, options, allocator)
         {
             if (!stream.CanWrite)
             {

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -355,7 +355,7 @@ namespace Apache.Arrow.Ipc
             if (_options.CompressionCodec.HasValue && _options.CompressionCodecFactory == null)
             {
                 throw new ArgumentException(
-                    "A CompressionCodecFactory must be provided when a CompressionCodec is specified",
+                    $"A {nameof(_options.CompressionCodecFactory)} must be provided when a {nameof(_options.CompressionCodec)} is specified",
                     nameof(options));
             }
         }

--- a/csharp/src/Apache.Arrow/Ipc/ICompressionCodec.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ICompressionCodec.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System;
+using System.IO;
 
 namespace Apache.Arrow.Ipc
 {
@@ -29,5 +30,19 @@ namespace Apache.Arrow.Ipc
         /// <param name="destination">Data buffer to write decompressed data to</param>
         /// <returns>The number of decompressed bytes written into the destination</returns>
         int Decompress(ReadOnlyMemory<byte> source, Memory<byte> destination);
+
+        /// <summary>
+        /// Write compressed data
+        /// </summary>
+        /// <param name="source">The data to compress</param>
+        /// <param name="destination">The stream to write compressed data to</param>
+        void Compress(ReadOnlyMemory<byte> source, Stream destination)
+#if NET6_0_OR_GREATER
+        {
+            throw new NotImplementedException("This codec does not support compression");
+        }
+#else
+        ;
+#endif
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ICompressionCodecFactory.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ICompressionCodecFactory.cs
@@ -20,6 +20,27 @@ namespace Apache.Arrow.Ipc
     /// </summary>
     public interface ICompressionCodecFactory
     {
+        /// <summary>
+        /// Create a new compression codec
+        /// </summary>
+        /// <param name="compressionCodecType">The type of codec to create</param>
+        /// <returns>The created codec</returns>
         ICompressionCodec CreateCodec(CompressionCodecType compressionCodecType);
+
+        /// <summary>
+        /// Create a new compression codec with a specified compression level
+        /// </summary>
+        /// <param name="compressionCodecType">The type of codec to create</param>
+        /// <param name="compressionLevel">The compression level to use when compressing data</param>
+        /// <returns>The created codec</returns>
+        ICompressionCodec CreateCodec(CompressionCodecType compressionCodecType, int? compressionLevel)
+#if NET6_0_OR_GREATER
+        {
+            // Default implementation ignores the compression level
+            return CreateCodec(compressionCodecType);
+        }
+#else
+        ;
+#endif
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
+++ b/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
@@ -25,6 +25,23 @@ namespace Apache.Arrow.Ipc
         /// </summary>
         public bool WriteLegacyIpcFormat { get; set; }
 
+        /// <summary>
+        /// The compression codec to use to compress data buffers.
+        /// If null (the default value), no compression is used.
+        /// </summary>
+        public CompressionCodecType? CompressionCodec { get; set; }
+
+        /// <summary>
+        /// The compression codec factory used to create compression codecs.
+        /// Must be provided if a CompressionCodec is specified.
+        /// </summary>
+        public ICompressionCodecFactory CompressionCodecFactory { get; set; }
+
+        /// <summary>
+        /// Sets the compression level to use for codecs that support this.
+        /// </summary>
+        public int? CompressionLevel { get; set; }
+
         public IpcOptions()
         {
         }

--- a/csharp/test/Apache.Arrow.Compression.Tests/Apache.Arrow.Compression.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Compression.Tests/Apache.Arrow.Compression.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Apache.Arrow\Apache.Arrow.csproj" />
     <ProjectReference Include="..\..\src\Apache.Arrow.Compression\Apache.Arrow.Compression.csproj" />
+    <ProjectReference Include="..\Apache.Arrow.Tests\Apache.Arrow.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Compression.Tests/ArrowFileWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Compression.Tests/ArrowFileWriterTests.cs
@@ -15,9 +15,9 @@
 
 using System;
 using System.Collections.Generic;
-using Apache.Arrow.Ipc;
 using System.IO;
 using System.Threading.Tasks;
+using Apache.Arrow.Ipc;
 using Apache.Arrow.Tests;
 using K4os.Compression.LZ4;
 using Xunit;

--- a/csharp/test/Apache.Arrow.Compression.Tests/ArrowStreamWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Compression.Tests/ArrowStreamWriterTests.cs
@@ -15,9 +15,9 @@
 
 using System;
 using System.Collections.Generic;
-using Apache.Arrow.Ipc;
 using System.IO;
 using System.Threading.Tasks;
+using Apache.Arrow.Ipc;
 using Apache.Arrow.Tests;
 using K4os.Compression.LZ4;
 using Xunit;

--- a/csharp/test/Apache.Arrow.Compression.Tests/ArrowStreamWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Compression.Tests/ArrowStreamWriterTests.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Apache.Arrow.Ipc;
+using System.IO;
+using Apache.Arrow.Tests;
+using Xunit;
+
+namespace Apache.Arrow.Compression.Tests
+{
+    public class ArrowStreamWriterTests
+    {
+        [Theory]
+        [InlineData(CompressionCodecType.Zstd)]
+        [InlineData(CompressionCodecType.Lz4Frame)]
+        public void CanWriteCompressedIpcStream(CompressionCodecType codec)
+        {
+            var batch = TestData.CreateSampleRecordBatch(length: 100);
+            var codecFactory = new CompressionCodecFactory();
+            var options = new IpcOptions
+            {
+                CompressionCodecFactory = codecFactory,
+                CompressionCodec = codec,
+            };
+            TestRoundTripRecordBatches(new [] {batch}, options, codecFactory);
+        }
+
+        private static void TestRoundTripRecordBatches(
+            IReadOnlyList<RecordBatch> originalBatches, IpcOptions options, ICompressionCodecFactory codecFactory)
+        {
+            using var stream = new MemoryStream();
+
+            using (var writer = new ArrowStreamWriter(stream, originalBatches[0].Schema, leaveOpen: true, options))
+            {
+                foreach (var originalBatch in originalBatches)
+                {
+                    writer.WriteRecordBatch(originalBatch);
+                }
+                writer.WriteEnd();
+            }
+
+            // Should throw if trying to read without an ICompressionCodecFactory
+            stream.Position = 0;
+            var exception = Assert.Throws<Exception>(() =>
+            {
+                using var reader = new ArrowStreamReader(stream, leaveOpen: true);
+                reader.ReadNextRecordBatch();
+            });
+            Assert.Contains(nameof(ICompressionCodecFactory), exception.Message);
+
+            stream.Position = 0;
+            using (var reader = new ArrowStreamReader(stream, codecFactory))
+            {
+                foreach (var originalBatch in originalBatches)
+                {
+                    var newBatch = reader.ReadNextRecordBatch();
+                    ArrowReaderVerifier.CompareBatches(originalBatch, newBatch);
+                }
+            }
+        }
+    }
+}
+

--- a/csharp/test/Apache.Arrow.IntegrationTest/Apache.Arrow.IntegrationTest.csproj
+++ b/csharp/test/Apache.Arrow.IntegrationTest/Apache.Arrow.IntegrationTest.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <ProjectReference Include="..\..\src\Apache.Arrow.Compression\Apache.Arrow.Compression.csproj" />
     <ProjectReference Include="..\..\src\Apache.Arrow\Apache.Arrow.csproj" />
     <ProjectReference Include="..\Apache.Arrow.Tests\Apache.Arrow.Tests.csproj" />
   </ItemGroup>

--- a/csharp/test/Apache.Arrow.IntegrationTest/IntegrationCommand.cs
+++ b/csharp/test/Apache.Arrow.IntegrationTest/IntegrationCommand.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Apache.Arrow.Compression;
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Tests;
 using Apache.Arrow.Types;
@@ -65,8 +66,9 @@ namespace Apache.Arrow.IntegrationTest
         {
             JsonFile jsonFile = await ParseJsonFile();
 
+            var compressionFactory = new CompressionCodecFactory();
             using FileStream arrowFileStream = ArrowFileInfo.OpenRead();
-            using ArrowFileReader reader = new ArrowFileReader(arrowFileStream);
+            using ArrowFileReader reader = new ArrowFileReader(arrowFileStream, compressionCodecFactory: compressionFactory);
             int batchCount = await reader.RecordBatchCountAsync();
 
             if (batchCount != jsonFile.Batches.Count)
@@ -122,7 +124,8 @@ namespace Apache.Arrow.IntegrationTest
 
         private async Task<int> StreamToFile()
         {
-            using ArrowStreamReader reader = new ArrowStreamReader(Console.OpenStandardInput());
+            var compressionFactory = new CompressionCodecFactory();
+            using ArrowStreamReader reader = new ArrowStreamReader(Console.OpenStandardInput(), compressionCodecFactory: compressionFactory);
 
             RecordBatch batch = await reader.ReadNextRecordBatchAsync();
 
@@ -145,7 +148,8 @@ namespace Apache.Arrow.IntegrationTest
         private async Task<int> FileToStream()
         {
             using FileStream fileStream = ArrowFileInfo.OpenRead();
-            using ArrowFileReader fileReader = new ArrowFileReader(fileStream);
+            var compressionFactory = new CompressionCodecFactory();
+            using ArrowFileReader fileReader = new ArrowFileReader(fileStream, compressionCodecFactory: compressionFactory);
 
             // read the record batch count to initialize the Schema
             await fileReader.RecordBatchCountAsync();

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -158,7 +158,6 @@ class IntegrationRunner(object):
                 skip_testers.add("JS")
                 skip_testers.add("Rust")
             if prefix == '2.0.0-compression':
-                skip_testers.add("C#")
                 skip_testers.add("JS")
 
             # See https://github.com/apache/arrow/pull/9822 for how to

--- a/docs/source/status.rst
+++ b/docs/source/status.rst
@@ -145,7 +145,7 @@ IPC Format
 +-----------------------------+-------+-------+-------+------------+-------+-------+-------+-------+
 | Sparse tensors              | ✓     |       |       |            |       |       |       |       |
 +-----------------------------+-------+-------+-------+------------+-------+-------+-------+-------+
-| Buffer compression          | ✓     | ✓ (3) | ✓     |            | ✓ (4) |  ✓    | ✓     |       |
+| Buffer compression          | ✓     | ✓ (3) | ✓     |            | ✓     |  ✓    | ✓     |       |
 +-----------------------------+-------+-------+-------+------------+-------+-------+-------+-------+
 | Endianness conversion       | ✓ (2) |       | ✓ (2) |            |       |       |       |       |
 +-----------------------------+-------+-------+-------+------------+-------+-------+-------+-------+
@@ -159,8 +159,6 @@ Notes:
 * \(2) Data with non-native endianness can be byte-swapped automatically when reading.
 
 * \(3) LZ4 Codec currently is quite inefficient. ARROW-11901 tracks improving performance.
-
-* \(4) Compression when writing is not supported, only decompression when reading.
 
 .. seealso::
    The :ref:`format-ipc` specification.


### PR DESCRIPTION
### Rationale for this change

This allows using compression when writing IPC streams and files with the Arrow .NET library

### What changes are included in this PR?

* Adds a compress method to the `ICompressionCodec` interface and implements this for Zstd and LZ4Frame in the `Apache.Arrow.Compression` package
* Adds new compression related options to `IpcOptions`
* Implements buffer compression in `ArrowStreamWriter`

### Are these changes tested?

Yes, new unit tests have been added

### Are there any user-facing changes?

Yes, this is a new user-facing feature and the `status.rst` and `csharp/README` files have been updated

* Closes: #24834