### PR TITLE
GH-39874: [CI][C++][Windows] Use pre-installed OpenSSL

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -284,10 +284,6 @@ jobs:
             /t REG_DWORD `
             /d 1 `
             /f
-      - name: Installed Packages
-        run: choco list
-      - name: Install Dependencies
-        run: choco install -y --no-progress openssl
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Rationale for this change

It seems that we can't use OpenSSL via Chocolatey.

```text
openssl v3.2.0 [Approved]
openssl package files install completed. Performing other installation steps.
Attempt to get headers for https://slproweb.com/download/Win64OpenSSL-3_2_0.exe failed.
  The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://slproweb.com/download/Win64OpenSSL-3_2_0.exe'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found."
Downloading openssl 64 bit
  from 'https://slproweb.com/download/Win64OpenSSL-3_2_0.exe'
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://slproweb.com/download/Win64OpenSSL-3_2_0.exe'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found." 
This package is likely not broken for licensed users - see https://docs.chocolatey.org/en-us/features/private-cdn.
The install of openssl was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\openssl\tools\chocolateyinstall.ps1'.
 See log for details.
```

### What changes are included in this PR?

Use pre-installed OpenSSL on self-hosted GitHub runner instead.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39874