### PR TITLE
MINOR: [Dev][C++] Fix SyntaxWarnings in asan_symbolize.py

### DIFF
--- a/cpp/build-support/asan_symbolize.py
+++ b/cpp/build-support/asan_symbolize.py
@@ -169,12 +169,12 @@ class DarwinSymbolizer(Symbolizer):
     atos_line = self.pipe.stdout.readline().rstrip()
     # A well-formed atos response looks like this:
     #   foo(type1, type2) (in object.name) (filename.cc:80)
-    match = re.match('^(.*) \(in (.*)\) \((.*:\d*)\)$', atos_line)
+    match = re.match(r'^(.*) \(in (.*)\) \((.*:\d*)\)$', atos_line)
     if DEBUG:
       print('atos_line: {0}'.format(atos_line))
     if match:
       function_name = match.group(1)
-      function_name = re.sub('\(.*?\)', '', function_name)
+      function_name = re.sub(r'\(.*?\)', '', function_name)
       file_name = fix_filename(match.group(3))
       return ['%s in %s %s' % (addr, function_name, file_name)]
     else:
@@ -342,7 +342,7 @@ class SymbolizationLoop(object):
       self.current_line = line.rstrip()
       #0 0x7f6e35cf2e45  (/blah/foo.so+0x11fe45)
       stack_trace_line_format = (
-          '^( *#([0-9]+) *)(0x[0-9a-f]+) *\((.*)\+(0x[0-9a-f]+)\)')
+          r'^( *#([0-9]+) *)(0x[0-9a-f]+) *\((.*)\+(0x[0-9a-f]+)\)')
       match = re.match(stack_trace_line_format, line)
       if not match:
         print(self.current_line)


### PR DESCRIPTION
### Rationale for this change

When running the C++ tests I noticed some warnings around string escape sequences in the [asan_symbolize.py](https://github.com/apache/arrow/blob/main/cpp/build-support/asan_symbolize.py):

```
70: Running arrow-s3fs-test, redirecting output into /Users/bryce/src/apache/arrow/cpp/build/build/test-logs/arrow-s3fs-test.txt (attempt 1/1)
70: /Users/bryce/src/apache/arrow/cpp/build-support/asan_symbolize.py:172: SyntaxWarning: invalid escape sequence '\('
70:   match = re.match('^(.*) \(in (.*)\) \((.*:\d*)\)$', atos_line)
70: /Users/bryce/src/apache/arrow/cpp/build-support/asan_symbolize.py:177: SyntaxWarning: invalid escape sequence '\('
70:   function_name = re.sub('\(.*?\)', '', function_name)
70: /Users/bryce/src/apache/arrow/cpp/build-support/asan_symbolize.py:345: SyntaxWarning: invalid escape sequence '\('
70:   '^( *#([0-9]+) *)(0x[0-9a-f]+) *\((.*)\+(0x[0-9a-f]+)\)')
```

It looks like this usage was [turned into a SyntaxWarning in Python 3.12](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes). Eventually they plan to change this to a SyntaxError so I think it's good to fix it now. I didn't look elsewhere in the codebase to find other instances.

### What changes are included in this PR?

Swapped affected instances for raw strings.

### Are these changes tested?

I haven't tested the script against what I assume would be ASAN output of some sort but I did test that the strings compile fine. For example,

```python
>>> atos_line = 'foo(type1, type2) (in object.name) (filename.cc:80)'
>>> re.match('^(.*) \(in (.*)\) \((.*:\d*)\)$', atos_line)
<re.Match object; span=(0, 51), match='foo(type1, type2) (in object.name) (filename.cc:8>
>>> re.match(r'^(.*) \(in (.*)\) \((.*:\d*)\)$', atos_line)
<re.Match object; span=(0, 51), match='foo(type1, type2) (in object.name) (filename.cc:8>
```

### Are there any user-facing changes?

No.