### PR TITLE
GH-40069: [C++] Make scalar scratch space immutable after initialization

### DIFF
--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -1063,7 +1063,8 @@ garrow_base_binary_scalar_get_value(GArrowBaseBinaryScalar *scalar)
   if (!priv->value) {
     const auto arrow_scalar = std::static_pointer_cast<arrow::BaseBinaryScalar>(
       garrow_scalar_get_raw(GARROW_SCALAR(scalar)));
-    priv->value = garrow_buffer_new_raw(&(arrow_scalar->value));
+    priv->value = garrow_buffer_new_raw(
+      const_cast<std::shared_ptr<arrow::Buffer> *>(&(arrow_scalar->value)));
   }
   return priv->value;
 }

--- a/c_glib/arrow-glib/scalar.cpp
+++ b/c_glib/arrow-glib/scalar.cpp
@@ -1984,7 +1984,8 @@ garrow_base_list_scalar_get_value(GArrowBaseListScalar *scalar)
   if (!priv->value) {
     const auto arrow_scalar = std::static_pointer_cast<arrow::BaseListScalar>(
       garrow_scalar_get_raw(GARROW_SCALAR(scalar)));
-    priv->value = garrow_array_new_raw(&(arrow_scalar->value));
+    priv->value = garrow_array_new_raw(
+      const_cast<std::shared_ptr<arrow::Array> *>(&(arrow_scalar->value)));
   }
   return priv->value;
 }

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <future>
 #include <limits>
 #include <memory>
 #include <numeric>
@@ -819,6 +820,39 @@ TEST_F(TestArray, TestFillFromScalar) {
       AssertArraysEqual(*array, *roundtripped_array);
       ASSERT_OK_AND_ASSIGN(auto roundtripped_scalar, roundtripped_array->GetScalar(0));
       AssertScalarsEqual(*scalar, *roundtripped_scalar);
+    }
+  }
+}
+
+TEST_F(TestArray, TestConcurrentFillFromScalar) {
+  for (auto type : TestArrayUtilitiesAgainstTheseTypes()) {
+    ARROW_SCOPED_TRACE("type = ", type->ToString());
+    for (auto seed : {0u, 0xdeadbeef, 42u}) {
+      ARROW_SCOPED_TRACE("seed = ", seed);
+
+      Field field("", type, /*nullable=*/true,
+                  key_value_metadata({{"extension_allow_random_storage", "true"}}));
+      auto array = random::GenerateArray(field, 1, seed);
+
+      ASSERT_OK_AND_ASSIGN(auto scalar, array->GetScalar(0));
+
+      // Lambda to create fill an ArraySpan with the scalar and use the ArraySpan a bit.
+      auto array_span_from_scalar = [&]() {
+        ArraySpan span(*scalar);
+        auto roundtripped_array = span.ToArray();
+        ASSERT_OK(roundtripped_array->ValidateFull());
+
+        AssertArraysEqual(*array, *roundtripped_array);
+        ASSERT_OK_AND_ASSIGN(auto roundtripped_scalar, roundtripped_array->GetScalar(0));
+        AssertScalarsEqual(*scalar, *roundtripped_scalar);
+      };
+
+      // Two concurrent calls to the lambda are just enough for TSAN to detect a race
+      // condition.
+      auto fut1 = std::async(std::launch::async, array_span_from_scalar);
+      auto fut2 = std::async(std::launch::async, array_span_from_scalar);
+      fut1.get();
+      fut2.get();
     }
   }
 }

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -824,6 +824,8 @@ TEST_F(TestArray, TestFillFromScalar) {
   }
 }
 
