### PR TITLE
GH-40040: [C++][Gandiva] Make Gandiva's default cache size to be 5000 for object code cache

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -243,6 +243,7 @@ endfunction()
 add_gandiva_test(internals-test
                  SOURCES
                  bitmap_accumulator_test.cc
+                 cache_test.cc
                  engine_llvm_test.cc
                  function_registry_test.cc
                  function_signature_test.cc


### PR DESCRIPTION
### Rationale for this change
Gandiva's default cache is object code cache, however, the default cache size is still the old value for LLVM module based cache, which is too small. 

More details about the `GANDIVA_ENABLE_OBJECT_CODE_CACHE` flag can be found in GH-40040

### What changes are included in this PR?
Remove the unused `GANDIVA_ENABLE_OBJECT_CODE_CACHE` flag and make the default cache size to be `500000` for object code cache.

### Are these changes tested?
No

### Are there any user-facing changes?
Yes, default cache size will be changed from 500 to 500000, and it may help the default deployment's performance.
* Closes: #40040