### PR TITLE
GH-39663: [C++] Ensure top-level benchmarks present informative metrics

### DIFF
--- a/cpp/src/arrow/builder_benchmark.cc
+++ b/cpp/src/arrow/builder_benchmark.cc
@@ -56,6 +56,7 @@ constexpr int64_t kRounds = 256;
 static VectorType kData = AlmostU8CompressibleVector();
 constexpr int64_t kBytesProcessPerRound = kNumberOfElements * sizeof(ValueType);
 constexpr int64_t kBytesProcessed = kRounds * kBytesProcessPerRound;
+constexpr int64_t kItemsProcessed = kRounds * kNumberOfElements;
 
 static const char* kBinaryString = "12345678";
 static std::string_view kBinaryView(kBinaryString);
@@ -73,6 +74,7 @@ static void BuildIntArrayNoNulls(benchmark::State& state) {  // NOLINT non-const
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 static void BuildAdaptiveIntNoNulls(
@@ -89,6 +91,7 @@ static void BuildAdaptiveIntNoNulls(
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 static void BuildAdaptiveIntNoNullsScalarAppend(
@@ -107,6 +110,7 @@ static void BuildAdaptiveIntNoNullsScalarAppend(
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 static void BuildBooleanArrayNoNulls(
@@ -127,6 +131,7 @@ static void BuildBooleanArrayNoNulls(
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 static void BuildBinaryArray(benchmark::State& state) {  // NOLINT non-const reference
@@ -142,6 +147,7 @@ static void BuildBinaryArray(benchmark::State& state) {  // NOLINT non-const ref
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 static void BuildChunkedBinaryArray(
@@ -161,6 +167,7 @@ static void BuildChunkedBinaryArray(
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 static void BuildFixedSizeBinaryArray(
@@ -179,6 +186,7 @@ static void BuildFixedSizeBinaryArray(
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 static void BuildDecimalArray(benchmark::State& state) {  // NOLINT non-const reference
@@ -199,6 +207,7 @@ static void BuildDecimalArray(benchmark::State& state) {  // NOLINT non-const re
   }
 
   state.SetBytesProcessed(state.iterations() * kRounds * kNumberOfElements * 16);
+  state.SetItemsProcessed(state.iterations() * kRounds * kNumberOfElements);
 }
 
 // ----------------------------------------------------------------------
@@ -317,6 +326,7 @@ static void BenchmarkDictionaryArray(
     fodder_nbytes = fodder.size() * sizeof(Scalar);
   }
   state.SetBytesProcessed(state.iterations() * fodder_nbytes * kRounds);
+  state.SetItemsProcessed(state.iterations() * fodder.size() * kRounds);
 }
 
 static void BuildInt64DictionaryArrayRandom(
@@ -361,6 +371,7 @@ static void ArrayDataConstructDestruct(
     InitArrays();
     arrays.clear();
   }
+  state.SetItemsProcessed(state.iterations() * kNumArrays);
 }
 
 // ----------------------------------------------------------------------
@@ -430,6 +441,7 @@ static void ReferenceBuildVectorNoNulls(
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+  state.SetItemsProcessed(state.iterations() * kItemsProcessed);
 }
 
 BENCHMARK(ReferenceBuildVectorNoNulls);

--- a/cpp/src/arrow/memory_pool_benchmark.cc
+++ b/cpp/src/arrow/memory_pool_benchmark.cc
@@ -23,6 +23,8 @@
 
 namespace arrow {
 
+static constexpr int64_t kCacheLineSize = 64;
+
 struct SystemAlloc {
   static Result<MemoryPool*> GetAllocator() { return system_memory_pool(); }
 };
@@ -51,8 +53,8 @@ static void TouchCacheLines(uint8_t* data, int64_t nbytes) {
   uint8_t total = 0;
   while (nbytes > 0) {
     total += *data;
-    data += 64;
-    nbytes -= 64;
+    data += kCacheLineSize;
+    nbytes -= kCacheLineSize;
   }
   benchmark::DoNotOptimize(total);
 }
@@ -71,6 +73,8 @@ static void TouchArea(benchmark::State& state) {  // NOLINT non-const reference
   }
 
   pool->Free(data, nbytes);
+  state.SetItemsProcessed(state.iterations());
+  state.SetBytesProcessed(state.iterations() * nbytes);
 }
 
 // Benchmark the raw cost of allocating memory.
@@ -88,6 +92,9 @@ static void AllocateDeallocate(benchmark::State& state) {  // NOLINT non-const r
     ARROW_CHECK_OK(pool->Allocate(nbytes, &data));
     pool->Free(data, nbytes);
   }
+  state.SetItemsProcessed(state.iterations());
+  // SetBytesProcessed() would give nonsensical figures since the data is not
+  // actually processed.
 }
 
 // Benchmark the cost of allocating memory plus accessing it.
@@ -103,6 +110,8 @@ static void AllocateTouchDeallocate(
     TouchCacheLines(data, nbytes);
     pool->Free(data, nbytes);
   }
+  state.SetItemsProcessed(state.iterations());
+  state.SetBytesProcessed(state.iterations() * nbytes);
 }
 
 #define BENCHMARK_ALLOCATE_ARGS \

--- a/cpp/src/arrow/util/int_util_benchmark.cc
+++ b/cpp/src/arrow/util/int_util_benchmark.cc
@@ -64,6 +64,7 @@ static void DetectUIntWidthNoNulls(
     benchmark::DoNotOptimize(result);
   }
   state.SetBytesProcessed(state.iterations() * values.size() * sizeof(uint64_t));
+  state.SetItemsProcessed(state.iterations() * values.size());
 }
 
 static void DetectUIntWidthNulls(benchmark::State& state) {  // NOLINT non-const reference
@@ -76,6 +77,7 @@ static void DetectUIntWidthNulls(benchmark::State& state) {  // NOLINT non-const
     benchmark::DoNotOptimize(result);
   }
   state.SetBytesProcessed(state.iterations() * values.size() * sizeof(uint64_t));
+  state.SetItemsProcessed(state.iterations() * values.size());
 }
 
 static void DetectIntWidthNoNulls(
@@ -87,6 +89,7 @@ static void DetectIntWidthNoNulls(
     benchmark::DoNotOptimize(result);
   }
   state.SetBytesProcessed(state.iterations() * values.size() * sizeof(uint64_t));
+  state.SetItemsProcessed(state.iterations() * values.size());
 }
 
 static void DetectIntWidthNulls(benchmark::State& state) {  // NOLINT non-const reference
@@ -99,6 +102,7 @@ static void DetectIntWidthNulls(benchmark::State& state) {  // NOLINT non-const 
     benchmark::DoNotOptimize(result);
   }
   state.SetBytesProcessed(state.iterations() * values.size() * sizeof(uint64_t));
+  state.SetItemsProcessed(state.iterations() * values.size());
 }
 
 static void CheckIndexBoundsInt32(

--- a/cpp/src/arrow/util/range_benchmark.cc
+++ b/cpp/src/arrow/util/range_benchmark.cc
@@ -46,6 +46,7 @@ void for_loop(benchmark::State& state) {
   for (auto _ : state) {
     for (int64_t index = 0; index < kSize; ++index) target[index] = source[index] + 1;
   }
+  state.SetItemsProcessed(state.iterations() * kSize);
 }
 
 BENCHMARK(for_loop);
@@ -58,6 +59,7 @@ void std_copy(benchmark::State& state) {
   for (auto _ : state) {
     std::copy(source.begin(), source.end(), target.begin());
   }
+  state.SetItemsProcessed(state.iterations() * kSize);
 }
 
 BENCHMARK(std_copy);
@@ -71,6 +73,7 @@ void std_copy_converting(benchmark::State& state) {
   for (auto _ : state) {
     std::copy(source.begin(), source.end(), target.begin());
   }
+  state.SetItemsProcessed(state.iterations() * kSize);
 }
 
 BENCHMARK(std_copy_converting);
@@ -85,6 +88,7 @@ void lazy_copy(benchmark::State& state) {
   for (auto _ : state) {
     std::copy(lazy_range.begin(), lazy_range.end(), target.begin());
   }
+  state.SetItemsProcessed(state.iterations() * kSize);
 }
 
 BENCHMARK(lazy_copy);
@@ -101,6 +105,7 @@ void lazy_copy_converting(benchmark::State& state) {
   for (auto _ : state) {
     std::copy(lazy_range.begin(), lazy_range.end(), target.begin());
   }
+  state.SetItemsProcessed(state.iterations() * kSize);
 }
 
 BENCHMARK(lazy_copy_converting);
@@ -119,6 +124,7 @@ void lazy_postinc(benchmark::State& state) {
 
     while (lazy_iter != lazy_end) *(target_iter++) = *(lazy_iter++);
   }
+  state.SetItemsProcessed(state.iterations() * kSize);
 }
 
 BENCHMARK(lazy_postinc);


### PR DESCRIPTION
### Rationale for this change

Some benchmarks may present only an iteration time, or not present sufficiently informative metrics.

### What changes are included in this PR?

Add bytes/second and/or items/second metrics to top-level benchmarks where applicable.

This PR only tackles miscellaneous benchmarks from the top-level Arrow directory, as well as IO, IPC and utilities.

### Are these changes tested?

Manually.

### Are there any user-facing changes?

No.
* Closes: #39663