### PR TITLE
GH-40280: [C++] Specialize ResolvedChunk::Value on value-specific types instead of entire class

### DIFF
--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -32,12 +32,12 @@ struct ChunkLocation {
   ///
   /// The value is always in the range `[0, chunks.size()]`. `chunks.size()` is used
   /// to represent out-of-bounds locations.
-  int64_t chunk_index;
+  int64_t chunk_index = 0;
 
   /// \brief Index of the value in the chunk
   ///
   /// The value is undefined if chunk_index >= chunks.size()
-  int64_t index_in_chunk;
+  int64_t index_in_chunk = 0;
 };
 
 /// \brief An utility that incrementally resolves logical indices into
@@ -96,16 +96,16 @@ struct ARROW_EXPORT ChunkResolver {
   /// \pre index >= 0
   /// \post location.chunk_index in [0, chunks.size()]
   /// \param index The logical index to resolve
-  /// \param cached_chunk_index 0 or the chunk_index of the last ChunkLocation
-  /// returned by this ChunkResolver.
+  /// \param hint ChunkLocation{} or the last ChunkLocation returned by
+  ///             this ChunkResolver.
   /// \return ChunkLocation with a valid chunk_index if index is within
   ///         bounds, or with chunk_index == chunks.size() if logical index is
   ///         `>= chunked_array.length()`.
   inline ChunkLocation ResolveWithChunkIndexHint(int64_t index,
-                                                 int64_t cached_chunk_index) const {
-    assert(cached_chunk_index < static_cast<int64_t>(offsets_.size()));
+                                                 ChunkLocation hint) const {
+    assert(hint.chunk_index < static_cast<int64_t>(offsets_.size()));
     const auto chunk_index =
-        ResolveChunkIndex</*StoreCachedChunk=*/false>(index, cached_chunk_index);
+        ResolveChunkIndex</*StoreCachedChunk=*/false>(index, hint.chunk_index);
     return {chunk_index, index - offsets_[chunk_index]};
   }
 

--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -56,19 +56,15 @@ struct ARROW_EXPORT ChunkResolver {
   mutable std::atomic<int64_t> cached_chunk_;
 
  public:
-  explicit ChunkResolver(const ArrayVector& chunks);
-  explicit ChunkResolver(const std::vector<const Array*>& chunks);
-  explicit ChunkResolver(const RecordBatchVector& batches);
+  explicit ChunkResolver(const ArrayVector& chunks) noexcept;
+  explicit ChunkResolver(const std::vector<const Array*>& chunks) noexcept;
+  explicit ChunkResolver(const RecordBatchVector& batches) noexcept;
 
-  ChunkResolver(ChunkResolver&& other) noexcept
-      : offsets_(std::move(other.offsets_)),
-        cached_chunk_(other.cached_chunk_.load(std::memory_order_relaxed)) {}
+  ChunkResolver(ChunkResolver&& other) noexcept;
+  ChunkResolver& operator=(ChunkResolver&& other) noexcept;
 
-  ChunkResolver& operator=(ChunkResolver&& other) {
-    offsets_ = std::move(other.offsets_);
-    cached_chunk_.store(other.cached_chunk_.load(std::memory_order_relaxed));
-    return *this;
-  }
+  ChunkResolver(const ChunkResolver& other) noexcept;
+  ChunkResolver& operator=(const ChunkResolver& other) noexcept;
 
   /// \brief Resolve a logical index to a ChunkLocation.
   ///

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -227,8 +227,6 @@ class Ranker<ChunkedArray> : public RankerMixin<ChunkedArray, Ranker<ChunkedArra
 
   template <typename InType>
   Status RankInternal() {
-    using ArrayType = typename TypeTraits<InType>::ArrayType;
-
     if (physical_chunks_.empty()) {
       return Status::OK();
     }
@@ -240,7 +238,7 @@ class Ranker<ChunkedArray> : public RankerMixin<ChunkedArray, Ranker<ChunkedArra
 
     const auto arrays = GetArrayPointers(physical_chunks_);
     auto value_selector = [resolver = ChunkedArrayResolver(arrays)](int64_t index) {
-      return resolver.Resolve<ArrayType>(index).Value();
+      return resolver.Resolve(index).Value<InType>();
     };
     ARROW_ASSIGN_OR_RAISE(*output_, CreateRankings(ctx_, sorted, null_placement_,
                                                    tiebreaker_, value_selector));

--- a/cpp/src/arrow/compute/kernels/vector_select_k.cc
+++ b/cpp/src/arrow/compute/kernels/vector_select_k.cc
@@ -406,10 +406,7 @@ class TableSelector : public TypeVisitor {
 
     // Find the target chunk and index in the target chunk from an
     // index in chunked array.
-    template <typename ArrayType>
-    ResolvedChunk<ArrayType> GetChunk(int64_t index) const {
-      return resolver.Resolve<ArrayType>(index);
-    }
+    ResolvedChunk GetChunk(int64_t index) const { return resolver.Resolve(index); }
 
     const SortOrder order;
     const std::shared_ptr<DataType> type;
@@ -495,7 +492,6 @@ class TableSelector : public TypeVisitor {
 
   template <typename InType, SortOrder sort_order>
   Status SelectKthInternal() {
-    using ArrayType = typename TypeTraits<InType>::ArrayType;
     auto& comparator = comparator_;
     const auto& first_sort_key = sort_keys_[0];
 
@@ -509,10 +505,10 @@ class TableSelector : public TypeVisitor {
     std::function<bool(const uint64_t&, const uint64_t&)> cmp;
     SelectKComparator<sort_order> select_k_comparator;
     cmp = [&](const uint64_t& left, const uint64_t& right) -> bool {
-      auto chunk_left = first_sort_key.template GetChunk<ArrayType>(left);
-      auto chunk_right = first_sort_key.template GetChunk<ArrayType>(right);
-      auto value_left = chunk_left.Value();
-      auto value_right = chunk_right.Value();
+      auto chunk_left = first_sort_key.GetChunk(left);
+      auto chunk_right = first_sort_key.GetChunk(right);
+      auto value_left = chunk_left.Value<InType>();
+      auto value_right = chunk_right.Value<InType>();
       if (value_left == value_right) {
         return comparator.Compare(left, right, 1);
       }

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -755,9 +755,9 @@ class TableSorter {
                [&](uint64_t left, uint64_t right) {
                  // First column is either null or nan
                  left_loc =
-                     left_resolver_.ResolveWithChunkIndexHint(left, left_loc.chunk_index);
-                 right_loc = right_resolver_.ResolveWithChunkIndexHint(
-                     right, right_loc.chunk_index);
+                     left_resolver_.ResolveWithChunkIndexHint(left, /*hint=*/left_loc);
+                 right_loc =
+                     right_resolver_.ResolveWithChunkIndexHint(right, /*hint=*/right_loc);
                  auto chunk_left = first_sort_key.GetChunk<ArrayType>(left_loc);
                  auto chunk_right = first_sort_key.GetChunk<ArrayType>(right_loc);
                  const auto left_is_null = chunk_left.IsNull();
@@ -794,9 +794,9 @@ class TableSorter {
                [&](uint64_t left, uint64_t right) {
                  // First column is always null
                  left_loc =
-                     left_resolver_.ResolveWithChunkIndexHint(left, left_loc.chunk_index);
-                 right_loc = right_resolver_.ResolveWithChunkIndexHint(
-                     right, right_loc.chunk_index);
+                     left_resolver_.ResolveWithChunkIndexHint(left, /*hint=*/left_loc);
+                 right_loc =
+                     right_resolver_.ResolveWithChunkIndexHint(right, /*hint=*/right_loc);
                  return comparator.Compare(left_loc, right_loc, 1);
                });
     // Copy back temp area into main buffer
@@ -822,9 +822,9 @@ class TableSorter {
                [&](uint64_t left, uint64_t right) {
                  // Both values are never null nor NaN.
                  left_loc =
-                     left_resolver_.ResolveWithChunkIndexHint(left, left_loc.chunk_index);
-                 right_loc = right_resolver_.ResolveWithChunkIndexHint(
-                     right, right_loc.chunk_index);
+                     left_resolver_.ResolveWithChunkIndexHint(left, /*hint=*/left_loc);
+                 right_loc =
+                     right_resolver_.ResolveWithChunkIndexHint(right, /*hint=*/right_loc);
                  auto chunk_left = first_sort_key.GetChunk<ArrayType>(left_loc);
                  auto chunk_right = first_sort_key.GetChunk<ArrayType>(right_loc);
                  DCHECK(!chunk_left.IsNull());


### PR DESCRIPTION
### Rationale for this change

Less template-specialization without any loss in efficiency.

### What changes are included in this PR?

 - `ChunkedResolver` tweak
 - Explicitly declare copy constructors of `ChunkedResolver`
     - at the moment they are necessary because `ChunkedArrayResolver` is copied in compute kernel code
 - Make `ChunkedArrayResolver` re-use `ChunkResolver` via composition instead of inheritance
     - This will allow the `ChunkResolver` API to evolve in ways that might not make sense if it's a sub-class of `ChunkedArrayResolver`
 - Use `std::enable_if` instead of duplicating the `ResolvedChunk` implementation and template-specializing
 - Only specialize `ResolvedChunk::Value` on value-type-specific types preserving the same type-safety checks (static and runtime)

### Are these changes tested?

Yes, by existing tests.

### Are there any user-facing changes?

No, because these are API are under the internal namespace at the moment even though there are plans to make it public. These changes are preparation for that if we end up making them public.
* GitHub Issue: #40280