### PR TITLE
GH-39996: [Archery] Fix Crossbow build on a PR from a fork's main branch

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -51,7 +51,7 @@ jobs:
           ARROW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
         run: |
-          archery trigger-bot \
+          archery --debug trigger-bot \
             --event-name ${{ github.event_name }} \
             --event-payload ${{ github.event_path }}
 


### PR DESCRIPTION
Instead of doing an intermediate bare clone, just fix the locally created branch name when fetching.

Amended from PR #39997, which wasn't sufficient (the `git fetch` that works for me doesn't seem to work on GHA).

* Closes: #39996