### PR TITLE
GH-40445: [C++] Fix static build on Windows

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -5018,6 +5018,9 @@ macro(build_awssdk)
                           "ncrypt.lib"
                           "Secur32.lib"
                           "Shlwapi.lib")
+    set_property(TARGET AWS::aws-c-io
+                 APPEND
+                 PROPERTY INTERFACE_LINK_LIBRARIES "crypt32.lib")
   endif()
 
   # AWSSDK is static-only build

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -478,7 +478,7 @@ set_source_files_properties(vendored/datetime/tz.cpp
 arrow_add_object_library(ARROW_VENDORED ${ARROW_VENDORED_SRCS})
 # Disable DLL exports in vendored uriparser library
 foreach(ARROW_VENDORED_TARGET ${ARROW_VENDORED_TARGETS})
-  target_compile_definitions(${ARROW_VENDORED_TARGET} PUBLIC URI_STATIC_BUILD)
+  target_compile_definitions(${ARROW_VENDORED_TARGET} PRIVATE URI_STATIC_BUILD)
 endforeach()
 
 set(ARROW_UTIL_SRCS
@@ -558,6 +558,11 @@ if(ARROW_WITH_ZSTD)
 endif()
 
 arrow_add_object_library(ARROW_UTIL ${ARROW_UTIL_SRCS})
+
+# Disable DLL exports in vendored uriparser library
+foreach(ARROW_UTIL_TARGET ${ARROW_UTIL_TARGETS})
+  target_compile_definitions(${ARROW_UTIL_TARGET} PRIVATE URI_STATIC_BUILD)
+endforeach()
 
 if(ARROW_USE_BOOST)
   foreach(ARROW_UTIL_TARGET ${ARROW_UTIL_TARGETS})


### PR DESCRIPTION
### Rationale for this change

```text
LINK : warning LNK4217: symbol 'uriEscapeExA' defined in 'arrow_static.lib(unity_0_c.c.obj)' is imported by 'arrow_static.lib(unity_5_cxx.cxx.obj)' in function '"class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl arrow::internal::UriEscape(class std::basic_string_view<char,struct std::char_traits<char> >)" (?UriEscape@internal@arrow@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$basic_string_view@DU?$char_traits@D@std@@@4@@Z)'
LINK : warning LNK4217: symbol 'uriUnescapeInPlaceA' defined in 'arrow_static.lib(unity_0_c.c.obj)' is imported by 'arrow_static.lib(unity_5_cxx.cxx.obj)' in function '"class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl arrow::internal::UriUnescape(class std::basic_string_view<char,struct std::char_traits<char> >)" (?UriUnescape@internal@arrow@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$basic_string_view@DU?$char_traits@D@std@@@4@@Z)'
LINK : warning LNK4217: symbol 'uriWindowsFilenameToUriStringA' defined in 'arrow_static.lib(unity_0_c.c.obj)' is imported by 'arrow_static.lib(unity_5_cxx.cxx.obj)' in function '"class arrow::Result<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > __cdecl arrow::internal::UriFromAbsolutePath(class std::basic_string_view<char,struct std::char_traits<char> >)" (?UriFromAbsolutePath@internal@arrow@@YA?AV?$Result@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@V?$basic_string_view@DU?$char_traits@D@std@@@std@@@Z)'
arrow_static.lib(unity_5_cxx.cxx.obj) : error LNK2019: unresolved external symbol __imp_uriParseSingleUriExA referenced in function "public: class arrow::Status __cdecl arrow::internal::Uri::Parse(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (?Parse@Uri@internal@arrow@@QEAA?AVStatus@3@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
arrow_static.lib(unity_5_cxx.cxx.obj) : error LNK2019: unresolved external symbol __imp_uriFreeUriMembersA referenced in function "public: __cdecl arrow::internal::Uri::Impl::~Impl(void)" (??1Impl@Uri@internal@arrow@@QEAA@XZ)
arrow_static.lib(unity_5_cxx.cxx.obj) : error LNK2019: unresolved external symbol __imp_uriDissectQueryMallocA referenced in function "public: class arrow::Result<class std::vector<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::allocator<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > > > > __cdecl arrow::internal::Uri::query_items(void)const " (?query_items@Uri@internal@arrow@@QEBA?AV?$Result@V?$vector@U?$pair@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@@std@@V?$allocator@U?$pair@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@@std@@@2@@std@@@3@XZ)
arrow_static.lib(unity_5_cxx.cxx.obj) : error LNK2019: unresolved external symbol __imp_uriFreeQueryListA referenced in function "public: class arrow::Result<class std::vector<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > >,class std::allocator<struct std::pair<class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > > > > __cdecl arrow::internal::Uri::query_items(void)const " (?query_items@Uri@internal@arrow@@QEBA?AV?$Result@V?$vector@U?$pair@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@@std@@V?$allocator@U?$pair@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V12@@std@@@2@@std@@@3@XZ)
aws-c-io.lib(secure_channel_tls_handler.c.obj) : error LNK2019: unresolved external symbol __imp_CertFreeCertificateContext referenced in function s_ctx_new
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2001: unresolved external symbol __imp_CertFreeCertificateContext
aws-c-io.lib(secure_channel_tls_handler.c.obj) : error LNK2019: unresolved external symbol __imp_CertCreateCertificateChainEngine referenced in function s_manually_verify_peer_cert
aws-c-io.lib(secure_channel_tls_handler.c.obj) : error LNK2019: unresolved external symbol __imp_CertFreeCertificateChainEngine referenced in function s_manually_verify_peer_cert
aws-c-io.lib(secure_channel_tls_handler.c.obj) : error LNK2019: unresolved external symbol __imp_CertGetCertificateChain referenced in function s_manually_verify_peer_cert
aws-c-io.lib(secure_channel_tls_handler.c.obj) : error LNK2019: unresolved external symbol __imp_CertFreeCertificateChain referenced in function s_manually_verify_peer_cert
aws-c-io.lib(secure_channel_tls_handler.c.obj) : error LNK2019: unresolved external symbol __imp_CertVerifyCertificateChainPolicy referenced in function s_manually_verify_peer_cert
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CryptDecodeObjectEx referenced in function aws_import_key_pair_to_cert_context
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CertOpenStore referenced in function aws_import_key_pair_to_cert_context
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CertCloseStore referenced in function aws_close_cert_store
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CertFindCertificateInStore referenced in function aws_load_cert_from_system_cert_store
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CertSetCertificateContextProperty referenced in function aws_import_key_pair_to_cert_context
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CertAddCertificateContextToStore referenced in function aws_import_key_pair_to_cert_context
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CryptQueryObject referenced in function aws_import_key_pair_to_cert_context
aws-c-io.lib(windows_pki_utils.c.obj) : error LNK2019: unresolved external symbol __imp_CryptStringToBinaryA referenced in function aws_load_cert_from_system_cert_store
```

### What changes are included in this PR?

* Add missing `URI_STATIC_BUILD` macro definition that was removed by #39824 accidentally.
* Add missing `crypt32.lib` dependency to `aws-c-io`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40445