### PR TITLE
GH-40023: [Python] Use Cast() instead of CastTo

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -3010,11 +3010,5 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py" nogil:
     CResult[shared_ptr[CRecordBatchReader]] CallTabularFunction(
         const c_string& func_name, const vector[CDatum]& args, CFunctionRegistry* registry)
 
-cdef extern from "arrow/type.h" namespace "arrow":
-    cdef cppclass CTypeHolder" arrow::TypeHolder":
-        CTypeHolder()
-        CTypeHolder(const shared_ptr[CDataType]& type)
-
 cdef extern from "arrow/compute/cast.h" namespace "arrow::compute":
-    CResult[CDatum] Cast(const CDatum& value, const CTypeHolder& to_type, const CCastOptions& options,
-                         CExecContext * ctx)
+    CResult[CDatum] Cast(const CDatum& value, const CCastOptions& options)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1161,7 +1161,6 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_bool Equals(const CScalar& other) const
         CStatus Validate() const
         CStatus ValidateFull() const
-        CResult[shared_ptr[CScalar]] CastTo(shared_ptr[CDataType] to) const
 
     cdef cppclass CScalarHash" arrow::Scalar::Hash":
         size_t operator()(const shared_ptr[CScalar]& scalar) const
@@ -3010,3 +3009,12 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py" nogil:
 
     CResult[shared_ptr[CRecordBatchReader]] CallTabularFunction(
         const c_string& func_name, const vector[CDatum]& args, CFunctionRegistry* registry)
+
+cdef extern from "arrow/type.h" namespace "arrow":
+    cdef cppclass CTypeHolder" arrow::TypeHolder":
+        CTypeHolder()
+        CTypeHolder(const shared_ptr[CDataType]& type)
+
+cdef extern from "arrow/compute/cast.h" namespace "arrow::compute":
+    CResult[CDatum] Cast(const CDatum& value, const CTypeHolder& to_type, const CCastOptions& options,
+                         CExecContext * ctx)

--- a/python/pyarrow/tests/pyarrow_cython_example.pyx
+++ b/python/pyarrow/tests/pyarrow_cython_example.pyx
@@ -42,7 +42,12 @@ def cast_scalar(scalar, to_type):
     cdef:
         shared_ptr[CScalar] c_scalar
         shared_ptr[CDataType] c_type
-        CResult[shared_ptr[CScalar]] c_result
+        CCastOptions cast_options
+        CExecContext * ctx = NULL
+        CDatum c_datum
+        CTypeHolder c_type_holder
+        CResult[CDatum] c_cast_result
+        CDatum c_result
 
     c_scalar = pyarrow_unwrap_scalar(scalar)
     if c_scalar.get() == NULL:
@@ -50,6 +55,9 @@ def cast_scalar(scalar, to_type):
     c_type = pyarrow_unwrap_data_type(to_type)
     if c_type.get() == NULL:
         raise TypeError("not a type")
-    c_result = c_scalar.get().CastTo(c_type)
-    c_scalar = GetResultValue(c_result)
-    return pyarrow_wrap_scalar(c_scalar)
+
+    c_datum = CDatum(c_scalar)
+    c_type_holder = CTypeHolder(c_type)
+    c_cast_result = Cast(c_datum, c_type_holder, cast_options, ctx)
+    c_datum = GetResultValue(c_cast_result)
+    return pyarrow_wrap_scalar(c_datum.scalar())

--- a/python/pyarrow/tests/pyarrow_cython_example.pyx
+++ b/python/pyarrow/tests/pyarrow_cython_example.pyx
@@ -43,9 +43,7 @@ def cast_scalar(scalar, to_type):
         shared_ptr[CScalar] c_scalar
         shared_ptr[CDataType] c_type
         CCastOptions cast_options
-        CExecContext * ctx = NULL
         CDatum c_datum
-        CTypeHolder c_type_holder
         CResult[CDatum] c_cast_result
 
     c_scalar = pyarrow_unwrap_scalar(scalar)
@@ -56,7 +54,8 @@ def cast_scalar(scalar, to_type):
         raise TypeError("not a type")
 
     c_datum = CDatum(c_scalar)
-    c_type_holder = CTypeHolder(c_type)
-    c_cast_result = Cast(c_datum, c_type_holder, cast_options, ctx)
+    cast_options = CCastOptions()
+    cast_options.to_type = c_type
+    c_cast_result = Cast(c_datum, cast_options)
     c_datum = GetResultValue(c_cast_result)
     return pyarrow_wrap_scalar(c_datum.scalar())

--- a/python/pyarrow/tests/pyarrow_cython_example.pyx
+++ b/python/pyarrow/tests/pyarrow_cython_example.pyx
@@ -47,7 +47,6 @@ def cast_scalar(scalar, to_type):
         CDatum c_datum
         CTypeHolder c_type_holder
         CResult[CDatum] c_cast_result
-        CDatum c_result
 
     c_scalar = pyarrow_unwrap_scalar(scalar)
     if c_scalar.get() == NULL:

--- a/python/pyarrow/tests/test_cython.py
+++ b/python/pyarrow/tests/test_cython.py
@@ -77,7 +77,7 @@ def check_cython_example_module(mod):
     cast_scal = mod.cast_scalar(scal, pa.utf8())
     assert cast_scal == pa.scalar("123")
     with pytest.raises(NotImplementedError,
-                       match="casting scalars of type int64 to type list"):
+                       match="Unsupported cast from int64 to list using function cast_list"):
         mod.cast_scalar(scal, pa.list_(pa.int64()))
 
 

--- a/python/pyarrow/tests/test_cython.py
+++ b/python/pyarrow/tests/test_cython.py
@@ -25,7 +25,6 @@ import pytest
 import pyarrow as pa
 import pyarrow.tests.util as test_util
 
-
 here = os.path.dirname(os.path.abspath(__file__))
 test_ld_path = os.environ.get('PYARROW_TEST_LD_PATH', '')
 if os.name == 'posix':
@@ -34,7 +33,6 @@ elif os.name == 'nt':
     compiler_opts = ['-D_ENABLE_EXTENDED_ALIGNED_STORAGE', '/std:c++17']
 else:
     compiler_opts = []
-
 
 setup_template = """if 1:
     from setuptools import setup
@@ -77,7 +75,8 @@ def check_cython_example_module(mod):
     cast_scal = mod.cast_scalar(scal, pa.utf8())
     assert cast_scal == pa.scalar("123")
     with pytest.raises(NotImplementedError,
-                       match="Unsupported cast from int64 to list using function cast_list"):
+                       match="Unsupported cast from int64 to list using function "
+                             "cast_list"):
         mod.cast_scalar(scal, pa.list_(pa.int64()))
 
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Remove legacy code

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

* Replace the legacy scalar CastTo implementation for Python.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #40023