### PR TITLE
MINOR: [Format] Clarify that the buffers for the Binary View layout differ in the C Data Interface

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -467,7 +467,10 @@ It has the following fields:
 
    Mandatory.  The number of physical buffers backing this array.  The
    number of buffers is a function of the data type, as described in the
-   :ref:`Columnar format specification <format_columnar>`.
+   :ref:`Columnar format specification <format_columnar>`, except for the
+   the binary or utf-8 view type, which has one additional buffer compared
+   to the Columnar format specification (see
+   :ref:`c-data-interface-binary-view-arrays`).
 
    Buffers of children arrays are not included.
 
@@ -551,6 +554,8 @@ parameterized extension types).
 
 The ``ArrowArray`` structure exported from an extension array simply points
 to the storage data of the extension array.
+
+.. _c-data-interface-binary-view-arrays:
 
 Binary view arrays
 ------------------

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -404,6 +404,9 @@ All integers (length, buffer index, and offset) are signed.
 
 This layout is adapted from TU Munich's `UmbraDB`_.
 
+Note that this layout uses one additional buffer to store the variadic buffer
+lengths in the :ref:`Arrow C data interface <c-data-interface-binary-view-arrays>`.
+
 .. _variable-size-list-layout:
 
 Variable-size List Layout


### PR DESCRIPTION
### Rationale for this change

Attempt to draw more attention to the fact that the buffer listing / number of buffers differ between the main Format spec and the C Data Interface, for the Binary View layout.

Triggered by feedback from implementing this in duckdb at https://github.com/duckdb/duckdb/pull/10481#discussion_r1489245865
