### PR TITLE
GH-40544: [Dev] Add cmake-format configuration to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,26 @@ repos:
         name: C/GLib Format
         files: >-
           ^c_glib/
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+      - id: cmake-format
+        name: CMake Format
+        files: >-
+          (
+          ?^ci/.*/.*\.cmake$|
+          ?^cpp/.*/.*\.cmake\.in$|
+          ?^cpp/.*/.*\.cmake$|
+          ?^cpp/.*/CMakeLists\.txt$|
+          ?^go/.*/CMakeLists\.txt$|
+          ?^java/.*/CMakeLists\.txt$|
+          ?^matlab/.*/CMakeLists\.txt$|
+          ?^python/.*/CMakeLists\.txt$|
+          )
+        exclude: >-
+          (
+          ?^cpp/cmake_modules/FindNumPy\.cmake$|
+          ?^cpp/cmake_modules/FindPythonLibsNew\.cmake$|
+          ?^cpp/cmake_modules/UseCython\.cmake$|
+          ?^cpp/src/arrow/util/config\.h\.cmake$|
+          )


### PR DESCRIPTION
### Rationale for this change

We can maintain cmake-format related configuration by just listing target files and excluded files in YAML instead of writing not only listing paths but also extra codes in Python by using pre-commit.

### What changes are included in this PR?

Add cmake-format related pre-commit configuration.

We don't remove cmake-format related code from Archery for now. We'll do it when pre-commit can replace `archery lint` entirely.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40544