### PR TITLE
GH-40393: [Java] add precondition for NullVector constructor to check field type

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -54,7 +54,7 @@ public class NullVector implements FieldVector {
    * @param name name of the vector
    */
   public NullVector(String name) {
-    this(name, 0);
+    this(name, FieldType.nullable(Types.MinorType.NULL.getType()));
   }
 
   /**
@@ -64,8 +64,7 @@ public class NullVector implements FieldVector {
    * @param valueCount number of values (i.e., nulls) in this vector.
    */
   public NullVector(String name, int valueCount) {
-    this.field = new Field(name, FieldType.nullable(Types.MinorType.NULL.getType()), null);
-    this.valueCount = valueCount;
+    this(new Field(name, FieldType.nullable(Types.MinorType.NULL.getType()), null), valueCount);
   }
 
   /**
@@ -74,9 +73,8 @@ public class NullVector implements FieldVector {
    * @param name      name of the vector
    * @param fieldType type of Field materialized by this vector.
    */
-  @Deprecated
   public NullVector(String name, FieldType fieldType) {
-    this(name);
+    this(new Field(name, fieldType, null));
   }
 
   /**
@@ -84,9 +82,8 @@ public class NullVector implements FieldVector {
    *
    * @param field field materialized by this vector.
    */
-  @Deprecated
   public NullVector(Field field) {
-    this(field.getName());
+    this(field, 0);
   }
 
   /**
@@ -95,14 +92,14 @@ public class NullVector implements FieldVector {
    * @param field field materialized by this vector.
    * @param valueCount number of values (i.e., nulls) in this vector.
    */
-  @Deprecated
   public NullVector(Field field, int valueCount) {
-    this(field.getName(), valueCount);
+    this.field = field;
+    this.valueCount = valueCount;
   }
 
   @Deprecated
   public NullVector() {
-    this(DATA_VECTOR_NAME);
+    this(new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null));
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -54,7 +54,7 @@ public class NullVector implements FieldVector {
    * @param name name of the vector
    */
   public NullVector(String name) {
-    this(name, FieldType.nullable(Types.MinorType.NULL.getType()));
+    this(name, 0);
   }
 
   /**
@@ -64,7 +64,8 @@ public class NullVector implements FieldVector {
    * @param valueCount number of values (i.e., nulls) in this vector.
    */
   public NullVector(String name, int valueCount) {
-    this(new Field(name, FieldType.nullable(Types.MinorType.NULL.getType()), null), valueCount);
+    this.field = new Field(name, FieldType.nullable(Types.MinorType.NULL.getType()), null);
+    this.valueCount = valueCount;
   }
 
   /**
@@ -73,8 +74,9 @@ public class NullVector implements FieldVector {
    * @param name      name of the vector
    * @param fieldType type of Field materialized by this vector.
    */
+  @Deprecated
   public NullVector(String name, FieldType fieldType) {
-    this(new Field(name, fieldType, null));
+    this(name);
   }
 
   /**
@@ -82,8 +84,9 @@ public class NullVector implements FieldVector {
    *
    * @param field field materialized by this vector.
    */
+  @Deprecated
   public NullVector(Field field) {
-    this(field, 0);
+    this(field.getName());
   }
 
   /**
@@ -92,14 +95,14 @@ public class NullVector implements FieldVector {
    * @param field field materialized by this vector.
    * @param valueCount number of values (i.e., nulls) in this vector.
    */
+  @Deprecated
   public NullVector(Field field, int valueCount) {
-    this.field = field;
-    this.valueCount = valueCount;
+    this(field.getName(), valueCount);
   }
 
   @Deprecated
   public NullVector() {
-    this(new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null));
+    this(DATA_VECTOR_NAME);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -93,6 +93,7 @@ public class NullVector implements FieldVector {
    * @param valueCount number of values (i.e., nulls) in this vector.
    */
   public NullVector(Field field, int valueCount) {
+    Preconditions.checkArgument(field.getFieldType().getType() == Types.MinorType.NULL.getType(), "NullVector must have null type.");
     this.field = field;
     this.valueCount = valueCount;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -93,7 +93,8 @@ public class NullVector implements FieldVector {
    * @param valueCount number of values (i.e., nulls) in this vector.
    */
   public NullVector(Field field, int valueCount) {
-    Preconditions.checkArgument(field.getFieldType().getType() == Types.MinorType.NULL.getType(), "NullVector must have null type.");
+    Preconditions.checkArgument(field.getFieldType().getType() == Types.MinorType.NULL.getType(),
+            "NullVector must have null type.");
     this.field = field;
     this.valueCount = valueCount;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -46,9 +46,8 @@ public final class ZeroVector extends NullVector {
    * @param name      name of the vector
    * @param fieldType type of Field materialized by this vector.
    */
-  @Deprecated
   public ZeroVector(String name, FieldType fieldType) {
-    this(name);
+    super(name, fieldType);
   }
 
   /**
@@ -56,9 +55,8 @@ public final class ZeroVector extends NullVector {
    *
    * @param field field materialized by this vector.
    */
-  @Deprecated
   public ZeroVector(Field field) {
-    this(field.getName());
+    super(field);
   }
 
   @Deprecated

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -46,8 +46,9 @@ public final class ZeroVector extends NullVector {
    * @param name      name of the vector
    * @param fieldType type of Field materialized by this vector.
    */
+  @Deprecated
   public ZeroVector(String name, FieldType fieldType) {
-    super(name, fieldType);
+    this(name);
   }
 
   /**
@@ -55,8 +56,9 @@ public final class ZeroVector extends NullVector {
    *
    * @param field field materialized by this vector.
    */
+  @Deprecated
   public ZeroVector(Field field) {
-    super(field);
+    this(field.getName());
   }
 
   @Deprecated


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://github.com/apache/arrow-java/issues/119

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This changes constructors of NullVector and ZeroVector to always set the field type to the Null type, and marks constructors that accept a field or a field type as deprecated.

### Are these changes tested?

This change should be covered by existing tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

Yes

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: apache/arrow-java#119