### PR TITLE
GH-20127: [Python][CI] Remove legacy hdfs tests from hdfs and hypothesis setup

### DIFF
--- a/ci/scripts/integration_hdfs.sh
+++ b/ci/scripts/integration_hdfs.sh
@@ -61,9 +61,8 @@ export PYARROW_TEST_HDFS=ON
 export PYARROW_HDFS_TEST_LIBHDFS_REQUIRE=ON
 
 pytest -vs --pyargs pyarrow.tests.test_fs
-pytest -vs --pyargs pyarrow.tests.test_hdfs
 
 use_libhdfs_dir
 pytest -vs --pyargs pyarrow.tests.test_fs
-pytest -vs --pyargs pyarrow.tests.test_hdfs
+
 use_hadoop_home


### PR DESCRIPTION
### Rationale for this change

Small follow-up on https://github.com/apache/arrow/pull/39825, which removed the `test_hdfs.py` file itself, but didn't remove it from the hypothesis script

* GitHub Issue: #20127