### PR TITLE
MINOR: [Java] Bump com.google.api.grpc:proto-google-common-protos from 1.12.0 to 2.37.1 in /java

### DIFF
--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
-      <version>1.12.0</version>
+      <version>2.37.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
See dependabot for more details https://github.com/apache/arrow/pull/40641#issue-2192785280