### PR TITLE
GH-39933: [R] Fix pointer conversion to Python for latest reticulate

### DIFF
--- a/r/R/python.R
+++ b/r/R/python.R
@@ -339,15 +339,9 @@ install_pyarrow <- function(envname = NULL, nightly = FALSE, ...) {
 }
 
 pyarrow_compatible_pointer <- function(ptr) {
-  pa <- reticulate::import("pyarrow")
-  version_string <- pa$`__version__`
-  # remove trailing .devXXX because it won't work with package_version()
-  pyarrow_version <- package_version(gsub("\\.dev.*?$", "", version_string))
-
-  # pyarrow pointers changed in version 7.0.0
-  if (pyarrow_version >= "7.0.0") {
-    return(ptr)
-  } else {
-    return(external_pointer_addr_double(ptr))
-  }
+  # Workaround because there is no built-in way to send a 64-bit integer
+  # to Python from an R object
+  py <- reticulate::import_builtins(convert = FALSE)
+  addr <- external_pointer_addr_character(ptr)
+  py$int(addr)
 }

--- a/r/R/python.R
+++ b/r/R/python.R
@@ -339,8 +339,8 @@ install_pyarrow <- function(envname = NULL, nightly = FALSE, ...) {
 }
 
 pyarrow_compatible_pointer <- function(ptr) {
-  # Workaround because there is no built-in way to send a 64-bit integer
-  # to Python from an R object
+  # GH-39933: Workaround because there is no built-in way to send a
+  # 64-bit integer to Python from an R object
   py <- reticulate::import_builtins(convert = FALSE)
   addr <- external_pointer_addr_character(ptr)
   py$int(addr)


### PR DESCRIPTION

### Rationale for this change

The integration tests and documentation build is failing

### What changes are included in this PR?

Instead of relying on how reticulate converts an R external pointer, use a Python integer instead. We can't use an R integer (because they're only 32 bits); we can't use an R double (because the static cast to/from uintptr_t is a bit iffy); however, we can use Python to convert a string to Python integer. This is probably how I should have written it the first time but it didn't occur to me at the time.

### Are these changes tested?

Yes, covered by existing tests.

### Are there any user-facing changes?

No
* Closes: #39933