### PR TITLE
GH-39978: [C++][Parquet] Expand BYTE_STREAM_SPLIT to support FIXED_LEN_BYTE_ARRAY, INT32 and INT64

### DIFF
--- a/cpp/src/arrow/util/byte_stream_split_test.cc
+++ b/cpp/src/arrow/util/byte_stream_split_test.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <functional>
@@ -35,7 +36,8 @@
 
 namespace arrow::util::internal {
 
-using ByteStreamSplitTypes = ::testing::Types<float, double>;
+using ByteStreamSplitTypes =
+    ::testing::Types<int8_t, int16_t, int32_t, int64_t, std::array<uint8_t, 3>>;
 
 template <typename Func>
 struct NamedFunc {
@@ -63,23 +65,12 @@ class TestByteStreamSplitSpecialized : public ::testing::Test {
  public:
   static constexpr int kWidth = static_cast<int>(sizeof(T));
 
-  using EncodeFunc = NamedFunc<std::function<decltype(ByteStreamSplitEncode<kWidth>)>>;
-  using DecodeFunc = NamedFunc<std::function<decltype(ByteStreamSplitDecode<kWidth>)>>;
+  using EncodeFunc = NamedFunc<std::function<decltype(ByteStreamSplitEncode)>>;
+  using DecodeFunc = NamedFunc<std::function<decltype(ByteStreamSplitDecode)>>;
 
   void SetUp() override {
-    encode_funcs_.push_back({"reference", &ReferenceEncode});
-    encode_funcs_.push_back({"scalar", &ByteStreamSplitEncodeScalar<kWidth>});
-    decode_funcs_.push_back({"scalar", &ByteStreamSplitDecodeScalar<kWidth>});
-#if defined(ARROW_HAVE_SIMD_SPLIT)
-    encode_funcs_.push_back({"simd", &ByteStreamSplitEncodeSimd<kWidth>});
-    decode_funcs_.push_back({"simd", &ByteStreamSplitDecodeSimd<kWidth>});
-    encode_funcs_.push_back({"simd128", &ByteStreamSplitEncodeSimd128<kWidth>});
-    decode_funcs_.push_back({"simd128", &ByteStreamSplitDecodeSimd128<kWidth>});
-#endif
-#if defined(ARROW_HAVE_AVX2)
-    encode_funcs_.push_back({"avx2", &ByteStreamSplitEncodeAvx2<kWidth>});
-    decode_funcs_.push_back({"avx2", &ByteStreamSplitDecodeAvx2<kWidth>});
-#endif
+    decode_funcs_ = MakeDecodeFuncs();
+    encode_funcs_ = MakeEncodeFuncs();
   }
 
   void TestRoundtrip(int64_t num_values) {
@@ -92,12 +83,12 @@ class TestByteStreamSplitSpecialized : public ::testing::Test {
     for (const auto& encode_func : encode_funcs_) {
       ARROW_SCOPED_TRACE("encode_func = ", encode_func);
       encoded.assign(encoded.size(), 0);
-      encode_func.func(reinterpret_cast<const uint8_t*>(input.data()), num_values,
+      encode_func.func(reinterpret_cast<const uint8_t*>(input.data()), kWidth, num_values,
                        encoded.data());
       for (const auto& decode_func : decode_funcs_) {
         ARROW_SCOPED_TRACE("decode_func = ", decode_func);
         decoded.assign(decoded.size(), T{});
-        decode_func.func(encoded.data(), num_values, /*stride=*/num_values,
+        decode_func.func(encoded.data(), kWidth, num_values, /*stride=*/num_values,
                          reinterpret_cast<uint8_t*>(decoded.data()));
         ASSERT_EQ(decoded, input);
       }
@@ -123,7 +114,8 @@ class TestByteStreamSplitSpecialized : public ::testing::Test {
       int64_t offset = 0;
       while (offset < num_values) {
         auto chunk_size = std::min<int64_t>(num_values - offset, chunk_size_dist(gen));
-        decode_func.func(encoded.data() + offset, chunk_size, /*stride=*/num_values,
+        decode_func.func(encoded.data() + offset, kWidth, chunk_size,
+                         /*stride=*/num_values,
                          reinterpret_cast<uint8_t*>(decoded.data() + offset));
         offset += chunk_size;
       }
@@ -141,20 +133,48 @@ class TestByteStreamSplitSpecialized : public ::testing::Test {
   static std::vector<T> MakeRandomInput(int64_t num_values) {
     std::vector<T> input(num_values);
     random_bytes(kWidth * num_values, seed_++, reinterpret_cast<uint8_t*>(input.data()));
-    // Avoid NaNs to ease comparison
-    for (auto& value : input) {
-      if (std::isnan(value)) {
-        value = nan_replacement_++;
-      }
-    }
     return input;
+  }
+
+  template <bool kSimdImplemented = (kWidth == 4 || kWidth == 8)>
+  static std::vector<DecodeFunc> MakeDecodeFuncs() {
+    std::vector<DecodeFunc> funcs;
+    funcs.push_back({"scalar_dynamic", &ByteStreamSplitDecodeScalarDynamic});
+    funcs.push_back({"scalar", &ByteStreamSplitDecodeScalar<kWidth>});
+#if defined(ARROW_HAVE_SIMD_SPLIT)
+    if constexpr (kSimdImplemented) {
+      funcs.push_back({"simd", &ByteStreamSplitDecodeSimd<kWidth>});
+      funcs.push_back({"simd128", &ByteStreamSplitDecodeSimd128<kWidth>});
+#if defined(ARROW_HAVE_AVX2)
+      funcs.push_back({"avx2", &ByteStreamSplitDecodeAvx2<kWidth>});
+#endif
+    }
+#endif  // defined(ARROW_HAVE_SIMD_SPLIT)
+    return funcs;
+  }
+
+  template <bool kSimdImplemented = (kWidth == 4 || kWidth == 8)>
+  static std::vector<EncodeFunc> MakeEncodeFuncs() {
+    std::vector<EncodeFunc> funcs;
+    funcs.push_back({"reference", &ReferenceByteStreamSplitEncode});
+    funcs.push_back({"scalar_dynamic", &ByteStreamSplitEncodeScalarDynamic});
+    funcs.push_back({"scalar", &ByteStreamSplitEncodeScalar<kWidth>});
+#if defined(ARROW_HAVE_SIMD_SPLIT)
+    if constexpr (kSimdImplemented) {
+      funcs.push_back({"simd", &ByteStreamSplitEncodeSimd<kWidth>});
+      funcs.push_back({"simd128", &ByteStreamSplitEncodeSimd128<kWidth>});
+#if defined(ARROW_HAVE_AVX2)
+      funcs.push_back({"avx2", &ByteStreamSplitEncodeAvx2<kWidth>});
+#endif
+    }
+#endif  // defined(ARROW_HAVE_SIMD_SPLIT)
+    return funcs;
   }
 
   std::vector<EncodeFunc> encode_funcs_;
   std::vector<DecodeFunc> decode_funcs_;
 
   static inline uint32_t seed_ = 42;
-  static inline T nan_replacement_ = 0;
 };
 
 TYPED_TEST_SUITE(TestByteStreamSplitSpecialized, ByteStreamSplitTypes);

--- a/cpp/src/parquet/column_io_benchmark.cc
+++ b/cpp/src/parquet/column_io_benchmark.cc
@@ -54,45 +54,57 @@ std::shared_ptr<ColumnDescriptor> Int64Schema(Repetition::type repetition) {
 }
 
 void SetBytesProcessed(::benchmark::State& state, Repetition::type repetition) {
-  int64_t bytes_processed = state.iterations() * state.range(0) * sizeof(int64_t);
+  int64_t num_values = state.iterations() * state.range(0);
+  int64_t bytes_processed = num_values * sizeof(int64_t);
   if (repetition != Repetition::REQUIRED) {
-    bytes_processed += state.iterations() * state.range(0) * sizeof(int16_t);
+    bytes_processed += num_values * sizeof(int16_t);
   }
   if (repetition == Repetition::REPEATED) {
-    bytes_processed += state.iterations() * state.range(0) * sizeof(int16_t);
+    bytes_processed += num_values * sizeof(int16_t);
   }
   state.SetBytesProcessed(bytes_processed);
+  state.SetItemsProcessed(num_values);
 }
 
-template <Repetition::type repetition,
-          Compression::type codec = Compression::UNCOMPRESSED>
-static void BM_WriteInt64Column(::benchmark::State& state) {
+static void BM_WriteInt64Column(::benchmark::State& state, Repetition::type repetition,
+                                Compression::type codec, Encoding::type encoding) {
   format::ColumnChunk thrift_metadata;
 
   ::arrow::random::RandomArrayGenerator rgen(1337);
   auto values = rgen.Int64(state.range(0), 0, 1000000, 0);
-  const auto& i8_values = static_cast<const ::arrow::Int64Array&>(*values);
+  const auto& int64_values = static_cast<const ::arrow::Int64Array&>(*values);
 
   std::vector<int16_t> definition_levels(state.range(0), 1);
   std::vector<int16_t> repetition_levels(state.range(0), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
   std::shared_ptr<WriterProperties> properties = WriterProperties::Builder()
                                                      .compression(codec)
-                                                     ->encoding(Encoding::PLAIN)
+                                                     ->encoding(encoding)
                                                      ->disable_dictionary()
                                                      ->build();
   auto metadata = ColumnChunkMetaDataBuilder::Make(
       properties, schema.get(), reinterpret_cast<uint8_t*>(&thrift_metadata));
 
-  while (state.KeepRunning()) {
+  int64_t data_size = values->length() * sizeof(int64_t);
+  int64_t stream_size = 0;
+  for (auto _ : state) {
     auto stream = CreateOutputStream();
     std::shared_ptr<Int64Writer> writer = BuildWriter(
         state.range(0), stream, metadata.get(), schema.get(), properties.get(), codec);
-    writer->WriteBatch(i8_values.length(), definition_levels.data(),
-                       repetition_levels.data(), i8_values.raw_values());
+    writer->WriteBatch(int64_values.length(), definition_levels.data(),
+                       repetition_levels.data(), int64_values.raw_values());
     writer->Close();
+    stream_size = stream->Tell().ValueOrDie();
   }
   SetBytesProcessed(state, repetition);
+  state.counters["compression_ratio"] = static_cast<double>(data_size) / stream_size;
+}
+
+template <Repetition::type repetition,
+          Compression::type codec = Compression::UNCOMPRESSED,
+          Encoding::type encoding = Encoding::PLAIN>
+static void BM_WriteInt64Column(::benchmark::State& state) {
+  BM_WriteInt64Column(state, repetition, codec, encoding);
 }
 
 BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REQUIRED)->Arg(1 << 20);
@@ -106,6 +118,12 @@ BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::OPTIONAL, Compression::SNAPP
     ->Arg(1 << 20);
 BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REPEATED, Compression::SNAPPY)
     ->Arg(1 << 20);
+BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REQUIRED, Compression::SNAPPY,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Arg(1 << 20);
+BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::OPTIONAL, Compression::SNAPPY,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Arg(1 << 20);
 #endif
 
 #ifdef ARROW_WITH_LZ4
@@ -115,6 +133,12 @@ BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::OPTIONAL, Compression::LZ4)
     ->Arg(1 << 20);
 BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REPEATED, Compression::LZ4)
     ->Arg(1 << 20);
+BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REQUIRED, Compression::LZ4,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Arg(1 << 20);
+BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::OPTIONAL, Compression::LZ4,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Arg(1 << 20);
 #endif
 
 #ifdef ARROW_WITH_ZSTD
@@ -123,6 +147,12 @@ BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REQUIRED, Compression::ZSTD)
 BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::OPTIONAL, Compression::ZSTD)
     ->Arg(1 << 20);
 BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REPEATED, Compression::ZSTD)
+    ->Arg(1 << 20);
+BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::REQUIRED, Compression::ZSTD,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Arg(1 << 20);
+BENCHMARK_TEMPLATE(BM_WriteInt64Column, Repetition::OPTIONAL, Compression::ZSTD,
+                   Encoding::BYTE_STREAM_SPLIT)
     ->Arg(1 << 20);
 #endif
 
@@ -135,17 +165,20 @@ std::shared_ptr<Int64Reader> BuildReader(std::shared_ptr<Buffer>& buffer,
       ColumnReader::Make(schema, std::move(page_reader)));
 }
 
-template <Repetition::type repetition,
-          Compression::type codec = Compression::UNCOMPRESSED>
-static void BM_ReadInt64Column(::benchmark::State& state) {
+static void BM_ReadInt64Column(::benchmark::State& state, Repetition::type repetition,
+                               Compression::type codec, Encoding::type encoding) {
   format::ColumnChunk thrift_metadata;
-  std::vector<int64_t> values(state.range(0), 128);
+
+  ::arrow::random::RandomArrayGenerator rgen(1337);
+  auto values = rgen.Int64(state.range(0), 0, 1000000, 0);
+  const auto& int64_values = static_cast<const ::arrow::Int64Array&>(*values);
+
   std::vector<int16_t> definition_levels(state.range(0), 1);
   std::vector<int16_t> repetition_levels(state.range(0), 0);
   std::shared_ptr<ColumnDescriptor> schema = Int64Schema(repetition);
   std::shared_ptr<WriterProperties> properties = WriterProperties::Builder()
                                                      .compression(codec)
-                                                     ->encoding(Encoding::PLAIN)
+                                                     ->encoding(encoding)
                                                      ->disable_dictionary()
                                                      ->build();
 
@@ -155,11 +188,14 @@ static void BM_ReadInt64Column(::benchmark::State& state) {
   auto stream = CreateOutputStream();
   std::shared_ptr<Int64Writer> writer = BuildWriter(
       state.range(0), stream, metadata.get(), schema.get(), properties.get(), codec);
-  writer->WriteBatch(values.size(), definition_levels.data(), repetition_levels.data(),
-                     values.data());
+  writer->WriteBatch(int64_values.length(), definition_levels.data(),
+                     repetition_levels.data(), int64_values.raw_values());
   writer->Close();
 
   PARQUET_ASSIGN_OR_THROW(auto src, stream->Finish());
+  int64_t stream_size = src->size();
+  int64_t data_size = int64_values.length() * sizeof(int64_t);
+
   std::vector<int64_t> values_out(state.range(1));
   std::vector<int16_t> definition_levels_out(state.range(1));
   std::vector<int16_t> repetition_levels_out(state.range(1));
@@ -167,12 +203,20 @@ static void BM_ReadInt64Column(::benchmark::State& state) {
     std::shared_ptr<Int64Reader> reader =
         BuildReader(src, state.range(1), codec, schema.get());
     int64_t values_read = 0;
-    for (size_t i = 0; i < values.size(); i += values_read) {
+    for (int64_t i = 0; i < int64_values.length(); i += values_read) {
       reader->ReadBatch(values_out.size(), definition_levels_out.data(),
                         repetition_levels_out.data(), values_out.data(), &values_read);
     }
   }
   SetBytesProcessed(state, repetition);
+  state.counters["compression_ratio"] = static_cast<double>(data_size) / stream_size;
+}
+
+template <Repetition::type repetition,
+          Compression::type codec = Compression::UNCOMPRESSED,
+          Encoding::type encoding = Encoding::PLAIN>
+static void BM_ReadInt64Column(::benchmark::State& state) {
+  BM_ReadInt64Column(state, repetition, codec, encoding);
 }
 
 void ReadColumnSetArgs(::benchmark::internal::Benchmark* bench) {
@@ -197,6 +241,13 @@ BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::OPTIONAL, Compression::SNAPPY
     ->Apply(ReadColumnSetArgs);
 BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::REPEATED, Compression::SNAPPY)
     ->Apply(ReadColumnSetArgs);
+
+BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::REQUIRED, Compression::SNAPPY,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Apply(ReadColumnSetArgs);
+BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::OPTIONAL, Compression::SNAPPY,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Apply(ReadColumnSetArgs);
 #endif
 
 #ifdef ARROW_WITH_LZ4
@@ -206,6 +257,13 @@ BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::OPTIONAL, Compression::LZ4)
     ->Apply(ReadColumnSetArgs);
 BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::REPEATED, Compression::LZ4)
     ->Apply(ReadColumnSetArgs);
+
+BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::REQUIRED, Compression::LZ4,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Apply(ReadColumnSetArgs);
+BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::OPTIONAL, Compression::LZ4,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Apply(ReadColumnSetArgs);
 #endif
 
 #ifdef ARROW_WITH_ZSTD
@@ -214,6 +272,13 @@ BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::REQUIRED, Compression::ZSTD)
 BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::OPTIONAL, Compression::ZSTD)
     ->Apply(ReadColumnSetArgs);
 BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::REPEATED, Compression::ZSTD)
+    ->Apply(ReadColumnSetArgs);
+
+BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::REQUIRED, Compression::ZSTD,
+                   Encoding::BYTE_STREAM_SPLIT)
+    ->Apply(ReadColumnSetArgs);
+BENCHMARK_TEMPLATE(BM_ReadInt64Column, Repetition::OPTIONAL, Compression::ZSTD,
+                   Encoding::BYTE_STREAM_SPLIT)
     ->Apply(ReadColumnSetArgs);
 #endif
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -507,23 +507,33 @@ TEST_F(TestValuesWriterInt32Type, RequiredDeltaBinaryPacked) {
   this->TestRequiredWithEncoding(Encoding::DELTA_BINARY_PACKED);
 }
 
+TEST_F(TestValuesWriterInt32Type, RequiredByteStreamSplit) {
+  this->TestRequiredWithEncoding(Encoding::BYTE_STREAM_SPLIT);
+}
+
 TEST_F(TestValuesWriterInt64Type, RequiredDeltaBinaryPacked) {
   this->TestRequiredWithEncoding(Encoding::DELTA_BINARY_PACKED);
+}
+
+TEST_F(TestValuesWriterInt64Type, RequiredByteStreamSplit) {
+  this->TestRequiredWithEncoding(Encoding::BYTE_STREAM_SPLIT);
 }
 
 TEST_F(TestByteArrayValuesWriter, RequiredDeltaLengthByteArray) {
   this->TestRequiredWithEncoding(Encoding::DELTA_LENGTH_BYTE_ARRAY);
 }
 
-/*
-TYPED_TEST(TestByteArrayValuesWriter, RequiredDeltaByteArray) {
+TEST_F(TestByteArrayValuesWriter, RequiredDeltaByteArray) {
   this->TestRequiredWithEncoding(Encoding::DELTA_BYTE_ARRAY);
 }
 
 TEST_F(TestFixedLengthByteArrayValuesWriter, RequiredDeltaByteArray) {
   this->TestRequiredWithEncoding(Encoding::DELTA_BYTE_ARRAY);
 }
-*/
+
+TEST_F(TestFixedLengthByteArrayValuesWriter, RequiredByteStreamSplit) {
+  this->TestRequiredWithEncoding(Encoding::BYTE_STREAM_SPLIT);
+}
 
 TYPED_TEST(TestPrimitiveWriter, RequiredRLEDictionary) {
   this->TestRequiredWithEncoding(Encoding::RLE_DICTIONARY);

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -123,6 +124,10 @@ std::string concatenated_gzip_members() {
 
 std::string byte_stream_split() { return data_file("byte_stream_split.zstd.parquet"); }
 
+std::string byte_stream_split_extended() {
+  return data_file("byte_stream_split_extended.gzip.parquet");
+}
+
 template <typename DType, typename ValueType = typename DType::c_type>
 std::vector<ValueType> ReadColumnValues(ParquetFileReader* file_reader, int row_group,
                                         int column, int64_t expected_values_read) {
@@ -152,6 +157,44 @@ void AssertColumnValues(std::shared_ptr<TypedColumnReader<DType>> col, int64_t b
 
   ASSERT_EQ(expected_values, values);
   ASSERT_EQ(expected_values_read, values_read);
+}
+
+template <typename DType, typename ValueType = typename DType::c_type>
+void AssertColumnValuesEqual(std::shared_ptr<TypedColumnReader<DType>> left_col,
+                             std::shared_ptr<TypedColumnReader<DType>> right_col,
+                             int64_t batch_size, int64_t expected_levels_read,
+                             int64_t expected_values_read) {
+  std::vector<ValueType> left_values(batch_size);
+  std::vector<ValueType> right_values(batch_size);
+  int64_t values_read, levels_read;
+
+  levels_read =
+      left_col->ReadBatch(batch_size, nullptr, nullptr, left_values.data(), &values_read);
+  ASSERT_EQ(expected_levels_read, levels_read);
+  ASSERT_EQ(expected_values_read, values_read);
+
+  levels_read = right_col->ReadBatch(batch_size, nullptr, nullptr, right_values.data(),
+                                     &values_read);
+  ASSERT_EQ(expected_levels_read, levels_read);
+  ASSERT_EQ(expected_values_read, values_read);
+
+  ASSERT_EQ(left_values, right_values);
+}
+
+template <typename DType, typename ValueType = typename DType::c_type>
+void AssertColumnValuesEqual(ParquetFileReader* file_reader, const std::string& left_col,
+                             const std::string& right_col, int64_t num_rows,
+                             int64_t row_group = 0) {
+  ARROW_SCOPED_TRACE("left_col = '", left_col, "', right_col = '", right_col, "'");
+
+  auto left_col_index = file_reader->metadata()->schema()->ColumnIndex(left_col);
+  auto right_col_index = file_reader->metadata()->schema()->ColumnIndex(right_col);
+  auto row_group_reader = file_reader->RowGroup(row_group);
+  auto left_reader = checked_pointer_cast<TypedColumnReader<DType>>(
+      row_group_reader->Column(left_col_index));
+  auto right_reader = checked_pointer_cast<TypedColumnReader<DType>>(
+      row_group_reader->Column(right_col_index));
+  AssertColumnValuesEqual(left_reader, right_reader, num_rows, num_rows, num_rows);
 }
 
 void CheckRowGroupMetadata(const RowGroupMetaData* rg_metadata,
@@ -1521,6 +1564,34 @@ TEST(TestByteStreamSplit, FloatIntegrationFile) {
   }
 }
 #endif  // ARROW_WITH_ZSTD
+
+#ifdef ARROW_WITH_ZLIB
+TEST(TestByteStreamSplit, ExtendedIntegrationFile) {
+  auto file_path = byte_stream_split_extended();
+  auto file = ParquetFileReader::OpenFile(file_path);
+
+  const int64_t kNumRows = 200;
+
+  ASSERT_EQ(kNumRows, file->metadata()->num_rows());
+  ASSERT_EQ(14, file->metadata()->num_columns());
+  ASSERT_EQ(1, file->metadata()->num_row_groups());
+
+  AssertColumnValuesEqual<FloatType>(file.get(), "float_plain", "float_byte_stream_split",
+                                     kNumRows);
+  AssertColumnValuesEqual<DoubleType>(file.get(), "double_plain",
+                                      "double_byte_stream_split", kNumRows);
+  AssertColumnValuesEqual<Int32Type>(file.get(), "int32_plain", "int32_byte_stream_split",
+                                     kNumRows);
+  AssertColumnValuesEqual<Int64Type>(file.get(), "int64_plain", "int64_byte_stream_split",
+                                     kNumRows);
+  AssertColumnValuesEqual<FLBAType>(file.get(), "float16_plain",
+                                    "float16_byte_stream_split", kNumRows);
+  AssertColumnValuesEqual<FLBAType>(file.get(), "flba5_plain", "flba5_byte_stream_split",
+                                    kNumRows);
+  AssertColumnValuesEqual<FLBAType>(file.get(), "decimal_plain",
+                                    "decimal_byte_stream_split", kNumRows);
+}
+#endif  // ARROW_WITH_ZLIB
 
 struct PageIndexReaderParam {
   std::vector<int32_t> row_group_indices;


### PR DESCRIPTION
### What changes are included in this PR?

Implement the format addition described in https://issues.apache.org/jira/browse/PARQUET-2414 .

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes (additional types supported for Parquet encoding).

* GitHub Issue: #39978