### PR TITLE
GH-40495: [GLib] Use G_DECLARE_DERIVABLE_TYPE()

### DIFF
--- a/c_glib/arrow-glib/input-stream.h
+++ b/c_glib/arrow-glib/input-stream.h
@@ -139,46 +139,15 @@ GArrowMemoryMappedInputStream *
 garrow_memory_mapped_input_stream_new(const gchar *path, GError **error);
 
 #define GARROW_TYPE_GIO_INPUT_STREAM (garrow_gio_input_stream_get_type())
-#define GARROW_GIO_INPUT_STREAM(obj)                                                     \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj), GARROW_TYPE_GIO_INPUT_STREAM, GArrowGIOInputStream))
-#define GARROW_GIO_INPUT_STREAM_CLASS(klass)                                             \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_GIO_INPUT_STREAM,                                 \
-                           GArrowGIOInputStreamClass))
-#define GARROW_IS_GIO_INPUT_STREAM(obj)                                                  \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_GIO_INPUT_STREAM))
-#define GARROW_IS_GIO_INPUT_STREAM_CLASS(klass)                                          \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_GIO_INPUT_STREAM))
-#define GARROW_GIO_INPUT_STREAM_GET_CLASS(obj)                                           \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_GIO_INPUT_STREAM,                               \
-                             GArrowGIOInputStreamClass))
-
-typedef struct _GArrowGIOInputStream GArrowGIOInputStream;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowGIOInputStreamClass GArrowGIOInputStreamClass;
-#endif
-
-/**
- * GArrowGIOInputStream:
- *
- * It's an input stream for `GInputStream`.
- */
-struct _GArrowGIOInputStream
-{
-  /*< private >*/
-  GArrowSeekableInputStream parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowGIOInputStream,
+                         garrow_gio_input_stream,
+                         GARROW,
+                         GIO_INPUT_STREAM,
+                         GArrowSeekableInputStream)
 struct _GArrowGIOInputStreamClass
 {
   GArrowSeekableInputStreamClass parent_class;
 };
-#endif
-
-GType
-garrow_gio_input_stream_get_type(void) G_GNUC_CONST;
 
 GArrowGIOInputStream *
 garrow_gio_input_stream_new(GInputStream *gio_input_stream);

--- a/c_glib/arrow-glib/output-stream.h
+++ b/c_glib/arrow-glib/output-stream.h
@@ -51,142 +51,43 @@ garrow_output_stream_write_record_batch(GArrowOutputStream *stream,
                                         GError **error);
 
 #define GARROW_TYPE_FILE_OUTPUT_STREAM (garrow_file_output_stream_get_type())
-#define GARROW_FILE_OUTPUT_STREAM(obj)                                                   \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_FILE_OUTPUT_STREAM,                            \
-                              GArrowFileOutputStream))
-#define GARROW_FILE_OUTPUT_STREAM_CLASS(klass)                                           \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_FILE_OUTPUT_STREAM,                               \
-                           GArrowFileOutputStreamClass))
-#define GARROW_IS_FILE_OUTPUT_STREAM(obj)                                                \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_FILE_OUTPUT_STREAM))
-#define GARROW_IS_FILE_OUTPUT_STREAM_CLASS(klass)                                        \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_FILE_OUTPUT_STREAM))
-#define GARROW_FILE_OUTPUT_STREAM_GET_CLASS(obj)                                         \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_FILE_OUTPUT_STREAM,                             \
-                             GArrowFileOutputStreamClass))
-
-typedef struct _GArrowFileOutputStream GArrowFileOutputStream;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowFileOutputStreamClass GArrowFileOutputStreamClass;
-#endif
-
-/**
- * GArrowFileOutputStream:
- *
- * It wraps `arrow::io::FileOutputStream`.
- */
-struct _GArrowFileOutputStream
-{
-  /*< private >*/
-  GArrowOutputStream parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowFileOutputStream,
+                         garrow_file_output_stream,
+                         GARROW,
+                         FILE_OUTPUT_STREAM,
+                         GArrowOutputStream)
 struct _GArrowFileOutputStreamClass
 {
   GArrowOutputStreamClass parent_class;
 };
