### PR TITLE
GH-40615: [Packaging][deb] Move libprotobuf-dev dependency to libarrow-dev from libarrow-flight-dev

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/debian/control.in
+++ b/dev/tasks/linux-packages/apache-arrow/debian/control.in
@@ -145,6 +145,8 @@ Depends:
   libcurl4-openssl-dev,
   liblz4-dev,
   libc-ares-dev,
+@USE_SYSTEM_PROTOBUF@  libprotobuf-dev,
+@USE_SYSTEM_PROTOBUF@  libprotoc-dev,
   libre2-dev,
   libsnappy-dev,
   libssl-dev,
@@ -203,9 +205,7 @@ Depends:
   libarrow-dev (= ${binary:Version}),
   libarrow-flight1600 (= ${binary:Version}),
   libc-ares-dev,
-@USE_SYSTEM_GRPC@  libgrpc++-dev,
-@USE_SYSTEM_PROTOBUF@  libprotobuf-dev,
-@USE_SYSTEM_PROTOBUF@  libprotoc-dev
+@USE_SYSTEM_GRPC@  libgrpc++-dev
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides C++ header files for Flight RPC system.


### PR DESCRIPTION
### Rationale for this change

This is a follow-up of GH-40399.

### What changes are included in this PR?

Move `libprotobuf-dev` dependency to `libarrow-dev` from `libarrow-flight-dev`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40615