### PR TITLE
MINOR: [Docs] Add link to ListView format in pyarrow docs

### DIFF
--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -231,7 +231,7 @@ like lists:
    print(nested_arr.type)
 
 ListView arrays
-~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 
 ``pyarrow.array`` can create an alternate list type called ListView:
 
@@ -251,6 +251,8 @@ This allows for ListView arrays to specify out-of-order offsets:
    sizes = [2, 2, 2]
    arr = pa.ListViewArray.from_arrays(offsets, sizes, values)
    arr
+
+See the format specification for more details on the :ref:`listview-layout`.
 
 Struct arrays
 ~~~~~~~~~~~~~

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -252,7 +252,7 @@ This allows for ListView arrays to specify out-of-order offsets:
    arr = pa.ListViewArray.from_arrays(offsets, sizes, values)
    arr
 
-See the format specification for more details on the :ref:`listview-layout`.
+See the format specification for more details on :ref:`listview-layout`.
 
 Struct arrays
 ~~~~~~~~~~~~~


### PR DESCRIPTION
### Rationale for this change

We should link to the list view format when referencing this new layout in pyarrow usage docs.

### What changes are included in this PR?

* Add a link to the listview layout

### Are these changes tested?

Yes, I generated docs and verified the link.

### Are there any user-facing changes?

No.