### PR TITLE
GH-40102: [Compute][C++] Compute scalar aggregate functions in ExecuteScalarExpression

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -24,6 +24,7 @@
 
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api_vector.h"
+#include "arrow/compute/exec_internal.h"
 #include "arrow/compute/expression_internal.h"
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/util.h"
@@ -36,7 +37,6 @@
 #include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"
 #include "arrow/util/vector.h"
-#include "exec_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -24,7 +24,6 @@
 
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api_vector.h"
-#include "arrow/compute/exec_internal.h"
 #include "arrow/compute/expression_internal.h"
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/util.h"

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -16,8 +16,6 @@
 // under the License.
 
 #include "arrow/compute/expression.h"
-#include <arrow/compute/api_aggregate.h> // TODO
-
 
 #include <chrono>
 #include <cstdint>
@@ -79,9 +77,7 @@ Expression true_unless_null(Expression argument) {
   return call("true_unless_null", {std::move(argument)});
 }
 
-Expression last(Expression l) {
-  return call("last", {std::move(l)});
-}
+Expression last(Expression l) { return call("last", {std::move(l)}); }
 
 Expression add(Expression l, Expression r) {
   return call("add", {std::move(l), std::move(r)});

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -77,7 +77,7 @@ Expression true_unless_null(Expression argument) {
   return call("true_unless_null", {std::move(argument)});
 }
 
-Expression last(Expression l) { return call("last", {std::move(l)}); }
+Expression last(Expression e) { return call("last", {std::move(e)}); }
 
 Expression add(Expression l, Expression r) {
   return call("add", {std::move(l), std::move(r)});


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

It would be great to support something like this:

```
import pyarrow.compute as pc
import pyarrow as pa

table = pa.Table.from_arrays([pa.array([1, 5, 3, 4])], names=["foo"])
expr = pc.field('foo') >= pc.last(pc.field('foo'))

# expected:  pa.Table.from_arrays([pa.array([5, 4])], names=["foo"])
```

However, filtering doesn't support scalar aggregations, despite them resulting in scalar values. Thus, you get an error that looks like:

```
ArrowInvalid: ExecuteScalarExpression cannot Execute non-scalar expression (foo == last(foo))
```

### What changes are included in this PR?

Adds support for executing ScalarAggregation kernels

### Are these changes tested?

Yes, added a test on `arrow::compute::Expression` for expression evaluation and `arrow::dataset::Dataset` for filtering

### Are there any user-facing changes?

Should be transparent to the user; this feature is additive
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #40102