### PR TITLE
GH-40706: [CI][Python] Activate ARROW_PYTHON_VENV if defined in sdist-test job

### DIFF
--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -55,6 +55,11 @@ if [ -n "${PYARROW_VERSION:-}" ]; then
 else
   sdist=$(ls ${arrow_dir}/python/dist/pyarrow-*.tar.gz | sort -r | head -n1)
 fi
+
+if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  . "${ARROW_PYTHON_VENV}/bin/activate"
+fi
+
 ${PYTHON:-python} -m pip install ${sdist}
 
 pytest -r s ${PYTEST_ARGS:-} --pyargs pyarrow


### PR DESCRIPTION
### Rationale for this change

[python-sdist](https://github.com/ursacomputing/crossbow/actions/runs/8355876590/job/22871821900) is failing.

### What changes are included in this PR?

Activate `ARROW_PYTHON_VENV` on `python_sdist_test.sh`

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #40706