### PR TITLE
GH-40066: [Python] Support `requested_schema` in `__arrow_c_stream__()`

### DIFF
--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -283,6 +283,14 @@ cdef extern from "arrow/python/ipc.h" namespace "arrow::py":
                                                      object)
 
 
+cdef extern from "arrow/python/ipc.h" namespace "arrow::py" nogil:
+    cdef cppclass CCastingRecordBatchReader" arrow::py::CastingRecordBatchReader" \
+            (CRecordBatchReader):
+        @staticmethod
+        CResult[shared_ptr[CRecordBatchReader]] Make(shared_ptr[CRecordBatchReader],
+                                                     shared_ptr[CSchema])
+
+
 cdef extern from "arrow/python/extension_type.h" namespace "arrow::py":
     cdef cppclass CPyExtensionType \
             " arrow::py::PyExtensionType"(CExtensionType):

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -793,8 +793,8 @@ cdef class RecordBatchReader(_Weakrefable):
 
         if self.schema.names != target_schema.names:
             raise ValueError("Target schema's field names are not matching "
-                             "the table's field names: {!r}, {!r}"
-                             .format(self.schema.names, target_schema.names))
+                             f"the table's field names: {self.schema.names}, "
+                             f"{target_schema.names}")
 
         c_schema = pyarrow_unwrap_schema(target_schema)
         c_reader = GetResultValue(CCastingRecordBatchReader.Make(

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -774,7 +774,7 @@ cdef class RecordBatchReader(_Weakrefable):
 
     def cast(self, schema):
         """
-        Wraps this reader with one that casts each batch lazily as it is pulled.
+        Wrap this reader with one that casts each batch lazily as it is pulled.
 
         Parameters
         ----------

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -780,6 +780,10 @@ cdef class RecordBatchReader(_Weakrefable):
         ----------
         schema : Schema
             The desired output schema
+
+        Returns
+        -------
+        RecordBatchReader
         """
         cdef:
             shared_ptr[CSchema] c_schema
@@ -849,8 +853,6 @@ cdef class RecordBatchReader(_Weakrefable):
             The schema to which the stream should be casted, passed as a
             PyCapsule containing a C ArrowSchema representation of the
             requested schema.
-            Currently, this is not supported and will raise a
-            NotImplementedError if the schema doesn't match the current schema.
 
         Returns
         -------

--- a/python/pyarrow/src/arrow/python/ipc.cc
+++ b/python/pyarrow/src/arrow/python/ipc.cc
@@ -106,6 +106,9 @@ Status CastingRecordBatchReader::ReadNext(std::shared_ptr<RecordBatch>* batch) {
   auto num_columns = out->num_columns();
   ArrayVector columns(num_columns);
   for (int i = 0; i < num_columns; i++) {
+    if (!schema_->field(i)->nullable()) {
+      return Status::Invalid("Cast to non-nullable not supported");
+    }
     ARROW_ASSIGN_OR_RAISE(columns[i],
                           compute::Cast(*out->column(i), schema_->field(i)->type()));
   }

--- a/python/pyarrow/src/arrow/python/ipc.cc
+++ b/python/pyarrow/src/arrow/python/ipc.cc
@@ -19,7 +19,7 @@
 
 #include <memory>
 
-#include "arrow/compute/api.h"
+#include "arrow/compute/cast.h"
 #include "arrow/python/pyarrow.h"
 
 namespace arrow {

--- a/python/pyarrow/src/arrow/python/ipc.cc
+++ b/python/pyarrow/src/arrow/python/ipc.cc
@@ -80,9 +80,9 @@ Status CastingRecordBatchReader::Init(std::shared_ptr<RecordBatchReader> parent,
   // Ensure all columns can be cast before succeeding
   for (int i = 0; i < num_fields; i++) {
     if (!compute::CanCast(*src->field(i)->type(), *schema->field(i)->type())) {
-      return Status::NotImplemented("Field ", i, " cannot be cast from ",
-                                    src->field(i)->type()->ToString(), " to ",
-                                    schema->field(i)->type()->ToString());
+      return Status::TypeError("Field ", i, " cannot be cast from ",
+                               src->field(i)->type()->ToString(), " to ",
+                               schema->field(i)->type()->ToString());
     }
   }
 

--- a/python/pyarrow/src/arrow/python/ipc.cc
+++ b/python/pyarrow/src/arrow/python/ipc.cc
@@ -64,7 +64,7 @@ Result<std::shared_ptr<RecordBatchReader>> PyRecordBatchReader::Make(
   return reader;
 }
 
-CastingRecordBatchReader::CastingRecordBatchReader() {}
+CastingRecordBatchReader::CastingRecordBatchReader() = default;
 
 Status CastingRecordBatchReader::Init(std::shared_ptr<RecordBatchReader> parent,
                                       std::shared_ptr<Schema> schema) {

--- a/python/pyarrow/src/arrow/python/ipc.cc
+++ b/python/pyarrow/src/arrow/python/ipc.cc
@@ -16,9 +16,6 @@
 // under the License.
 
 #include "ipc.h"
-#include <arrow/array/util.h>
-#include <arrow/compute/cast.h>
-#include <arrow/result.h>
 
 #include <memory>
 

--- a/python/pyarrow/src/arrow/python/ipc.cc
+++ b/python/pyarrow/src/arrow/python/ipc.cc
@@ -97,6 +97,7 @@ Status CastingRecordBatchReader::ReadNext(std::shared_ptr<RecordBatch>* batch) {
   std::shared_ptr<RecordBatch> out;
   ARROW_RETURN_NOT_OK(parent_->ReadNext(&out));
   if (!out) {
+    batch->reset();
     return Status::OK();
   }
 

--- a/python/pyarrow/src/arrow/python/ipc.h
+++ b/python/pyarrow/src/arrow/python/ipc.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <arrow/status.h>
 #include <memory>
 
 #include "arrow/python/common.h"
@@ -46,6 +47,25 @@ class ARROW_PYTHON_EXPORT PyRecordBatchReader : public RecordBatchReader {
 
   std::shared_ptr<Schema> schema_;
   OwnedRefNoGIL iterator_;
+};
+
+class ARROW_PYTHON_EXPORT CastingRecordBatchReader : public RecordBatchReader {
+ public:
+  std::shared_ptr<Schema> schema() const override;
+
+  Status ReadNext(std::shared_ptr<RecordBatch>* batch) override;
+
+  static Result<std::shared_ptr<RecordBatchReader>> Make(
+      std::shared_ptr<RecordBatchReader> parent, std::shared_ptr<Schema> schema);
+
+ protected:
+ CastingRecordBatchReader();
+
+  Status Init(std::shared_ptr<RecordBatchReader> parent,
+                           std::shared_ptr<Schema> schema);
+
+  std::shared_ptr<RecordBatchReader> parent_;
+  std::shared_ptr<Schema> schema_;
 };
 
 }  // namespace py

--- a/python/pyarrow/src/arrow/python/ipc.h
+++ b/python/pyarrow/src/arrow/python/ipc.h
@@ -57,6 +57,8 @@ class ARROW_PYTHON_EXPORT CastingRecordBatchReader : public RecordBatchReader {
   static Result<std::shared_ptr<RecordBatchReader>> Make(
       std::shared_ptr<RecordBatchReader> parent, std::shared_ptr<Schema> schema);
 
+  Status Close() override;
+
  protected:
   CastingRecordBatchReader();
 

--- a/python/pyarrow/src/arrow/python/ipc.h
+++ b/python/pyarrow/src/arrow/python/ipc.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <arrow/status.h>
 #include <memory>
 
 #include "arrow/python/common.h"

--- a/python/pyarrow/src/arrow/python/ipc.h
+++ b/python/pyarrow/src/arrow/python/ipc.h
@@ -58,10 +58,9 @@ class ARROW_PYTHON_EXPORT CastingRecordBatchReader : public RecordBatchReader {
       std::shared_ptr<RecordBatchReader> parent, std::shared_ptr<Schema> schema);
 
  protected:
- CastingRecordBatchReader();
+  CastingRecordBatchReader();
 
-  Status Init(std::shared_ptr<RecordBatchReader> parent,
-                           std::shared_ptr<Schema> schema);
+  Status Init(std::shared_ptr<RecordBatchReader> parent, std::shared_ptr<Schema> schema);
 
   std::shared_ptr<RecordBatchReader> parent_;
   std::shared_ptr<Schema> schema_;

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2701,7 +2701,8 @@ cdef class RecordBatch(_Tabular):
         # Wrap the more general Table cast implementation
         tbl = Table.from_batches([self])
         casted_tbl = tbl.cast(target_schema, safe=safe, options=options)
-        return list(casted_tbl.to_batches())[0]
+        casted_batch, = casted_tbl.to_batches()
+        return casted_batch
 
     def _to_pandas(self, options, **kwargs):
         return Table.from_batches([self])._to_pandas(options, **kwargs)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2995,7 +2995,7 @@ cdef class RecordBatch(_Tabular):
         ----------
         requested_schema : PyCapsule | None
             A PyCapsule containing a C ArrowSchema representation of a requested
-            schema. PyArrow will attempt to cast the batch to this schema.
+            schema. PyArrow will attempt to cast each batch to this schema.
             If None, the schema will be returned as-is, with a schema matching the
             one returned by :meth:`__arrow_c_schema__()`.
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2681,6 +2681,28 @@ cdef class RecordBatch(_Tabular):
 
         return pyarrow_wrap_batch(c_batch)
 
+    def cast(self, Schema target_schema, safe=None, options=None):
+        """
+        Cast batch values to another schema.
+
+        Parameters
+        ----------
+        target_schema : Schema
+            Schema to cast to, the names and order of fields must match.
+        safe : bool, default True
+            Check for overflows or other unsafe conversions.
+        options : CastOptions, default None
+            Additional checks pass by CastOptions
+
+        Returns
+        -------
+        RecordBatch
+        """
+        # Wrap the more general Table cast implementation
+        tbl = Table.from_batches([self])
+        casted_tbl = tbl.cast(target_schema, safe=safe, options=options)
+        return list(casted_tbl.to_batches())[0]
+
     def _to_pandas(self, options, **kwargs):
         return Table.from_batches([self])._to_pandas(options, **kwargs)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3018,7 +3018,7 @@ cdef class RecordBatch(_Tabular):
         ----------
         requested_schema : PyCapsule | None
             A PyCapsule containing a C ArrowSchema representation of a requested
-            schema. PyArrow will attempt to cast each batch to this schema.
+            schema. PyArrow will attempt to cast the batch to this schema.
             If None, the schema will be returned as-is, with a schema matching the
             one returned by :meth:`__arrow_c_schema__()`.
 

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -594,10 +594,7 @@ def test_roundtrip_batch_reader_capsule_requested_schema():
     batch = make_batch()
     requested_schema = pa.schema([('ints', pa.list_(pa.int64()))])
     requested_capsule = requested_schema.__arrow_c_schema__()
-    # RecordBatch has no cast() method
-    batch_as_requested = list(
-        pa.Table.from_batches([batch]).cast(requested_schema).to_batches()
-    )[0]
+    batch_as_requested = batch.cast(requested_schema)
 
     capsule = batch.__arrow_c_stream__(requested_capsule)
     assert PyCapsule_IsValid(capsule, b"arrow_array_stream") == 1

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -577,9 +577,8 @@ def test_roundtrip_reader_capsule(constructor):
 
     obj = constructor(schema, batches)
 
-    # TODO: turn this to ValueError once we implement validation.
     bad_schema = pa.schema({'ints': pa.int32()})
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError):
         obj.__arrow_c_stream__(bad_schema.__arrow_c_schema__())
 
     # Can work with matching schema
@@ -589,6 +588,24 @@ def test_roundtrip_reader_capsule(constructor):
     assert imported_reader.schema == matching_schema
     for batch, expected in zip(imported_reader, batches):
         assert batch.equals(expected)
+
+
+def test_roundtrip_batch_reader_capsule_requested_schema():
+    batch = make_batch()
+    requested_schema = pa.schema([('ints', pa.list_(pa.int64()))])
+    requested_capsule = requested_schema.__arrow_c_schema__()
+    # RecordBatch has no cast() method
+    batch_as_requested = list(
+        pa.Table.from_batches([batch]).cast(requested_schema).to_batches()
+    )[0]
+
+    capsule = batch.__arrow_c_stream__(requested_capsule)
+    assert PyCapsule_IsValid(capsule, b"arrow_array_stream") == 1
+    imported_reader = pa.RecordBatchReader._import_from_c_capsule(capsule)
+    assert imported_reader.schema == requested_schema
+    assert imported_reader.read_next_batch().equals(batch_as_requested)
+    with pytest.raises(StopIteration):
+        imported_reader.read_next_batch()
 
 
 def test_roundtrip_batch_reader_capsule():

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -578,7 +578,7 @@ def test_roundtrip_reader_capsule(constructor):
     obj = constructor(schema, batches)
 
     bad_schema = pa.schema({'ints': pa.int32()})
-    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Unsupported cast"):
+    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Field 0 cannot be cast"):
         obj.__arrow_c_stream__(bad_schema.__arrow_c_schema__())
 
     # Can work with matching schema

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -578,7 +578,7 @@ def test_roundtrip_reader_capsule(constructor):
     obj = constructor(schema, batches)
 
     bad_schema = pa.schema({'ints': pa.int32()})
-    with pytest.raises(ValueError):
+    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Unsupported cast"):
         obj.__arrow_c_stream__(bad_schema.__arrow_c_schema__())
 
     # Can work with matching schema

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -578,7 +578,7 @@ def test_roundtrip_reader_capsule(constructor):
     obj = constructor(schema, batches)
 
     bad_schema = pa.schema({'ints': pa.int32()})
-    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Field 0 cannot be cast"):
+    with pytest.raises(pa.lib.ArrowTypeError, match="Field 0 cannot be cast"):
         obj.__arrow_c_stream__(bad_schema.__arrow_c_schema__())
 
     # Can work with matching schema

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1303,7 +1303,7 @@ def test_record_batch_reader_cast_nulls():
 
     # Cast to non-nullable destination should error if there are nulls
     # when the batch is pulled
-    reader = pa.RecordBatchReader.from_batches(schema_src, data_without_nulls)
+    reader = pa.RecordBatchReader.from_batches(schema_src, data_with_nulls)
     casted_reader = reader.cast(schema_dst)
-    with pytest.raises(pa.lib.ArrowInvalid, match="fish"):
+    with pytest.raises(pa.lib.ArrowInvalid, match="Can't cast array"):
         casted_reader.read_all()

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1241,7 +1241,7 @@ def test_record_batch_reader_from_arrow_stream():
 
 
 def test_record_batch_reader_cast():
-    schema_src = pa.schema([pa.field("a", pa.int64())])
+    schema_src = pa.schema([pa.field('a', pa.int64())])
     data = [
         pa.record_batch([pa.array([1, 2, 3], type=pa.int64())], names=['a']),
         pa.record_batch([pa.array([4, 5, 6], type=pa.int64())], names=['a']),
@@ -1265,7 +1265,7 @@ def test_record_batch_reader_cast():
     # Check error for impossible cast in call to .cast()
     reader = pa.RecordBatchReader.from_batches(schema_src, data)
     with pytest.raises(pa.lib.ArrowTypeError, match='Field 0 cannot be cast'):
-        reader.cast(pa.schema([pa.field("a", pa.list_(pa.int32()))]))
+        reader.cast(pa.schema([pa.field('a', pa.list_(pa.int32()))]))
 
 
 def test_record_batch_reader_cast_nulls():

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1238,3 +1238,60 @@ def test_record_batch_reader_from_arrow_stream():
 
     with pytest.raises(TypeError):
         pa.RecordBatchReader.from_stream(expected, schema=data[0])
+
+
+def test_record_batch_reader_cast():
+    schema_src = pa.schema([pa.field("a", pa.int64())])
+    data = [
+        pa.record_batch([pa.array([1, 2, 3], type=pa.int64())], names=['a']),
+        pa.record_batch([pa.array([4, 5, 6], type=pa.int64())], names=['a']),
+    ]
+    table_src = pa.Table.from_batches(data)
+
+    # Cast to same type should always work
+    reader = pa.RecordBatchReader.from_batches(schema_src, data)
+    assert reader.cast(schema_src).read_all() == table_src
+
+    # Check non-trivial cast
+    schema_dst = pa.schema([pa.field('a', pa.int32())])
+    reader = pa.RecordBatchReader.from_batches(schema_src, data)
+    assert reader.cast(schema_dst).read_all() == table_src.cast(schema_dst)
+
+    # Check error for field name/length mismatch
+    reader = pa.RecordBatchReader.from_batches(schema_src, data)
+    with pytest.raises(ValueError, match="Target schema's field names"):
+        reader.cast(pa.schema([]))
+
+    # Check error for impossible cast in call to .cast()
+    reader = pa.RecordBatchReader.from_batches(schema_src, data)
+    with pytest.raises(pa.lib.ArrowTypeError, match='Field 0 cannot be cast'):
+        reader.cast(pa.schema([pa.field("a", pa.list_(pa.int32()))]))
+
+
+def test_record_batch_reader_cast_nulls():
+    schema_src = pa.schema([pa.field('a', pa.int64())])
+    data_with_nulls = [
+        pa.record_batch([pa.array([1, 2, None], type=pa.int64())], names=['a']),
+    ]
+    data_without_nulls = [
+        pa.record_batch([pa.array([1, 2, 3], type=pa.int64())], names=['a']),
+    ]
+    table_with_nulls = pa.Table.from_batches(data_with_nulls)
+    table_without_nulls = pa.Table.from_batches(data_without_nulls)
+
+    # Cast to nullable destination should work
+    reader = pa.RecordBatchReader.from_batches(schema_src, data_with_nulls)
+    schema_dst = pa.schema([pa.field('a', pa.int32())])
+    assert reader.cast(schema_dst).read_all() == table_with_nulls.cast(schema_dst)
+
+    # Cast to non-nullable destination should work if there are no nulls
+    reader = pa.RecordBatchReader.from_batches(schema_src, data_without_nulls)
+    schema_dst = pa.schema([pa.field('a', pa.int32(), nullable=False)])
+    assert reader.cast(schema_dst).read_all() == table_without_nulls.cast(schema_dst)
+
+    # Cast to non-nullable destination should error if there are nulls
+    # when the batch is pulled
+    reader = pa.RecordBatchReader.from_batches(schema_src, data_with_nulls)
+    casted_reader = reader.cast(schema_dst)
+    with pytest.raises(pa.lib.ArrowInvalid, match="Can't cast array"):
+        casted_reader.read_all()

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -51,16 +51,16 @@ class IpcFixture:
 
     def write_batches(self, num_batches=5, as_table=False):
         nrows = 5
-        schema = pa.schema([("one", pa.float64()), ("two", pa.utf8())])
+        schema = pa.schema([('one', pa.float64()), ('two', pa.utf8())])
 
         writer = self._get_writer(self.sink, schema)
 
         batches = []
         for i in range(num_batches):
             batch = pa.record_batch(
-                [np.random.randn(nrows), ["foo", None, "bar", "bazbaz", "qux"]],
-                schema=schema,
-            )
+                [np.random.randn(nrows),
+                 ['foo', None, 'bar', 'bazbaz', 'qux']],
+                schema=schema)
             batches.append(batch)
 
         if as_table:
@@ -140,18 +140,22 @@ def stream_fixture():
     return StreamFormatFixture()
 
 
-@pytest.fixture(
-    params=[
-        pytest.param("file_fixture", id="File Format"),
-        pytest.param("stream_fixture", id="Stream Format"),
-    ]
-)
+@pytest.fixture(params=[
+    pytest.param(
+        'file_fixture',
+        id='File Format'
+    ),
+    pytest.param(
+        'stream_fixture',
+        id='Stream Format'
+    )
+])
 def format_fixture(request):
     return request.getfixturevalue(request.param)
 
 
 def test_empty_file():
-    buf = b""
+    buf = b''
     with pytest.raises(pa.ArrowInvalid):
         pa.ipc.open_file(pa.BufferReader(buf))
 
@@ -164,9 +168,10 @@ def test_file_write_table(file_fixture):
     file_fixture._check_roundtrip(as_table=True)
 
 
-@pytest.mark.parametrize(
-    "sink_factory", [lambda: io.BytesIO(), lambda: pa.BufferOutputStream()]
-)
+@pytest.mark.parametrize("sink_factory", [
+    lambda: io.BytesIO(),
+    lambda: pa.BufferOutputStream()
+])
 def test_file_read_all(sink_factory):
     fixture = FileFormatFixture(sink_factory)
 
@@ -219,8 +224,8 @@ def test_file_pathlib(file_fixture, tmpdir):
     file_fixture.write_batches()
     source = file_fixture.get_source()
 
-    path = tmpdir.join("file.arrow").strpath
-    with open(path, "wb") as f:
+    path = tmpdir.join('file.arrow').strpath
+    with open(path, 'wb') as f:
         f.write(source)
 
     t1 = pa.ipc.open_file(pathlib.Path(path)).read_all()
@@ -230,7 +235,7 @@ def test_file_pathlib(file_fixture, tmpdir):
 
 
 def test_empty_stream():
-    buf = io.BytesIO(b"")
+    buf = io.BytesIO(b'')
     with pytest.raises(pa.ArrowInvalid):
         pa.ipc.open_stream(buf)
 
@@ -243,34 +248,31 @@ def test_read_year_month_nano_interval(tmpdir):
     that they are when no other library functions are invoked.
     """
     mdn_interval_type = pa.month_day_nano_interval()
-    schema = pa.schema([pa.field("nums", mdn_interval_type)])
+    schema = pa.schema([pa.field('nums', mdn_interval_type)])
 
-    path = tmpdir.join("file.arrow").strpath
-    with pa.OSFile(path, "wb") as sink:
+    path = tmpdir.join('file.arrow').strpath
+    with pa.OSFile(path, 'wb') as sink:
         with pa.ipc.new_file(sink, schema) as writer:
             interval_array = pa.array([(1, 2, 3)], type=mdn_interval_type)
             batch = pa.record_batch([interval_array], schema)
             writer.write(batch)
-    invoke_script("read_record_batch.py", path)
+    invoke_script('read_record_batch.py', path)
 
 
 @pytest.mark.pandas
 def test_stream_categorical_roundtrip(stream_fixture):
-    df = pd.DataFrame(
-        {
-            "one": np.random.randn(5),
-            "two": pd.Categorical(
-                ["foo", np.nan, "bar", "foo", "foo"],
-                categories=["foo", "bar"],
-                ordered=True,
-            ),
-        }
-    )
+    df = pd.DataFrame({
+        'one': np.random.randn(5),
+        'two': pd.Categorical(['foo', np.nan, 'bar', 'foo', 'foo'],
+                              categories=['foo', 'bar'],
+                              ordered=True)
+    })
     batch = pa.RecordBatch.from_pandas(df)
     with stream_fixture._get_writer(stream_fixture.sink, batch.schema) as wr:
         wr.write_batch(batch)
 
-    table = pa.ipc.open_stream(pa.BufferReader(stream_fixture.get_source())).read_all()
+    table = (pa.ipc.open_stream(pa.BufferReader(stream_fixture.get_source()))
+             .read_all())
     assert_frame_equal(table.to_pandas(), df)
 
 
@@ -299,13 +301,10 @@ def test_open_stream_from_buffer(stream_fixture):
     assert tuple(st1) == tuple(stream_fixture.write_stats)
 
 
-@pytest.mark.parametrize(
-    "options",
-    [
-        pa.ipc.IpcReadOptions(),
-        pa.ipc.IpcReadOptions(use_threads=False),
-    ],
-)
+@pytest.mark.parametrize('options', [
+    pa.ipc.IpcReadOptions(),
+    pa.ipc.IpcReadOptions(use_threads=False),
+])
 def test_open_stream_options(stream_fixture, options):
     stream_fixture.write_batches()
     source = stream_fixture.get_source()
@@ -328,13 +327,10 @@ def test_open_stream_with_wrong_options(stream_fixture):
         pa.ipc.open_stream(source, options=True)
 
 
-@pytest.mark.parametrize(
-    "options",
-    [
-        pa.ipc.IpcReadOptions(),
-        pa.ipc.IpcReadOptions(use_threads=False),
-    ],
-)
+@pytest.mark.parametrize('options', [
+    pa.ipc.IpcReadOptions(),
+    pa.ipc.IpcReadOptions(use_threads=False),
+])
 def test_open_file_options(file_fixture, options):
     file_fixture.write_batches()
     source = file_fixture.get_source()
@@ -359,34 +355,30 @@ def test_open_file_with_wrong_options(file_fixture):
 @pytest.mark.pandas
 def test_stream_write_dispatch(stream_fixture):
     # ARROW-1616
-    df = pd.DataFrame(
-        {
-            "one": np.random.randn(5),
-            "two": pd.Categorical(
-                ["foo", np.nan, "bar", "foo", "foo"],
-                categories=["foo", "bar"],
-                ordered=True,
-            ),
-        }
-    )
+    df = pd.DataFrame({
+        'one': np.random.randn(5),
+        'two': pd.Categorical(['foo', np.nan, 'bar', 'foo', 'foo'],
+                              categories=['foo', 'bar'],
+                              ordered=True)
+    })
     table = pa.Table.from_pandas(df, preserve_index=False)
     batch = pa.RecordBatch.from_pandas(df, preserve_index=False)
     with stream_fixture._get_writer(stream_fixture.sink, table.schema) as wr:
         wr.write(table)
         wr.write(batch)
 
-    table = pa.ipc.open_stream(pa.BufferReader(stream_fixture.get_source())).read_all()
-    assert_frame_equal(table.to_pandas(), pd.concat([df, df], ignore_index=True))
+    table = (pa.ipc.open_stream(pa.BufferReader(stream_fixture.get_source()))
+             .read_all())
+    assert_frame_equal(table.to_pandas(),
+                       pd.concat([df, df], ignore_index=True))
 
 
 @pytest.mark.pandas
 def test_stream_write_table_batches(stream_fixture):
     # ARROW-504
-    df = pd.DataFrame(
-        {
-            "one": np.random.randn(20),
-        }
-    )
+    df = pd.DataFrame({
+        'one': np.random.randn(20),
+    })
 
     b1 = pa.RecordBatch.from_pandas(df[:10], preserve_index=False)
     b2 = pa.RecordBatch.from_pandas(df, preserve_index=False)
@@ -400,12 +392,12 @@ def test_stream_write_table_batches(stream_fixture):
 
     assert list(map(len, batches)) == [10, 15, 5, 10]
     result_table = pa.Table.from_batches(batches)
-    assert_frame_equal(
-        result_table.to_pandas(), pd.concat([df[:10], df, df[:10]], ignore_index=True)
-    )
+    assert_frame_equal(result_table.to_pandas(),
+                       pd.concat([df[:10], df, df[:10]],
+                                 ignore_index=True))
 
 
-@pytest.mark.parametrize("use_legacy_ipc_format", [False, True])
+@pytest.mark.parametrize('use_legacy_ipc_format', [False, True])
 def test_stream_simple_roundtrip(stream_fixture, use_legacy_ipc_format):
     stream_fixture.use_legacy_ipc_format = use_legacy_ipc_format
     batches = stream_fixture.write_batches()
@@ -431,15 +423,17 @@ def test_compression_roundtrip():
     values = np.random.randint(0, 3, 10000)
     table = pa.Table.from_arrays([values], names=["values"])
 
-    options = pa.ipc.IpcWriteOptions(compression="zstd")
-    with pa.ipc.RecordBatchFileWriter(sink, table.schema, options=options) as writer:
+    options = pa.ipc.IpcWriteOptions(compression='zstd')
+    with pa.ipc.RecordBatchFileWriter(
+            sink, table.schema, options=options) as writer:
         writer.write_table(table)
     len1 = len(sink.getvalue())
 
     sink2 = io.BytesIO()
-    codec = pa.Codec("zstd", compression_level=5)
+    codec = pa.Codec('zstd', compression_level=5)
     options = pa.ipc.IpcWriteOptions(compression=codec)
-    with pa.ipc.RecordBatchFileWriter(sink2, table.schema, options=options) as writer:
+    with pa.ipc.RecordBatchFileWriter(
+            sink2, table.schema, options=options) as writer:
         writer.write_table(table)
     len2 = len(sink2.getvalue())
 
@@ -468,12 +462,12 @@ def test_write_options():
 
     options.metadata_version = pa.ipc.MetadataVersion.V4
     assert options.metadata_version == pa.ipc.MetadataVersion.V4
-    for value in ("V5", 42):
+    for value in ('V5', 42):
         with pytest.raises((TypeError, ValueError)):
             options.metadata_version = value
 
     assert options.compression is None
-    for value in ["lz4", "zstd"]:
+    for value in ['lz4', 'zstd']:
         if pa.Codec.is_available(value):
             options.compression = value
             assert options.compression == value
@@ -489,42 +483,37 @@ def test_write_options():
     options.use_threads = False
     assert options.use_threads is False
 
-    if pa.Codec.is_available("lz4"):
+    if pa.Codec.is_available('lz4'):
         options = pa.ipc.IpcWriteOptions(
             metadata_version=pa.ipc.MetadataVersion.V4,
             allow_64bit=True,
             use_legacy_format=True,
-            compression="lz4",
-            use_threads=False,
-        )
+            compression='lz4',
+            use_threads=False)
         assert options.metadata_version == pa.ipc.MetadataVersion.V4
         assert options.allow_64bit is True
         assert options.use_legacy_format is True
-        assert options.compression == "lz4"
+        assert options.compression == 'lz4'
         assert options.use_threads is False
 
 
 def test_write_options_legacy_exclusive(stream_fixture):
     with pytest.raises(
-        ValueError, match="provide at most one of options and use_legacy_format"
-    ):
+            ValueError,
+            match="provide at most one of options and use_legacy_format"):
         stream_fixture.use_legacy_ipc_format = True
         stream_fixture.options = pa.ipc.IpcWriteOptions()
         stream_fixture.write_batches()
 
 
-@pytest.mark.parametrize(
-    "options",
-    [
-        pa.ipc.IpcWriteOptions(),
-        pa.ipc.IpcWriteOptions(allow_64bit=True),
-        pa.ipc.IpcWriteOptions(use_legacy_format=True),
-        pa.ipc.IpcWriteOptions(metadata_version=pa.ipc.MetadataVersion.V4),
-        pa.ipc.IpcWriteOptions(
-            use_legacy_format=True, metadata_version=pa.ipc.MetadataVersion.V4
-        ),
-    ],
-)
+@pytest.mark.parametrize('options', [
+    pa.ipc.IpcWriteOptions(),
+    pa.ipc.IpcWriteOptions(allow_64bit=True),
+    pa.ipc.IpcWriteOptions(use_legacy_format=True),
+    pa.ipc.IpcWriteOptions(metadata_version=pa.ipc.MetadataVersion.V4),
+    pa.ipc.IpcWriteOptions(use_legacy_format=True,
+                           metadata_version=pa.ipc.MetadataVersion.V4),
+])
 def test_stream_options_roundtrip(stream_fixture, options):
     stream_fixture.use_legacy_ipc_format = None
     stream_fixture.options = options
@@ -568,7 +557,8 @@ def test_read_options():
         options.included_fields = None
 
     options = pa.ipc.IpcReadOptions(
-        use_threads=False, ensure_native_endian=False, included_fields=[1]
+        use_threads=False, ensure_native_endian=False,
+        included_fields=[1]
     )
     assert options.use_threads is False
     assert options.ensure_native_endian is False
@@ -578,18 +568,16 @@ def test_read_options():
 def test_read_options_included_fields(stream_fixture):
     options1 = pa.ipc.IpcReadOptions()
     options2 = pa.ipc.IpcReadOptions(included_fields=[1])
-    table = pa.Table.from_arrays(
-        [pa.array(["foo", "bar", "baz", "qux"]), pa.array([1, 2, 3, 4])],
-        names=["a", "b"],
-    )
+    table = pa.Table.from_arrays([pa.array(['foo', 'bar', 'baz', 'qux']),
+                                 pa.array([1, 2, 3, 4])],
+                                 names=['a', 'b'])
     with stream_fixture._get_writer(stream_fixture.sink, table.schema) as wr:
         wr.write_table(table)
     source = stream_fixture.get_source()
 
     reader1 = pa.ipc.open_stream(source, options=options1)
     reader2 = pa.ipc.open_stream(
-        source, options=options2, memory_pool=pa.system_memory_pool()
-    )
+        source, options=options2, memory_pool=pa.system_memory_pool())
 
     result1 = reader1.read_all()
     result2 = reader2.read_all()
@@ -604,22 +592,21 @@ def test_read_options_included_fields(stream_fixture):
 
 def test_dictionary_delta(format_fixture):
     ty = pa.dictionary(pa.int8(), pa.utf8())
-    data = [
-        ["foo", "foo", None],
-        ["foo", "bar", "foo"],  # potential delta
-        ["foo", "bar"],  # nothing new
-        ["foo", None, "bar", "quux"],  # potential delta
-        ["bar", "quux"],  # replacement
-    ]
+    data = [["foo", "foo", None],
+            ["foo", "bar", "foo"],  # potential delta
+            ["foo", "bar"],  # nothing new
+            ["foo", None, "bar", "quux"],  # potential delta
+            ["bar", "quux"],  # replacement
+            ]
     batches = [
-        pa.RecordBatch.from_arrays([pa.array(v, type=ty)], names=["dicts"])
-        for v in data
-    ]
+        pa.RecordBatch.from_arrays([pa.array(v, type=ty)], names=['dicts'])
+        for v in data]
     batches_delta_only = batches[:4]
     schema = batches[0].schema
 
     def write_batches(batches, as_table=False):
-        with format_fixture._get_writer(pa.MockOutputStream(), schema) as writer:
+        with format_fixture._get_writer(pa.MockOutputStream(),
+                                        schema) as writer:
             if as_table:
                 table = pa.Table.from_batches(batches)
                 writer.write_table(table)
@@ -644,7 +631,8 @@ def test_dictionary_delta(format_fixture):
         assert st.num_dictionary_deltas == 0
 
     format_fixture.use_legacy_ipc_format = None
-    format_fixture.options = pa.ipc.IpcWriteOptions(emit_dictionary_deltas=True)
+    format_fixture.options = pa.ipc.IpcWriteOptions(
+        emit_dictionary_deltas=True)
     if format_fixture.is_file:
         # File format cannot handle replacement
         with pytest.raises(pa.ArrowInvalid):
@@ -662,7 +650,9 @@ def test_dictionary_delta(format_fixture):
     assert st.num_replaced_dictionaries == 0
     assert st.num_dictionary_deltas == 2
 
-    format_fixture.options = pa.ipc.IpcWriteOptions(unify_dictionaries=True)
+    format_fixture.options = pa.ipc.IpcWriteOptions(
+        unify_dictionaries=True
+    )
     st = write_batches(batches, as_table=True)
     assert st.num_record_batches == 5
     if format_fixture.is_file:
@@ -676,7 +666,7 @@ def test_dictionary_delta(format_fixture):
 
 
 def test_envvar_set_legacy_ipc_format():
-    schema = pa.schema([pa.field("foo", pa.int32())])
+    schema = pa.schema([pa.field('foo', pa.int32())])
 
     writer = pa.ipc.new_stream(pa.BufferOutputStream(), schema)
     assert not writer._use_legacy_format
@@ -685,7 +675,7 @@ def test_envvar_set_legacy_ipc_format():
     assert not writer._use_legacy_format
     assert writer._metadata_version == pa.ipc.MetadataVersion.V5
 
-    with changed_environ("ARROW_PRE_0_15_IPC_FORMAT", "1"):
+    with changed_environ('ARROW_PRE_0_15_IPC_FORMAT', '1'):
         writer = pa.ipc.new_stream(pa.BufferOutputStream(), schema)
         assert writer._use_legacy_format
         assert writer._metadata_version == pa.ipc.MetadataVersion.V5
@@ -693,7 +683,7 @@ def test_envvar_set_legacy_ipc_format():
         assert writer._use_legacy_format
         assert writer._metadata_version == pa.ipc.MetadataVersion.V5
 
-    with changed_environ("ARROW_PRE_1_0_METADATA_VERSION", "1"):
+    with changed_environ('ARROW_PRE_1_0_METADATA_VERSION', '1'):
         writer = pa.ipc.new_stream(pa.BufferOutputStream(), schema)
         assert not writer._use_legacy_format
         assert writer._metadata_version == pa.ipc.MetadataVersion.V4
@@ -701,8 +691,8 @@ def test_envvar_set_legacy_ipc_format():
         assert not writer._use_legacy_format
         assert writer._metadata_version == pa.ipc.MetadataVersion.V4
 
-    with changed_environ("ARROW_PRE_1_0_METADATA_VERSION", "1"):
-        with changed_environ("ARROW_PRE_0_15_IPC_FORMAT", "1"):
+    with changed_environ('ARROW_PRE_1_0_METADATA_VERSION', '1'):
+        with changed_environ('ARROW_PRE_0_15_IPC_FORMAT', '1'):
             writer = pa.ipc.new_stream(pa.BufferOutputStream(), schema)
             assert writer._use_legacy_format
             assert writer._metadata_version == pa.ipc.MetadataVersion.V4
@@ -753,13 +743,13 @@ def test_message_reader(example_messages):
     _, messages = example_messages
 
     assert len(messages) == 6
-    assert messages[0].type == "schema"
+    assert messages[0].type == 'schema'
     assert isinstance(messages[0].metadata, pa.Buffer)
     assert isinstance(messages[0].body, pa.Buffer)
     assert messages[0].metadata_version == pa.MetadataVersion.V5
 
     for msg in messages[1:]:
-        assert msg.type == "record batch"
+        assert msg.type == 'record batch'
         assert isinstance(msg.metadata, pa.Buffer)
         assert isinstance(msg.body, pa.Buffer)
         assert msg.metadata_version == pa.MetadataVersion.V5
@@ -783,7 +773,7 @@ def test_message_serialize_read_message(example_messages):
     assert msg.equals(restored4)
 
     with pytest.raises(pa.ArrowInvalid, match="Corrupted message"):
-        pa.ipc.read_message(pa.BufferReader(b"ab"))
+        pa.ipc.read_message(pa.BufferReader(b'ab'))
 
     with pytest.raises(EOFError):
         pa.ipc.read_message(reader)
@@ -795,14 +785,13 @@ def test_message_read_from_compressed(example_messages):
     _, messages = example_messages
     for message in messages:
         raw_out = pa.BufferOutputStream()
-        with pa.output_stream(raw_out, compression="gzip") as compressed_out:
+        with pa.output_stream(raw_out, compression='gzip') as compressed_out:
             message.serialize_to(compressed_out)
 
         compressed_buf = raw_out.getvalue()
 
-        result = pa.ipc.read_message(
-            pa.input_stream(compressed_buf, compression="gzip")
-        )
+        result = pa.ipc.read_message(pa.input_stream(compressed_buf,
+                                                     compression='gzip'))
         assert result.equals(message)
 
 
@@ -822,12 +811,14 @@ def test_message_read_record_batch(example_messages):
 
 def test_read_record_batch_on_stream_error_message():
     # ARROW-5374
-    batch = pa.record_batch([pa.array([b"foo"], type=pa.utf8())], names=["strs"])
+    batch = pa.record_batch([pa.array([b"foo"], type=pa.utf8())],
+                            names=['strs'])
     stream = pa.BufferOutputStream()
     with pa.ipc.new_stream(stream, batch.schema) as writer:
         writer.write_batch(batch)
     buf = stream.getvalue()
-    with pytest.raises(IOError, match="type record batch but got schema"):
+    with pytest.raises(IOError,
+                       match="type record batch but got schema"):
         pa.ipc.read_record_batch(buf, batch.schema)
 
 
@@ -839,7 +830,7 @@ class StreamReaderServer(threading.Thread):
 
     def init(self, do_read_all):
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._sock.bind(("127.0.0.1", 0))
+        self._sock.bind(('127.0.0.1', 0))
         self._sock.listen(1)
         host, port = self._sock.getsockname()
         self._do_read_all = do_read_all
@@ -851,7 +842,7 @@ class StreamReaderServer(threading.Thread):
     def run(self):
         connection, client_address = self._sock.accept()
         try:
-            source = connection.makefile(mode="rb")
+            source = connection.makefile(mode='rb')
             reader = pa.ipc.open_stream(source)
             self._schema = reader.schema
             if self._do_read_all:
@@ -864,7 +855,8 @@ class StreamReaderServer(threading.Thread):
             self._sock.close()
 
     def get_result(self):
-        return (self._schema, self._table if self._do_read_all else self._batches)
+        return (self._schema, self._table if self._do_read_all
+                else self._batches)
 
 
 class SocketStreamFixture(IpcFixture):
@@ -879,20 +871,19 @@ class SocketStreamFixture(IpcFixture):
         port = self._server.init(do_read_all)
         self._server.start()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self._sock.connect(("127.0.0.1", port))
+        self._sock.connect(('127.0.0.1', port))
         self.sink = self.get_sink()
 
     def stop_and_get_result(self):
         import struct
-
-        self.sink.write(struct.pack("Q", 0))
+        self.sink.write(struct.pack('Q', 0))
         self.sink.flush()
         self._sock.close()
         self._server.join()
         return self._server.get_result()
 
     def get_sink(self):
-        return self._sock.makefile(mode="wb")
+        return self._sock.makefile(mode='wb')
 
     def _get_writer(self, sink, schema):
         return pa.RecordBatchStreamWriter(sink, schema)
@@ -926,11 +917,10 @@ def test_socket_read_all(socket_fixture):
 # ----------------------------------------------------------------------
 # Miscellaneous IPC tests
 
-
 @pytest.mark.pandas
 def test_ipc_file_stream_has_eos():
     # ARROW-5395
-    df = pd.DataFrame({"foo": [1.5]})
+    df = pd.DataFrame({'foo': [1.5]})
     batch = pa.RecordBatch.from_pandas(df)
     sink = pa.BufferOutputStream()
     write_file(batch, sink)
@@ -947,7 +937,7 @@ def test_ipc_file_stream_has_eos():
 
 @pytest.mark.pandas
 def test_ipc_zero_copy_numpy():
-    df = pd.DataFrame({"foo": [1.5]})
+    df = pd.DataFrame({'foo': [1.5]})
 
     batch = pa.RecordBatch.from_pandas(df)
     sink = pa.BufferOutputStream()
@@ -965,13 +955,14 @@ def test_ipc_zero_copy_numpy():
 @pytest.mark.pandas
 @pytest.mark.parametrize("ipc_type", ["stream", "file"])
 def test_batches_with_custom_metadata_roundtrip(ipc_type):
-    df = pd.DataFrame({"foo": [1.5]})
+    df = pd.DataFrame({'foo': [1.5]})
 
     batch = pa.RecordBatch.from_pandas(df)
     sink = pa.BufferOutputStream()
 
     batch_count = 2
-    file_factory = {"stream": pa.ipc.new_stream, "file": pa.ipc.new_file}[ipc_type]
+    file_factory = {"stream": pa.ipc.new_stream,
+                    "file": pa.ipc.new_file}[ipc_type]
 
     with file_factory(sink, batch.schema) as writer:
         for i in range(batch_count):
@@ -986,14 +977,13 @@ def test_batches_with_custom_metadata_roundtrip(ipc_type):
             batch_with_metas = list(reader.iter_batches_with_custom_metadata())
     else:
         with pa.ipc.open_file(buffer) as reader:
-            batch_with_metas = [
-                reader.get_batch_with_custom_metadata(i)
-                for i in range(reader.num_record_batches)
-            ]
+            batch_with_metas = [reader.get_batch_with_custom_metadata(i)
+                                for i in range(reader.num_record_batches)]
 
     for i in range(batch_count):
         assert batch_with_metas[i].batch.num_rows == 1
-        assert isinstance(batch_with_metas[i].custom_metadata, pa.KeyValueMetadata)
+        assert isinstance(
+            batch_with_metas[i].custom_metadata, pa.KeyValueMetadata)
         assert batch_with_metas[i].custom_metadata == {"batch_id": str(i)}
 
     # the last batch has no custom metadata
@@ -1003,10 +993,9 @@ def test_batches_with_custom_metadata_roundtrip(ipc_type):
 
 def test_ipc_stream_no_batches():
     # ARROW-2307
-    table = pa.Table.from_arrays(
-        [pa.array([1, 2, 3, 4]), pa.array(["foo", "bar", "baz", "qux"])],
-        names=["a", "b"],
-    )
+    table = pa.Table.from_arrays([pa.array([1, 2, 3, 4]),
+                                  pa.array(['foo', 'bar', 'baz', 'qux'])],
+                                 names=['a', 'b'])
 
     sink = pa.BufferOutputStream()
     with pa.ipc.new_stream(sink, table.schema):
@@ -1024,7 +1013,7 @@ def test_ipc_stream_no_batches():
 def test_get_record_batch_size():
     N = 10
     itemsize = 8
-    df = pd.DataFrame({"foo": np.random.randn(N)})
+    df = pd.DataFrame({'foo': np.random.randn(N)})
 
     batch = pa.RecordBatch.from_pandas(df)
     assert pa.ipc.get_record_batch_size(batch) > (N * itemsize)
@@ -1039,33 +1028,35 @@ def _check_serialize_pandas_round_trip(df, use_threads=False):
 
 @pytest.mark.pandas
 def test_pandas_serialize_round_trip():
-    index = pd.Index([1, 2, 3], name="my_index")
-    columns = ["foo", "bar"]
+    index = pd.Index([1, 2, 3], name='my_index')
+    columns = ['foo', 'bar']
     df = pd.DataFrame(
-        {"foo": [1.5, 1.6, 1.7], "bar": list("abc")}, index=index, columns=columns
+        {'foo': [1.5, 1.6, 1.7], 'bar': list('abc')},
+        index=index, columns=columns
     )
     _check_serialize_pandas_round_trip(df)
 
 
 @pytest.mark.pandas
 def test_pandas_serialize_round_trip_nthreads():
-    index = pd.Index([1, 2, 3], name="my_index")
-    columns = ["foo", "bar"]
+    index = pd.Index([1, 2, 3], name='my_index')
+    columns = ['foo', 'bar']
     df = pd.DataFrame(
-        {"foo": [1.5, 1.6, 1.7], "bar": list("abc")}, index=index, columns=columns
+        {'foo': [1.5, 1.6, 1.7], 'bar': list('abc')},
+        index=index, columns=columns
     )
     _check_serialize_pandas_round_trip(df, use_threads=True)
 
 
 @pytest.mark.pandas
 def test_pandas_serialize_round_trip_multi_index():
-    index1 = pd.Index([1, 2, 3], name="level_1")
-    index2 = pd.Index(list("def"), name=None)
+    index1 = pd.Index([1, 2, 3], name='level_1')
+    index2 = pd.Index(list('def'), name=None)
     index = pd.MultiIndex.from_arrays([index1, index2])
 
-    columns = ["foo", "bar"]
+    columns = ['foo', 'bar']
     df = pd.DataFrame(
-        {"foo": [1.5, 1.6, 1.7], "bar": list("abc")},
+        {'foo': [1.5, 1.6, 1.7], 'bar': list('abc')},
         index=index,
         columns=columns,
     )
@@ -1080,7 +1071,7 @@ def test_serialize_pandas_empty_dataframe():
 
 @pytest.mark.pandas
 def test_pandas_serialize_round_trip_not_string_columns():
-    df = pd.DataFrame(list(zip([1.5, 1.6, 1.7], "abc")))
+    df = pd.DataFrame(list(zip([1.5, 1.6, 1.7], 'abc')))
     buf = pa.serialize_pandas(df)
     result = pa.deserialize_pandas(buf)
     assert_frame_equal(result, df)
@@ -1088,8 +1079,8 @@ def test_pandas_serialize_round_trip_not_string_columns():
 
 @pytest.mark.pandas
 def test_serialize_pandas_no_preserve_index():
-    df = pd.DataFrame({"a": [1, 2, 3]}, index=[1, 2, 3])
-    expected = pd.DataFrame({"a": [1, 2, 3]})
+    df = pd.DataFrame({'a': [1, 2, 3]}, index=[1, 2, 3])
+    expected = pd.DataFrame({'a': [1, 2, 3]})
 
     buf = pa.serialize_pandas(df, preserve_index=False)
     result = pa.deserialize_pandas(buf)
@@ -1103,9 +1094,9 @@ def test_serialize_pandas_no_preserve_index():
 @pytest.mark.pandas
 def test_schema_batch_serialize_methods():
     nrows = 5
-    df = pd.DataFrame(
-        {"one": np.random.randn(nrows), "two": ["foo", np.nan, "bar", "bazbaz", "qux"]}
-    )
+    df = pd.DataFrame({
+        'one': np.random.randn(nrows),
+        'two': ['foo', np.nan, 'bar', 'bazbaz', 'qux']})
     batch = pa.RecordBatch.from_pandas(df)
 
     s_schema = batch.schema.serialize()
@@ -1117,11 +1108,11 @@ def test_schema_batch_serialize_methods():
 
 
 def test_schema_serialization_with_metadata():
-    field_metadata = {b"foo": b"bar", b"kind": b"field"}
-    schema_metadata = {b"foo": b"bar", b"kind": b"schema"}
+    field_metadata = {b'foo': b'bar', b'kind': b'field'}
+    schema_metadata = {b'foo': b'bar', b'kind': b'schema'}
 
-    f0 = pa.field("a", pa.int8())
-    f1 = pa.field("b", pa.string(), metadata=field_metadata)
+    f0 = pa.field('a', pa.int8())
+    f1 = pa.field('b', pa.string(), metadata=field_metadata)
 
     schema = pa.schema([f0, f1], metadata=schema_metadata)
 
@@ -1147,7 +1138,7 @@ def read_file(source):
 def test_write_empty_ipc_file():
     # ARROW-3894: IPC file was not being properly initialized when no record
     # batches are being written
-    schema = pa.schema([("field", pa.int64())])
+    schema = pa.schema([('field', pa.int64())])
 
     sink = pa.BufferOutputStream()
     with pa.ipc.new_file(sink, schema):
@@ -1162,7 +1153,7 @@ def test_write_empty_ipc_file():
 
 def test_py_record_batch_reader():
     def make_schema():
-        return pa.schema([("field", pa.int64())])
+        return pa.schema([('field', pa.int64())])
 
     def make_batches():
         schema = make_schema()
@@ -1174,7 +1165,8 @@ def test_py_record_batch_reader():
     batches = UserList(make_batches())  # weakrefable
     wr = weakref.ref(batches)
 
-    with pa.RecordBatchReader.from_batches(make_schema(), batches) as reader:
+    with pa.RecordBatchReader.from_batches(make_schema(),
+                                           batches) as reader:
         batches = None
         assert wr() is not None
         assert list(reader) == make_batches()
@@ -1184,7 +1176,8 @@ def test_py_record_batch_reader():
     batches = iter(UserList(make_batches()))  # weakrefable
     wr = weakref.ref(batches)
 
-    with pa.RecordBatchReader.from_batches(make_schema(), batches) as reader:
+    with pa.RecordBatchReader.from_batches(make_schema(),
+                                           batches) as reader:
         batches = None
         assert wr() is not None
         assert list(reader) == make_batches()
@@ -1194,7 +1187,8 @@ def test_py_record_batch_reader():
     # (https://issues.apache.org/jira/browse/ARROW-18229)
     batches = make_batches()
     with pytest.raises(TypeError):
-        reader = pa.RecordBatchReader.from_batches([("field", pa.int64())], batches)
+        reader = pa.RecordBatchReader.from_batches(
+            [('field', pa.int64())], batches)
         pass
 
     with pytest.raises(TypeError):
@@ -1210,13 +1204,12 @@ def test_record_batch_reader_from_arrow_stream():
 
         def __arrow_c_stream__(self, requested_schema=None):
             reader = pa.RecordBatchReader.from_batches(
-                self.batches[0].schema, self.batches
-            )
+                self.batches[0].schema, self.batches)
             return reader.__arrow_c_stream__(requested_schema)
 
     data = [
-        pa.record_batch([pa.array([1, 2, 3], type=pa.int64())], names=["a"]),
-        pa.record_batch([pa.array([4, 5, 6], type=pa.int64())], names=["a"]),
+        pa.record_batch([pa.array([1, 2, 3], type=pa.int64())], names=['a']),
+        pa.record_batch([pa.array([4, 5, 6], type=pa.int64())], names=['a'])
     ]
     wrapper = StreamWrapper(data)
 
@@ -1233,77 +1226,15 @@ def test_record_batch_reader_from_arrow_stream():
     reader = pa.RecordBatchReader.from_stream(wrapper, schema=data[0].schema)
     assert reader.read_all() == expected
 
-    # Passing a different but castable schema works
-    good_schema = pa.schema([pa.field("a", pa.int32())])
-    reader = pa.RecordBatchReader.from_stream(wrapper, schema=good_schema)
-    assert reader.read_all() == expected.cast(good_schema)
-
-    # If schema doesn't match, raises TypeError
-    with pytest.raises(pa.lib.ArrowTypeError, match="Field 0 cannot be cast"):
+    # If schema doesn't match, raises NotImplementedError
+    with pytest.raises(NotImplementedError):
         pa.RecordBatchReader.from_stream(
-            wrapper, schema=pa.schema([pa.field("a", pa.list_(pa.int32()))])
+            wrapper, schema=pa.schema([pa.field('a', pa.int32())])
         )
 
     # Proper type errors for wrong input
     with pytest.raises(TypeError):
-        pa.RecordBatchReader.from_stream(data[0]["a"])
+        pa.RecordBatchReader.from_stream(data[0]['a'])
 
     with pytest.raises(TypeError):
         pa.RecordBatchReader.from_stream(expected, schema=data[0])
-
-
-def test_record_batch_reader_cast():
-    schema_src = pa.schema([pa.field("a", pa.int64())])
-    data = [
-        pa.record_batch([pa.array([1, 2, 3], type=pa.int64())], names=["a"]),
-        pa.record_batch([pa.array([4, 5, 6], type=pa.int64())], names=["a"]),
-    ]
-    table_src = pa.Table.from_batches(data)
-
-    # Cast to same type should always work
-    reader = pa.RecordBatchReader.from_batches(schema_src, data)
-    assert reader.cast(schema_src).read_all() == table_src
-
-    # Check non-trivial cast
-    schema_dst = pa.schema([pa.field("a", pa.int32())])
-    reader = pa.RecordBatchReader.from_batches(schema_src, data)
-    assert reader.cast(schema_dst).read_all() == table_src.cast(schema_dst)
-
-    # Check error for field name/length mismatch
-    reader = pa.RecordBatchReader.from_batches(schema_src, data)
-    with pytest.raises(ValueError, match="Target schema's field names"):
-        reader.cast(pa.schema([]))
-
-    # Check error for impossible cast in call to .cast()
-    reader = pa.RecordBatchReader.from_batches(schema_src, data)
-    with pytest.raises(pa.lib.ArrowTypeError, match="Field 0 cannot be cast"):
-        reader.cast(pa.schema([pa.field("a", pa.list_(pa.int32()))]))
-
-
-def test_record_batch_reader_cast_nulls():
-    schema_src = pa.schema([pa.field("a", pa.int64())])
-    data_with_nulls = [
-        pa.record_batch([pa.array([1, 2, None], type=pa.int64())], names=["a"]),
-    ]
-    data_without_nulls = [
-        pa.record_batch([pa.array([1, 2, 3], type=pa.int64())], names=["a"]),
-    ]
-    table_with_nulls = pa.Table.from_batches(data_with_nulls)
-    table_without_nulls = pa.Table.from_batches(data_without_nulls)
-
-    # Cast to nullable destination should work
-    reader = pa.RecordBatchReader.from_batches(schema_src, data_with_nulls)
-    schema_dst = pa.schema([pa.field("a", pa.int32())])
-    assert reader.cast(schema_dst).read_all() == table_with_nulls.cast(schema_dst)
-
-    # Cast to non-nullable destination should work if there are no nulls
-    reader = pa.RecordBatchReader.from_batches(schema_src, data_without_nulls)
-    schema_dst = pa.schema([pa.field("a", pa.int32(), nullable=False)])
-    assert reader.cast(schema_dst).read_all() == table_without_nulls.cast(schema_dst)
-
-    # Cast to non-nullable destination should error if there are nulls
-    # when the batch is pulled
-    reader = pa.RecordBatchReader.from_batches(schema_src, data_with_nulls)
-    casted_reader = reader.cast(schema_dst)
-    with pytest.raises(pa.lib.ArrowInvalid, match="Can't cast array"):
-        casted_reader.read_all()

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1232,7 +1232,7 @@ def test_record_batch_reader_from_arrow_stream():
     assert reader.read_all() == expected.cast(good_schema)
 
     # If schema doesn't match, raises NotImplementedError
-    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Unsupported cast"):
+    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Field 0 cannot be cast"):
         pa.RecordBatchReader.from_stream(
             wrapper, schema=pa.schema([pa.field('a', pa.list_(pa.int32()))])
         )

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1238,8 +1238,8 @@ def test_record_batch_reader_from_arrow_stream():
     reader = pa.RecordBatchReader.from_stream(wrapper, schema=good_schema)
     assert reader.read_all() == expected.cast(good_schema)
 
-    # If schema doesn't match, raises NotImplementedError
-    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Field 0 cannot be cast"):
+    # If schema doesn't match, raises TypeError
+    with pytest.raises(pa.lib.ArrowTypeError, match="Field 0 cannot be cast"):
         pa.RecordBatchReader.from_stream(
             wrapper, schema=pa.schema([pa.field("a", pa.list_(pa.int32()))])
         )
@@ -1276,7 +1276,7 @@ def test_record_batch_reader_cast():
 
     # Check error for impossible cast in call to .cast()
     reader = pa.RecordBatchReader.from_batches(schema_src, data)
-    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Field 0 cannot be cast"):
+    with pytest.raises(pa.lib.ArrowTypeError, match="Field 0 cannot be cast"):
         reader.cast(pa.schema([pa.field("a", pa.list_(pa.int32()))]))
 
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1269,9 +1269,9 @@ def test_record_batch_reader_cast():
     reader = pa.RecordBatchReader.from_batches(schema_src, data)
     assert reader.cast(schema_dst).read_all() == table_src.cast(schema_dst)
 
-    # Check error for non-equal number of fields
+    # Check error for field name/length mismatch
     reader = pa.RecordBatchReader.from_batches(schema_src, data)
-    with pytest.raises(pa.lib.ArrowInvalid, match="requested schema has 0"):
+    with pytest.raises(ValueError, match="Target schema's field names"):
         reader.cast(pa.schema([]))
 
     # Check error for impossible cast in call to .cast()

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -1226,10 +1226,15 @@ def test_record_batch_reader_from_arrow_stream():
     reader = pa.RecordBatchReader.from_stream(wrapper, schema=data[0].schema)
     assert reader.read_all() == expected
 
+    # Passing a different but castable schema works
+    good_schema = pa.schema([pa.field('a', pa.int32())])
+    reader = pa.RecordBatchReader.from_stream(wrapper, schema=good_schema)
+    assert reader.read_all() == expected.cast(good_schema)
+
     # If schema doesn't match, raises NotImplementedError
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Unsupported cast"):
         pa.RecordBatchReader.from_stream(
-            wrapper, schema=pa.schema([pa.field('a', pa.int32())])
+            wrapper, schema=pa.schema([pa.field('a', pa.list_(pa.int32()))])
         )
 
     # Proper type errors for wrong input

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -642,7 +642,7 @@ def test_table_c_stream_interface():
 
     # If schema doesn't match, raises NotImplementedError
     with pytest.raises(
-        pa.lib.ArrowNotImplementedError, match="Field 0 cannot be cast"
+        pa.lib.ArrowTypeError, match="Field 0 cannot be cast"
     ):
         pa.table(
             wrapper, schema=pa.schema([pa.field('a', pa.list_(pa.int32()))])

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -641,7 +641,9 @@ def test_table_c_stream_interface():
     assert result == expected.cast(good_schema)
 
     # If schema doesn't match, raises NotImplementedError
-    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Unsupported cast"):
+    with pytest.raises(
+        pa.lib.ArrowNotImplementedError, match="Field 0 cannot be cast"
+    ):
         pa.table(
             wrapper, schema=pa.schema([pa.field('a', pa.list_(pa.int32()))])
         )

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -636,7 +636,7 @@ def test_table_c_stream_interface():
     assert result == expected
 
     # Passing a different schema will cast
-    good_schema  = pa.schema([pa.field('a', pa.int32())])
+    good_schema = pa.schema([pa.field('a', pa.int32())])
     result = pa.table(wrapper, schema=good_schema)
     assert result == expected.cast(good_schema)
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -635,9 +635,16 @@ def test_table_c_stream_interface():
     result = pa.table(wrapper, schema=data[0].schema)
     assert result == expected
 
+    # Passing a different schema will cast
+    good_schema  = pa.schema([pa.field('a', pa.int32())])
+    result = pa.table(wrapper, schema=good_schema)
+    assert result == expected.cast(good_schema)
+
     # If schema doesn't match, raises NotImplementedError
-    with pytest.raises(NotImplementedError):
-        pa.table(wrapper, schema=pa.schema([pa.field('a', pa.int32())]))
+    with pytest.raises(pa.lib.ArrowNotImplementedError, match="Unsupported cast"):
+        pa.table(
+            wrapper, schema=pa.schema([pa.field('a', pa.list_(pa.int32()))])
+        )
 
 
 def test_recordbatch_itercolumns():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2629,6 +2629,25 @@ def test_record_batch_sort():
     assert sorted_rb_dict["c"] == ["foobar", "bar", "foo", "car"]
 
 
+def test_record_batch_cast():
+    rb = pa.RecordBatch.from_arrays([
+        pa.array([None, 1]),
+        pa.array([False, True])
+    ], names=["a", "b"])
+    new_schema = pa.schema([pa.field("a", "int64", nullable=True),
+                            pa.field("b", "bool", nullable=False)])
+
+    assert rb.cast(new_schema).schema == new_schema
+
+    # Casting a nullable field to non-nullable is invalid
+    rb = pa.RecordBatch.from_arrays([
+        pa.array([None, 1]),
+        pa.array([None, True])
+    ], names=["a", "b"])
+    with pytest.raises(ValueError):
+        rb.cast(new_schema)
+
+
 @pytest.mark.parametrize("constructor", [pa.table, pa.record_batch])
 def test_numpy_asarray(constructor):
     table = constructor([[1, 2, 3], [4.0, 5.0, 6.0]], names=["a", "b"])


### PR DESCRIPTION
### Rationale for this change

The `requested_schema` portion of the `__arrow_c_stream__()` protocol methods errored in all cases if passed an unequal schema. There was a note about figuring out how to check the cast before doing it and a comment in https://github.com/apache/arrow/issues/40066 about how it should be done lazily. This PR (hopefully) solves both!

### What changes are included in this PR?

- Added `arrow::py::CastingRecordBatchReader`, which wraps a `arrow::RecordBatchReader`, casting each batch as it is pulled.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes: the current approach adds `RecordBatchReader.cast()` as the way to access the casting reader.

* Closes: #40066
* GitHub Issue: #40066