### PR TITLE
GH-40439: [Python] Fix flake8 failures in python/benchmarks/parquet.py

### DIFF
--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -187,11 +187,12 @@ def python_linter(src, fix=False):
         return
 
     # Gather files for autopep8
-    patterns = ["python/pyarrow/**/*.py",
+    patterns = ["python/benchmarks/**/*.py",
+                "python/examples/**/*.py",
+                "python/pyarrow/**/*.py",
                 "python/pyarrow/**/*.pyx",
                 "python/pyarrow/**/*.pxd",
                 "python/pyarrow/**/*.pxi",
-                "python/examples/**/*.py",
                 "dev/*.py",
                 "dev/archery/**/*.py",
                 "dev/release/**/*.py"]
@@ -232,8 +233,8 @@ def python_linter(src, fix=False):
     yield LintResult.from_cmd(
         flake8("--extend-exclude=" + ','.join(flake8_exclude),
                "--config=" + os.path.join(src.python, "setup.cfg"),
-               setup_py, src.pyarrow, os.path.join(src.python, "examples"),
-               src.dev, check=False))
+               setup_py, src.pyarrow, os.path.join(src.python, "benchmarks"),
+               os.path.join(src.python, "examples"), src.dev, check=False))
 
     logger.info("Running Cython linter (cython-lint)")
 

--- a/python/benchmarks/parquet.py
+++ b/python/benchmarks/parquet.py
@@ -15,12 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import shutil
-import tempfile
-
 from pandas.util.testing import rands
 import numpy as np
-import pandas as pd
 
 import pyarrow as pa
 try:


### PR DESCRIPTION
### Rationale for this change

Failures:

    /arrow/python/benchmarks/parquet.py:18:1: F401 'shutil' imported but unused
    /arrow/python/benchmarks/parquet.py:19:1: F401 'tempfile' imported but unused
    /arrow/python/benchmarks/parquet.py:23:1: F401 'pandas as pd' imported but unused

### What changes are included in this PR?

* Remove unused imports.
* Add python/benchmarks/ to lint targets.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40439