### PR TITLE
GH-34535: [C++] Move `ChunkResolver` to the public API

### DIFF
--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -79,8 +79,14 @@ RUN apt-get purge -y npm && \
 COPY docs/requirements.txt /arrow/docs/
 RUN pip install -r arrow/docs/requirements.txt meson
 
+# TODO: Why is this failing?
+#
+#  > [10/16] RUN gem install --no-document bundler &&     bundle install --gemfile /arrow/c_glib/Gemfile:                                      
+# 24.94 ERROR:  Error installing bundler:                                                                                                      
+# 24.94   The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
+# 24.94   bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.0.0.
 COPY c_glib/Gemfile /arrow/c_glib/
-RUN gem install --no-document bundler && \
+RUN gem install --no-document bundler -v 2.4.22 && \
     bundle install --gemfile /arrow/c_glib/Gemfile
 
 # Ensure parallel R package installation, set CRAN repo mirror,

--- a/cpp/src/arrow/chunk_resolver.cc
+++ b/cpp/src/arrow/chunk_resolver.cc
@@ -26,7 +26,6 @@
 #include "arrow/record_batch.h"
 
 namespace arrow {
-namespace internal {
 
 namespace {
 template <typename T>
@@ -65,5 +64,4 @@ ChunkResolver::ChunkResolver(const std::vector<const Array*>& chunks)
 ChunkResolver::ChunkResolver(const RecordBatchVector& batches)
     : offsets_(MakeChunksOffsets(batches)), cached_chunk_(0) {}
 
-}  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -24,26 +24,28 @@
 
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 
-struct ChunkLocation {
+/// \brief The location of a logical index in a ChunkedArray.
+struct ARROW_EXPORT ChunkLocation {
   /// \brief Index of the chunk in the array of chunks
   ///
-  /// The value is always in the range `[0, chunks.size()]`. `chunks.size()` is used
-  /// to represent out-of-bounds locations.
+  /// The value is always in the range `[0, chunks.size()]`. `chunks.size()`
+  /// (the number of chunks in the ChunkedArray) is used to represent out-of-bounds
+  /// locations.
   int64_t chunk_index = 0;
 
   /// \brief Index of the value in the chunk
   ///
-  /// The value is undefined if chunk_index >= chunks.size()
+  /// The value is undefined if `chunk_index >= chunks.size()`.
   int64_t index_in_chunk = 0;
 };
 
-/// \class ChunkResolver
 /// \brief An utility that incrementally resolves logical indices into
 /// physical indices in a chunked array.
-struct ARROW_EXPORT ChunkResolver {
+class ARROW_EXPORT ChunkResolver {
  private:
   /// \brief Array containing `chunks.size() + 1` offsets.
   ///
@@ -57,8 +59,16 @@ struct ARROW_EXPORT ChunkResolver {
   mutable std::atomic<int64_t> cached_chunk_;
 
  public:
+  /// \brief Initialize from an `ArrayVector`.
   explicit ChunkResolver(const ArrayVector& chunks);
+
+  /// \brief Initialize from a vector of raw `Array` pointers.
   explicit ChunkResolver(const std::vector<const Array*>& chunks);
+
+  /// \brief Initialize from a `RecordBatchVector`.
+  ///
+  /// Because all `Array`s in a `RecordBatch` must have the same length, this
+  /// can be useful for iterating over multiple columns simultaneously.
   explicit ChunkResolver(const RecordBatchVector& batches);
 
   ChunkResolver(ChunkResolver&& other) noexcept
@@ -77,10 +87,10 @@ struct ARROW_EXPORT ChunkResolver {
   /// equivalent to the logical index.
   ///
   /// \pre `index >= 0`
-  /// \post location.chunk_index in `[0, chunks.size()]`
+  /// \post `location.chunk_index` in `[0, chunks.size()]`
   /// \param index The logical index to resolve
   /// \return ChunkLocation with a valid chunk_index if index is within
-  ///         bounds, or with chunk_index == chunks.size() if logical index is
+  ///         bounds, or with `chunk_index == chunks.size()` if logical index is
   ///         `>= chunked_array.length()`.
   inline ChunkLocation Resolve(int64_t index) const {
     const auto cached_chunk = cached_chunk_.load(std::memory_order_relaxed);
@@ -94,13 +104,13 @@ struct ARROW_EXPORT ChunkResolver {
   /// The returned ChunkLocation contains the chunk index and the within-chunk index
   /// equivalent to the logical index.
   ///
-  /// \pre index >= 0
-  /// \post location.chunk_index in [0, chunks.size()]
+  /// \pre `index >= 0`
+  /// \post `location.chunk_index` in `[0, chunks.size()]`
   /// \param index The logical index to resolve
   /// \param hint The last ChunkLocation or a default-intitialized ChunkLocation
   /// returned by this ChunkResolver.
   /// \return ChunkLocation with a valid chunk_index if index is within
-  ///         bounds, or with chunk_index == chunks.size() if logical index is
+  ///         bounds, or with `chunk_index == chunks.size()` if logical index is
   ///         `>= chunked_array.length()`.
   inline ChunkLocation ResolveWithHint(int64_t index, ChunkLocation hint) const {
     assert(hint.chunk_index < static_cast<int64_t>(offsets_.size()));

--- a/cpp/src/arrow/chunked_array.h
+++ b/cpp/src/arrow/chunked_array.h
@@ -191,7 +191,7 @@ class ARROW_EXPORT ChunkedArray {
  private:
   template <typename T, typename V>
   friend class ::arrow::stl::ChunkedArrayIterator;
-  internal::ChunkResolver chunk_resolver_;
+  ChunkResolver chunk_resolver_;
   ARROW_DISALLOW_COPY_AND_ASSIGN(ChunkedArray);
 };
 

--- a/cpp/src/arrow/compute/kernels/chunked_internal.h
+++ b/cpp/src/arrow/compute/kernels/chunked_internal.h
@@ -61,16 +61,16 @@ struct ResolvedChunk<Array> {
   bool IsNull() const { return array->IsNull(index); }
 };
 
-struct ChunkedArrayResolver : protected ::arrow::internal::ChunkResolver {
+struct ChunkedArrayResolver : protected ::arrow::ChunkResolver {
   ChunkedArrayResolver(const ChunkedArrayResolver& other)
-      : ::arrow::internal::ChunkResolver(other.chunks_), chunks_(other.chunks_) {}
+      : ::arrow::ChunkResolver(other.chunks_), chunks_(other.chunks_) {}
 
   explicit ChunkedArrayResolver(const std::vector<const Array*>& chunks)
-      : ::arrow::internal::ChunkResolver(chunks), chunks_(chunks) {}
+      : ::arrow::ChunkResolver(chunks), chunks_(chunks) {}
 
   template <typename ArrayType>
   ResolvedChunk<ArrayType> Resolve(int64_t index) const {
-    const auto loc = ::arrow::internal::ChunkResolver::Resolve(index);
+    const auto loc = ::arrow::ChunkResolver::Resolve(index);
     return {checked_cast<const ArrayType*>(chunks_[loc.chunk_index]), loc.index_in_chunk};
   }
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -24,7 +24,6 @@
 namespace arrow {
 
 using internal::checked_cast;
-using internal::ChunkLocation;
 
 namespace compute {
 namespace internal {
@@ -754,10 +753,8 @@ class TableSorter {
     std::merge(nulls_begin, nulls_middle, nulls_middle, nulls_end, temp_indices,
                [&](uint64_t left, uint64_t right) {
                  // First column is either null or nan
-                 left_loc =
-                     left_resolver_.ResolveWithChunkIndexHint(left, left_loc.chunk_index);
-                 right_loc = right_resolver_.ResolveWithChunkIndexHint(
-                     right, right_loc.chunk_index);
+                 left_loc = left_resolver_.ResolveWithHint(left, left_loc);
+                 right_loc = right_resolver_.ResolveWithHint(right, right_loc);
                  auto chunk_left = first_sort_key.GetChunk<ArrayType>(left_loc);
                  auto chunk_right = first_sort_key.GetChunk<ArrayType>(right_loc);
                  const auto left_is_null = chunk_left.IsNull();
@@ -793,10 +790,8 @@ class TableSorter {
     std::merge(nulls_begin, nulls_middle, nulls_middle, nulls_end, temp_indices,
                [&](uint64_t left, uint64_t right) {
                  // First column is always null
-                 left_loc =
-                     left_resolver_.ResolveWithChunkIndexHint(left, left_loc.chunk_index);
-                 right_loc = right_resolver_.ResolveWithChunkIndexHint(
-                     right, right_loc.chunk_index);
+                 left_loc = left_resolver_.ResolveWithHint(left, left_loc);
+                 right_loc = right_resolver_.ResolveWithHint(right, right_loc);
                  return comparator.Compare(left_loc, right_loc, 1);
                });
     // Copy back temp area into main buffer
@@ -821,10 +816,8 @@ class TableSorter {
     std::merge(range_begin, range_middle, range_middle, range_end, temp_indices,
                [&](uint64_t left, uint64_t right) {
                  // Both values are never null nor NaN.
-                 left_loc =
-                     left_resolver_.ResolveWithChunkIndexHint(left, left_loc.chunk_index);
-                 right_loc = right_resolver_.ResolveWithChunkIndexHint(
-                     right, right_loc.chunk_index);
+                 left_loc = left_resolver_.ResolveWithHint(left, left_loc);
+                 right_loc = right_resolver_.ResolveWithHint(right, right_loc);
                  auto chunk_left = first_sort_key.GetChunk<ArrayType>(left_loc);
                  auto chunk_right = first_sort_key.GetChunk<ArrayType>(right_loc);
                  DCHECK(!chunk_left.IsNull());
@@ -862,7 +855,7 @@ class TableSorter {
   const RecordBatchVector batches_;
   const SortOptions& options_;
   const NullPlacement null_placement_;
-  const ::arrow::internal::ChunkResolver left_resolver_, right_resolver_;
+  const ::arrow::ChunkResolver left_resolver_, right_resolver_;
   const std::vector<ResolvedSortKey> sort_keys_;
   uint64_t* indices_begin_;
   uint64_t* indices_end_;

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -752,10 +752,10 @@ struct ResolvedTableSortKey {
         order(order),
         null_count(null_count) {}
 
-  using LocationType = ::arrow::internal::ChunkLocation;
+  using LocationType = ::arrow::ChunkLocation;
 
   template <typename ArrayType>
-  ResolvedChunk<ArrayType> GetChunk(::arrow::internal::ChunkLocation loc) const {
+  ResolvedChunk<ArrayType> GetChunk(::arrow::ChunkLocation loc) const {
     return {checked_cast<const ArrayType*>(chunks[loc.chunk_index]), loc.index_in_chunk};
   }
 

--- a/cpp/src/arrow/stl_iterator.h
+++ b/cpp/src/arrow/stl_iterator.h
@@ -237,7 +237,7 @@ class ChunkedArrayIterator {
   }
 
  private:
-  arrow::internal::ChunkLocation GetChunkLocation(int64_t index) const {
+  arrow::ChunkLocation GetChunkLocation(int64_t index) const {
     assert(chunked_array_);
     return chunked_array_->chunk_resolver_.Resolve(index);
   }

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -317,6 +317,9 @@ namespace compute {
 class CastOptions;
 }
 
+/// \defgroup promote-table-to-schema Schema Promotion
+/// @{
+
 /// \brief Promotes a table to conform to the given schema.
 ///
 /// If a field in the schema does not have a corresponding column in
@@ -363,5 +366,7 @@ ARROW_EXPORT
 Result<std::shared_ptr<Table>> PromoteTableToSchema(
     const std::shared_ptr<Table>& table, const std::shared_ptr<Schema>& schema,
     const compute::CastOptions& options, MemoryPool* pool = default_memory_pool());
+
+/// @}
 
 }  // namespace arrow

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -73,8 +73,11 @@ struct ArraySpan;
 class ArrayBuilder;
 struct Scalar;
 
+/// \typedef ArrayDataVector
 using ArrayDataVector = std::vector<std::shared_ptr<ArrayData>>;
+/// \typedef ArrayVector
 using ArrayVector = std::vector<std::shared_ptr<Array>>;
+/// \typedef ScalarVector
 using ScalarVector = std::vector<std::shared_ptr<Scalar>>;
 
 class ChunkedArray;
@@ -85,8 +88,11 @@ class Table;
 struct Datum;
 struct TypeHolder;
 
+/// \typedef ChunkedArrayVector
 using ChunkedArrayVector = std::vector<std::shared_ptr<ChunkedArray>>;
+/// \typedef RecordBatchVector
 using RecordBatchVector = std::vector<std::shared_ptr<RecordBatch>>;
+/// \typedef RecordBatchIterator
 using RecordBatchIterator = Iterator<std::shared_ptr<RecordBatch>>;
 
 class DictionaryType;

--- a/docs/source/cpp/api/array.rst
+++ b/docs/source/cpp/api/array.rst
@@ -71,7 +71,6 @@ Extension arrays
 .. doxygenclass:: arrow::ExtensionArray
    :members:
 
-
 Chunked Arrays
 ==============
 
@@ -79,6 +78,9 @@ Chunked Arrays
    :project: arrow_cpp
    :members:
 
+.. doxygenclass:: arrow::ChunkResolver
+   :project: arrow_cpp
+   :members:
 
 Utilities
 =========

--- a/docs/source/cpp/api/array.rst
+++ b/docs/source/cpp/api/array.rst
@@ -89,3 +89,15 @@ Utilities
    :project: arrow_cpp
    :members:
    :undoc-members:
+
+Aliases
+=======
+
+.. doxygentypedef:: arrow::ArrayDataVector
+   :project: arrow_cpp
+
+.. doxygentypedef:: arrow::ArrayVector
+   :project: arrow_cpp
+
+.. doxygentypedef:: arrow::ChunkedArrayVector
+   :project: arrow_cpp

--- a/docs/source/cpp/api/array.rst
+++ b/docs/source/cpp/api/array.rst
@@ -19,6 +19,9 @@
 Arrays
 ======
 
+Base classes
+============
+
 .. doxygenclass:: arrow::ArrayData
    :project: arrow_cpp
    :members:
@@ -75,6 +78,10 @@ Chunked Arrays
 ==============
 
 .. doxygenclass:: arrow::ChunkedArray
+   :project: arrow_cpp
+   :members:
+
+.. doxygenstruct:: arrow::ChunkLocation
    :project: arrow_cpp
    :members:
 

--- a/docs/source/cpp/api/table.rst
+++ b/docs/source/cpp/api/table.rst
@@ -44,5 +44,6 @@ Tables
 .. doxygenfunction:: arrow::ConcatenateTables
    :project: arrow_cpp
 
-.. doxygenfunction:: arrow::PromoteTableToSchema
+.. doxygengroup:: promote-table-to-schema
    :project: arrow_cpp
+   :content-only:

--- a/docs/source/cpp/api/table.rst
+++ b/docs/source/cpp/api/table.rst
@@ -47,3 +47,12 @@ Tables
 .. doxygengroup:: promote-table-to-schema
    :project: arrow_cpp
    :content-only:
+
+Aliases
+=======
+
+.. doxygentypedef:: arrow::RecordBatchVector
+   :project: arrow_cpp
+
+.. doxygentypedef:: arrow::RecordBatchIterator
+   :project: arrow_cpp

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -87,13 +87,13 @@ class ArrowAltrepData {
 
   const std::shared_ptr<ChunkedArray>& chunked_array() { return chunked_array_; }
 
-  arrow::internal::ChunkLocation locate(int64_t index) {
+  arrow::ChunkLocation locate(int64_t index) {
     return resolver_.Resolve(index);
   }
 
  private:
   std::shared_ptr<ChunkedArray> chunked_array_;
-  arrow::internal::ChunkResolver resolver_;
+  arrow::ChunkResolver resolver_;
 };
 
 // the ChunkedArray that is being wrapped by the altrep object


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

See https://github.com/apache/arrow/issues/34535.

### What changes are included in this PR?

- [ ] Check unit test coverage and expand as necessary to handle edge cases
- [x] Move `ChunkResolver` out of the `internal` namespace
  - [x] Refactor current usages of the class in Arrow C++ as necessary
- [ ] Update the documentation
  - [x] Update the API/reference docs as necessary
  - [ ] Add a section, perhaps in the User Guide or Examples, on how to use this class

As [requested by @felipecrv](https://github.com/apache/arrow/issues/34535#issuecomment-1927733262), this PR also contains a minor simplification to `ChunkResolver`'s existing interface.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Opening PR in draft state, unit tests still need to be implemented.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes, users will now be able to use the `ChunkResolver` from the public `::arrow` namespace. There are no breaking changes.

Opening PR in draft state, some documentation may still need to be added.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #34535