### PR TITLE
GH-39752: [Java] Remove Static imports for Utf8 Usage

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
@@ -18,13 +18,13 @@
 package org.apache.arrow.driver.jdbc.accessor.impl.text;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Time;
@@ -81,7 +81,7 @@ public class ArrowFlightJdbcVarCharVectorAccessor extends ArrowFlightJdbcAccesso
   @Override
   public String getObject() {
     final byte[] bytes = getBytes();
-    return bytes == null ? null : new String(bytes, UTF_8);
+    return bytes == null ? null : new String(bytes, StandardCharsets.UTF_8);
   }
 
   @Override

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Strings.emptyToNull;
 import static com.google.protobuf.Any.pack;
 import static com.google.protobuf.ByteString.copyFrom;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.isNull;
 import static java.util.UUID.randomUUID;
@@ -43,6 +42,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -428,7 +428,7 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
 
             range(0, split.length)
                 .forEach(i -> {
-                  byte[] bytes = split[i].getBytes(UTF_8);
+                  byte[] bytes = split[i].getBytes(StandardCharsets.UTF_8);
                   Preconditions.checkState(bytes.length < 1024,
                       "The amount of bytes is greater than what the ArrowBuf supports");
                   buf.setBytes(0, bytes);
@@ -701,7 +701,7 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   @Override
   public FlightInfo getFlightInfoStatement(final CommandStatementQuery request, final CallContext context,
                                            final FlightDescriptor descriptor) {
-    ByteString handle = copyFrom(randomUUID().toString().getBytes(UTF_8));
+    ByteString handle = copyFrom(randomUUID().toString().getBytes(StandardCharsets.UTF_8));
 
     try {
       // Ownership of the connection will be passed to the context. Do NOT close!
@@ -778,7 +778,7 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     // Running on another thread
     Future<?> unused = executorService.submit(() -> {
       try {
-        final ByteString preparedStatementHandle = copyFrom(randomUUID().toString().getBytes(UTF_8));
+        final ByteString preparedStatementHandle = copyFrom(randomUUID().toString().getBytes(StandardCharsets.UTF_8));
         // Ownership of the connection will be passed to the context. Do NOT close!
         final Connection connection = dataSource.getConnection();
         final PreparedStatement preparedStatement = connection.prepareStatement(request.getQuery(),

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -21,7 +21,6 @@ import static com.fasterxml.jackson.core.JsonToken.END_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;
 import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.arrow.vector.BufferLayout.BufferType.DATA;
 import static org.apache.arrow.vector.BufferLayout.BufferType.OFFSET;
 import static org.apache.arrow.vector.BufferLayout.BufferType.TYPE;
@@ -31,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -538,7 +538,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
       long bufferSize = 0L;
       for (int i = 0; i < count; i++) {
         parser.nextToken();
-        final byte[] value = parser.getValueAsString().getBytes(UTF_8);
+        final byte[] value = parser.getValueAsString().getBytes(StandardCharsets.UTF_8);
         values.add(value);
         bufferSize += value.length;
       }


### PR DESCRIPTION
### What changes are included in this PR?

Removing static imports of UTF_8. This has been identified as a minor enhancement as documented here: https://github.com/apache/arrow/issues/39752 and discussed in a review [here](https://github.com/apache/arrow/pull/39529#discussion_r1455672602). 

### Are these changes tested?

Tested by existing test cases. 

### Are there any user-facing changes?

No
* GitHub Issue: #39752