### PR TITLE
GH-40500: [C++] Ensure using bundled FlatBuffers

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -692,18 +692,21 @@ if("${ARROW_TEST_LINKAGE}" STREQUAL "shared")
 pass ARROW_BUILD_SHARED=on")
   endif()
   # Use shared linking for unit tests if it's available
-  set(ARROW_TEST_LINK_LIBS arrow_testing_shared ${ARROW_GTEST_GMOCK}
-                           ${ARROW_GTEST_GTEST_MAIN})
+  set(ARROW_TEST_LINK_LIBS arrow_testing_shared)
   set(ARROW_EXAMPLE_LINK_LIBS arrow_shared)
 else()
   if(ARROW_BUILD_TESTS AND NOT ARROW_BUILD_STATIC)
     message(FATAL_ERROR "If using static linkage for unit tests, must also \
 pass ARROW_BUILD_STATIC=on")
   endif()
-  set(ARROW_TEST_LINK_LIBS arrow_testing_static ${ARROW_GTEST_GMOCK}
-                           ${ARROW_GTEST_GTEST_MAIN})
+  set(ARROW_TEST_LINK_LIBS arrow_testing_static)
   set(ARROW_EXAMPLE_LINK_LIBS arrow_static)
 endif()
+# arrow::flatbuffers isn't needed for all tests but we specify it as
+# the first link library. It's for prioritizing bundled FlatBuffers
+# than system FlatBuffers.
+list(PREPEND ARROW_TEST_LINK_LIBS arrow::flatbuffers)
+list(APPEND ARROW_TEST_LINK_LIBS ${ARROW_GTEST_GMOCK} ${ARROW_GTEST_GTEST_MAIN})
 
 if(ARROW_BUILD_BENCHMARKS)
   set(ARROW_BENCHMARK_LINK_LIBS benchmark::benchmark_main ${ARROW_TEST_LINK_LIBS})

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -145,11 +145,10 @@ if(NOT MSVC_TOOLCHAIN)
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS ${CMAKE_DL_LIBS})
 endif()
 
-set(ARROW_TEST_LINK_TOOLCHAIN arrow::flatbuffers ${ARROW_GTEST_GMOCK}
-                              ${ARROW_GTEST_GTEST_MAIN})
-set(ARROW_TEST_STATIC_LINK_LIBS arrow_testing_static arrow_static
+set(ARROW_TEST_LINK_TOOLCHAIN ${ARROW_GTEST_GMOCK} ${ARROW_GTEST_GTEST_MAIN})
+set(ARROW_TEST_STATIC_LINK_LIBS arrow::flatbuffers arrow_testing_static arrow_static
                                 ${ARROW_TEST_LINK_TOOLCHAIN})
-set(ARROW_TEST_SHARED_LINK_LIBS arrow_testing_shared arrow_shared
+set(ARROW_TEST_SHARED_LINK_LIBS arrow::flatbuffers arrow_testing_shared arrow_shared
                                 ${ARROW_TEST_LINK_TOOLCHAIN})
 if(NOT MSVC)
   list(APPEND ARROW_TEST_SHARED_LINK_LIBS ${CMAKE_DL_LIBS})

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -59,8 +59,8 @@ add_arrow_lib(arrow_cuda
               SHARED_LINK_FLAGS
               ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
-              arrow_shared
               ${ARROW_CUDA_LINK_LIBS}
+              arrow_shared
               ${ARROW_CUDA_SHARED_LINK_LIBS}
               SHARED_INSTALL_INTERFACE_LIBS
               Arrow::arrow_shared

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -39,7 +39,7 @@ endfunction()
 
 add_arrow_test(feather_test)
 add_arrow_ipc_test(json_simple_test)
-add_arrow_ipc_test(read_write_test EXTRA_LINK_LIBS arrow::flatbuffers)
+add_arrow_ipc_test(read_write_test)
 add_arrow_ipc_test(tensor_test)
 
 # Headers: top level


### PR DESCRIPTION
### Rationale for this change

We'rebundling FlatBuffers and generated files by FlatBuffers. If we use system FlatBuffers that is different version of bundled one, we got a build error. 

### What changes are included in this PR?

Use `arrow::flatbuffers` as the first link library to prioritize bundled FlatBuffers than system FlatBuffers.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40500