### PR TITLE
GH-40199: [R] dbplyr 2.5.0 forward compatibility

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -64,7 +64,7 @@ to_duckdb <- function(.data,
   tbl <- dplyr::tbl(con, table_name)
   groups <- dplyr::groups(.data)
   if (length(groups)) {
-    tbl <- dplyr::group_by(tbl, groups)
+    tbl <- dplyr::group_by(tbl, !!!groups)
   }
 
   if (auto_disconnect) {


### PR DESCRIPTION
I'm not sure why this worked before, but 2.5.0 got a little stricter and now warns about this minor infelicity.

I _think_ this is the only issue with 2.5.0, but if there's any way you could run your CI checks with dev dbplyr I'd really appreciate it!

* GitHub Issue: #40199