### PR TITLE
GH-40342: [C++] move LocalFileSystem to the registry

### DIFF
--- a/cpp/examples/arrow/filesystem_definition_example.cc
+++ b/cpp/examples/arrow/filesystem_definition_example.cc
@@ -16,7 +16,10 @@
 // under the License.
 
 #include <arrow/filesystem/filesystem.h>
+<<<<<<< HEAD
 #include <arrow/filesystem/filesystem_library.h>
+=======
+>>>>>>> e447cfaac (GH-38309: [C++] build filesystems as separate modules)
 #include <arrow/io/memory.h>
 #include <arrow/result.h>
 #include <arrow/util/uri.h>

--- a/cpp/examples/arrow/filesystem_definition_example.cc
+++ b/cpp/examples/arrow/filesystem_definition_example.cc
@@ -16,10 +16,7 @@
 // under the License.
 
 #include <arrow/filesystem/filesystem.h>
-<<<<<<< HEAD
 #include <arrow/filesystem/filesystem_library.h>
-=======
->>>>>>> e447cfaac (GH-38309: [C++] build filesystems as separate modules)
 #include <arrow/io/memory.h>
 #include <arrow/result.h>
 #include <arrow/util/uri.h>
@@ -141,7 +138,7 @@ class ExampleFileSystem : public fs::FileSystem {
   }
 };
 
-fs::FileSystemRegistrar kExampleFileSystemModule{
+auto kExampleFileSystemModule = ARROW_REGISTER_FILESYSTEM(
     "example",
     [](const arrow::util::Uri& uri, const io::IOContext& io_context,
        std::string* out_path) -> Result<std::shared_ptr<fs::FileSystem>> {
@@ -151,4 +148,4 @@ fs::FileSystemRegistrar kExampleFileSystemModule{
       }
       return fs;
     },
-};
+    {});

--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -28,7 +28,9 @@ add_arrow_test(filesystem-test
                EXTRA_LABELS
                filesystem
                DEFINITIONS
-               ARROW_FILESYSTEM_EXAMPLE_LIBPATH="$<TARGET_FILE:arrow_filesystem_example>")
+               ARROW_FILESYSTEM_EXAMPLE_LIBPATH="$<TARGET_FILE:arrow_filesystem_example>"
+               EXTRA_DEPENDENCIES
+               arrow_filesystem_example)
 
 if(ARROW_BUILD_BENCHMARKS)
   add_arrow_benchmark(localfs_benchmark

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -56,16 +56,13 @@
 #include "arrow/util/visibility.h"
 #include "arrow/util/windows_fixup.h"
 
-namespace arrow {
+namespace arrow::fs {
 
-using internal::checked_pointer_cast;
-using internal::TaskHints;
-using io::internal::SubmitIO;
-using util::Uri;
-
-namespace fs {
-
+using arrow::internal::checked_pointer_cast;
 using arrow::internal::GetEnvVar;
+using arrow::internal::TaskHints;
+using arrow::io::internal::SubmitIO;
+using arrow::util::Uri;
 using internal::ConcatAbstractPath;
 using internal::EnsureTrailingSlash;
 using internal::GetAbstractPathParent;
@@ -722,8 +719,8 @@ class FileSystemFactoryRegistry {
         continue;
       }
 
-      auto [it, success] =
-          main_registry->scheme_to_factory_.emplace(std::move(scheme), registered);
+      auto [it, success] = main_registry->scheme_to_factory_.emplace(
+          std::move(scheme), std::move(registered));
       if (success) continue;
 
       duplicated_schemes.emplace_back(it->first);
@@ -969,5 +966,4 @@ Status Initialize(const FileSystemGlobalOptions& options) {
   return Status::OK();
 }
 
-}  // namespace fs
-}  // namespace arrow
+}  // namespace arrow::fs

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -39,6 +39,7 @@
 #include "arrow/io/type_fwd.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/io_util.h"
+#include "arrow/util/string.h"
 #include "arrow/util/uri.h"
 #include "arrow/util/windows_fixup.h"
 
@@ -246,8 +247,20 @@ Result<LocalFileSystemOptions> LocalFileSystemOptions::FromUri(
         std::string(internal::RemoveTrailingSlash(uri.path(), /*preserve_root=*/true));
   }
 
-  // TODO handle use_mmap option
-  return LocalFileSystemOptions();
+  LocalFileSystemOptions options;
+  ARROW_ASSIGN_OR_RAISE(auto params, uri.query_items());
+  for (const auto& [key, value] : params) {
+    if (key == "use_mmap") {
+      if (value.empty()) {
+        options.use_mmap = true;
+        continue;
+      } else {
+        ARROW_ASSIGN_OR_RAISE(options.use_mmap, ::arrow::internal::ParseBoolean(value));
+      }
+      break;
+    }
+  }
+  return options;
 }
 
 LocalFileSystem::LocalFileSystem(const io::IOContext& io_context)
