### PR TITLE
GH-39880: [Python][CI] Pin moto<5 for dask integration tests

### DIFF
--- a/ci/scripts/install_dask.sh
+++ b/ci/scripts/install_dask.sh
@@ -35,4 +35,5 @@ else
 fi
 
 # additional dependencies needed for dask's s3 tests
+# Moto 5 results in timeouts in s3 tests: https://github.com/dask/dask/issues/10869
 pip install "moto[server]<5" flask requests

--- a/ci/scripts/install_dask.sh
+++ b/ci/scripts/install_dask.sh
@@ -35,4 +35,4 @@ else
 fi
 
 # additional dependencies needed for dask's s3 tests
-pip install moto[server] flask requests
+pip install "moto[server]<5" flask requests


### PR DESCRIPTION
See upstream pin being added (https://github.com/dask/dask/pull/10868 / https://github.com/dask/dask/issues/10869), we are seeing the same failures
* Closes: #39880