### PR TITLE
GH-39791: [C++][Flight RPC] Flight C++ ServerMiddleware::SendingHeaders call ordering fix

### DIFF
--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -404,7 +404,7 @@ class GrpcServiceHandler final : public FlightService::Service {
                                pb::FlightInfo* response) {
     GrpcServerCallContext flight_context(context);
     GRPC_RETURN_NOT_GRPC_OK(
-        CheckAuth(FlightMethod::GetFlightInfo, context, flight_context));
+        CheckAuth(FlightMethod::GetFlightInfo, context, flight_context, true));
 
     CHECK_ARG_NOT_NULL(flight_context, request, "FlightDescriptor cannot be null");
 
@@ -412,8 +412,9 @@ class GrpcServiceHandler final : public FlightService::Service {
     SERVICE_RETURN_NOT_OK(flight_context, internal::FromProto(*request, &descr));
 
     std::unique_ptr<FlightInfo> info;
-    SERVICE_RETURN_NOT_OK(flight_context,
-                          impl_->base()->GetFlightInfo(flight_context, descr, &info));
+    auto res = impl_->base()->GetFlightInfo(flight_context, descr, &info);
+    addMiddlewareHeaders(context, flight_context);
+    SERVICE_RETURN_NOT_OK(flight_context, res);
 
     if (!info) {
       // Treat null listing as no flights available

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -290,7 +290,8 @@ class GrpcServiceHandler final : public FlightService::Service {
 
   // Authenticate the client (if applicable) and construct the call context
   ::grpc::Status CheckAuth(const FlightMethod& method, ServerContext* context,
-                           GrpcServerCallContext& flight_context) {
+                           GrpcServerCallContext& flight_context,
+                           bool skip_headers = false) {
     if (!auth_handler_) {
       const auto auth_context = context->auth_context();
       if (auth_context && auth_context->IsPeerAuthenticated()) {
@@ -320,11 +321,11 @@ class GrpcServiceHandler final : public FlightService::Service {
 
   // Authenticate the client (if applicable) and construct the call context
   ::grpc::Status MakeCallContext(const FlightMethod& method, ServerContext* context,
-                                 GrpcServerCallContext& flight_context) {
+                                 GrpcServerCallContext& flight_context,
+                                 bool skip_headers = false) {
     // Run server middleware
     const CallInfo info{method};
 
-    GrpcAddServerHeaders outgoing_headers(context);
     for (const auto& factory : middleware_) {
       std::shared_ptr<ServerMiddleware> instance;
       Status result = factory.second->StartCall(info, flight_context, &instance);
@@ -336,11 +337,23 @@ class GrpcServiceHandler final : public FlightService::Service {
       if (instance != nullptr) {
         flight_context.middleware_.push_back(instance);
         flight_context.middleware_map_.insert({factory.first, instance});
-        instance->SendingHeaders(&outgoing_headers);
       }
     }
 
+    // TODO factor this out after fixing all streaming and non-streaming handlers
+    if (!skip_headers) {
+      addMiddlewareHeaders(context, flight_context);
+    }
+
     return ::grpc::Status::OK;
+  }
+
+  void addMiddlewareHeaders(ServerContext* context,
+                            GrpcServerCallContext& flight_context) {
+    GrpcAddServerHeaders outgoing_headers(context);
+    for (const std::shared_ptr<ServerMiddleware>& instance : flight_context.middleware_) {
+      instance->SendingHeaders(&outgoing_headers);
+    }
   }
 
   ::grpc::Status Handshake(

--- a/cpp/src/arrow/flight/transport/grpc/util_internal.h
+++ b/cpp/src/arrow/flight/transport/grpc/util_internal.h
@@ -34,6 +34,23 @@ class Status;
 
 namespace flight {
 
+#define GRPC_CALL_THEN_RETURN_NOT_OK(call, expr)       \
+  do {                                                 \
+    ::arrow::Status _s = (expr);                       \
+    if (ARROW_PREDICT_FALSE(!_s.ok())) {               \
+      (call);                                          \
+      return _s;                                       \
+  } while (0)
+
+#define GRPC_CALL_THEN_RETURN_NOT_GRPC_OK(call, expr)  \
+  do {                                                 \
+    ::grpc::Status _s = (expr);                        \
+    if (ARROW_PREDICT_FALSE(!_s.ok())) {               \
+      (call);                                          \
+      return _s;                                       \
+    }                                                  \
+  } while (0)
+
 #define GRPC_RETURN_NOT_OK(expr)                                 \
   do {                                                           \
     ::arrow::Status _s = (expr);                                 \

--- a/cpp/src/arrow/flight/transport/grpc/util_internal.h
+++ b/cpp/src/arrow/flight/transport/grpc/util_internal.h
@@ -40,6 +40,7 @@ namespace flight {
     if (ARROW_PREDICT_FALSE(!_s.ok())) {         \
       (call);                                    \
       return _s;                                 \
+    }                                            \
   } while (0)
 
 #define GRPC_CALL_THEN_RETURN_NOT_GRPC_OK(call, expr) \

--- a/cpp/src/arrow/flight/transport/grpc/util_internal.h
+++ b/cpp/src/arrow/flight/transport/grpc/util_internal.h
@@ -34,21 +34,21 @@ class Status;
 
 namespace flight {
 
-#define GRPC_CALL_THEN_RETURN_NOT_OK(call, expr)       \
-  do {                                                 \
-    ::arrow::Status _s = (expr);                       \
-    if (ARROW_PREDICT_FALSE(!_s.ok())) {               \
-      (call);                                          \
-      return _s;                                       \
+#define GRPC_CALL_THEN_RETURN_NOT_OK(call, expr) \
+  do {                                           \
+    ::arrow::Status _s = (expr);                 \
+    if (ARROW_PREDICT_FALSE(!_s.ok())) {         \
+      (call);                                    \
+      return _s;                                 \
   } while (0)
 
-#define GRPC_CALL_THEN_RETURN_NOT_GRPC_OK(call, expr)  \
-  do {                                                 \
-    ::grpc::Status _s = (expr);                        \
-    if (ARROW_PREDICT_FALSE(!_s.ok())) {               \
-      (call);                                          \
-      return _s;                                       \
-    }                                                  \
+#define GRPC_CALL_THEN_RETURN_NOT_GRPC_OK(call, expr) \
+  do {                                                \
+    ::grpc::Status _s = (expr);                       \
+    if (ARROW_PREDICT_FALSE(!_s.ok())) {              \
+      (call);                                         \
+      return _s;                                      \
+    }                                                 \
   } while (0)
 
 #define GRPC_RETURN_NOT_OK(expr)                                 \


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Documentation for C++ Flight server middleware implies that SendingHeaders is called when headers are to be sent, however it is instead called when middleware is initialized, prior to the app's RPC handler.  This is also inconsistent with e.g. Java where the call happens post-handler.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

[In-progress] Fix for the above call ordering, so far affecting only non-streaming handlers, including DoAction() but not yet including Handshake().  This PR should also [pending] include a more involved fix for DoGet, DoPut, and DoExchange, for which helpers are already present.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Existing integration tests pass.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Barely:  There is a "breaking" change in that if a C++ RPC handler mutates the call's middleware instance in a way that affects its SendingHeaders() behaviour, this will now work as expected.  However, apps relying on this being broken (i.e. doing something currently moot and expecting it not to work) are themselves fundamentally broken so I am not concerned about this breaking aspect of this change.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**This PR includes breaking changes to public APIs.**

See above regarding user-facing changes.  This SHOULD have zero affect on even remotely sane applications, as above.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #39791