### PR TITLE
GH-40274: [C++] Add support for system glog 0.7

### DIFF
--- a/cpp/cmake_modules/FindglogAlt.cmake
+++ b/cpp/cmake_modules/FindglogAlt.cmake
@@ -15,14 +15,22 @@
 #
 # Usage of this module as follows:
 #
-#  find_package(GLOG)
+#  find_package(glogAlt)
 
-find_package(glog CONFIG)
-if(glog_FOUND)
+if(glogAlt_FOUND)
   return()
 endif()
 
-if(GLOG_FOUND)
+set(find_package_args CONFIG)
+if(glogAlt_FIND_VERSION)
+  list(APPEND find_package_args ${glogAlt_FIND_VERSION})
+endif()
+if(glogAlt_FIND_QUIETLY)
+  list(APPEND find_package_args QUIET)
+endif()
+find_package(glog ${find_package_args})
+if(glog_FOUND)
+  set(glogAlt_FOUND TRUE)
   return()
 endif()
 
@@ -55,9 +63,9 @@ else()
             PATH_SUFFIXES ${ARROW_INCLUDE_PATH_SUFFIXES})
 endif()
 
-find_package_handle_standard_args(GLOG REQUIRED_VARS GLOG_INCLUDE_DIR GLOG_LIB)
+find_package_handle_standard_args(glogAlt REQUIRED_VARS GLOG_INCLUDE_DIR GLOG_LIB)
 
-if(GLOG_FOUND)
+if(glogAlt_FOUND)
   add_library(glog::glog UNKNOWN IMPORTED)
   set_target_properties(glog::glog
                         PROPERTIES IMPORTED_LOCATION "${GLOG_LIB}"

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -115,7 +115,7 @@ if("${lz4_SOURCE}" STREQUAL "" AND NOT "${Lz4_SOURCE}" STREQUAL "")
   set(lz4_SOURCE ${Lz4_SOURCE})
 endif()
 
-# For backward compatibility. We use "glog_SOURCE" if "GLOG_SOURCE"
+# For backward compatibility. We use "GLOG_SOURCE" if "glog_SOURCE"
 # isn't specified and "GLOG_SOURCE" is specified.
 # We renamed "GLOG" dependency name to "glog" in 16.0.0 because
 # upstream uses "glog" not "GLOG" as package name.

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -55,7 +55,7 @@ set(ARROW_THIRDPARTY_DEPENDENCIES
     BZip2
     c-ares
     gflags
-    GLOG
+    glog
     google_cloud_cpp_storage
     gRPC
     GTest
@@ -113,6 +113,14 @@ endif()
 # upstream uses "lz4" not "Lz4" as package name.
 if("${lz4_SOURCE}" STREQUAL "" AND NOT "${Lz4_SOURCE}" STREQUAL "")
   set(lz4_SOURCE ${Lz4_SOURCE})
+endif()
+
+# For backward compatibility. We use "glog_SOURCE" if "GLOG_SOURCE"
+# isn't specified and "GLOG_SOURCE" is specified.
+# We renamed "GLOG" dependency name to "glog" in 16.0.0 because
+# upstream uses "glog" not "GLOG" as package name.
+if("${glog_SOURCE}" STREQUAL "" AND NOT "${GLOG_SOURCE}" STREQUAL "")
+  set(glog_SOURCE ${GLOG_SOURCE})
 endif()
 
 # For backward compatibility. We use bundled jemalloc by default.
@@ -184,7 +192,7 @@ macro(build_dependency DEPENDENCY_NAME)
     build_cares()
   elseif("${DEPENDENCY_NAME}" STREQUAL "gflags")
     build_gflags()
-  elseif("${DEPENDENCY_NAME}" STREQUAL "GLOG")
+  elseif("${DEPENDENCY_NAME}" STREQUAL "glog")
     build_glog()
   elseif("${DEPENDENCY_NAME}" STREQUAL "google_cloud_cpp_storage")
     build_google_cloud_cpp_storage()
@@ -1533,7 +1541,11 @@ macro(build_glog)
 endmacro()
 
 if(ARROW_USE_GLOG)
-  resolve_dependency(GLOG PC_PACKAGE_NAMES libglog)
+  resolve_dependency(glog
+                     HAVE_ALT
+                     TRUE
+                     PC_PACKAGE_NAMES
+                     libglog)
 endif()
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
### Rationale for this change

glog uses "glog" not "GLOG" as CMake package name. So we should follow it.

### What changes are included in this PR?

Use "glogAlt" for our glog CMake module name to distinct upstream's CMake package name. 

### Are these changes tested?

No. We don't have CI with glog 0.7 yet.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40274