### PR TITLE
MINOR: [C++][Parquet][Docs] Increase chunk_size in docs

### DIFF
--- a/cpp/examples/arrow/parquet_read_write.cc
+++ b/cpp/examples/arrow/parquet_read_write.cc
@@ -120,7 +120,7 @@ arrow::Status WriteFullFile(std::string path_to_file) {
 
   ARROW_RETURN_NOT_OK(parquet::arrow::WriteTable(*table.get(),
                                                  arrow::default_memory_pool(), outfile,
-                                                 /*chunk_size=*/3, props, arrow_props));
+                                                 /*chunk_size=*/64*1024, props, arrow_props));
   return arrow::Status::OK();
 }
 


### PR DESCRIPTION
### Rationale for this change

Is there a reason we're using a low value here. All other examples use `128*1024` or `64*1024`.

I was stumped by this as I used it without really reading about the parameter and spent a day figuring out why my parquet writes were so slow.

### What changes are included in this PR?

Increase `chunk_size` to `64*1024`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.