### PR TITLE
GH-40215: [Format][Docs] Document Arrow Columnar Format version history

### DIFF
--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -25,7 +25,7 @@ Canonical Extension Types
 Introduction
 ============
 
-The Arrow Columnar Format allows defining
+The Arrow columnar format allows defining
 :ref:`extension types <format_metadata_extension_types>` so as to extend
 standard Arrow data types with custom semantics.  Often these semantics
 will be specific to a system or application.  However, it is beneficial

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -21,7 +21,7 @@
 Arrow Columnar Format
 *********************
 
-:ref:`*Version: 1.4* <format-version-1-4>`
+:ref:`Version: 1.4 <format-version-1-4>`
 
 The "Arrow Columnar Format" includes a language-agnostic in-memory
 data structure specification, metadata serialization, and a protocol

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -49,6 +49,47 @@ data representation and serialization details; issues such as
 coordinating mutation of data structures are left to be handled by
 implementations.
 
+Version History
+===============
+
+At the 1.0.0 release, the Arrow columnar format was declared stable, with
+forward and backward compatibility guarantees. See
+:doc:`./format/Versioning` for more details.
+
+.. note::
+
+  Arrow libraries are versioned separately from the Arrow columnar format.
+
+Since version 1.0.0, there have been four new minor versions and zero new
+major versions of the Arrow columnar format. Each new minor version added
+new features. When these new features are not used, the new minor format
+versions are compatible with format version 1.0.0. The new features added
+in each minor version since 1.0.0 are as follows:
+
+Version 1.1
+-----------
+
+* Added 256-bit Decimal type.
+
+Version 1.2
+-----------
+
+* Added MonthDayNano interval type.
+
+Version 1.3
+-----------
+
+* Added :ref:`run-end-encoded-layout`.
+
+Version 1.4
+-----------
+
+* Added :ref:`variable-size-binary-view-layout` and the associated BinaryView
+  and Utf8View types.
+* Added :ref:`listview-layout` and the associated ListView and LargeListView
+  types.
+* Added :ref:`variadic-buffers`.
+
 Terminology
 ===========
 
@@ -359,6 +400,8 @@ will be represented as follows: ::
     |----------------|-----------------------|
     | joemark        | unspecified (padding) |
 
+.. _variable-size-binary-view-layout:
+
 Variable-size Binary View Layout
 --------------------------------
 
@@ -499,8 +542,12 @@ will be represented as follows: ::
           |-------------------------------|-----------------------|
           | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 | unspecified (padding) |
 
+.. _listview-layout:
+
 ListView Layout
 ~~~~~~~~~~~~~~~
+
+.. versionadded:: Arrow Columnar Format 1.4
 
 The ListView layout is defined by three buffers: a validity bitmap, an offsets
 buffer, and an additional sizes buffer. Sizes and offsets have the identical bit
@@ -957,6 +1004,8 @@ below.
 Run-End Encoded Layout
 ----------------------
 
+.. versionadded:: Arrow Columnar Format 1.3
+
 Run-end encoding (REE) is a variation of run-length encoding (RLE). These
 encodings are well-suited for representing data containing sequences of the
 same value, called runs. In run-end encoding, each run is represented as a
@@ -1232,8 +1281,12 @@ bytes. Since this metadata can be used to communicate in-memory pointer
 addresses between libraries, it is recommended to set ``size`` to the actual
 memory size rather than the padded size.
 
+.. _variadic-buffers:
+
 Variadic buffers
 ----------------
+
+.. versionadded:: Arrow Columnar Format 1.4
 
 Some types such as Utf8View are represented using a variable number of buffers.
 For each such Field in the pre-ordered flattened logical schema, there will be

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -21,7 +21,9 @@
 Arrow Columnar Format
 *********************
 
-:ref:`Version: 1.4 <format-version-1-4>`
+*Version: 1.4*
+
+.. seealso:: :ref:`post-1-0-0-format-versions`
 
 The "Arrow Columnar Format" includes a language-agnostic in-memory
 data structure specification, metadata serialization, and a protocol

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -21,7 +21,7 @@
 Arrow Columnar Format
 *********************
 
-*Version: 1.4*
+:ref:`*Version: 1.4* <format-version-1-4>`
 
 The "Arrow Columnar Format" includes a language-agnostic in-memory
 data structure specification, metadata serialization, and a protocol
@@ -48,47 +48,6 @@ mutation operations. This document is concerned only with in-memory
 data representation and serialization details; issues such as
 coordinating mutation of data structures are left to be handled by
 implementations.
-
-Version History
-===============
-
-At the 1.0.0 release, the Arrow columnar format was declared stable, with
-forward and backward compatibility guarantees. See
-:doc:`./Versioning` for more details.
-
-.. note::
-
-  Arrow libraries are versioned separately from the Arrow columnar format.
-
-Since version 1.0.0, there have been four new minor versions and zero new
-major versions of the Arrow columnar format. Each new minor version added
-new features. When these new features are not used, the new minor format
-versions are compatible with format version 1.0.0. The new features added
-in each minor version since 1.0.0 are as follows:
-
-Version 1.1
------------
-
-* Added 256-bit Decimal type.
-
-Version 1.2
------------
-
-* Added MonthDayNano interval type.
-
-Version 1.3
------------
-
-* Added :ref:`run-end-encoded-layout`.
-
-Version 1.4
------------
-
-* Added :ref:`variable-size-binary-view-layout` and the associated BinaryView
-  and Utf8View types.
-* Added :ref:`listview-layout` and the associated ListView and LargeListView
-  types.
-* Added :ref:`variadic-buffers`.
 
 Terminology
 ===========

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -23,9 +23,10 @@ Arrow Columnar Format
 
 *Version: 1.4*
 
