### PR TITLE
GH-40306: [C++] Fix a wrong total_bytes to generate StringType's test data in vector_hash_benchmark

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_hash_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_benchmark.cc
@@ -87,32 +87,23 @@ struct HashBenchCase {
   double null_probability;
 };
 
-template <typename Type>
+template <typename ArrowType>
 struct HashParams {
-  using T = typename Type::c_type;
-
+  using CType = typename TypeTraits<ArrowType>::CType;
   HashBenchCase params;
 
   void GenerateTestData(std::shared_ptr<Array>* arr) const {
-    std::vector<int64_t> draws;
-    std::vector<T> values;
-    std::vector<bool> is_valid;
-    randint<int64_t>(params.length, 0, params.num_unique, &draws);
-    for (int64_t draw : draws) {
-      values.push_back(static_cast<T>(draw));
-    }
-    if (params.null_probability > 0) {
-      random_is_valid(params.length, params.null_probability, &is_valid);
-      ArrayFromVector<Type, T>(is_valid, values, arr);
-    } else {
-      ArrayFromVector<Type, T>(values, arr);
-    }
+    random::RandomArrayGenerator rand(0);
+    auto min = static_cast<CType>(0);
+    auto max = static_cast<CType>(params.num_unique);
+
+    *arr = rand.Numeric<ArrowType>(params.length, min, max, params.null_probability);
   }
 
   void SetMetadata(benchmark::State& state) const {
     state.counters["null_percent"] = params.null_probability * 100;
     state.counters["num_unique"] = static_cast<double>(params.num_unique);
-    state.SetBytesProcessed(state.iterations() * params.length * sizeof(T));
+    state.SetBytesProcessed(state.iterations() * params.length * sizeof(CType));
     state.SetItemsProcessed(state.iterations() * params.length);
   }
 };
@@ -122,29 +113,10 @@ struct HashParams<StringType> {
   HashBenchCase params;
   int32_t byte_width;
   void GenerateTestData(std::shared_ptr<Array>* arr) const {
-    std::vector<int64_t> draws;
-    randint<int64_t>(params.length, 0, params.num_unique, &draws);
-
-    const int64_t total_bytes = this->byte_width * params.length;
-    std::vector<uint8_t> uniques(total_bytes);
-    const uint32_t seed = 0;
-    random_bytes(total_bytes, seed, uniques.data());
-
-    std::vector<bool> is_valid;
-    if (params.null_probability > 0) {
-      random_is_valid(params.length, params.null_probability, &is_valid);
-    }
-
-    StringBuilder builder;
-    for (int64_t i = 0; i < params.length; ++i) {
-      if (params.null_probability == 0 || is_valid[i]) {
-        ABORT_NOT_OK(builder.Append(uniques.data() + this->byte_width * draws[i],
-                                    this->byte_width));
-      } else {
-        ABORT_NOT_OK(builder.AppendNull());
-      }
-    }
-    ABORT_NOT_OK(builder.Finish(arr));
+    random::RandomArrayGenerator rnd(/*seed=*/0);
+    *arr = rnd.StringWithRepeats(
+        params.length, params.num_unique, /*min_length=*/this->byte_width,
+        /*max_length=*/this->byte_width, params.null_probability);
   }
 
   void SetMetadata(benchmark::State& state) const {

--- a/cpp/src/arrow/compute/kernels/vector_hash_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_benchmark.cc
@@ -125,7 +125,7 @@ struct HashParams<StringType> {
     std::vector<int64_t> draws;
     randint<int64_t>(params.length, 0, params.num_unique, &draws);
 
-    const int64_t total_bytes = this->byte_width * params.num_unique;
+    const int64_t total_bytes = this->byte_width * params.length;
     std::vector<uint8_t> uniques(total_bytes);
     const uint32_t seed = 0;
     random_bytes(total_bytes, seed, uniques.data());


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fix a wrong total_bytes to generate StringType's test data in vector_hash_benchmark
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Use  `params.length*byte_width` as the length of `std::vector<uint8_t> uniques` array.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40306