### PR TITLE
GH-40964: [CI][Archery] Archery linking should also check for undefined symbols Linux

### DIFF
--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -67,6 +67,9 @@ class DynamicLibrary:
     def _just_symbols(self, symbol_info):
         return [line.split(' ')[-1] for line in symbol_info if line]
 
+    def _no_weak(self, lines):
+        return [line for line in lines if ' W ' not in line and ' w ' not in line]
+
     def list_symbols_for_dependency(self, dependency, remove_symbol_versions=False):
         result = _nm.run('-D',
                          dependency, stdout=subprocess.PIPE)
@@ -82,6 +85,7 @@ class DynamicLibrary:
         lines = result.stdout.decode('utf-8').splitlines()
         if remove_symbol_versions:
             lines = [line.split('@@', 1)[0] for line in lines]
+        lines = self._no_weak(lines)
         return self._just_symbols(lines)
 
     def find_library_paths(self, libraries):

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -85,13 +85,13 @@ class DynamicLibrary:
         return self._just_symbols(lines)
 
     def find_library_paths(self, libraries):
-        result = _ldconfig.run('-p', stdout=subprocess.PIPE)
-        lines = result.stdout.decode('utf-8').splitlines()
         paths = {}
         system = platform.system()
         for lib in libraries:
             paths[lib] = []
             if system == 'Linux':
+                result = _ldconfig.run('-p', stdout=subprocess.PIPE)
+                lines = result.stdout.decode('utf-8').splitlines()
                 for line in lines:
                     if lib in line:
                         match = re.search(r' => (.*)', line)

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -72,7 +72,8 @@ class DynamicLibrary:
             lines = [line.split('@@', 1)[0] for line in lines]
         return lines
 
