### PR TITLE
GH-40334: [C++][Gandiva] Add missing OpenSSL dependency to encrypt_utils_test.cc

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -269,7 +269,8 @@ add_gandiva_test(internals-test
                  interval_holder_test.cc
                  tests/test_util.cc
                  EXTRA_LINK_LIBS
-                 re2::re2)
+                 re2::re2
+                 ${GANDIVA_OPENSSL_LIBS})
 
 add_subdirectory(precompiled)
 add_subdirectory(tests)


### PR DESCRIPTION
### Rationale for this change

The OpenSSL library (`${GANDIVA_OPENSSL_LIBS}`) is needed for `cpp/src/gandiva/encrypt_utils_test.cc`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Add OpenSSL dependency to `cpp/src/gandiva/encrypt_utils_test.cc`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. I did a build test for Gandiva.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40334