-#endif
-
-GType
-garrow_file_output_stream_get_type(void) G_GNUC_CONST;
 
 GArrowFileOutputStream *
 garrow_file_output_stream_new(const gchar *path, gboolean append, GError **error);
 
 #define GARROW_TYPE_BUFFER_OUTPUT_STREAM (garrow_buffer_output_stream_get_type())
-#define GARROW_BUFFER_OUTPUT_STREAM(obj)                                                 \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_BUFFER_OUTPUT_STREAM,                          \
-                              GArrowBufferOutputStream))
-#define GARROW_BUFFER_OUTPUT_STREAM_CLASS(klass)                                         \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_BUFFER_OUTPUT_STREAM,                             \
-                           GArrowBufferOutputStreamClass))
-#define GARROW_IS_BUFFER_OUTPUT_STREAM(obj)                                              \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_BUFFER_OUTPUT_STREAM))
-#define GARROW_IS_BUFFER_OUTPUT_STREAM_CLASS(klass)                                      \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_BUFFER_OUTPUT_STREAM))
-#define GARROW_BUFFER_OUTPUT_STREAM_GET_CLASS(obj)                                       \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_BUFFER_OUTPUT_STREAM,                           \
-                             GArrowBufferOutputStreamClass))
-
-typedef struct _GArrowBufferOutputStream GArrowBufferOutputStream;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowBufferOutputStreamClass GArrowBufferOutputStreamClass;
-#endif
-
-/**
- * GArrowBufferOutputStream:
- *
- * It wraps `arrow::io::BufferOutputStream`.
- */
-struct _GArrowBufferOutputStream
-{
-  /*< private >*/
-  GArrowOutputStream parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowBufferOutputStream,
+                         garrow_buffer_output_stream,
+                         GARROW,
+                         BUFFER_OUTPUT_STREAM,
+                         GArrowOutputStream)
 struct _GArrowBufferOutputStreamClass
 {
   GArrowOutputStreamClass parent_class;
 };
-#endif
-
-GType
-garrow_buffer_output_stream_get_type(void) G_GNUC_CONST;
 
 GArrowBufferOutputStream *
 garrow_buffer_output_stream_new(GArrowResizableBuffer *buffer);
 
 #define GARROW_TYPE_GIO_OUTPUT_STREAM (garrow_gio_output_stream_get_type())
-#define GARROW_GIO_OUTPUT_STREAM(obj)                                                    \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_GIO_OUTPUT_STREAM,                             \
-                              GArrowGIOOutputStream))
-#define GARROW_GIO_OUTPUT_STREAM_CLASS(klass)                                            \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_GIO_OUTPUT_STREAM,                                \
-                           GArrowGIOOutputStreamClass))
-#define GARROW_IS_GIO_OUTPUT_STREAM(obj)                                                 \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_GIO_OUTPUT_STREAM))
-#define GARROW_IS_GIO_OUTPUT_STREAM_CLASS(klass)                                         \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_GIO_OUTPUT_STREAM))
-#define GARROW_GIO_OUTPUT_STREAM_GET_CLASS(obj)                                          \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_GIO_OUTPUT_STREAM,                              \
-                             GArrowGIOOutputStreamClass))
-
-typedef struct _GArrowGIOOutputStream GArrowGIOOutputStream;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowGIOOutputStreamClass GArrowGIOOutputStreamClass;
-#endif
-
-/**
- * GArrowGIOOutputStream:
- *
- * It's an output stream for `GOutputStream`.
- */
-struct _GArrowGIOOutputStream
-{
-  /*< private >*/
-  GArrowOutputStream parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowGIOOutputStream,
+                         garrow_gio_output_stream,
+                         GARROW,
+                         GIO_OUTPUT_STREAM,
+                         GArrowOutputStream)
 struct _GArrowGIOOutputStreamClass
 {
   GArrowOutputStreamClass parent_class;
 };
