### PR TITLE
[Python][CI] Failing test_dateutil_tzinfo_to_string due to new release of python-dateutil 

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -346,11 +346,6 @@ def test_pytz_tzinfo_to_string():
 
 
 def test_dateutil_tzinfo_to_string():
-    if sys.platform == 'win32':
-        # Skip due to new release of python-dateutil
-        # https://github.com/apache/arrow/issues/40485
-        pytest.skip('Skip on Win due to new release of python-dateutil')
-
     pytest.importorskip("dateutil")
     import dateutil.tz
 

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -357,6 +357,7 @@ def test_dateutil_tzinfo_to_string():
     tz = dateutil.tz.UTC
     assert pa.lib.tzinfo_to_string(tz) == 'UTC'
     tz = dateutil.tz.gettz('Europe/Paris')
+    print(tz)
     assert pa.lib.tzinfo_to_string(tz) == 'Europe/Paris'
 
 


### PR DESCRIPTION
### Rationale for this change

`test_dateutil_tzinfo_to_string` started failing with:

```Python
         tz = dateutil.tz.gettz('Europe/Paris')
>       assert pa.lib.tzinfo_to_string(tz) == 'Europe/Paris'
E       AssertionError: assert 'Europe/Monaco' == 'Europe/Paris'
E         - Europe/Paris
E         + Europe/Monaco
```

and it is most probably due to new release of `python-dateutil` package.

### What changes are included in this PR?

Currently, we are using this PR to debug the test on Windows platform.

### Are these changes tested?

A tests is failing and it needs to be fixed.

### Are there any user-facing changes?

No.