### PR TITLE
GH-40327: [C++][Parquet] Add missing config.h include in key_management_test.cc

### DIFF
--- a/cpp/src/parquet/encryption/key_management_test.cc
+++ b/cpp/src/parquet/encryption/key_management_test.cc
@@ -22,9 +22,9 @@
 #include <thread>
 #include <unordered_map>
 
-#include "arrow/io/file.h"
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/filesystem/localfs.h"
+#include "arrow/io/file.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"

--- a/cpp/src/parquet/encryption/key_management_test.cc
+++ b/cpp/src/parquet/encryption/key_management_test.cc
@@ -22,12 +22,13 @@
 #include <thread>
 #include <unordered_map>
 
-#include <arrow/io/file.h>
+#include "arrow/io/file.h"
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/filesystem/localfs.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
+#include "arrow/util/config.h"
 #include "arrow/util/logging.h"
 
 #include "parquet/encryption/crypto_factory.h"


### PR DESCRIPTION
### Rationale for this change

We need it for `ARROW_WITH_SNAPPY` and `ARROW_ENABLE_THREADING` definitions.

### What changes are included in this PR?

Add missing `#include "arrow/util/config.h"`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40327