### PR TITLE
GH-40227: [R] ensure executable files in `create_package_with_all_dependencies`

### DIFF
--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -251,7 +251,7 @@ create_package_with_all_dependencies <- function(dest_file = NULL, source_file =
   setwd(untar_dir)
 
   message("Repacking tar.gz file to ", dest_file)
-  tar_successful <- utils::tar(dest_file, compression = "gz") == 0
+  tar_successful <- utils::tar(dest_file, compression = "gz", extra_flags = NULL) == 0
   if (!tar_successful) {
     stop("Failed to create new tar.gz file")
   }


### PR DESCRIPTION
### What changes are included in this PR?

-  Set the `utils::tar` `extra_flags` argument to `NULL` (default `""`). This benefits from logic baked in (also used by `R CMD BUILD`) that checks the mode of `configure` and `cleanup` files and sets them to be executable if they are not already.

### Are these changes tested?

No. I didn't see any existing tests for this function (which perhaps is not a valid reason). 

### Are there any user-facing changes?

No. Although if `configure` and/or `cleanup` are not executable, that will be corrected with a user-facing `warning`.

* GitHub Issue: #40227

edit: revised the description based on the new approach in 40e8add.