### PR TITLE
MINOR: [Java] Bump Netty to 4.1.108.Final

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,7 @@
     <dep.junit.jupiter.version>5.10.2</dep.junit.jupiter.version>
     <dep.slf4j.version>2.0.11</dep.slf4j.version>
     <dep.guava-bom.version>33.0.0-jre</dep.guava-bom.version>
-    <dep.netty-bom.version>4.1.106.Final</dep.netty-bom.version>
+    <dep.netty-bom.version>4.1.108.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.61.1</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.16.1</dep.jackson-bom.version>


### PR DESCRIPTION
### Rationale for this change

[Java] bump to latest version of Netty

https://netty.io/news/2024/02/13/4-1-107-Final.html

https://netty.io/news/2024/03/21/4-1-108-Final.html

### What changes are included in this PR?

modified Java pom.xml

### Are these changes tested?

GitHub Actions CI build

### Are there any user-facing changes?

No

