### PR TITLE
GH-40357: [C++] Add benchmark for ToTensor conversions

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -1175,6 +1175,7 @@ add_arrow_benchmark(builder_benchmark)
 add_arrow_benchmark(compare_benchmark)
 add_arrow_benchmark(memory_pool_benchmark)
 add_arrow_benchmark(type_benchmark)
+add_arrow_benchmark(to_tensor_benchmark)
 
 #
 # Recurse into sub-directories

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -1175,7 +1175,7 @@ add_arrow_benchmark(builder_benchmark)
 add_arrow_benchmark(compare_benchmark)
 add_arrow_benchmark(memory_pool_benchmark)
 add_arrow_benchmark(type_benchmark)
-add_arrow_benchmark(to_tensor_benchmark)
+add_arrow_benchmark(tensor_benchmark)
 
 #
 # Recurse into sub-directories

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -30,7 +30,8 @@ static void BatchToTensorSimple(benchmark::State& state) {
   using CType = typename ValueType::c_type;
   std::shared_ptr<DataType> ty = TypeTraits<ValueType>::type_singleton();
 
-  const int64_t kNumRows = state.range(0) / sizeof(CType);
+  const int64_t num_cols = state.range(1);
+  const int64_t num_rows = state.range(0) / num_cols / sizeof(CType);
   arrow::random::RandomArrayGenerator gen_{42};
 
   std::vector<std::shared_ptr<Field>> fields = {};

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -27,11 +27,10 @@ namespace arrow {
 
 template <typename ValueType>
 static void BatchToTensorSimple(benchmark::State& state) {
-  RegressionArgs args(state);
   using CType = typename ValueType::c_type;
   std::shared_ptr<DataType> ty = TypeTraits<ValueType>::type_singleton();
 
-  const int64_t kNumRows = args.size / sizeof(CType);
+  const int64_t kNumRows = state.range(0) / sizeof(CType);
   arrow::random::RandomArrayGenerator gen_{42};
 
   std::vector<std::shared_ptr<Field>> fields = {};

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -28,9 +28,10 @@ namespace arrow {
 template <typename ValueType>
 static void BatchToTensorSimple(benchmark::State& state) {
   RegressionArgs args(state);
+  using CType = typename ValueType::c_type;
   std::shared_ptr<DataType> ty = TypeTraits<ValueType>::type_singleton();
 
-  const int64_t kNumRows = args.size;
+  const int64_t kNumRows = args.size / sizeof(CType);
   arrow::random::RandomArrayGenerator gen_{42};
 
   std::vector<std::shared_ptr<Field>> fields = {};

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -57,16 +57,9 @@ void SetArgs(benchmark::internal::Benchmark* bench) {
   }
 }
 
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt64Type)->Apply(SetArgs);
 BENCHMARK_TEMPLATE(BatchToTensorSimple, Int8Type)->Apply(SetArgs);
 BENCHMARK_TEMPLATE(BatchToTensorSimple, Int16Type)->Apply(SetArgs);
 BENCHMARK_TEMPLATE(BatchToTensorSimple, Int32Type)->Apply(SetArgs);
 BENCHMARK_TEMPLATE(BatchToTensorSimple, Int64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, HalfFloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, FloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, DoubleType)->Apply(SetArgs);
 
 }  // namespace arrow

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -34,13 +34,13 @@ static void BatchToTensorSimple(benchmark::State& state) {
   std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
   auto schema = ::arrow::schema(fields);
 
-  constexpr int kNumRows = 500;
+  constexpr int kNumRows = 100000;
   arrow::random::RandomArrayGenerator gen_{42};
-  auto a0 = gen_.ArrayOf(ty, kNumRows);
-  auto a1 = gen_.ArrayOf(ty, kNumRows);
-  auto a2 = gen_.ArrayOf(ty, kNumRows);
-
-  auto batch = RecordBatch::Make(schema, kNumRows, {a0, a1, a2});
+  std::vector<std::shared_ptr<Array>> columns = {};
+  for (int i = 0; i < 100; ++i) {
+    columns.push_back(gen_.ArrayOf(ty, kNumRows));
+  }
+  auto batch = RecordBatch::Make(schema, kNumRows, columns);
 
   ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
 

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -36,7 +36,8 @@ static void BatchToTensorSimple(benchmark::State& state) {
   std::vector<std::shared_ptr<Field>> fields = {};
   std::vector<std::shared_ptr<Array>> columns = {};
 
-  for (int i = 0; i < 100; ++i) {
+  const int NumCols = state.range(1);
+  for (int i = 0; i < NumCols; ++i) {
     fields.push_back(field("f" + std::to_string(i), ty));
     columns.push_back(gen_.ArrayOf(ty, kNumRows));
   }
@@ -46,14 +47,15 @@ static void BatchToTensorSimple(benchmark::State& state) {
   for (auto _ : state) {
     ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
   }
-  state.SetItemsProcessed(state.iterations() * kNumRows * batch->num_columns());
-  state.SetBytesProcessed(state.iterations() * ty->byte_width() * kNumRows *
-                          batch->num_columns());
+  state.SetItemsProcessed(state.iterations() * kNumRows * NumCols);
+  state.SetBytesProcessed(state.iterations() * ty->byte_width() * kNumRows * NumCols);
 }
 
 void SetArgs(benchmark::internal::Benchmark* bench) {
   for (int64_t size : {kL1Size, kL2Size}) {
-    bench->Arg(size);
+    for (int number_of_columns : {3, 30, 300}) {
+      bench->Args({size, number_of_columns});
+    }
   }
 }
 

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -47,7 +47,8 @@ static void BatchToTensorSimple(benchmark::State& state) {
     ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
   }
   state.SetItemsProcessed(state.iterations() * kNumRows * batch->num_columns());
-  state.SetBytesProcessed(state.iterations() * ty->bit_width() * kNumRows * batch->num_columns());
+  state.SetBytesProcessed(state.iterations() * ty->bit_width() * kNumRows *
+                          batch->num_columns());
 }
 
 void SetArgs(benchmark::internal::Benchmark* bench) {

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -53,8 +53,9 @@ static void BatchToTensorSimple(benchmark::State& state) {
 
 void SetArgs(benchmark::internal::Benchmark* bench) {
   for (int64_t size : {kL1Size, kL2Size}) {
-    for (int64_t number_of_columns : {3, 30, 300}) {
-      bench->Args({size, number_of_columns});
+    for (int64_t num_columns : {3, 30, 300}) {
+      bench->Args({size, num_columns});
+      bench->ArgNames({"size", "num_columns"});
     }
   }
 }

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -48,7 +48,7 @@ static void BatchToTensorSimple(benchmark::State& state) {
     ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
   }
   state.SetItemsProcessed(state.iterations() * kNumRows * batch->num_columns());
-  state.SetBytesProcessed(state.iterations() * ty->bit_width() * kNumRows *
+  state.SetBytesProcessed(state.iterations() * ty->byte_width() * kNumRows *
                           batch->num_columns());
 }
 

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -30,7 +30,7 @@ static void BatchToTensorSimple(benchmark::State& state) {
   RegressionArgs args(state);
   std::shared_ptr<DataType> ty = TypeTraits<ValueType>::type_singleton();
 
-  const int64_t kNumRows = args.size * 8;
+  const int64_t kNumRows = args.size;
   arrow::random::RandomArrayGenerator gen_{42};
 
   std::vector<std::shared_ptr<Field>> fields = {};
@@ -52,7 +52,9 @@ static void BatchToTensorSimple(benchmark::State& state) {
 }
 
 void SetArgs(benchmark::internal::Benchmark* bench) {
-  BenchmarkSetArgsWithSizes(bench, {kL1Size, kL2Size});
+  for (int64_t size : {kL1Size, kL2Size}) {
+    bench->Arg(size);
+  }
 }
 
 BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt8Type)->Apply(SetArgs);

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -37,24 +37,23 @@ static void BatchToTensorSimple(benchmark::State& state) {
   std::vector<std::shared_ptr<Field>> fields = {};
   std::vector<std::shared_ptr<Array>> columns = {};
 
-  const int NumCols = state.range(1);
-  for (int i = 0; i < NumCols; ++i) {
+  for (int64_t i = 0; i < num_cols; ++i) {
     fields.push_back(field("f" + std::to_string(i), ty));
-    columns.push_back(gen_.ArrayOf(ty, kNumRows));
+    columns.push_back(gen_.ArrayOf(ty, num_rows));
   }
   auto schema = std::make_shared<Schema>(std::move(fields));
-  auto batch = RecordBatch::Make(schema, kNumRows, columns);
+  auto batch = RecordBatch::Make(schema, num_rows, columns);
 
   for (auto _ : state) {
     ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
   }
-  state.SetItemsProcessed(state.iterations() * kNumRows * NumCols);
-  state.SetBytesProcessed(state.iterations() * ty->byte_width() * kNumRows * NumCols);
+  state.SetItemsProcessed(state.iterations() * num_rows * num_cols);
+  state.SetBytesProcessed(state.iterations() * ty->byte_width() * num_rows * num_cols);
 }
 
 void SetArgs(benchmark::internal::Benchmark* bench) {
   for (int64_t size : {kL1Size, kL2Size}) {
-    for (int number_of_columns : {3, 30, 300}) {
+    for (int64_t number_of_columns : {3, 30, 300}) {
       bench->Args({size, number_of_columns});
     }
   }

--- a/cpp/src/arrow/tensor_benchmark.cc
+++ b/cpp/src/arrow/tensor_benchmark.cc
@@ -21,48 +21,49 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/type.h"
+#include "arrow/util/benchmark_util.h"
 
 namespace arrow {
 
 template <typename ValueType>
 static void BatchToTensorSimple(benchmark::State& state) {
+  RegressionArgs args(state);
   std::shared_ptr<DataType> ty = TypeTraits<ValueType>::type_singleton();
-  auto f0 = field("f0", ty);
-  auto f1 = field("f1", ty);
-  auto f2 = field("f2", ty);
 
-  std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
-  auto schema = ::arrow::schema(fields);
-
-  constexpr int kNumRows = 100000;
+  const int64_t kNumRows = args.size * 8;
   arrow::random::RandomArrayGenerator gen_{42};
+
+  std::vector<std::shared_ptr<Field>> fields = {};
   std::vector<std::shared_ptr<Array>> columns = {};
+
   for (int i = 0; i < 100; ++i) {
+    fields.push_back(field("f" + std::to_string(i), ty));
     columns.push_back(gen_.ArrayOf(ty, kNumRows));
   }
+  auto schema = std::make_shared<Schema>(std::move(fields));
   auto batch = RecordBatch::Make(schema, kNumRows, columns);
-
-  ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
 
   for (auto _ : state) {
     ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
   }
-  benchmark::DoNotOptimize(tensor);
-  state.SetItemsProcessed(state.iterations() * batch->num_rows() * batch->num_columns());
-  state.SetBytesProcessed(state.iterations() * ty->bit_width() * batch->num_columns() *
-                          batch->num_rows());
+  state.SetItemsProcessed(state.iterations() * kNumRows * batch->num_columns());
+  state.SetBytesProcessed(state.iterations() * ty->bit_width() * kNumRows * batch->num_columns());
 }
 
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt8Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt16Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt32Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt64Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, Int8Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, Int16Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, Int32Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, Int64Type);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, HalfFloatType);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, FloatType);
-BENCHMARK_TEMPLATE(BatchToTensorSimple, DoubleType);
+void SetArgs(benchmark::internal::Benchmark* bench) {
+  BenchmarkSetArgsWithSizes(bench, {kL1Size, kL2Size});
+}
+
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt8Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt16Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt32Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt64Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int8Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int16Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int32Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int64Type)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, HalfFloatType)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, FloatType)->Apply(SetArgs);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, DoubleType)->Apply(SetArgs);
 
 }  // namespace arrow

--- a/cpp/src/arrow/to_tensor_benchmark.cc
+++ b/cpp/src/arrow/to_tensor_benchmark.cc
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/record_batch.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/type.h"
+
+namespace arrow {
+
+static void RecordBatchUniformTypesSimple(
+    benchmark::State& state) {  // NOLINT non-const reference
+  const int length = 9;
+  auto ty = int32();
+
+  auto f0 = field("f0", ty);
+  auto f1 = field("f1", ty);
+  auto f2 = field("f2", ty);
+
+  std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
+  auto schema = ::arrow::schema(fields);
+
+  auto a0 = ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6, 7, 8, 9]");
+  auto a1 = ArrayFromJSON(ty, "[10, 20, 30, 40, 50, 60, 70, 80, 90]");
+  auto a2 = ArrayFromJSON(ty, "[100, 100, 100, 100, 100, 100, 100, 100, 100]");
+
+  auto batch = RecordBatch::Make(schema, length, {a0, a1, a2});
+
+  ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
+
+  for (auto _ : state) {
+    ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
+  }
+  benchmark::DoNotOptimize(tensor);
+  state.SetItemsProcessed(state.iterations() * batch->num_rows() * batch->num_columns());
+  state.SetBytesProcessed(state.iterations() * ty->bit_width() * batch->num_columns() *
+                          batch->num_rows());
+}
+
+BENCHMARK(RecordBatchUniformTypesSimple);
+
+}  // namespace arrow

--- a/cpp/src/arrow/to_tensor_benchmark.cc
+++ b/cpp/src/arrow/to_tensor_benchmark.cc
@@ -19,15 +19,14 @@
 
 #include "arrow/record_batch.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
 #include "arrow/type.h"
 
 namespace arrow {
 
-static void RecordBatchUniformTypesSimple(
-    benchmark::State& state) {  // NOLINT non-const reference
-  const int length = 9;
-  auto ty = int32();
-
+template <typename ValueType>
+static void BatchToTensorSimple(benchmark::State& state) {
+  std::shared_ptr<DataType> ty = TypeTraits<ValueType>::type_singleton();
   auto f0 = field("f0", ty);
   auto f1 = field("f1", ty);
   auto f2 = field("f2", ty);
@@ -35,11 +34,13 @@ static void RecordBatchUniformTypesSimple(
   std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
   auto schema = ::arrow::schema(fields);
 
-  auto a0 = ArrayFromJSON(ty, "[1, 2, 3, 4, 5, 6, 7, 8, 9]");
-  auto a1 = ArrayFromJSON(ty, "[10, 20, 30, 40, 50, 60, 70, 80, 90]");
-  auto a2 = ArrayFromJSON(ty, "[100, 100, 100, 100, 100, 100, 100, 100, 100]");
+  constexpr int kNumRows = 500;
+  arrow::random::RandomArrayGenerator gen_{42};
+  auto a0 = gen_.ArrayOf(ty, kNumRows);
+  auto a1 = gen_.ArrayOf(ty, kNumRows);
+  auto a2 = gen_.ArrayOf(ty, kNumRows);
 
-  auto batch = RecordBatch::Make(schema, length, {a0, a1, a2});
+  auto batch = RecordBatch::Make(schema, kNumRows, {a0, a1, a2});
 
   ASSERT_OK_AND_ASSIGN(auto tensor, batch->ToTensor());
 
@@ -52,6 +53,16 @@ static void RecordBatchUniformTypesSimple(
                           batch->num_rows());
 }
 
-BENCHMARK(RecordBatchUniformTypesSimple);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt8Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt16Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt32Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, UInt64Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int8Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int16Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int32Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, Int64Type);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, HalfFloatType);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, FloatType);
+BENCHMARK_TEMPLATE(BatchToTensorSimple, DoubleType);
 
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

We should add benchmarks to be sure not to cause regressions while working on additional implementations of `RecordBatch::ToTensor` and `Table::ToTensor`.

### What changes are included in this PR?

New `cpp/src/arrow/to_tensor_benchmark.cc file`.
* GitHub Issue: #40357