### PR TITLE
GH-40522: [Dev][Go] Add Dependabot configuration for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [CI] "
+  - package-ecosystem: "gomod"
+    directory: "/go/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "MINOR: [Go] "
   - package-ecosystem: "maven"
     directory: "/java/"
     schedule:


### PR DESCRIPTION
### Rationale for this change

We don't want to update dependencies manually.

### What changes are included in this PR?

Enable Dependabot.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #40522