### PR TITLE
GH-40126: [C++] Decimal types with different precisions and scales  bind failed in resolve type when call arithmetic function

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -555,48 +555,45 @@ Result<Expression> BindNonRecursive(Expression::Call call, bool insert_implicit_
 
   // First try and bind exactly
   Result<const Kernel*> maybe_exact_match = call.function->DispatchExact(types);
-  if (maybe_exact_match.ok()) {
+  if (maybe_exact_match.ok() && FinishBind().ok()) {
     call.kernel = *maybe_exact_match;
-
     if (FinishBind().ok()) {
       return Expression(std::move(call));
     }
   }
 
-  {
-    if (!insert_implicit_casts) {
-      return maybe_exact_match.status();
+  if (!insert_implicit_casts) {
+    return maybe_exact_match.status();
+  }
+
+  // If exact binding fails, and we are allowed to cast, then prefer casting literals
+  // first.  Since DispatchBest generally prefers up-casting the best way to do this is
+  // first down-cast the literals as much as possible
+  types = GetTypesWithSmallestLiteralRepresentation(call.arguments);
+  ARROW_ASSIGN_OR_RAISE(call.kernel, call.function->DispatchBest(&types));
+
+  for (size_t i = 0; i < types.size(); ++i) {
+    if (types[i] == call.arguments[i].type()) continue;
+
+    if (const Datum* lit = call.arguments[i].literal()) {
+      ARROW_ASSIGN_OR_RAISE(Datum new_lit, compute::Cast(*lit, types[i].GetSharedPtr()));
+      call.arguments[i] = literal(std::move(new_lit));
+      continue;
     }
-    // If exact binding fails, and we are allowed to cast, then prefer casting literals
-    // first.  Since DispatchBest generally prefers up-casting the best way to do this is
-    // first down-cast the literals as much as possible
-    types = GetTypesWithSmallestLiteralRepresentation(call.arguments);
-    ARROW_ASSIGN_OR_RAISE(call.kernel, call.function->DispatchBest(&types));
 
-    for (size_t i = 0; i < types.size(); ++i) {
-      if (types[i] == call.arguments[i].type()) continue;
+    // construct an implicit cast Expression with which to replace this argument
+    Expression::Call implicit_cast;
+    implicit_cast.function_name = "cast";
+    implicit_cast.arguments = {std::move(call.arguments[i])};
 
-      if (const Datum* lit = call.arguments[i].literal()) {
-        ARROW_ASSIGN_OR_RAISE(Datum new_lit,
-                              compute::Cast(*lit, types[i].GetSharedPtr()));
-        call.arguments[i] = literal(std::move(new_lit));
-        continue;
-      }
+    // TODO(wesm): Use TypeHolder in options
+    implicit_cast.options = std::make_shared<compute::CastOptions>(
+        compute::CastOptions::Safe(types[i].GetSharedPtr()));
 
-      // construct an implicit cast Expression with which to replace this argument
-      Expression::Call implicit_cast;
-      implicit_cast.function_name = "cast";
-      implicit_cast.arguments = {std::move(call.arguments[i])};
-
-      // TODO(wesm): Use TypeHolder in options
-      implicit_cast.options = std::make_shared<compute::CastOptions>(
-          compute::CastOptions::Safe(types[i].GetSharedPtr()));
-
-      ARROW_ASSIGN_OR_RAISE(
-          call.arguments[i],
-          BindNonRecursive(std::move(implicit_cast),
-                           /*insert_implicit_casts=*/false, exec_context));
-    }
+    ARROW_ASSIGN_OR_RAISE(
+        call.arguments[i],
+        BindNonRecursive(std::move(implicit_cast),
+                         /*insert_implicit_casts=*/false, exec_context));
   }
 
   RETURN_NOT_OK(FinishBind());

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -555,7 +555,7 @@ Result<Expression> BindNonRecursive(Expression::Call call, bool insert_implicit_
 
   // First try and bind exactly
   Result<const Kernel*> maybe_exact_match = call.function->DispatchExact(types);
-  if (maybe_exact_match.ok() && FinishBind().ok()) {
+  if (maybe_exact_match.ok()) {
     call.kernel = *maybe_exact_match;
     if (FinishBind().ok()) {
       return Expression(std::move(call));

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -604,6 +604,20 @@ TEST(Expression, BindCall) {
                 add(cast(field_ref("i32"), float32()), literal(3.5F)));
 }
 
+TEST(Expression, BindWithDecimalArithmeticOps) {
+  for (const std::string& arith_op : {"add", "subtract", "multiply", "divide"}) {
+    auto expr = call(arith_op, {field_ref("d1"), field_ref("d2")});
+    EXPECT_FALSE(expr.IsBound());
+
+    static const std::vector<std::pair<int, int>> scales = {{3, 9}, {6, 6}, {9, 3}};
+    for (const auto& s : scales) {
+      auto schema = arrow::schema(
+          {field("d1", decimal256(30, s.first)), field("d2", decimal256(20, s.second))});
+      ExpectBindsTo(expr, no_change, &expr, *schema);
+    }
+  }
+}
+
 TEST(Expression, BindWithImplicitCasts) {
   for (auto cmp : {equal, not_equal, less, less_equal, greater, greater_equal}) {
     // cast arguments to common numeric type

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -605,12 +605,12 @@ TEST(Expression, BindCall) {
 }
 
 TEST(Expression, BindWithDecimalArithmeticOps) {
-  for (const std::string& arith_op : {"add", "subtract", "multiply", "divide"}) {
+  for (std::string arith_op : {"add", "subtract", "multiply", "divide"}) {
     auto expr = call(arith_op, {field_ref("d1"), field_ref("d2")});
     EXPECT_FALSE(expr.IsBound());
 
     static const std::vector<std::pair<int, int>> scales = {{3, 9}, {6, 6}, {9, 3}};
-    for (const auto& s : scales) {
+    for (auto s : scales) {
       auto schema = arrow::schema(
           {field("d1", decimal256(30, s.first)), field("d2", decimal256(20, s.second))});
       ExpectBindsTo(expr, no_change, &expr, *schema);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -499,8 +499,9 @@ Result<TypeHolder> ResolveDecimalBinaryOperationOutput(
   DCHECK_EQ(left_type.id(), right_type.id());
 
   int32_t precision, scale;
-  std::tie(precision, scale) = getter(left_type.precision(), left_type.scale(),
-                                      right_type.precision(), right_type.scale());
+  ARROW_ASSIGN_OR_RAISE(std::tie(precision, scale),
+                        ToResult(getter(left_type.precision(), left_type.scale(),
+                                        right_type.precision(), right_type.scale())));
   ARROW_ASSIGN_OR_RAISE(auto type, DecimalType::Make(left_type.id(), precision, scale));
   return std::move(type);
 }
@@ -508,7 +509,13 @@ Result<TypeHolder> ResolveDecimalBinaryOperationOutput(
 Result<TypeHolder> ResolveDecimalAdditionOrSubtractionOutput(
     KernelContext*, const std::vector<TypeHolder>& types) {
   return ResolveDecimalBinaryOperationOutput(
-      types, [](int32_t p1, int32_t s1, int32_t p2, int32_t s2) {
+      types,
+      [](int32_t p1, int32_t s1, int32_t p2,
+         int32_t s2) -> Result<std::pair<int32_t, int32_t>> {
+        if (s1 != s2) {
+          return Status::Invalid("Addition or subtraction of two decimal ",
+                                 "types scale1 != scale2. (", s1, s2, ").");
+        }
         DCHECK_EQ(s1, s2);
         const int32_t scale = s1;
         const int32_t precision = std::max(p1 - s1, p2 - s2) + scale + 1;
@@ -519,7 +526,9 @@ Result<TypeHolder> ResolveDecimalAdditionOrSubtractionOutput(
 Result<TypeHolder> ResolveDecimalMultiplicationOutput(
     KernelContext*, const std::vector<TypeHolder>& types) {
   return ResolveDecimalBinaryOperationOutput(
-      types, [](int32_t p1, int32_t s1, int32_t p2, int32_t s2) {
+      types,
+      [](int32_t p1, int32_t s1, int32_t p2,
+         int32_t s2) -> Result<std::pair<int32_t, int32_t>> {
         const int32_t scale = s1 + s2;
         const int32_t precision = p1 + p2 + 1;
         return std::make_pair(precision, scale);
@@ -529,7 +538,13 @@ Result<TypeHolder> ResolveDecimalMultiplicationOutput(
 Result<TypeHolder> ResolveDecimalDivisionOutput(KernelContext*,
                                                 const std::vector<TypeHolder>& types) {
   return ResolveDecimalBinaryOperationOutput(
-      types, [](int32_t p1, int32_t s1, int32_t p2, int32_t s2) {
+      types,
+      [](int32_t p1, int32_t s1, int32_t p2,
+         int32_t s2) -> Result<std::pair<int32_t, int32_t>> {
+        if (s1 < s2) {
+          return Status::Invalid("Division of two decimal types scale1 < scale2. ", "(",
+                                 s1, s2, ").");
+        }
         DCHECK_GE(s1, s2);
         const int32_t scale = s1 - s2;
         const int32_t precision = p1;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fix decimal types with different precisions and scales  bind failed in resolve type when call arithmetic function.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Add `IsNeedDispatchBest` function to check the decimal types and arithmetic functions, if success we will
go into the dispatchBest path and do the implicit cast correctly.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes, user needn't do their own cast for decimal related logic.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40126