### PR TITLE
GH-38936: [JS] Add bundle test for toNodeStream failures

### DIFF
--- a/js/test/bundle/toNodeStream.js
+++ b/js/test/bundle/toNodeStream.js
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { RecordBatchStreamWriter } from 'apache-arrow';
+
+const stream = new RecordBatchStreamWriter().toNodeStream();
+
+console.log(stream);


### PR DESCRIPTION
As requested [here](https://github.com/apache/arrow-js/issues/73), this adds a failing test for using `RecordBatchStreamWriter#toNodeStream` in bundled environments. This test is not expected to run green until a fix is landed for the issue (I think apache/arrow#39714 is the working fix, but there was also a draft at apache/arrow#39472).
* Closes: apache/arrow-js#73
* GitHub Issue: #73