@@ -271,6 +284,11 @@ Result<std::string> LocalFileSystem::PathFromUri(const std::string& uri_string) 
 #endif
   return internal::PathFromUriHelper(uri_string, {"file"}, /*accept_local_paths=*/true,
                                      authority_handling);
+}
+
+Result<std::string> LocalFileSystem::MakeUri(std::string path) const {
+  ARROW_ASSIGN_OR_RAISE(path, DoNormalizePath(std::move(path)));
+  return "file://" + path + (options_.use_mmap ? "?use_mmap" : "");
 }
 
 bool LocalFileSystem::Equals(const FileSystem& other) const {
@@ -685,5 +703,20 @@ Result<std::shared_ptr<io::OutputStream>> LocalFileSystem::OpenAppendStream(
   bool append = true;
   return OpenOutputStreamGeneric(path, truncate, append);
 }
+
+static Result<std::shared_ptr<fs::FileSystem>> LocalFileSystemFactory(
+    const arrow::util::Uri& uri, const io::IOContext& io_context, std::string* out_path) {
+  std::string path;
+  ARROW_ASSIGN_OR_RAISE(auto options, LocalFileSystemOptions::FromUri(uri, &path));
+  if (out_path != nullptr) {
+    *out_path = std::move(path);
+  }
+  return std::make_shared<LocalFileSystem>(options, io_context);
+}
+
+FileSystemRegistrar kLocalFileSystemModule[]{
+    ARROW_REGISTER_FILESYSTEM("file", LocalFileSystemFactory, {}),
+    ARROW_REGISTER_FILESYSTEM("local", LocalFileSystemFactory, {}),
+};
 
 }  // namespace arrow::fs

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -83,6 +83,7 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
 
   Result<std::string> NormalizePath(std::string path) override;
   Result<std::string> PathFromUri(const std::string& uri_string) const override;
+  Result<std::string> MakeUri(std::string path) const override;
 
   bool Equals(const FileSystem& other) const override;
 

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -423,9 +423,11 @@ TYPED_TEST(TestLocalFS, FileSystemFromUriFile) {
   this->TestLocalUri("file:///some%20path/%25percent", "/some path/%percent");
 
   this->TestLocalUri("file:///_?use_mmap", "/_");
-  ASSERT_TRUE(this->local_fs_->options().use_mmap);
-  ASSERT_OK_AND_ASSIGN(auto uri, this->fs_->MakeUri("/_"));
-  EXPECT_EQ(uri, "file:///_?use_mmap");
+  if (this->path_formatter_.supports_uri()) {
+    ASSERT_TRUE(this->local_fs_->options().use_mmap);
+    ASSERT_OK_AND_ASSIGN(auto uri, this->fs_->MakeUri("/_"));
+    EXPECT_EQ(uri, "file:///_?use_mmap");
+  }
 
 #ifdef _WIN32
   this->TestLocalUri("file:/C:/foo/bar", "C:/foo/bar");

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cerrno>
-#include <chrono>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -113,10 +111,8 @@ Result<std::shared_ptr<FileSystem>> SlowFileSystemFactory(const Uri& uri,
   }
   return std::make_shared<SlowFileSystemPublicProps>(base_fs, average_latency, seed);
 }