-.. seealso:: :ref:`post-1-0-0-format-versions`
+.. seealso:: :ref:`Additions to the Arrow columnar format since version 1.0.0
+   <post-1-0-0-format-versions>`
 
-The "Arrow Columnar Format" includes a language-agnostic in-memory
+The **Arrow columnar format** includes a language-agnostic in-memory
 data structure specification, metadata serialization, and a protocol
 for serialization and generic data transport.
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -54,7 +54,7 @@ Version History
 
 At the 1.0.0 release, the Arrow columnar format was declared stable, with
 forward and backward compatibility guarantees. See
-:doc:`./format/Versioning` for more details.
+:doc:`./Versioning` for more details.
 
 .. note::
 

--- a/docs/source/format/Versioning.rst
+++ b/docs/source/format/Versioning.rst
@@ -15,8 +15,9 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
+*******************************
 Format Versioning and Stability
-===============================
+*******************************
 
 Starting with version 1.0.0, Apache Arrow uses
 **two versions** to describe each release of the project:
@@ -32,7 +33,7 @@ changes. From 1.0.0 onward, we follow `Semantic Versioning
 expect most releases to be major library releases.
 
 Backward Compatibility
-----------------------
+======================
 
 A newer versioned client library will be able to read any data and
 metadata produced by an older client library.
@@ -41,7 +42,7 @@ So long as the **major** format version is not changed, a newer
 library is backward compatible with an older library.
 
 Forward Compatibility
----------------------
+=====================
 
 An older client library must be able to either read data generated
 from a new client library or detect that it cannot properly read the
@@ -53,7 +54,7 @@ available in 1.0.0. So long as these features are not used (such as a
 new logical data type), forward compatibility is preserved.
 
 Long-Term Stability
--------------------
+===================
 
 A change in the format major version (e.g. from 1.0.0 to 2.0.0)
 indicates a disruption to these compatibility guarantees in some way.
@@ -63,9 +64,50 @@ event and, should this come to pass, we would exercise caution in
 ensuring that production applications are not harmed.
 
 Pre-1.0.0 Versions
-------------------
+==================
 
 We made no forward or backward compatibility guarantees for
 versions prior to 1.0.0. However, we made every effort to ensure
 that new clients can read serialized data produced by library version
 0.8.0 and onward.
+
+Post-1.0.0 Format Versions
+==========================
+
+Since version 1.0.0, there have been four new minor versions and zero new
+major versions of the Arrow format. Each new minor version added new features.
+When these new features are not used, the new minor format versions are
+compatible with format version 1.0.0. The new features added in each minor
+format version since 1.0.0 are as follows:
+
+.. _format-version-1-1:
+
+Version 1.1
+-----------
+
+* Added 256-bit Decimal type.
+
+.. _format-version-1-2:
+
+Version 1.2
+-----------
+
+* Added MonthDayNano interval type.
+
+.. _format-version-1-3:
+
+Version 1.3
+-----------
+
+* Added :ref:`run-end-encoded-layout`.
+
+.. _format-version-1-4:
+
+Version 1.4
+-----------
+
+* Added :ref:`variable-size-binary-view-layout` and the associated BinaryView
+  and Utf8View types.
+* Added :ref:`listview-layout` and the associated ListView and LargeListView
+  types.
+* Added :ref:`variadic-buffers`.

--- a/docs/source/format/Versioning.rst
+++ b/docs/source/format/Versioning.rst
@@ -71,6 +71,8 @@ versions prior to 1.0.0. However, we made every effort to ensure
 that new clients can read serialized data produced by library version
 0.8.0 and onward.
 
+.. _post-1-0-0-format-versions:
+
 Post-1.0.0 Format Versions
 ==========================
 
@@ -80,28 +82,20 @@ When these new features are not used, the new minor format versions are
 compatible with format version 1.0.0. The new features added in each minor
 format version since 1.0.0 are as follows:
 
-.. _format-version-1-1:
-
 Version 1.1
 -----------
 
 * Added 256-bit Decimal type.
-
-.. _format-version-1-2:
 
 Version 1.2
 -----------
 
 * Added MonthDayNano interval type.
 
-.. _format-version-1-3:
-
 Version 1.3
 -----------
 
 * Added :ref:`run-end-encoded-layout`.
-
-.. _format-version-1-4:
 
 Version 1.4
 -----------

--- a/docs/source/status.rst
+++ b/docs/source/status.rst
@@ -21,9 +21,9 @@ Implementation Status
 
 The following tables summarize the features available in the various official
 Arrow libraries. All libraries currently follow version 1.0.0 of the Arrow
-format. See :doc:`./format/Versioning` for details about versioning. Unless
-otherwise stated, the Python, R, Ruby and C/GLib libraries follow the C++
-Arrow library.
+format, or later minor versions that are compatible with version 1.0.0. See
+:doc:`./format/Versioning` for details about versioning. Unless otherwise
+stated, the Python, R, Ruby and C/GLib libraries follow the C++ Arrow library.
 
 Data Types
 ==========


### PR DESCRIPTION
This PR:
- Adds a new **Post-1.0.0 Format Versions** section to the **Format Versioning and Stability** docs page
- Adds a **See also** box near the top of the **Arrow Columnar Format** docs page that links to the new section.
- Adds a few associated link anchors and "New in version" info boxes to the **Arrow Columnar Format** docs page
- Updates a reference about the format version on the **Implementation Status** docs page
- Removes the quotes around "Arrow Columnar Format" at the top of the **Arrow Columnar Format** docs page, using bold text instead
- Standardizes the capitalization to "Arrow columnar format" outside of titles (no capitalization for the second and third words when used in sentence text) across the docs

Preview: http://crossbow.voltrondata.com/pr_docs/40219/format/Versioning.html

* GitHub Issue: #40215