### PR TITLE
MINOR: [Docs] Tweak language in basic_arrow.rst

### DIFF
--- a/docs/source/cpp/tutorials/basic_arrow.rst
+++ b/docs/source/cpp/tutorials/basic_arrow.rst
@@ -197,7 +197,7 @@ Making a ChunkedArray
 
 Let’s say that we want an array made up of sub-arrays, because it
 can be useful for avoiding data copies when concatenating, for parallelizing work, for fitting each chunk
-cutely into cache, or for exceeding the 2,147,483,647 row limit in a
+into cache, or for exceeding the 2,147,483,647 row limit in a
 standard Arrow :class:`Array`. For this, Arrow offers :class:`ChunkedArray`, which can be
 made up of individual Arrow :class:`Arrays <Array>`. In this example, we can reuse the arrays
 we made earlier in part of our chunked array, allowing us to extend them without having to copy


### PR DESCRIPTION
### Rationale for this change

I came across this use of the word "cutely" and thought it might trip people up. I think the author was trying to make a point about CPU cache-friendliness and I don't think cutely is a common enough way to talk about CPU caches to be used here.

### What changes are included in this PR?

It might be more specific to say that it's the data that's in buffers of the chunks that is either in the CPU cache or not but I think the simpler language I went with matches the high-level nature of this document.

### Are these changes tested?

No

### Are there any user-facing changes?

Yes, just to docs.