### PR TITLE
GH-40074: [C++][FS][Azure] Implement `DeleteFile()` for flat-namespace storage accounts

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1292,7 +1292,8 @@ class AzureFileSystem::Impl {
       }
       return ExceptionToStatus(
           exception, "GetProperties for '", file_client.GetUrl(),
-          "' failed. GetFileInfo is unable to determine whether the path exists.");
+          "' failed. GetFileInfo is unable to determine whether the path exists: ",
+          location.all);
     }
   }
 
@@ -1346,7 +1347,9 @@ class AzureFileSystem::Impl {
       }
       return ExceptionToStatus(
           exception, "ListBlobsByHierarchy failed for prefix='", *options.Prefix,
-          "'. GetFileInfo is unable to determine whether the path exists.");
+          "' on '", container_client.GetUrl(),
+          "'. GetFileInfo is unable to determine whether the path exists: '",
+          location.all, "'");
     }
   }
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -266,6 +266,24 @@ struct AzureLocation {
     return parent;
   }
 
+  /// \brief Create a copy of this location with the trailing slash removed from the
+  /// path.
+  ///
+  /// \param[in] preserve_original If true, the original string that was parsed
+  /// into this location is preserved as is.
+  AzureLocation RemoveTrailingSlash(bool preserve_original) const {
+    AzureLocation result;
+    if (preserve_original) {
+      result.all = all;
+    } else {
+      result.all = internal::RemoveTrailingSlash(all);
+    }
+    result.container = container;
+    result.path = internal::RemoveTrailingSlash(path);
+    result.path_parts = path_parts;
+    return result;
+  }
+
   Result<AzureLocation> join(const std::string& stem) const {
     return FromString(internal::ConcatAbstractPath(all, stem));
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -2102,7 +2102,11 @@ class AzureFileSystem::Impl {
     // When it's known that the blob doesn't exist as a file, check if it exists as a
     // directory to generate the appropriate error message.
     auto check_if_location_exists_as_dir = [&]() -> Status {
-      ARROW_ASSIGN_OR_RAISE(auto file_info, GetFileInfo(container_client, location));
+      auto no_trailing_slash = location;
+      no_trailing_slash.path = internal::RemoveTrailingSlash(location.path);
+      no_trailing_slash.all = internal::RemoveTrailingSlash(location.all);
+      ARROW_ASSIGN_OR_RAISE(auto file_info,
+                            GetFileInfo(container_client, no_trailing_slash));
       if (file_info.type() == FileType::NotFound) {
         return require_file_to_exist ? PathNotFound(location) : Status::OK();
       }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1924,26 +1924,6 @@ class AzureFileSystem::Impl {
     }
   }
 
-  Status DeleteFile(const AzureLocation& location) {
-    RETURN_NOT_OK(ValidateFileLocation(location));
-    auto file_client = datalake_service_client_->GetFileSystemClient(location.container)
-                           .GetFileClient(location.path);
-    try {
-      auto response = file_client.Delete();
-      // Only the "*IfExists" functions ever set Deleted to false.
-      // All the others either succeed or throw an exception.
-      DCHECK(response.Value.Deleted);
-    } catch (const Storage::StorageException& exception) {
-      if (exception.ErrorCode == "FilesystemNotFound" ||
-          exception.ErrorCode == "PathNotFound") {
-        return PathNotFound(location);
-      }
-      return ExceptionToStatus(exception, "Failed to delete a file: ", location.path,
-                               ": ", file_client.GetUrl());
-    }
-    return Status::OK();
-  }
-
  private:
   /// \brief Create a BlobLeaseClient and acquire a lease on the container.
   ///
@@ -2055,6 +2035,116 @@ class AzureFileSystem::Impl {
   static constexpr auto kTimeNeededForFileOrDirectoryRename = std::chrono::seconds{3};
 
  public:
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  /// \pre location.path does not end with a trailing slash.
+  Status DeleteFileOnFileSystem(const DataLake::DataLakeFileSystemClient& adlfs_client,
+                                const AzureLocation& location, bool require_file_to_exist,
+                                Azure::Nullable<std::string> lease_id = {}) {
+    DCHECK(!location.container.empty());
+    DCHECK(!location.path.empty());
+    DCHECK(!internal::HasTrailingSlash(location.path));
+    auto file_client = adlfs_client.GetFileClient(location.path);
+    DataLake::GetPathPropertiesOptions get_options;
+    get_options.AccessConditions.LeaseId = lease_id;
+    DataLake::DeleteFileOptions delete_options;
+    delete_options.AccessConditions.LeaseId = std::move(lease_id);
+    try {
+      // This is necessary to avoid deletion of directories via DeleteFile.
+      auto properties = file_client.GetProperties(get_options);
+      if (properties.Value.IsDirectory) {
+        return internal::NotAFile(location.all);
+      }
+      auto response = file_client.Delete(delete_options);
+      // Only the "*IfExists" functions ever set Deleted to false.
+      // All the others either succeed or throw an exception.
+      DCHECK(response.Value.Deleted);
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        // ErrorCode can be "FilesystemNotFound", "PathNotFound"...
+        if (require_file_to_exist) {
+          return PathNotFound(location);
+        }
+        return Status::OK();
+      }
+      return ExceptionToStatus(exception, "Failed to delete a file: ", location.path,
+                               ": ", file_client.GetUrl());
+    }
+    return Status::OK();
+  }
+
+  /// \pre location.container is not empty.
+  /// \pre location.path is not empty.
+  /// \pre location.path does not end with a trailing slash.
+  Status DeleteFileOnContainer(const Blobs::BlobContainerClient& container_client,
+                               const AzureLocation& location, bool require_file_to_exist,
+                               const char* operation) {
+    DCHECK(!location.container.empty());
+    DCHECK(!location.path.empty());
+    DCHECK(!internal::HasTrailingSlash(location.path));
+    constexpr auto kFileBlobLeaseTime = std::chrono::seconds{15};
+
+    // If the parent directory of a file is not the container itself, there is a
+    // risk that deleting the file also deletes the *implied directory* -- the
+    // directory that is implied by the existence of the file path.
+    //
+    // In this case, we must ensure that the deletion is not semantically
+    // equivalent to also deleting the directory. This is done by ensuring the
+    // directory marker blob exists before the file is deleted.
+    std::optional<LeaseGuard> file_blob_lease_guard;
+    const auto parent = location.parent();
+    if (!parent.path.empty()) {
+      // We have to check the existence of the file before checking the
+      // existence of the parent directory marker, so we acquire a lease on the
+      // file first.
+      ARROW_ASSIGN_OR_RAISE(auto file_blob_lease_client,
+                            AcquireBlobLease(location, kFileBlobLeaseTime,
+                                             /*allow_missing=*/!require_file_to_exist));
+      if (file_blob_lease_client) {
+        file_blob_lease_guard.emplace(std::move(file_blob_lease_client),
+                                      kFileBlobLeaseTime);
+        // Ensure the empty directory marker blob exists before the file is deleted.
+        //
+        // There is not need to hold a lease on the directory marker because if
+        // a concurrent client deletes the directory marker right after we
+        // create it, the file deletion itself won't be the cause of the directory
+        // deletion. Additionally, the fact that a lease is held on the blob path
+        // semantically preserves the directory -- its existence is implied
+        // until the blob representing the file is deleted -- even if another
+        // client deletes the directory marker.
+        RETURN_NOT_OK(EnsureEmptyDirExists(container_client, parent, operation));
+      } else {
+        // File blob doesn't exist and require_file_to_exists is false, so just return OK.
+        // Trying to delete a file that doesn't exist, costs only one request to the
+        // server.
+        DCHECK(!require_file_to_exist);
+        return Status::OK();
+      }
+    }
+
+    auto blob_client = container_client.GetBlobClient(location.path);
+    Blobs::DeleteBlobOptions options;
+    if (file_blob_lease_guard) {
+      options.AccessConditions.LeaseId = file_blob_lease_guard->LeaseId();
+    }
+    try {
+      auto response = blob_client.Delete(options);
+      // Only the "*IfExists" functions ever set Deleted to false.
+      // All the others either succeed or throw an exception.
+      DCHECK(response.Value.Deleted);
+    } catch (const Storage::StorageException& exception) {
+      if (exception.StatusCode == Http::HttpStatusCode::NotFound) {
+        if (require_file_to_exist) {
+          return PathNotFound(location);
+        }
+        return Status::OK();
+      }
+      return ExceptionToStatus(exception, "Failed to delete a file: ", location.all, ": ",
+                               blob_client.GetUrl());
+    }
+    return Status::OK();
+  }
+
   /// The conditions for a successful container rename are derived from the
   /// conditions for a successful `Move("/$src.container", "/$dest.container")`.
   /// The numbers here match the list in `Move`.
@@ -2545,7 +2635,28 @@ Status AzureFileSystem::DeleteRootDirContents() {
 
 Status AzureFileSystem::DeleteFile(const std::string& path) {
   ARROW_ASSIGN_OR_RAISE(auto location, AzureLocation::FromString(path));
-  return impl_->DeleteFile(location);
+  if (location.container.empty()) {
+    return Status::Invalid("DeleteFile requires a non-empty path.");
+  }
+  if (internal::HasTrailingSlash(location.path) || location.path.empty()) {
+    // Container paths (locations w/o path) or paths ending with a slash are not file
+    // paths.
+    return NotAFile(location);
+  }
+  auto adlfs_client = impl_->GetFileSystemClient(location.container);
+  ARROW_ASSIGN_OR_RAISE(auto hns_support,
+                        impl_->HierarchicalNamespaceSupport(adlfs_client));
+  if (hns_support == HNSSupport::kContainerNotFound) {
+    return PathNotFound(location);
+  }
+  if (hns_support == HNSSupport::kEnabled) {
+    return impl_->DeleteFileOnFileSystem(adlfs_client, location,
+                                         /*require_file_to_exist=*/true);
+  }
+  auto container_client = impl_->GetBlobContainerClient(location.container);
+  return impl_->DeleteFileOnContainer(container_client, location,
+                                      /*require_file_to_exist=*/true,
+                                      /*operation=*/"DeleteFile");
 }
 
 Status AzureFileSystem::Move(const std::string& src, const std::string& dest) {

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -269,11 +269,15 @@ struct AzureLocation {
   /// \brief Create a copy of this location with the trailing slash removed from the
   /// path.
   ///
-  /// The original string that was parsed into this location -- all -- is preserved as is
-  /// to make error messages show what the user originally provided.
-  AzureLocation RemoveTrailingSlashFromPath() const {
+  /// \param[in] preserve_original If true, the original string that was parsed
+  /// into this location is preserved as is.
+  AzureLocation RemoveTrailingSlash(bool preserve_original) const {
     AzureLocation result;
-    result.all = all;
+    if (preserve_original) {
+      result.all = all;
+    } else {
+      result.all = internal::RemoveTrailingSlash(all);
+    }
     result.container = container;
     result.path = internal::RemoveTrailingSlash(path);
     result.path_parts = path_parts;

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -266,24 +266,6 @@ struct AzureLocation {
     return parent;
   }
 
-  /// \brief Create a copy of this location with the trailing slash removed from the
-  /// path.
-  ///
-  /// \param[in] preserve_original If true, the original string that was parsed
-  /// into this location is preserved as is.
-  AzureLocation RemoveTrailingSlash(bool preserve_original) const {
-    AzureLocation result;
-    if (preserve_original) {
-      result.all = all;
-    } else {
-      result.all = internal::RemoveTrailingSlash(all);
-    }
-    result.container = container;
-    result.path = internal::RemoveTrailingSlash(path);
-    result.path_parts = path_parts;
-    return result;
-  }
-
   Result<AzureLocation> join(const std::string& stem) const {
     return FromString(internal::ConcatAbstractPath(all, stem));
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -2144,7 +2144,6 @@ class AzureFileSystem::Impl {
       }
     }
 
-    DCHECK(!internal::HasTrailingSlash(location.path));
     auto blob_client = container_client.GetBlobClient(location.path);
     Blobs::DeleteBlobOptions options;
     if (file_blob_lease_guard) {

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1292,8 +1292,7 @@ class AzureFileSystem::Impl {
       }
       return ExceptionToStatus(
           exception, "GetProperties for '", file_client.GetUrl(),
-          "' failed. GetFileInfo is unable to determine whether the path exists: ",
-          location.all);
+          "' failed. GetFileInfo is unable to determine whether the path exists.");
     }
   }
 
@@ -1347,9 +1346,7 @@ class AzureFileSystem::Impl {
       }
       return ExceptionToStatus(
           exception, "ListBlobsByHierarchy failed for prefix='", *options.Prefix,
-          "' on '", container_client.GetUrl(),
-          "'. GetFileInfo is unable to determine whether the path exists: '",
-          location.all, "'");
+          "'. GetFileInfo is unable to determine whether the path exists.");
     }
   }
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1103,7 +1103,11 @@ class LeaseGuard {
     return Status::OK();
   }
 
-  /// \brief Break the lease before deleting or renaming the resource.
+  /// \brief Break the lease before deleting or renaming the resource via the
+  /// DataLakeFileSystemClient API.
+  ///
+  /// NOTE: When using the Blobs API, this is not necessary -- you can release a
+  /// lease on a path after it's deleted with a lease on it.
   ///
   /// Calling this is recommended when the resource for which the lease was acquired is
   /// about to be deleted as there is no way of releasing the lease after that, we can

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1992,7 +1992,7 @@ class AzureFileSystem::Impl {
   /// optional (nullptr denotes blob not found)
   Result<std::unique_ptr<Blobs::BlobLeaseClient>> AcquireBlobLease(
       const AzureLocation& location, std::chrono::seconds lease_duration,
-      bool allow_missing = false, bool retry_allowed = true) {
+      bool allow_missing, bool retry_allowed = true) {
     DCHECK(!location.container.empty() && !location.path.empty());
     auto path = std::string{internal::RemoveTrailingSlash(location.path)};
     auto blob_client = GetBlobClient(location.container, std::move(path));
@@ -2236,7 +2236,8 @@ class AzureFileSystem::Impl {
     const auto dest_path = std::string{internal::RemoveTrailingSlash(dest.path)};
 
     // Ensure that src exists and, if path has a trailing slash, that it's a directory.
-    ARROW_ASSIGN_OR_RAISE(auto src_lease_client, AcquireBlobLease(src, kLeaseDuration));
+    ARROW_ASSIGN_OR_RAISE(auto src_lease_client,
+                          AcquireBlobLease(src, kLeaseDuration, /*allow_missing=*/false));
     LeaseGuard src_lease_guard{std::move(src_lease_client), kLeaseDuration};
     // It might be necessary to check src is a directory 0-3 times in this function,
     // so we use a lazy evaluation function to avoid redundant calls to GetFileInfo().

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -2102,9 +2102,7 @@ class AzureFileSystem::Impl {
     // When it's known that the blob doesn't exist as a file, check if it exists as a
     // directory to generate the appropriate error message.
     auto check_if_location_exists_as_dir = [&]() -> Status {
-      auto no_trailing_slash_location = location.RemoveTrailingSlashFromPath();
-      ARROW_ASSIGN_OR_RAISE(auto file_info,
-                            GetFileInfo(container_client, no_trailing_slash_location));
+      ARROW_ASSIGN_OR_RAISE(auto file_info, GetFileInfo(container_client, location));
       if (file_info.type() == FileType::NotFound) {
         return require_file_to_exist ? PathNotFound(location) : Status::OK();
       }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -269,15 +269,11 @@ struct AzureLocation {
   /// \brief Create a copy of this location with the trailing slash removed from the
   /// path.
   ///
-  /// \param[in] preserve_original If true, the original string that was parsed
-  /// into this location is preserved as is.
-  AzureLocation RemoveTrailingSlash(bool preserve_original) const {
+  /// The original string that was parsed into this location -- all -- is preserved as is
+  /// to make error messages show what the user originally provided.
+  AzureLocation RemoveTrailingSlashFromPath() const {
     AzureLocation result;
-    if (preserve_original) {
-      result.all = all;
-    } else {
-      result.all = internal::RemoveTrailingSlash(all);
-    }
+    result.all = all;
     result.container = container;
     result.path = internal::RemoveTrailingSlash(path);
     result.path_parts = path_parts;
@@ -2102,8 +2098,7 @@ class AzureFileSystem::Impl {
     DCHECK(!location.container.empty());
     DCHECK(!location.path.empty());
     constexpr auto kFileBlobLeaseTime = std::chrono::seconds{15};
-    auto no_trailing_slash_location = location.RemoveTrailingSlash(
-        /*preserve_original=*/true);
+    auto no_trailing_slash_location = location.RemoveTrailingSlashFromPath();
 
     std::optional<FileType> location_type_opt;
     auto location_type_lazy = [&]() -> Result<FileType> {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -908,14 +908,14 @@ class TestAzureFileSystem : public ::testing::Test {
 
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         IOError,
-        ::testing::HasSubstr("Path does not exist '" + data.Path("nonexistent-file") +
+        ::testing::HasSubstr("Path does not exist '" + data.Path("nonexistent-path") +
                              "'"),
-        fs()->DeleteFile(data.Path("nonexistent-file")));
+        fs()->DeleteFile(data.Path("nonexistent-path")));
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         IOError,
-        ::testing::HasSubstr("Not a regular file: '" + data.Path("nonexistent-file/") +
+        ::testing::HasSubstr("Not a regular file: '" + data.Path("nonexistent-path/") +
                              "'"),
-        fs()->DeleteFile(data.Path("nonexistent-file/")));
+        fs()->DeleteFile(data.Path("nonexistent-path/")));
 
     arrow::fs::AssertFileInfo(fs(), data.ObjectPath(), FileType::File);
     ASSERT_OK(fs()->DeleteFile(data.ObjectPath()));
@@ -959,14 +959,14 @@ class TestAzureFileSystem : public ::testing::Test {
     // Trying to delete a non-existing file in an existing directory should fail
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         IOError,
-        ::testing::HasSubstr("Path does not exist '" + data.Path("dir/nonexistent-file") +
+        ::testing::HasSubstr("Path does not exist '" + data.Path("dir/nonexistent-path") +
                              "'"),
-        fs()->DeleteFile(data.Path("dir/nonexistent-file")));
+        fs()->DeleteFile(data.Path("dir/nonexistent-path")));
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         IOError,
         ::testing::HasSubstr("Not a regular file: '" +
-                             data.Path("dir/nonexistent-file/") + "'"),
-        fs()->DeleteFile(data.Path("dir/nonexistent-file/")));
+                             data.Path("dir/nonexistent-path/") + "'"),
+        fs()->DeleteFile(data.Path("dir/nonexistent-path/")));
 
     // Trying to delete the directory with DeleteFile should fail
     if (WithHierarchicalNamespace()) {
@@ -993,11 +993,11 @@ class TestAzureFileSystem : public ::testing::Test {
     // Recreating the file on the same path gurantees leases were properly released/broken
     setup_dir_file0();
 
-    arrow::fs::AssertFileInfo(fs(), data.Path("dir/file0"), FileType::File);
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         IOError,
         ::testing::HasSubstr("Not a regular file: '" + data.Path("dir/file0/") + "'"),
         fs()->DeleteFile(data.Path("dir/file0/")));
+    arrow::fs::AssertFileInfo(fs(), data.Path("dir/file0"), FileType::File);
   }
 
  private:


### PR DESCRIPTION
### Rationale for this change

It was not implemented yet.

### What changes are included in this PR?

 - An implementation of `DeleteFile()` that is specialized to storage accounts that don't have HNS support enabled
 - This fixes a semantic issue: deleting a file should not delete the parent directory when the file deleted was the last one
 - Increased test coverage
 - Fix of a bug in the version that deletes files in HNS-enabled accounts (we shouldn't let `DeleteFile` delete directories even if they are empty)

### Are these changes tested?

Yes. Tests were re-written and moved to `TestAzureFileSystemOnAllScenarios`.
* Closes: #40074