-    def list_undefined_symbols_for_dependency(self, dependency, remove_symbol_versions=False):
+    def list_undefined_symbols_for_dependency(self, dependency,
+                                              remove_symbol_versions=False):
         result = _nm.run('--format=just-symbols', '-u',
                          dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -97,12 +97,20 @@ class DynamicLibrary:
             result = _ldd.run(file_path, stdout=subprocess.PIPE)
             lines = result.stdout.decode('utf-8').splitlines()
             for line in lines:
-                print(line)
+                # Input:
+                #    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f8c9dd90000)
+                # Match:
+                #   group(1): librt.so.1
+                #   group(2): /lib/x86_64-linux-gnu/librt.so.1
                 match = re.search(r'(\S*) => (\S*)', line)
                 if match:
                     paths[match.group(1)] = match.group(2)
                 else:
                     match = re.search(r'(\S*) \(.*\)', line)
+                    # Input:
+                    #    /lib64/ld-linux-x86-64.so.2 (0x00007c1af3a26000)
+                    # Match:
+                    #  group(1): /lib64/ld-linux-x86-64.so.2
                     if match:
                         paths[match.group(1)] = match.group(1)
         else:
@@ -115,8 +123,7 @@ def _check_undefined_symbols(dylib, allowed):
     undefined_symbols = dylib.list_undefined_symbols_for_dependency(dylib.path, True)
     expected_lib_paths = dylib.extract_library_paths(dylib.path)
     all_paths = list(expected_lib_paths.values())
-    print("All Paths")
-    print(all_paths)
+
     for lib_path in all_paths:
         if lib_path:
             expected_symbols = dylib.list_symbols_for_dependency(lib_path, True)

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -64,11 +64,11 @@ class DynamicLibrary:
         return names
 
     def _remove_weak_symbols(self, symbol_info):
-        return [line for line in symbol_info if not re.search(r'\s[Ww]\s', line)]
+        return [line for line in symbol_info if not line.endswith(" w")]
 
     def _capture_symbols(self, remove_symbol_versions, symbol_info):
         if remove_symbol_versions:
-            symbol_info = [line.split('@')[0] for line in symbol_info]
+            symbol_info = [line.split('@')[0].strip() for line in symbol_info]
         return symbol_info
 
     def list_symbols_for_dependency(self, dependency, remove_symbol_versions=False):
@@ -77,7 +77,8 @@ class DynamicLibrary:
             return []
         result = _nm.run('-D', '-P', dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
-        return self._capture_symbols(remove_symbol_versions, lines)
+        lines = self._capture_symbols(remove_symbol_versions, lines)
+        return self._remove_weak_symbols(lines)
 
     def list_undefined_symbols_for_dependency(self, dependency,
                                               remove_symbol_versions=False):

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -65,13 +65,13 @@ class DynamicLibrary:
         return names
 
     def list_symbols_for_dependency(self, dependency):
-        result = _nm.run('--format=just-symbols', '-D',
+        result = _nm.run('--format=bsd', '-D',
                          dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
         return lines
 
     def list_undefined_symbols_for_dependency(self, dependency):
-        result = _nm.run('--format=just-symbols', '-u',
+        result = _nm.run('--format=bsd', '-u',
                          dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
         return lines
@@ -103,13 +103,14 @@ def check_dynamic_library_dependencies(path, allowed, disallowed):
             )
     # Check for undefined symbols
     undefined_symbols = dylib.list_undefined_symbols_for_dependency(path)
+    print(len(undefined_symbols))
     expected_lib_paths = dylib.find_library_paths(allowed)
     for lb_path in expected_lib_paths.values():
         expected_symbols = dylib.list_symbols_for_dependency(lb_path)
         for exp_sym in expected_symbols:
             if exp_sym in undefined_symbols:
                 undefined_symbols.remove(exp_sym)
-
+    print(len(undefined_symbols))
     if undefined_symbols:
         undefined_symbols_str = '\n'.join(undefined_symbols)
         raise DependencyError(

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -99,7 +99,7 @@ class DynamicLibrary:
             lines = result.stdout.decode('utf-8').splitlines()
             for line in lines:
                 # Input:
-                #    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f8c9dd90000)
+                #   librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f8c9dd90000)
                 # Match:
                 #   group(1): librt.so.1
                 #   group(2): /lib/x86_64-linux-gnu/librt.so.1
@@ -109,9 +109,9 @@ class DynamicLibrary:
                 else:
                     match = re.search(r'(\S*) \(.*\)', line)
                     # Input:
-                    #    /lib64/ld-linux-x86-64.so.2 (0x00007c1af3a26000)
+                    #   /lib64/ld-linux-x86-64.so.2 (0x00007c1af3a26000)
                     # Match:
-                    #  group(1): /lib64/ld-linux-x86-64.so.2
+                    #   group(1): /lib64/ld-linux-x86-64.so.2
                     if match:
                         paths[match.group(1)] = match.group(1)
         else:

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -108,7 +108,8 @@ def _check_undefined_symbols(dylib, allowed):
     undefined_symbols = dylib.list_undefined_symbols_for_dependency(dylib.path, True)
     expected_lib_paths = dylib.extract_library_paths(dylib.path)
     all_paths = list(expected_lib_paths.values())
-
+    print("All Paths")
+    print(all_paths)
     for lib_path in all_paths:
         expected_symbols = dylib.list_symbols_for_dependency(lib_path, True)
         undefined_symbols = [

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -63,9 +63,6 @@ class DynamicLibrary:
             names.append(name)
         return names
 
-    def _extract_symbols(self, symbol_info):
-        return [re.search(r'\S+$', line).group() for line in symbol_info if line]
-
     def _remove_weak_symbols(self, symbol_info):
         return [line for line in symbol_info if not re.search(r'\s[Ww]\s', line)]
 
@@ -78,18 +75,16 @@ class DynamicLibrary:
         if dependency == 'linux-vdso.so.1':
             # this is a virtual library, thus symbols cannot be listed
             return []
-        result = _nm.run('-D', dependency, stdout=subprocess.PIPE)
+        result = _nm.run('-D', '-P', dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
-        lines = self._capture_symbols(remove_symbol_versions, lines)
-        return self._extract_symbols(lines)
+        return self._capture_symbols(remove_symbol_versions, lines)
 
     def list_undefined_symbols_for_dependency(self, dependency,
                                               remove_symbol_versions=False):
-        result = _nm.run('-u', dependency, stdout=subprocess.PIPE)
+        result = _nm.run('-u', '-P', dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
         lines = self._capture_symbols(remove_symbol_versions, lines)
-        lines = self._remove_weak_symbols(lines)
-        return self._extract_symbols(lines)
+        return self._remove_weak_symbols(lines)
 
     def extract_library_paths(self, file_path):
         system = platform.system()

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -75,6 +75,8 @@ class DynamicLibrary:
         return symbol_info
 
     def list_symbols_for_dependency(self, dependency, remove_symbol_versions=False):
+        if dependency == 'linux-vdso.so.1':
+            return []
         result = _nm.run('-D', dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
         lines = self._capture_symbols(remove_symbol_versions, lines)
@@ -95,9 +97,14 @@ class DynamicLibrary:
             result = _ldd.run(file_path, stdout=subprocess.PIPE)
             lines = result.stdout.decode('utf-8').splitlines()
             for line in lines:
+                print(line)
                 match = re.search(r'(\S*) => (\S*)', line)
                 if match:
                     paths[match.group(1)] = match.group(2)
+                else:
+                    match = re.search(r'(\S*) \(.*\)', line)
+                    if match:
+                        paths[match.group(1)] = match.group(1)
         else:
             raise ValueError(f"{system} is not supported")
         return paths

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -114,7 +114,8 @@ def _check_undefined_symbols(dylib, allowed):
         if lib_path:
             expected_symbols = dylib.list_symbols_for_dependency(lib_path, True)
             undefined_symbols = [
-                symbol for symbol in undefined_symbols if symbol not in expected_symbols]
+                symbol for symbol in undefined_symbols
+                if symbol not in expected_symbols]
 
     if undefined_symbols:
         undefined_symbols_str = '\n'.join(undefined_symbols)

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -111,9 +111,10 @@ def _check_undefined_symbols(dylib, allowed):
     print("All Paths")
     print(all_paths)
     for lib_path in all_paths:
-        expected_symbols = dylib.list_symbols_for_dependency(lib_path, True)
-        undefined_symbols = [
-            symbol for symbol in undefined_symbols if symbol not in expected_symbols]
+        if lib_path:
+            expected_symbols = dylib.list_symbols_for_dependency(lib_path, True)
+            undefined_symbols = [
+                symbol for symbol in undefined_symbols if symbol not in expected_symbols]
 
     if undefined_symbols:
         undefined_symbols_str = '\n'.join(undefined_symbols)

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -101,6 +101,7 @@ class DynamicLibrary:
                             paths[lib].append(match.group(1))
             elif system == 'Darwin':
                 result = _otool.run("-L", lib, stdout=subprocess.PIPE)
+                lines = result.stdout.decode('utf-8').splitlines()
                 for line in lines[1:]:
                     match = re.search(r'\s*(\S*)', line)
                     if match:
@@ -124,7 +125,6 @@ def check_dynamic_library_dependencies(path, allowed, disallowed):
             )
     # Check for undefined symbols
     undefined_symbols = dylib.list_undefined_symbols_for_dependency(path, True)
-    print("Allowed: ", allowed)
     expected_lib_paths = dylib.find_library_paths(allowed)
     all_paths = []
 

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -108,6 +108,8 @@ def check_dynamic_library_dependencies(path, allowed, disallowed):
                 f"Disallowed shared dependency found in {dylib.path}: `{dep}`"
             )
     # Check for undefined symbols
+    result = _nm.run('--version', stdout=subprocess.PIPE)
+    print(result.stdout.decode('utf-8'))
     undefined_symbols = dylib.list_undefined_symbols_for_dependency(path, True)
     print(len(undefined_symbols))
     expected_lib_paths = dylib.find_library_paths(allowed)

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -65,12 +65,14 @@ class DynamicLibrary:
         return names
 
     def list_symbols_for_dependency(self, dependency):
-        result = _nm.run('--format=just-symbols', '-D', dependency, stdout=subprocess.PIPE)
+        result = _nm.run('--format=just-symbols', '-D',
+                         dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
         return lines
 
     def list_undefined_symbols_for_dependency(self, dependency):
-        result = _nm.run('--format=just-symbols', '-u', dependency, stdout=subprocess.PIPE)
+        result = _nm.run('--format=just-symbols', '-u',
+                         dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
         return lines
 

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -66,10 +66,8 @@ class DynamicLibrary:
     def _remove_weak_symbols(self, symbol_info):
         return [line for line in symbol_info if not line.endswith(" w")]
 
-    def _capture_symbols(self, remove_symbol_versions, symbol_info):
-        if remove_symbol_versions:
-            symbol_info = [line.split('@')[0].strip() for line in symbol_info]
-        return symbol_info
+    def _remove_symbol_versions(self, symbol_info):
+        return [line.split('@')[0].strip() for line in symbol_info]
 
     def list_symbols_for_dependency(self, dependency, remove_symbol_versions=False):
         if dependency == 'linux-vdso.so.1':
@@ -77,14 +75,16 @@ class DynamicLibrary:
             return []
         result = _nm.run('-D', '-P', dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
-        lines = self._capture_symbols(remove_symbol_versions, lines)
+        if remove_symbol_versions:
+            lines = self._remove_symbol_versions(lines)
         return self._remove_weak_symbols(lines)
 
     def list_undefined_symbols_for_dependency(self, dependency,
                                               remove_symbol_versions=False):
         result = _nm.run('-u', '-P', dependency, stdout=subprocess.PIPE)
         lines = result.stdout.decode('utf-8').splitlines()
-        lines = self._capture_symbols(remove_symbol_versions, lines)
+        if remove_symbol_versions:
+            lines = self._remove_symbol_versions(lines)
         return self._remove_weak_symbols(lines)
 
     def extract_library_paths(self, file_path):

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -64,7 +64,7 @@ class DynamicLibrary:
         return names
 
     def _remove_weak_symbols(self, symbol_info):
-        return [line for line in symbol_info if not line.endswith(" w")]
+        return [line for line in symbol_info if not line.endswith((" v", " V", " w", " W"))]
 
     def _remove_symbol_versions(self, symbol_info):
         return [line.split('@')[0].strip() for line in symbol_info]

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -103,7 +103,7 @@ class DynamicLibrary:
                 if match:
                     paths[match.group(1)] = match.group(2)
                 else:
-                    match = re.search(r'(\S*) \(.*\)', line)
+                    match = re.search(r'(\S*) \(0x[0-9a-fA-F]*\)', line)
                     # Input:
                     #   /lib64/ld-linux-x86-64.so.2 (0x00007c1af3a26000)
                     # Match:

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -64,7 +64,8 @@ class DynamicLibrary:
         return names
 
     def _remove_weak_symbols(self, symbol_info):
-        return [line for line in symbol_info if not line.endswith((" v", " V", " w", " W"))]
+        return [line for line in symbol_info if not line.endswith(
+            (" v", " V", " w", " W"))]
 
     def _remove_symbol_versions(self, symbol_info):
         return [line.split('@')[0].strip() for line in symbol_info]

--- a/dev/archery/archery/tests/test_linking.py
+++ b/dev/archery/archery/tests/test_linking.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from linking import _remove_weak_symbols, _remove_symbol_versions
+
+
+def test_remove_weak_symbols(self):
+    symbol_info = ["symbol1 v", "symbol2 V", "symbol3", "symbol4 w", "symbol5 W", "symbol6"]
+    expected_result = ["symbol3", "symbol6"]
+    self.assertEqual(_remove_weak_symbols(self, symbol_info), expected_result)
+
+def test_remove_symbol_versions(self):
+        symbol_info = ["symbol1@version1", "symbol2@version2", "symbol3", "symbol4@version4"]
+        expected_result = ["symbol1", "symbol2", "symbol3", "symbol4"]
+        self.assertEqual(_remove_symbol_versions(self, symbol_info), expected_result)

--- a/dev/archery/archery/tests/test_linking.py
+++ b/dev/archery/archery/tests/test_linking.py
@@ -15,18 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from linking import _remove_weak_symbols, _remove_symbol_versions
+import pytest
+from archery.linking import DynamicLibrary
 
 
-def test_remove_weak_symbols(self):
+@pytest.fixture(autouse=True)
+def dynamic_library():
+    return DynamicLibrary("")
+
+
+def test_remove_weak_symbols(dynamic_library):
     symbol_info = ["symbol1 v", "symbol2 V",
                    "symbol3", "symbol4 w", "symbol5 W", "symbol6"]
     expected_result = ["symbol3", "symbol6"]
-    self.assertEqual(_remove_weak_symbols(self, symbol_info), expected_result)
+    assert dynamic_library._remove_weak_symbols(symbol_info) == expected_result
 
 
-def test_remove_symbol_versions(self):
+def test_remove_symbol_versions(dynamic_library):
     symbol_info = ["symbol1@version1",
                    "symbol2@version2", "symbol3", "symbol4@version4"]
     expected_result = ["symbol1", "symbol2", "symbol3", "symbol4"]
-    self.assertEqual(_remove_symbol_versions(self, symbol_info), expected_result)
+    assert dynamic_library._remove_symbol_versions(symbol_info) == expected_result

--- a/dev/archery/archery/tests/test_linking.py
+++ b/dev/archery/archery/tests/test_linking.py
@@ -19,11 +19,14 @@ from linking import _remove_weak_symbols, _remove_symbol_versions
 
 
 def test_remove_weak_symbols(self):
-    symbol_info = ["symbol1 v", "symbol2 V", "symbol3", "symbol4 w", "symbol5 W", "symbol6"]
+    symbol_info = ["symbol1 v", "symbol2 V",
+                   "symbol3", "symbol4 w", "symbol5 W", "symbol6"]
     expected_result = ["symbol3", "symbol6"]
     self.assertEqual(_remove_weak_symbols(self, symbol_info), expected_result)
 
+
 def test_remove_symbol_versions(self):
-        symbol_info = ["symbol1@version1", "symbol2@version2", "symbol3", "symbol4@version4"]
-        expected_result = ["symbol1", "symbol2", "symbol3", "symbol4"]
-        self.assertEqual(_remove_symbol_versions(self, symbol_info), expected_result)
+    symbol_info = ["symbol1@version1",
+                   "symbol2@version2", "symbol3", "symbol4@version4"]
+    expected_result = ["symbol1", "symbol2", "symbol3", "symbol4"]
+    self.assertEqual(_remove_symbol_versions(self, symbol_info), expected_result)


### PR DESCRIPTION
### Rationale for this change

This PR includes a check to find out if there are undefined symbols associated with the libraries. 

### What changes are included in this PR?

Includes a util functions which uses `nm` and `ldconfig` tools to find out libraries and their symbols and determine
if there are undefined symbols excluding the symbols in the allowed dependencies. 

### Are these changes tested?

Locally tested with a faulty shared library, but this needs validation on versions as there is a version mismatch in the local libraries. 

### Are there any user-facing changes?

No
* GitHub Issue: apache/arrow#40964
* GitHub Issue: #40964