### PR TITLE
GH-40621: [C++] Add missing util/config.h in arrow/io/compressed_test.cc

### DIFF
--- a/cpp/src/arrow/io/compressed_test.cc
+++ b/cpp/src/arrow/io/compressed_test.cc
@@ -33,6 +33,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/config.h"
 
 namespace arrow {
 namespace io {


### PR DESCRIPTION
### Rationale for this change

This is a follow-up of #40222. We need `#include arrow/util/config.h` for `ARROW_WITH_*`.

### What changes are included in this PR?

Add missing `#include`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40621