### PR TITLE
GH-36026: [C++][ORC] Catch all ORC exceptions to avoid crash

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -18,7 +18,6 @@
 #include "arrow/adapters/orc/adapter.h"
 
 #include <algorithm>
-#include <cstdlib>
 #include <filesystem>
 #include <list>
 #include <memory>
@@ -75,6 +74,12 @@ namespace liborc = orc;
   }                                            \
   catch (const liborc::NotImplementedYet& e) { \
     return Status::NotImplemented(e.what());   \
+  }                                            \
+  catch (const std::exception& e) {            \
+    return Status::Invalid(e.what());          \
+  }                                            \
+  catch (...) {                                \
+    return Status::UnknownError("ORC error");  \
   }
 
 #define ORC_CATCH_NOT_OK(_s)  \
@@ -178,7 +183,8 @@ liborc::RowReaderOptions default_row_reader_options() {
   return options;
 }
 
-// Remove this check once https://issues.apache.org/jira/browse/ORC-1661 is fixed.
+// Proactively check the availability of timezone database.
+// Remove it once https://issues.apache.org/jira/browse/ORC-1661 has been fixed.
 Status check_timezone_database_availability() {
   auto tz_dir = std::getenv("TZDIR");
   bool is_tzdb_avaiable = tz_dir != nullptr

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "arrow/adapters/orc/options.h"
@@ -45,6 +46,16 @@ struct StripeInformation {
   int64_t num_rows;
   /// \brief Index of the first row of the stripe
   int64_t first_row_id;
+};
+
+/// \brief Version provided by the official ORC C++ library.
+struct ARROW_EXPORT OrcVersion {
+  int major;
+  int minor;
+  int patch;
+
+  /// \brief Return the current version of ORC C++ library.
+  static std::optional<OrcVersion> Get();
 };
 
 /// \class ORCFileReader

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include "arrow/adapters/orc/options.h"

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -48,16 +48,6 @@ struct StripeInformation {
   int64_t first_row_id;
 };
 
-/// \brief Version provided by the official ORC C++ library.
-struct ARROW_EXPORT OrcVersion {
-  int major;
-  int minor;
-  int patch;
-
-  /// \brief Return the current version of ORC C++ library.
-  static std::optional<OrcVersion> Get();
-};
-
 /// \class ORCFileReader
 /// \brief Read an Arrow Table or RecordBatch from an ORC file.
 class ARROW_EXPORT ORCFileReader {

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -638,37 +638,33 @@ TEST(TestAdapterReadWrite, FieldAttributesRoundTrip) {
   AssertSchemaEqual(schema, read_schema, /*check_metadata=*/true);
 }
 
-TEST(TestAdapterReadWrite, catchTimezoneError) {
-  // Write a simple ORC file with timestamp type.
-  auto table_schema = schema({field("a", timestamp(TimeUnit::NANO))});
-  const auto table = GenerateRandomTable(table_schema, /*size=1*/ 1, /*min_num_chunks=*/1,
-                                         /*max_num_chunks=*/1, /*null_probability=*/0);
-  EXPECT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create(4096));
-  EXPECT_OK_AND_ASSIGN(auto writer, adapters::orc::ORCFileWriter::Open(out_stream.get()));
-  ARROW_EXPECT_OK(writer->Write(*table));
-  ARROW_EXPECT_OK(writer->Close());
-  EXPECT_OK_AND_ASSIGN(auto buffer, out_stream->Finish());
+TEST(TestAdapterReadWrite, ThrowWhenTZDBUnavaiable) {
+  auto orc_version = adapters::orc::OrcVersion::Get();
+  if (orc_version.has_value() && orc_version->major >= 2) {
+    GTEST_SKIP() << "Only ORC pre-2.0.0 versions have the time zone database check";
+  }
 
-  // Backup the original TZDIR env and set a wrong value by purpose.
+  // Backup the original TZDIR env and set a wrong value by purpose to trigger the check.
   const char* tzdir_env_key = "TZDIR";
+  const char* expect_str = "IANA time zone database is unavailable but required by ORC";
   auto tzdir_env_backup = std::getenv(tzdir_env_key);
-  ARROW_EXPECT_OK(arrow::internal::SetEnvVar(tzdir_env_key, "/invalid_path"));
+  ARROW_EXPECT_OK(arrow::internal::SetEnvVar(tzdir_env_key, "/a/b/c/d/e"));
 
-  EXPECT_OK_AND_ASSIGN(auto reader, adapters::orc::ORCFileReader::Open(
-                                        std::make_shared<io::BufferReader>(buffer),
-                                        default_memory_pool()));
+  EXPECT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create(1024));
+  EXPECT_THAT(
+      adapters::orc::ORCFileWriter::Open(out_stream.get(), adapters::orc::WriteOptions()),
+      Raises(StatusCode::Invalid, testing::HasSubstr(expect_str)));
 
-  // Verify that we have caught the orc::TimezoneError exception.
-  EXPECT_THAT(reader->Read(),
-              Raises(StatusCode::UnknownError, testing::HasSubstr("/invalid_path")));
+  EXPECT_OK_AND_ASSIGN(auto buffer, out_stream->Finish());
+  EXPECT_THAT(adapters::orc::ORCFileReader::Open(
+                  std::make_shared<io::BufferReader>(buffer), default_memory_pool()),
+              Raises(StatusCode::Invalid, testing::HasSubstr(expect_str)));
 
-  // Restore TZDIR env to verify timestamp values can be read successfully.
+  // Restore TZDIR env.
   ARROW_EXPECT_OK(arrow::internal::DelEnvVar(tzdir_env_key));
   if (tzdir_env_backup) {
     ARROW_EXPECT_OK(arrow::internal::SetEnvVar(tzdir_env_key, tzdir_env_backup));
   }
-  EXPECT_OK_AND_ASSIGN(auto read_table, reader->Read());
-  EXPECT_TRUE(read_table->Equals(*table));
 }
 
 // Trivial

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -638,28 +638,37 @@ TEST(TestAdapterReadWrite, FieldAttributesRoundTrip) {
   AssertSchemaEqual(schema, read_schema, /*check_metadata=*/true);
 }
 
-TEST(TestAdapterReadWrite, ThrowWhenTZDBUnavaiable) {
-  // Backup the original TZDIR env and set a wrong value by purpose to trigger the check.
-  const char* tzdir_env_key = "TZDIR";
-  const char* expect_str = "IANA timezone database is unavailable but required by ORC";
-  auto tzdir_env_backup = std::getenv(tzdir_env_key);
-  ARROW_EXPECT_OK(arrow::internal::SetEnvVar(tzdir_env_key, "/a/b/c/d/e"));
-
-  EXPECT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create(1024));
-  EXPECT_THAT(
-      adapters::orc::ORCFileWriter::Open(out_stream.get(), adapters::orc::WriteOptions()),
-      Raises(StatusCode::Invalid, testing::HasSubstr(expect_str)));
-
+TEST(TestAdapterReadWrite, catchTimezoneError) {
+  // Write a simple ORC file with timestamp type.
+  auto table_schema = schema({field("a", timestamp(TimeUnit::NANO))});
+  const auto table = GenerateRandomTable(table_schema, /*size=1*/ 1, /*min_num_chunks=*/1,
+                                         /*max_num_chunks=*/1, /*null_probability=*/0);
+  EXPECT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create(4096));
+  EXPECT_OK_AND_ASSIGN(auto writer, adapters::orc::ORCFileWriter::Open(out_stream.get()));
+  ARROW_EXPECT_OK(writer->Write(*table));
+  ARROW_EXPECT_OK(writer->Close());
   EXPECT_OK_AND_ASSIGN(auto buffer, out_stream->Finish());
-  EXPECT_THAT(adapters::orc::ORCFileReader::Open(
-                  std::make_shared<io::BufferReader>(buffer), default_memory_pool()),
-              Raises(StatusCode::Invalid, testing::HasSubstr(expect_str)));
 
-  // Restore TZDIR env.
+  // Backup the original TZDIR env and set a wrong value by purpose.
+  const char* tzdir_env_key = "TZDIR";
+  auto tzdir_env_backup = std::getenv(tzdir_env_key);
+  ARROW_EXPECT_OK(arrow::internal::SetEnvVar(tzdir_env_key, "/invalid_path"));
+
+  EXPECT_OK_AND_ASSIGN(auto reader, adapters::orc::ORCFileReader::Open(
+                                        std::make_shared<io::BufferReader>(buffer),
+                                        default_memory_pool()));
+
+  // Verify that we have caught the orc::TimezoneError exception.
+  EXPECT_THAT(reader->Read(),
+              Raises(StatusCode::UnknownError, testing::HasSubstr("/invalid_path")));
+
+  // Restore TZDIR env to verify timestamp values can be read successfully.
   ARROW_EXPECT_OK(arrow::internal::DelEnvVar(tzdir_env_key));
   if (tzdir_env_backup) {
     ARROW_EXPECT_OK(arrow::internal::SetEnvVar(tzdir_env_key, tzdir_env_backup));
   }
+  EXPECT_OK_AND_ASSIGN(auto read_table, reader->Read());
+  EXPECT_TRUE(read_table->Equals(*table));
 }
 
 // Trivial

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -37,6 +37,7 @@
 
 #include "orc/MemoryPool.hh"
 #include "orc/OrcFile.hh"
