### PR TITLE
GH-40443: [Python] Suppress python/examples/minimal_build/Dockerfile.* warnings

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -18,7 +18,8 @@
 ignored:
   - DL3008
   - DL3013
+  - DL3015 # Avoid additional packages by specifying `--no-install-recommends`
   - DL3018
-  - DL3015  # Avoid additional packages by specifying `--no-install-recommends`
-  - DL3028  # Ruby gem version pinning
+  - DL3028 # Ruby gem version pinning
   - DL3007 # r-sanitizer must use latest
+  - DL3041 # Specify version with `dnf install -y <package>-<version>`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         name: Docker Format
         language: docker_image
         types:
-         - dockerfile
+          - dockerfile
         entry: --entrypoint /bin/hadolint hadolint/hadolint:latest -
         exclude: ^dev/.*$
   - repo: https://github.com/pycqa/flake8

--- a/python/examples/minimal_build/Dockerfile.fedora
+++ b/python/examples/minimal_build/Dockerfile.fedora
@@ -27,6 +27,7 @@ RUN dnf update -y && \
         make \
         cmake \
         ninja-build \
-        python3-devel
+        python3-devel && \
+    dnf clean all
 
-RUN pip3 install -U pip setuptools
+RUN pip3 install --no-cache-dir -U pip setuptools

--- a/python/examples/minimal_build/Dockerfile.ubuntu
+++ b/python/examples/minimal_build/Dockerfile.ubuntu
@@ -35,4 +35,4 @@ RUN apt-get update -y -q && \
       && \
       apt-get clean && rm -rf /var/lib/apt/lists*
 
-RUN pip3 install -U pip setuptools
+RUN pip3 install --no-cache-dir -U pip setuptools


### PR DESCRIPTION
### Rationale for this change

    python/examples/minimal_build/Dockerfile.fedora:20 DL3040 warning: `dnf clean all` missing after dnf command.
    python/examples/minimal_build/Dockerfile.fedora:20 DL3041 warning: Specify version with `dnf install -y <package>-<version>`.
    python/examples/minimal_build/Dockerfile.fedora:32 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
    python/examples/minimal_build/Dockerfile.ubuntu:38 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`

### What changes are included in this PR?

* Ignore "DL3041 warning: Specify version with `dnf install -y <package>-<version>`." because we don't specify version.
* Suppress other warnings.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40443