### PR TITLE
MINOR: [Documentation][C++][Python][R] Clarify docstrings around max_chunksize

### DIFF
--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -113,8 +113,8 @@ class ARROW_EXPORT RecordBatchWriter {
 
   /// \brief Write Table with a particular chunksize
   /// \param[in] table table to write
-  /// \param[in] max_chunksize maximum length of table chunks. To indicate
-  /// that no maximum should be enforced, pass -1.
+  /// \param[in] max_chunksize maximum number of rows for table chunks. To
+  /// indicate that no maximum should be enforced, pass -1.
   /// \return Status
   virtual Status WriteTable(const Table& table, int64_t max_chunksize);
 

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -251,9 +251,9 @@ class ARROW_EXPORT TableBatchReader : public RecordBatchReader {
 
   Status ReadNext(std::shared_ptr<RecordBatch>* out) override;
 
-  /// \brief Set the desired maximum chunk size of record batches
+  /// \brief Set the desired maximum number of rows for record batches
   ///
-  /// The actual chunk size of each record batch may be smaller, depending
+  /// The actual number of rows in each record batch may be smaller, depending
   /// on actual chunking characteristics of each table column.
   void set_chunksize(int64_t chunksize);
 

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1134,8 +1134,8 @@ cdef class MetadataRecordBatchWriter(_CRecordBatchWriter):
         ----------
         table : Table
         max_chunksize : int, default None
-            Maximum size for RecordBatch chunks. Individual chunks may be
-            smaller depending on the chunk layout of individual columns.
+            Maximum number of rows for RecordBatch chunks. Individual chunks may
+            be smaller depending on the chunk layout of individual columns.
         """
         cdef:
             # max_chunksize must be > 0 to have any impact

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -515,8 +515,8 @@ cdef class _CRecordBatchWriter(_Weakrefable):
         ----------
         table : Table
         max_chunksize : int, default None
-            Maximum size for RecordBatch chunks. Individual chunks may be
-            smaller depending on the chunk layout of individual columns.
+            Maximum number of rows for RecordBatch chunks. Individual chunks may
+            be smaller depending on the chunk layout of individual columns.
         """
         cdef:
             # max_chunksize must be > 0 to have any impact

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4094,8 +4094,8 @@ cdef class Table(_Tabular):
         Parameters
         ----------
         max_chunksize : int, default None
-            Maximum size for ChunkedArray chunks. Individual chunks may be
-            smaller depending on the chunk layout of individual columns.
+            Maximum number of rows for ChunkedArray chunks. Individual chunks
+            may be smaller depending on the chunk layout of individual columns.
 
         Returns
         -------
@@ -4189,8 +4189,8 @@ cdef class Table(_Tabular):
         Parameters
         ----------
         max_chunksize : int, default None
-            Maximum size for RecordBatch chunks. Individual chunks may be
-            smaller depending on the chunk layout of individual columns.
+            Maximum number of rows for each RecordBatch chunk. Individual chunks
+            may be smaller depending on the chunk layout of individual columns.
 
         Returns
         -------
@@ -4259,8 +4259,8 @@ cdef class Table(_Tabular):
         Parameters
         ----------
         max_chunksize : int, default None
-            Maximum size for RecordBatch chunks. Individual chunks may be
-            smaller depending on the chunk layout of individual columns.
+            Maximum number of rows for each RecordBatch chunk. Individual chunks
+            may be smaller depending on the chunk layout of individual columns.
 
         Returns
         -------

--- a/r/R/flight.R
+++ b/r/R/flight.R
@@ -56,7 +56,8 @@ flight_disconnect <- function(client) {
 #' @param overwrite logical: if `path` exists on `client` already, should we
 #' replace it with the contents of `data`? Default is `TRUE`; if `FALSE` and
 #' `path` exists, the function will error.
-#' @param max_chunksize integer: Maximum size for RecordBatch chunks when a `data.frame` is sent.
+#' @param max_chunksize integer: Maximum number of rows for RecordBatch chunks
+#'   when a `data.frame` is sent.
 #' Individual chunks may be smaller depending on the chunk layout of individual columns.
 #' @return `client`, invisibly.
 #' @export

--- a/r/man/flight_put.Rd
+++ b/r/man/flight_put.Rd
@@ -17,7 +17,8 @@ flight_put(client, data, path, overwrite = TRUE, max_chunksize = NULL)
 replace it with the contents of \code{data}? Default is \code{TRUE}; if \code{FALSE} and
 \code{path} exists, the function will error.}
 
-\item{max_chunksize}{integer: Maximum size for RecordBatch chunks when a \code{data.frame} is sent.
+\item{max_chunksize}{integer: Maximum number of rows for RecordBatch chunks
+when a \code{data.frame} is sent.
 Individual chunks may be smaller depending on the chunk layout of individual columns.}
 }
 \value{


### PR DESCRIPTION
### Rationale for this change

A user [ran into confusion](https://lists.apache.org/thread/8ym8r1z5gys7dpcr8rw8dvjbkqc2lf7f) over the units of the `max_chunksize` argument in PyArrow and didn't see any reason not to make the documentation more explicit.

### What changes are included in this PR?

Just changes to docstrings.

### Are these changes tested?

No, though I did go through every change to see if it was correct and I'm pretty sure it's right. Good to double-check during review though.

### Are there any user-facing changes?

Just docs.