### PR TITLE
MINOR: [C++][Parquet] Remove undefined GetArrowType from schema_internal.h

### DIFF
--- a/cpp/src/parquet/arrow/schema_internal.h
+++ b/cpp/src/parquet/arrow/schema_internal.h
@@ -34,10 +34,6 @@ Result<std::shared_ptr<::arrow::DataType>> FromFLBA(const LogicalType& logical_t
 Result<std::shared_ptr<::arrow::DataType>> FromInt32(const LogicalType& logical_type);
 Result<std::shared_ptr<::arrow::DataType>> FromInt64(const LogicalType& logical_type);
 
-Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type,
-                                                        const LogicalType& logical_type,
-                                                        int type_length);
-
 Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
     Type::type physical_type, const LogicalType& logical_type, int type_length,
     ::arrow::TimeUnit::type int96_arrow_time_unit = ::arrow::TimeUnit::NANO);


### PR DESCRIPTION
### Rationale for this change

We have redundant declarations below and the 1st one should be removed:
```cpp
Result<std::shared_ptr<::arrow::DataType>> GetArrowType(Type::type physical_type,
                                                        const LogicalType& logical_type,
                                                        int type_length);

Result<std::shared_ptr<::arrow::DataType>> GetArrowType(
    Type::type physical_type, const LogicalType& logical_type, int type_length,
    ::arrow::TimeUnit::type int96_arrow_time_unit = ::arrow::TimeUnit::NANO);
```

### What changes are included in this PR?

Remove the redundant function declaration described above.

### Are these changes tested?

Make sure build and test pass.

### Are there any user-facing changes?

No.