### PR TITLE
GH-40558: [C++][CI] Fix TSAN and ASAN/UBSAN crashes

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -145,6 +145,8 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
+          # GH-40558: reduce ASLR to avoid ASAN crashing
+          sudo sysctl -w vm.mmap_rnd_bits=28
           sudo sysctl -w kernel.core_pattern="core.%e.%p"
           ulimit -c unlimited
           archery docker run ${{ matrix.image }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -145,7 +145,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          # GH-40558: reduce ASLR to avoid ASAN crashing
+          # GH-40558: reduce ASLR to avoid ASAN/LSAN crashes
           sudo sysctl -w vm.mmap_rnd_bits=28
           sudo sysctl -w kernel.core_pattern="core.%e.%p"
           ulimit -c unlimited

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -35,6 +35,8 @@ jobs:
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: |
+          # GH-40558: reduce ASLR to avoid TSAN crashing
+          sudo sysctl -w vm.mmap_rnd_bits=28
           archery docker run \
             -e SETUPTOOLS_SCM_PRETEND_VERSION="{{ arrow.no_rc_version }}" \
             {{ flags|default("") }} \


### PR DESCRIPTION
### Rationale for this change

A recent kernel update on some distributions (particularly Ubuntu) broke sanitizers:
https://github.com/google/sanitizers/issues/1716

### What changes are included in this PR?

Apply recommended workaround by reducing the number of bits used by ASLR (address space layout randomization).

### Are these changes tested?

Yes, they should fix the failing C++ sanitizer jobs.

### Are there any user-facing changes?

No.

* GitHub Issue: #40558