### PR TITLE
GH-40485: [Python][CI] Skip failing test_dateutil_tzinfo_to_string

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -346,6 +346,11 @@ def test_pytz_tzinfo_to_string():
 
 
 def test_dateutil_tzinfo_to_string():
+    if sys.platform == 'win32':
+        # Skip due to new release of python-dateutil
+        # https://github.com/apache/arrow/issues/40485
+        pytest.skip('Skip on Win due to new release of python-dateutil')
+
     pytest.importorskip("dateutil")
     import dateutil.tz
 


### PR DESCRIPTION

* GitHub Issue: #40485