### PR TITLE
GH-39942: [Python] Make capsule name check more lenient

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -124,7 +124,7 @@ cdef void* _as_c_pointer(v, allow_null=False) except *:
         c_ptr = <void*> <uintptr_t > v
     elif PyCapsule_CheckExact(v):
         capsule_name = PyCapsule_GetName(v)
-        if capsule_name == NULL or strcmp(capsule_name, "r_extptr") == 0:
+        if capsule_name == NULL or capsule_name == "r_extptr":
             c_ptr = PyCapsule_GetPointer(v, capsule_name)
         else:
             capsule_name_str = capsule_name.decode("UTF-8")

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -124,7 +124,7 @@ cdef void* _as_c_pointer(v, allow_null=False) except *:
         c_ptr = <void*> <uintptr_t > v
     elif PyCapsule_CheckExact(v):
         capsule_name = PyCapsule_GetName(v)
-        if capsule_name == NULL or strcmp(capsule_name, "r_extptr") != 0:
+        if capsule_name == NULL or strcmp(capsule_name, "r_extptr") == 0:
             c_ptr = PyCapsule_GetPointer(v, capsule_name)
         else:
             capsule_name_str = capsule_name.decode("UTF-8")

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -127,7 +127,7 @@ cdef void* _as_c_pointer(v, allow_null=False) except *:
         if capsule_name == NULL or capsule_name == "r_extptr":
             c_ptr = PyCapsule_GetPointer(v, capsule_name)
         else:
-            capsule_name_str = capsule_name.decode("UTF-8")
+            capsule_name_str = capsule_name.decode()
             raise ValueError(
                 f"Can't convert PyCapsule with name '{capsule_name_str}' to pointer address"
             )

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -125,7 +125,7 @@ cdef void* _as_c_pointer(v, allow_null=False) except *:
     elif PyCapsule_CheckExact(v):
         capsule_name = PyCapsule_GetName(v)
         if capsule_name == NULL or strcmp(capsule_name, "r_extptr") != 0:
-            c_ptr = PyCapsule_GetPointer(v, NULL)
+            c_ptr = PyCapsule_GetPointer(v, capsule_name)
         else:
             capsule_name_str = capsule_name.decode("UTF-8")
             raise ValueError(

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -121,8 +121,8 @@ cdef void* _as_c_pointer(v, allow_null=False) except *:
             "Arrow library", UserWarning, stacklevel=2)
         c_ptr = <void*> <uintptr_t > v
     elif PyCapsule_CheckExact(v):
-        # An R external pointer was how the R passed pointer values to Python
-        # from versions 7 to 15 (inclusive); however, the reticulate 1.35.0
+        # An R external pointer was how the R bindings passed pointer values to
+        # Python from versions 7 to 15 (inclusive); however, the reticulate 1.35.0
         # update changed the name of the capsule from NULL to "r_extptr".
         # Newer versions of the R package pass a Python integer; however, this
         # workaround ensures that old versions of the R package continue to work


### PR DESCRIPTION
### Rationale for this change

While #39969 fixed the immediate issue caused by the update of the capsule name used by reticulate whilst converting an R "external pointer", it will still result in an error if somebody is using an older version of the Arrow R package.

### What changes are included in this PR?

The pyarrow Cython code was modified to accept capsules with the name NULL or "r_extptr".

### Are these changes tested?

Not sure where the best place for this is, but:

CRAN arrow + released pyarrow + new reticulate (errors):

``` r
library(arrow, warn.conflicts = FALSE)
reticulate::use_virtualenv("~/Desktop/rscratch/arrow/.venv")
packageVersion("arrow")
#> [1] '14.0.0.2'
packageVersion("reticulate")
#> [1] '1.35.0'
pa <- reticulate::import("pyarrow")
pa[["__version__"]]
#> [1] "15.0.0"

reticulate::r_to_py(arrow::int32())
#> PyCapsule_GetPointer called with incorrect name
```

CRAN arrow + pyarrow from this PR + old reticulate:

``` r
library(arrow, warn.conflicts = FALSE)
reticulate::use_virtualenv("~/Desktop/rscratch/arrow/.venv")
packageVersion("arrow")
#> [1] '14.0.0.2'
packageVersion("reticulate")
#> [1] '1.34.0'
pa <- reticulate::import("pyarrow")
pa[["__version__"]]
#> [1] "16.0.0.dev92+geafcff7a5"

reticulate::r_to_py(arrow::int32())
#> DataType(int32)
```

CRAN arrow + pyarrow from this PR + new reticulate:

``` r
library(arrow, warn.conflicts = FALSE)
reticulate::use_virtualenv("~/Desktop/rscratch/arrow/.venv")
packageVersion("arrow")
#> [1] '14.0.0.2'
packageVersion("reticulate")
#> [1] '1.35.0'
pa <- reticulate::import("pyarrow")
pa[["__version__"]]
#> [1] "16.0.0.dev92+geafcff7a5"

reticulate::r_to_py(arrow::int32())
#> DataType(int32)
```

### Are there any user-facing changes?

No
* Closes: #39942