### PR TITLE
MINOR: [Java] add toString on AbstractContainerVector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType.List;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
  * Base class for composite vectors.
@@ -46,6 +47,14 @@ public abstract class AbstractContainerVector implements ValueVector, DensityAwa
     this.name = name;
     this.allocator = allocator;
     this.callBack = callBack;
+  }
+
+  /**
+   * Representation of vector suitable for debugging.
+   */
+  @Override
+  public String toString() {
+    return ValueVectorUtility.getToString(this, 0, getValueCount());
   }
 
   @Override


### PR DESCRIPTION
### Rationale for this change

Adding the ability to see the values in vectors derived from AbstractContainerVector (e.g. structs, dense unions) when something's not quite going as you're expecting :slightly_smiling_face:  

### What changes are included in this PR?

Add AbstractContainerVector.toString in line with BaseValueVector.toString

### Are these changes tested?

Yes, as part of our XTDB development, but not in the Arrow repo - I didn't see any other tests for ValueVector.toString implementations?

### Are there any user-facing changes?

Strictly speaking, yes, if the user's printing out the vector - but Object.toString isn't often considered part of the public API in my experience?

Cheers!

James