### PR TITLE
GH-40207: [C++] TakeCC: Concatenate only once and delegate to TakeAA instead of TakeCA

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
@@ -353,15 +353,15 @@ static void TakeFixedSizeBinaryMonotonicIndices(benchmark::State& state) {
       .FixedSizeBinary();
 }
 
-static void TakeChunkedInt64RandomIndicesNoNulls(benchmark::State& state) {
+static void TakeChunkedChunkedInt64RandomIndicesNoNulls(benchmark::State& state) {
   TakeBenchmark(state, false).ChunkedInt64();
 }
 
-static void TakeChunkedInt64RandomIndicesWithNulls(benchmark::State& state) {
+static void TakeChunkedChunkedInt64RandomIndicesWithNulls(benchmark::State& state) {
   TakeBenchmark(state, true).ChunkedInt64();
 }
 
-static void TakeChunkedInt64MonotonicIndices(benchmark::State& state) {
+static void TakeChunkedChunkedInt64MonotonicIndices(benchmark::State& state) {
   TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true).ChunkedInt64();
 }
 
@@ -451,9 +451,9 @@ void TakeFSBSetArgs(benchmark::internal::Benchmark* bench) {
 BENCHMARK(TakeInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
 BENCHMARK(TakeInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
 BENCHMARK(TakeInt64MonotonicIndices)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedInt64MonotonicIndices)->Apply(TakeSetArgs);
+BENCHMARK(TakeChunkedChunkedInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
+BENCHMARK(TakeChunkedChunkedInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
+BENCHMARK(TakeChunkedChunkedInt64MonotonicIndices)->Apply(TakeSetArgs);
 BENCHMARK(TakeFixedSizeBinaryRandomIndicesNoNulls)->Apply(TakeFSBSetArgs);
 BENCHMARK(TakeFixedSizeBinaryRandomIndicesWithNulls)->Apply(TakeFSBSetArgs);
 BENCHMARK(TakeFixedSizeBinaryMonotonicIndices)->Apply(TakeFSBSetArgs);

--- a/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
@@ -202,6 +202,7 @@ struct TakeBenchmark {
         ABORT_NOT_OK(Take(values, indices).status());
       }
     }
+    state.SetItemsProcessed(state.iterations() * values->length());
   }
 };
 
@@ -343,11 +344,11 @@ static void FilterRecordBatchWithNulls(benchmark::State& state) {
 }
 
 static void TakeInt64RandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, false).Int64();
+  TakeBenchmark(state, /*indices_with_nulls=*/false).Int64();
 }
 
 static void TakeInt64RandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, true).Int64();
+  TakeBenchmark(state, /*indices_with_nulls=*/true).Int64();
 }
 
 static void TakeInt64MonotonicIndices(benchmark::State& state) {
@@ -355,11 +356,11 @@ static void TakeInt64MonotonicIndices(benchmark::State& state) {
 }
 
 static void TakeFixedSizeBinaryRandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, false).FixedSizeBinary();
+  TakeBenchmark(state, /*indices_with_nulls=*/false).FixedSizeBinary();
 }
 
 static void TakeFixedSizeBinaryRandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, true).FixedSizeBinary();
+  TakeBenchmark(state, /*indices_with_nulls=*/true).FixedSizeBinary();
 }
 
 static void TakeFixedSizeBinaryMonotonicIndices(benchmark::State& state) {
@@ -368,12 +369,13 @@ static void TakeFixedSizeBinaryMonotonicIndices(benchmark::State& state) {
 }
 
 static void TakeChunkedChunkedInt64RandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, false)
+  TakeBenchmark(state, /*indices_with_nulls=*/false)
       .ChunkedInt64(/*num_chunks=*/100, /*chunk_indices_too=*/true);
 }
 
 static void TakeChunkedChunkedInt64RandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, true).ChunkedInt64(/*num_chunks=*/100, /*chunk_indices_too=*/true);
