### PR TITLE
GH-40113: [Go][Parquet] New RegisterCodec function

### DIFF
--- a/go/parquet/compress/brotli.go
+++ b/go/parquet/compress/brotli.go
@@ -110,5 +110,5 @@ func (brotliCodec) NewWriterLevel(w io.Writer, level int) (io.WriteCloser, error
 }
 
 func init() {
-	codecs[Codecs.Brotli] = brotliCodec{}
+	RegisterCodec(Codecs.Brotli, brotliCodec{})
 }

--- a/go/parquet/compress/compress.go
+++ b/go/parquet/compress/compress.go
@@ -92,22 +92,22 @@ type Codec interface {
 
 var codecs = map[Compression]Codec{}
 
-// RegisterCodec add new or override existing codec implementation for a given compression algorithm.
+// RegisterCodec adds or overrides a codec implementation for a given compression algorithm.
 // The intended use case is within the init() section of a package. For example,
 //
-//	    // inside a custom codec package, say czstd
+//	// inside a custom codec package, say czstd
 //
-//		func init() {
-//		    RegisterCodec(compress.Codecs.Zstd, czstdCodec{})
-//		}
+//	func init() {
+//	    RegisterCodec(compress.Codecs.Zstd, czstdCodec{})
+//	}
 //
-//		type czstdCodec struct{} // implementing Codec interface using CGO based ZSTD wrapper
+//	type czstdCodec struct{} // implementing Codec interface using CGO based ZSTD wrapper
 //
 // And user of the custom codec can import the above package like below,
 //
-//	    package main
+//	package main
 //
-//		import _ "package/path/to/czstd"
+//	import _ "package/path/to/czstd"
 func RegisterCodec(compression Compression, codec Codec) {
 	codecs[compression] = codec
 }

--- a/go/parquet/compress/compress.go
+++ b/go/parquet/compress/compress.go
@@ -92,6 +92,22 @@ type Codec interface {
 
 var codecs = map[Compression]Codec{}
 
+// RegisterCodec add new or override existing codec implementation for a given compression algorithm.
+// The intended use case is within the init() section of a package. For example,
+//
+//	    // inside a custom codec package, say czstd
+//
+//		func init() {
+//		    RegisterCodec(compress.Codecs.Zstd, czstdCodec{})
+//		}
+//
+//		type czstdCodec struct{} // implementing Codec interface using CGO based ZSTD wrapper
+//
+// And user of the custom codec can import the above package like below,
+//
+//	    package main
+//
+//		import _ "package/path/to/czstd"
 func RegisterCodec(compression Compression, codec Codec) {
 	codecs[compression] = codec
 }

--- a/go/parquet/compress/compress.go
+++ b/go/parquet/compress/compress.go
@@ -92,6 +92,10 @@ type Codec interface {
 
 var codecs = map[Compression]Codec{}
 
+func RegisterCodec(compression Compression, codec Codec) {
+	codecs[compression] = codec
+}
+
 type nocodec struct{}
 
 func (nocodec) NewReader(r io.Reader) io.ReadCloser {

--- a/go/parquet/compress/gzip.go
+++ b/go/parquet/compress/gzip.go
@@ -93,5 +93,5 @@ func (gzipCodec) NewWriterLevel(w io.Writer, level int) (io.WriteCloser, error) 
 }
 
 func init() {
-	codecs[Codecs.Gzip] = gzipCodec{}
+	RegisterCodec(Codecs.Gzip, gzipCodec{})
 }

--- a/go/parquet/compress/snappy.go
+++ b/go/parquet/compress/snappy.go
@@ -57,5 +57,5 @@ func (s snappyCodec) NewWriterLevel(w io.Writer, _ int) (io.WriteCloser, error) 
 }
 
 func init() {
-	codecs[Codecs.Snappy] = snappyCodec{}
+	RegisterCodec(Codecs.Snappy, snappyCodec{})
 }

--- a/go/parquet/compress/zstd.go
+++ b/go/parquet/compress/zstd.go
@@ -108,5 +108,5 @@ func (zstdCodec) CompressBound(len int64) int64 {
 }
 
 func init() {
-	codecs[Codecs.Zstd] = zstdCodec{}
+	RegisterCodec(Codecs.Zstd, zstdCodec{})
 }


### PR DESCRIPTION
This is to allow addition/overwrite of custom codec implementation

This allows other modules to provide alternative implementations for the compression algorithms, such as using libdeflate for Gzip, or CGO version of ZSTD.

In addition, it allows others to supply codecs that cannot be easily supported by this library such as LZO due to license reasons or LZ4.


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

See #40113

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

A new RegisterCodec function added 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

It's an addition more targeted towards library writers. 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #40113