### PR TITLE
GH-40619: [Java] JDBC Adapter Build Issue

### DIFF
--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -105,7 +105,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration combine.self="override">
-                            <argLine>--add-reads=org.apache.arrow.adapter.jdbc=com.fasterxml.jackson.dataformat.yaml --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
+                            <argLine>--add-reads=org.apache.arrow.adapter.jdbc=com.fasterxml.jackson.dataformat.yaml --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -Duser.timezone=UTC</argLine>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
### Rationale for this change

Compiling JDBC Adapter module fails when running from a time zone which is not UTC. The tests assume the set time zone is UTC. Since running from a location where the timezone is not UTC, the error documented in https://github.com/apache/arrow/issues/40619 occurs. 

### What changes are included in this PR?

Adding the time zone as a property to maven profile. 

### Are these changes tested?

These changes have been tested locally in a non-UTC timezone (+0530).

### Are there any user-facing changes?

No
* GitHub Issue: #40619