### PR TITLE
GH-38794: [C++][S3] Handle conventional content-type for directories

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -154,7 +154,7 @@ using internal::S3Backend;
 using internal::ToAwsString;
 using internal::ToURLEncodedAwsString;
 
-static const char kSep = '/';
+constexpr const char kSep = '/';
 constexpr const char kAwsEndpointUrlEnvVar[] = "AWS_ENDPOINT_URL";
 constexpr const char kAwsEndpointUrlS3EnvVar[] = "AWS_ENDPOINT_URL_S3";
 constexpr const char kAwsDirectoryContentType[] = "application/x-directory";
@@ -1216,7 +1216,9 @@ Status SetObjectMetadata(const std::shared_ptr<const KeyValueMetadata>& metadata
 }
 
 bool IsDirectory(std::string_view key, const S3Model::HeadObjectResult& result) {
-  // If it has a non-zero length, it's a regular file
+  // If it has a non-zero length, it's a regular file. We do this even if
+  // the key has a trailing slash, as directory markers should never have
+  // any data associated to them.
   if (result.GetContentLength() > 0) {
     return false;
   }

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1221,7 +1221,7 @@ bool IsDirectory(std::string_view key, const S3Model::HeadObjectResult& result) 
     return false;
   }
   // Otherwise, if it has a trailing slash, it's a directory
-  if (key[key.size() - 1] == kSep) {
+  if (internal::HasTrailingSlash(key)) {
     return true;
   }
   // Otherwise, if its content type starts with "application/x-directory",


### PR DESCRIPTION
### Rationale for this change

Some AWS-related tools write and expect the content-type "application/x-directory" for directory-like entries.

This PR does two things:
1) set the object's content-type to "application/x-directory" when the user explicitly creates a directory
2) when a 0-sized object with content-type starting with "application/x-directory" is encountered, consider it a directory

### Are these changes tested?

Unfortunately, this cannot be tested with MinIO, as it seems to ignore the content-type set on directories (as opposed to regular files).

### Are there any user-facing changes?

Hopefully better compatibility with existing S3 filesystem hierarchies.

* Closes: #38794
* GitHub Issue: #38794