### PR TITLE
GH-40668: [Ruby][CI] Require GLib 2.58 or later for timezone

### DIFF
--- a/ruby/red-arrow/test/helper/omittable.rb
+++ b/ruby/red-arrow/test/helper/omittable.rb
@@ -37,5 +37,13 @@ module Helper
         GObjectIntrospection::Version::STRING
       omit(message)
     end
+
+    def require_glib(major, minor, micro)
+      return if GLib::Version.or_later?(major, minor, micro)
+      message =
+        "Require GLib #{major}.#{minor}.#{micro} or later: " +
+        GLib::Version::STRING
+      omit(message)
+    end
   end
 end

--- a/ruby/red-arrow/test/test-csv-loader.rb
+++ b/ruby/red-arrow/test/test-csv-loader.rb
@@ -17,6 +17,7 @@
 
 class CSVLoaderTest < Test::Unit::TestCase
   include Helper::Fixture
+  include Helper::Omittable
 
   def load_csv(input)
     Arrow::CSVLoader.load(input, skip_lines: /^#/)
@@ -249,6 +250,7 @@ count
 
     sub_test_case(":timestamp_parsers") do
       test(":iso8601") do
+        require_glib(2, 58, 0)
         data_type = Arrow::TimestampDataType.new(:second,
                                                  GLib::TimeZone.new("UTC"))
         timestamps = [


### PR DESCRIPTION
### Rationale for this change

GLib 2.58 or later is required for `TimestampDataType`'s timezone support.

### What changes are included in this PR?

Check GLib version.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40668