### PR TITLE
GH-40266: [Python] Mark ListView as a nested type

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -216,6 +216,8 @@ def test_is_nested_or_struct():
     assert types.is_nested(pa.list_(pa.int32()))
     assert types.is_nested(pa.list_(pa.int32(), 3))
     assert types.is_nested(pa.large_list(pa.int32()))
+    assert types.is_nested(pa.list_view(pa.int32()))
+    assert types.is_nested(pa.large_list_view(pa.int32()))
     assert not types.is_nested(pa.int32())
 
 

--- a/python/pyarrow/types.py
+++ b/python/pyarrow/types.py
@@ -41,6 +41,7 @@ _TEMPORAL_TYPES = ({lib.Type_TIMESTAMP,
                    _INTERVAL_TYPES)
 _UNION_TYPES = {lib.Type_SPARSE_UNION, lib.Type_DENSE_UNION}
 _NESTED_TYPES = {lib.Type_LIST, lib.Type_FIXED_SIZE_LIST, lib.Type_LARGE_LIST,
+                 lib.Type_LIST_VIEW, lib.Type_LARGE_LIST_VIEW,
                  lib.Type_STRUCT, lib.Type_MAP} | _UNION_TYPES
 
 


### PR DESCRIPTION
### Rationale for this change

ListView types are nested, so `is_nested()` should return True.

### What changes are included in this PR?

* `pa.types.is_nested(pa.list_view(<type>))` returns True

### Are these changes tested?

Yes, unit tested.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40266