### PR TITLE
GH-39943: [CI][Python] Update manylinux images to avoid GPG problems downloading packages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1030,7 +1030,7 @@ services:
       args:
         arch: ${ARCH}
         arch_short: ${ARCH_SHORT}
-        base: quay.io/pypa/manylinux2014_${ARCH_ALIAS}:2023-10-03-72cdc42
+        base: quay.io/pypa/manylinux2014_${ARCH_ALIAS}:2024-02-04-ea37246
         vcpkg: ${VCPKG}
         python: ${PYTHON}
         manylinux: 2014
@@ -1053,7 +1053,7 @@ services:
       args:
         arch: ${ARCH}
         arch_short: ${ARCH_SHORT}
-        base: quay.io/pypa/manylinux_2_28_${ARCH_ALIAS}:2023-10-03-72cdc42
+        base: quay.io/pypa/manylinux_2_28_${ARCH_ALIAS}:2024-02-04-ea37246
         vcpkg: ${VCPKG}
         python: ${PYTHON}
         manylinux: 2_28


### PR DESCRIPTION
### Rationale for this change

Old manylinux images seem to have issues with a GPG key in order to download packages.

### What changes are included in this PR?

Update the manylinux image used for the latest one.

### Are these changes tested?

Via archery jobs

### Are there any user-facing changes?

No
* Closes: #39943