### PR TITLE
[DO NOT MERGE][C++][Gandiva]: gandiva: Use ARROW_FORCE_INLINE instead of GDV-prefixed macro

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -44,17 +44,6 @@ using gdv_binary = char*;
 using gdv_day_time_interval = int64_t;
 using gdv_month_interval = int32_t;
 
-#ifdef GANDIVA_UNIT_TEST
-// unit tests may be compiled without O2, so inlining may not happen.
-#define GDV_FORCE_INLINE
-#else
-#ifdef _MSC_VER
-#define GDV_FORCE_INLINE __forceinline
-#else
-#define GDV_FORCE_INLINE inline __attribute__((always_inline))
-#endif
-#endif
-
 GANDIVA_EXPORT
 int64_t gdv_fn_crc_32_utf8(int64_t ctx, const char* input, int32_t input_len);
 

--- a/cpp/src/gandiva/gdv_string_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_string_function_stubs.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "arrow/util/double_conversion.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/utf8_internal.h"
 #include "arrow/util/value_parsing.h"
 
@@ -165,8 +166,8 @@ CAST_VARLEN_TYPE_FROM_NUMERIC(VARBINARY)
 #undef GDV_FN_CAST_VARLEN_TYPE_FROM_TYPE
 #undef GDV_FN_CAST_VARLEN_TYPE_FROM_REAL
 
-GDV_FORCE_INLINE
-void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
+ARROW_FORCE_INLINE
+static void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
   char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
@@ -175,8 +176,8 @@ void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
   free(error);
 }
 
-GDV_FORCE_INLINE
-int32_t gdv_fn_utf8_char_length(char c) {
+ARROW_FORCE_INLINE
+static int32_t gdv_fn_utf8_char_length_inline(char c) {
   if ((signed char)c >= 0) {  // 1-byte char (0x00 ~ 0x7F)
     return 1;
   } else if ((c & 0xE0) == 0xC0) {  // 2-byte char
@@ -189,6 +190,8 @@ int32_t gdv_fn_utf8_char_length(char c) {
   // invalid char
   return 0;
 }
+
+int32_t gdv_fn_utf8_char_length(char c) { return gdv_fn_utf8_char_length_inline(c); }
 
 // Convert an utf8 string to its corresponding lowercase string
 GANDIVA_EXPORT
@@ -213,7 +216,7 @@ const char* gdv_fn_lower_utf8(int64_t context, const char* data, int32_t data_le
   uint32_t char_codepoint;
 
   for (int32_t i = 0; i < data_len; i += char_len) {
-    char_len = gdv_fn_utf8_char_length(data[i]);
+    char_len = gdv_fn_utf8_char_length_inline(data[i]);
     // For single byte characters:
     // If it is an uppercase ASCII character, set the output to its corresponding
     // lowercase character; else, set the output to the read character
@@ -285,7 +288,7 @@ const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_le
   uint32_t char_codepoint;
 
   for (int32_t i = 0; i < data_len; i += char_len) {
-    char_len = gdv_fn_utf8_char_length(data[i]);
+    char_len = gdv_fn_utf8_char_length_inline(data[i]);
     // For single byte characters:
     // If it is a lowercase ASCII character, set the output to its corresponding uppercase
     // character; else, set the output to the read character
@@ -335,7 +338,6 @@ const char* gdv_fn_upper_utf8(int64_t context, const char* data, int32_t data_le
 }
 
 // Substring_index
-GDV_FORCE_INLINE
 const char* gdv_fn_substring_index(int64_t context, const char* txt, int32_t txt_len,
                                    const char* pat, int32_t pat_len, int32_t cnt,
                                    int32_t* out_len) {
@@ -432,8 +434,8 @@ const char* gdv_fn_substring_index(int64_t context, const char* txt, int32_t txt
 // The Unicode characters also are divided between categories. This link
 // https://www.compart.com/en/unicode/category shows
 // more information about characters categories.
-GDV_FORCE_INLINE
-bool gdv_fn_is_codepoint_for_space(uint32_t val) {
+ARROW_FORCE_INLINE
+static bool gdv_fn_is_codepoint_for_space(uint32_t val) {
   auto category = utf8proc_category(val);
 
   return category != utf8proc_category_t::UTF8PROC_CATEGORY_LU &&
@@ -498,7 +500,7 @@ const char* gdv_fn_initcap_utf8(int64_t context, const char* data, int32_t data_
       continue;
     }
 
-    char_len = gdv_fn_utf8_char_length(data[i]);
+    char_len = gdv_fn_utf8_char_length_inline(data[i]);
 
     // Control reaches here when we encounter a multibyte character
     const auto* in_char = (const uint8_t*)(data + i);
@@ -697,7 +699,7 @@ const char* translate_utf8_utf8_utf8(int64_t context, const char* in, int32_t in
 
     for (int in_for = 0; in_for < in_len; in_for += len_char_in) {
       // Updating len to char in this position
-      len_char_in = gdv_fn_utf8_char_length(in[in_for]);
+      len_char_in = gdv_fn_utf8_char_length_inline(in[in_for]);
       // Making copy to std::string with length for this char position
       std::string insert_copy_key(in + in_for, len_char_in);
       if (subs_list.find(insert_copy_key) != subs_list.end()) {
@@ -710,7 +712,7 @@ const char* translate_utf8_utf8_utf8(int64_t context, const char* in, int32_t in
       } else {
         for (int from_for = 0; from_for <= from_len; from_for += len_char_from) {
           // Updating len to char in this position
-          len_char_from = gdv_fn_utf8_char_length(from[from_for]);
+          len_char_from = gdv_fn_utf8_char_length_inline(from[from_for]);
           // Making copy to std::string with length for this char position
           std::string copy_from_compare(from + from_for, len_char_from);
           if (from_for == from_len) {
@@ -736,7 +738,7 @@ const char* translate_utf8_utf8_utf8(int64_t context, const char* in, int32_t in
           } else {
             // If exist and the start_compare is in range, add to map with the
             // corresponding TO in position start_compare
-            len_char_to = gdv_fn_utf8_char_length(to[start_compare]);
+            len_char_to = gdv_fn_utf8_char_length_inline(to[start_compare]);
             std::string insert_copy_value(to + start_compare, len_char_to);
             // Insert in map to next loops
             subs_list.insert(


### PR DESCRIPTION
### Rationale for this change

Simplicity.

### What changes are included in this PR?

Correct use of the force inline attributes on gandiva functions.

### Are these changes tested?

By existing tests.

### Are there any user-facing changes?

`GDV_FORCE_INLINE` macro removed from header.