### PR TITLE
GH-34235: [Python] Correct test marker for join_asof tests

### DIFF
--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2901,6 +2901,7 @@ def test_table_join_asof_by_length_mismatch():
         )
 
 
+@pytest.mark.dataset
 def test_table_join_asof_by_type_mismatch():
     t1 = pa.table({
         "colA": [1, 2, 6],
@@ -2922,6 +2923,7 @@ def test_table_join_asof_by_type_mismatch():
         )
 
 
+@pytest.mark.dataset
 def test_table_join_asof_on_type_mismatch():
     t1 = pa.table({
         "colA": [1, 2, 6],


### PR DESCRIPTION
Small follow-up on https://github.com/apache/arrow/pull/34234 fixing the marker for a newly added test, fixing the minimal builds
* GitHub Issue: #34235