### PR TITLE
GH-37931: [Python] Revert "GH-37803: [CI][Dev][Python] Release and merge script errors (#37819)"

### DIFF
--- a/ci/conda_env_archery.txt
+++ b/ci/conda_env_archery.txt
@@ -25,7 +25,7 @@ jira
 pygit2
 pygithub
 ruamel.yaml
-setuptools_scm<8.0.0
+setuptools_scm
 toolz
 
 # benchmark

--- a/ci/conda_env_crossbow.txt
+++ b/ci/conda_env_crossbow.txt
@@ -21,5 +21,5 @@ jinja2
 jira
 pygit2
 ruamel.yaml
-setuptools_scm<8.0.0
+setuptools_scm
 toolz

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -27,4 +27,4 @@ pytest<8
 pytest-faulthandler
 s3fs>=2023.10.0
 setuptools
-setuptools_scm<8.0.0
+setuptools_scm

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -30,7 +30,7 @@ jinja_req = 'jinja2>=2.11'
 extras = {
     'benchmark': ['pandas'],
     'crossbow': ['github3.py', jinja_req, 'pygit2>=1.6.0', 'requests',
-                 'ruamel.yaml', 'setuptools_scm<8.0.0'],
+                 'ruamel.yaml', 'setuptools_scm'],
     'crossbow-upload': ['github3.py', jinja_req, 'ruamel.yaml',
                         'setuptools_scm'],
     'docker': ['ruamel.yaml', 'python-dotenv'],

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -240,7 +240,7 @@ outputs:
         - numpy
         - python
         - setuptools
-        - setuptools_scm <8.0.0
+        - setuptools_scm
       run:
         - {{ pin_subpackage('libarrow', exact=True) }}
         - {{ pin_compatible('numpy') }}
@@ -322,7 +322,7 @@ outputs:
         - numpy
         - python
         - setuptools
-        - setuptools_scm <8.0.0
+        - setuptools_scm
       run:
         - {{ pin_subpackage('pyarrow', exact=True) }}
         - python

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ requires = [
     # continue using oldest-support-numpy.
     "oldest-supported-numpy>=0.14; python_version<'3.9'",
     "numpy>=1.25; python_version>='3.9'",
-    "setuptools_scm < 8.0.0",
+    "setuptools_scm",
     "setuptools >= 40.1.0",
     "wheel"
 ]

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,5 +1,5 @@
 cython>=0.29.31
 oldest-supported-numpy>=0.14; python_version<'3.9'
 numpy>=1.25; python_version>='3.9'
-setuptools_scm<8.0.0
+setuptools_scm
 setuptools>=38.6.0

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,6 +1,6 @@
 cython>=0.29.31
 oldest-supported-numpy>=0.14; python_version<'3.9'
 numpy>=1.25; python_version>='3.9'
-setuptools_scm<8.0.0
+setuptools_scm
 setuptools>=58
 wheel

--- a/python/setup.py
+++ b/python/setup.py
@@ -492,7 +492,7 @@ setup(
                                  'pyarrow/_generated_version.py'),
         'version_scheme': guess_next_dev_version
     },
-    setup_requires=['setuptools_scm < 8.0.0', 'cython >= 0.29.31'] + setup_requires,
+    setup_requires=['setuptools_scm', 'cython >= 0.29.31'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas', 'hypothesis'],
     python_requires='>=3.8',


### PR DESCRIPTION
This reverts commit 79e49dbfb71efc70555417ba19cb612eb50924e8.

#37931 should have been fixed as of https://github.com/pypa/setuptools_scm/commit/056584b49f039f0913bd6ee5bb5a5befdb396dec in setuptools_scm 8.0.4; I tested that this works in https://github.com/conda-forge/arrow-cpp-feedstock/pull/1314.

CC @AlenkaF @raulcd 
* Closes: #37931