### PR TITLE
GH-40405: [C++] Produce better error message when Move is attempted on flat-namespace accounts

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -2523,7 +2523,9 @@ class AzureFileSystem::Impl {
       }
       return CrossContainerMoveNotImplemented(src, dest);
     }
-    return Status::NotImplemented("The Azure FileSystem is not fully implemented");
+    return Status::NotImplemented(
+        "FileSystem::Move() is not implemented for Azure Storage accounts "
+        "without Hierarchical Namespace support (see arrow/issues/40405).");
   }
 
   Status MovePath(const AzureLocation& src, const AzureLocation& dest) {


### PR DESCRIPTION
### Rationale for this change

To guide users that might try to `Move` on accounts without HNS.

### What changes are included in this PR?

The rewrite of the error message.

### Are these changes tested?

Covered by existing tests.
* GitHub Issue: #40405