### PR TITLE
GH-40153: [Python] Fix OverflowError in foreign_buffer on 32-bit platforms

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1987,7 +1987,7 @@ def foreign_buffer(address, size, base=None):
         Object that owns the referenced memory.
     """
     cdef:
-        intptr_t c_addr = address
+        uintptr_t c_addr = address
         int64_t c_size = size
         shared_ptr[CBuffer] buf
 


### PR DESCRIPTION
Use `uintptr_t` rather than `intptr_t` to fix `OverflowError`, visible e.g. when running `tests/interchange/test_conversion.py` tests on 32-bit platforms.


### Rationale for this change

This fixes the `OverflowError`s from #40153, and makes `pyarrow/tests/interchange/` all pass on 32-bit x86.

### What changes are included in this PR?

- change the type used to store pointer from `intptr_t` to `uintptr_t` to provide coverage for pointers above `0x80000000`.

### Are these changes tested?

These changes are covered by the tests in `pyarrow/tests/interchange`.

### Are there any user-facing changes?

It fixes `OverflowError` that can be triggered by working with pandas data types, possibly more (though I'm not sure if this qualifies as a "crash").

* Closes: #40153