### PR TITLE
GH-40273: [Python] Support construction of Run-End Encoded arrays in pa.array(..)

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -118,6 +118,13 @@ def _handle_arrow_array_protocol(obj, type, mask, size):
     return res
 
 
+def _handle_run_end_encoded_arrays(obj, type):
+    from pyarrow.compute import run_end_encode
+    ree_arr = run_end_encode(obj)
+    return RunEndEncodedArray.from_arrays(
+        ree_arr.run_ends.to_pylist(), ree_arr.values.to_pylist(), type)
+
+
 def array(object obj, type=None, mask=None, size=None, from_pandas=None,
           bint safe=True, MemoryPool memory_pool=None):
     """
@@ -339,10 +346,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
             if type and type.id == _Type_RUN_END_ENCODED:
                 if mask is not None:
                     raise ValueError("Cannot pass a mask for Run-End Encoded arrays.")
-                from pyarrow.compute import run_end_encode
-                ree_arr = run_end_encode(obj)
-                result = RunEndEncodedArray.from_arrays(
-                    ree_arr.run_ends.to_pylist(), ree_arr.values.to_pylist(), type)
+                result = _handle_run_end_encoded_arrays(obj, type)
             else:
                 result = _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                            pool)
@@ -350,10 +354,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         if type and type.id == _Type_RUN_END_ENCODED:
             if mask is not None:
                 raise ValueError("Cannot pass a mask for Run-End Encoded arrays.")
-            from pyarrow.compute import run_end_encode
-            ree_arr = run_end_encode(obj)
-            result = RunEndEncodedArray.from_arrays(
-                ree_arr.run_ends.to_pylist(), ree_arr.values.to_pylist(), type)
+            result = _handle_run_end_encoded_arrays(obj, type)
         # ConvertPySequence does strict conversion if type is explicitly passed
         else:
             result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -339,7 +339,8 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
             if type and type.id == _Type_RUN_END_ENCODED:
                 arr = _ndarray_to_array(
                     values, mask, type.value_type, c_from_pandas, safe, pool)
-                result = _pc().run_end_encode(arr, run_end_type=type.run_end_type)
+                result = _pc().run_end_encode(arr, run_end_type=type.run_end_type,
+                                              memory_pool=pool)
             else:
                 result = _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                            pool)
@@ -347,7 +348,8 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         if type and type.id == _Type_RUN_END_ENCODED:
             arr = _sequence_to_array(
                 obj, mask, size, type.value_type, pool, from_pandas)
-            result = _pc().run_end_encode(arr, run_end_type=type.run_end_type)
+            result = _pc().run_end_encode(arr, run_end_type=type.run_end_type,
+                                          memory_pool=pool)
         # ConvertPySequence does strict conversion if type is explicitly passed
         else:
             result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -339,8 +339,12 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
             result = _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                        pool)
     else:
+        if type and type.id == _Type_RUN_END_ENCODED:
+            from pyarrow.compute import run_end_encode
+            result = run_end_encode(obj)
         # ConvertPySequence does strict conversion if type is explicitly passed
-        result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)
+        else:
+            result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)
 
     if extension_type is not None:
         result = ExtensionArray.from_storage(extension_type, result)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -340,7 +340,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 arr = _ndarray_to_array(
                     values, mask, type.value_type, c_from_pandas, safe, pool)
                 result = _pc().run_end_encode(arr, run_end_type=type.run_end_type,
-                                              memory_pool=pool)
+                                              memory_pool=memory_pool)
             else:
                 result = _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                            pool)
@@ -349,7 +349,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
             arr = _sequence_to_array(
                 obj, mask, size, type.value_type, pool, from_pandas)
             result = _pc().run_end_encode(arr, run_end_type=type.run_end_type,
-                                          memory_pool=pool)
+                                          memory_pool=memory_pool)
         # ConvertPySequence does strict conversion if type is explicitly passed
         else:
             result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -21,8 +21,6 @@ import os
 import warnings
 from cython import sizeof
 
-from pyarrow.compute import run_end_encode
-
 
 cdef _sequence_to_array(object sequence, object mask, object size,
                         DataType type, CMemoryPool* pool, c_bool from_pandas):
@@ -341,7 +339,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
             if type and type.id == _Type_RUN_END_ENCODED:
                 arr = _ndarray_to_array(
                     values, mask, type.value_type, c_from_pandas, safe, pool)
-                result = run_end_encode(arr, run_end_type=type.run_end_type)
+                result = _pc().run_end_encode(arr, run_end_type=type.run_end_type)
             else:
                 result = _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                            pool)
@@ -349,7 +347,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         if type and type.id == _Type_RUN_END_ENCODED:
             arr = _sequence_to_array(
                 obj, mask, size, type.value_type, pool, from_pandas)
-            result = run_end_encode(arr, run_end_type=type.run_end_type)
+            result = _pc().run_end_encode(arr, run_end_type=type.run_end_type)
         # ConvertPySequence does strict conversion if type is explicitly passed
         else:
             result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -118,11 +118,12 @@ def _handle_arrow_array_protocol(obj, type, mask, size):
     return res
 
 
-def _handle_run_end_encoded_arrays(obj, type):
+cdef _handle_run_end_encoded_arrays(object sequence, object mask, object size,
+                                    DataType type, CMemoryPool* pool,
+                                    c_bool from_pandas):
     from pyarrow.compute import run_end_encode
-    ree_arr = run_end_encode(obj)
-    return RunEndEncodedArray.from_arrays(
-        ree_arr.run_ends.to_pylist(), ree_arr.values.to_pylist(), type)
+    arr = _sequence_to_array(sequence, mask, size, type.value_type, pool, from_pandas)
+    return run_end_encode(arr, run_end_type=type.run_end_type)
 
 
 def array(object obj, type=None, mask=None, size=None, from_pandas=None,
@@ -344,17 +345,15 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 values, type = pandas_api.compat.get_datetimetz_type(
                     values, obj.dtype, type)
             if type and type.id == _Type_RUN_END_ENCODED:
-                if mask is not None:
-                    raise ValueError("Cannot pass a mask for Run-End Encoded arrays.")
-                result = _handle_run_end_encoded_arrays(obj, type)
+                result = _handle_run_end_encoded_arrays(obj, mask, size, type,
+                                                        pool, c_from_pandas)
             else:
                 result = _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                            pool)
     else:
         if type and type.id == _Type_RUN_END_ENCODED:
-            if mask is not None:
-                raise ValueError("Cannot pass a mask for Run-End Encoded arrays.")
-            result = _handle_run_end_encoded_arrays(obj, type)
+            result = _handle_run_end_encoded_arrays(obj, mask, size, type, pool,
+                                                    c_from_pandas)
         # ConvertPySequence does strict conversion if type is explicitly passed
         else:
             result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3605,10 +3605,14 @@ def test_run_end_encoded_from_array_with_type():
     assert result.run_ends.equals(run_ends)
     assert result.values.equals(values)
 
-    mask = pa.array([False, True, False, True, False])
-    msg = "Cannot pass a mask for Run-End Encoded arrays."
-    with pytest.raises(ValueError, match=msg):
-        pa.array(arr, type=ree_type, mask=mask)
+    mask = pa.array([False, False, False, True, False, True])
+    result = pa.array(arr, type=ree_type, mask=mask)
+
+    run_ends = pa.array([1, 3, 4, 5, 6], type=pa.int32())
+    values = pa.array([1, 2, None, 3, None], type=pa.int64())
+
+    assert result.run_ends.equals(run_ends)
+    assert result.values.equals(values)
 
 
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3580,15 +3580,35 @@ def test_run_end_encoded_from_buffers():
 
 
 def test_run_end_encoded_from_array_with_type():
-    arr = [1, 2, 2, 3, 3, 3]
     run_ends = pa.array([1, 3, 6], type=pa.int32())
     values = pa.array([1, 2, 3], type=pa.int64())
 
     ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
+
+    arr = [1, 2, 2, 3, 3, 3]
     result = pa.array(arr, type=ree_type)
 
     assert result.run_ends.equals(run_ends)
     assert result.values.equals(values)
+
+    result = pa.array(np.array(arr), type=ree_type)
+
+    assert result.run_ends.equals(run_ends)
+    assert result.values.equals(values)
+
+    arr = [1, 2, 2, 3, 3, None]
+    result = pa.array(arr, type=ree_type)
+
+    run_ends = pa.array([1, 3, 5, 6], type=pa.int32())
+    values = pa.array([1, 2, 3, None], type=pa.int64())
+
+    assert result.run_ends.equals(run_ends)
+    assert result.values.equals(values)
+
+    mask = pa.array([False, True, False, True, False])
+    msg = "Cannot pass a mask for Run-End Encoded arrays."
+    with pytest.raises(ValueError, match=msg):
+        pa.array(arr, type=ree_type, mask=mask)
 
 
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3582,37 +3582,42 @@ def test_run_end_encoded_from_buffers():
 def test_run_end_encoded_from_array_with_type():
     run_ends = pa.array([1, 3, 6], type=pa.int32())
     values = pa.array([1, 2, 3], type=pa.int64())
-
     ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
+    expected = pa.RunEndEncodedArray.from_arrays(run_ends, values,
+                                                 ree_type)
 
     arr = [1, 2, 2, 3, 3, 3]
+    result = pa.array(arr)
+    assert result.equals(expected)
     result = pa.array(arr, type=ree_type)
-
-    assert result.run_ends.equals(run_ends)
-    assert result.values.equals(values)
-
+    assert result.equals(expected)
     result = pa.array(np.array(arr), type=ree_type)
+    assert result.equals(expected)
 
-    assert result.run_ends.equals(run_ends)
-    assert result.values.equals(values)
-
-    arr = [1, 2, 2, 3, 3, None]
-    result = pa.array(arr, type=ree_type)
+    ree_type_2 = pa.run_end_encoded(pa.int16(), pa.float32())
+    result = pa.array(arr, type=ree_type_2)
+    assert not result.equals(expected)
+    expected_2 = pa.RunEndEncodedArray.from_arrays(run_ends, values,
+                                                   ree_type_2)
+    assert result.equals(expected_2)
 
     run_ends = pa.array([1, 3, 5, 6], type=pa.int32())
     values = pa.array([1, 2, 3, None], type=pa.int64())
+    expected = pa.RunEndEncodedArray.from_arrays(run_ends, values,
+                                                 ree_type)
 
-    assert result.run_ends.equals(run_ends)
-    assert result.values.equals(values)
-
-    mask = pa.array([False, False, False, True, False, True])
-    result = pa.array(arr, type=ree_type, mask=mask)
+    arr = [1, 2, 2, 3, 3, None]
+    result = pa.array(arr, type=ree_type)
+    assert result.equals(expected)
 
     run_ends = pa.array([1, 3, 4, 5, 6], type=pa.int32())
     values = pa.array([1, 2, None, 3, None], type=pa.int64())
+    expected = pa.RunEndEncodedArray.from_arrays(run_ends, values,
+                                                 ree_type)
 
-    assert result.run_ends.equals(run_ends)
-    assert result.values.equals(values)
+    mask = pa.array([False, False, False, True, False, True])
+    result = pa.array(arr, type=ree_type, mask=mask)
+    assert result.equals(expected)
 
 
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3579,6 +3579,18 @@ def test_run_end_encoded_from_buffers():
                                            1, offset, children)
 
 
+def test_run_end_encoded_from_array_with_type():
+    arr = [1, 2, 2, 3, 3, 3]
+    run_ends = pa.array([1, 3, 6], type=pa.int32())
+    values = pa.array([1, 2, 3], type=pa.int64())
+
+    ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
+    result = pa.array(arr, type=ree_type)
+
+    assert result.run_ends.equals(run_ends)
+    assert result.values.equals(values)
+
+
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),
                          [(pa.ListViewArray, pa.list_view),
                           (pa.LargeListViewArray, pa.large_list_view)])

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3587,8 +3587,6 @@ def test_run_end_encoded_from_array_with_type():
                                                  ree_type)
 
     arr = [1, 2, 2, 3, 3, 3]
-    result = pa.array(arr)
-    assert result.equals(expected)
     result = pa.array(arr, type=ree_type)
     assert result.equals(expected)
     result = pa.array(np.array(arr), type=ree_type)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3580,8 +3580,8 @@ def test_run_end_encoded_from_buffers():
 
 
 def test_run_end_encoded_from_array_with_type():
-    run_ends = pa.array([1, 3, 6], type=pa.int32())
-    values = pa.array([1, 2, 3], type=pa.int64())
+    run_ends = [1, 3, 6]
+    values = [1, 2, 3]
     ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
     expected = pa.RunEndEncodedArray.from_arrays(run_ends, values,
                                                  ree_type)
@@ -3601,8 +3601,8 @@ def test_run_end_encoded_from_array_with_type():
                                                    ree_type_2)
     assert result.equals(expected_2)
 
-    run_ends = pa.array([1, 3, 5, 6], type=pa.int32())
-    values = pa.array([1, 2, 3, None], type=pa.int64())
+    run_ends = [1, 3, 5, 6]
+    values = [1, 2, 3, None]
     expected = pa.RunEndEncodedArray.from_arrays(run_ends, values,
                                                  ree_type)
 
@@ -3610,8 +3610,8 @@ def test_run_end_encoded_from_array_with_type():
     result = pa.array(arr, type=ree_type)
     assert result.equals(expected)
 
-    run_ends = pa.array([1, 3, 4, 5, 6], type=pa.int32())
-    values = pa.array([1, 2, None, 3, None], type=pa.int64())
+    run_ends = [1, 3, 4, 5, 6]
+    values = [1, 2, None, 3, None]
     expected = pa.RunEndEncodedArray.from_arrays(run_ends, values,
                                                  ree_type)
 


### PR DESCRIPTION
### Rationale for this change

We want to enable the construction of a Run-End Encoded arrays with `pyarrow.array `constructor

### What changes are included in this PR?

Added a check for Run-End Encoded Type in the `pyarrow.array` constructor code.

### Are these changes tested?

Yes, added test_run_end_encoded_from_array_with_type.

### Are there any user-facing changes?

No.
* GitHub Issue: #40273