### PR TITLE
GH-40025: [C++][FS][Azure] Implement Move() for flat namespace storage accounts

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -266,6 +266,20 @@ struct AzureLocation {
     return parent;
   }
 
+  /// \brief Create a copy of this location with the trailing slash removed from the
+  /// path.
+  ///
+  /// The original string that was parsed into this location -- all -- is preserved as is
+  /// to make error messages show what the user originally provided.
+  AzureLocation RemoveTrailingSlashFromPath() const {
+    AzureLocation result;
+    result.all = all;
+    result.container = container;
+    result.path = internal::RemoveTrailingSlash(path);
+    result.path_parts = path_parts;
+    return result;
+  }
+
   Result<AzureLocation> join(const std::string& stem) const {
     return FromString(internal::ConcatAbstractPath(all, stem));
   }
@@ -2348,8 +2362,8 @@ class AzureFileSystem::Impl {
       const AzureLocation& src, const AzureLocation& dest) {
     DCHECK(!src.container.empty() && !src.path.empty());
     DCHECK(!dest.container.empty() && !dest.path.empty());
-    const auto src_no_trailing_slash = src.RemoveTrailingSlash(/*preserve_root=*/true);
-    const auto dest_no_trailing_slash = dest.RemoveTrailingSlash(/*preserve_root=*/true);
+    const auto src_no_trailing_slash = src.RemoveTrailingSlashFromPath();
+    const auto dest_no_trailing_slash = dest.RemoveTrailingSlashFromPath();
 
     // Ensure that src exists and, if path has a trailing slash, that it's a directory.
     ARROW_ASSIGN_OR_RAISE(

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1362,14 +1362,15 @@ class TestAzureFileSystem : public ::testing::Test {
         fs()->Move(data.ObjectPath(), ConcatAbstractPath(another_container, "path")));
     AssertFileInfo(fs(), data.ObjectPath(), FileType::File);
 
-    if (!WithHierarchicalNamespace()) {
-      GTEST_SKIP() << "The rest of TestMovePath is not implemented for non-HNS scenarios";
-    }
-
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         IOError, HasMissingParentDirMessage(data.Path("missing-subdir/file")),
         fs()->Move(data.ObjectPath(), data.Path("missing-subdir/file")));
     AssertFileInfo(fs(), data.ObjectPath(), FileType::File);
+
+    if (!WithHierarchicalNamespace()) {
+      GTEST_SKIP()
+          << "The rest of TestMovePath is not implemented for non-HNS scenarios ";
+    }
 
     // src is a file and dest does not exists
     ASSERT_MOVE_OK(data.ObjectPath(), data.Path("file0"));


### PR DESCRIPTION
### Rationale for this change

Move is currently only supported on HNS-enabled storage accounts.

### What changes are included in this PR?

Implementation of all the checks + a TODO on the actual blob moves.

### Are these changes tested?

 - By the same tests that cover the HNS storage account Move (pending removal of a conditional)
* GitHub Issue: #40025