### PR TITLE
GH-40616: [Docs][GLib] Ensure overwriting placeholder front pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1764,8 +1764,8 @@ services:
     command: &docs-command >
       /bin/bash -c "
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
-        /arrow/ci/scripts/c_glib_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
+        /arrow/ci/scripts/c_glib_build.sh /arrow /build &&
         /arrow/ci/scripts/r_build.sh /arrow /build &&
         /arrow/ci/scripts/js_build.sh /arrow /build &&
         /arrow/ci/scripts/java_build.sh /arrow /build"


### PR DESCRIPTION
### Rationale for this change

Place holder font pages are still used because Sphinx build is executed before GLib docs build.

### What changes are included in this PR?

Build Sphinx docs before GLib docs are built.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40616