### PR TITLE
GH-40690: [C#][FlightRPC] Add do_exchange csharp implementation

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
+++ b/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
@@ -107,6 +107,22 @@ namespace Apache.Arrow.Flight.Client
             return call;
         }
 
+        public FlightRecordBatchExchangeCall DoExchange(FlightDescriptor flightDescriptor, Metadata headers = null)
+        {
+            var channel = _client.DoExchange(headers);
+            var requestStream = new FlightClientRecordBatchStreamWriter(channel.RequestStream, flightDescriptor);
+            var responseStream = new FlightClientRecordBatchStreamReader(channel.ResponseStream);
+            var call = new FlightRecordBatchExchangeCall(
+                requestStream,
+                responseStream,
+                channel.ResponseHeadersAsync,
+                channel.GetStatus,
+                channel.GetTrailers,
+                channel.Dispose);
+
+            return call;
+        }
+
         public AsyncServerStreamingCall<FlightResult> DoAction(FlightAction action, Metadata headers = null)
         {
             var stream = _client.DoAction(action.ToProtocol(), headers);

--- a/csharp/src/Apache.Arrow.Flight/Client/FlightRecordBatchExchangeCall.cs
+++ b/csharp/src/Apache.Arrow.Flight/Client/FlightRecordBatchExchangeCall.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Grpc.Core;
+using System.Threading.Tasks;
+
+namespace Apache.Arrow.Flight.Client
+{
+    public class FlightRecordBatchExchangeCall : IDisposable
+    {
+        private readonly Func<Status> _getStatusFunc;
+        private readonly Func<Metadata> _getTrailersFunc;
+        private readonly Action _disposeAction;
+
+        internal FlightRecordBatchExchangeCall(
+            FlightClientRecordBatchStreamWriter requestStream,
+            FlightClientRecordBatchStreamReader responseStream,
+            Task<Metadata> responseHeadersAsync,
+            Func<Status> getStatusFunc,
+            Func<Metadata> getTrailersFunc,
+            Action disposeAction)
+        {
+            RequestStream = requestStream;
+            ResponseStream = responseStream;
+            ResponseHeadersAsync = responseHeadersAsync;
+            _getStatusFunc = getStatusFunc;
+            _getTrailersFunc = getTrailersFunc;
+            _disposeAction = disposeAction;
+        }
+
+        /// <summary>
+        ///  Async stream to read streaming responses.
+        /// </summary>
+        public FlightClientRecordBatchStreamReader ResponseStream { get; }
+
+        /// <summary>
+        /// Async stream to send streaming requests.
+        /// </summary>
+        public FlightClientRecordBatchStreamWriter RequestStream { get; }
+
+        /// <summary>
+        /// Asynchronous access to response headers.
+        /// </summary>
+        public Task<Metadata> ResponseHeadersAsync { get; }
+
+        /// <summary>
+        /// Provides means to cleanup after the call. If the call has already finished normally
+        /// (response stream has been fully read), doesn't do anything. Otherwise, requests
+        /// cancellation of the call which should terminate all pending async operations
+        /// associated with the call. As a result, all resources being used by the call should
+        /// be released eventually.
+        /// </summary>
+        /// <remarks>
+        /// Normally, there is no need for you to dispose the call unless you want to utilize
+        /// the "Cancel" semantics of invoking Dispose.
+        /// </remarks>
+        public void Dispose()
+        {
+            _disposeAction();
+        }
+
+        /// <summary>
+        /// Gets the call status if the call has already finished. Throws InvalidOperationException otherwise.
+        /// </summary>
+        /// <returns></returns>
+        public Status GetStatus()
+        {
+            return _getStatusFunc();
+        }
+
+        /// <summary>
+        /// Gets the call trailing metadata if the call has already finished. Throws InvalidOperationException otherwise.
+        /// </summary>
+        /// <returns></returns>
+        public Metadata GetTrailers()
+        {
+            return _getTrailersFunc();
+        }
+    }
+}

--- a/csharp/src/Apache.Arrow.Flight/Client/FlightRecordBatchExchangeCall.cs
+++ b/csharp/src/Apache.Arrow.Flight/Client/FlightRecordBatchExchangeCall.cs
@@ -1,4 +1,19 @@
-﻿using System;
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Grpc.Core;
 using System.Threading.Tasks;
 

--- a/csharp/src/Apache.Arrow.Flight/Server/FlightServer.cs
+++ b/csharp/src/Apache.Arrow.Flight/Server/FlightServer.cs
@@ -60,5 +60,10 @@ namespace Apache.Arrow.Flight.Server
         {
             throw new NotImplementedException();
         }
+
+        public virtual Task DoExchange(FlightServerRecordBatchStreamReader requestStream, FlightServerRecordBatchStreamWriter responseStream, ServerCallContext context)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/csharp/src/Apache.Arrow.Flight/Server/Internal/FlightServerImplementation.cs
+++ b/csharp/src/Apache.Arrow.Flight/Server/Internal/FlightServerImplementation.cs
@@ -84,8 +84,9 @@ namespace Apache.Arrow.Flight.Server.Internal
 
         public override Task DoExchange(IAsyncStreamReader<Protocol.FlightData> requestStream, IServerStreamWriter<Protocol.FlightData> responseStream, ServerCallContext context)
         {
-            //Exchange is not yet implemented
-            throw new NotImplementedException();
+            var readStream = new FlightServerRecordBatchStreamReader(requestStream);
+            var writeStream = new FlightServerRecordBatchStreamWriter(responseStream);
+            return _flightServer.DoExchange(readStream, writeStream, context);
         }
 
         public override Task Handshake(IAsyncStreamReader<HandshakeRequest> requestStream, IServerStreamWriter<HandshakeResponse> responseStream, ServerCallContext context)

--- a/csharp/test/Apache.Arrow.Flight.TestWeb/TestFlightServer.cs
+++ b/csharp/test/Apache.Arrow.Flight.TestWeb/TestFlightServer.cs
@@ -128,5 +128,13 @@ namespace Apache.Arrow.Flight.TestWeb
                 await responseStream.WriteAsync(flightInfo);
             }
         }
+
+        public override async Task DoExchange(FlightServerRecordBatchStreamReader requestStream, FlightServerRecordBatchStreamWriter responseStream, ServerCallContext context)
+        {
+            while(await requestStream.MoveNext().ConfigureAwait(false))
+            {
+                await responseStream.WriteAsync(requestStream.Current, requestStream.ApplicationMetadata.FirstOrDefault()).ConfigureAwait(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Rationale for this change

This is a draft implementation of DoExchange. A simple usage demo is in FlightTests.cs and TestFlightServer.cs.
I've tried to share the implementation with DoGet/DoPut as much as possible.

### What changes are included in this PR?

- FlightServer.cs and related FlightServerImplementation.cs
- FlightClient.cs with (new) FlightRecordBatchExchangeCall.cs wrapper call.

### Are these changes tested?

Yes, tests are added in FlightTest.cs and TestFlightServer.cs
I've tested locally with the C++ implementation.

### Are there any user-facing changes?

No and the DoExchange documentation is already present

* GitHub Issue: #40690