### PR TITLE
GH-40684: [Java][Docs] JNI module debugging with IntelliJ

### DIFF
--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -347,6 +347,11 @@ Arrow repository, and update the following settings:
 * If using IntelliJ's Maven integration to build, you may need to change
   ``<fork>`` to ``false`` in the pom.xml files due to an `IntelliJ bug
   <https://youtrack.jetbrains.com/issue/IDEA-278903>`__.
+* To enable debugging JNI-based modules like ``dataset``,
+  activate specific profiles in the Maven tab under "Profiles."
+  Ensure the profiles ``arrow-c-data``, ``arrow-jni``, ``generate-libs-cdata-all-os``,
+  ``generate-libs-jni-macos-linux``, and ``jdk11+`` are enabled, which equips the IDE
+  with the necessary debugging utilities for test classes.
 
 You may not need to update all of these settings if you build/test with the
 IntelliJ Maven integration instead of with IntelliJ directly.

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -350,8 +350,8 @@ Arrow repository, and update the following settings:
 * To enable debugging JNI-based modules like ``dataset``,
   activate specific profiles in the Maven tab under "Profiles".
   Ensure the profiles ``arrow-c-data``, ``arrow-jni``, ``generate-libs-cdata-all-os``,
-  ``generate-libs-jni-macos-linux``, and ``jdk11+`` are enabled, which equips the IDE
-  with the necessary debugging utilities for test classes.
+  ``generate-libs-jni-macos-linux``, and ``jdk11+`` are enabled, so that the 
+  IDE can build them and enable debugging.
 
 You may not need to update all of these settings if you build/test with the
 IntelliJ Maven integration instead of with IntelliJ directly.

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -348,7 +348,7 @@ Arrow repository, and update the following settings:
   ``<fork>`` to ``false`` in the pom.xml files due to an `IntelliJ bug
   <https://youtrack.jetbrains.com/issue/IDEA-278903>`__.
 * To enable debugging JNI-based modules like ``dataset``,
-  activate specific profiles in the Maven tab under "Profiles."
+  activate specific profiles in the Maven tab under "Profiles".
   Ensure the profiles ``arrow-c-data``, ``arrow-jni``, ``generate-libs-cdata-all-os``,
   ``generate-libs-jni-macos-linux``, and ``jdk11+`` are enabled, which equips the IDE
   with the necessary debugging utilities for test classes.


### PR DESCRIPTION
### Rationale for this change

Adding documentation for debugging JNI-based Java modules. 


### What changes are included in this PR?

Documentation update for developer docs for Java development.

### Are these changes tested?

Locally built the docs and it shows the expected content. 

### Are there any user-facing changes?

N/A
* GitHub Issue: #40684