### PR TITLE
MINOR: [Dev][Archery] Reinstate version constraint on setuptools_scm for comment bot

### DIFF
--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -30,7 +30,7 @@ jinja_req = 'jinja2>=2.11'
 extras = {
     'benchmark': ['pandas'],
     'crossbow': ['github3.py', jinja_req, 'pygit2>=1.6.0', 'requests',
-                 'ruamel.yaml', 'setuptools_scm'],
+                 'ruamel.yaml', 'setuptools_scm<8.0.0'],
     'crossbow-upload': ['github3.py', jinja_req, 'ruamel.yaml',
                         'setuptools_scm'],
     'docker': ['ruamel.yaml', 'python-dotenv'],


### PR DESCRIPTION
The comment bot depends on an internal setuptools_scm API that was changed in setuptools_scm 8.
We therefore need to reinstate the Archery version constraint that was removed in https://github.com/apache/arrow/pull/40150

See example failure at https://github.com/apache/arrow/actions/runs/7976567301/job/21777437575
