### PR TITLE
GH-40209: [C++][CMake] Use "RapidJSON" CMake target for RapidJSON

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -848,8 +848,8 @@ if(ARROW_WITH_RE2)
 endif()
 
 if(ARROW_WITH_RAPIDJSON)
-  list(APPEND ARROW_SHARED_LINK_LIBS rapidjson::rapidjson)
-  list(APPEND ARROW_STATIC_LINK_LIBS rapidjson::rapidjson)
+  list(APPEND ARROW_SHARED_LINK_LIBS RapidJSON)
+  list(APPEND ARROW_STATIC_LINK_LIBS RapidJSON)
 endif()
 
 if(ARROW_USE_XSIMD)

--- a/cpp/cmake_modules/FindRapidJSONAlt.cmake
+++ b/cpp/cmake_modules/FindRapidJSONAlt.cmake
@@ -29,7 +29,14 @@ endif()
 find_package(RapidJSON ${find_package_args})
 if(RapidJSON_FOUND)
   set(RapidJSONAlt_FOUND TRUE)
-  set(RAPIDJSON_INCLUDE_DIR ${RAPIDJSON_INCLUDE_DIRS})
+  if(NOT TARGET RapidJSON)
+    add_library(RapidJSON INTERFACE IMPORTED)
+    if(RapidJSON_INCLUDE_DIRS)
+      target_include_directories(RapidJSON INTERFACE "${RapidJSON_INCLUDE_DIRS}")
+    else()
+      target_include_directories(RapidJSON INTERFACE "${RAPIDJSON_INCLUDE_DIRS}")
+    endif()
+  endif()
   return()
 endif()
 
@@ -74,3 +81,14 @@ find_package_handle_standard_args(
   RapidJSONAlt
   REQUIRED_VARS RAPIDJSON_INCLUDE_DIR
   VERSION_VAR RAPIDJSON_VERSION)
+
+if(RapidJSONAlt_FOUND)
+  if(WIN32 AND "${RAPIDJSON_INCLUDE_DIR}" MATCHES "^/")
+    # MSYS2
+    execute_process(COMMAND "cygpath" "--windows" "${RAPIDJSON_INCLUDE_DIR}"
+                    OUTPUT_VARIABLE RAPIDJSON_INCLUDE_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+  add_library(RapidJSON INTERFACE IMPORTED)
+  target_include_directories(RapidJSON INTERFACE "${RAPIDJSON_INCLUDE_DIR}")
+endif()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -18,7 +18,6 @@
 include(ProcessorCount)
 processorcount(NPROC)
 
-add_custom_target(rapidjson)
 add_custom_target(toolchain)
 add_custom_target(toolchain-benchmarks)
 add_custom_target(toolchain-tests)
@@ -2328,9 +2327,9 @@ macro(build_rapidjson)
   # The include directory must exist before it is referenced by a target.
   file(MAKE_DIRECTORY "${RAPIDJSON_INCLUDE_DIR}")
 
-  add_dependencies(toolchain rapidjson_ep)
-  add_dependencies(toolchain-tests rapidjson_ep)
-  add_dependencies(rapidjson rapidjson_ep)
+  add_library(RapidJSON INTERFACE IMPORTED)
+  target_include_directories(RapidJSON INTERFACE "${RAPIDJSON_INCLUDE_DIR}")
+  add_dependencies(RapidJSON rapidjson_ep)
 
   set(RAPIDJSON_VENDORED TRUE)
 endmacro()
@@ -2344,19 +2343,6 @@ if(ARROW_WITH_RAPIDJSON)
                      ${ARROW_RAPIDJSON_REQUIRED_VERSION}
                      IS_RUNTIME_DEPENDENCY
                      FALSE)
-
-  if(RapidJSON_INCLUDE_DIR)
-    set(RAPIDJSON_INCLUDE_DIR "${RapidJSON_INCLUDE_DIR}")
-  endif()
-  if(WIN32 AND "${RAPIDJSON_INCLUDE_DIR}" MATCHES "^/")
-    # MSYS2
-    execute_process(COMMAND "cygpath" "--windows" "${RAPIDJSON_INCLUDE_DIR}"
-                    OUTPUT_VARIABLE RAPIDJSON_INCLUDE_DIR
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-  endif()
-
-  add_library(rapidjson::rapidjson INTERFACE IMPORTED)
-  target_include_directories(rapidjson::rapidjson INTERFACE "${RAPIDJSON_INCLUDE_DIR}")
 endif()
 
 macro(build_xsimd)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -337,9 +337,9 @@ if(ARROW_WITH_ZSTD)
   list(APPEND ARROW_SRCS util/compression_zstd.cc)
 endif()
 
-set(ARROW_TESTING_SHARED_LINK_LIBS arrow::flatbuffers rapidjson::rapidjson arrow_shared
+set(ARROW_TESTING_SHARED_LINK_LIBS arrow::flatbuffers RapidJSON arrow_shared
                                    ${ARROW_GTEST_GTEST})
-set(ARROW_TESTING_STATIC_LINK_LIBS arrow::flatbuffers rapidjson::rapidjson arrow_static
+set(ARROW_TESTING_STATIC_LINK_LIBS arrow::flatbuffers RapidJSON arrow_static
                                    ${ARROW_GTEST_GTEST})
 
 set(ARROW_TESTING_SRCS


### PR DESCRIPTION
### Rationale for this change

Because upstream uses "RapidJSON" for CMake target name.

### What changes are included in this PR?

Rename "rapidjson::rapidjson" to "RapidJSON".

FindRapidJSONAlt.cmake provides "RapidJSON" CMake target instead of just providing RAPIDJSON_INCLUDE_DIR.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40209