### PR TITLE
GH-40112: [CI][Python] Ensure CPython is selected, not PyPy

### DIFF
--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -28,7 +28,7 @@ COPY ci/conda_env_python.txt \
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
         $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb") \
-        "python=${python}=*_cpython" \
+        "python=${python}.*=*_cpython" \
         nomkl && \
     mamba clean --all
 

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -28,7 +28,7 @@ COPY ci/conda_env_python.txt \
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
         $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb") \
-        python=${python} \
+        "python=${python}=*_cpython" \
         nomkl && \
     mamba clean --all
 


### PR DESCRIPTION
Sometimes, mamba might select PyPy over CPython in certain environment upgrade/downgrade scenarios.

* Closes: #40112