-#endif
-
-GType
-garrow_gio_output_stream_get_type(void) G_GNUC_CONST;
 
 GArrowGIOOutputStream *
 garrow_gio_output_stream_new(GOutputStream *gio_output_stream);

--- a/c_glib/arrow-glib/reader.h
+++ b/c_glib/arrow-glib/reader.h
@@ -100,95 +100,29 @@ garrow_table_batch_reader_set_max_chunk_size(GArrowTableBatchReader *reader,
 
 #define GARROW_TYPE_RECORD_BATCH_STREAM_READER                                           \
   (garrow_record_batch_stream_reader_get_type())
-#define GARROW_RECORD_BATCH_STREAM_READER(obj)                                           \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_RECORD_BATCH_STREAM_READER,                    \
-                              GArrowRecordBatchStreamReader))
-#define GARROW_RECORD_BATCH_STREAM_READER_CLASS(klass)                                   \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_RECORD_BATCH_STREAM_READER,                       \
-                           GArrowRecordBatchStreamReaderClass))
-#define GARROW_IS_RECORD_BATCH_STREAM_READER(obj)                                        \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_RECORD_BATCH_STREAM_READER))
-#define GARROW_IS_RECORD_BATCH_STREAM_READER_CLASS(klass)                                \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_RECORD_BATCH_STREAM_READER))
-#define GARROW_RECORD_BATCH_STREAM_READER_GET_CLASS(obj)                                 \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_RECORD_BATCH_STREAM_READER,                     \
-                             GArrowRecordBatchStreamReaderClass))
-
-typedef struct _GArrowRecordBatchStreamReader GArrowRecordBatchStreamReader;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowRecordBatchStreamReaderClass GArrowRecordBatchStreamReaderClass;
-#endif
-
-/**
- * GArrowRecordBatchStreamReader:
- *
- * It wraps `arrow::ipc::RecordBatchStreamReader`.
- */
-struct _GArrowRecordBatchStreamReader
-{
-  /*< private >*/
-  GArrowRecordBatchReader parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowRecordBatchStreamReader,
+                         garrow_record_batch_stream_reader,
+                         GARROW,
+                         RECORD_BATCH_STREAM_READER,
+                         GArrowRecordBatchReader)
 struct _GArrowRecordBatchStreamReaderClass
 {
   GArrowRecordBatchReaderClass parent_class;
 };
-#endif
-
-GType
-garrow_record_batch_stream_reader_get_type(void) G_GNUC_CONST;
 
 GArrowRecordBatchStreamReader *
 garrow_record_batch_stream_reader_new(GArrowInputStream *stream, GError **error);
 
 #define GARROW_TYPE_RECORD_BATCH_FILE_READER (garrow_record_batch_file_reader_get_type())
-#define GARROW_RECORD_BATCH_FILE_READER(obj)                                             \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_RECORD_BATCH_FILE_READER,                      \
-                              GArrowRecordBatchFileReader))
-#define GARROW_RECORD_BATCH_FILE_READER_CLASS(klass)                                     \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_RECORD_BATCH_FILE_READER,                         \
-                           GArrowRecordBatchFileReaderClass))
-#define GARROW_IS_RECORD_BATCH_FILE_READER(obj)                                          \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_RECORD_BATCH_FILE_READER))
-#define GARROW_IS_RECORD_BATCH_FILE_READER_CLASS(klass)                                  \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_RECORD_BATCH_FILE_READER))
-#define GARROW_RECORD_BATCH_FILE_READER_GET_CLASS(obj)                                   \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_RECORD_BATCH_FILE_READER,                       \
-                             GArrowRecordBatchFileReaderClass))
-
-typedef struct _GArrowRecordBatchFileReader GArrowRecordBatchFileReader;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowRecordBatchFileReaderClass GArrowRecordBatchFileReaderClass;
-#endif
-
-/**
- * GArrowRecordBatchFileReader:
- *
- * It wraps `arrow::ipc::RecordBatchFileReader`.
- */
-struct _GArrowRecordBatchFileReader
-{
-  /*< private >*/
-  GObject parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowRecordBatchFileReader,
+                         garrow_record_batch_file_reader,
+                         GARROW,
+                         RECORD_BATCH_FILE_READER,
+                         GObject)
 struct _GArrowRecordBatchFileReaderClass
 {
   GObjectClass parent_class;
 };
