### PR TITLE
GH-40142: [Python] Allow FileInfo instances to be passed to dataset init

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -3192,7 +3192,7 @@ cdef class FileSystemDatasetFactory(DatasetFactory):
                     c_options
                 )
         elif isinstance(paths_or_selector, (list, tuple)):
-            if isinstance(paths_or_selector[0], FileInfo):
+            if len(paths_or_selector) > 0 and isinstance(paths_or_selector[0], FileInfo):
                 finfos = unwrap_finfos(paths_or_selector)
                 with nogil:
                     result = CFileSystemDatasetFactory.MakeFromFileInfos(

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -3139,6 +3139,13 @@ cdef class FileSystemFactoryOptions(_Weakrefable):
         self.options.selector_ignore_prefixes = [tobytes(v) for v in values]
 
 
+cdef vector[CFileInfo] unwrap_finfos(finfos):
+    cdef vector[CFileInfo] o_vect
+    for fi in finfos:
+        o_vect.push_back((<FileInfo> fi).unwrap())
+    return o_vect
+
+
 cdef class FileSystemDatasetFactory(DatasetFactory):
     """
     Create a DatasetFactory from a list of paths with schema inspection.
@@ -3163,6 +3170,7 @@ cdef class FileSystemDatasetFactory(DatasetFactory):
                  FileSystemFactoryOptions options=None):
         cdef:
             vector[c_string] paths
+            vector[CFileInfo] finfos
             CFileSelector c_selector
             CResult[shared_ptr[CDatasetFactory]] result
             shared_ptr[CFileSystem] c_filesystem
@@ -3184,14 +3192,24 @@ cdef class FileSystemDatasetFactory(DatasetFactory):
                     c_options
                 )
         elif isinstance(paths_or_selector, (list, tuple)):
-            paths = [tobytes(s) for s in paths_or_selector]
-            with nogil:
-                result = CFileSystemDatasetFactory.MakeFromPaths(
-                    c_filesystem,
-                    paths,
-                    c_format,
-                    c_options
-                )
+            if isinstance(paths_or_selector[0], FileInfo):
+                finfos = unwrap_finfos(paths_or_selector)
+                with nogil:
+                    result = CFileSystemDatasetFactory.MakeFromFileInfos(
+                        c_filesystem,
+                        finfos,
+                        c_format,
+                        c_options
+                    )
+            else:
+                paths = [tobytes(s) for s in paths_or_selector]
+                with nogil:
+                    result = CFileSystemDatasetFactory.MakeFromPaths(
+                        c_filesystem,
+                        paths,
+                        c_format,
+                        c_options
+                    )
         else:
             raise TypeError('Must pass either paths or a FileSelector, but '
                             'passed {}'.format(type(paths_or_selector)))

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -456,11 +456,22 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     -------
     FileSystemDataset
     """
+    from pyarrow.fs import LocalFileSystem, _ensure_filesystem, FileInfo
+
     format = _ensure_format(format or 'parquet')
     partitioning = _ensure_partitioning(partitioning)
 
     if isinstance(source, (list, tuple)):
-        fs, paths_or_selector = _ensure_multiple_sources(source, filesystem)
+        if isinstance(source[0], FileInfo):
+            if filesystem is None:
+                # fall back to local file system as the default
+                fs = LocalFileSystem()
+            else:
+                # construct a filesystem if it is a valid URI
+                fs = _ensure_filesystem(filesystem)
+            paths_or_selector = source
+        else:
+            fs, paths_or_selector = _ensure_multiple_sources(source, filesystem)
     else:
         fs, paths_or_selector = _ensure_single_source(source, filesystem)
 
@@ -767,6 +778,7 @@ RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
     ...     dataset("local/path/to/data", format="ipc")
     ... ]) # doctest: +SKIP
     """
+    from pyarrow.fs import FileInfo
     # collect the keyword arguments for later reuse
     kwargs = dict(
         schema=schema,
@@ -781,7 +793,7 @@ RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
     if _is_path_like(source):
         return _filesystem_dataset(source, **kwargs)
     elif isinstance(source, (tuple, list)):
-        if all(_is_path_like(elem) for elem in source):
+        if all(_is_path_like(elem) or isinstance(elem, FileInfo) for elem in source):
             return _filesystem_dataset(source, **kwargs)
         elif all(isinstance(elem, Dataset) for elem in source):
             return _union_dataset(source, **kwargs)

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -462,7 +462,7 @@ def _filesystem_dataset(source, schema=None, filesystem=None,
     partitioning = _ensure_partitioning(partitioning)
 
     if isinstance(source, (list, tuple)):
-        if isinstance(source[0], FileInfo):
+        if source and isinstance(source[0], FileInfo):
             if filesystem is None:
                 # fall back to local file system as the default
                 fs = LocalFileSystem()

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -403,3 +403,11 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             shared_ptr[CFileFormat] format,
             CFileSystemFactoryOptions options
         )
+
+        @staticmethod
+        CResult[shared_ptr[CDatasetFactory]] MakeFromFileInfos "Make"(
+            shared_ptr[CFileSystem] filesystem,
+            vector[CFileInfo] files,
+            shared_ptr[CFileFormat] format,
+            CFileSystemFactoryOptions options
+        )

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -221,7 +221,7 @@ def s3_server(s3_connection, tmpdir_factory):
         yield {
             'connection': s3_connection,
             'process': proc,
-            'tempdir': tmpdir,
+            'tempdir': tmpdir
         }
     finally:
         if proc is not None:

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -204,7 +204,8 @@ def s3_server(s3_connection, tmpdir_factory):
     env = os.environ.copy()
     env.update({
         'MINIO_ACCESS_KEY': access_key,
-        'MINIO_SECRET_KEY': secret_key
+        'MINIO_SECRET_KEY': secret_key,
+        'MINIO_PROMETHEUS_AUTH_TYPE': 'public',
     })
 
     args = ['minio', '--compat', 'server', '--quiet', '--address',
@@ -221,7 +222,8 @@ def s3_server(s3_connection, tmpdir_factory):
         yield {
             'connection': s3_connection,
             'process': proc,
-            'tempdir': tmpdir
+            'tempdir': tmpdir,
+            'address': address,
         }
     finally:
         if proc is not None:

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -204,8 +204,7 @@ def s3_server(s3_connection, tmpdir_factory):
     env = os.environ.copy()
     env.update({
         'MINIO_ACCESS_KEY': access_key,
-        'MINIO_SECRET_KEY': secret_key,
-        'MINIO_PROMETHEUS_AUTH_TYPE': 'public',
+        'MINIO_SECRET_KEY': secret_key
     })
 
     args = ['minio', '--compat', 'server', '--quiet', '--address',
@@ -223,7 +222,6 @@ def s3_server(s3_connection, tmpdir_factory):
             'connection': s3_connection,
             'process': proc,
             'tempdir': tmpdir,
-            'address': address,
         }
     finally:
         if proc is not None:

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2726,6 +2726,25 @@ def test_open_dataset_from_uri_s3(s3_example_simple, dataset_reader):
 
 
 @pytest.mark.parquet
+@pytest.mark.s3
+def test_dataset_from_fileinfos(s3_example_simple, dataset_reader, s3_server):
+    table, path, filesystem, uri, _, _, _, _ = s3_example_simple
+
+    selector = fs.FileSelector("mybucket")
+    finfos = filesystem.get_file_info(selector)
+    dataset = ds.dataset(finfos, format="parquet", filesystem=filesystem)
+    assert dataset_reader.to_table(dataset).equals(table)
+    import urllib
+
+    resp = urllib.request.urlopen(
+        f"http://{s3_server['address']}/minio/v2/metrics/cluster"
+    )
+    assert resp.status == 200
+    # minio_s3_requests_total{api="headobject",...} 2
+    assert "headobject" not in resp.read().decode("utf-8")
+
+
+@pytest.mark.parquet
 @pytest.mark.s3  # still needed to create the data
 def test_open_dataset_from_uri_s3_fsspec(s3_example_simple):
     table, path, _, _, host, port, access_key, secret_key = s3_example_simple

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2727,7 +2727,7 @@ def test_open_dataset_from_uri_s3(s3_example_simple, dataset_reader):
 
 @pytest.mark.parquet
 @pytest.mark.s3
-def test_dataset_from_fileinfos(s3_example_simple, dataset_reader):
+def test_open_dataset_from_fileinfos(s3_example_simple, dataset_reader):
     table, path, filesystem, uri, _, _, _, _ = s3_example_simple
     selector = fs.FileSelector("mybucket")
     finfos = filesystem.get_file_info(selector)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2727,21 +2727,12 @@ def test_open_dataset_from_uri_s3(s3_example_simple, dataset_reader):
 
 @pytest.mark.parquet
 @pytest.mark.s3
-def test_dataset_from_fileinfos(s3_example_simple, dataset_reader, s3_server):
+def test_dataset_from_fileinfos(s3_example_simple, dataset_reader):
     table, path, filesystem, uri, _, _, _, _ = s3_example_simple
-
     selector = fs.FileSelector("mybucket")
     finfos = filesystem.get_file_info(selector)
     dataset = ds.dataset(finfos, format="parquet", filesystem=filesystem)
     assert dataset_reader.to_table(dataset).equals(table)
-    import urllib
-
-    resp = urllib.request.urlopen(
-        f"http://{s3_server['address']}/minio/v2/metrics/cluster"
-    )
-    assert resp.status == 200
-    # minio_s3_requests_total{api="headobject",...} 2
-    assert "headobject" not in resp.read().decode("utf-8")
 
 
 @pytest.mark.parquet


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Closes https://github.com/apache/arrow/issues/40142

I'm developing a new dask integration with pyarrow parquet reader (see https://github.com/dask-contrib/dask-expr/pull/882) and want to rely on the pyarrow Filesystem more.

Right now, we are performing a list operation ourselves to get all touched files and I would like to pass the retrieved `FileInfo` objects directly to the dataset constructor. This API is already exposed in C++ and this PR is adding the necessary python bindings.

The benefit of this is that there is API is that it cuts the need to perform additional HEAD requests to a remote storage.

This came up in https://github.com/apache/arrow/issues/38389#issuecomment-1774777681 and there's been related work already with https://github.com/apache/arrow/issues/37857

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Python bindings for the `DatasetFactory` constructor that accepts a list/vector of `FileInfo` objects.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

~I slightly modified the minio test setup such that the prometheus endpoint is exposed. This can be used to assert that there hasn't been any HEAD requests.~ I ended up removing this again since parsing the response is a bit brittle.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* Closes: #40142