+// GH-40069: Data-race when concurrent calling ArraySpan::FillFromScalar of the same
+// scalar instance.
 TEST_F(TestArray, TestConcurrentFillFromScalar) {
   for (auto type : TestArrayUtilitiesAgainstTheseTypes()) {
     ARROW_SCOPED_TRACE("type = ", type->ToString());

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -285,10 +285,10 @@ namespace {
 
 template <typename offset_type>
 BufferSpan OffsetsForScalar(uint8_t* scratch_space, offset_type value_size) {
-  auto* offsets = reinterpret_cast<offset_type*>(scratch_space);
-  offsets[0] = 0;
-  offsets[1] = static_cast<offset_type>(value_size);
-  static_assert(2 * sizeof(offset_type) <= 16);
+  // auto* offsets = reinterpret_cast<offset_type*>(scratch_space);
+  // offsets[0] = 0;
+  // offsets[1] = static_cast<offset_type>(value_size);
+  // static_assert(2 * sizeof(offset_type) <= 16);
   return {scratch_space, sizeof(offset_type) * 2};
 }
 
@@ -297,9 +297,9 @@ std::pair<BufferSpan, BufferSpan> OffsetsAndSizesForScalar(uint8_t* scratch_spac
                                                            offset_type value_size) {
   auto* offsets = scratch_space;
   auto* sizes = scratch_space + sizeof(offset_type);
-  reinterpret_cast<offset_type*>(offsets)[0] = 0;
-  reinterpret_cast<offset_type*>(sizes)[0] = value_size;
-  static_assert(2 * sizeof(offset_type) <= 16);
+  // reinterpret_cast<offset_type*>(offsets)[0] = 0;
+  // reinterpret_cast<offset_type*>(sizes)[0] = value_size;
+  // static_assert(2 * sizeof(offset_type) <= 16);
   return {BufferSpan{offsets, sizeof(offset_type)},
           BufferSpan{sizes, sizeof(offset_type)}};
 }
@@ -428,14 +428,14 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
 
     this->buffers[1].size = BinaryViewType::kSize;
     this->buffers[1].data = scalar.scratch_space_;
-    static_assert(sizeof(BinaryViewType::c_type) <= sizeof(scalar.scratch_space_));
-    auto* view = new (&scalar.scratch_space_) BinaryViewType::c_type;
-    if (scalar.is_valid) {
-      *view = util::ToBinaryView(std::string_view{*scalar.value}, 0, 0);
-      this->buffers[2] = internal::PackVariadicBuffers({&scalar.value, 1});
-    } else {
-      *view = {};
-    }
+    // static_assert(sizeof(BinaryViewType::c_type) <= sizeof(scalar.scratch_space_));
+    // auto* view = new (&scalar.scratch_space_) BinaryViewType::c_type;
+    // if (scalar.is_valid) {
+    //   *view = util::ToBinaryView(std::string_view{*scalar.value}, 0, 0);
+    //   this->buffers[2] = internal::PackVariadicBuffers({&scalar.value, 1});
+    // } else {
+    //   *view = {};
+    // }
   } else if (type_id == Type::FIXED_SIZE_BINARY) {
     const auto& scalar = checked_cast<const BaseBinaryScalar&>(value);
     this->buffers[1].data = const_cast<uint8_t*>(scalar.value->data());
@@ -492,7 +492,7 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
     // First buffer is kept null since unions have no validity vector
     this->buffers[0] = {};
 
-    union_scratch_space->type_code = checked_cast<const UnionScalar&>(value).type_code;
+    // union_scratch_space->type_code = checked_cast<const UnionScalar&>(value).type_code;
     this->buffers[1].data = reinterpret_cast<uint8_t*>(&union_scratch_space->type_code);
     this->buffers[1].size = 1;
 
@@ -541,7 +541,7 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
       e.null_count = 0;
       e.buffers[1].data = scalar.scratch_space_;
       e.buffers[1].size = sizeof(run_end);
-      reinterpret_cast<decltype(run_end)*>(scalar.scratch_space_)[0] = run_end;
+      // reinterpret_cast<decltype(run_end)*>(scalar.scratch_space_)[0] = run_end;
     };
 
     switch (scalar.run_end_type()->id()) {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -491,11 +491,11 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
       this->child_data[i].FillFromScalar(*scalar.value[i]);
     }
   } else if (is_union(type_id)) {
-    // Dense union needs scratch space to store both offsets and a type code
-    struct UnionScratchSpace {
-      alignas(int64_t) int8_t type_code;
-      alignas(int64_t) uint8_t offsets[sizeof(int32_t) * 2];
-    };
+    // // Dense union needs scratch space to store both offsets and a type code
+    // struct UnionScratchSpace {
+    //   alignas(int64_t) int8_t type_code;
+    //   alignas(int64_t) uint8_t offsets[sizeof(int32_t) * 2];
+    // };
     // static_assert(sizeof(UnionScratchSpace) <= sizeof(UnionScalar::scratch_space_));
 
     // First buffer is kept null since unions have no validity vector
@@ -505,7 +505,7 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
     if (type_id == Type::DENSE_UNION) {
       const auto& scalar = checked_cast<const DenseUnionScalar&>(value);
       auto* union_scratch_space =
-          reinterpret_cast<UnionScratchSpace*>(&scalar.scratch_space_);
+          reinterpret_cast<UnionScalar::UnionScratchSpace*>(&scalar.scratch_space_);
 
       // union_scratch_space->type_code = checked_cast<const
       // UnionScalar&>(value).type_code;
@@ -531,7 +531,7 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
     } else {
       const auto& scalar = checked_cast<const SparseUnionScalar&>(value);
       auto* union_scratch_space =
-          reinterpret_cast<UnionScratchSpace*>(&scalar.scratch_space_);
+          reinterpret_cast<UnionScalar::UnionScratchSpace*>(&scalar.scratch_space_);
 
       // union_scratch_space->type_code = checked_cast<const
       // UnionScalar&>(value).type_code;

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -430,12 +430,12 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
     this->buffers[1].data = scalar.scratch_space_;
     // static_assert(sizeof(BinaryViewType::c_type) <= sizeof(scalar.scratch_space_));
     // auto* view = new (&scalar.scratch_space_) BinaryViewType::c_type;
-    // if (scalar.is_valid) {
-    //   *view = util::ToBinaryView(std::string_view{*scalar.value}, 0, 0);
-    //   this->buffers[2] = internal::PackVariadicBuffers({&scalar.value, 1});
-    // } else {
-    //   *view = {};
-    // }
+    if (scalar.is_valid) {
+      //   *view = util::ToBinaryView(std::string_view{*scalar.value}, 0, 0);
+      this->buffers[2] = internal::PackVariadicBuffers({&scalar.value, 1});
+    } else {
+      //   *view = {};
+    }
   } else if (type_id == Type::FIXED_SIZE_BINARY) {
     const auto& scalar = checked_cast<const BaseBinaryScalar&>(value);
     this->buffers[1].data = const_cast<uint8_t*>(scalar.value->data());

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -283,25 +283,15 @@ void ArraySpan::SetMembers(const ArrayData& data) {
 
 namespace {
 
-template <typename offset_type>
-BufferSpan OffsetsForScalar(uint8_t* scratch_space, offset_type value_size) {
-  // auto* offsets = reinterpret_cast<offset_type*>(scratch_space);
-  // offsets[0] = 0;
-  // offsets[1] = static_cast<offset_type>(value_size);
-  // static_assert(2 * sizeof(offset_type) <= 16);
-  return {scratch_space, sizeof(offset_type) * 2};
+BufferSpan OffsetsForScalar(uint8_t* scratch_space, int64_t offset_width) {
+  return {scratch_space, offset_width};
 }
 
-template <typename offset_type>
 std::pair<BufferSpan, BufferSpan> OffsetsAndSizesForScalar(uint8_t* scratch_space,
-                                                           offset_type value_size) {
+                                                           int64_t offset_width) {
   auto* offsets = scratch_space;
-  auto* sizes = scratch_space + sizeof(offset_type);
-  // reinterpret_cast<offset_type*>(offsets)[0] = 0;
-  // reinterpret_cast<offset_type*>(sizes)[0] = value_size;
-  // static_assert(2 * sizeof(offset_type) <= 16);
-  return {BufferSpan{offsets, sizeof(offset_type)},
-          BufferSpan{sizes, sizeof(offset_type)}};
+  auto* sizes = scratch_space + offset_width;
+  return {BufferSpan{offsets, offset_width}, BufferSpan{sizes, offset_width}};
 }
 
 int GetNumBuffers(const DataType& type) {
@@ -416,12 +406,12 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
     }
     if (is_binary_like(type_id)) {
       const auto& binary_scalar = checked_cast<const BinaryScalar&>(value);
-      this->buffers[1] =
-          OffsetsForScalar(binary_scalar.scratch_space_, static_cast<int32_t>(data_size));
+      this->buffers[1] = OffsetsForScalar(binary_scalar.scratch_space_, sizeof(int32_t));
     } else {
       // is_large_binary_like
       const auto& large_binary_scalar = checked_cast<const LargeBinaryScalar&>(value);
-      this->buffers[1] = OffsetsForScalar(large_binary_scalar.scratch_space_, data_size);
+      this->buffers[1] =
+          OffsetsForScalar(large_binary_scalar.scratch_space_, sizeof(int64_t));
     }
     this->buffers[2].data = const_cast<uint8_t*>(data_buffer);
     this->buffers[2].size = data_size;
@@ -430,13 +420,8 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
 
     this->buffers[1].size = BinaryViewType::kSize;
     this->buffers[1].data = scalar.scratch_space_;
-    // static_assert(sizeof(BinaryViewType::c_type) <= sizeof(scalar.scratch_space_));
-    // auto* view = new (&scalar.scratch_space_) BinaryViewType::c_type;
     if (scalar.is_valid) {
-      //   *view = util::ToBinaryView(std::string_view{*scalar.value}, 0, 0);
       this->buffers[2] = internal::PackVariadicBuffers({&scalar.value, 1});
-    } else {
-      //   *view = {};
     }
   } else if (type_id == Type::FIXED_SIZE_BINARY) {
     const auto& scalar = checked_cast<const BaseBinaryScalar&>(value);
@@ -445,12 +430,10 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
   } else if (is_var_length_list_like(type_id) || type_id == Type::FIXED_SIZE_LIST) {
     const auto& scalar = checked_cast<const BaseListScalar&>(value);
 
-    int64_t value_length = 0;
     this->child_data.resize(1);
     if (scalar.value != nullptr) {
       // When the scalar is null, scalar.value can also be null
       this->child_data[0].SetMembers(*scalar.value->data());
-      value_length = scalar.value->length();
     } else {
       // Even when the value is null, we still must populate the
       // child_data to yield a valid array. Tedious
@@ -460,24 +443,23 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
 
     if (type_id == Type::LIST) {
       const auto& list_scalar = checked_cast<const ListScalar&>(value);
-      this->buffers[1] = OffsetsForScalar(list_scalar.scratch_space_,
-                                          static_cast<int32_t>(value_length));
+      this->buffers[1] = OffsetsForScalar(list_scalar.scratch_space_, sizeof(int32_t));
     } else if (type_id == Type::MAP) {
       const auto& map_scalar = checked_cast<const MapScalar&>(value);
-      this->buffers[1] =
-          OffsetsForScalar(map_scalar.scratch_space_, static_cast<int32_t>(value_length));
+      this->buffers[1] = OffsetsForScalar(map_scalar.scratch_space_, sizeof(int32_t));
     } else if (type_id == Type::LARGE_LIST) {
       const auto& large_list_scalar = checked_cast<const LargeListScalar&>(value);
-      this->buffers[1] = OffsetsForScalar(large_list_scalar.scratch_space_, value_length);
+      this->buffers[1] =
+          OffsetsForScalar(large_list_scalar.scratch_space_, sizeof(int64_t));
     } else if (type_id == Type::LIST_VIEW) {
       const auto& list_view_scalar = checked_cast<const ListViewScalar&>(value);
-      std::tie(this->buffers[1], this->buffers[2]) = OffsetsAndSizesForScalar(
-          list_view_scalar.scratch_space_, static_cast<int32_t>(value_length));
+      std::tie(this->buffers[1], this->buffers[2]) =
+          OffsetsAndSizesForScalar(list_view_scalar.scratch_space_, sizeof(int32_t));
     } else if (type_id == Type::LARGE_LIST_VIEW) {
       const auto& large_list_view_scalar =
           checked_cast<const LargeListViewScalar&>(value);
-      std::tie(this->buffers[1], this->buffers[2]) =
-          OffsetsAndSizesForScalar(large_list_view_scalar.scratch_space_, value_length);
+      std::tie(this->buffers[1], this->buffers[2]) = OffsetsAndSizesForScalar(
+          large_list_view_scalar.scratch_space_, sizeof(int64_t));
     } else {
       DCHECK_EQ(type_id, Type::FIXED_SIZE_LIST);
       // FIXED_SIZE_LIST: does not have a second buffer
@@ -491,13 +473,6 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
       this->child_data[i].FillFromScalar(*scalar.value[i]);
     }
   } else if (is_union(type_id)) {
-    // // Dense union needs scratch space to store both offsets and a type code
-    // struct UnionScratchSpace {
-    //   alignas(int64_t) int8_t type_code;
-    //   alignas(int64_t) uint8_t offsets[sizeof(int32_t) * 2];
-    // };
-    // static_assert(sizeof(UnionScratchSpace) <= sizeof(UnionScalar::scratch_space_));
-
     // First buffer is kept null since unions have no validity vector
     this->buffers[0] = {};
 
@@ -507,13 +482,10 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
       auto* union_scratch_space =
           reinterpret_cast<UnionScalar::UnionScratchSpace*>(&scalar.scratch_space_);
 
-      // union_scratch_space->type_code = checked_cast<const
-      // UnionScalar&>(value).type_code;
       this->buffers[1].data = reinterpret_cast<uint8_t*>(&union_scratch_space->type_code);
       this->buffers[1].size = 1;
 
-      this->buffers[2] =
-          OffsetsForScalar(union_scratch_space->offsets, static_cast<int32_t>(1));
+      this->buffers[2] = OffsetsForScalar(union_scratch_space->offsets, sizeof(int32_t));
       // We can't "see" the other arrays in the union, but we put the "active"
       // union array in the right place and fill zero-length arrays for the
       // others
@@ -533,8 +505,6 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
       auto* union_scratch_space =
           reinterpret_cast<UnionScalar::UnionScratchSpace*>(&scalar.scratch_space_);
 
-      // union_scratch_space->type_code = checked_cast<const
-      // UnionScalar&>(value).type_code;
       this->buffers[1].data = reinterpret_cast<uint8_t*>(&union_scratch_space->type_code);
       this->buffers[1].size = 1;
 
@@ -562,7 +532,6 @@ void ArraySpan::FillFromScalar(const Scalar& value) {
       e.null_count = 0;
       e.buffers[1].data = scalar.scratch_space_;
       e.buffers[1].size = sizeof(run_end);
-      // reinterpret_cast<decltype(run_end)*>(scalar.scratch_space_)[0] = run_end;
     };
 
     switch (scalar.run_end_type()->id()) {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -284,7 +284,7 @@ void ArraySpan::SetMembers(const ArrayData& data) {
 namespace {
 
 BufferSpan OffsetsForScalar(uint8_t* scratch_space, int64_t offset_width) {
-  return {scratch_space, offset_width};
+  return {scratch_space, offset_width * 2};
 }
 
 std::pair<BufferSpan, BufferSpan> OffsetsAndSizesForScalar(uint8_t* scratch_space,

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -369,42 +369,42 @@ struct UnboxScalar<Decimal256Type> {
   }
 };
 
-template <typename Type, typename Enable = void>
-struct BoxScalar;
+// template <typename Type, typename Enable = void>
+// struct BoxScalar;
 
-template <typename Type>
-struct BoxScalar<Type, enable_if_has_c_type<Type>> {
-  using T = typename GetOutputType<Type>::T;
-  static void Box(T val, Scalar* out) {
-    // Enables BoxScalar<Int64Type> to work on a (for example) Time64Scalar
-    T* mutable_data = reinterpret_cast<T*>(
-        checked_cast<::arrow::internal::PrimitiveScalarBase*>(out)->mutable_data());
-    *mutable_data = val;
-  }
-};
+// template <typename Type>
+// struct BoxScalar<Type, enable_if_has_c_type<Type>> {
+//   using T = typename GetOutputType<Type>::T;
+//   static void Box(T val, Scalar* out) {
+//     // Enables BoxScalar<Int64Type> to work on a (for example) Time64Scalar
+//     T* mutable_data = reinterpret_cast<T*>(
+//         checked_cast<::arrow::internal::PrimitiveScalarBase*>(out)->mutable_data());
+//     *mutable_data = val;
+//   }
+// };
 
-template <typename Type>
-struct BoxScalar<Type, enable_if_base_binary<Type>> {
-  using T = typename GetOutputType<Type>::T;
-  using ScalarType = typename TypeTraits<Type>::ScalarType;
-  static void Box(T val, Scalar* out) {
-    checked_cast<ScalarType*>(out)->value = std::make_shared<Buffer>(val);
-  }
-};
+// template <typename Type>
+// struct BoxScalar<Type, enable_if_base_binary<Type>> {
+//   using T = typename GetOutputType<Type>::T;
+//   using ScalarType = typename TypeTraits<Type>::ScalarType;
+//   static void Box(T val, Scalar* out) {
+//     checked_cast<ScalarType*>(out)->value = std::make_shared<Buffer>(val);
+//   }
+// };
 
-template <>
-struct BoxScalar<Decimal128Type> {
-  using T = Decimal128;
-  using ScalarType = Decimal128Scalar;
-  static void Box(T val, Scalar* out) { checked_cast<ScalarType*>(out)->value = val; }
-};
+// template <>
+// struct BoxScalar<Decimal128Type> {
+//   using T = Decimal128;
+//   using ScalarType = Decimal128Scalar;
+//   static void Box(T val, Scalar* out) { checked_cast<ScalarType*>(out)->value = val; }
+// };
 
-template <>
-struct BoxScalar<Decimal256Type> {
-  using T = Decimal256;
-  using ScalarType = Decimal256Scalar;
-  static void Box(T val, Scalar* out) { checked_cast<ScalarType*>(out)->value = val; }
-};
+// template <>
+// struct BoxScalar<Decimal256Type> {
+//   using T = Decimal256;
+//   using ScalarType = Decimal256Scalar;
+//   static void Box(T val, Scalar* out) { checked_cast<ScalarType*>(out)->value = val; }
+// };
 
 // A VisitArraySpanInline variant that calls its visitor function with logical
 // values, such as Decimal128 rather than std::string_view.

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -369,43 +369,6 @@ struct UnboxScalar<Decimal256Type> {
   }
 };
 
-// template <typename Type, typename Enable = void>
-// struct BoxScalar;
-
-// template <typename Type>
-// struct BoxScalar<Type, enable_if_has_c_type<Type>> {
-//   using T = typename GetOutputType<Type>::T;
-//   static void Box(T val, Scalar* out) {
-//     // Enables BoxScalar<Int64Type> to work on a (for example) Time64Scalar
-//     T* mutable_data = reinterpret_cast<T*>(
-//         checked_cast<::arrow::internal::PrimitiveScalarBase*>(out)->mutable_data());
-//     *mutable_data = val;
-//   }
-// };
-
-// template <typename Type>
-// struct BoxScalar<Type, enable_if_base_binary<Type>> {
-//   using T = typename GetOutputType<Type>::T;
-//   using ScalarType = typename TypeTraits<Type>::ScalarType;
-//   static void Box(T val, Scalar* out) {
-//     checked_cast<ScalarType*>(out)->value = std::make_shared<Buffer>(val);
-//   }
-// };
-
-// template <>
-// struct BoxScalar<Decimal128Type> {
-//   using T = Decimal128;
-//   using ScalarType = Decimal128Scalar;
-//   static void Box(T val, Scalar* out) { checked_cast<ScalarType*>(out)->value = val; }
-// };
-
-// template <>
-// struct BoxScalar<Decimal256Type> {
-//   using T = Decimal256;
-//   using ScalarType = Decimal256Scalar;
-//   static void Box(T val, Scalar* out) { checked_cast<ScalarType*>(out)->value = val; }
-// };
-
 // A VisitArraySpanInline variant that calls its visitor function with logical
 // values, such as Decimal128 rather than std::string_view.
 

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -538,9 +538,8 @@ struct ScalarMinMax {
 
     bool initialize_output = true;
     if (scalar_count > 0) {
-      ARROW_ASSIGN_OR_RAISE(
-          std::shared_ptr<Scalar> temp_scalar,
-          ExecScalar(batch, options, out->type()->GetSharedPtr()));
+      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> temp_scalar,
+                            ExecScalar(batch, options, out->type()->GetSharedPtr()));
       if (temp_scalar->is_valid) {
         const auto value = UnboxScalar<OutType>::Unbox(*temp_scalar);
         initialize_output = false;

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -540,7 +540,7 @@ struct ScalarMinMax {
     if (scalar_count > 0) {
       ARROW_ASSIGN_OR_RAISE(
           std::shared_ptr<Scalar> temp_scalar,
-          ExecScalar(batch, options, out->type()->GetSharedPtr(), temp_scalar.get()));
+          ExecScalar(batch, options, out->type()->GetSharedPtr()));
       if (temp_scalar->is_valid) {
         const auto value = UnboxScalar<OutType>::Unbox(*temp_scalar);
         initialize_output = false;

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -491,8 +491,9 @@ template <typename OutType, typename Op>
 struct ScalarMinMax {
   using OutValue = typename GetOutputType<OutType>::T;
 
-  static void ExecScalar(const ExecSpan& batch,
-                         const ElementWiseAggregateOptions& options, Scalar* out) {
+  static Result<std::shared_ptr<Scalar>> ExecScalar(
+      const ExecSpan& batch, const ElementWiseAggregateOptions& options,
+      std::shared_ptr<DataType> type) {
     // All arguments are scalar
     OutValue value{};
     bool valid = false;
@@ -502,8 +503,8 @@ struct ScalarMinMax {
       const Scalar& scalar = *arg.scalar;
       if (!scalar.is_valid) {
         if (options.skip_nulls) continue;
-        out->is_valid = false;
-        return;
+        valid = false;
+        break;
       }
       if (!valid) {
         value = UnboxScalar<OutType>::Unbox(scalar);
@@ -513,9 +514,10 @@ struct ScalarMinMax {
             value, UnboxScalar<OutType>::Unbox(scalar));
       }
     }
-    out->is_valid = valid;
     if (valid) {
-      BoxScalar<OutType>::Box(value, out);
+      return MakeScalar(std::move(type), std::move(value));
+    } else {
+      return MakeNullScalar(std::move(type));
     }
   }
 
@@ -536,9 +538,9 @@ struct ScalarMinMax {
 
     bool initialize_output = true;
     if (scalar_count > 0) {
-      ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> temp_scalar,
-                            MakeScalar(out->type()->GetSharedPtr(), 0));
-      ExecScalar(batch, options, temp_scalar.get());
+      ARROW_ASSIGN_OR_RAISE(
+          std::shared_ptr<Scalar> temp_scalar,
+          ExecScalar(batch, options, out->type()->GetSharedPtr(), temp_scalar.get()));
       if (temp_scalar->is_valid) {
         const auto value = UnboxScalar<OutType>::Unbox(*temp_scalar);
         initialize_output = false;

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1313,8 +1313,8 @@ CastImpl(const BaseListScalar& from, std::shared_ptr<DataType> to_type) {
 }
 
 // union types to string
-template <typename ToScalar>
-typename std::enable_if_t<std::is_same<ToScalar, StringScalar>::value,
+template <typename To>
+typename std::enable_if_t<std::is_same<To, StringType>::value,
                           Result<std::shared_ptr<Scalar>>>
 CastImpl(const UnionScalar& from, std::shared_ptr<DataType> to_type) {
   const auto& union_ty = checked_cast<const UnionType&>(*from.type);

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1301,7 +1301,7 @@ Result<std::shared_ptr<Scalar>> CastImpl(const StringScalar& from,
 
 // binary/large binary/large string to string
 template <typename To, typename From>
-enable_if_t<std::is_same<To, StringScalar>::value &&
+enable_if_t<std::is_same<To, StringType>::value &&
                 std::is_base_of_v<BaseBinaryScalar, From> &&
                 !std::is_same<From, StringScalar>::value,
             Result<std::shared_ptr<Scalar>>>

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -625,7 +625,7 @@ void ListScalar::FillScratchSpace() {
 }
 
 LargeListScalar::LargeListScalar(std::shared_ptr<Array> value, bool is_valid)
-    : LargeListScalar(value, large_list(value->type()), is_valid) {}
+    : BaseListScalar(value, large_list(value->type()), is_valid) {}
 
 void LargeListScalar::FillScratchSpace() {
   FillScalarScratchSpace(scratch_space_, int64_t(0),
@@ -633,7 +633,7 @@ void LargeListScalar::FillScratchSpace() {
 }
 
 ListViewScalar::ListViewScalar(std::shared_ptr<Array> value, bool is_valid)
-    : ListViewScalar(value, list_view(value->type()), is_valid) {}
+    : BaseListScalar(value, list_view(value->type()), is_valid) {}
 
 void ListViewScalar::FillScratchSpace() {
   FillScalarScratchSpace(scratch_space_, int32_t(0),
@@ -641,7 +641,7 @@ void ListViewScalar::FillScratchSpace() {
 }
 
 LargeListViewScalar::LargeListViewScalar(std::shared_ptr<Array> value, bool is_valid)
-    : LargeListViewScalar(value, large_list_view(value->type()), is_valid) {}
+    : BaseListScalar(value, large_list_view(value->type()), is_valid) {}
 
 void LargeListViewScalar::FillScratchSpace() {
   FillScalarScratchSpace(scratch_space_, int64_t(0),
@@ -655,7 +655,7 @@ inline std::shared_ptr<DataType> MakeMapType(const std::shared_ptr<DataType>& pa
 }
 
 MapScalar::MapScalar(std::shared_ptr<Array> value, bool is_valid)
-    : MapScalar(value, MakeMapType(value->type()), is_valid) {}
+    : BaseListScalar(value, MakeMapType(value->type()), is_valid) {}
 
 void MapScalar::FillScratchSpace() {
   FillScalarScratchSpace(scratch_space_, int32_t(0),

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -566,6 +566,7 @@ Status Scalar::Validate() const {
 }
 
 Status Scalar::ValidateFull() const {
+  // TODO: Validate scratch space content?
   return ScalarValidateImpl(/*full_validation=*/true).Validate(*this);
 }
 
@@ -573,14 +574,16 @@ BaseBinaryScalar::BaseBinaryScalar(std::string s, std::shared_ptr<DataType> type
     : BaseBinaryScalar(Buffer::FromString(std::move(s)), std::move(type)) {}
 
 void BinaryScalar::FillScratchSpace() {
+  // TODO: Test value being nullptr.
   FillScalarScratchSpace(scratch_space_, int32_t(0),
-                         is_valid ? static_cast<int32_t>(value->size()) : int32_t(0));
+                         value ? static_cast<int32_t>(value->size()) : int32_t(0));
 }
 
 void BinaryViewScalar::FillScratchSpace() {
+  // TODO: Test value being nullptr.
   static_assert(sizeof(BinaryViewType::c_type) <= internal::kScalarScratchSpaceSize);
   auto* view = new (&scratch_space_) BinaryViewType::c_type;
-  if (is_valid) {
+  if (value) {
     *view = util::ToBinaryView(std::string_view{*value}, 0, 0);
   } else {
     *view = {};
@@ -588,8 +591,9 @@ void BinaryViewScalar::FillScratchSpace() {
 }
 
 void LargeBinaryScalar::FillScratchSpace() {
+  // TODO: Test value being nullptr.
   FillScalarScratchSpace(scratch_space_, int64_t(0),
-                         is_valid ? static_cast<int64_t>(value->size()) : int64_t(0));
+                         value ? static_cast<int64_t>(value->size()) : int64_t(0));
 }
 
 FixedSizeBinaryScalar::FixedSizeBinaryScalar(std::shared_ptr<Buffer> value,

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1162,7 +1162,7 @@ enable_if_number<To, Result<std::shared_ptr<Scalar>>> CastImpl(
 template <typename To, typename From>
 enable_if_boolean<To, Result<std::shared_ptr<Scalar>>> CastImpl(
     const NumericScalar<From>& from, std::shared_ptr<DataType> to_type) {
-  constexpr auto zero = static_cast<typename To::c_type>(0);
+  constexpr auto zero = static_cast<typename From::c_type>(0);
   return std::make_shared<BooleanScalar>(from.value != zero, std::move(to_type));
 }
 

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1391,6 +1391,8 @@ struct FromTypeVisitor : CastImplVisitor {
     return CastFromListLike(large_list_view_type);
   }
 
+  Status Visit(const MapType& map_type) { return CastFromListLike(map_type); }
+
   Status Visit(const NullType&) { return NotImplemented(); }
   Status Visit(const DictionaryType&) { return NotImplemented(); }
   Status Visit(const ExtensionType&) { return NotImplemented(); }

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -566,7 +566,6 @@ Status Scalar::Validate() const {
 }
 
 Status Scalar::ValidateFull() const {
-  // TODO: Validate scratch space content?
   return ScalarValidateImpl(/*full_validation=*/true).Validate(*this);
 }
 
@@ -1245,24 +1244,6 @@ CastImpl(const From& from, std::shared_ptr<DataType> to_type) {
   return std::make_shared<StringScalar>(FormatToBuffer(Formatter{from.type.get()}, from),
                                         std::move(to_type));
 }
-
-// template <typename To>
-// typename std::enable_if_t<std::is_same<To, StringType>::value,
-//                           Result<std::shared_ptr<Scalar>>>
-// CastImpl(const Decimal128Scalar& from, std::shared_ptr<DataType> to_type) {
-//   auto from_type = checked_cast<const Decimal128Type*>(from.type.get());
-//   return std::make_shared<StringScalar>(
-//       Buffer::FromString(from.value.ToString(from_type->scale())), std::move(to_type));
-// }
-
-// template <typename To>
-// typename std::enable_if_t<std::is_same<To, StringType>::value,
-//                           Result<std::shared_ptr<Scalar>>>
-// CastImpl(const Decimal256Scalar& from, std::shared_ptr<DataType> to_type) {
-//   auto from_type = checked_cast<const Decimal256Type*>(from.type.get());
-//   return std::make_shared<StringScalar>(
-//       Buffer::FromString(from.value.ToString(from_type->scale())), std::move(to_type));
-// }
 
 template <typename To>
 typename std::enable_if_t<std::is_same<To, StringType>::value,

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1245,6 +1245,7 @@ CastImpl(const From& from, std::shared_ptr<DataType> to_type) {
                                         std::move(to_type));
 }
 
+// struct to string
 template <typename To>
 typename std::enable_if_t<std::is_same<To, StringType>::value,
                           Result<std::shared_ptr<Scalar>>>

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -538,12 +538,13 @@ struct ARROW_EXPORT Decimal256Scalar : public DecimalScalar<Decimal256Type, Deci
 };
 
 struct ARROW_EXPORT BaseListScalar : public Scalar {
+  using Scalar::Scalar;
   using ValueType = std::shared_ptr<Array>;
-
-  std::shared_ptr<Array> value;
 
   BaseListScalar(std::shared_ptr<Array> value, std::shared_ptr<DataType> type,
                  bool is_valid = true);
+
+  std::shared_ptr<Array> value;
 };
 
 struct ARROW_EXPORT ListScalar

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -540,13 +540,12 @@ struct ARROW_EXPORT Decimal256Scalar : public DecimalScalar<Decimal256Type, Deci
 };
 
 struct ARROW_EXPORT BaseListScalar : public Scalar {
-  using Scalar::Scalar;
   using ValueType = std::shared_ptr<Array>;
 
   BaseListScalar(std::shared_ptr<Array> value, std::shared_ptr<DataType> type,
                  bool is_valid = true);
 
-  std::shared_ptr<Array> value;
+  const std::shared_ptr<Array> value;
 };
 
 struct ARROW_EXPORT ListScalar
@@ -659,7 +658,7 @@ struct ARROW_EXPORT StructScalar : public Scalar {
 };
 
 struct ARROW_EXPORT UnionScalar : public Scalar {
-  int8_t type_code;
+  const int8_t type_code;
 
   virtual const std::shared_ptr<Scalar>& child_value() const = 0;
 
@@ -687,7 +686,7 @@ struct ARROW_EXPORT SparseUnionScalar
   // nonetheless construct a vector of scalars, one per union value, to have
   // enough data to reconstruct a valid ArraySpan of length 1 from this scalar
   using ValueType = std::vector<std::shared_ptr<Scalar>>;
-  ValueType value;
+  const ValueType value;
 
   // The value index corresponding to the active type code
   int child_id;
@@ -720,7 +719,7 @@ struct ARROW_EXPORT DenseUnionScalar
   // For DenseUnionScalar, we can make a valid ArraySpan of length 1 from this
   // scalar
   using ValueType = std::shared_ptr<Scalar>;
-  ValueType value;
+  const ValueType value;
 
   const std::shared_ptr<Scalar>& child_value() const override { return this->value; }
 
@@ -743,7 +742,7 @@ struct ARROW_EXPORT RunEndEncodedScalar
   using ArraySpanFillFromScalarScratchSpace =
       internal::ArraySpanFillFromScalarScratchSpace<RunEndEncodedScalar>;
 
-  ValueType value;
+  const ValueType value;
 
   RunEndEncodedScalar(std::shared_ptr<Scalar> value, std::shared_ptr<DataType> type);
 

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -254,7 +254,6 @@ struct ARROW_EXPORT DoubleScalar : public NumericScalar<DoubleType> {
 };
 
 struct ARROW_EXPORT BaseBinaryScalar : public internal::PrimitiveScalarBase {
-  using internal::PrimitiveScalarBase::PrimitiveScalarBase;
   using ValueType = std::shared_ptr<Buffer>;
 
   const std::shared_ptr<Buffer> value;
@@ -268,6 +267,9 @@ struct ARROW_EXPORT BaseBinaryScalar : public internal::PrimitiveScalarBase {
   std::string_view view() const override {
     return value ? std::string_view(*value) : std::string_view();
   }
+
+  BaseBinaryScalar(std::shared_ptr<DataType> type)
+      : internal::PrimitiveScalarBase(std::move(type)) {}
 
   BaseBinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type)
       : internal::PrimitiveScalarBase{std::move(type), true}, value(std::move(value)) {}

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -279,7 +279,7 @@ struct ARROW_EXPORT BaseBinaryScalar
   template <typename FillScalarScratchSpaceFactoryT>
   BaseBinaryScalar(std::shared_ptr<DataType> type, FillScalarScratchSpaceFactoryT factory)
       : PrimitiveScalarBase(std::move(type)),
-        ArraySpanFillFromScalarScratchSpace(factory(false, nullptr)) {}
+        ArraySpanFillFromScalarScratchSpace(factory(false, NULLPTR)) {}
 
   template <typename FillScalarScratchSpaceFactoryT>
   BaseBinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type,

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -268,7 +268,7 @@ struct ARROW_EXPORT BaseBinaryScalar : public internal::PrimitiveScalarBase {
     return value ? std::string_view(*value) : std::string_view();
   }
 
-  BaseBinaryScalar(std::shared_ptr<DataType> type)
+  explicit BaseBinaryScalar(std::shared_ptr<DataType> type)
       : internal::PrimitiveScalarBase(std::move(type)) {}
 
   BaseBinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type)

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -159,7 +159,7 @@ struct ARROW_EXPORT PrimitiveScalarBase : public Scalar {
   /// \brief Get a const pointer to the value of this scalar. May be null.
   virtual const void* data() const = 0;
   /// \brief Get a mutable pointer to the value of this scalar. May be null.
-  virtual void* mutable_data() = 0;
+  // virtual void* mutable_data() = 0;
   /// \brief Get an immutable view of the value of this scalar as bytes.
   virtual std::string_view view() const = 0;
 };
@@ -180,7 +180,7 @@ struct ARROW_EXPORT PrimitiveScalar : public PrimitiveScalarBase {
   ValueType value{};
 
   const void* data() const override { return &value; }
-  void* mutable_data() override { return &value; }
+  // void* mutable_data() override { return &value; }
   std::string_view view() const override {
     return std::string_view(reinterpret_cast<const char*>(&value), sizeof(ValueType));
   };
@@ -263,14 +263,14 @@ struct ARROW_EXPORT BaseBinaryScalar
       private internal::ArraySpanFillFromScalarScratchSpace {
   using ValueType = std::shared_ptr<Buffer>;
 
-  std::shared_ptr<Buffer> value;
+  const std::shared_ptr<Buffer> value;
 
   const void* data() const override {
     return value ? reinterpret_cast<const void*>(value->data()) : NULLPTR;
   }
-  void* mutable_data() override {
-    return value ? reinterpret_cast<void*>(value->mutable_data()) : NULLPTR;
-  }
+  // void* mutable_data() override {
+  //   return value ? reinterpret_cast<void*>(value->mutable_data()) : NULLPTR;
+  // }
   std::string_view view() const override {
     return value ? std::string_view(*value) : std::string_view();
   }
@@ -572,9 +572,9 @@ struct ARROW_EXPORT DecimalScalar : public internal::PrimitiveScalarBase {
     return reinterpret_cast<const void*>(value.native_endian_bytes());
   }
 
-  void* mutable_data() override {
-    return reinterpret_cast<void*>(value.mutable_native_endian_bytes());
-  }
+  // void* mutable_data() override {
+  //   return reinterpret_cast<void*>(value.mutable_native_endian_bytes());
+  // }
 
   std::string_view view() const override {
     return std::string_view(reinterpret_cast<const char*>(value.native_endian_bytes()),
@@ -880,10 +880,10 @@ struct ARROW_EXPORT DictionaryScalar : public internal::PrimitiveScalarBase {
   const void* data() const override {
     return internal::checked_cast<internal::PrimitiveScalarBase&>(*value.index).data();
   }
-  void* mutable_data() override {
-    return internal::checked_cast<internal::PrimitiveScalarBase&>(*value.index)
-        .mutable_data();
-  }
+  // void* mutable_data() override {
+  //   return internal::checked_cast<internal::PrimitiveScalarBase&>(*value.index)
+  //       .mutable_data();
+  // }
   std::string_view view() const override {
     return internal::checked_cast<const internal::PrimitiveScalarBase&>(*value.index)
         .view();

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -256,7 +256,7 @@ struct ARROW_EXPORT DoubleScalar : public NumericScalar<DoubleType> {
 struct ARROW_EXPORT BaseBinaryScalar : public internal::PrimitiveScalarBase {
   using ValueType = std::shared_ptr<Buffer>;
 
-  const std::shared_ptr<Buffer> value;
+  const std::shared_ptr<Buffer> value = NULLPTR;
 
   const void* data() const override {
     return value ? reinterpret_cast<const void*>(value->data()) : NULLPTR;

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1286,6 +1286,17 @@ TEST(TestMapScalar, Cast) {
   CheckListCastError(scalar, invalid_cast_type);
 }
 
+TEST(TestMapScalar, ToString) {
+  auto key_value_type = struct_({field("key", utf8(), false), field("value", int8())});
+  auto value = ArrayFromJSON(key_value_type,
+                             R"([{"key": "a", "value": 1}, {"key": "b", "value": 2}])");
+  auto scalar = MapScalar(value);
+
+  ASSERT_EQ(
+      scalar.ToString(),
+      R"(map<string, int8>[{key:string = a, value:int8 = 1}, {key:string = b, value:int8 = 2}])");
+}
+
 TEST(TestStructScalar, FieldAccess) {
   StructScalar abc({MakeScalar(true), MakeNullScalar(int32()), MakeScalar("hello"),
                     MakeNullScalar(int64())},

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1711,6 +1711,16 @@ class TestUnionScalar : public ::testing::Test {
     }
   }
 
+  void TestToString() {
+    ASSERT_EQ(union_alpha_->ToString(), "union{string: string = alpha}");
+    ASSERT_EQ(union_beta_->ToString(), "union{string: string = beta}");
+    ASSERT_EQ(union_two_->ToString(), "union{number: uint64 = 2}");
+    ASSERT_EQ(union_other_two_->ToString(), "union{other_number: uint64 = 2}");
+    ASSERT_EQ(union_three_->ToString(), "union{number: uint64 = 3}");
+    ASSERT_EQ(union_string_null_->ToString(), "null");
+    ASSERT_EQ(union_number_null_->ToString(), "null");
+  }
+
  protected:
   std::shared_ptr<DataType> type_;
   const UnionType* union_type_;
@@ -1728,6 +1738,8 @@ TYPED_TEST(TestUnionScalar, ValidateErrors) { this->TestValidateErrors(); }
 TYPED_TEST(TestUnionScalar, Equals) { this->TestEquals(); }
 
 TYPED_TEST(TestUnionScalar, MakeNullScalar) { this->TestMakeNullScalar(); }
+
+TYPED_TEST(TestUnionScalar, ToString) { this->TestToString(); }
 
 class TestSparseUnionScalar : public TestUnionScalar<SparseUnionType> {};
 

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -709,11 +709,6 @@ TEST(TestStringScalar, MakeScalarString) {
   ASSERT_EQ(StringScalar("three"), *three);
 }
 
-TEST(TestStringScalar, Cast) {
-  std::string s = "test data";
-  // TODO: all others.
-}
-
 TEST(TestFixedSizeBinaryScalar, Basics) {
   std::string data = "test data";
   auto buf = std::make_shared<Buffer>(data);

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -2066,6 +2066,15 @@ TEST_F(TestExtensionScalar, ValidateErrors) {
   // If the scalar is null it's okay
   scalar.is_valid = false;
   ASSERT_OK(scalar.ValidateFull());
+
+  // Invalid storage scalar (invalid UTF8)
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Scalar> invalid_storage,
+                       MakeScalar(utf8(), std::make_shared<Buffer>("\xff")));
+  ASSERT_OK(invalid_storage->Validate());
+  ASSERT_RAISES(Invalid, invalid_storage->ValidateFull());
+  scalar = ExtensionScalar(invalid_storage, type_);
+  ASSERT_OK(scalar.Validate());
+  ASSERT_RAISES(Invalid, scalar.ValidateFull());
 }
 
 }  // namespace arrow


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

As #40069 shows, TSAN reports data race that is caused by concurrent filling the scratch space of a scalar instance. The concurrent use of the same scalar could be parallel executing an acero plan containing a literal (a "constant" that is simply represented by an underlying scalar), and this is totally legit. The problem lies in the fact that the scratch space of the scalar is filled "lazily" by the time when it is being involved in the computation and transformed to an array span, for *every* thread.

After piloting several approaches (relaxed atomic - an earlier version of this PR, locking - #40260), @pitrou and @bkietz suggested an immutable-after-initialization approach, for which the latest version of this PR is.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

There are generally two parts in this PR:
1. Mandate the initialization of the scratch space in constructor of the concrete subclass of `Scalar`.
2. In order to keep the content of the scratch space consistent with the underlying `value` of the scalar, make the `value` constant. This effectively makes legacy code that directly assigning to the `value` invalid, which is refactored accordingly:
  2.1 `BoxScalar` in https://github.com/apache/arrow/pull/40237/files#diff-08d11e02c001c82b1aa89565e16760a8bcca4a608c22619fb45da42fd0ebebac
  2.2 `Scalar::CastTo` in https://github.com/apache/arrow/pull/40237/files#diff-b4b83682450006616fa7e4f6f2ea3031cf1a22d734f4bee42a99af313e808f9e
  2.3 `ScalarMinMax` in https://github.com/apache/arrow/pull/40237/files#diff-368ab7e748bd4432c92d9fdc26b51e131742b968e3eb32a6fcea4b9f02fa36aa

Besides, when refactoring 2.2, I found the current `Scalar::CastTo` is not fully covered by the existing tests. So I also added some lacking ones.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**This PR includes breaking changes to public APIs.**
The `value` member of `BaseBinaryScalar` and subclasses/`BaseListScalar` and subclasses/`SparseUnionScalar`/`DenseUnionScalar`/`RunEndEncodedScalar` is made constant, thus code directly assigning to this member will no more compile.

Also the `Scalar::mutable_data()` member function is removed because it's against the immutable nature of `Scalar`.

However the impact of these changes seems limited. I don't think much user code is depending on these two old pieces of code.

Also after an quick search, I didn't find any document that need to be updated according to this change. There could be none. But if there is, may someone please redirect me to it so I can update. Thanks.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40069