-#endif
-
-GType
-garrow_record_batch_file_reader_get_type(void) G_GNUC_CONST;
 
 GArrowRecordBatchFileReader *
 garrow_record_batch_file_reader_new(GArrowSeekableInputStream *file, GError **error);

--- a/c_glib/arrow-glib/writer.h
+++ b/c_glib/arrow-glib/writer.h
@@ -28,48 +28,15 @@
 G_BEGIN_DECLS
 
 #define GARROW_TYPE_RECORD_BATCH_WRITER (garrow_record_batch_writer_get_type())
-#define GARROW_RECORD_BATCH_WRITER(obj)                                                  \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_RECORD_BATCH_WRITER,                           \
-                              GArrowRecordBatchWriter))
-#define GARROW_RECORD_BATCH_WRITER_CLASS(klass)                                          \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_RECORD_BATCH_WRITER,                              \
-                           GArrowRecordBatchWriterClass))
-#define GARROW_IS_RECORD_BATCH_WRITER(obj)                                               \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_RECORD_BATCH_WRITER))
-#define GARROW_IS_RECORD_BATCH_WRITER_CLASS(klass)                                       \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_RECORD_BATCH_WRITER))
-#define GARROW_RECORD_BATCH_WRITER_GET_CLASS(obj)                                        \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_RECORD_BATCH_WRITER,                            \
-                             GArrowRecordBatchWriterClass))
-
-typedef struct _GArrowRecordBatchWriter GArrowRecordBatchWriter;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowRecordBatchWriterClass GArrowRecordBatchWriterClass;
-#endif
-
-/**
- * GArrowRecordBatchWriter:
- *
- * It wraps `arrow::ipc::RecordBatchWriter`.
- */
-struct _GArrowRecordBatchWriter
-{
-  /*< private >*/
-  GObject parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowRecordBatchWriter,
+                         garrow_record_batch_writer,
+                         GARROW,
+                         RECORD_BATCH_WRITER,
+                         GObject)
 struct _GArrowRecordBatchWriterClass
 {
   GObjectClass parent_class;
 };
-#endif
-
-GType
-garrow_record_batch_writer_get_type(void) G_GNUC_CONST;
 
 gboolean
 garrow_record_batch_writer_write_record_batch(GArrowRecordBatchWriter *writer,
@@ -84,48 +51,15 @@ garrow_record_batch_writer_close(GArrowRecordBatchWriter *writer, GError **error
 
 #define GARROW_TYPE_RECORD_BATCH_STREAM_WRITER                                           \
   (garrow_record_batch_stream_writer_get_type())
-#define GARROW_RECORD_BATCH_STREAM_WRITER(obj)                                           \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_RECORD_BATCH_STREAM_WRITER,                    \
-                              GArrowRecordBatchStreamWriter))
-#define GARROW_RECORD_BATCH_STREAM_WRITER_CLASS(klass)                                   \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_RECORD_BATCH_STREAM_WRITER,                       \
-                           GArrowRecordBatchStreamWriterClass))
-#define GARROW_IS_RECORD_BATCH_STREAM_WRITER(obj)                                        \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_RECORD_BATCH_STREAM_WRITER))
-#define GARROW_IS_RECORD_BATCH_STREAM_WRITER_CLASS(klass)                                \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_RECORD_BATCH_STREAM_WRITER))
-#define GARROW_RECORD_BATCH_STREAM_WRITER_GET_CLASS(obj)                                 \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_RECORD_BATCH_STREAM_WRITER,                     \
-                             GArrowRecordBatchStreamWriterClass))
-
-typedef struct _GArrowRecordBatchStreamWriter GArrowRecordBatchStreamWriter;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowRecordBatchStreamWriterClass GArrowRecordBatchStreamWriterClass;
-#endif
-
-/**
- * GArrowRecordBatchStreamWriter:
- *
- * It wraps `arrow::ipc::RecordBatchStreamWriter`.
- */
-struct _GArrowRecordBatchStreamWriter
-{
-  /*< private >*/
-  GArrowRecordBatchWriter parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowRecordBatchStreamWriter,
+                         garrow_record_batch_stream_writer,
+                         GARROW,
+                         RECORD_BATCH_STREAM_WRITER,
+                         GArrowRecordBatchWriter)
 struct _GArrowRecordBatchStreamWriterClass
 {
   GArrowRecordBatchWriterClass parent_class;
 };
