### PR TITLE
GH-40159: [Python][CI] Add 32-bit Debian build on Crossbow

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1192,12 +1192,22 @@ tasks:
         PYTHON: "3.10"
       image: conda-python-cython2
 
-  test-debian-11-python-3:
+  test-debian-11-python-3-amd64:
     ci: azure
     template: docker-tests/azure.linux.yml
     params:
       env:
         DEBIAN: 11
+      image: debian-python
+
+  test-debian-11-python-3-i386:
+    ci: github
+    template: docker-tests/github.linux.yml
+    params:
+      env:
+        ARCH: i386
+        DEBIAN: 11
+      flags: "-e ARROW_S3=OFF -e ARROW_GANDIVA=OFF"
       image: debian-python
 
   test-ubuntu-20.04-python-3:


### PR DESCRIPTION
### What changes are included in this PR?

Add a Debian-based i386 test build for Python, similar to the existing one for C++.

### Are these changes tested?

Yes. The test suite step in the new build will fail until GH-40153 is entirely fixed.

### Are there any user-facing changes?

No.
* Closes: #40159