### PR TITLE
GH-40236: [Python][CI] Disable generating C lines in Cython tracebacks

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -722,6 +722,9 @@ endif()
 
 # Error on any warnings not already explicitly ignored.
 set(CYTHON_FLAGS "${CYTHON_FLAGS}" "--warning-errors")
+# GH-40236: make generated C++ code easier to compile by disabling an
+# undocumented Cython feature.
+set(CYTHON_FLAGS "${CYTHON_FLAGS}" "--no-c-in-traceback")
 
 foreach(module ${CYTHON_EXTENSIONS})
   string(REPLACE "." ";" directories ${module})


### PR DESCRIPTION
### Rationale for this change

We're getting timeouts (on AppVeyor) and very long compilation times (on GHA wheel builds) for `lib.cpp`, a Cython-generated C++ file. Examination suggests that `lib.cpp` is more than 300 thousand lines long, and we can hypothesize that this can blow up available memory on some machines and compilers.

### What changes are included in this PR?

Disable a not really useful (and undocumented) Cython feature to make C++ code slightly easier to compile.

### Are these changes tested?

Yes. This solves, at least temporarily, the timeout issues on AppVeyor and makes the wheel builds much faster (down to ~35 minutes for the wheel build step, instead of 3 hours).

### Are there any user-facing changes?

No.
* GitHub Issue: #40236