### PR TITLE
MINOR: [Documentation] Fix LargeListView format string in example

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -251,7 +251,7 @@ Examples
   array has format string ``d:12,5``.
 * A ``list<uint64>`` array has format string ``+l``, and its single child
   has format string ``L``.
-* A ``large_list_view<uint64>`` array has format string ``+Lv``, and its single
+* A ``large_list_view<uint64>`` array has format string ``+vL``, and its single
   child has format string ``L``.
 * A ``struct<ints: int32, floats: float32>`` has format string ``+s``; its two
   children have names ``ints`` and ``floats``, and format strings ``i`` and


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/38899 fixed the format string for LargeListView in the table but left the incorrect format string in the example below. This fixes that.

### What changes are included in this PR?

Documentation change

### Are these changes tested?

N/A