### PR TITLE
GH-40703: [CI][Packaging] Homebrew can't install Python 3.12 on GHA runners

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -239,7 +239,7 @@ on:
       # The GHA runners install of python > 3.10 is incompatible with brew so we
       # have to force overwriting of the symlinks
       # see https://github.com/actions/runner-images/issues/6868
-      brew install --overwrite python@3.11 python@3.10
+      brew install --overwrite python@3.12 python@3.11 python@3.10
 
       set -x
       ARROW_GLIB_FORMULA=$(echo ${ARROW_FORMULA} | sed -e 's/\.rb/-glib.rb/')


### PR DESCRIPTION
### Rationale for this change

The hombrew-cpp nightly job is failing.

### What changes are included in this PR?

Force install install for Python 3.12

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #40703