### PR TITLE
GH-40028: [C++][FS][Azure] Add AzureFileSystem support to FileSystemFromUri()

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -105,9 +105,6 @@ Result<AzureOptions> AzureOptions::FromUri(const arrow::internal::Uri& uri,
   }
   const auto account_key = uri.password();
 
-  if (container.empty()) {
-    return Status::Invalid("Missing container name in Azure Blob File System URI");
-  }
   if (out_path != nullptr) {
     *out_path = std::string(internal::ConcatAbstractPath(container, path));
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -109,19 +109,14 @@ Result<AzureOptions> AzureOptions::FromUri(const arrow::internal::Uri& uri,
     *out_path = std::string(internal::ConcatAbstractPath(container, path));
   }
 
-  std::unordered_map<std::string, std::string> options_map;
-  ARROW_ASSIGN_OR_RAISE(const auto options_items, uri.query_items());
-  for (const auto& kv : options_items) {
-    options_map.emplace(kv.first, kv.second);
-  }
-
   CredentialKind credential_kind = options.account_name.empty()
                                        ? CredentialKind::kAnonymous
                                        : CredentialKind::kDefault;
   std::string tenant_id;
   std::string client_id;
   std::string client_secret;
-  for (const auto& kv : options_map) {
+  ARROW_ASSIGN_OR_RAISE(const auto options_items, uri.query_items());
+  for (const auto& kv : options_items) {
     if (kv.first == "blob_storage_authority") {
       options.blob_storage_authority = kv.second;
     } else if (kv.first == "dfs_storage_authority") {

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -65,115 +65,162 @@ AzureOptions::AzureOptions() = default;
 
 AzureOptions::~AzureOptions() = default;
 
-Result<AzureOptions> AzureOptions::FromUri(const arrow::internal::Uri& uri,
-                                           std::string* out_path) {
-  AzureOptions options;
+void AzureOptions::ExtractFromUriSchemeAndHierPart(const arrow::internal::Uri& uri,
+                                                   std::string* out_path) {
   const auto host = uri.host();
-  std::string container;
   std::string path;
-  if (arrow::internal::EndsWith(host, options.blob_storage_authority)) {
-    options.account_name =
-        host.substr(0, host.size() - options.blob_storage_authority.size());
-    auto components = internal::SplitAbstractPath(uri.path());
-    if (!components.empty()) {
-      container = components[0];
-      path = internal::JoinAbstractPath(components.begin() + 1, components.end());
-    }
-  } else if (arrow::internal::EndsWith(host, options.dfs_storage_authority)) {
-    options.account_name =
-        host.substr(0, host.size() - options.dfs_storage_authority.size());
-    container = uri.username();
-    path = uri.path();
+  if (arrow::internal::EndsWith(host, blob_storage_authority)) {
+    account_name = host.substr(0, host.size() - blob_storage_authority.size());
+    path = internal::RemoveLeadingSlash(uri.path());
+  } else if (arrow::internal::EndsWith(host, dfs_storage_authority)) {
+    account_name = host.substr(0, host.size() - dfs_storage_authority.size());
+    path = internal::ConcatAbstractPath(uri.username(), uri.path());
   } else {
-    options.account_name = uri.username();
-    std::string host_port = host;
+    account_name = uri.username();
     const auto port_text = uri.port_text();
-    if (!port_text.empty()) {
-      host_port += ":" + port_text;
-    }
-    options.blob_storage_authority = host_port;
-    options.dfs_storage_authority = host_port;
-    if (uri.scheme() == "abfs") {
-      options.blob_storage_scheme = "http";
-      options.dfs_storage_scheme = "http";
-    }
-    auto components = internal::SplitAbstractPath(uri.path());
-    if (!components.empty()) {
-      container = components[0];
-      path = internal::JoinAbstractPath(components.begin() + 1, components.end());
+    if (host.find(".") == std::string::npos && port_text.empty()) {
+      // abfs://container/dir/file
+      path = internal::ConcatAbstractPath(host, uri.path());
+    } else {
+      // abfs://host.domain/container/dir/file
+      // abfs://host.domain:port/container/dir/file
+      // abfs://host:port/container/dir/file
+      std::string host_port = host;
+      if (!port_text.empty()) {
+        host_port += ":" + port_text;
+      }
+      blob_storage_authority = host_port;
+      dfs_storage_authority = host_port;
+      path = internal::RemoveLeadingSlash(uri.path());
     }
   }
-  const auto account_key = uri.password();
-
   if (out_path != nullptr) {
-    *out_path = std::string(internal::ConcatAbstractPath(container, path));
+    *out_path = path;
   }
+}
 
-  CredentialKind credential_kind = options.account_name.empty()
-                                       ? CredentialKind::kAnonymous
-                                       : CredentialKind::kDefault;
+Status AzureOptions::ExtractFromUriQuery(const arrow::internal::Uri& uri) {
+  const auto account_key = uri.password();
+  std::optional<CredentialKind> credential_kind;
+  std::optional<std::string> credential_kind_value;
   std::string tenant_id;
   std::string client_id;
   std::string client_secret;
   ARROW_ASSIGN_OR_RAISE(const auto options_items, uri.query_items());
   for (const auto& kv : options_items) {
     if (kv.first == "blob_storage_authority") {
-      options.blob_storage_authority = kv.second;
+      blob_storage_authority = kv.second;
     } else if (kv.first == "dfs_storage_authority") {
-      options.dfs_storage_authority = kv.second;
-    } else if (kv.first == "blob_storage_scheme") {
-      options.blob_storage_scheme = kv.second;
-    } else if (kv.first == "dfs_storage_scheme") {
-      options.dfs_storage_scheme = kv.second;
+      dfs_storage_authority = kv.second;
     } else if (kv.first == "credential_kind") {
       if (kv.second == "default") {
         credential_kind = CredentialKind::kDefault;
       } else if (kv.second == "anonymous") {
         credential_kind = CredentialKind::kAnonymous;
-      } else if (kv.second == "storage_shared_key") {
-        credential_kind = CredentialKind::kStorageSharedKey;
-      } else if (kv.second == "client_secret") {
-        credential_kind = CredentialKind::kClientSecret;
-      } else if (kv.second == "managed_identity") {
-        credential_kind = CredentialKind::kManagedIdentity;
       } else if (kv.second == "workload_identity") {
         credential_kind = CredentialKind::kWorkloadIdentity;
       } else {
+        // Other credential kinds should be inferred from the given
+        // parameters automatically.
         return Status::Invalid("Unexpected credential_kind: '", kv.second, "'");
       }
+      credential_kind_value = kv.second;
     } else if (kv.first == "tenant_id") {
       tenant_id = kv.second;
     } else if (kv.first == "client_id") {
       client_id = kv.second;
     } else if (kv.first == "client_secret") {
       client_secret = kv.second;
+    } else if (kv.first == "enable_tls") {
+      ARROW_ASSIGN_OR_RAISE(auto enable_tls, ::arrow::internal::ParseBoolean(kv.second));
+      if (enable_tls) {
+        blob_storage_scheme = "https";
+        dfs_storage_scheme = "https";
+      } else {
+        blob_storage_scheme = "http";
+        dfs_storage_scheme = "http";
+      }
     } else {
       return Status::Invalid(
           "Unexpected query parameter in Azure Blob File System URI: '", kv.first, "'");
     }
   }
 
-  switch (credential_kind) {
-    case CredentialKind::kDefault:
-      break;
-    case CredentialKind::kAnonymous:
-      RETURN_NOT_OK(options.ConfigureAnonymousCredential());
-      break;
-    case CredentialKind::kStorageSharedKey:
-      RETURN_NOT_OK(options.ConfigureAccountKeyCredential(account_key));
-      break;
-    case CredentialKind::kClientSecret:
-      RETURN_NOT_OK(
-          options.ConfigureClientSecretCredential(tenant_id, client_id, client_secret));
-      break;
-    case CredentialKind::kManagedIdentity:
-      RETURN_NOT_OK(options.ConfigureManagedIdentityCredential(client_id));
-      break;
-    case CredentialKind::kWorkloadIdentity:
-      RETURN_NOT_OK(options.ConfigureWorkloadIdentityCredential());
-      break;
-  }
+  if (credential_kind) {
+    if (!account_key.empty()) {
+      return Status::Invalid("Password must not be specified with credential_kind=",
+                             *credential_kind_value);
+    }
+    if (!tenant_id.empty()) {
+      return Status::Invalid("tenant_id must not be specified with credential_kind=",
+                             *credential_kind_value);
+    }
+    if (!client_id.empty()) {
+      return Status::Invalid("client_id must not be specified with credential_kind=",
+                             *credential_kind_value);
+    }
+    if (!client_secret.empty()) {
+      return Status::Invalid("client_secret must not be specified with credential_kind=",
+                             *credential_kind_value);
+    }
 
+    switch (*credential_kind) {
+      case CredentialKind::kAnonymous:
+        RETURN_NOT_OK(ConfigureAnonymousCredential());
+        break;
+      case CredentialKind::kWorkloadIdentity:
+        RETURN_NOT_OK(ConfigureWorkloadIdentityCredential());
+        break;
+      default:
+        // Default credential
+        break;
+    }
+  } else {
+    if (!account_key.empty()) {
+      // With password
+      if (!tenant_id.empty()) {
+        return Status::Invalid("tenant_id must not be specified with password");
+      }
+      if (!client_id.empty()) {
+        return Status::Invalid("client_id must not be specified with password");
+      }
+      if (!client_secret.empty()) {
+        return Status::Invalid("client_secret must not be specified with password");
+      }
+      RETURN_NOT_OK(ConfigureAccountKeyCredential(account_key));
+    } else {
+      // Without password
+      if (tenant_id.empty() && client_id.empty() && client_secret.empty()) {
+        // No related parameters
+        if (account_name.empty()) {
+          RETURN_NOT_OK(ConfigureAnonymousCredential());
+        } else {
+          // Default credential
+        }
+      } else {
+        // One or more tenant_id, client_id or client_secret are specified
+        if (client_id.empty()) {
+          return Status::Invalid("client_id must be specified");
+        }
+        if (tenant_id.empty() && client_secret.empty()) {
+          RETURN_NOT_OK(ConfigureManagedIdentityCredential(client_id));
+        } else if (!tenant_id.empty() && !client_secret.empty()) {
+          RETURN_NOT_OK(
+              ConfigureClientSecretCredential(tenant_id, client_id, client_secret));
+        } else {
+          return Status::Invalid("Both of tenant_id and client_secret must be specified");
+        }
+      }
+    }
+  }
+  return Status::OK();
+}
+
+Result<AzureOptions> AzureOptions::FromUri(const arrow::internal::Uri& uri,
+                                           std::string* out_path) {
+  AzureOptions options;
+  options.ExtractFromUriSchemeAndHierPart(uri, out_path);
+  RETURN_NOT_OK(options.ExtractFromUriQuery(uri));
   return options;
 }
 

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -136,10 +136,10 @@ struct ARROW_EXPORT AzureOptions {
   ///
   /// Supported formats:
   ///
-  /// 1. abfs[s]://[:<password>@]<account>.blob.core.windows.net[/<container>[/<path>]]
-  /// 2. abfs[s]://<container>[:<password>]@<account>.dfs.core.windows.net[/path]
-  /// 3. abfs[s]://[<account[:<password>]@]<host[.domain]>[<:port>][/<container>[/path]]
-  /// 4. abfs[s]://[<account[:<password>]@]<container>[/path]
+  /// 1. abfs[s]://[:\<password\>@]\<account\>.blob.core.windows.net[/\<container\>[/\<path\>]]
+  /// 2. abfs[s]://\<container\>[:\<password\>]@\<account\>.dfs.core.windows.net[/path]
+  /// 3. abfs[s]://[\<account[:\<password\>]@]\<host[.domain]\>[\<:port\>][/\<container\>[/path]]
+  /// 4. abfs[s]://[\<account[:\<password\>]@]\<container\>[/path]
   ///
   /// 1. and 2. are compatible with the Azure Data Lake Storage Gen2 URIs:
   /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -45,6 +45,7 @@ class DataLakeServiceClient;
 namespace arrow::fs {
 
 class TestAzureFileSystem;
+class TestAzureOptions;
 
 /// Options for the AzureFileSystem implementation.
 ///
@@ -59,6 +60,8 @@ class TestAzureFileSystem;
 ///
 /// Functions are provided for explicit configuration of credentials if that is preferred.
 struct ARROW_EXPORT AzureOptions {
+  friend class TestAzureOptions;
+
   /// \brief The name of the Azure Storage Account being accessed.
   ///
   /// All service URLs will be constructed using this storage account name.
@@ -122,6 +125,11 @@ struct ARROW_EXPORT AzureOptions {
  public:
   AzureOptions();
   ~AzureOptions();
+
+  /// Initialize from URIs such as "abfs://container/blog".
+  static Result<AzureOptions> FromUri(const arrow::internal::Uri& uri,
+                                      std::string* out_path);
+  static Result<AzureOptions> FromUri(const std::string& uri, std::string* out_path);
 
   Status ConfigureDefaultCredential();
   Status ConfigureAnonymousCredential();

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -136,9 +136,11 @@ struct ARROW_EXPORT AzureOptions {
   ///
   /// Supported formats:
   ///
-  /// 1. abfs[s]://[:\<password\>@]\<account\>.blob.core.windows.net[/\<container\>[/\<path\>]]
+  /// 1.
+  /// abfs[s]://[:\<password\>@]\<account\>.blob.core.windows.net[/\<container\>[/\<path\>]]
   /// 2. abfs[s]://\<container\>[:\<password\>]@\<account\>.dfs.core.windows.net[/path]
-  /// 3. abfs[s]://[\<account[:\<password\>]@]\<host[.domain]\>[\<:port\>][/\<container\>[/path]]
+  /// 3.
+  /// abfs[s]://[\<account[:\<password\>]@]\<host[.domain]\>[\<:port\>][/\<container\>[/path]]
   /// 4. abfs[s]://[\<account[:\<password\>]@]\<container\>[/path]
   ///
   /// 1. and 2. are compatible with the Azure Data Lake Storage Gen2 URIs:

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -136,11 +136,12 @@ struct ARROW_EXPORT AzureOptions {
   ///
   /// Supported formats:
   ///
-  /// 1.
-  /// abfs[s]://[:\<password\>@]\<account\>.blob.core.windows.net[/\<container\>[/\<path\>]]
-  /// 2. abfs[s]://\<container\>[:\<password\>]@\<account\>.dfs.core.windows.net[/path]
-  /// 3.
-  /// abfs[s]://[\<account[:\<password\>]@]\<host[.domain]\>[\<:port\>][/\<container\>[/path]]
+  /// 1. abfs[s]://[:\<password\>@]\<account\>.blob.core.windows.net
+  ///    [/\<container\>[/\<path\>]]
+  /// 2. abfs[s]://\<container\>[:\<password\>]@\<account\>.dfs.core.windows.net
+  ///     [/path]
+  /// 3. abfs[s]://[\<account[:\<password\>]@]\<host[.domain]\>[\<:port\>]
+  ///    [/\<container\>[/path]]
   /// 4. abfs[s]://[\<account[:\<password\>]@]\<container\>[/path]
   ///
   /// 1. and 2. are compatible with the Azure Data Lake Storage Gen2 URIs:

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -126,7 +126,9 @@ struct ARROW_EXPORT AzureOptions {
   AzureOptions();
   ~AzureOptions();
 
-  /// Initialize from URIs such as "abfs://container/blog".
+  /// Initialize from URIs such as
+  /// "abfs://account.blob.core.windows.net/container/dir/blob" and
+  /// "abfs://file_system@account.dfs.core.windows.net/dir/file".
   static Result<AzureOptions> FromUri(const arrow::internal::Uri& uri,
                                       std::string* out_path);
   static Result<AzureOptions> FromUri(const std::string& uri, std::string* out_path);

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -126,9 +126,52 @@ struct ARROW_EXPORT AzureOptions {
   AzureOptions();
   ~AzureOptions();
 
-  /// Initialize from URIs such as
-  /// "abfs://account.blob.core.windows.net/container/dir/blob" and
-  /// "abfs://file_system@account.dfs.core.windows.net/dir/file".
+ private:
+  void ExtractFromUriSchemeAndHierPart(const arrow::internal::Uri& uri,
+                                       std::string* out_path);
+  Status ExtractFromUriQuery(const arrow::internal::Uri& uri);
+
+ public:
+  /// \brief Construct a new AzureOptions from an URI.
+  ///
+  /// Supported formats:
+  ///
+  /// 1. abfs[s]://[:<password>@]<account>.blob.core.windows.net[/<container>[/<path>]]
+  /// 2. abfs[s]://<container>[:<password>]@<account>.dfs.core.windows.net[/path]
+  /// 3. abfs[s]://[<account[:<password>]@]<host[.domain]>[<:port>][/<container>[/path]]
+  /// 4. abfs[s]://[<account[:<password>]@]<container>[/path]
+  ///
+  /// 1. and 2. are compatible with the Azure Data Lake Storage Gen2 URIs:
+  /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri
+  ///
+  /// 3. is for Azure Blob Storage compatible service including Azurite.
+  ///
+  /// 4. is a shorter version of 1. and 2.
+  ///
+  /// Note that there is no difference between abfs and abfss. HTTPS is
+  /// used with abfs by default. You can force to use HTTP by specifying
+  /// "enable_tls=false" query.
+  ///
+  /// Supported query parameters:
+  ///
+  /// * blob_storage_authority: Set AzureOptions::blob_storage_authority
+  /// * dfs_storage_authority: Set AzureOptions::dfs_storage_authority
+  /// * enable_tls: If it's "false" or "0", HTTP not HTTPS is used.
+  /// * credential_kind: One of "default", "anonymous",
+  ///   "workload_identity". If "default" is specified, it's just
+  ///   ignored.  If "anonymous" is specified,
+  ///   AzureOptions::ConfigureAnonymousCredential() is called. If
+  ///   "workload_identity" is specified,
+  ///   AzureOptions::ConfigureWorkloadIdentityCredential() is called.
+  /// * tenant_id: You must specify "client_id" and "client_secret"
+  ///   too. AzureOptions::ConfigureClientSecretCredential() is called.
+  /// * client_id: If you don't specify "tenant_id" and
+  ///   "client_secret",
+  ///   AzureOptions::ConfigureManagedIdentityCredential() is
+  ///   called. If you specify "tenant_id" and "client_secret" too,
+  ///   AzureOptions::ConfigureClientSecretCredential() is called.
+  /// * client_secret: You must specify "tenant_id" and "client_id"
+  ///   too. AzureOptions::ConfigureClientSecretCredential() is called.
   static Result<AzureOptions> FromUri(const arrow::internal::Uri& uri,
                                       std::string* out_path);
   static Result<AzureOptions> FromUri(const std::string& uri, std::string* out_path);

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -354,11 +354,6 @@ class TestAzureOptions : public ::testing::Test {
     ASSERT_EQ(path, "container/dir/blob");
   }
 
-  void TestFromUriBlobStorageEmptyContainer() {
-    ASSERT_RAISES(
-        Invalid, AzureOptions::FromUri("abfs://account.blob.core.windows.net/", nullptr));
-  }
-
   void TestFromUriDfsStorage() {
     AzureOptions default_options;
     std::string path;
@@ -375,11 +370,6 @@ class TestAzureOptions : public ::testing::Test {
     ASSERT_EQ(path, "file_system/dir/file");
   }
 
-  void TestFromUriDfsStorageEmptyContainer() {
-    ASSERT_RAISES(Invalid, AzureOptions::FromUri(
-                               "abfs://account.dfs.core.windows.net/dir/file", nullptr));
-  }
-
   void TestFromUriAbfs() {
     std::string path;
     ASSERT_OK_AND_ASSIGN(
@@ -393,11 +383,6 @@ class TestAzureOptions : public ::testing::Test {
     ASSERT_EQ(options.dfs_storage_scheme, "http");
     ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kDefault);
     ASSERT_EQ(path, "container/dir/blob");
-  }
-
-  void TestFromUriAbfsEmptyContainer() {
-    ASSERT_RAISES(Invalid, AzureOptions::FromUri(
-                               "abfs://account:password@127.0.0.1:10000/", nullptr));
   }
 
   void TestFromUriAbfss() {
@@ -524,15 +509,8 @@ class TestAzureOptions : public ::testing::Test {
 };
 
 TEST_F(TestAzureOptions, FromUriBlobStorage) { TestFromUriBlobStorage(); }
-TEST_F(TestAzureOptions, FromUriBlobStorageEmptyContainer) {
-  TestFromUriBlobStorageEmptyContainer();
-}
 TEST_F(TestAzureOptions, FromUriDfsStorage) { TestFromUriDfsStorage(); }
-TEST_F(TestAzureOptions, FromUriDfsStorageEmptyContainer) {
-  TestFromUriDfsStorageEmptyContainer();
-}
 TEST_F(TestAzureOptions, FromUriAbfs) { TestFromUriAbfs(); }
-TEST_F(TestAzureOptions, FromUriAbfsEmptyContainer) { TestFromUriAbfsEmptyContainer(); }
 TEST_F(TestAzureOptions, FromUriAbfss) { TestFromUriAbfss(); }
 TEST_F(TestAzureOptions, FromUriCredentialDefault) { TestFromUriCredentialDefault(); }
 TEST_F(TestAzureOptions, FromUriCredentialAnonymous) { TestFromUriCredentialAnonymous(); }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -336,6 +336,229 @@ TEST(AzureFileSystem, OptionsCompare) {
   EXPECT_TRUE(options.Equals(options));
 }
 
+class TestAzureOptions : public ::testing::Test {
+ public:
+  void TestFromUriBlobStorage() {
+    AzureOptions default_options;
+    std::string path;
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob",
+                              &path));
+    ASSERT_EQ(options.account_name, "account");
+    ASSERT_EQ(options.blob_storage_authority, default_options.blob_storage_authority);
+    ASSERT_EQ(options.dfs_storage_authority, default_options.dfs_storage_authority);
+    ASSERT_EQ(options.blob_storage_scheme, default_options.blob_storage_scheme);
+    ASSERT_EQ(options.dfs_storage_scheme, default_options.dfs_storage_scheme);
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kDefault);
+    ASSERT_EQ(path, "container/dir/blob");
+  }
+
+  void TestFromUriBlobStorageEmptyContainer() {
+    ASSERT_RAISES(
+        Invalid, AzureOptions::FromUri("abfs://account.blob.core.windows.net/", nullptr));
+  }
+
+  void TestFromUriDfsStorage() {
+    AzureOptions default_options;
+    std::string path;
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://file_system@account.dfs.core.windows.net/dir/file",
+                              &path));
+    ASSERT_EQ(options.account_name, "account");
+    ASSERT_EQ(options.blob_storage_authority, default_options.blob_storage_authority);
+    ASSERT_EQ(options.dfs_storage_authority, default_options.dfs_storage_authority);
+    ASSERT_EQ(options.blob_storage_scheme, default_options.blob_storage_scheme);
+    ASSERT_EQ(options.dfs_storage_scheme, default_options.dfs_storage_scheme);
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kDefault);
+    ASSERT_EQ(path, "file_system/dir/file");
+  }
+
+  void TestFromUriDfsStorageEmptyContainer() {
+    ASSERT_RAISES(Invalid, AzureOptions::FromUri(
+                               "abfs://account.dfs.core.windows.net/dir/file", nullptr));
+  }
+
+  void TestFromUriAbfs() {
+    std::string path;
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri(
+            "abfs://account:password@127.0.0.1:10000/container/dir/blob", &path));
+    ASSERT_EQ(options.account_name, "account");
+    ASSERT_EQ(options.blob_storage_authority, "127.0.0.1:10000");
+    ASSERT_EQ(options.dfs_storage_authority, "127.0.0.1:10000");
+    ASSERT_EQ(options.blob_storage_scheme, "http");
+    ASSERT_EQ(options.dfs_storage_scheme, "http");
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kDefault);
+    ASSERT_EQ(path, "container/dir/blob");
+  }
+
+  void TestFromUriAbfsEmptyContainer() {
+    ASSERT_RAISES(Invalid, AzureOptions::FromUri(
+                               "abfs://account:password@127.0.0.1:10000/", nullptr));
+  }
+
+  void TestFromUriAbfss() {
+    std::string path;
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri(
+            "abfss://account:password@127.0.0.1:10000/container/dir/blob", &path));
+    ASSERT_EQ(options.account_name, "account");
+    ASSERT_EQ(options.blob_storage_authority, "127.0.0.1:10000");
+    ASSERT_EQ(options.dfs_storage_authority, "127.0.0.1:10000");
+    ASSERT_EQ(options.blob_storage_scheme, "https");
+    ASSERT_EQ(options.dfs_storage_scheme, "https");
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kDefault);
+    ASSERT_EQ(path, "container/dir/blob");
+  }
+
+  void TestFromUriCredentialDefault() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "credential_kind=default",
+                              nullptr));
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kDefault);
+  }
+
+  void TestFromUriCredentialAnonymous() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "credential_kind=anonymous",
+                              nullptr));
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kAnonymous);
+  }
+
+  void TestFromUriCredentialStorageSharedKey() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "credential_kind=storage_shared_key",
+                              nullptr));
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kStorageSharedKey);
+  }
+
+  void TestFromUriCredentialClientSecret() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "credential_kind=client_secret&"
+                              "tenant_id=tenant-id&"
+                              "client_id=client-id&"
+                              "client_secret=client-secret",
+                              nullptr));
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kClientSecret);
+  }
+
+  void TestFromUriCredentialManagedIdentity() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "credential_kind=managed_identity&"
+                              "client_id=client-id",
+                              nullptr));
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kManagedIdentity);
+  }
+
+  void TestFromUriCredentialWorkloadIdentity() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "credential_kind=workload_identity",
+                              nullptr));
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kWorkloadIdentity);
+  }
+
+  void TestFromUriCredentialInvalid() {
+    ASSERT_RAISES(Invalid, AzureOptions::FromUri(
+                               "abfs://file_system@account.dfs.core.windows.net/dir/file?"
+                               "credential_kind=invalid",
+                               nullptr));
+  }
+  void TestFromUriBlobStorageAuthority() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "blob_storage_authority=.blob.local",
+                              nullptr));
+    ASSERT_EQ(options.blob_storage_authority, ".blob.local");
+  }
+
+  void TestFromUriDfsStorageAuthority() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://file_system@account.dfs.core.windows.net/dir/file?"
+                              "dfs_storage_authority=.dfs.local",
+                              nullptr));
+    ASSERT_EQ(options.dfs_storage_authority, ".dfs.local");
+  }
+
+  void TestFromUriBlobStorageScheme() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://account.blob.core.windows.net/container/dir/blob?"
+                              "blob_storage_scheme=http",
+                              nullptr));
+    ASSERT_EQ(options.blob_storage_scheme, "http");
+  }
+
+  void TestFromUriDfsStorageScheme() {
+    ASSERT_OK_AND_ASSIGN(
+        auto options,
+        AzureOptions::FromUri("abfs://file_system@account.dfs.core.windows.net/dir/file?"
+                              "dfs_storage_scheme=http",
+                              nullptr));
+    ASSERT_EQ(options.dfs_storage_scheme, "http");
+  }
+
+  void TestFromUriInvalidQueryParameter() {
+    ASSERT_RAISES(Invalid, AzureOptions::FromUri(
+                               "abfs://file_system@account.dfs.core.windows.net/dir/file?"
+                               "unknown=invalid",
+                               nullptr));
+  }
+};
+
+TEST_F(TestAzureOptions, FromUriBlobStorage) { TestFromUriBlobStorage(); }
+TEST_F(TestAzureOptions, FromUriBlobStorageEmptyContainer) {
+  TestFromUriBlobStorageEmptyContainer();
+}
+TEST_F(TestAzureOptions, FromUriDfsStorage) { TestFromUriDfsStorage(); }
+TEST_F(TestAzureOptions, FromUriDfsStorageEmptyContainer) {
+  TestFromUriDfsStorageEmptyContainer();
+}
+TEST_F(TestAzureOptions, FromUriAbfs) { TestFromUriAbfs(); }
+TEST_F(TestAzureOptions, FromUriAbfsEmptyContainer) { TestFromUriAbfsEmptyContainer(); }
+TEST_F(TestAzureOptions, FromUriAbfss) { TestFromUriAbfss(); }
+TEST_F(TestAzureOptions, FromUriCredentialDefault) { TestFromUriCredentialDefault(); }
+TEST_F(TestAzureOptions, FromUriCredentialAnonymous) { TestFromUriCredentialAnonymous(); }
+TEST_F(TestAzureOptions, FromUriCredentialStorageSharedKey) {
+  TestFromUriCredentialStorageSharedKey();
+}
+TEST_F(TestAzureOptions, FromUriCredentialClientSecret) {
+  TestFromUriCredentialClientSecret();
+}
+TEST_F(TestAzureOptions, FromUriCredentialManagedIdentity) {
+  TestFromUriCredentialManagedIdentity();
+}
+TEST_F(TestAzureOptions, FromUriCredentialWorkloadIdentity) {
+  TestFromUriCredentialWorkloadIdentity();
+}
+TEST_F(TestAzureOptions, FromUriCredentialInvalid) { TestFromUriCredentialInvalid(); }
+TEST_F(TestAzureOptions, FromUriBlobStorageAuthority) {
+  TestFromUriBlobStorageAuthority();
+}
+TEST_F(TestAzureOptions, FromUriDfsStorageAuthority) { TestFromUriDfsStorageAuthority(); }
+TEST_F(TestAzureOptions, FromUriBlobStorageScheme) { TestFromUriBlobStorageScheme(); }
+TEST_F(TestAzureOptions, FromUriDfsStorageScheme) { TestFromUriDfsStorageScheme(); }
+TEST_F(TestAzureOptions, FromUriInvalidQueryParameter) {
+  TestFromUriInvalidQueryParameter();
+}
+
 struct PreexistingData {
  public:
   using RNG = random::pcg32_fast;

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -693,6 +693,11 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriReal(const Uri& uri,
     }
     return std::make_shared<LocalFileSystem>(options, io_context);
   }
