### PR TITLE
GH-40659: [Python][C++] Support conversion of pyarrow.RunEndEncodedArray to numpy/pandas

### DIFF
--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -2293,9 +2293,6 @@ std::shared_ptr<ChunkedArray> GetStorageChunkedArray(std::shared_ptr<ChunkedArra
 
 // Helper function for decoded RunEndEncodedArray
 std::shared_ptr<ChunkedArray> GetDecodedChunkedArray(Datum decoded) {
-  // if (decoded.is_array()) {
-  //   return std::make_shared<ChunkedArray>(decoded.make_array());
-  // }
   DCHECK(decoded.is_chunked_array());
   return decoded.chunked_array();
 };
@@ -2333,11 +2330,6 @@ class ConsolidatedBlockCreator : public PandasBlockCreator {
       else if (arrays_[column_index]->type()->id() == Type::RUN_END_ENCODED) {
         ARROW_ASSIGN_OR_RAISE(Datum decoded,
                               compute::RunEndDecode(arrays_[column_index]));
-        // ARROW_ASSIGN_OR_RAISE(
-        //     Datum decoded, arrays_[column_index]->num_chunks() > 1
-        //                        ? compute::RunEndDecode(arrays_[column_index])
-        //                        :
-        //                        compute::RunEndDecode(arrays_[column_index]->chunk(0)));
         arrays_[column_index] = GetDecodedChunkedArray(decoded);
       }
       return GetPandasWriterType(*arrays_[column_index], options_, out);
@@ -2577,9 +2569,6 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
   // In case of a RunEndEncodedArray decode the array
   else if (arr->type()->id() == Type::RUN_END_ENCODED) {
     ARROW_ASSIGN_OR_RAISE(Datum decoded, compute::RunEndDecode(arr));
-    // ARROW_ASSIGN_OR_RAISE(Datum decoded, arr->num_chunks() > 1
-    //                                          ? compute::RunEndDecode(arr)
-    //                                          : compute::RunEndDecode(arr));
     arr = GetDecodedChunkedArray(decoded);
 
     // Because we built a new array when we decoded the RunEndEncodedArray

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -2336,7 +2336,8 @@ class ConsolidatedBlockCreator : public PandasBlockCreator {
         // ARROW_ASSIGN_OR_RAISE(
         //     Datum decoded, arrays_[column_index]->num_chunks() > 1
         //                        ? compute::RunEndDecode(arrays_[column_index])
-        //                        : compute::RunEndDecode(arrays_[column_index]->chunk(0)));
+        //                        :
+        //                        compute::RunEndDecode(arrays_[column_index]->chunk(0)));
         arrays_[column_index] = GetDecodedChunkedArray(decoded);
       }
       return GetPandasWriterType(*arrays_[column_index], options_, out);

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -2569,6 +2569,10 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
   }
   // In case of a RunEndEncodedArray decode the array
   else if (arr->type()->id() == Type::RUN_END_ENCODED) {
+    if (options.zero_copy_only) {
+      return Status::Invalid("Need to dencode a RunEndEncodedArray, but ",
+                             "only zero-copy conversions allowed");
+    }
     ARROW_ASSIGN_OR_RAISE(arr, GetDecodedChunkedArray(arr));
 
     // Because we built a new array when we decoded the RunEndEncodedArray

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -2581,6 +2581,10 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
     //                                          ? compute::RunEndDecode(arr)
     //                                          : compute::RunEndDecode(arr));
     arr = GetDecodedChunkedArray(decoded);
+
+    // Because we built a new array when we decoded the RunEndEncodedArray
+    // the final resulting numpy array should own the memory through a Capsule
+    py_ref = nullptr;
   }
 
   PandasWriter::type output_type;

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -2328,7 +2328,7 @@ class ConsolidatedBlockCreator : public PandasBlockCreator {
       if (arrays_[column_index]->type()->id() == Type::EXTENSION) {
         arrays_[column_index] = GetStorageChunkedArray(arrays_[column_index]);
       }
-      // In case of a RunEndEncodedArray default to the storage type
+      // In case of a RunEndEncodedArray default to the values type
       else if (arrays_[column_index]->type()->id() == Type::RUN_END_ENCODED) {
         ARROW_ASSIGN_OR_RAISE(arrays_[column_index],
                               GetDecodedChunkedArray(arrays_[column_index]));

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3619,18 +3619,24 @@ def test_run_end_encoded_from_array_with_type():
     assert result.equals(expected)
 
 
-def test_run_end_encoded_to_numpy_to_pandas():
+def _generate_ree_array():
     run_ends = [1, 3, 6]
     values = [1, 2, 3]
     ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
-    ree_array = pa.RunEndEncodedArray.from_arrays(run_ends, values,
-                                                  ree_type)
+    return pa.RunEndEncodedArray.from_arrays(run_ends, values,
+                                             ree_type)
 
-    arr = [1, 2, 2, 3, 3, 3]
-    expected = np.array(arr)
 
+def test_run_end_encoded_to_numpy():
+    ree_array = _generate_ree_array()
+    expected = np.array([1, 2, 2, 3, 3, 3])
     np.testing.assert_array_equal(ree_array.to_numpy(), expected)
-    assert ree_array.to_pandas().tolist() == arr
+
+
+@pytest.mark.pandas
+def test_run_end_encoded_to_pandas():
+    ree_array = _generate_ree_array()
+    assert ree_array.to_pandas().tolist() == [1, 2, 2, 3, 3, 3]
 
 
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3619,24 +3619,18 @@ def test_run_end_encoded_from_array_with_type():
     assert result.equals(expected)
 
 
-def _generate_ree_array():
-    run_ends = [1, 3, 6]
-    values = [1, 2, 3]
-    ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
-    return pa.RunEndEncodedArray.from_arrays(run_ends, values,
-                                             ree_type)
-
-
 def test_run_end_encoded_to_numpy():
-    ree_array = _generate_ree_array()
-    expected = np.array([1, 2, 2, 3, 3, 3])
+    arr = [1, 2, 2, 3, 3, 3]
+    ree_array = pa.array(arr, pa.run_end_encoded(pa.int32(), pa.int64()))
+    expected = np.array(arr)
     np.testing.assert_array_equal(ree_array.to_numpy(), expected)
 
 
 @pytest.mark.pandas
 def test_run_end_encoded_to_pandas():
-    ree_array = _generate_ree_array()
-    assert ree_array.to_pandas().tolist() == [1, 2, 2, 3, 3, 3]
+    arr = [1, 2, 2, 3, 3, 3]
+    ree_array = pa.array(arr, pa.run_end_encoded(pa.int32(), pa.int64()))
+    assert ree_array.to_pandas().tolist() == arr
 
 
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3619,6 +3619,17 @@ def test_run_end_encoded_from_array_with_type():
     assert result.equals(expected)
 
 
+def test_run_end_encoded_to_numpy():
+    run_ends = [1, 3, 6]
+    values = [1, 2, 3]
+    ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
+    ree_array = pa.RunEndEncodedArray.from_arrays(run_ends, values,
+                                                  ree_type)
+    expected = np.array([1, 2, 2, 3, 3, 3])
+
+    np.testing.assert_array_equal(ree_array.to_numpy(), expected)
+
+
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),
                          [(pa.ListViewArray, pa.list_view),
                           (pa.LargeListViewArray, pa.large_list_view)])

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3619,15 +3619,18 @@ def test_run_end_encoded_from_array_with_type():
     assert result.equals(expected)
 
 
-def test_run_end_encoded_to_numpy():
+def test_run_end_encoded_to_numpy_to_pandas():
     run_ends = [1, 3, 6]
     values = [1, 2, 3]
     ree_type = pa.run_end_encoded(pa.int32(), pa.int64())
     ree_array = pa.RunEndEncodedArray.from_arrays(run_ends, values,
                                                   ree_type)
-    expected = np.array([1, 2, 2, 3, 3, 3])
+
+    arr = [1, 2, 2, 3, 3, 3]
+    expected = np.array(arr)
 
     np.testing.assert_array_equal(ree_array.to_numpy(), expected)
+    assert ree_array.to_pandas().tolist() == arr
 
 
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3623,14 +3623,22 @@ def test_run_end_encoded_to_numpy():
     arr = [1, 2, 2, 3, 3, 3]
     ree_array = pa.array(arr, pa.run_end_encoded(pa.int32(), pa.int64()))
     expected = np.array(arr)
-    np.testing.assert_array_equal(ree_array.to_numpy(), expected)
+
+    np.testing.assert_array_equal(ree_array.to_numpy(zero_copy_only=False), expected)
+
+    with pytest.raises(pa.ArrowInvalid):
+        ree_array.to_numpy()
 
 
 @pytest.mark.pandas
 def test_run_end_encoded_to_pandas():
     arr = [1, 2, 2, 3, 3, 3]
     ree_array = pa.array(arr, pa.run_end_encoded(pa.int32(), pa.int64()))
+
     assert ree_array.to_pandas().tolist() == arr
+
+    with pytest.raises(pa.ArrowInvalid):
+        ree_array.to_pandas(zero_copy_only=True)
 
 
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),


### PR DESCRIPTION
### Rationale for this change

We want to enable the conversion of Run-End Encoded arrays to numpy and pandas.

### What changes are included in this PR?

In case of RunEndEncodedArray we first decode the array and then convert the decoded array to numpy or pandas.

### Are these changes tested?

Yes, in Python.

### Are there any user-facing changes?

No.
* GitHub Issue: #40659