### PR TITLE
GH-40248: [R] fallback to the correct libtool when we find a GNU one

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -104,7 +104,6 @@ function(arrow_create_merged_static_lib output_target)
 
     # check in the obvious places first to find Apple's libtool
     find_program(LIBTOOL_MACOS libtool
-                 PATHS /usr/bin /Library/Developer/CommandLineTools/usr/bin
                  NO_DEFAULT_PATH)
 
     # if it's not found in obvious places, check on the standard path

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -100,17 +100,13 @@ function(arrow_create_merged_static_lib output_target)
     # The apple-distributed libtool is what we want for bundling, but there is
     # a GNU libtool that has a namecollision (and happens to be bundled with R, too).
     # We are not compatible with GNU libtool, so we need to avoid it.
-    # TODO: use a VALIDATOR when we require cmake >= 3.25
 
     # check in the obvious places first to find Apple's libtool
+    # HINTS is used before system paths and before PATHS, so we use that
+    # even though hard coded paths should go in PATHS
+    # TODO: use a VALIDATOR when we require cmake >= 3.25
     find_program(LIBTOOL_MACOS libtool
-                 PATHS /usr/bin /Library/Developer/CommandLineTools/usr/bin
-                 NO_DEFAULT_PATH)
-
-    # if it's not found in obvious places, check on the standard path
-    if(LIBTOOL_MACOS-NOTFOUND)
-      set(LIBTOOL_MACOS "libtool")
-    endif()
+                HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin)
 
     # confirm that the libtool we found is not GNU libtool
     execute_process(COMMAND ${LIBTOOL_MACOS} -V

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -105,15 +105,16 @@ function(arrow_create_merged_static_lib output_target)
     # HINTS is used before system paths and before PATHS, so we use that
     # even though hard coded paths should go in PATHS
     # TODO: use a VALIDATOR when we require cmake >= 3.25
-    find_program(LIBTOOL_MACOS libtool
-                HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin)
+    find_program(LIBTOOL_MACOS libtool HINTS /usr/bin
+                                             /Library/Developer/CommandLineTools/usr/bin)
 
     # confirm that the libtool we found is not GNU libtool
     execute_process(COMMAND ${LIBTOOL_MACOS} -V
                     OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
-      message(FATAL_ERROR "libtool found appears to be the incompatible GNU libtool: ${LIBTOOL_MACOS}")
+      message(FATAL_ERROR "libtool found appears to be the incompatible GNU libtool: ${LIBTOOL_MACOS}"
+      )
     endif()
 
     set(BUNDLE_COMMAND ${LIBTOOL_MACOS} "-no_warning_for_no_symbols" "-static" "-o"

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -104,6 +104,7 @@ function(arrow_create_merged_static_lib output_target)
 
     # check in the obvious places first to find Apple's libtool
     find_program(LIBTOOL_MACOS libtool
+                 PATHS /usr/bin /Library/Developer/CommandLineTools/usr/bin
                  NO_DEFAULT_PATH)
 
     # if it's not found in obvious places, check on the standard path

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -97,8 +97,18 @@ function(arrow_create_merged_static_lib output_target)
   endforeach()
 
   if(APPLE)
-    set(BUNDLE_COMMAND "libtool" "-no_warning_for_no_symbols" "-static" "-o"
-                       ${output_lib_path} ${all_library_paths})
+    execute_process(COMMAND "libtool" -V
+    OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if("${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
+      # this is the macOS provided libtool
+      set(BUNDLE_COMMAND "libtool" "-no_warning_for_no_symbols" "-static" "-o"
+      ${output_lib_path} ${all_library_paths})
+    else()
+      # this is the GNU libtool, but we should be able to find the macos libtool we want
+      set(BUNDLE_COMMAND "/usr/bin/libtool" "-no_warning_for_no_symbols" "-static" "-o"
+          ${output_lib_path} ${all_library_paths})
+    endif()
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|GNU|Intel|IntelLLVM)$")
     set(ar_script_path ${CMAKE_BINARY_DIR}/${ARG_NAME}.ar)
 

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -117,7 +117,7 @@ function(arrow_create_merged_static_lib output_target)
                     OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
-      message(FATAL_ERROR "libtool found appears to be the incompatible GNU libtool")
+      message(FATAL_ERROR "libtool found appears to be the incompatible GNU libtool: ${LIBTOOL_MACOS}")
     endif()
 
     set(BUNDLE_COMMAND ${LIBTOOL_MACOS} "-no_warning_for_no_symbols" "-static" "-o"

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -79,7 +79,6 @@ jobs:
           LIBARROW_BINARY: false
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
-          echo "$PATH"
           sccache --start-server || echo 'sccache not found'
           cd arrow/r
           R CMD INSTALL . --install-tests

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -58,12 +58,13 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+      # CRAN builders have the entire bin here added to the path. This sometimes
+      # includes things like GNU libtool which name-collide with what we expect
       - name: Add R.framework/Resources/bin to the path
-        run: |
-          # CRAN builders have the entire bin here added to the path. This sometimes
-          # includes things like GNU libtool which name-collide with what we expect
-          echo "/Library/Frameworks/R.framework/Resources/bin" >> $GITHUB_PATH
+        if: contains(matrix.os, 'macOS')
+        run: echo "/Library/Frameworks/R.framework/Resources/bin" >> $GITHUB_PATH
       - name : Check whether libtool in R is used
+        if: contains(matrix.os, 'macOS')
         run: |
           if [ "$(which libtool)" != "/Library/Frameworks/R.framework/Resources/bin/libtool" ]; then
             echo "libtool provided by R isn't found: $(which libtool)"

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -46,6 +46,9 @@ jobs:
           # brew install sccache
           # remove cmake so that we can test our cmake downloading abilities
           brew uninstall cmake
+          # install GNU libtool to ensure that we simulate the CRAN macOS builders
+          brew install libtool
+          echo "/usr/local/opt/libtool/libexec/gnubin" >> $GITHUB_PATH
       - name: Configure dependencies (linux)
         if: contains(matrix.os, 'ubuntu')
         run: |
@@ -76,6 +79,7 @@ jobs:
           LIBARROW_BINARY: false
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         run: |
+          echo "$PATH"
           sccache --start-server || echo 'sccache not found'
           cd arrow/r
           R CMD INSTALL . --install-tests

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -46,9 +46,6 @@ jobs:
           # brew install sccache
           # remove cmake so that we can test our cmake downloading abilities
           brew uninstall cmake
-          # install GNU libtool to ensure that we simulate the CRAN macOS builders
-          brew install libtool
-          echo "/usr/local/opt/libtool/libexec/gnubin" >> $GITHUB_PATH
       - name: Configure dependencies (linux)
         if: contains(matrix.os, 'ubuntu')
         run: |
@@ -61,6 +58,11 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+      - name: Add R.framework/Resources/bin to the path
+        run: |
+          # CRAN builders have the entire bin here added to the path. This sometimes
+          # includes things like GNU libtool which name-collide with what we expect
+          echo "/Library/Frameworks/R.framework/Resources/bin" >> $GITHUB_PATH
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -63,6 +63,12 @@ jobs:
           # CRAN builders have the entire bin here added to the path. This sometimes
           # includes things like GNU libtool which name-collide with what we expect
           echo "/Library/Frameworks/R.framework/Resources/bin" >> $GITHUB_PATH
+      - name : Check whether libtool in R is used
+        run: |
+          if [ "$(which libtool)" != "/Library/Frameworks/R.framework/Resources/bin/libtool" ]; then
+            echo "libtool provided by R isn't found: $(which libtool)"
+            exit 1
+          fi
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
### Rationale for this change

On the CRAN build machines the GNU libtool is on the path in front of the macOS libtool. Though these are named the same thing, they are actually very different and don't actually appear to be substitutes

I checked on a non-developer's machine to see if `/usr/bin/libtool` exists, and it did. So I believe we _should_ be ok with this even if xcode / command line tools haven't been installed.

One note: it's possible that we could get the GNU libtool in link mode to work with the right incantation (something like `libtool --mode=link --tag=CXX ${cmake_compiler} -o ...` but when I tried this I kept getting symbol not found errors. Ultimately, I think any mac that we are on will have the apple-provided libtool, so decided to go the route of finding it. 

### What changes are included in this PR?

When we detect we are on a GNU libtool, we look to `/usr/bin/libtool` instead.

### Are these changes tested?

Yes. See a broken config failing at https://github.com/apache/arrow/pull/40259#issuecomment-1967762074 and then the next one passes

### Are there any user-facing changes?

We will remain on CRAN

**This PR contains a "Critical Fix".**
* GitHub Issue: #40248