### PR TITLE
GH-39992: [CI][Docs][Java] ubuntu-docs uses Maven version in .env

### DIFF
--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update -y && \
 
 ENV JAVA_HOME=/usr/lib/jvm/java-${jdk}-openjdk-amd64
 
-ARG maven=3.5.4
+ARG maven=3.6.3
 COPY ci/scripts/util_download_apache.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/util_download_apache.sh \
     "maven/maven-3/${maven}/binaries/apache-maven-${maven}-bin.tar.gz" /opt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1740,6 +1740,7 @@ services:
       args:
         r: ${R}
         jdk: ${JDK}
+        maven: ${MAVEN}
         node: ${NODE}
         base: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-python-3
     environment:


### PR DESCRIPTION
### Rationale for this change

GH-39696 updated Maven version but `ubuntu-docs` haven't used it yet.

### What changes are included in this PR?

Use `MAVEN` in `.env` in `ubuntu-docs`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #39992