### PR TITLE
GH-40308: [C++][Gandiva] Add support for compute module's decimal promotion rules

### DIFF
--- a/cpp/src/gandiva/decimal_type_util.cc
+++ b/cpp/src/gandiva/decimal_type_util.cc
@@ -30,9 +30,10 @@ constexpr int32_t DecimalTypeUtil::kMinAdjustedScale;
 
 // Implementation of decimal rules.
 // In addition to having a precision beyond 38, it is compatible with
-// **Redshift's decimal promotion rules**.
+// **Redshift's decimal promotion rules** if enable use_redshift_rules.
 Status DecimalTypeUtil::GetResultType(Op op, const Decimal128TypeVector& in_types,
-                                      Decimal128TypePtr* out_type) {
+                                      Decimal128TypePtr* out_type,
+                                      bool use_redshift_rules) {
   DCHECK_EQ(in_types.size(), 2);
 
   *out_type = nullptr;
@@ -61,7 +62,8 @@ Status DecimalTypeUtil::GetResultType(Op op, const Decimal128TypeVector& in_type
       break;
 
     case kOpDivide:
-      result_scale = std::max(4, s1 + p2 - s2 + 1);
+      result_scale = use_redshift_rules ? std::max(4, s1 + p2 - s2 + 1)
+                                        : std::max(kMinAdjustedScale, s1 + p2 + 1);
       result_precision = p1 - s1 + s2 + result_scale;
       break;
 

--- a/cpp/src/gandiva/decimal_type_util.cc
+++ b/cpp/src/gandiva/decimal_type_util.cc
@@ -29,11 +29,9 @@ constexpr int32_t DecimalTypeUtil::kMinAdjustedScale;
   }
 
 // Implementation of decimal rules.
-// In addition to having a precision beyond 38, it is compatible with
-// **Redshift's decimal promotion rules** if enable use_redshift_rules.
 Status DecimalTypeUtil::GetResultType(Op op, const Decimal128TypeVector& in_types,
                                       Decimal128TypePtr* out_type,
-                                      bool use_redshift_rules) {
+                                      bool use_compute_rules) {
   DCHECK_EQ(in_types.size(), 2);
 
   *out_type = nullptr;
@@ -62,8 +60,9 @@ Status DecimalTypeUtil::GetResultType(Op op, const Decimal128TypeVector& in_type
       break;
 
     case kOpDivide:
-      result_scale = use_redshift_rules ? std::max(4, s1 + p2 - s2 + 1)
-                                        : std::max(kMinAdjustedScale, s1 + p2 + 1);
+      result_scale = use_compute_rules
+                         ? std::max(kMinComputeAdjustedScale, s1 + p2 - s2 + 1)
+                         : std::max(kMinAdjustedScale, s1 + p2 + 1);
       result_precision = p1 - s1 + s2 + result_scale;
       break;
 
@@ -72,7 +71,17 @@ Status DecimalTypeUtil::GetResultType(Op op, const Decimal128TypeVector& in_type
       result_precision = std::min(p1 - s1, p2 - s2) + result_scale;
       break;
   }
-  *out_type = MakeAdjustedType(result_precision, result_scale);
+
+  if (use_compute_rules) {
+    if (result_precision < kMinPrecision || result_precision > kMaxPrecision) {
+      return Status::Invalid("Decimal precision out of range [", int32_t(kMinPrecision),
+                             ", ", int32_t(kMaxPrecision), "]: ", result_precision);
+    }
+    *out_type = MakeType(result_precision, result_scale);
+  } else {
+    *out_type = MakeAdjustedType(result_precision, result_scale);
+  }
+
   return Status::OK();
 }
 

--- a/cpp/src/gandiva/decimal_type_util.cc
+++ b/cpp/src/gandiva/decimal_type_util.cc
@@ -29,6 +29,8 @@ constexpr int32_t DecimalTypeUtil::kMinAdjustedScale;
   }
 
 // Implementation of decimal rules.
+// In addition to having a precision beyond 38, it is compatible with
+// **Redshift's decimal promotion rules**.
 Status DecimalTypeUtil::GetResultType(Op op, const Decimal128TypeVector& in_types,
                                       Decimal128TypePtr* out_type) {
   DCHECK_EQ(in_types.size(), 2);
@@ -59,7 +61,7 @@ Status DecimalTypeUtil::GetResultType(Op op, const Decimal128TypeVector& in_type
       break;
 
     case kOpDivide:
-      result_scale = std::max(kMinAdjustedScale, s1 + p2 + 1);
+      result_scale = std::max(4, s1 + p2 - s2 + 1);
       result_precision = p1 - s1 + s2 + result_scale;
       break;
 

--- a/cpp/src/gandiva/decimal_type_util.h
+++ b/cpp/src/gandiva/decimal_type_util.h
@@ -60,7 +60,8 @@ class GANDIVA_EXPORT DecimalTypeUtil {
   // For specified operation and input scale/precision, determine the output
   // scale/precision.
   static Status GetResultType(Op op, const Decimal128TypeVector& in_types,
-                              Decimal128TypePtr* out_type);
+                              Decimal128TypePtr* out_type,
+                              bool use_redshift_rules = false);
 
   static Decimal128TypePtr MakeType(int32_t precision, int32_t scale) {
     return std::dynamic_pointer_cast<arrow::Decimal128Type>(

--- a/cpp/src/gandiva/decimal_type_util.h
+++ b/cpp/src/gandiva/decimal_type_util.h
@@ -45,6 +45,9 @@ class GANDIVA_EXPORT DecimalTypeUtil {
   /// The maximum precision representable by a 8-byte decimal
   static constexpr int32_t kMaxDecimal64Precision = 18;
 
+  /// The minimum precision representable by a 16-byte decimal
+  static constexpr int32_t kMinPrecision = 1;
+
   /// The maximum precision representable by a 16-byte decimal
   static constexpr int32_t kMaxPrecision = 38;
 
@@ -57,11 +60,19 @@ class GANDIVA_EXPORT DecimalTypeUtil {
   // * There is no strong reason for 6, but both SQLServer and Impala use 6 too.
   static constexpr int32_t kMinAdjustedScale = 6;
 
+  // The same function with kMinAdjustedScale, just for compatibility with
+  // compute module's decimal promotion rules.
+  static constexpr int32_t kMinComputeAdjustedScale = 4;
+
   // For specified operation and input scale/precision, determine the output
   // scale/precision.
+  //
+  // The 'use_compute_rules' is for compatibility with compute module's
+  // decimal promotion rules:
+  // https://arrow.apache.org/docs/cpp/compute.html#arithmetic-functions
   static Status GetResultType(Op op, const Decimal128TypeVector& in_types,
                               Decimal128TypePtr* out_type,
-                              bool use_redshift_rules = false);
+                              bool use_compute_rules = false);
 
   static Decimal128TypePtr MakeType(int32_t precision, int32_t scale) {
     return std::dynamic_pointer_cast<arrow::Decimal128Type>(

--- a/cpp/src/gandiva/precompiled/decimal_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops_test.cc
@@ -340,10 +340,10 @@ TEST_F(TestDecimalSql, Multiply) {
 }
 
 TEST_F(TestDecimalSql, Divide) {
-  DivideAndVerifyAllSign(DecimalScalar128{"201", 10, 3},           // x
-                         DecimalScalar128{"301", 10, 2},           // y
-                         DecimalScalar128{"66777408638", 21, 12},  // expected
-                         false);                                   // overflow
+  DivideAndVerifyAllSign(DecimalScalar128{"201", 10, 3},             // x
+                         DecimalScalar128{"301", 10, 2},             // y
+                         DecimalScalar128{"6677740863787", 23, 14},  // expected
+                         false);                                     // overflow
 
   DivideAndVerifyAllSign(DecimalScalar128{"201", 20, 3},                  // x
                          DecimalScalar128{"301", 20, 2},                  // y

--- a/cpp/src/gandiva/precompiled/decimal_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops_test.cc
@@ -340,10 +340,10 @@ TEST_F(TestDecimalSql, Multiply) {
 }
 
 TEST_F(TestDecimalSql, Divide) {
-  DivideAndVerifyAllSign(DecimalScalar128{"201", 10, 3},             // x
-                         DecimalScalar128{"301", 10, 2},             // y
-                         DecimalScalar128{"6677740863787", 23, 14},  // expected
-                         false);                                     // overflow
+  DivideAndVerifyAllSign(DecimalScalar128{"201", 10, 3},           // x
+                         DecimalScalar128{"301", 10, 2},           // y
+                         DecimalScalar128{"66777408638", 21, 12},  // expected
+                         false);                                   // overflow
 
   DivideAndVerifyAllSign(DecimalScalar128{"201", 20, 3},                  // x
                          DecimalScalar128{"301", 20, 2},                  // y

--- a/cpp/src/gandiva/tests/decimal_single_test.cc
+++ b/cpp/src/gandiva/tests/decimal_single_test.cc
@@ -283,9 +283,9 @@ TEST_F(TestDecimalOps, TestMultiply) {
 }
 
 TEST_F(TestDecimalOps, TestDivide) {
-  DivideAndVerify(decimal_literal("201", 10, 3),              // x
-                  decimal_literal("301", 10, 2),              // y
-                  decimal_literal("6677740863787", 23, 14));  // expected
+  DivideAndVerify(decimal_literal("201", 10, 3),            // x
+                  decimal_literal("301", 10, 2),            // y
+                  decimal_literal("66777408638", 21, 12));  // expected
 
   DivideAndVerify(DecimalScalar128(std::string(38, '9'), 38, 20),  // x
                   DecimalScalar128(std::string(35, '9'), 38, 20),  // x


### PR DESCRIPTION
### Rationale for this change

Gandiva decimal divide rules are different with our compute module's rules. Some systems such as Redshift use the same rules as our compute module's rules. So it's useful that Gandiva support our compute module's rules too. 

### What changes are included in this PR?
Support an option argument in GetResultType for compatibilty with  **compute module's decimal promotion rules**.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40308