-FileSystemRegistrar kSlowFileSystemModule{
-    "slowfile",
-    SlowFileSystemFactory,
-};
+auto kSlowFileSystemModule =
+    ARROW_REGISTER_FILESYSTEM("slowfile", SlowFileSystemFactory, {});
 
 TEST(FileSystemFromUri, LinkedRegisteredFactory) {
   // Since the registrar's definition is in this translation unit (which is linked to the
@@ -155,23 +151,24 @@ TEST(FileSystemFromUri, RuntimeRegisteredFactory) {
   EXPECT_THAT(FileSystemFromUri("slowfile2:///hey/yo", &path),
               Raises(StatusCode::Invalid));
 
-  EXPECT_THAT(RegisterFileSystemFactory("slowfile2", SlowFileSystemFactory), Ok());
+  EXPECT_THAT(RegisterFileSystemFactory("slowfile2", {SlowFileSystemFactory, "", 0}),
+              Ok());
 
   ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri("slowfile2:///hey/yo", &path));
   EXPECT_EQ(path, "/hey/yo");
   EXPECT_EQ(fs->type_name(), "slow");
 
   EXPECT_THAT(
-      RegisterFileSystemFactory("slowfile2", SlowFileSystemFactory),
+      RegisterFileSystemFactory("slowfile2", {SlowFileSystemFactory, "", 0}),
       Raises(StatusCode::KeyError,
              testing::HasSubstr("Attempted to register factory for scheme 'slowfile2' "
                                 "but that scheme is already registered")));
 }
 
 FileSystemRegistrar kSegfaultFileSystemModule[]{
-    {"segfault", nullptr},
-    {"segfault", nullptr},
-    {"segfault", nullptr},
+    ARROW_REGISTER_FILESYSTEM("segfault", nullptr, {}),
+    ARROW_REGISTER_FILESYSTEM("segfault", nullptr, {}),
+    ARROW_REGISTER_FILESYSTEM("segfault", nullptr, {}),
 };
 TEST(FileSystemFromUri, LinkedRegisteredFactoryNameCollision) {
   // Since multiple registrars are defined in this translation unit which all
@@ -185,86 +182,6 @@ TEST(FileSystemFromUri, LinkedRegisteredFactoryNameCollision) {
 }
 ////////////////////////////////////////////////////////////////////////////
 // Misc tests
-
-Result<std::shared_ptr<FileSystem>> SlowFileSystemFactory(const Uri& uri,
-                                                          const io::IOContext& io_context,
-                                                          std::string* out_path) {
-  auto local_uri = "file" + uri.ToString().substr(uri.scheme().size());
-  ARROW_ASSIGN_OR_RAISE(auto base_fs, FileSystemFromUri(local_uri, io_context, out_path));
-  double average_latency = 1;
-  int32_t seed = 0xDEADBEEF;
-  ARROW_ASSIGN_OR_RAISE(auto params, uri.query_items());
-  for (const auto& [key, value] : params) {
-    if (key == "average_latency") {
-      average_latency = std::stod(value);
-    }
-    if (key == "seed") {
-      seed = std::stoi(value, nullptr, /*base=*/16);
-    }
-  }
-  return std::make_shared<SlowFileSystem>(base_fs, average_latency, seed);
-}
-FileSystemRegistrar kSlowFileSystemModule{
-    "slowfile",
-    SlowFileSystemFactory,
-};
-
-TEST(FileSystemFromUri, LinkedRegisteredFactory) {
-  // Since the registrar's definition is in this translation unit (which is linked to the
-  // unit test executable), its factory will be registered be loaded automatically before
-  // main() is entered.
-  std::string path;
-  ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri("slowfile:///hey/yo", &path));
-  EXPECT_EQ(path, "/hey/yo");
-  EXPECT_EQ(fs->type_name(), "slow");
-}
-
-TEST(FileSystemFromUri, LoadedRegisteredFactory) {
-  // Since the registrar's definition is in libarrow_filesystem_example.so,
-  // its factory will be registered only after the library is dynamically loaded.
-  std::string path;
-  EXPECT_THAT(FileSystemFromUri("example:///hey/yo", &path), Raises(StatusCode::Invalid));
-
-  EXPECT_THAT(LoadFileSystemFactories(ARROW_FILESYSTEM_EXAMPLE_LIBPATH), Ok());
-
-  ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri("example:///hey/yo", &path));
-  EXPECT_EQ(path, "/hey/yo");
-  EXPECT_EQ(fs->type_name(), "local");
-}
-
-TEST(FileSystemFromUri, RuntimeRegisteredFactory) {
-  std::string path;
-  EXPECT_THAT(FileSystemFromUri("slowfile2:///hey/yo", &path),
-              Raises(StatusCode::Invalid));
-
-  EXPECT_THAT(RegisterFileSystemFactory("slowfile2", SlowFileSystemFactory), Ok());
-
-  ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri("slowfile2:///hey/yo", &path));
-  EXPECT_EQ(path, "/hey/yo");
-  EXPECT_EQ(fs->type_name(), "slow");
-
-  EXPECT_THAT(
-      RegisterFileSystemFactory("slowfile2", SlowFileSystemFactory),
-      Raises(StatusCode::KeyError,
-             testing::HasSubstr("Attempted to register factory for scheme 'slowfile2' "
-                                "but that scheme is already registered")));
-}
-
-FileSystemRegistrar kSegfaultFileSystemModule[]{
-    {"segfault", nullptr},
-    {"segfault", nullptr},
-    {"segfault", nullptr},
-};
-TEST(FileSystemFromUri, LinkedRegisteredFactoryNameCollision) {
-  // Since multiple registrars are defined in this translation unit which all
-  // register factories for the 'segfault' scheme, using that scheme in FileSystemFromUri
-  // is invalidated and raises KeyError.
-  std::string path;
-  EXPECT_THAT(FileSystemFromUri("segfault:///hey/yo", &path),
-              Raises(StatusCode::KeyError));
-  // other schemes are not affected by the collision
-  EXPECT_THAT(FileSystemFromUri("slowfile:///hey/yo", &path), Ok());
-}
 
 TEST(DetectAbsolutePath, Basics) {
   ASSERT_TRUE(DetectAbsolutePath("/"));
@@ -389,6 +306,7 @@ class TestLocalFS : public LocalFSTestMixin {
     std::string path;
     ASSERT_OK_AND_ASSIGN(fs_, fs_from_uri(uri, &path));
     ASSERT_EQ(fs_->type_name(), "local");
+    local_fs_ = ::arrow::internal::checked_pointer_cast<LocalFileSystem>(fs_);
     ASSERT_EQ(path, expected_path);
     ASSERT_OK_AND_ASSIGN(path, fs_->PathFromUri(uri));
     ASSERT_EQ(path, expected_path);
@@ -500,8 +418,15 @@ TYPED_TEST(TestLocalFS, FileSystemFromUriFile) {
 
   // Variations
   this->TestLocalUri("file:/foo/bar", "/foo/bar");
+  ASSERT_FALSE(this->local_fs_->options().use_mmap);
   this->TestLocalUri("file:///foo/bar", "/foo/bar");
   this->TestLocalUri("file:///some%20path/%25percent", "/some path/%percent");
+
+  this->TestLocalUri("file:///_?use_mmap", "/_");
+  ASSERT_TRUE(this->local_fs_->options().use_mmap);
+  ASSERT_OK_AND_ASSIGN(auto uri, this->fs_->MakeUri("/_"));
+  EXPECT_EQ(uri, "file:///_?use_mmap");
+
 #ifdef _WIN32
   this->TestLocalUri("file:/C:/foo/bar", "C:/foo/bar");
   this->TestLocalUri("file:///C:/foo/bar", "C:/foo/bar");

--- a/cpp/src/arrow/testing/examplefs.cc
+++ b/cpp/src/arrow/testing/examplefs.cc
@@ -16,12 +16,18 @@
 // under the License.
 
 #include "arrow/filesystem/filesystem.h"
+<<<<<<< HEAD
 #include "arrow/filesystem/filesystem_library.h"
 #include "arrow/result.h"
 #include "arrow/util/uri.h"
 
 #include <gtest/gtest.h>
 
+=======
+#include "arrow/result.h"
+#include "arrow/util/uri.h"
+
+>>>>>>> e447cfaac (GH-38309: [C++] build filesystems as separate modules)
 namespace arrow::fs {
 
 FileSystemRegistrar kExampleFileSystemModule{
@@ -29,7 +35,10 @@ FileSystemRegistrar kExampleFileSystemModule{
     [](const Uri& uri, const io::IOContext& io_context,
        std::string* out_path) -> Result<std::shared_ptr<FileSystem>> {
       constexpr std::string_view kScheme = "example";
+<<<<<<< HEAD
       EXPECT_EQ(uri.scheme(), kScheme);
+=======
+>>>>>>> e447cfaac (GH-38309: [C++] build filesystems as separate modules)
       auto local_uri = "file" + uri.ToString().substr(kScheme.size());
       return FileSystemFromUri(local_uri, io_context, out_path);
     },

--- a/cpp/src/arrow/testing/examplefs.cc
+++ b/cpp/src/arrow/testing/examplefs.cc
@@ -16,32 +16,23 @@
 // under the License.
 
 #include "arrow/filesystem/filesystem.h"
-<<<<<<< HEAD
 #include "arrow/filesystem/filesystem_library.h"
 #include "arrow/result.h"
 #include "arrow/util/uri.h"
 
 #include <gtest/gtest.h>
 
-=======
-#include "arrow/result.h"
-#include "arrow/util/uri.h"
-
->>>>>>> e447cfaac (GH-38309: [C++] build filesystems as separate modules)
 namespace arrow::fs {
 
-FileSystemRegistrar kExampleFileSystemModule{
+auto kExampleFileSystemModule = ARROW_REGISTER_FILESYSTEM(
     "example",
     [](const Uri& uri, const io::IOContext& io_context,
        std::string* out_path) -> Result<std::shared_ptr<FileSystem>> {
       constexpr std::string_view kScheme = "example";
-<<<<<<< HEAD
       EXPECT_EQ(uri.scheme(), kScheme);
-=======
->>>>>>> e447cfaac (GH-38309: [C++] build filesystems as separate modules)
       auto local_uri = "file" + uri.ToString().substr(kScheme.size());
       return FileSystemFromUri(local_uri, io_context, out_path);
     },
-};
+    {});
 
 }  // namespace arrow::fs

--- a/docs/source/cpp/io.rst
+++ b/docs/source/cpp/io.rst
@@ -144,4 +144,3 @@ should have exactly one of its sources
 ``#include "arrow/filesystem/filesystem_library.h"``
 in order to ensure the presence of the symbol on which
 :func:`~arrow::fs::LoadFileSystemFactories` depends.
-

--- a/docs/source/cpp/io.rst
+++ b/docs/source/cpp/io.rst
@@ -116,15 +116,15 @@ scope, which will register a factory whenever the instance is loaded:
 
 .. code-block:: cpp
 
-    arrow::fs::FileSystemRegistrar kExampleFileSystemModule{
+    auto kExampleFileSystemModule = ARROW_REGISTER_FILESYSTEM(
       "example",
       [](const Uri& uri, const io::IOContext& io_context,
           std::string* out_path) -> Result<std::shared_ptr<arrow::fs::FileSystem>> {
         EnsureExampleFileSystemInitialized();
         return std::make_shared<ExampleFileSystem>();
       },
-      &EnsureExampleFileSystemFinalized,
-    };
+      &EnsureExampleFileSystemFinalized
+    );
 
 If a filesystem implementation requires initialization before any instances
 may be constructed, this should be included in the corresponding factory or

--- a/python/pyarrow/_fs.pxd
+++ b/python/pyarrow/_fs.pxd
@@ -67,9 +67,6 @@ cdef class FileSystem(_Weakrefable):
 
 
 cdef class LocalFileSystem(FileSystem):
-    cdef:
-        CLocalFileSystem* localfs
-
     cdef init(self, const shared_ptr[CFileSystem]& wrapped)
 
 

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -1104,6 +1104,7 @@ cdef class LocalFileSystem(FileSystem):
             shared_ptr[CFileSystem] fs
             c_string c_uri
 
+        # from_uri needs a non-empty path, so just use a placeholder of /_
         c_uri = tobytes(f"file:///_?use_mmap={int(use_mmap)}")
         with nogil:
             fs = GetResultValue(CFileSystemFromUri(c_uri))

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -18,7 +18,6 @@
 # cython: language_level = 3
 
 from cpython.datetime cimport datetime, PyDateTime_DateTime
-from cython cimport binding
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow_python cimport PyDateTime_to_TimePoint
@@ -420,6 +419,11 @@ cdef class FileSystem(_Weakrefable):
         raise TypeError("FileSystem is an abstract class, instantiate one of "
                         "the subclasses instead: LocalFileSystem or "
                         "SubTreeFileSystem")
+
+    @staticmethod
+    def _from_uri(uri):
+        fs, _path = FileSystem.from_uri(uri)
+        return fs
 
     @staticmethod
     def from_uri(uri):
@@ -1097,30 +1101,17 @@ cdef class LocalFileSystem(FileSystem):
 
     def __init__(self, *, use_mmap=False):
         cdef:
-            CLocalFileSystemOptions opts
-            shared_ptr[CLocalFileSystem] fs
+            shared_ptr[CFileSystem] fs
+            c_string c_uri
 
-        opts = CLocalFileSystemOptions.Defaults()
-        opts.use_mmap = use_mmap
-
-        fs = make_shared[CLocalFileSystem](opts)
+        c_uri = tobytes(f"file:///_?use_mmap={int(use_mmap)}")
+        with nogil:
+            fs = GetResultValue(CFileSystemFromUri(c_uri))
         self.init(<shared_ptr[CFileSystem]> fs)
 
-    cdef init(self, const shared_ptr[CFileSystem]& c_fs):
-        FileSystem.init(self, c_fs)
-        self.localfs = <CLocalFileSystem*> c_fs.get()
-
-    @staticmethod
-    @binding(True)  # Required for cython < 3
-    def _reconstruct(kwargs):
-        # __reduce__ doesn't allow passing named arguments directly to the
-        # reconstructor, hence this wrapper.
-        return LocalFileSystem(**kwargs)
-
     def __reduce__(self):
-        cdef CLocalFileSystemOptions opts = self.localfs.options()
-        return LocalFileSystem._reconstruct, (dict(
-            use_mmap=opts.use_mmap),)
+        uri = frombytes(GetResultValue(self.fs.MakeUri(b"/_")))
+        return FileSystem._from_uri, (uri,)
 
 
 cdef class SubTreeFileSystem(FileSystem):

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -61,6 +61,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         shared_ptr[CFileSystem] shared_from_this()
         c_string type_name() const
         CResult[c_string] NormalizePath(c_string path)
+        CResult[c_string] MakeUri(c_string path)
         CResult[CFileInfo] GetFileInfo(const c_string& path)
         CResult[vector[CFileInfo]] GetFileInfo(
             const vector[c_string]& paths)
@@ -85,6 +86,8 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_bool Equals(shared_ptr[CFileSystem] other)
 
     CResult[shared_ptr[CFileSystem]] CFileSystemFromUri \
+        "arrow::fs::FileSystemFromUri"(const c_string& uri)
+    CResult[shared_ptr[CFileSystem]] CFileSystemFromUri \
         "arrow::fs::FileSystemFromUri"(const c_string& uri, c_string* out_path)
     CResult[shared_ptr[CFileSystem]] CFileSystemFromUriOrPath \
         "arrow::fs::FileSystemFromUriOrPath"(const c_string& uri,
@@ -97,19 +100,6 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
 
     CStatus CFileSystemsInitialize "arrow::fs::Initialize" \
         (const CFileSystemGlobalOptions& options)
-
-    cdef cppclass CLocalFileSystemOptions "arrow::fs::LocalFileSystemOptions":
-        c_bool use_mmap
-
-        @staticmethod
-        CLocalFileSystemOptions Defaults()
-
-        c_bool Equals(const CLocalFileSystemOptions& other)
-
-    cdef cppclass CLocalFileSystem "arrow::fs::LocalFileSystem"(CFileSystem):
-        CLocalFileSystem()
-        CLocalFileSystem(CLocalFileSystemOptions)
-        CLocalFileSystemOptions options()
 
     cdef cppclass CSubTreeFileSystem \
             "arrow::fs::SubTreeFileSystem"(CFileSystem):

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1348,10 +1348,6 @@ fs___FileSystem__type_name <- function(file_system) {
   .Call(`_arrow_fs___FileSystem__type_name`, file_system)
 }
 
-fs___LocalFileSystem__create <- function() {
-  .Call(`_arrow_fs___LocalFileSystem__create`)
-}
-
 fs___SubTreeFileSystem__create <- function(base_path, base_fs) {
   .Call(`_arrow_fs___SubTreeFileSystem__create`, base_path, base_fs)
 }

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -390,7 +390,7 @@ are_urls <- function(x) if (!is.character(x)) FALSE else grepl("://", x)
 #' @export
 LocalFileSystem <- R6Class("LocalFileSystem", inherit = FileSystem)
 LocalFileSystem$create <- function() {
-  fs___LocalFileSystem__create()
+  FileSystem$from_uri("file:///_")$fs
 }
 
 #' @usage NULL

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -390,6 +390,7 @@ are_urls <- function(x) if (!is.character(x)) FALSE else grepl("://", x)
 #' @export
 LocalFileSystem <- R6Class("LocalFileSystem", inherit = FileSystem)
 LocalFileSystem$create <- function() {
+  # from_uri needs a non-empty path, so just use a placeholder of /_
   FileSystem$from_uri("file:///_")$fs
 }
 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3464,13 +3464,6 @@ BEGIN_CPP11
 END_CPP11
 }
 // filesystem.cpp
-std::shared_ptr<fs::LocalFileSystem> fs___LocalFileSystem__create();
-extern "C" SEXP _arrow_fs___LocalFileSystem__create(){
-BEGIN_CPP11
-	return cpp11::as_sexp(fs___LocalFileSystem__create());
-END_CPP11
-}
-// filesystem.cpp
 std::shared_ptr<fs::SubTreeFileSystem> fs___SubTreeFileSystem__create(const std::string& base_path, const std::shared_ptr<fs::FileSystem>& base_fs);
 extern "C" SEXP _arrow_fs___SubTreeFileSystem__create(SEXP base_path_sexp, SEXP base_fs_sexp){
 BEGIN_CPP11
@@ -6005,7 +5998,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_fs___FileSystem__OpenOutputStream", (DL_FUNC) &_arrow_fs___FileSystem__OpenOutputStream, 2}, 
 		{ "_arrow_fs___FileSystem__OpenAppendStream", (DL_FUNC) &_arrow_fs___FileSystem__OpenAppendStream, 2}, 
 		{ "_arrow_fs___FileSystem__type_name", (DL_FUNC) &_arrow_fs___FileSystem__type_name, 1}, 
-		{ "_arrow_fs___LocalFileSystem__create", (DL_FUNC) &_arrow_fs___LocalFileSystem__create, 0}, 
 		{ "_arrow_fs___SubTreeFileSystem__create", (DL_FUNC) &_arrow_fs___SubTreeFileSystem__create, 2}, 
 		{ "_arrow_fs___SubTreeFileSystem__base_fs", (DL_FUNC) &_arrow_fs___SubTreeFileSystem__base_fs, 1}, 
 		{ "_arrow_fs___SubTreeFileSystem__base_path", (DL_FUNC) &_arrow_fs___SubTreeFileSystem__base_path, 1}, 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -239,13 +239,6 @@ std::string fs___FileSystem__type_name(
 }
 
 // [[arrow::export]]
-std::shared_ptr<fs::LocalFileSystem> fs___LocalFileSystem__create() {
-  // Affects OpenInputFile/OpenInputStream
-  auto io_context = MainRThread::GetInstance().CancellableIOContext();
-  return std::make_shared<fs::LocalFileSystem>(io_context);
-}
-
-// [[arrow::export]]
 std::shared_ptr<fs::SubTreeFileSystem> fs___SubTreeFileSystem__create(
     const std::string& base_path, const std::shared_ptr<fs::FileSystem>& base_fs) {
   return std::make_shared<fs::SubTreeFileSystem>(base_path, base_fs);
@@ -268,9 +261,10 @@ cpp11::writable::list fs___FileSystemFromUri(const std::string& path) {
   using cpp11::literals::operator"" _nm;
 
   std::string out_path;
-  return cpp11::writable::list(
-      {"fs"_nm = cpp11::to_r6(ValueOrStop(fs::FileSystemFromUri(path, &out_path))),
-       "path"_nm = out_path});
+  auto io_context = MainRThread::GetInstance().CancellableIOContext();
+  return cpp11::writable::list({"fs"_nm = cpp11::to_r6(ValueOrStop(
+                                    fs::FileSystemFromUri(path, io_context, &out_path))),
+                                "path"_nm = out_path});
 }
 
 // [[arrow::export]]


### PR DESCRIPTION
### Rationale for this change

Moving LocalFileSystem into the registry is a good first usage and will help us hammer out which aspects of built in file systems should remain public.


### What changes are included in this PR?

A factory for LocalFileSystem is added to the registry. `FileSystem::MakeUri` ( https://github.com/apache/arrow/issues/18316 ) is added to enable roundtripping filesystems through URIs. `file://` URIs now support a use_mmap query parameter, and `local://` URIs are also supported as an alias.

<h6 id="reduce">Reducing the set of bound classes</h6>

Some unnecessary bindings to the LocalFileSystem concrete class are removed. This demonstrates that with a registered factory pattern, it is no longer necessary to keep a class hierarchy public for binding. Eventually (if desired), we can move concrete subclasses of FileSystem entirely out of public headers.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, all existing tests for file:// URIs continue to pass

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

For consistency, local:// URIs will now be considered equivalent to corresponding file:// URIs

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40342