### PR TITLE
GH-40649: [CI][Release][Java] Use Maven 3.8 for verify-rc-source-java-linux-almalinux-8-amd64

### DIFF
--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -26,6 +26,8 @@ set -exu
 dnf -y install 'dnf-command(config-manager)'
 dnf config-manager --set-enabled powertools
 dnf -y update
+dnf -y module disable maven
+dnf -y module enable maven:3.8
 dnf -y module disable nodejs
 dnf -y module enable nodejs:18
 dnf -y module disable ruby
@@ -39,7 +41,6 @@ dnf -y install \
   libcurl-devel \
   llvm-devel \
   llvm-toolset \
-  maven \
   ncurses-devel \
   ninja-build \
   nodejs \

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -41,6 +41,7 @@ dnf -y install \
   libcurl-devel \
   llvm-devel \
   llvm-toolset \
+  maven \
   ncurses-devel \
   ninja-build \
   nodejs \


### PR DESCRIPTION
### Rationale for this change

#39696 requires Maven 3.6 or later.

### What changes are included in this PR?

Use Maven 3.8.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40649