### PR TITLE
GH-40097: [Go][FlightRPC] Enable disabling TLS

### DIFF
--- a/go/arrow/flight/flightsql/driver/driver.go
+++ b/go/arrow/flight/flightsql/driver/driver.go
@@ -364,10 +364,11 @@ func (c *Connector) Configure(config *DriverConfig) error {
 
 	// Set authentication credentials
 	rpcCreds := grpcCredentials{
-		username: config.Username,
-		password: config.Password,
-		token:    config.Token,
-		params:   config.Params,
+		username:   config.Username,
+		password:   config.Password,
+		token:      config.Token,
+		params:     config.Params,
+		tlsEnabled: config.TLSEnabled,
 	}
 	c.options = append(c.options, grpc.WithPerRPCCredentials(rpcCreds))
 

--- a/go/arrow/flight/flightsql/driver/utils.go
+++ b/go/arrow/flight/flightsql/driver/utils.go
@@ -27,10 +27,11 @@ import (
 
 // *** GRPC helpers ***
 type grpcCredentials struct {
-	username string
-	password string
-	token    string
-	params   map[string]string
+	username   string
+	password   string
+	token      string
+	params     map[string]string
+	tlsEnabled bool
 }
 
 func (g grpcCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
@@ -53,7 +54,7 @@ func (g grpcCredentials) GetRequestMetadata(ctx context.Context, uri ...string) 
 }
 
 func (g grpcCredentials) RequireTransportSecurity() bool {
-	return g.token != "" || g.username != ""
+	return g.tlsEnabled && (g.token != "" || g.username != "")
 }
 
 // *** Type conversions ***


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

See https://github.com/apache/arrow/issues/40097 for more in-depth description
about the problem that led me to file this PR.

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Because it's annoying to not be able to connect to a non-TLS flightsql endpoint
in my development environment just because my development environment happens
to still use token authentication.

### What changes are included in this PR?

Thread the flightsql `DriverConfig.TLSEnabled` parameter into the
`grpcCredentials` type so that `grpcCredentials.RequireTransportSecurity` can
return false if TLS is not enabled on the driver config.

One thing that occurred to me about the `DriverConfig.TLSEnabled` field is that
its semantics seem very mildly dangerous since golang `bool` types are `false`
by default and golang doesn't require fields on structs to be explicitly
initialized. It seems to me that `DriverConfig.TLSDisabled` would be better (semantically speaking)
because then the API user doesn't have to explicitly enable TLS. But I suppose
it's probably undesirable to change the name of a public field on a public type.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

I haven't written any tests, mostly because there weren't already any tests for
the `grpcCredentials` type but I have manually verified this fixes the problem
I described in https://github.com/apache/arrow/issues/40097 by rebuilding my
tool and running it against the non-TLS listening thing in my development
environment.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

* Closes: #40097