### PR TITLE
GH-40575: [Docs][Python] Added JsonFileFormat to docs

### DIFF
--- a/docs/source/python/api/dataset.rst
+++ b/docs/source/python/api/dataset.rst
@@ -45,6 +45,7 @@ Classes
    CsvFileFormat
    CsvFragmentScanOptions
    IpcFileFormat
+   JsonFileFormat
    ParquetFileFormat
    ParquetReadOptions
    ParquetFragmentScanOptions


### PR DESCRIPTION
### Rationale for this change

Docs for JsonFileFormat is missing in the documentation. In this PR, I am adding it to the documentation.

### Are these changes tested?

Tested minimally by building in local machine (installed pyarrow by `pip install pyarrow`, built the docs, and observed `pyarrow.dataset.JsonFileFormat.md` being generated.)

### Are there any user-facing changes?

No.

* GitHub Issue: #40575