### PR TITLE
GH-40312: [Python] Add ListView documentation to user guide

### DIFF
--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -240,7 +240,9 @@ ListView arrays
    nested_arr = pa.array([[], None, [1, 2], [None, 1]], type=pa.list_view(pa.int64()))
    print(nested_arr.type)
 
-ListView arrays can specify out-of-order offsets when constructed from arrays:
+ListView arrays have a different set of buffers than List arrays. The ListView array
+has both an offsets and sizes buffer, while a List array only has an offsets buffer.
+This allows for ListView arrays to specify out-of-order offsets:
 
 .. ipython:: python
 
@@ -248,7 +250,7 @@ ListView arrays can specify out-of-order offsets when constructed from arrays:
    offsets = [4, 2, 0]
    sizes = [2, 2, 2]
    arr = pa.ListViewArray.from_arrays(offsets, sizes, values)
-   print(arr)
+   arr
 
 Struct arrays
 ~~~~~~~~~~~~~

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -230,6 +230,26 @@ like lists:
    nested_arr = pa.array([[], None, [1, 2], [None, 1]])
    print(nested_arr.type)
 
+ListView arrays
+~~~~~~~~~~~
+
+``pyarrow.array`` can create an alternate list type called ListView:
+
+.. ipython:: python
+
+   nested_arr = pa.array([[], None, [1, 2], [None, 1]], type=pa.list_view(pa.int64()))
+   print(nested_arr.type)
+
+ListView arrays can specify out-of-order offsets when constructed from arrays:
+
+.. ipython:: python
+
+   values = [1, 2, 3, 4, 5, 6]
+   offsets = [4, 2, 0]
+   sizes = [2, 2, 2]
+   arr = pa.ListViewArray.from_arrays(offsets, sizes, values)
+   print(arr)
+
 Struct arrays
 ~~~~~~~~~~~~~
 
@@ -240,7 +260,7 @@ dictionaries:
 
    pa.array([{'x': 1, 'y': True}, {'z': 3.4, 'x': 4}])
 
-Struct arrays can be initialized from a sequence of Python dicts or tuples. For tuples, 
+Struct arrays can be initialized from a sequence of Python dicts or tuples. For tuples,
 you must explicitly pass the type:
 
 .. ipython:: python
@@ -282,10 +302,10 @@ the type is explicitly passed into :meth:`array`:
    ty = pa.map_(pa.string(), pa.int64())
    pa.array(data, type=ty)
 
-MapArrays can also be constructed from offset, key, and item arrays. Offsets represent the 
+MapArrays can also be constructed from offset, key, and item arrays. Offsets represent the
 starting position of each map. Note that the :attr:`MapArray.keys` and :attr:`MapArray.items`
-properties give the *flattened* keys and items. To keep the keys and items associated to 
-their row, use the :meth:`ListArray.from_arrays` constructor with the 
+properties give the *flattened* keys and items. To keep the keys and items associated to
+their row, use the :meth:`ListArray.from_arrays` constructor with the
 :attr:`MapArray.offsets` property.
 
 .. ipython:: python


### PR DESCRIPTION
### Rationale for this change

Add documentation of the new ListView array type.

### What changes are included in this PR?

* Update the PyArrow data types documentation page

### Are these changes tested?

Yes, built docs locally and verified.

### Are there any user-facing changes?

No, unless you count documentation updates as user-facing.
* GitHub Issue: #40312