### PR TITLE
MINOR: [R][Docs] Fix typo in s3_bucket example code

### DIFF
--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -486,7 +486,7 @@ default_s3_options <- list(
 #' @examplesIf FALSE
 #' # Turn on debug logging. The following line of code should be run in a fresh
 #' # R session prior to any calls to `s3_bucket()` (or other S3 functions)
-#' Sys.setenv("ARROW_S3_LOG_LEVEL", "DEBUG")
+#' Sys.setenv("ARROW_S3_LOG_LEVEL"="DEBUG")
 #' bucket <- s3_bucket("voltrondata-labs-datasets")
 #'
 #' @export

--- a/r/man/s3_bucket.Rd
+++ b/r/man/s3_bucket.Rd
@@ -35,7 +35,7 @@ bucket <- s3_bucket("voltrondata-labs-datasets")
 \dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 # Turn on debug logging. The following line of code should be run in a fresh
 # R session prior to any calls to `s3_bucket()` (or other S3 functions)
-Sys.setenv("ARROW_S3_LOG_LEVEL", "DEBUG")
+Sys.setenv("ARROW_S3_LOG_LEVEL"="DEBUG")
 bucket <- s3_bucket("voltrondata-labs-datasets")
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
### Rationale for this change

The current code is invalid R code and will error so I'd like to fix that.

### Are these changes tested?

Yes, but manually.

Current code:

```r
>  Sys.setenv("ARROW_S3_LOG_LEVEL","DEBUG")
Error in Sys.setenv("ARROW_S3_LOG_LEVEL", "DEBUG") :
  all arguments must be named
```

New code:

```r
>  Sys.setenv("ARROW_S3_LOG_LEVEL"="DEBUG")
```

### Are there any user-facing changes?

Correct docs.