### PR TITLE
MINOR: [Dev] Remove auto close link forced in PR description

### DIFF
--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -82,7 +82,7 @@ async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
 async function commentGitHubURL(github, context, pullRequestNumber, issueID) {
   // Make the call to ensure issue exists before adding comment
   const issueInfo = await helpers.getGitHubInfo(github, context, issueID, pullRequestNumber);
-  const message = "* Closes: #" + issueInfo.number
+  const message = "* GitHub Issue: #" + issueInfo.number
   if (issueInfo) {
     const body = context.payload.pull_request.body || "";
     if (body.includes(message)) {


### PR DESCRIPTION
For some reason, https://github.com/apache/arrow/pull/14783 changed the automatic GH issue link to a "Closes" reference that will forcefully close the linked issue *even if the committer chooses not to close the issue using the merge script*.

Since the original change was done without discussion, this is a MINOR PR as well.
