### PR TITLE
GH-40252: [C++] Make span SFINAE standards-conforming to enable compilation with nvcc

### DIFF
--- a/cpp/src/arrow/util/span.h
+++ b/cpp/src/arrow/util/span.h
@@ -59,7 +59,8 @@ writing code which would break when it is replaced by std::span.)");
   template <
       typename R,
       typename DisableUnlessConstructibleFromDataAndSize =
-          decltype(span<T>(std::data(std::declval<R>()), std::size(std::declval<R>()))),
+          std::enable_if_t<std::is_convertible_v< std::remove_pointer_t<decltype(std::data(std::declval<R&>()))> (*)[],
+                                              T(*)[]>>,
       typename DisableUnlessSimilarTypes = std::enable_if_t<std::is_same_v<
           std::decay_t<std::remove_pointer_t<decltype(std::data(std::declval<R>()))>>,
           std::decay_t<T>>>>

--- a/cpp/src/arrow/util/span.h
+++ b/cpp/src/arrow/util/span.h
@@ -25,20 +25,17 @@
 
 namespace arrow::util {
 
-template<class T>
+template <class T>
 class span;
 
-template<class T, class R, class Enable = void>
+template <class T, class R, class Enable = void>
 struct ConstructibleFromDataAndSize : std::false_type {};
 
-template<class T, class R>
-struct ConstructibleFromDataAndSize<span<T>, R,
-  std::void_t<
-    decltype(span<T>{
-      std::data(std::declval<R>()), std::size(std::declval<R>())
-    })
-  >
-> : std::true_type {};
+template <class T, class R>
+struct ConstructibleFromDataAndSize<
+    span<T>, R,
+    std::void_t<decltype(span<T>{std::data(std::declval<R>()),
+                                 std::size(std::declval<R>())})>> : std::true_type {};
 
 /// std::span polyfill.
 ///
@@ -71,7 +68,7 @@ writing code which would break when it is replaced by std::span.)");
   constexpr span(T* begin, T* end)
       : data_{begin}, size_{static_cast<size_t>(end - begin)} {}
 
-  template<
+  template <
       typename R,
       std::enable_if_t<ConstructibleFromDataAndSize<span<T>, R>::value, bool> = true,
       typename DisableUnlessSimilarTypes = std::enable_if_t<std::is_same_v<
@@ -79,7 +76,6 @@ writing code which would break when it is replaced by std::span.)");
           std::decay_t<T>>>>
   // NOLINTNEXTLINE runtime/explicit, non-const reference
   constexpr span(R&& range) : span{std::data(range), std::size(range)} {}
-
 
   constexpr T* begin() const { return data_; }
   constexpr T* end() const { return data_ + size_; }

--- a/cpp/src/arrow/util/span.h
+++ b/cpp/src/arrow/util/span.h
@@ -28,6 +28,19 @@ namespace arrow::util {
 template <class T>
 class span;
 
+// This trait is used to check if a type R can be used to construct a span<T>.
+// Specifically, it checks if std::data(R) and std::size(R) are valid expressions
+// that may be passed to the span(T*, size_t) constructor. The reason this trait
+// is needed rather than expressing this directly in the relevant span constructor
+// is that this check requires instantiating span<T>, which would violate the
+// C++ standard if written directly in the constructor's enable_if clause
+// because span<T> is an incomplete type at that point. By defining this trait
+// instead, we add an extra level of indirection that lets us delay the
+// evaluation of the template until the first time the associated constructor
+// is actually called, at which point span<T> is a complete type.
+//
+// Note that most compilers do support the noncompliant construct, but nvcc
+// does not. See https://github.com/apache/arrow/issues/40252
 template <class T, class R, class Enable = void>
 struct ConstructibleFromDataAndSize : std::false_type {};
 

--- a/cpp/src/arrow/util/span.h
+++ b/cpp/src/arrow/util/span.h
@@ -65,7 +65,7 @@ writing code which would break when it is replaced by std::span.)");
           std::decay_t<std::remove_pointer_t<decltype(std::data(std::declval<R>()))>>,
           std::decay_t<T>>>>
   // NOLINTNEXTLINE runtime/explicit, non-const reference
-  constexpr span(R& range) : span{std::data(range), std::size(range)} {}
+  constexpr span(R&& range) : span{std::data(range), std::size(range)} {}
 
   constexpr T* begin() const { return data_; }
   constexpr T* end() const { return data_ + size_; }

--- a/cpp/src/arrow/util/span.h
+++ b/cpp/src/arrow/util/span.h
@@ -65,7 +65,7 @@ writing code which would break when it is replaced by std::span.)");
           std::decay_t<std::remove_pointer_t<decltype(std::data(std::declval<R>()))>>,
           std::decay_t<T>>>>
   // NOLINTNEXTLINE runtime/explicit, non-const reference
-  constexpr span(R&& range) : span{std::data(range), std::size(range)} {}
+  constexpr span(R& range) : span{std::data(range), std::size(range)} {}
 
   constexpr T* begin() const { return data_; }
   constexpr T* end() const { return data_ + size_; }

--- a/cpp/src/arrow/util/span_test.cc
+++ b/cpp/src/arrow/util/span_test.cc
@@ -51,7 +51,6 @@ TEST(Span, Construction) {
 
   static_assert(std::is_constructible_v<span<const int>, decltype(arr)&>);
   static_assert(std::is_constructible_v<span<const int>, decltype(const_arr)&>);
-  static_assert(std::is_constructible_v<span<const int>, span<int>>);
 
   static_assert(std::is_constructible_v<span<int>, std::vector<int>&>);
   static_assert(!std::is_constructible_v<span<int>, const std::vector<int>&>);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The current code uses an incomplete type in a SFINAE construct.

Closes #40252 

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR changes the way that the type is specified to avoid any UB.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I tested locally that code that originally failed to compile with nvcc now compiles successfully. The same code also compiles under clang and gcc. This is a minimal reproducer:
```
#include <arrow/api.h>
#include <vector>

int main() {
  arrow::util::span<int> x{std::vector<int>{1, 2, 3}};
}
```

I did not include it here because it is a compile-time rather than runtime issue, and because at present it only manifests on nvcc.

### Are there any user-facing changes?

No.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40252