### PR TITLE
GH-40535: [Docs][R] Set RETICULATE_PYTHON_ENV in order to find pyarrow

### DIFF
--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -76,6 +76,9 @@ RUN apt-get purge -y npm && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
+# Expose ARROW_PYTHON_VENV from BASE
+ENV ARROW_PYTHON_VENV /arrow-dev
+
 COPY docs/requirements.txt /arrow/docs/
 RUN pip install -r arrow/docs/requirements.txt meson
 

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update -y && \
         libtiff-dev \
         libtool \
         libxml2-dev \
+        meson \
         ninja-build \
         nvidia-cuda-toolkit \
         openjdk-${jdk}-jdk-headless \
@@ -76,11 +77,10 @@ RUN apt-get purge -y npm && \
     rm -rf /var/lib/apt/lists/* && \
     npm install -g yarn
 
-# Expose ARROW_PYTHON_VENV from BASE
-ENV ARROW_PYTHON_VENV /arrow-dev
-
 COPY docs/requirements.txt /arrow/docs/
-RUN pip install -r arrow/docs/requirements.txt meson
+RUN python3 -m venv ${ARROW_PYTHON_VENV} && \
+    . ${ARROW_PYTHON_VENV}/bin/activate && \
+    pip install -r arrow/docs/requirements.txt
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN gem install --no-document bundler && \
@@ -114,4 +114,5 @@ ENV ARROW_ACERO=ON \
     ARROW_JSON=ON \
     ARROW_S3=ON \
     ARROW_USE_GLOG=OFF \
-    CMAKE_UNITY_BUILD=ON
+    CMAKE_UNITY_BUILD=ON \
+    RETICULATE_PYTHON_ENV=${ARROW_PYTHON_VENV}

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -31,9 +31,6 @@ ${R_BIN} CMD build .
 ${R_BIN} CMD INSTALL ${INSTALL_ARGS} arrow*.tar.gz
 
 if [ "${BUILD_DOCS_R}" == "ON" ]; then
-  if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
-    RETICULATE_PYTHON_ENV=${ARROW_PYTHON_VENV}
-  fi
   ${R_BIN} -e "pkgdown::build_site(install = FALSE)"
   rsync -a ${source_dir}/docs/ ${build_dir}/docs/r
 fi

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -31,6 +31,9 @@ ${R_BIN} CMD build .
 ${R_BIN} CMD INSTALL ${INSTALL_ARGS} arrow*.tar.gz
 
 if [ "${BUILD_DOCS_R}" == "ON" ]; then
+  if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+    RETICULATE_PYTHON_ENV=${ARROW_PYTHON_VENV}
+  fi
   ${R_BIN} -e "pkgdown::build_site(install = FALSE)"
   rsync -a ${source_dir}/docs/ ${build_dir}/docs/r
 fi


### PR DESCRIPTION
### Rationale for this change

With the changes in https://github.com/apache/arrow/pull/40455 reticulate can't find pyarrow.

### What changes are included in this PR?

Set `RETICULATE_PYTHON_ENV` to `ARROW_PYTHON_VENV`.
See https://rstudio.github.io/reticulate/articles/versions.html#order-of-discovery why we can use `RETICULATE_PYTHON_ENV`.

This also simplifies the current configurations:
* Install Meson by `apt-get`.
* Use `ARROW_PYTHON_VENV` to install Sphinx and related packages.

### Are these changes tested?

Via archery.

### Are there any user-facing changes?

No
* GitHub Issue: #40535