### PR TITLE
MINOR: [Python] Avoid failing pyarrow compute test on leap day

### DIFF
--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3214,8 +3214,7 @@ def test_list_element():
 
 
 def test_count_distinct():
-    seed = datetime.datetime.now()
-    samples = [seed.replace(year=y) for y in range(1992, 2092)]
+    samples = [datetime.datetime(year=y, month=1, day=1) for y in range(1992, 2092)]
     arr = pa.array(samples, pa.timestamp("ns"))
     assert pc.count_distinct(arr) == pa.scalar(len(samples), type=pa.int64())
 


### PR DESCRIPTION
### Rationale for this change

Avoid creation of invalid datetimes when it is Feb 29, avoiding to have to investigate every four years why a lot of tests are failing
