### PR TITLE
GH-40631: [C++] Add lost conjunctions back in FoldConstants and GuaranteeConjunctionMembers

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -874,7 +874,7 @@ Result<Expression> FoldConstants(Expression expr) {
           }
         }
 
-        if (call->function_name == "and_kleene") {
+        if (call->function_name == "and_kleene" || call->function_name == "and") {
           for (auto args : ArgumentsAndFlippedArguments(*call)) {
             // true and x == x
             if (args.first == literal(true)) return args.second;
@@ -888,7 +888,7 @@ Result<Expression> FoldConstants(Expression expr) {
           return expr;
         }
 
-        if (call->function_name == "or_kleene") {
+        if (call->function_name == "or_kleene" || call->function_name == "or") {
           for (auto args : ArgumentsAndFlippedArguments(*call)) {
             // false or x == x
             if (args.first == literal(false)) return args.second;
@@ -911,7 +911,8 @@ namespace {
 std::vector<Expression> GuaranteeConjunctionMembers(
     const Expression& guaranteed_true_predicate) {
   auto guarantee = guaranteed_true_predicate.call();
-  if (!guarantee || guarantee->function_name != "and_kleene") {
+  if (!guarantee ||
+      (guarantee->function_name != "and_kleene" && guarantee->function_name != "and")) {
     return {guaranteed_true_predicate};
   }
   return FlattenedAssociativeChain(guaranteed_true_predicate).fringe;

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -1039,10 +1039,16 @@ TEST(Expression, FoldConstantsBoolean) {
   ExpectFoldsTo(and_(false_, whatever), false_);
   ExpectFoldsTo(and_(true_, whatever), whatever);
   ExpectFoldsTo(and_(whatever, whatever), whatever);
+  ExpectFoldsTo(call("and", {false_, whatever}), false_);
+  ExpectFoldsTo(call("and", {true_, whatever}), whatever);
+  ExpectFoldsTo(call("and", {whatever, whatever}), whatever);
 
   ExpectFoldsTo(or_(true_, whatever), true_);
   ExpectFoldsTo(or_(false_, whatever), whatever);
   ExpectFoldsTo(or_(whatever, whatever), whatever);
+  ExpectFoldsTo(call("or", {true_, whatever}), true_);
+  ExpectFoldsTo(call("or", {false_, whatever}), whatever);
+  ExpectFoldsTo(call("or", {whatever, whatever}), whatever);
 }
 
 void ExpectRemovesRefsTo(Expression expr, Expression expected,
@@ -1111,6 +1117,10 @@ TEST(Expression, ExtractKnownFieldValues) {
                     equal(field_ref("f32"), field_ref("f32_req")),
                     equal(field_ref("i32_req"), literal(1))}),
               {{"i32", Datum(3)}, {"i32_req", Datum(1)}});
+
+  ExpectKnown(call("and", {equal(field_ref("i32"), literal(3)),
+                           equal(field_ref("f32"), literal(1.5F))}),
+              {{"i32", Datum(3)}, {"f32", Datum(1.5F)}});
 }
 
 TEST(Expression, ReplaceFieldsWithKnownValues) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
We have lost some conjunctions check in FoldConstants and GuaranteeConjunctionMembers, this will cause our simplification operations on some expressions to fail.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Add the `and` and `or` conjunctions check into `FoldConstants` and `GuaranteeConjunctionMembers` , so we could simplify some expressions normally.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40631