### PR TITLE
GH-40011: [CI] Update Fedora to 39 from 38

### DIFF
--- a/.env
+++ b/.env
@@ -49,7 +49,7 @@ ULIMIT_CORE=-1
 ALMALINUX=8
 ALPINE_LINUX=3.16
 DEBIAN=11
-FEDORA=38
+FEDORA=39
 UBUNTU=20.04
 
 # Default versions for various dependencies

--- a/ci/docker/fedora-39-cpp.dockerfile
+++ b/ci/docker/fedora-39-cpp.dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG arch
-FROM ${arch}/fedora:38
+FROM ${arch}/fedora:39
 ARG arch
 
 # install dependencies

--- a/ci/docker/fedora-39-cpp.dockerfile
+++ b/ci/docker/fedora-39-cpp.dockerfile
@@ -76,6 +76,8 @@ RUN /arrow/ci/scripts/install_gcs_testbench.sh default
 COPY ci/scripts/install_sccache.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin
 
+# PYARROW_TEST_GANDIVA=OFF: GH-39695: We need to make LLVM symbols visible in
+# Python process explicitly if we use LLVM 17 or later.
 ENV absl_SOURCE=BUNDLED \
     ARROW_ACERO=ON \
     ARROW_BUILD_TESTS=ON \
@@ -103,4 +105,5 @@ ENV absl_SOURCE=BUNDLED \
     google_cloud_cpp_storage_SOURCE=BUNDLED \
     PARQUET_BUILD_EXAMPLES=ON \
     PARQUET_BUILD_EXECUTABLES=ON \
-    PATH=/usr/lib/ccache/:$PATH
+    PATH=/usr/lib/ccache/:$PATH \
+    PYARROW_TEST_GANDIVA=OFF

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1104,12 +1104,12 @@ tasks:
       image: debian-cpp
 {% endfor %}
 
-  test-fedora-38-cpp:
+  test-fedora-39-cpp:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        FEDORA: 38
+        FEDORA: 39
       image: fedora-cpp
 
 {% for cpp_standard in [20] %}
@@ -1217,12 +1217,12 @@ tasks:
         UBUNTU: 22.04
       image: ubuntu-python
 
-  test-fedora-38-python-3:
+  test-fedora-39-python-3:
     ci: azure
     template: docker-tests/azure.linux.yml
     params:
       env:
-        FEDORA: 38
+        FEDORA: 39
       image: fedora-python
 
   test-r-linux-valgrind:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -658,7 +658,7 @@ services:
     #   docker-compose run --rm fedora-cpp
     # Parameters:
     #   ARCH: amd64, arm64v8, ...
-    #   FEDORA: 38
+    #   FEDORA: 39
     image: ${REPO}:${ARCH}-fedora-${FEDORA}-cpp
     build:
       context: .
@@ -959,7 +959,7 @@ services:
     #   docker-compose run --rm fedora-python
     # Parameters:
     #   ARCH: amd64, arm64v8, ...
-    #   FEDORA: 38
+    #   FEDORA: 39
     image: ${REPO}:${ARCH}-fedora-${FEDORA}-python-3
     build:
       context: .

--- a/python/examples/minimal_build/Dockerfile.fedora
+++ b/python/examples/minimal_build/Dockerfile.fedora
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM fedora:35
+FROM fedora:39
 
 RUN dnf update -y && \
     dnf install -y \


### PR DESCRIPTION
### Rationale for this change

Fedora 39 is the latest release and Fedora 38 will reach EOL on 2024-05-14.

### What changes are included in this PR?

Use Fedora 39.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* Closes: #40011