### PR TITLE
MINOR: [CI] Accept only binary packages for grpcio

### DIFF
--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -41,5 +41,5 @@ if [[ "${version}" -eq "default" ]]; then
   ${PYTHON:-python3} -m pip install --upgrade setuptools
 fi
 
-${PYTHON:-python3} -m pip install \
+${PYTHON:-python3} -m pip install --only-binary grpcio \
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"


### PR DESCRIPTION
Avoid wasting time trying to compile grpcio if for some reason binary packages are not available.