### PR TITLE
GH-40024: [C++][Gandiva] Constructing LLVM module with only necessary functions

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -36,6 +36,7 @@ provide_cmake_module(GandivaAddBitcode "Gandiva")
 
 # Set the path where the bitcode file generated, see precompiled/CMakeLists.txt
 set(GANDIVA_PRECOMPILED_BC_PATH "${CMAKE_CURRENT_BINARY_DIR}/irhelpers.bc")
+set(GANDIVA_PRECOMPILED_MANDATORY_BC_PATH "${CMAKE_CURRENT_BINARY_DIR}/mandatory_ir.bc")
 set(GANDIVA_PRECOMPILED_CC_PATH "${CMAKE_CURRENT_BINARY_DIR}/precompiled_bitcode.cc")
 set(GANDIVA_PRECOMPILED_CC_IN_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/precompiled_bitcode.cc.in")

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -562,6 +562,7 @@ void Engine::AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_ty
 }
 
 arrow::Status Engine::AddGlobalMappings() {
+  ARROW_LOG(INFO) << "Adding global mappings for exported functions";
   ARROW_RETURN_NOT_OK(ExportedFuncsRegistry::AddMappings(this));
   ExternalCFunctions c_funcs(function_registry_);
   return c_funcs.AddMappings(this);

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -312,7 +312,8 @@ Status Engine::LoadFunctionIRs() {
     mandatory_functions_loaded_ = true;
   }
 
-  if (!functions_loaded_ && used_functions_.size() > used_c_functions_.size()) {
+  bool is_ir_function_used = used_functions_.size() > used_c_functions_.size();
+  if (!functions_loaded_ && is_ir_function_used) {
     ARROW_RETURN_NOT_OK(LoadPreCompiledIR());
     ARROW_RETURN_NOT_OK(DecimalIR::AddFunctions(this));
     ARROW_RETURN_NOT_OK(LoadExternalPreCompiledIR());

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -92,7 +92,8 @@ class GANDIVA_EXPORT Engine {
   Status LoadFunctionIRs();
 
   /// Post construction init. This _must_ be called after the constructor.
-  /// @param[in] used_functions set of function names that are expected to be used by the engine
+  /// @param[in] used_functions set of function names that are expected to be used by the
+  /// engine
   Status Init(std::unordered_set<std::string> used_functions);
 
  private:
@@ -124,6 +125,15 @@ class GANDIVA_EXPORT Engine {
 
   std::vector<std::string> functions_to_compile_;
   std::unordered_set<std::string> used_functions_;
+  std::unordered_set<std::string> used_c_functions_;
+  static inline const std::unordered_set<std::string> internal_functions_ = {
+      "gdv_fn_populate_varlen_vector",
+      "gdv_fn_context_arena_reset",
+      "bitMapGetBit",
+      "bitMapValidityGetBit",
+      "bitMapClearBitIfFalse",
+      "gdv_fn_context_arena_malloc",
+      "gdv_fn_context_set_error_msg"};
 
   bool optimize_ = true;
   bool module_finalized_ = false;

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -99,7 +99,7 @@ class GANDIVA_EXPORT Engine {
  private:
   Engine(const std::shared_ptr<Configuration>& conf,
          std::unique_ptr<llvm::orc::LLJIT> lljit,
-         std::unique_ptr<llvm::TargetMachine> target_machine, bool cached);
+         llvm::TargetIRAnalysis target_is_analysis, bool cached);
 
   static void InitOnce();
 
@@ -107,8 +107,8 @@ class GANDIVA_EXPORT Engine {
   /// the main module.
   Status LoadPreCompiledIR();
 
-  /// load mandatory pre-compiled IR modules from precompiled_bitcode.cc and merge them into
-  /// the main module. Mandatory IR includes functions manipulating bitmaps
+  /// load mandatory pre-compiled IR modules from precompiled_bitcode.cc and merge them
+  /// into the main module. Mandatory IR includes functions manipulating bitmaps
   Status LoadMandatoryPreCompiledIR();
 
   // load external pre-compiled bitcodes into module
@@ -148,6 +148,7 @@ class GANDIVA_EXPORT Engine {
   std::shared_ptr<FunctionRegistry> function_registry_;
   std::string module_ir_;
   std::unique_ptr<llvm::TargetMachine> target_machine_;
+  llvm::TargetIRAnalysis target_ir_analysis_;
   const std::shared_ptr<Configuration> conf_;
 };
 

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -91,13 +91,14 @@ class GANDIVA_EXPORT Engine {
   /// Load the function IRs that can be accessed in the module.
   Status LoadFunctionIRs();
 
+  /// Post construction init. This _must_ be called after the constructor.
+  /// @param[in] used_functions set of function names that are expected to be used by the engine
+  Status Init(std::unordered_set<std::string> used_functions);
+
  private:
   Engine(const std::shared_ptr<Configuration>& conf,
          std::unique_ptr<llvm::orc::LLJIT> lljit,
          std::unique_ptr<llvm::TargetMachine> target_machine, bool cached);
-
-  // Post construction init. This _must_ be called after the constructor.
-  Status Init();
 
   static void InitOnce();
 
@@ -122,6 +123,7 @@ class GANDIVA_EXPORT Engine {
   LLVMTypes types_;
 
   std::vector<std::string> functions_to_compile_;
+  std::unordered_set<std::string> used_functions_;
 
   bool optimize_ = true;
   bool module_finalized_ = false;

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -130,15 +130,26 @@ class GANDIVA_EXPORT Engine {
   std::vector<std::string> functions_to_compile_;
   std::unordered_set<std::string> used_functions_;
   std::unordered_set<std::string> used_c_functions_;
+
+  // all internally used C stub functions and IR function names
   static inline const std::unordered_set<std::string> internal_functions_ = {
+      // internal C stub functions
+      "gdv_fn_context_arena_malloc",
+      "gdv_fn_context_set_error_msg",
       "gdv_fn_populate_varlen_vector",
       "gdv_fn_context_arena_reset",
+      "gdv_fn_in_expr_lookup_int32",
+      "gdv_fn_in_expr_lookup_int64",
+      "gdv_fn_in_expr_lookup_float",
+      "gdv_fn_in_expr_lookup_double",
+      "gdv_fn_in_expr_lookup_decimal",
+      "gdv_fn_in_expr_lookup_utf8",
+      // internal IR functions
       "bitMapGetBit",
       "bitMapSetBit",
       "bitMapValidityGetBit",
       "bitMapClearBitIfFalse",
-      "gdv_fn_context_arena_malloc",
-      "gdv_fn_context_set_error_msg"};
+  };
 
   bool optimize_ = true;
   bool module_finalized_ = false;

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/ExecutionEngine/Orc/Mangling.h>
 
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
@@ -115,6 +116,7 @@ class GANDIVA_EXPORT Engine {
 
   std::unique_ptr<llvm::LLVMContext> context_;
   std::unique_ptr<llvm::orc::LLJIT> lljit_;
+  std::unique_ptr<llvm::orc::MangleAndInterner> mangle_;
   std::unique_ptr<llvm::IRBuilder<>> ir_builder_;
   std::unique_ptr<llvm::Module> module_;
   LLVMTypes types_;

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -107,6 +107,10 @@ class GANDIVA_EXPORT Engine {
   /// the main module.
   Status LoadPreCompiledIR();
 
+  /// load mandatory pre-compiled IR modules from precompiled_bitcode.cc and merge them into
+  /// the main module. Mandatory IR includes functions manipulating bitmaps
+  Status LoadMandatoryPreCompiledIR();
+
   // load external pre-compiled bitcodes into module
   Status LoadExternalPreCompiledIR();
 
@@ -130,6 +134,7 @@ class GANDIVA_EXPORT Engine {
       "gdv_fn_populate_varlen_vector",
       "gdv_fn_context_arena_reset",
       "bitMapGetBit",
+      "bitMapSetBit",
       "bitMapValidityGetBit",
       "bitMapClearBitIfFalse",
       "gdv_fn_context_arena_malloc",
@@ -139,6 +144,7 @@ class GANDIVA_EXPORT Engine {
   bool module_finalized_ = false;
   bool cached_;
   bool functions_loaded_ = false;
+  bool mandatory_functions_loaded_ = false;
   std::shared_ptr<FunctionRegistry> function_registry_;
   std::string module_ir_;
   std::unique_ptr<llvm::TargetMachine> target_machine_;

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -164,7 +164,6 @@ class GANDIVA_EXPORT Engine {
   std::string module_ir_;
   std::unique_ptr<llvm::TargetMachine> target_machine_;
   llvm::TargetIRAnalysis target_ir_analysis_;
-  std::unique_ptr<llvm::ObjectCache> object_cache_;
   const std::shared_ptr<Configuration> conf_;
 };
 

--- a/cpp/src/gandiva/expr_decomposer.cc
+++ b/cpp/src/gandiva/expr_decomposer.cc
@@ -69,6 +69,7 @@ Status ExprDecomposer::Visit(const FunctionNode& in_node) {
   const NativeFunction* native_function = registry_.LookupSignature(signature);
   DCHECK(native_function) << "Missing Signature " << signature.ToString();
 
+  used_functions_.emplace(native_function->pc_name());
   // decompose the children.
   std::vector<ValueValidityPairPtr> args;
   for (auto& child : node.children()) {

--- a/cpp/src/gandiva/expr_decomposer.h
+++ b/cpp/src/gandiva/expr_decomposer.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <stack>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 #include "gandiva/arrow.h"
@@ -47,6 +48,10 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
       *out = std::move(result_);
     }
     return status;
+  }
+
+  [[nodiscard]] const std::unordered_set<std::string>& UsedFunctions() const {
+    return used_functions_;
   }
 
  private:
@@ -125,6 +130,7 @@ class GANDIVA_EXPORT ExprDecomposer : public NodeVisitor {
   Annotator& annotator_;
   std::stack<std::unique_ptr<IfStackEntry>> if_entries_stack_;
   ValueValidityPairPtr result_;
+  std::unordered_set<std::string> used_functions_;
   bool nested_if_else_;
 };
 

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -850,19 +850,6 @@ arrow::Status ExportedStubFunctions::AddMappings(Engine* engine) const {
                                   types->i32_type() /*return_type*/, args,
                                   reinterpret_cast<void*>(gdv_fn_dec_from_string));
 
-  // gdv_fn_dec_to_string
-  args = {
-      types->i64_type(),      // context
-      types->i64_type(),      // int64_t x_high
-      types->i64_type(),      // int64_t x_low
-      types->i32_type(),      // int32_t x_scale
-      types->i64_ptr_type(),  // int64_t* dec_str_len
-  };
-
-  engine->AddGlobalMappingForFunc("gdv_fn_dec_to_string",
-                                  types->i8_ptr_type() /*return_type*/, args,
-                                  reinterpret_cast<void*>(gdv_fn_dec_to_string));
-
   // gdv_fn_in_expr_lookup_int32
   args = {types->i64_type(),  // int64_t in holder ptr
           types->i32_type(),  // int32 value

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -184,9 +184,12 @@ class GANDIVA_EXPORT LLVMGenerator {
     bool has_arena_allocs_;
   };
 
+  arrow::Result<ValueValidityPairPtr> Decompose(const ExpressionPtr& expr);
+
   // Generate the code for one expression for default mode, with the output of
   // the expression going to 'output'.
-  Status Add(const ExpressionPtr expr, const FieldDescriptorPtr output);
+  Status Add(const ExpressionPtr expr, ValueValidityPairPtr value_validity,
+             const FieldDescriptorPtr output);
 
   /// Generate code to load the vector at specified index in the 'arg_addrs' array.
   llvm::Value* LoadVectorAtIndex(llvm::Value* arg_addrs, llvm::Type* type, int idx,
@@ -263,6 +266,7 @@ class GANDIVA_EXPORT LLVMGenerator {
   // used for debug
   bool enable_ir_traces_;
   std::vector<std::string> trace_strings_;
+  std::unordered_set<std::string> functions_in_exprs_;
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/make_precompiled_bitcode.py
+++ b/cpp/src/gandiva/make_precompiled_bitcode.py
@@ -19,7 +19,6 @@
 
 import sys
 
-marker = b"<DATA_CHARS>"
 
 def expand(data):
     """
@@ -29,21 +28,26 @@ def expand(data):
     return expanded_data.encode('ascii')
 
 
-def apply_template(template, data):
+def apply_template(template, marker, data):
     if template.count(marker) != 1:
         raise ValueError("Invalid template")
     return template.replace(marker, expand(data))
 
+def read_file(filepath):
+    with open(filepath, "rb") as file:
+        return file.read()
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        raise ValueError("Usage: {0} <template file> <data file> "
+    if len(sys.argv) != 5:
+        raise ValueError("Usage: {0} <template file> <mandatory data file> <data file> "
                          "<output file>".format(sys.argv[0]))
-    with open(sys.argv[1], "rb") as f:
-        template = f.read()
-    with open(sys.argv[2], "rb") as f:
-        data = f.read()
 
-    expanded_data = apply_template(template, data)
-    with open(sys.argv[3], "wb") as f:
+    template = read_file(sys.argv[1])
+    mandatory_data = read_file(sys.argv[2])
+    data = read_file(sys.argv[3])
+
+    expanded_data = apply_template(template, b"<MANDATORY_DATA_CHARS>", mandatory_data)
+    expanded_data = apply_template(expanded_data, b"<DATA_CHARS>", data)
+
+    with open(sys.argv[4], "wb") as f:
         f.write(expanded_data)

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -43,8 +43,7 @@ set(PRECOMPILED_SRCS
     ../../arrow/util/basic_decimal.cc)
 generate_and_link_bitcode("${PRECOMPILED_SRCS}" ${GANDIVA_PRECOMPILED_BC_PATH})
 
-set(MANDATORY_SRCS
-    bitmap.cc)
+set(MANDATORY_SRCS bitmap.cc)
 generate_and_link_bitcode("${MANDATORY_SRCS}" ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH})
 
 # turn the bitcode file into a C++ static data variable.
@@ -58,9 +57,10 @@ add_custom_command(OUTPUT ${GANDIVA_PRECOMPILED_CC_PATH}
                            ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH}
                            ${GANDIVA_PRECOMPILED_BC_PATH})
 
-add_custom_target(precompiled ALL DEPENDS ${GANDIVA_PRECOMPILED_BC_PATH}
-                                          ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH}
-                                          ${GANDIVA_PRECOMPILED_CC_PATH})
+add_custom_target(precompiled ALL
+                  DEPENDS ${GANDIVA_PRECOMPILED_BC_PATH}
+                          ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH}
+                          ${GANDIVA_PRECOMPILED_CC_PATH})
 
 # testing
 if(ARROW_BUILD_TESTS)

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -15,9 +15,23 @@
 # specific language governing permissions and limitations
 # under the License.
 
+function(generate_and_link_bitcode src_files bitcode_output_path)
+  set(local_precompiled_bc_files) 
+  foreach(SOURCE ${src_files})
+    gandiva_add_bitcode(${SOURCE}) 
+    get_filename_component(SOURCE_BASE ${SOURCE} NAME_WE)
+    list(APPEND local_precompiled_bc_files ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_BASE}.bc)
+  endforeach()
+
+# link all of the bitcode files into a single bitcode file.
+  add_custom_command(OUTPUT ${bitcode_output_path}
+                     COMMAND ${LLVM_LINK_EXECUTABLE} -o ${bitcode_output_path}
+                             ${local_precompiled_bc_files}
+                     DEPENDS ${local_precompiled_bc_files})
+endfunction()
+
 set(PRECOMPILED_SRCS
     arithmetic_ops.cc
-    bitmap.cc
     decimal_ops.cc
     decimal_wrapper.cc
     extended_math_ops.cc
@@ -27,29 +41,24 @@ set(PRECOMPILED_SRCS
     time.cc
     timestamp_arithmetic.cc
     ../../arrow/util/basic_decimal.cc)
-set(GANDIVA_PRECOMPILED_BC_FILES)
-foreach(SOURCE ${PRECOMPILED_SRCS})
-  gandiva_add_bitcode(${SOURCE})
-  get_filename_component(SOURCE_BASE ${SOURCE} NAME_WE)
-  list(APPEND GANDIVA_PRECOMPILED_BC_FILES ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_BASE}.bc)
-endforeach()
+generate_and_link_bitcode("${PRECOMPILED_SRCS}" ${GANDIVA_PRECOMPILED_BC_PATH})
 
-# link all of the bitcode files into a single bitcode file.
-add_custom_command(OUTPUT ${GANDIVA_PRECOMPILED_BC_PATH}
-                   COMMAND ${LLVM_LINK_EXECUTABLE} -o ${GANDIVA_PRECOMPILED_BC_PATH}
-                           ${GANDIVA_PRECOMPILED_BC_FILES}
-                   DEPENDS ${GANDIVA_PRECOMPILED_BC_FILES})
+set(MANDATORY_SRCS bitmap.cc)
+generate_and_link_bitcode("${MANDATORY_SRCS}" ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH})
 
 # turn the bitcode file into a C++ static data variable.
 add_custom_command(OUTPUT ${GANDIVA_PRECOMPILED_CC_PATH}
                    COMMAND ${PYTHON_EXECUTABLE}
                            "${CMAKE_CURRENT_SOURCE_DIR}/../make_precompiled_bitcode.py"
                            ${GANDIVA_PRECOMPILED_CC_IN_PATH}
+                           ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH} 
                            ${GANDIVA_PRECOMPILED_BC_PATH} ${GANDIVA_PRECOMPILED_CC_PATH}
                    DEPENDS ${GANDIVA_PRECOMPILED_CC_IN_PATH}
+                           ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH} 
                            ${GANDIVA_PRECOMPILED_BC_PATH})
 
 add_custom_target(precompiled ALL DEPENDS ${GANDIVA_PRECOMPILED_BC_PATH}
+                                          ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH} 
                                           ${GANDIVA_PRECOMPILED_CC_PATH})
 
 # testing

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -16,14 +16,14 @@
 # under the License.
 
 function(generate_and_link_bitcode src_files bitcode_output_path)
-  set(local_precompiled_bc_files) 
+  set(local_precompiled_bc_files)
   foreach(SOURCE ${src_files})
-    gandiva_add_bitcode(${SOURCE}) 
+    gandiva_add_bitcode(${SOURCE})
     get_filename_component(SOURCE_BASE ${SOURCE} NAME_WE)
     list(APPEND local_precompiled_bc_files ${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_BASE}.bc)
   endforeach()
 
-# link all of the bitcode files into a single bitcode file.
+  # link all of the bitcode files into a single bitcode file.
   add_custom_command(OUTPUT ${bitcode_output_path}
                      COMMAND ${LLVM_LINK_EXECUTABLE} -o ${bitcode_output_path}
                              ${local_precompiled_bc_files}
@@ -43,7 +43,8 @@ set(PRECOMPILED_SRCS
     ../../arrow/util/basic_decimal.cc)
 generate_and_link_bitcode("${PRECOMPILED_SRCS}" ${GANDIVA_PRECOMPILED_BC_PATH})
 
-set(MANDATORY_SRCS bitmap.cc)
+set(MANDATORY_SRCS
+    bitmap.cc)
 generate_and_link_bitcode("${MANDATORY_SRCS}" ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH})
 
 # turn the bitcode file into a C++ static data variable.
@@ -51,14 +52,14 @@ add_custom_command(OUTPUT ${GANDIVA_PRECOMPILED_CC_PATH}
                    COMMAND ${PYTHON_EXECUTABLE}
                            "${CMAKE_CURRENT_SOURCE_DIR}/../make_precompiled_bitcode.py"
                            ${GANDIVA_PRECOMPILED_CC_IN_PATH}
-                           ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH} 
+                           ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH}
                            ${GANDIVA_PRECOMPILED_BC_PATH} ${GANDIVA_PRECOMPILED_CC_PATH}
                    DEPENDS ${GANDIVA_PRECOMPILED_CC_IN_PATH}
-                           ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH} 
+                           ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH}
                            ${GANDIVA_PRECOMPILED_BC_PATH})
 
 add_custom_target(precompiled ALL DEPENDS ${GANDIVA_PRECOMPILED_BC_PATH}
-                                          ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH} 
+                                          ${GANDIVA_PRECOMPILED_MANDATORY_BC_PATH}
                                           ${GANDIVA_PRECOMPILED_CC_PATH})
 
 # testing

--- a/cpp/src/gandiva/precompiled_bitcode.cc.in
+++ b/cpp/src/gandiva/precompiled_bitcode.cc.in
@@ -21,6 +21,11 @@ namespace gandiva {
 
 // Content of precompiled bitcode file.
 extern const unsigned char kPrecompiledBitcode[] = { <DATA_CHARS> };
+
+extern const unsigned char kPrecompiledMandatoryBitcode[] = { <MANDATORY_DATA_CHARS> };
+
 extern const size_t kPrecompiledBitcodeSize = sizeof(kPrecompiledBitcode);
+
+extern const size_t kPrecompiledMandatoryBitcodeSize = sizeof(kPrecompiledMandatoryBitcode);
 
 } // namespace gandiva

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -3691,19 +3691,17 @@ TEST_F(TestProjector, TestLiteralProjection) {
   auto literal = TreeExprBuilder::MakeExpression(
       TreeExprBuilder::MakeLiteral(literal_value), out_field);
 
-  for (int i = 0; i < 1000; i++) {
-    std::shared_ptr<Projector> projector;
-    ARROW_EXPECT_OK(Projector::Make(schema, {literal}, TestConfiguration(), &projector));
+  std::shared_ptr<Projector> projector;
+  ARROW_EXPECT_OK(Projector::Make(schema, {literal}, TestConfiguration(), &projector));
 
-    int num_records = 4;
-    auto array = MakeArrowArrayInt64({1, 2, 3, 4}, {true, true, true, true});
-    auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array});
-    auto out = MakeArrowArrayInt64({1, 1, 1, 1}, {true, true, true, true});
+  int num_records = 4;
+  auto array = MakeArrowArrayInt64({1, 2, 3, 4}, {true, true, true, true});
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array});
+  auto out = MakeArrowArrayInt64({1, 1, 1, 1}, {true, true, true, true});
 
-    arrow::ArrayVector outs;
-    ARROW_EXPECT_OK(projector->Evaluate(*in_batch, pool_, &outs));
-    EXPECT_ARROW_ARRAY_EQUALS(out, outs.at(0));
-  }
+  arrow::ArrayVector outs;
+  ARROW_EXPECT_OK(projector->Evaluate(*in_batch, pool_, &outs));
+  EXPECT_ARROW_ARRAY_EQUALS(out, outs.at(0));
 }
 
 TEST_F(TestProjector, TestInExprProjection) {

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -3683,4 +3683,26 @@ TEST_F(TestProjector, TestExtendedCFunctionThatNeedsContext) {
   EXPECT_ARROW_ARRAY_EQUALS(out, outs.at(0));
 }
 
+TEST_F(TestProjector, TestLiteralProjection) {
+  auto in_field = field("in", arrow::int64());
+  auto schema = arrow::schema({in_field});
+  auto out_field = field("out", arrow::int64());
+  auto literal =
+      TreeExprBuilder::MakeExpression(TreeExprBuilder::MakeLiteral(1LL), out_field);
+
+  for (int i = 0; i < 1000; i++) {
+    std::shared_ptr<Projector> projector;
+    ARROW_EXPECT_OK(Projector::Make(schema, {literal}, TestConfiguration(), &projector));
+
+    int num_records = 4;
+    auto array = MakeArrowArrayInt64({1, 2, 3, 4}, {true, true, true, true});
+    auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array});
+    auto out = MakeArrowArrayInt64({1, 1, 1, 1}, {true, true, true, true});
+
+    arrow::ArrayVector outs;
+    ARROW_EXPECT_OK(projector->Evaluate(*in_batch, pool_, &outs));
+    EXPECT_ARROW_ARRAY_EQUALS(out, outs.at(0));
+  }
+}
+
 }  // namespace gandiva


### PR DESCRIPTION
### Rationale for this change
This PR tries to address GH-40024. It keeps track of used functions in Gandiva expressions, and uses that information to avoid defining unused C functions in LLVM module, and avoid loading/linking the LLVM bitcode if no LLVM IR function is used in the expressions. And this helps expression compilation performance.

### What changes are included in this PR?
* `ExprDecomposer` has a new member called `used_functions_` to keep track of used functions after visiting the expressions.
* `Engine`'s `Init` process is postponed to after all expressions are decomposed, so that all functions used can be obtained before constructing LLVM modules.
* `AddGlobalMappingForFunc` only for used functions
* Separate LLVM bitcode (`irhelpers.bc`) into two parts, one for mandatory bitcode, and the other for optional bitcode.
* Load bitcode only when necessary 

### Are these changes tested?
* Yes, several unit tests are added to cover these changes. 
* And several micro benchmarks are added to verify the performance change.

### Are there any user-facing changes?
No
* Closes: #40024