+#include "orc/orc-config.hh"
 
 // alias to not interfere with nested orc namespace
 namespace liborc = orc;
@@ -1218,6 +1219,13 @@ Result<std::shared_ptr<Field>> GetArrowField(const std::string& name,
   ARROW_ASSIGN_OR_RAISE(auto arrow_type, GetArrowType(type));
   ARROW_ASSIGN_OR_RAISE(auto metadata, GetFieldMetadata(type));
   return field(name, std::move(arrow_type), nullable, std::move(metadata));
+}
+
+int GetOrcMajorVersion() {
+  std::stringstream orc_version(ORC_VERSION);
+  std::string major_version;
+  std::getline(orc_version, major_version, '.');
+  return std::stoi(major_version);
 }
 
 }  // namespace orc

--- a/cpp/src/arrow/adapters/orc/util.h
+++ b/cpp/src/arrow/adapters/orc/util.h
@@ -60,6 +60,9 @@ ARROW_EXPORT Status WriteBatch(const ChunkedArray& chunked_array, int64_t length
                                int* arrow_chunk_offset, int64_t* arrow_index_offset,
                                liborc::ColumnVectorBatch* column_vector_batch);
 
+/// \brief Get the major version provided by the official ORC C++ library.
+ARROW_EXPORT int GetOrcMajorVersion();
+
 }  // namespace orc
 }  // namespace adapters
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

When /usr/share/zoneinfo is unavailable and TZDIR env is unset, creating C++ ORC reader will crash on Windows. We need to eagerly check this and prevent followup crash.

### What changes are included in this PR?

Eagerly check TZDB availability before creating ORC reader/writer.

### Are these changes tested?

Yes, added a test case to make sure the check work as expected.

### Are there any user-facing changes?

Users on Windows (or other cases when TZDB is not availble) will clearly see this error message instead of crash.
* GitHub Issue: #36026