-#endif
-
-GType
-garrow_record_batch_stream_writer_get_type(void) G_GNUC_CONST;
 
 GArrowRecordBatchStreamWriter *
 garrow_record_batch_stream_writer_new(GArrowOutputStream *sink,
@@ -133,48 +67,15 @@ garrow_record_batch_stream_writer_new(GArrowOutputStream *sink,
                                       GError **error);
 
 #define GARROW_TYPE_RECORD_BATCH_FILE_WRITER (garrow_record_batch_file_writer_get_type())
-#define GARROW_RECORD_BATCH_FILE_WRITER(obj)                                             \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                                     \
-                              GARROW_TYPE_RECORD_BATCH_FILE_WRITER,                      \
-                              GArrowRecordBatchFileWriter))
-#define GARROW_RECORD_BATCH_FILE_WRITER_CLASS(klass)                                     \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                                      \
-                           GARROW_TYPE_RECORD_BATCH_FILE_WRITER,                         \
-                           GArrowRecordBatchFileWriterClass))
-#define GARROW_IS_RECORD_BATCH_FILE_WRITER(obj)                                          \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GARROW_TYPE_RECORD_BATCH_FILE_WRITER))
-#define GARROW_IS_RECORD_BATCH_FILE_WRITER_CLASS(klass)                                  \
-  (G_TYPE_CHECK_CLASS_TYPE((klass), GARROW_TYPE_RECORD_BATCH_FILE_WRITER))
-#define GARROW_RECORD_BATCH_FILE_WRITER_GET_CLASS(obj)                                   \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                                      \
-                             GARROW_TYPE_RECORD_BATCH_FILE_WRITER,                       \
-                             GArrowRecordBatchFileWriterClass))
-
-typedef struct _GArrowRecordBatchFileWriter GArrowRecordBatchFileWriter;
-#ifndef __GTK_DOC_IGNORE__
-typedef struct _GArrowRecordBatchFileWriterClass GArrowRecordBatchFileWriterClass;
-#endif
-
-/**
- * GArrowRecordBatchFileWriter:
- *
- * It wraps `arrow::ipc::RecordBatchFileWriter`.
- */
-struct _GArrowRecordBatchFileWriter
-{
-  /*< private >*/
-  GArrowRecordBatchStreamWriter parent_instance;
-};
-
-#ifndef __GTK_DOC_IGNORE__
+G_DECLARE_DERIVABLE_TYPE(GArrowRecordBatchFileWriter,
+                         garrow_record_batch_file_writer,
+                         GARROW,
+                         RECORD_BATCH_FILE_WRITER,
+                         GArrowRecordBatchStreamWriter)
 struct _GArrowRecordBatchFileWriterClass
 {
   GArrowRecordBatchStreamWriterClass parent_class;
 };
-#endif
-
-GType
-garrow_record_batch_file_writer_get_type(void) G_GNUC_CONST;
 
 GArrowRecordBatchFileWriter *
 garrow_record_batch_file_writer_new(GArrowOutputStream *sink,


### PR DESCRIPTION
### Rationale for this change

Using `G_DECLARE_DERIVABLE_TYPE()` or its family is the recommended way to declare a class (type).

### What changes are included in this PR?

Replace raw `#define`s with `G_DECLARE_DERIVABLE_TYPE()`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40495