### PR TITLE
GH-39897: [C++][FS][S3] Ensure `AwsInstance::EnsureInitialized` to do initialization exactly once under concurrency

### DIFF
--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1904,3 +1904,22 @@ def test_s3_finalize_region_resolver():
             resolve_s3_region('voltrondata-labs-datasets')
         """
     subprocess.check_call([sys.executable, "-c", code])
+
+@pytest.mark.s3
+def test_concurrent_fs_init():
+    code = """if 1:
+        import threading
+        import pytest
+        from pyarrow.fs import (FileSystem, S3FileSystem
+                                ensure_s3_initialized, finalize_s3) 
+        threads = []
+        for i in range(4):
+            thread = threading.Thread(target = lambda: FileSystem.from_uri('s3://mf-nwp-models/README.txt'))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        finalize_s3()
+    """

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1907,7 +1907,8 @@ def test_s3_finalize_region_resolver():
 
 
 @pytest.mark.s3
-def test_concurrent_fs_init():
+def test_concurrent_s3fs_init():
+    # GH-39897: lazy concurrent initialization of S3 subsystem should not crash
     code = """if 1:
         import threading
         import pytest

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1905,16 +1905,18 @@ def test_s3_finalize_region_resolver():
         """
     subprocess.check_call([sys.executable, "-c", code])
 
+
 @pytest.mark.s3
 def test_concurrent_fs_init():
     code = """if 1:
         import threading
         import pytest
-        from pyarrow.fs import (FileSystem, S3FileSystem
-                                ensure_s3_initialized, finalize_s3) 
+        from pyarrow.fs import (FileSystem, S3FileSystem,
+                                ensure_s3_initialized, finalize_s3)
         threads = []
+        fn = lambda: FileSystem.from_uri('s3://mf-nwp-models/README.txt')
         for i in range(4):
-            thread = threading.Thread(target = lambda: FileSystem.from_uri('s3://mf-nwp-models/README.txt'))
+            thread = threading.Thread(target = fn)
             threads.append(thread)
             thread.start()
 
@@ -1922,4 +1924,5 @@ def test_concurrent_fs_init():
             thread.join()
 
         finalize_s3()
-    """
+        """
+    subprocess.check_call([sys.executable, "-c", code])


### PR DESCRIPTION
### Rationale for this change

`FileSystemFromUri` could be called concurrently, and its implicit call to `AwsInstance::EnsureInitialized` will cause segment fault due to data race.

Therefore, make init stage thread-safe for `AwsInstance::EnsureInitialized`.

### What changes are included in this PR?

Serialize calls to S3 initialization to ensure initialization is done exactly once.

### Are these changes tested?

Yes, a test is added for the PyArrow bindings.

### Are there any user-facing changes?

No.

* Closes: #39897
* GitHub Issue: #39897