### PR TITLE
GH-40586: [Dev][C++][Python][R] Use pre-commit for clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,26 @@ repos:
     rev: v14.0.6
     hooks:
       - id: clang-format
+        name: C++ Format
+        types_or:
+          - c++
+          # - json
+          # - proto
+        files: >-
+          ^cpp/
+        exclude: >-
+          (
+          ?\.grpc\.fb\.(cc|h)$|
+          ?\.pb\.(cc|h)$|
+          ?_generated.*\.(cc|h)$|
+          ?^cpp/src/arrow/vendored/|
+          ?^cpp/src/generated/|
+          ?^cpp/thirdparty/|
+          )
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.6
+    hooks:
+      - id: clang-format
         name: C/GLib Format
         files: >-
           ^c_glib/
@@ -66,6 +86,30 @@ repos:
         name: MATLAB (C++) Format
         files: >-
           ^matlab/src/cpp/
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.6
+    hooks:
+      - id: clang-format
+        name: Python (C++) Format
+        files: >-
+          ^python/pyarrow/src/
+        exclude: >-
+          (
+          ?\.grpc\.fb\.(cc|h)$|
+          ?.pb\.(cc|h)$|
+          ?^cpp/src/generated/|
+          )
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v14.0.6
+    hooks:
+      - id: clang-format
+        name: R (C++) Format
+        files: >-
+          ^r/src/
+        exclude: >-
+          (
+          ?^r/src/arrowExports\.cpp$|
+          )
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/cpp/src/arrow/util/windows_compatibility.h
+++ b/cpp/src/arrow/util/windows_compatibility.h
@@ -33,7 +33,6 @@
 #endif
 
 #include <winsock2.h>
-#include <windows.h>
 
 #include "arrow/util/windows_fixup.h"
 


### PR DESCRIPTION
### Rationale for this change

We can run `clang-format` easily than `archery lint` by using `pre-commit`:

* We don't need to install `clang-format-14` separately because `pre-commit` prepare it automatically.
* We don't need to run `cmake` to run `clang-format-14`. 

### What changes are included in this PR?

Add `clang-format` related `pre-commit` configurations.

This doesn't change `archery lint` because our `pre-commit` configurations can't replace `archery lint` entirely yet.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40586