### PR TITLE
GH-40407: [JS] Fix string coercion in MapRowProxyHandler.ownKeys

### DIFF
--- a/js/src/row/map.ts
+++ b/js/src/row/map.ts
@@ -24,6 +24,8 @@ import { instance as setVisitor } from '../visitor/set.js';
 
 /** @ignore */ export const kKeys = Symbol.for('keys');
 /** @ignore */ export const kVals = Symbol.for('vals');
+/** @ignore */ export const kKeysAsStrings = Symbol.for('kKeysAsStrings');
+/** @ignore */ export const _kKeysAsStrings = Symbol.for('_kKeysAsStrings');
 
 export class MapRow<K extends DataType = any, V extends DataType = any> {
 
@@ -31,11 +33,17 @@ export class MapRow<K extends DataType = any, V extends DataType = any> {
 
     declare private [kKeys]: Vector<K>;
     declare private [kVals]: Data<V>;
+    declare private [_kKeysAsStrings]: string[];
 
     constructor(slice: Data<Struct<{ key: K; value: V }>>) {
         this[kKeys] = new Vector([slice.children[0]]).memoize() as Vector<K>;
         this[kVals] = slice.children[1] as Data<V>;
         return new Proxy(this, new MapRowProxyHandler<K, V>());
+    }
+
+    /** @ignore */
+    get [kKeysAsStrings]() {
+        return this[_kKeysAsStrings] || (this[_kKeysAsStrings] = Array.from(this[kKeys].toArray(), String));
     }
 
     [Symbol.iterator]() {
@@ -107,13 +115,13 @@ class MapRowProxyHandler<K extends DataType = any, V extends DataType = any> imp
     deleteProperty() { return false; }
     preventExtensions() { return true; }
     ownKeys(row: MapRow<K, V>) {
-        return Array.from(row[kKeys].toArray(), String);
+        return row[kKeysAsStrings];
     }
     has(row: MapRow<K, V>, key: string | symbol) {
-        return row[kKeys].includes(key);
+        return row[kKeysAsStrings].includes(key as string);
     }
     getOwnPropertyDescriptor(row: MapRow<K, V>, key: string | symbol) {
-        const idx = row[kKeys].indexOf(key);
+        const idx = row[kKeysAsStrings].indexOf(key as string);
         if (idx !== -1) {
             return { writable: true, enumerable: true, configurable: true };
         }
@@ -124,7 +132,7 @@ class MapRowProxyHandler<K extends DataType = any, V extends DataType = any> imp
         if (Reflect.has(row, key)) {
             return (row as any)[key];
         }
-        const idx = row[kKeys].indexOf(key);
+        const idx = row[kKeysAsStrings].indexOf(key as string);
         if (idx !== -1) {
             const val = getVisitor.visit(Reflect.get(row, kVals), idx);
             // Cache key/val lookups
@@ -133,7 +141,7 @@ class MapRowProxyHandler<K extends DataType = any, V extends DataType = any> imp
         }
     }
     set(row: MapRow<K, V>, key: string | symbol, val: V) {
-        const idx = row[kKeys].indexOf(key);
+        const idx = row[kKeysAsStrings].indexOf(key as string);
         if (idx !== -1) {
             setVisitor.visit(Reflect.get(row, kVals), idx, val);
             // Cache key/val lookups
@@ -149,4 +157,5 @@ Object.defineProperties(MapRow.prototype, {
     [Symbol.toStringTag]: { enumerable: false, configurable: false, value: 'Row' },
     [kKeys]: { writable: true, enumerable: false, configurable: false, value: null },
     [kVals]: { writable: true, enumerable: false, configurable: false, value: null },
+    [_kKeysAsStrings]: { writable: true, enumerable: false, configurable: false, value: null },
 });

--- a/js/src/row/map.ts
+++ b/js/src/row/map.ts
@@ -107,7 +107,7 @@ class MapRowProxyHandler<K extends DataType = any, V extends DataType = any> imp
     deleteProperty() { return false; }
     preventExtensions() { return true; }
     ownKeys(row: MapRow<K, V>) {
-        return row[kKeys].toArray().map(String);
+        return Array.from(row[kKeys].toArray(), String);
     }
     has(row: MapRow<K, V>, key: string | symbol) {
         return row[kKeys].includes(key);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The `ProxyHandler.ownKeys` implementation must return strings or symbols. Because of this bug, it was returning numbers, causing the `in` operator to crash when trying to iterate over the keys of a `MapRow` object.

An example of this is a DuckDB SQL query using the `HISTOGRAM` operator:

```sql
SELECT HISTOGRAM(phot_g_mean_mag) FROM gaia
```

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Instead of calling `array.map(String)`, which returns a typed array of non-strings when `array` is a typed array, call `Array.from` which is guaranteed to return strings.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Apologies, but I don’t know how to test this.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

This fixes a crash when using the `in` operator on a `MapRow` object.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40407