+  /// "abfs" and "abfss" schemes are taken from
+  /// the Azure Data Lake Storage Gen2 URI:
+  /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri
+  ///
+  /// abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>/<file_name>
   if (scheme == "abfs" || scheme == "abfss") {
 #ifdef ARROW_AZURE
     ARROW_ASSIGN_OR_RAISE(auto options, AzureOptions::FromUri(uri, out_path));

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -693,11 +693,6 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriReal(const Uri& uri,
     }
     return std::make_shared<LocalFileSystem>(options, io_context);
   }
-  /// "abfs" and "abfss" schemes are taken from
-  /// the Azure Data Lake Storage Gen2 URI:
-  /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri
-  ///
-  /// abfs[s]://<file_system>@<account_name>.dfs.core.windows.net/<path>/<file_name>
   if (scheme == "abfs" || scheme == "abfss") {
 #ifdef ARROW_AZURE
     ARROW_ASSIGN_OR_RAISE(auto options, AzureOptions::FromUri(uri, out_path));


### PR DESCRIPTION
### Rationale for this change

`FileSystemFromUri()` is a common API to create a file system object. `FileSystemFromUri()` should be able to create an `AzureFileSystem` object.

### What changes are included in this PR?

Add `AzureOptions::FromUri()` and use it from `FileSystemFromUri()`.

See the `AzureOptions::FromUri()`'s docstring about the supported formats.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40028