### PR TITLE
GH-39069: [C++][FS][Azure] Use the generic filesystem tests

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -377,10 +377,13 @@ class TestAzureFileSystemGeneric : public ::testing::Test, public GenericFileSys
   bool allow_write_file_over_dir() const override { return true; }
   bool allow_read_dir_as_file() const override { return true; }
   bool allow_move_dir() const override { return false; }
+  // Azurite doesn't support moving files over containers.
+  bool allow_move_file() const override { return false; }
   bool allow_append_to_file() const override { return true; }
   bool have_directory_mtimes() const override { return false; }
   bool have_flaky_directory_tree_deletion() const override { return false; }
-  bool have_file_metadata() const override { return true; }
+  bool have_file_metadata() const override { return false; }
+  bool have_default_file_metadata() const override { return true; }
 
   std::shared_ptr<AzureFileSystem> azure_fs_;
   std::shared_ptr<FileSystem> fs_;
@@ -1100,9 +1103,7 @@ class TestAzureFileSystem : public ::testing::Test {
 
     auto path2 = data.Path("directory2");
     ASSERT_OK(fs()->OpenOutputStream(path2));
-    // CreateDir returns OK even if there is already a file or directory at this
-    // location. Whether or not this is the desired behaviour is debatable.
-    ASSERT_OK(fs()->CreateDir(path2));
+    ASSERT_RAISES(IOError, fs()->CreateDir(path2));
     AssertFileInfo(fs(), path2, FileType::File);
   }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -395,6 +395,21 @@ class TestGeneric : public ::testing::Test, public GenericFileSystemTest {
   bool have_directory_mtimes() const override { return false; }
   bool have_flaky_directory_tree_deletion() const override { return false; }
   bool have_file_metadata() const override { return true; }
+  // calloc() used in libxml2's xmlNewGlobalState() is detected as a
+  // memory leak like the following. But it's a false positive. It's
+  // used in ListBlobsByHierarchy() for GetFileInfo() and it's freed
+  // in the call. This is detected as a memory leak only with
+  // generator API (GetFileInfoGenerator()) and not detected with
+  // non-generator API (GetFileInfo()). So this is a false positive.
+  //
+  // ==2875409==ERROR: LeakSanitizer: detected memory leaks
+  //
+  // Direct leak of 968 byte(s) in 1 object(s) allocated from:
+  //     #0 0x55d02c967bdc in calloc (build/debug/arrow-azurefs-test+0x17bbdc) (BuildId:
+  //     520690d1b20e860cc1feef665dce8196e64f955e) #1 0x7fa914b1cd1e in xmlNewGlobalState
+  //     builddir/main/../../threads.c:580:10 #2 0x7fa914b1cd1e in xmlGetGlobalState
+  //     builddir/main/../../threads.c:666:31
+  bool have_false_positive_memory_leak_with_generator() const override { return true; }
 
   BaseAzureEnv* env_;
   std::shared_ptr<AzureFileSystem> azure_fs_;

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -382,8 +382,7 @@ class TestAzureFileSystemGeneric : public ::testing::Test, public GenericFileSys
   bool allow_append_to_file() const override { return true; }
   bool have_directory_mtimes() const override { return false; }
   bool have_flaky_directory_tree_deletion() const override { return false; }
-  bool have_file_metadata() const override { return false; }
-  bool have_default_file_metadata() const override { return true; }
+  bool have_file_metadata() const override { return true; }
 
   std::shared_ptr<AzureFileSystem> azure_fs_;
   std::shared_ptr<FileSystem> fs_;

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -212,7 +212,7 @@ class AzuriteEnv : public AzureEnvImpl<AzuriteEnv> {
   /// SubmitBatch is used by:
   ///  - AzureFileSystem::DeleteDir
   ///  - AzureFileSystem::DeleteDirContents
-  bool HasSubmitBatchBug() const {
+  bool HasSubmitBatchBug() const override {
 #ifdef __APPLE__
     return true;
 #else

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -385,6 +385,10 @@ void GenericFileSystemTest::TestDeleteFiles(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestMoveFile(FileSystem* fs) {
+  if (!allow_move_file()) {
+    GTEST_SKIP() << "Filesystem doesn't allow moving files";
+  }
+
   ASSERT_OK(fs->CreateDir("AB/CD"));
   ASSERT_OK(fs->CreateDir("EF"));
   CreateFile(fs, "abc", "data");
@@ -922,7 +926,11 @@ void GenericFileSystemTest::TestOpenOutputStream(FileSystem* fs) {
     ASSERT_OK_AND_EQ("x-arrow/filesystem-test", got_metadata->Get("Content-Type"));
   } else {
     if (got_metadata) {
-      ASSERT_EQ(got_metadata->size(), 0);
+      if (have_default_file_metadata()) {
+        ASSERT_GT(got_metadata->size(), 0);
+      } else {
+        ASSERT_EQ(got_metadata->size(), 0);
+      }
     }
   }
 

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -252,8 +252,7 @@ void GenericFileSystemTest::TestCreateDir(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestDeleteDir(FileSystem* fs) {
-  if (have_flaky_directory_tree_deletion())
-    GTEST_SKIP() << "Flaky directory deletion on Windows";
+  if (have_flaky_directory_tree_deletion()) GTEST_SKIP() << "Flaky directory deletion";
 
   ASSERT_OK(fs->CreateDir("AB/CD/EF"));
   ASSERT_OK(fs->CreateDir("AB/GH/IJ"));
@@ -281,8 +280,7 @@ void GenericFileSystemTest::TestDeleteDir(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestDeleteDirContents(FileSystem* fs) {
-  if (have_flaky_directory_tree_deletion())
-    GTEST_SKIP() << "Flaky directory deletion on Windows";
+  if (have_flaky_directory_tree_deletion()) GTEST_SKIP() << "Flaky directory deletion";
 
   ASSERT_OK(fs->CreateDir("AB/CD/EF"));
   ASSERT_OK(fs->CreateDir("AB/GH/IJ"));
@@ -313,6 +311,8 @@ void GenericFileSystemTest::TestDeleteDirContents(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestDeleteRootDirContents(FileSystem* fs) {
+  if (have_flaky_directory_tree_deletion()) GTEST_SKIP() << "Flaky directory deletion";
+
   ASSERT_OK(fs->CreateDir("AB/CD"));
   CreateFile(fs, "AB/abc", "");
 
@@ -323,9 +323,7 @@ void GenericFileSystemTest::TestDeleteRootDirContents(FileSystem* fs) {
     AssertAllDirs(fs, {"AB", "AB/CD"});
     AssertAllFiles(fs, {"AB/abc"});
   } else {
-    if (!have_flaky_directory_tree_deletion()) {
-      AssertAllDirs(fs, {});
-    }
+    AssertAllDirs(fs, {});
     AssertAllFiles(fs, {});
   }
 }

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -752,6 +752,12 @@ void GenericFileSystemTest::TestGetFileInfoSelector(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestGetFileInfoGenerator(FileSystem* fs) {
+#ifdef ADDRESS_SANITIZER
+  if (have_false_positive_memory_leak_with_generator()) {
+    GTEST_SKIP() << "Filesystem have false positive memory leak with generator";
+  }
+#endif
+
   ASSERT_OK(fs->CreateDir("AB/CD"));
   CreateFile(fs, "abc", "data");
   CreateFile(fs, "AB/def", "some data");

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -1179,10 +1179,12 @@ void GenericFileSystemTest::TestSpecialChars(FileSystem* fs) {
   AssertFileContents(fs, "Special and%different.txt", "data");
 
   ASSERT_OK(fs->DeleteFile("Special and%different.txt"));
-  if (!have_flaky_directory_tree_deletion()) {
+  if (have_flaky_directory_tree_deletion()) {
+    ASSERT_OK(fs->DeleteFile("Blank Char/Special%Char.txt"));
+  } else {
     ASSERT_OK(fs->DeleteDir("Blank Char"));
+    AssertAllDirs(fs, {});
   }
-  AssertAllDirs(fs, {});
   AssertAllFiles(fs, {});
 }
 

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -926,11 +926,7 @@ void GenericFileSystemTest::TestOpenOutputStream(FileSystem* fs) {
     ASSERT_OK_AND_EQ("x-arrow/filesystem-test", got_metadata->Get("Content-Type"));
   } else {
     if (got_metadata) {
-      if (have_default_file_metadata()) {
-        ASSERT_GT(got_metadata->size(), 0);
-      } else {
-        ASSERT_EQ(got_metadata->size(), 0);
-      }
+      ASSERT_EQ(got_metadata->size(), 0);
     }
   }
 

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -1179,7 +1179,9 @@ void GenericFileSystemTest::TestSpecialChars(FileSystem* fs) {
   AssertFileContents(fs, "Special and%different.txt", "data");
 
   ASSERT_OK(fs->DeleteFile("Special and%different.txt"));
-  ASSERT_OK(fs->DeleteDir("Blank Char"));
+  if (!have_flaky_directory_tree_deletion()) {
+    ASSERT_OK(fs->DeleteDir("Blank Char"));
+  }
   AssertAllDirs(fs, {});
   AssertAllFiles(fs, {});
 }

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -184,8 +184,6 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   virtual bool have_flaky_directory_tree_deletion() const { return false; }
   // - Whether the filesystem stores some metadata alongside files
   virtual bool have_file_metadata() const { return false; }
-  // - Whether the filesystem returns some default metadata alongside files
-  virtual bool have_default_file_metadata() const { return false; }
 
   void TestEmpty(FileSystem* fs);
   void TestNormalizePath(FileSystem* fs);

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -184,6 +184,8 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   virtual bool have_flaky_directory_tree_deletion() const { return false; }
   // - Whether the filesystem stores some metadata alongside files
   virtual bool have_file_metadata() const { return false; }
+  // - Whether the filesystem has a false positive memory leak with generator
+  virtual bool have_false_positive_memory_leak_with_generator() const { return false; }
 
   void TestEmpty(FileSystem* fs);
   void TestNormalizePath(FileSystem* fs);

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -168,6 +168,8 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   virtual bool allow_write_file_over_dir() const { return false; }
   // - Whether the filesystem allows reading a directory
   virtual bool allow_read_dir_as_file() const { return false; }
+  // - Whether the filesystem allows moving a file
+  virtual bool allow_move_file() const { return true; }
   // - Whether the filesystem allows moving a directory
   virtual bool allow_move_dir() const { return true; }
   // - Whether the filesystem allows moving a directory "over" a non-empty destination
@@ -182,6 +184,8 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   virtual bool have_flaky_directory_tree_deletion() const { return false; }
   // - Whether the filesystem stores some metadata alongside files
   virtual bool have_file_metadata() const { return false; }
+  // - Whether the filesystem returns some default metadata alongside files
+  virtual bool have_default_file_metadata() const { return false; }
 
   void TestEmpty(FileSystem* fs);
   void TestNormalizePath(FileSystem* fs);


### PR DESCRIPTION
### Rationale for this change

We should provide common spec for all filesystem API.

### What changes are included in this PR?

Enable the generic filesystem tests.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #39069