### PR TITLE
GH-40183: [C++] Fix cast function bind failed after add an alias name through AddAlias

### DIFF
--- a/cpp/src/arrow/compute/expression_internal.h
+++ b/cpp/src/arrow/compute/expression_internal.h
@@ -278,9 +278,12 @@ struct FlattenedAssociativeChain {
 
 inline Result<std::shared_ptr<compute::Function>> GetFunction(
     const Expression::Call& call, compute::ExecContext* exec_context) {
-  if (call.function_name != "cast") {
-    return exec_context->func_registry()->GetFunction(call.function_name);
+  ARROW_ASSIGN_OR_RAISE(auto function,
+                        exec_context->func_registry()->GetFunction(call.function_name));
+  if (function.get() != exec_context->func_registry()->cast_function()) {
+    return function;
   }
+
   // XXX this special case is strange; why not make "cast" a ScalarFunction?
   const TypeHolder& to_type =
       ::arrow::internal::checked_cast<const compute::CastOptions&>(*call.options).to_type;

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -604,6 +604,17 @@ TEST(Expression, BindCall) {
                 add(cast(field_ref("i32"), float32()), literal(3.5F)));
 }
 
+TEST(Expression, BindWithAliasCasts) {
+  auto fm = GetFunctionRegistry();
+  EXPECT_OK(fm->AddAlias("alias_cast", "cast"));
+
+  auto expr = call("alias_cast", {field_ref("f1")}, CastOptions::Unsafe(arrow::int32()));
+  EXPECT_FALSE(expr.IsBound());
+
+  auto schema = arrow::schema({field("f1", decimal128(30, 3))});
+  ExpectBindsTo(expr, no_change, &expr, *schema);
+}
+
 TEST(Expression, BindWithDecimalArithmeticOps) {
   for (std::string arith_op : {"add", "subtract", "multiply", "divide"}) {
     auto expr = call(arith_op, {field_ref("d1"), field_ref("d2")});

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -125,6 +125,8 @@ class FunctionRegistry::FunctionRegistryImpl {
            static_cast<int>(name_to_function_.size());
   }
 
+  const Function* cast_function() { return cast_function_; }
+
  private:
   // must not acquire mutex
   Status CanAddFunctionName(const std::string& name, bool allow_overwrite) {
@@ -169,6 +171,9 @@ class FunctionRegistry::FunctionRegistryImpl {
     RETURN_NOT_OK(CanAddFunctionName(name, allow_overwrite));
     if (add) {
       name_to_function_[name] = std::move(function);
+      if (name == "cast") {
+        cast_function_ = name_to_function_[name].get();
+      }
     }
     return Status::OK();
   }
@@ -205,6 +210,8 @@ class FunctionRegistry::FunctionRegistryImpl {
   std::mutex lock_;
   std::unordered_map<std::string, std::shared_ptr<Function>> name_to_function_;
   std::unordered_map<std::string, const FunctionOptionsType*> name_to_options_type_;
+  
+  const Function* cast_function_;
 };
 
 std::unique_ptr<FunctionRegistry> FunctionRegistry::Make() {
@@ -267,6 +274,8 @@ Result<const FunctionOptionsType*> FunctionRegistry::GetFunctionOptionsType(
 }
 
 int FunctionRegistry::num_functions() const { return impl_->num_functions(); }
+
+const Function* FunctionRegistry::cast_function() const { return impl_->cast_function(); }
 
 namespace internal {
 

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -210,7 +210,7 @@ class FunctionRegistry::FunctionRegistryImpl {
   std::mutex lock_;
   std::unordered_map<std::string, std::shared_ptr<Function>> name_to_function_;
   std::unordered_map<std::string, const FunctionOptionsType*> name_to_options_type_;
-  
+
   const Function* cast_function_;
 };
 

--- a/cpp/src/arrow/compute/registry.h
+++ b/cpp/src/arrow/compute/registry.h
@@ -107,6 +107,11 @@ class ARROW_EXPORT FunctionRegistry {
   /// \brief The number of currently registered functions.
   int num_functions() const;
 
+  /// \brief The cast function object registered in AddFunction.
+  ///
+  /// Helpful for get cast function as needed.
+  const Function* cast_function() const;
+
  private:
   FunctionRegistry();
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Cast function bind failed after add a alias name through AddAlias.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add a const `cast_function` which registered in `AddFunction` for check cast alias in `arrow::compute::GetFunction`.

### Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes, cast's alias name can also execute with expression system.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

* GitHub Issue: #40183