+  TakeBenchmark(state, /*indices_with_nulls=*/true)
+      .ChunkedInt64(/*num_chunks=*/100, /*chunk_indices_too=*/true);
 }
 
 static void TakeChunkedChunkedInt64MonotonicIndices(benchmark::State& state) {
@@ -383,26 +385,27 @@ static void TakeChunkedChunkedInt64MonotonicIndices(benchmark::State& state) {
 }
 
 static void TakeChunkedFlatInt64RandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, false)
-      .ChunkedInt64(/*num_chunks=*/100, /*chunk_indices_too=*/true);
+  TakeBenchmark(state, /*indices_with_nulls=*/false)
+      .ChunkedInt64(/*num_chunks=*/100, /*chunk_indices_too=*/false);
 }
 
 static void TakeChunkedFlatInt64RandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, true).ChunkedInt64(/*num_chunks=*/100, /*chunk_indices_too=*/true);
+  TakeBenchmark(state, /*indices_with_nulls=*/true)
+      .ChunkedInt64(/*num_chunks=*/100, /*chunk_indices_too=*/false);
 }
 
 static void TakeChunkedFlatInt64MonotonicIndices(benchmark::State& state) {
   TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true)
       .ChunkedInt64(
-          /*num_chunks=*/100, /*chunk_indices_too=*/true);
+          /*num_chunks=*/100, /*chunk_indices_too=*/false);
 }
 
 static void TakeFSLInt64RandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, false).FSLInt64();
+  TakeBenchmark(state, /*indices_with_nulls=*/false).FSLInt64();
 }
 
 static void TakeFSLInt64RandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, true).FSLInt64();
+  TakeBenchmark(state, /*indices_with_nulls=*/true).FSLInt64();
 }
 
 static void TakeFSLInt64MonotonicIndices(benchmark::State& state) {
@@ -410,11 +413,11 @@ static void TakeFSLInt64MonotonicIndices(benchmark::State& state) {
 }
 
 static void TakeStringRandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, false).String();
+  TakeBenchmark(state, /*indices_with_nulls=*/false).String();
 }
 
 static void TakeStringRandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, true).String();
+  TakeBenchmark(state, /*indices_with_nulls=*/true).String();
 }
 
 static void TakeStringMonotonicIndices(benchmark::State& state) {

--- a/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_benchmark.cc
@@ -343,6 +343,10 @@ static void FilterRecordBatchWithNulls(benchmark::State& state) {
   FilterBenchmark(state, true).BenchRecordBatch();
 }
 
+static void  marker(benchmark::State& state) {
+  FilterBenchmark(state, true).BenchRecordBatch();
+}
+
 static void TakeInt64RandomIndicesNoNulls(benchmark::State& state) {
   TakeBenchmark(state, /*indices_with_nulls=*/false).Int64();
 }
@@ -366,6 +370,30 @@ static void TakeFixedSizeBinaryRandomIndicesWithNulls(benchmark::State& state) {
 static void TakeFixedSizeBinaryMonotonicIndices(benchmark::State& state) {
   TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true)
       .FixedSizeBinary();
+}
+
+static void TakeFSLInt64RandomIndicesNoNulls(benchmark::State& state) {
+  TakeBenchmark(state, /*indices_with_nulls=*/false).FSLInt64();
+}
+
+static void TakeFSLInt64RandomIndicesWithNulls(benchmark::State& state) {
+  TakeBenchmark(state, /*indices_with_nulls=*/true).FSLInt64();
+}
+
+static void TakeFSLInt64MonotonicIndices(benchmark::State& state) {
+  TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true).FSLInt64();
+}
+
+static void TakeStringRandomIndicesNoNulls(benchmark::State& state) {
+  TakeBenchmark(state, /*indices_with_nulls=*/false).String();
+}
+
+static void TakeStringRandomIndicesWithNulls(benchmark::State& state) {
+  TakeBenchmark(state, /*indices_with_nulls=*/true).String();
+}
+
+static void TakeStringMonotonicIndices(benchmark::State& state) {
+  TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true).FSLInt64();
 }
 
 static void TakeChunkedChunkedInt64RandomIndicesNoNulls(benchmark::State& state) {
@@ -398,30 +426,6 @@ static void TakeChunkedFlatInt64MonotonicIndices(benchmark::State& state) {
   TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true)
       .ChunkedInt64(
           /*num_chunks=*/100, /*chunk_indices_too=*/false);
-}
-
-static void TakeFSLInt64RandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, /*indices_with_nulls=*/false).FSLInt64();
-}
-
-static void TakeFSLInt64RandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, /*indices_with_nulls=*/true).FSLInt64();
-}
-
-static void TakeFSLInt64MonotonicIndices(benchmark::State& state) {
-  TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true).FSLInt64();
-}
-
-static void TakeStringRandomIndicesNoNulls(benchmark::State& state) {
-  TakeBenchmark(state, /*indices_with_nulls=*/false).String();
-}
-
-static void TakeStringRandomIndicesWithNulls(benchmark::State& state) {
-  TakeBenchmark(state, /*indices_with_nulls=*/true).String();
-}
-
-static void TakeStringMonotonicIndices(benchmark::State& state) {
-  TakeBenchmark(state, /*indices_with_nulls=*/false, /*monotonic=*/true).FSLInt64();
 }
 
 void FilterSetArgs(benchmark::internal::Benchmark* bench) {
@@ -483,15 +487,10 @@ void TakeFSBSetArgs(benchmark::internal::Benchmark* bench) {
   }
 }
 
+// Flat values x Flat indices
 BENCHMARK(TakeInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
 BENCHMARK(TakeInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
 BENCHMARK(TakeInt64MonotonicIndices)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedChunkedInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedChunkedInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedChunkedInt64MonotonicIndices)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedFlatInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedFlatInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
-BENCHMARK(TakeChunkedFlatInt64MonotonicIndices)->Apply(TakeSetArgs);
 BENCHMARK(TakeFixedSizeBinaryRandomIndicesNoNulls)->Apply(TakeFSBSetArgs);
 BENCHMARK(TakeFixedSizeBinaryRandomIndicesWithNulls)->Apply(TakeFSBSetArgs);
 BENCHMARK(TakeFixedSizeBinaryMonotonicIndices)->Apply(TakeFSBSetArgs);
@@ -501,6 +500,16 @@ BENCHMARK(TakeFSLInt64MonotonicIndices)->Apply(TakeSetArgs);
 BENCHMARK(TakeStringRandomIndicesNoNulls)->Apply(TakeSetArgs);
 BENCHMARK(TakeStringRandomIndicesWithNulls)->Apply(TakeSetArgs);
 BENCHMARK(TakeStringMonotonicIndices)->Apply(TakeSetArgs);
+
+// Chunked values x Chunked indices
+BENCHMARK(TakeChunkedChunkedInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
+BENCHMARK(TakeChunkedChunkedInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
+BENCHMARK(TakeChunkedChunkedInt64MonotonicIndices)->Apply(TakeSetArgs);
+
+// Chunked values x Flat indices
+BENCHMARK(TakeChunkedFlatInt64RandomIndicesNoNulls)->Apply(TakeSetArgs);
+BENCHMARK(TakeChunkedFlatInt64RandomIndicesWithNulls)->Apply(TakeSetArgs);
+BENCHMARK(TakeChunkedFlatInt64MonotonicIndices)->Apply(TakeSetArgs);
 
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

`take` concatenates chunks when it's applied to a chunked `values` array, but when the `indices` arrays is also `chunked` it concatenates `values` more than once -- one `Concatenate` call with `values.chunks()` for every chunk in `indices`. This PR doesn't remove the concatenation, but ensures it's done only once instead of `indices.size()` times.

### What changes are included in this PR?

 - Adding return type to the `TakeXX` names (-> `TakeXXY`) to makes code easier to understand
 - Adding benchmarks to `TakeCCC` — copied from #13857
 - Remove the concatenation from the loop body (!)

### Are these changes tested?

By existing tests.

### Are there any user-facing changes?

A faster compute kernel.
* GitHub Issue: #40207