### PR TITLE
GH-39131: [JS] Add at() for array like types

### DIFF
--- a/js/bin/integration.ts
+++ b/js/bin/integration.ts
@@ -223,7 +223,7 @@ function compareVectors(actual: Vector, expected: Vector) {
 
     (() => {
         for (let i = -1, n = actual.length; ++i < n;) {
-            const x1 = actual.get(i), x2 = expected.get(i);
+            const x1 = actual.at(i), x2 = expected.at(i);
             if (!createElementComparator(x2)(x1)) {
                 throw new Error(`${i}: ${x1} !== ${x2}`);
             }

--- a/js/bin/print-buffer-alignment.ts
+++ b/js/bin/print-buffer-alignment.ts
@@ -35,10 +35,9 @@ import { RecordBatch, AsyncMessageReader, makeData, Struct, Schema, Field } from
     while (1) {
         // @ts-ignore
         if ((metadataLength = (await reader.readMetadataLength())).done) { break; }
-        if (metadataLength.value === -1) {
+        if (metadataLength.value === -1 &&
             // @ts-ignore
-            if ((metadataLength = (await reader.readMetadataLength())).done) { break; }
-        }
+            (metadataLength = (await reader.readMetadataLength())).done) { break; }
         // @ts-ignore
         if ((message = (await reader.readMetadata(metadataLength.value))).done) { break; }
 
@@ -65,9 +64,9 @@ import { RecordBatch, AsyncMessageReader, makeData, Struct, Schema, Field } from
                     bodyByteLength: body.byteLength,
                 });
             byteOffset += metadataLength.value;
-            bufferRegions.forEach(({ offset, length: byteLength }, i) => {
+            for (const [i, { offset, length: byteLength }] of bufferRegions.entries()) {
                 console.log(`\tbuffer ${i + 1}:`, { byteOffset: byteOffset + offset, byteLength });
-            });
+            }
             byteOffset += body.byteLength;
         } else if (message.value.isDictionaryBatch()) {
             const header = message.value.header();
@@ -85,9 +84,9 @@ import { RecordBatch, AsyncMessageReader, makeData, Struct, Schema, Field } from
                     bodyByteLength: body.byteLength,
                 });
             byteOffset += metadataLength.value;
-            bufferRegions.forEach(({ offset, length: byteLength }, i) => {
+            for (const [i, { offset, length: byteLength }] of bufferRegions.entries()) {
                 console.log(`\tbuffer ${i + 1}:`, { byteOffset: byteOffset + offset, byteLength });
-            });
+            }
             byteOffset += body.byteLength;
         }
     }

--- a/js/perf/index.ts
+++ b/js/perf/index.ts
@@ -127,7 +127,7 @@ b.suite(
     ...Object.entries(vectors).map(([name, vector]) =>
         b.add(`from: ${name}`, () => {
             for (let i = -1, n = vector.length; ++i < n;) {
-                vector.get(i);
+                vector.at(i);
             }
         })),
 
@@ -155,7 +155,7 @@ for (const { name, ipc, table } of config) {
         suite_name: `Get values by index`,
         fn(vector: Arrow.Vector<any>) {
             for (let i = -1, n = vector.length; ++i < n;) {
-                vector.get(i);
+                vector.at(i);
             }
         }
     }, {
@@ -205,9 +205,9 @@ for (const { name, table, counts } of config) {
             table.toArray();
         }),
 
-        b.add(`get, dataset: ${name}, numRows: ${formatNumber(table.numRows)}`, () => {
+        b.add(`at, dataset: ${name}, numRows: ${formatNumber(table.numRows)}`, () => {
             for (let i = -1, n = table.numRows; ++i < n;) {
-                table.get(i);
+                table.at(i);
             }
         }),
 
@@ -233,7 +233,7 @@ for (const { name, table, counts } of config) {
                             const vector = batch.getChildAt(colidx)!;
                             // yield all indices
                             for (let index = -1, length = batch.numRows; ++index < length;) {
-                                sum += (vector.get(index) >= value) ? 1 : 0;
+                                sum += (vector.at(index) >= value) ? 1 : 0;
                             }
                         }
                         return sum;
@@ -249,7 +249,7 @@ for (const { name, table, counts } of config) {
                             const vector = batch.getChildAt(colidx)!;
                             // yield all indices
                             for (let index = -1, length = batch.numRows; ++index < length;) {
-                                sum += (vector.get(index) === value) ? 1 : 0;
+                                sum += (vector.at(index) === value) ? 1 : 0;
                             }
                         }
                         return sum;

--- a/js/src/builder/buffer.ts
+++ b/js/src/builder/buffer.ts
@@ -91,8 +91,8 @@ export class BufferBuilder<T extends TypedArray | BigIntArray> {
 
 /** @ignore */
 export class DataBufferBuilder<T extends TypedArray | BigIntArray> extends BufferBuilder<T> {
-    public last() { return this.get(this.length - 1); }
-    public get(index: number): T[0] { return this.buffer[index]; }
+    public last() { return this.at(- 1); }
+    public at(index: number): T[0] { return this.buffer[index]; }
     public set(index: number, value: T[0]) {
         this.reserve(index - this.length + 1);
         this.buffer[index * this.stride] = value;
@@ -107,7 +107,7 @@ export class BitmapBufferBuilder extends DataBufferBuilder<Uint8Array> {
 
     public numValid = 0;
     public get numInvalid() { return this.length - this.numValid; }
-    public get(idx: number) { return this.buffer[idx >> 3] >> idx % 8 & 1; }
+    public at(idx: number) { return this.buffer[idx >> 3] >> idx % 8 & 1; }
     public set(idx: number, val: number) {
         const { buffer } = this.reserve(idx - this.length + 1);
         const byte = idx >> 3, bit = idx % 8, cur = buffer[byte] >> bit & 1;

--- a/js/src/recordbatch.ts
+++ b/js/src/recordbatch.ts
@@ -21,7 +21,7 @@ import { Vector } from './vector.js';
 import { Schema, Field } from './schema.js';
 import { DataType, Struct, Null, TypeMap } from './type.js';
 
-import { instance as getVisitor } from './visitor/get.js';
+import { instance as atVisitor } from './visitor/at.js';
 import { instance as setVisitor } from './visitor/set.js';
 import { instance as indexOfVisitor } from './visitor/indexof.js';
 import { instance as iteratorVisitor } from './visitor/iterator.js';
@@ -124,11 +124,21 @@ export class RecordBatch<T extends TypeMap = any> {
     }
 
     /**
+     * @deprecated Use `at()` instead.
+     *
      * Get a row by position.
      * @param index The index of the element to read.
      */
     public get(index: number) {
-        return getVisitor.visit(this.data, index);
+        return this.at(index);
+    }
+
+    /**
+     * Get an element value by position.
+     * @param index The index of the element to read. A negative index will count back from the last element.
+     */
+    public at(index: number) {
+        return atVisitor.visit(this.data, index);
     }
 
     /**

--- a/js/src/row/map.ts
+++ b/js/src/row/map.ts
@@ -19,7 +19,7 @@ import { Data } from '../data.js';
 import { Vector } from '../vector.js';
 import { DataType, Struct } from '../type.js';
 import { valueToString } from '../util/pretty.js';
-import { instance as getVisitor } from '../visitor/get.js';
+import { instance as atVisitor } from '../visitor/at.js';
 import { instance as setVisitor } from '../visitor/set.js';
 
 /** @ignore */ export const kKeys = Symbol.for('keys');
@@ -51,7 +51,7 @@ export class MapRow<K extends DataType = any, V extends DataType = any> {
         const vals = this[kVals];
         const json = {} as { [P in K['TValue']]: V['TValue'] };
         for (let i = -1, n = keys.length; ++i < n;) {
-            json[keys.get(i)] = getVisitor.visit(vals, i);
+            json[keys.at(i)] = atVisitor.visit(vals, i);
         }
         return json;
     }
@@ -94,8 +94,8 @@ class MapRowIterator<K extends DataType = any, V extends DataType = any>
         return {
             done: false,
             value: [
-                this.keys.get(i),
-                getVisitor.visit(this.vals, i),
+                this.keys.at(i),
+                atVisitor.visit(this.vals, i),
             ] as [K['TValue'], V['TValue'] | null]
         };
     }
@@ -126,7 +126,7 @@ class MapRowProxyHandler<K extends DataType = any, V extends DataType = any> imp
         }
         const idx = row[kKeys].indexOf(key);
         if (idx !== -1) {
-            const val = getVisitor.visit(Reflect.get(row, kVals), idx);
+            const val = atVisitor.visit(Reflect.get(row, kVals), idx);
             // Cache key/val lookups
             Reflect.set(row, key, val);
             return val;

--- a/js/src/row/struct.ts
+++ b/js/src/row/struct.ts
@@ -19,7 +19,7 @@ import { Data } from '../data.js';
 import { Field } from '../schema.js';
 import { Struct, TypeMap } from '../type.js';
 import { valueToString } from '../util/pretty.js';
-import { instance as getVisitor } from '../visitor/get.js';
+import { instance as atVisitor } from '../visitor/at.js';
 import { instance as setVisitor } from '../visitor/set.js';
 
 /** @ignore */ const kParent = Symbol.for('parent');
@@ -50,7 +50,7 @@ export class StructRow<T extends TypeMap = any> {
         const keys = parent.type.children;
         const json = {} as { [P in string & keyof T]: T[P]['TValue'] };
         for (let j = -1, n = keys.length; ++j < n;) {
-            json[keys[j].name as string & keyof T] = getVisitor.visit(parent.children[j], i);
+            json[keys[j].name as string & keyof T] = atVisitor.visit(parent.children[j], i);
         }
         return json;
     }
@@ -102,7 +102,7 @@ class StructRowIterator<T extends TypeMap = any>
                 done: false,
                 value: [
                     this.childFields[i].name,
-                    getVisitor.visit(this.children[i], this.rowIndex)
+                    atVisitor.visit(this.children[i], this.rowIndex)
                 ]
             } as IteratorYieldResult<[any, any]>;
         }
@@ -139,7 +139,7 @@ class StructRowProxyHandler<T extends TypeMap = any> implements ProxyHandler<Str
         }
         const idx = row[kParent].type.children.findIndex((f) => f.name === key);
         if (idx !== -1) {
-            const val = getVisitor.visit(row[kParent].children[idx], row[kRowIndex]);
+            const val = atVisitor.visit(row[kParent].children[idx], row[kRowIndex]);
             // Cache key/val lookups
             Reflect.set(row, key, val);
             return val;

--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -34,7 +34,7 @@ import {
     sliceChunks,
 } from './util/chunk.js';
 
-import { instance as getVisitor } from './visitor/get.js';
+import { instance as atVisitor } from './visitor/at.js';
 import { instance as setVisitor } from './visitor/set.js';
 import { instance as indexOfVisitor } from './visitor/indexof.js';
 import { instance as iteratorVisitor } from './visitor/iterator.js';
@@ -189,12 +189,23 @@ export class Table<T extends TypeMap = any> {
     public isValid(index: number): boolean { return false; }
 
     /**
+     * @deprecated Use `at()` instead.
+     *
      * Get an element value by position.
      *
      * @param index The index of the element to read.
      */
     // @ts-ignore
-    public get(index: number): Struct<T>['TValue'] | null { return null; }
+    public get(index: number): Struct<T>['TValue'] | null {
+        return this.at(index);
+    }
+
+    /**
+     * Get an element value by position.
+     * @param index The index of the element to read. A negative index will count back from the last element.
+     */
+    // @ts-ignore
+    public at(index: number): Struct<T>['TValue'] | null { return null; }
 
     /**
      * Set an element value by position.
@@ -379,7 +390,7 @@ export class Table<T extends TypeMap = any> {
         (proto as any)._nullCount = -1;
         (proto as any)[Symbol.isConcatSpreadable] = true;
         (proto as any)['isValid'] = wrapChunkedCall1(isChunkedValid);
-        (proto as any)['get'] = wrapChunkedCall1(getVisitor.getVisitFn(Type.Struct));
+        (proto as any)['at'] = wrapChunkedCall1(atVisitor.getVisitFn(Type.Struct));
         (proto as any)['set'] = wrapChunkedCall2(setVisitor.getVisitFn(Type.Struct));
         (proto as any)['indexOf'] = wrapChunkedIndexOf(indexOfVisitor.getVisitFn(Type.Struct));
         return 'Table';

--- a/js/src/util/chunk.ts
+++ b/js/src/util/chunk.ts
@@ -120,6 +120,9 @@ export function isChunkedValid<T extends DataType>(data: Data<T>, index: number)
 export function wrapChunkedCall1<T extends DataType>(fn: (c: Data<T>, _1: number) => any) {
     function chunkedFn(chunks: ReadonlyArray<Data<T>>, i: number, j: number) { return fn(chunks[i], j); }
     return function (this: any, index: number) {
+        // negative indexes count from the back
+        if (index < 0) index += this.length;
+
         const data = this.data as ReadonlyArray<Data<T>>;
         return binarySearch(data, this._offsets, index, chunkedFn);
     };
@@ -130,6 +133,9 @@ export function wrapChunkedCall2<T extends DataType>(fn: (c: Data<T>, _1: number
     let _2: any;
     function chunkedFn(chunks: ReadonlyArray<Data<T>>, i: number, j: number) { return fn(chunks[i], j, _2); }
     return function (this: any, index: number, value: any) {
+        // negative indexes count from the back
+        if (index < 0) index += this.length;
+
         const data = this.data as ReadonlyArray<Data<T>>;
         _2 = value;
         const result = binarySearch(data, this._offsets, index, chunkedFn);

--- a/js/src/util/vector.ts
+++ b/js/src/util/vector.ts
@@ -114,7 +114,7 @@ function createMapComparator(lhs: Map<any, any>) {
 function createVectorComparator(lhs: Vector<any>) {
     const comparators = [] as ((x: any) => boolean)[];
     for (let i = -1, n = lhs.length; ++i < n;) {
-        comparators[i] = createElementComparator(lhs.get(i));
+        comparators[i] = createElementComparator(lhs.at(i));
     }
     return createSubElementsComparator(comparators);
 }
@@ -163,7 +163,7 @@ function compareVector(comparators: ((x: any) => boolean)[], vec: Vector) {
     const n = comparators.length;
     if (vec.length !== n) { return false; }
     for (let i = -1; ++i < n;) {
-        if (!(comparators[i](vec.get(i)))) { return false; }
+        if (!(comparators[i](vec.at(i)))) { return false; }
     }
     return true;
 }

--- a/js/src/vector.ts
+++ b/js/src/vector.ts
@@ -78,9 +78,9 @@ export class Vector<T extends DataType = any> {
                 const { at, set, indexOf } = visitorsByTypeId[type.typeId];
                 const unchunkedData = data[0];
 
-                this.isValid = (index: number) => isChunkedValid(unchunkedData, index);
-                this.at = (index: number) => at(unchunkedData, index);
-                this.set = (index: number, value: T) => set(unchunkedData, index, value);
+                this.isValid = (index: number) => isChunkedValid(unchunkedData, index < 0 ? index + this.length : index);
+                this.at = (index: number) => at(unchunkedData, index < 0 ? index + this.length : index);
+                this.set = (index: number, value: T) => set(unchunkedData, index < 0 ? index + this.length : index, value);
                 this.indexOf = (index: number) => indexOf(unchunkedData, index);
                 this._offsets = [0, unchunkedData.length];
                 break;
@@ -395,6 +395,9 @@ class MemoizedVector<T extends DataType = any> extends Vector<T> {
 
         Object.defineProperty(this, 'at', {
             value(index: number) {
+                // negative indexes count from the back
+                if (index < 0) index += this.length;
+
                 const cachedValue = cache[index];
                 if (cachedValue !== undefined) {
                     return cachedValue;
@@ -407,6 +410,9 @@ class MemoizedVector<T extends DataType = any> extends Vector<T> {
 
         Object.defineProperty(this, 'set', {
             value(index: number, value: T['TValue'] | null) {
+                // negative indexes count from the back
+                if (index < 0) index += this.length;
+
                 set.call(this, index, value);
                 cache[index] = value;
             }

--- a/js/src/visitor/at.ts
+++ b/js/src/visitor/at.ts
@@ -40,11 +40,11 @@ import {
 } from '../type.js';
 
 /** @ignore */
-export interface GetVisitor extends Visitor {
+export interface AtVisitor extends Visitor {
     visit<T extends DataType>(node: Data<T>, index: number): T['TValue'] | null;
     visitMany<T extends DataType>(nodes: Data<T>[], indices: number[]): (T['TValue'] | null)[];
-    getVisitFn<T extends DataType>(node: Vector<T> | Data<T> | T): (data: Data<T>, index: number) => T['TValue'] | null;
-    getVisitFn<T extends Type>(node: T): (data: Data<TypeToDataType<T>>, index: number) => TypeToDataType<T>['TValue'];
+    atVisitFn<T extends DataType>(node: Vector<T> | Data<T> | T): (data: Data<T>, index: number) => T['TValue'] | null;
+    atVisitFn<T extends Type>(node: T): (data: Data<TypeToDataType<T>>, index: number) => TypeToDataType<T>['TValue'];
     visitNull<T extends Null>(data: Data<T>, index: number): T['TValue'] | null;
     visitBool<T extends Bool>(data: Data<T>, index: number): T['TValue'] | null;
     visitInt<T extends Int>(data: Data<T>, index: number): T['TValue'] | null;
@@ -98,10 +98,10 @@ export interface GetVisitor extends Visitor {
 }
 
 /** @ignore */
-export class GetVisitor extends Visitor { }
+export class AtVisitor extends Visitor { }
 
 /** @ignore */
-function wrapGet<T extends DataType>(fn: (data: Data<T>, _1: any) => any) {
+function wrapAt<T extends DataType>(fn: (data: Data<T>, _1: any) => any) {
     return (data: Data<T>, _1: any) => data.getValid(_1) ? fn(data, _1) : null;
 }
 
@@ -115,9 +115,9 @@ function wrapGet<T extends DataType>(fn: (data: Data<T>, _1: any) => any) {
 /** @ignore */const epochMillisecondsLongToDate = (data: Int32Array, index: number) => epochMillisecondsToDate(epochMillisecondsLongToMs(data, index));
 
 /** @ignore */
-const getNull = <T extends Null>(_data: Data<T>, _index: number): T['TValue'] => null;
+const atNull = <T extends Null>(_data: Data<T>, _index: number): T['TValue'] => null;
 /** @ignore */
-const getVariableWidthBytes = (values: Uint8Array, valueOffsets: Int32Array | BigInt64Array, index: number) => {
+const atVariableWidthBytes = (values: Uint8Array, valueOffsets: Int32Array | BigInt64Array, index: number) => {
     if (index + 1 >= valueOffsets.length) {
         return null as any;
     }
@@ -127,7 +127,7 @@ const getVariableWidthBytes = (values: Uint8Array, valueOffsets: Int32Array | Bi
 };
 
 /** @ignore */
-const getBool = <T extends Bool>({ offset, values }: Data<T>, index: number): T['TValue'] => {
+const atBool = <T extends Bool>({ offset, values }: Data<T>, index: number): T['TValue'] => {
     const idx = offset + index;
     const byte = values[idx >> 3];
     return (byte & 1 << (idx % 8)) !== 0;
@@ -139,87 +139,87 @@ type Numeric1X = Int8 | Int16 | Int32 | Uint8 | Uint16 | Uint32 | Float32 | Floa
 type Numeric2X = Int64 | Uint64;
 
 /** @ignore */
-const getDateDay = <T extends DateDay>({ values }: Data<T>, index: number): T['TValue'] => epochDaysToDate(values, index);
+const atDateDay = <T extends DateDay>({ values }: Data<T>, index: number): T['TValue'] => epochDaysToDate(values, index);
 /** @ignore */
-const getDateMillisecond = <T extends DateMillisecond>({ values }: Data<T>, index: number): T['TValue'] => epochMillisecondsLongToDate(values, index * 2);
+const atDateMillisecond = <T extends DateMillisecond>({ values }: Data<T>, index: number): T['TValue'] => epochMillisecondsLongToDate(values, index * 2);
 /** @ignore */
-const getNumeric = <T extends Numeric1X>({ stride, values }: Data<T>, index: number): T['TValue'] => values[stride * index];
+const atNumeric = <T extends Numeric1X>({ stride, values }: Data<T>, index: number): T['TValue'] => values[stride * index];
 /** @ignore */
-const getFloat16 = <T extends Float16>({ stride, values }: Data<T>, index: number): T['TValue'] => uint16ToFloat64(values[stride * index]);
+const atFloat16 = <T extends Float16>({ stride, values }: Data<T>, index: number): T['TValue'] => uint16ToFloat64(values[stride * index]);
 /** @ignore */
-const getBigInts = <T extends Numeric2X>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atBigInts = <T extends Numeric2X>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /** @ignore */
-const getFixedSizeBinary = <T extends FixedSizeBinary>({ stride, values }: Data<T>, index: number): T['TValue'] => values.subarray(stride * index, stride * (index + 1));
+const atFixedSizeBinary = <T extends FixedSizeBinary>({ stride, values }: Data<T>, index: number): T['TValue'] => values.subarray(stride * index, stride * (index + 1));
 
 /** @ignore */
-const getBinary = <T extends Binary | LargeBinary>({ values, valueOffsets }: Data<T>, index: number): T['TValue'] => getVariableWidthBytes(values, valueOffsets, index);
+const atBinary = <T extends Binary | LargeBinary>({ values, valueOffsets }: Data<T>, index: number): T['TValue'] => atVariableWidthBytes(values, valueOffsets, index);
 /** @ignore */
-const getUtf8 = <T extends Utf8 | LargeUtf8>({ values, valueOffsets }: Data<T>, index: number): T['TValue'] => {
-    const bytes = getVariableWidthBytes(values, valueOffsets, index);
+const atUtf8 = <T extends Utf8 | LargeUtf8>({ values, valueOffsets }: Data<T>, index: number): T['TValue'] => {
+    const bytes = atVariableWidthBytes(values, valueOffsets, index);
     return bytes !== null ? decodeUtf8(bytes) : null as any;
 };
 
 /* istanbul ignore next */
 /** @ignore */
-const getInt = <T extends Int>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atInt = <T extends Int>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 
 /* istanbul ignore next */
 /** @ignore */
-const getFloat = <T extends Float>({ type, values }: Data<T>, index: number): T['TValue'] => (
+const atFloat = <T extends Float>({ type, values }: Data<T>, index: number): T['TValue'] => (
     type.precision !== Precision.HALF ? values[index] : uint16ToFloat64(values[index])
 );
 
 /* istanbul ignore next */
 /** @ignore */
-const getDate = <T extends Date_>(data: Data<T>, index: number): T['TValue'] => (
+const atDate = <T extends Date_>(data: Data<T>, index: number): T['TValue'] => (
     data.type.unit === DateUnit.DAY
-        ? getDateDay(data as Data<DateDay>, index)
-        : getDateMillisecond(data as Data<DateMillisecond>, index)
+        ? atDateDay(data as Data<DateDay>, index)
+        : atDateMillisecond(data as Data<DateMillisecond>, index)
 );
 
 /** @ignore */
-const getTimestampSecond = <T extends TimestampSecond>({ values }: Data<T>, index: number): T['TValue'] => 1000 * epochMillisecondsLongToMs(values, index * 2);
+const atTimestampSecond = <T extends TimestampSecond>({ values }: Data<T>, index: number): T['TValue'] => 1000 * epochMillisecondsLongToMs(values, index * 2);
 /** @ignore */
-const getTimestampMillisecond = <T extends TimestampMillisecond>({ values }: Data<T>, index: number): T['TValue'] => epochMillisecondsLongToMs(values, index * 2);
+const atTimestampMillisecond = <T extends TimestampMillisecond>({ values }: Data<T>, index: number): T['TValue'] => epochMillisecondsLongToMs(values, index * 2);
 /** @ignore */
-const getTimestampMicrosecond = <T extends TimestampMicrosecond>({ values }: Data<T>, index: number): T['TValue'] => epochMicrosecondsLongToMs(values, index * 2);
+const atTimestampMicrosecond = <T extends TimestampMicrosecond>({ values }: Data<T>, index: number): T['TValue'] => epochMicrosecondsLongToMs(values, index * 2);
 /** @ignore */
-const getTimestampNanosecond = <T extends TimestampNanosecond>({ values }: Data<T>, index: number): T['TValue'] => epochNanosecondsLongToMs(values, index * 2);
+const atTimestampNanosecond = <T extends TimestampNanosecond>({ values }: Data<T>, index: number): T['TValue'] => epochNanosecondsLongToMs(values, index * 2);
 /* istanbul ignore next */
 /** @ignore */
-const getTimestamp = <T extends Timestamp>(data: Data<T>, index: number): T['TValue'] => {
+const atTimestamp = <T extends Timestamp>(data: Data<T>, index: number): T['TValue'] => {
     switch (data.type.unit) {
-        case TimeUnit.SECOND: return getTimestampSecond(data as Data<TimestampSecond>, index);
-        case TimeUnit.MILLISECOND: return getTimestampMillisecond(data as Data<TimestampMillisecond>, index);
-        case TimeUnit.MICROSECOND: return getTimestampMicrosecond(data as Data<TimestampMicrosecond>, index);
-        case TimeUnit.NANOSECOND: return getTimestampNanosecond(data as Data<TimestampNanosecond>, index);
+        case TimeUnit.SECOND: return atTimestampSecond(data as Data<TimestampSecond>, index);
+        case TimeUnit.MILLISECOND: return atTimestampMillisecond(data as Data<TimestampMillisecond>, index);
+        case TimeUnit.MICROSECOND: return atTimestampMicrosecond(data as Data<TimestampMicrosecond>, index);
+        case TimeUnit.NANOSECOND: return atTimestampNanosecond(data as Data<TimestampNanosecond>, index);
     }
 };
 
 /** @ignore */
-const getTimeSecond = <T extends TimeSecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atTimeSecond = <T extends TimeSecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /** @ignore */
-const getTimeMillisecond = <T extends TimeMillisecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atTimeMillisecond = <T extends TimeMillisecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /** @ignore */
-const getTimeMicrosecond = <T extends TimeMicrosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atTimeMicrosecond = <T extends TimeMicrosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /** @ignore */
-const getTimeNanosecond = <T extends TimeNanosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atTimeNanosecond = <T extends TimeNanosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /* istanbul ignore next */
 /** @ignore */
-const getTime = <T extends Time>(data: Data<T>, index: number): T['TValue'] => {
+const atTime = <T extends Time>(data: Data<T>, index: number): T['TValue'] => {
     switch (data.type.unit) {
-        case TimeUnit.SECOND: return getTimeSecond(data as Data<TimeSecond>, index);
-        case TimeUnit.MILLISECOND: return getTimeMillisecond(data as Data<TimeMillisecond>, index);
-        case TimeUnit.MICROSECOND: return getTimeMicrosecond(data as Data<TimeMicrosecond>, index);
-        case TimeUnit.NANOSECOND: return getTimeNanosecond(data as Data<TimeNanosecond>, index);
+        case TimeUnit.SECOND: return atTimeSecond(data as Data<TimeSecond>, index);
+        case TimeUnit.MILLISECOND: return atTimeMillisecond(data as Data<TimeMillisecond>, index);
+        case TimeUnit.MICROSECOND: return atTimeMicrosecond(data as Data<TimeMicrosecond>, index);
+        case TimeUnit.NANOSECOND: return atTimeNanosecond(data as Data<TimeNanosecond>, index);
     }
 };
 
 /** @ignore */
-const getDecimal = <T extends Decimal>({ values, stride }: Data<T>, index: number): T['TValue'] => BN.decimal(values.subarray(stride * index, stride * (index + 1)));
+const atDecimal = <T extends Decimal>({ values, stride }: Data<T>, index: number): T['TValue'] => BN.decimal(values.subarray(stride * index, stride * (index + 1)));
 
 /** @ignore */
-const getList = <T extends List>(data: Data<T>, index: number): T['TValue'] => {
+const atList = <T extends List>(data: Data<T>, index: number): T['TValue'] => {
     const { valueOffsets, stride, children } = data;
     const { [index * stride]: begin, [index * stride + 1]: end } = valueOffsets;
     const child: Data<T['valueType']> = children[0];
@@ -228,7 +228,7 @@ const getList = <T extends List>(data: Data<T>, index: number): T['TValue'] => {
 };
 
 /** @ignore */
-const getMap = <T extends Map_>(data: Data<T>, index: number): T['TValue'] => {
+const atMap = <T extends Map_>(data: Data<T>, index: number): T['TValue'] => {
     const { valueOffsets, children } = data;
     const { [index]: begin, [index + 1]: end } = valueOffsets;
     const child = children[0] as Data<T['childType']>;
@@ -236,51 +236,51 @@ const getMap = <T extends Map_>(data: Data<T>, index: number): T['TValue'] => {
 };
 
 /** @ignore */
-const getStruct = <T extends Struct>(data: Data<T>, index: number): T['TValue'] => {
+const atStruct = <T extends Struct>(data: Data<T>, index: number): T['TValue'] => {
     return new StructRow(data, index) as StructRowProxy<T['TValue']>;
 };
 
 /* istanbul ignore next */
 /** @ignore */
-const getUnion = <
+const atUnion = <
     D extends Data<Union> | Data<DenseUnion> | Data<SparseUnion>
 >(data: D, index: number): D['TValue'] => {
     return data.type.mode === UnionMode.Dense ?
-        getDenseUnion(data as Data<DenseUnion>, index) :
-        getSparseUnion(data as Data<SparseUnion>, index);
+        atDenseUnion(data as Data<DenseUnion>, index) :
+        atSparseUnion(data as Data<SparseUnion>, index);
 };
 
 /** @ignore */
-const getDenseUnion = <T extends DenseUnion>(data: Data<T>, index: number): T['TValue'] => {
+const atDenseUnion = <T extends DenseUnion>(data: Data<T>, index: number): T['TValue'] => {
     const childIndex = data.type.typeIdToChildIndex[data.typeIds[index]];
     const child = data.children[childIndex];
     return instance.visit(child, data.valueOffsets[index]);
 };
 
 /** @ignore */
-const getSparseUnion = <T extends SparseUnion>(data: Data<T>, index: number): T['TValue'] => {
+const atSparseUnion = <T extends SparseUnion>(data: Data<T>, index: number): T['TValue'] => {
     const childIndex = data.type.typeIdToChildIndex[data.typeIds[index]];
     const child = data.children[childIndex];
     return instance.visit(child, index);
 };
 
 /** @ignore */
-const getDictionary = <T extends Dictionary>(data: Data<T>, index: number): T['TValue'] => {
-    return data.dictionary?.get(data.values[index]);
+const atDictionary = <T extends Dictionary>(data: Data<T>, index: number): T['TValue'] => {
+    return data.dictionary?.at(data.values[index]);
 };
 
 /* istanbul ignore next */
 /** @ignore */
-const getInterval = <T extends Interval>(data: Data<T>, index: number): T['TValue'] =>
+const atInterval = <T extends Interval>(data: Data<T>, index: number): T['TValue'] =>
     (data.type.unit === IntervalUnit.DAY_TIME)
-        ? getIntervalDayTime(data as Data<IntervalDayTime>, index)
-        : getIntervalYearMonth(data as Data<IntervalYearMonth>, index);
+        ? atIntervalDayTime(data as Data<IntervalDayTime>, index)
+        : atIntervalYearMonth(data as Data<IntervalYearMonth>, index);
 
 /** @ignore */
-const getIntervalDayTime = <T extends IntervalDayTime>({ values }: Data<T>, index: number): T['TValue'] => values.subarray(2 * index, 2 * (index + 1));
+const atIntervalDayTime = <T extends IntervalDayTime>({ values }: Data<T>, index: number): T['TValue'] => values.subarray(2 * index, 2 * (index + 1));
 
 /** @ignore */
-const getIntervalYearMonth = <T extends IntervalYearMonth>({ values }: Data<T>, index: number): T['TValue'] => {
+const atIntervalYearMonth = <T extends IntervalYearMonth>({ values }: Data<T>, index: number): T['TValue'] => {
     const interval = values[index];
     const int32s = new Int32Array(2);
     int32s[0] = Math.trunc(interval / 12); /* years */
@@ -289,82 +289,82 @@ const getIntervalYearMonth = <T extends IntervalYearMonth>({ values }: Data<T>, 
 };
 
 /** @ignore */
-const getDurationSecond = <T extends DurationSecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atDurationSecond = <T extends DurationSecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /** @ignore */
-const getDurationMillisecond = <T extends DurationMillisecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atDurationMillisecond = <T extends DurationMillisecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /** @ignore */
-const getDurationMicrosecond = <T extends DurationMicrosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atDurationMicrosecond = <T extends DurationMicrosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /** @ignore */
-const getDurationNanosecond = <T extends DurationNanosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
+const atDurationNanosecond = <T extends DurationNanosecond>({ values }: Data<T>, index: number): T['TValue'] => values[index];
 /* istanbul ignore next */
 /** @ignore */
-const getDuration = <T extends Duration>(data: Data<T>, index: number): T['TValue'] => {
+const atDuration = <T extends Duration>(data: Data<T>, index: number): T['TValue'] => {
     switch (data.type.unit) {
-        case TimeUnit.SECOND: return getDurationSecond(data as Data<DurationSecond>, index);
-        case TimeUnit.MILLISECOND: return getDurationMillisecond(data as Data<DurationMillisecond>, index);
-        case TimeUnit.MICROSECOND: return getDurationMicrosecond(data as Data<DurationMicrosecond>, index);
-        case TimeUnit.NANOSECOND: return getDurationNanosecond(data as Data<DurationNanosecond>, index);
+        case TimeUnit.SECOND: return atDurationSecond(data as Data<DurationSecond>, index);
+        case TimeUnit.MILLISECOND: return atDurationMillisecond(data as Data<DurationMillisecond>, index);
+        case TimeUnit.MICROSECOND: return atDurationMicrosecond(data as Data<DurationMicrosecond>, index);
+        case TimeUnit.NANOSECOND: return atDurationNanosecond(data as Data<DurationNanosecond>, index);
     }
 };
 
 /** @ignore */
-const getFixedSizeList = <T extends FixedSizeList>(data: Data<T>, index: number): T['TValue'] => {
+const atFixedSizeList = <T extends FixedSizeList>(data: Data<T>, index: number): T['TValue'] => {
     const { stride, children } = data;
     const child: Data<T['valueType']> = children[0];
     const slice = child.slice(index * stride, stride);
     return new Vector([slice]);
 };
 
-GetVisitor.prototype.visitNull = wrapGet(getNull);
-GetVisitor.prototype.visitBool = wrapGet(getBool);
-GetVisitor.prototype.visitInt = wrapGet(getInt);
-GetVisitor.prototype.visitInt8 = wrapGet(getNumeric);
-GetVisitor.prototype.visitInt16 = wrapGet(getNumeric);
-GetVisitor.prototype.visitInt32 = wrapGet(getNumeric);
-GetVisitor.prototype.visitInt64 = wrapGet(getBigInts);
-GetVisitor.prototype.visitUint8 = wrapGet(getNumeric);
-GetVisitor.prototype.visitUint16 = wrapGet(getNumeric);
-GetVisitor.prototype.visitUint32 = wrapGet(getNumeric);
-GetVisitor.prototype.visitUint64 = wrapGet(getBigInts);
-GetVisitor.prototype.visitFloat = wrapGet(getFloat);
-GetVisitor.prototype.visitFloat16 = wrapGet(getFloat16);
-GetVisitor.prototype.visitFloat32 = wrapGet(getNumeric);
-GetVisitor.prototype.visitFloat64 = wrapGet(getNumeric);
-GetVisitor.prototype.visitUtf8 = wrapGet(getUtf8);
-GetVisitor.prototype.visitLargeUtf8 = wrapGet(getUtf8);
-GetVisitor.prototype.visitBinary = wrapGet(getBinary);
-GetVisitor.prototype.visitLargeBinary = wrapGet(getBinary);
-GetVisitor.prototype.visitFixedSizeBinary = wrapGet(getFixedSizeBinary);
-GetVisitor.prototype.visitDate = wrapGet(getDate);
-GetVisitor.prototype.visitDateDay = wrapGet(getDateDay);
-GetVisitor.prototype.visitDateMillisecond = wrapGet(getDateMillisecond);
-GetVisitor.prototype.visitTimestamp = wrapGet(getTimestamp);
-GetVisitor.prototype.visitTimestampSecond = wrapGet(getTimestampSecond);
-GetVisitor.prototype.visitTimestampMillisecond = wrapGet(getTimestampMillisecond);
-GetVisitor.prototype.visitTimestampMicrosecond = wrapGet(getTimestampMicrosecond);
-GetVisitor.prototype.visitTimestampNanosecond = wrapGet(getTimestampNanosecond);
-GetVisitor.prototype.visitTime = wrapGet(getTime);
-GetVisitor.prototype.visitTimeSecond = wrapGet(getTimeSecond);
-GetVisitor.prototype.visitTimeMillisecond = wrapGet(getTimeMillisecond);
-GetVisitor.prototype.visitTimeMicrosecond = wrapGet(getTimeMicrosecond);
-GetVisitor.prototype.visitTimeNanosecond = wrapGet(getTimeNanosecond);
-GetVisitor.prototype.visitDecimal = wrapGet(getDecimal);
-GetVisitor.prototype.visitList = wrapGet(getList);
-GetVisitor.prototype.visitStruct = wrapGet(getStruct);
-GetVisitor.prototype.visitUnion = wrapGet(getUnion);
-GetVisitor.prototype.visitDenseUnion = wrapGet(getDenseUnion);
-GetVisitor.prototype.visitSparseUnion = wrapGet(getSparseUnion);
-GetVisitor.prototype.visitDictionary = wrapGet(getDictionary);
-GetVisitor.prototype.visitInterval = wrapGet(getInterval);
-GetVisitor.prototype.visitIntervalDayTime = wrapGet(getIntervalDayTime);
-GetVisitor.prototype.visitIntervalYearMonth = wrapGet(getIntervalYearMonth);
-GetVisitor.prototype.visitDuration = wrapGet(getDuration);
-GetVisitor.prototype.visitDurationSecond = wrapGet(getDurationSecond);
-GetVisitor.prototype.visitDurationMillisecond = wrapGet(getDurationMillisecond);
-GetVisitor.prototype.visitDurationMicrosecond = wrapGet(getDurationMicrosecond);
-GetVisitor.prototype.visitDurationNanosecond = wrapGet(getDurationNanosecond);
-GetVisitor.prototype.visitFixedSizeList = wrapGet(getFixedSizeList);
-GetVisitor.prototype.visitMap = wrapGet(getMap);
+AtVisitor.prototype.visitNull = wrapAt(atNull);
+AtVisitor.prototype.visitBool = wrapAt(atBool);
+AtVisitor.prototype.visitInt = wrapAt(atInt);
+AtVisitor.prototype.visitInt8 = wrapAt(atNumeric);
+AtVisitor.prototype.visitInt16 = wrapAt(atNumeric);
+AtVisitor.prototype.visitInt32 = wrapAt(atNumeric);
+AtVisitor.prototype.visitInt64 = wrapAt(atBigInts);
+AtVisitor.prototype.visitUint8 = wrapAt(atNumeric);
+AtVisitor.prototype.visitUint16 = wrapAt(atNumeric);
+AtVisitor.prototype.visitUint32 = wrapAt(atNumeric);
+AtVisitor.prototype.visitUint64 = wrapAt(atBigInts);
+AtVisitor.prototype.visitFloat = wrapAt(atFloat);
+AtVisitor.prototype.visitFloat16 = wrapAt(atFloat16);
+AtVisitor.prototype.visitFloat32 = wrapAt(atNumeric);
+AtVisitor.prototype.visitFloat64 = wrapAt(atNumeric);
+AtVisitor.prototype.visitUtf8 = wrapAt(atUtf8);
+AtVisitor.prototype.visitLargeUtf8 = wrapAt(atUtf8);
+AtVisitor.prototype.visitBinary = wrapAt(atBinary);
+AtVisitor.prototype.visitLargeBinary = wrapAt(atBinary);
+AtVisitor.prototype.visitFixedSizeBinary = wrapAt(atFixedSizeBinary);
+AtVisitor.prototype.visitDate = wrapAt(atDate);
+AtVisitor.prototype.visitDateDay = wrapAt(atDateDay);
+AtVisitor.prototype.visitDateMillisecond = wrapAt(atDateMillisecond);
+AtVisitor.prototype.visitTimestamp = wrapAt(atTimestamp);
+AtVisitor.prototype.visitTimestampSecond = wrapAt(atTimestampSecond);
+AtVisitor.prototype.visitTimestampMillisecond = wrapAt(atTimestampMillisecond);
+AtVisitor.prototype.visitTimestampMicrosecond = wrapAt(atTimestampMicrosecond);
+AtVisitor.prototype.visitTimestampNanosecond = wrapAt(atTimestampNanosecond);
+AtVisitor.prototype.visitTime = wrapAt(atTime);
+AtVisitor.prototype.visitTimeSecond = wrapAt(atTimeSecond);
+AtVisitor.prototype.visitTimeMillisecond = wrapAt(atTimeMillisecond);
+AtVisitor.prototype.visitTimeMicrosecond = wrapAt(atTimeMicrosecond);
+AtVisitor.prototype.visitTimeNanosecond = wrapAt(atTimeNanosecond);
+AtVisitor.prototype.visitDecimal = wrapAt(atDecimal);
+AtVisitor.prototype.visitList = wrapAt(atList);
+AtVisitor.prototype.visitStruct = wrapAt(atStruct);
+AtVisitor.prototype.visitUnion = wrapAt(atUnion);
+AtVisitor.prototype.visitDenseUnion = wrapAt(atDenseUnion);
+AtVisitor.prototype.visitSparseUnion = wrapAt(atSparseUnion);
+AtVisitor.prototype.visitDictionary = wrapAt(atDictionary);
+AtVisitor.prototype.visitInterval = wrapAt(atInterval);
+AtVisitor.prototype.visitIntervalDayTime = wrapAt(atIntervalDayTime);
+AtVisitor.prototype.visitIntervalYearMonth = wrapAt(atIntervalYearMonth);
+AtVisitor.prototype.visitDuration = wrapAt(atDuration);
+AtVisitor.prototype.visitDurationSecond = wrapAt(atDurationSecond);
+AtVisitor.prototype.visitDurationMillisecond = wrapAt(atDurationMillisecond);
+AtVisitor.prototype.visitDurationMicrosecond = wrapAt(atDurationMicrosecond);
+AtVisitor.prototype.visitDurationNanosecond = wrapAt(atDurationNanosecond);
+AtVisitor.prototype.visitFixedSizeList = wrapAt(atFixedSizeList);
+AtVisitor.prototype.visitMap = wrapAt(atMap);
 
 /** @ignore */
-export const instance = new GetVisitor();
+export const instance = new AtVisitor();

--- a/js/src/visitor/indexof.ts
+++ b/js/src/visitor/indexof.ts
@@ -18,7 +18,7 @@
 import { Data } from '../data.js';
 import { Type } from '../enum.js';
 import { Visitor } from '../visitor.js';
-import { instance as getVisitor } from './get.js';
+import { instance as atVisitor } from './at.js';
 import { TypeToDataType } from '../interfaces.js';
 import { getBool, BitIterator } from '../util/bit.js';
 import { createElementComparator } from '../util/vector.js';
@@ -132,10 +132,10 @@ function indexOfValue<T extends DataType>(data: Data<T>, searchElement?: T['TVal
                 return indexOfNull(data, fromIndex);
         }
     }
-    const get = getVisitor.getVisitFn(data);
+    const at = atVisitor.getVisitFn(data);
     const compare = createElementComparator(searchElement);
     for (let i = (fromIndex || 0) - 1, n = data.length; ++i < n;) {
-        if (compare(get(data, i))) {
+        if (compare(at(data, i))) {
             return i;
         }
     }
@@ -148,10 +148,10 @@ function indexOfUnion<T extends DataType>(data: Data<T>, searchElement?: T['TVal
     // If the searchElement is null, we don't know whether it came from the Union's
     // bitmap or one of its children's. So we don't interrogate the Union's bitmap,
     // since that will report the wrong index if a child has a null before the Union.
-    const get = getVisitor.getVisitFn(data);
+    const at = atVisitor.getVisitFn(data);
     const compare = createElementComparator(searchElement);
     for (let i = (fromIndex || 0) - 1, n = data.length; ++i < n;) {
-        if (compare(get(data, i))) {
+        if (compare(at(data, i))) {
             return i;
         }
     }

--- a/js/src/visitor/iterator.ts
+++ b/js/src/visitor/iterator.ts
@@ -132,7 +132,7 @@ class VectorIterator<T extends DataType> implements IterableIterator<T['TValue']
     next(): IteratorResult<T['TValue'] | null> {
         if (this.index < this.vector.length) {
             return {
-                value: this.vector.get(this.index++)
+                value: this.vector.at(this.index++)
             };
         }
 

--- a/js/src/visitor/set.ts
+++ b/js/src/visitor/set.ts
@@ -229,7 +229,7 @@ const setList = <T extends List>(data: Data<T>, index: number, value: T['TValue'
         }
     } else {
         for (let idx = -1, itr = valueOffsets[index], end = valueOffsets[index + 1]; itr < end;) {
-            set(values, itr++, value.get(++idx));
+            set(values, itr++, value.at(++idx));
         }
     }
 };
@@ -253,7 +253,7 @@ const setMap = <T extends Map_>(data: Data<T>, index: number, value: T['TValue']
     <T extends DataType>(set: SetFunc<T>, c: Data<T>, _: Field, i: number) => c && set(c, o, v[i]);
 
 /** @ignore */ const _setStructVectorValue = (o: number, v: Vector) =>
-    <T extends DataType>(set: SetFunc<T>, c: Data<T>, _: Field, i: number) => c && set(c, o, v.get(i));
+    <T extends DataType>(set: SetFunc<T>, c: Data<T>, _: Field, i: number) => c && set(c, o, v.at(i));
 
 /** @ignore */ const _setStructMapValue = (o: number, v: Map<string, any>) =>
     <T extends DataType>(set: SetFunc<T>, c: Data<T>, f: Field, _: number) => c && set(c, o, v.get(f.name));
@@ -347,7 +347,7 @@ const setFixedSizeList = <T extends FixedSizeList>(data: Data<T>, index: number,
         }
     } else {
         for (let idx = -1, offset = index * stride; ++idx < stride;) {
-            set(child, offset + idx, value.get(idx));
+            set(child, offset + idx, value.at(idx));
         }
     }
 };

--- a/js/test/inference/column.ts
+++ b/js/test/inference/column.ts
@@ -38,8 +38,8 @@ const boolColumn = new Vector([
     new Vector([makeData({ type: boolType, length: 10, nullCount: 0, data: new Uint8Array(2) })]),
 ]);
 
-expect(typeof boolVector.get(0) === 'boolean').toBe(true);
-expect(typeof boolColumn.get(0) === 'boolean').toBe(true);
+expect(typeof boolVector.at(0) === 'boolean').toBe(true);
+expect(typeof boolColumn.at(0) === 'boolean').toBe(true);
 
 type IndexSchema = {
     0: Int8;
@@ -61,8 +61,8 @@ const structColumn = new Vector([
     new Vector([makeData({ type: structType, length: 0, nullCount: 0, children: [] })]),
 ]);
 
-const [x1, y1, z1] = structVector.get(0)!;
-const [x2, y2, z2] = structColumn.get(0)!;
+const [x1, y1, z1] = structVector.at(0)!;
+const [x2, y2, z2] = structColumn.at(0)!;
 
 console.log(x1, y1, z1);
 console.log(x2, y2, z2);

--- a/js/test/inference/nested.ts
+++ b/js/test/inference/nested.ts
@@ -42,7 +42,7 @@ function checkIndexTypes(schema: IndexSchema) {
         length: 0, offset: 0, nullCount: 0, nullBitmap: null, children: []
     });
 
-    const row = new Vector([data]).get(0)!;
+    const row = new Vector([data]).at(0)!;
 
     const check_0 = (x = row[0]) => expect(typeof x === 'number').toBe(true);
     const check_1 = (x = row[1]) => expect(typeof x === 'string').toBe(true);
@@ -64,7 +64,7 @@ function checkNamedTypes(schema: NamedSchema) {
         length: 0, offset: 0, nullCount: 0, nullBitmap: null, children: []
     });
 
-    const row = new Vector([data]).get(0)!;
+    const row = new Vector([data]).at(0)!;
 
     const check_a = (x = row.a) => expect(typeof x === 'number').toBe(true);
     const check_b = (x = row.b) => expect(typeof x === 'string').toBe(true);

--- a/js/test/inference/visitor/at.ts
+++ b/js/test/inference/visitor/at.ts
@@ -20,7 +20,7 @@ import {
     Bool, List, Dictionary
 } from 'apache-arrow';
 
-import { instance as getVisitor } from 'apache-arrow/visitor/get';
+import { instance as atVisitor } from 'apache-arrow/visitor/at';
 
 const data_Bool = new Data(new Bool(), 0, 0);
 const data_List_Bool = new Data(new List<Bool>(null as any), 0, 0);
@@ -29,48 +29,48 @@ const data_Dictionary_List_Bool = new Data(new Dictionary<List<Bool>>(null!, nul
 
 const boolVec = new Vector([data_Bool]);
 // @ts-ignore
-const boolVec_getRaw = boolVec.get(0);
+const boolVec_getRaw = boolVec.at(0);
 // @ts-ignore
-const boolVec_getVisit = getVisitor.visit(boolVec.data[0], 0);
+const boolVec_getVisit = atVisitor.visit(boolVec.data[0], 0);
 // @ts-ignore
-const boolVec_getFactory = getVisitor.getVisitFn(boolVec)(boolVec.data[0], 0);
+const boolVec_getFactory = atVisitor.getVisitFn(boolVec)(boolVec.data[0], 0);
 // @ts-ignore
-const boolVec_getFactoryData = getVisitor.getVisitFn(boolVec.data[0])(boolVec.data[0], 0);
+const boolVec_getFactoryData = atVisitor.getVisitFn(boolVec.data[0])(boolVec.data[0], 0);
 // @ts-ignore
-const boolVec_getFactoryType = getVisitor.getVisitFn(boolVec.type)(boolVec.data[0], 0);
+const boolVec_getFactoryType = atVisitor.getVisitFn(boolVec.type)(boolVec.data[0], 0);
 
 const listVec = new Vector([data_List_Bool]);
 // @ts-ignore
-const listVec_getRaw = listVec.get(0);
+const listVec_getRaw = listVec.at(0);
 // @ts-ignore
-const listVec_getVisit = getVisitor.visit(listVec.data[0], 0);
+const listVec_getVisit = atVisitor.visit(listVec.data[0], 0);
 // @ts-ignore
-const listVec_getFactory = getVisitor.getVisitFn(listVec)(listVec.data[0], 0);
+const listVec_getFactory = atVisitor.getVisitFn(listVec)(listVec.data[0], 0);
 // @ts-ignore
-const listVec_getFactoryData = getVisitor.getVisitFn(listVec.data[0])(listVec.data[0], 0);
+const listVec_getFactoryData = atVisitor.getVisitFn(listVec.data[0])(listVec.data[0], 0);
 // @ts-ignore
-const listVec_getFactoryType = getVisitor.getVisitFn(listVec.type)(listVec.data[0], 0);
+const listVec_getFactoryType = atVisitor.getVisitFn(listVec.type)(listVec.data[0], 0);
 
 const dictVec = new Vector([data_Dictionary_Bool]);
 // @ts-ignore
-const dictVec_getRaw = dictVec.get(0);
+const dictVec_getRaw = dictVec.at(0);
 // @ts-ignore
-const dictVec_getVisit = getVisitor.visit(dictVec.data[0], 0);
+const dictVec_getVisit = atVisitor.visit(dictVec.data[0], 0);
 // @ts-ignore
-const dictVec_getFactory = getVisitor.getVisitFn(dictVec)(dictVec.data[0], 0);
+const dictVec_getFactory = atVisitor.atVisitFn(dictVec)(dictVec.data[0], 0);
 // @ts-ignore
-const dictVec_getFactoryData = getVisitor.getVisitFn(dictVec.data[0])(dictVec.data[0], 0);
+const dictVec_getFactoryData = atVisitor.getVisitFn(dictVec.data[0])(dictVec.data[0], 0);
 // @ts-ignore
-const dictVec_getFactoryType = getVisitor.getVisitFn(dictVec.type)(dictVec.data[0], 0);
+const dictVec_getFactoryType = atVisitor.getVisitFn(dictVec.type)(dictVec.data[0], 0);
 
 const dictOfListVec = new Vector([data_Dictionary_List_Bool]);
 // @ts-ignore
-const dictOfListVec_getRaw = dictOfListVec.get(0);
+const dictOfListVec_getRaw = dictOfListVec.at(0);
 // @ts-ignore
-const dictOfListVec_getVisit = getVisitor.visit(dictOfListVec.data[0], 0);
+const dictOfListVec_getVisit = atVisitor.visit(dictOfListVec.data[0], 0);
 // @ts-ignore
-const dictOfListVec_getFactory = getVisitor.getVisitFn(dictOfListVec)(dictOfListVec.data[0], 0);
+const dictOfListVec_getFactory = atVisitor.getVisitFn(dictOfListVec)(dictOfListVec.data[0], 0);
 // @ts-ignore
-const dictOfListVec_getFactoryData = getVisitor.getVisitFn(dictOfListVec.data[0])(dictOfListVec.data[0], 0);
+const dictOfListVec_getFactoryData = atVisitor.getVisitFn(dictOfListVec.data[0])(dictOfListVec.data[0], 0);
 // @ts-ignore
-const dictOfListVec_getFactoryType = getVisitor.getVisitFn(dictOfListVec.type)(dictOfListVec.data[0], 0);
+const dictOfListVec_getFactoryType = atVisitor.getVisitFn(dictOfListVec.type)(dictOfListVec.data[0], 0);

--- a/js/test/jest-extensions.ts
+++ b/js/test/jest-extensions.ts
@@ -124,7 +124,7 @@ function toEqualVector<
         }
     }
     for (let i = -1, n = v1.length; ++i < n;) {
-        const x1 = v1.get(i), x2 = v2.get(i);
+        const x1 = v1.at(i), x2 = v2.at(i);
         if (!util.createElementComparator(x2)(x1)) {
             getFailures.push(`${i}: ${format(this, x1, x2, ' !== ')}`);
         }

--- a/js/test/unit/bn-tests.ts
+++ b/js/test/unit/bn-tests.ts
@@ -71,7 +71,7 @@ describe(`BN`, () => {
                 nullValues: []
             });
             builder.append(val);
-            return <Arrow.Type.Decimal><any>builder.finish().toVector().get(0);
+            return <Arrow.Type.Decimal><any>builder.finish().toVector().at(0);
         };
 
         const d2 = toDecimal(new Uint32Array([0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF]));

--- a/js/test/unit/builders/utils.ts
+++ b/js/test/unit/builders/utils.ts
@@ -166,7 +166,7 @@ export function validateVector<T extends DataType>(vals: (T['TValue'] | null)[],
     } catch (e: any) {
         // Uncomment these two lines to catch and debug the value retrieval that failed
         // debugger;
-        // vec.get(i);
+        // vec.at(i);
         throw new Error([
             `${(vec as any).VectorName}[${i}]: ${e?.stack || e}`,
             `nulls: [${nullVals.join(', ')}]`,

--- a/js/test/unit/generated-data-validators.ts
+++ b/js/test/unit/generated-data-validators.ts
@@ -109,7 +109,7 @@ function vectorTests(values: any[], vector: Vector<any>, keys?: number[]) {
         let i = -1, n = vector.length, actual, expected;
         try {
             while (++i < n) {
-                actual = vector.get(i);
+                actual = vector.at(i);
                 expected = values[i];
                 expect(actual).toArrowCompare(expected);
             }
@@ -125,8 +125,8 @@ function vectorTests(values: any[], vector: Vector<any>, keys?: number[]) {
             try {
                 while (++i < n) {
                     indices.isValid(i)
-                        ? expect(indices.get(i)).toBe(keys[i])
-                        : expect(indices.get(i)).toBeNull();
+                        ? expect(indices.at(i)).toBe(keys[i])
+                        : expect(indices.at(i)).toBeNull();
                 }
             } catch (e) {
                 throw new Error(`${indices}[${i}]: ${e}`);
@@ -140,7 +140,7 @@ function vectorTests(values: any[], vector: Vector<any>, keys?: number[]) {
             while (++i < n) {
                 expected = values[i];
                 vector.set(i, expected);
-                actual = vector.get(i);
+                actual = vector.at(i);
                 expect(actual).toArrowCompare(expected);
             }
         } catch (e: any) {

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -317,7 +317,7 @@ describe(`Table`, () => {
                 const table = datum.table();
                 const values = datum.values();
                 for (let i = -1; ++i < values.length;) {
-                    const row = table.get(i)!;
+                    const row = table.at(i)!;
                     expect(row).not.toBeNull();
                     const expected = values[i];
                     expect(row.f32).toEqual(expected[F32]);

--- a/js/test/unit/vector/bool-vector-tests.ts
+++ b/js/test/unit/vector/bool-vector-tests.ts
@@ -25,9 +25,9 @@ describe(`BoolVector`, () => {
     const n = values.length;
     const vector = newBoolVector(n, new Uint8Array([27, 0, 0, 0, 0, 0, 0, 0]));
     test(`gets expected values`, () => {
-        let i = -1;
-        while (++i < n) {
-            expect(vector.at(i)).toEqual(values[i]);
+        for (let i = 0; i < values.length; i++) {
+            expect(vector.at(i)).toEqual(values.at(i));
+            expect(vector.at(-i)).toEqual(values.at(-i));
         }
     });
     test(`iterates expected values`, () => {
@@ -53,7 +53,7 @@ describe(`BoolVector`, () => {
         const expected2 = [true, true, true, true, true, false, false, false];
         const expected3 = [true, true, false, false, false, false, true, true];
         function validate(expected: boolean[]) {
-            for (let i = -1; ++i < n;) {
+            for (let i = 0; i < n; i++) {
                 expect(v.at(i)).toEqual(expected[i]);
             }
         }

--- a/js/test/unit/vector/bool-vector-tests.ts
+++ b/js/test/unit/vector/bool-vector-tests.ts
@@ -27,7 +27,7 @@ describe(`BoolVector`, () => {
     test(`gets expected values`, () => {
         let i = -1;
         while (++i < n) {
-            expect(vector.get(i)).toEqual(values[i]);
+            expect(vector.at(i)).toEqual(values[i]);
         }
     });
     test(`iterates expected values`, () => {
@@ -54,7 +54,7 @@ describe(`BoolVector`, () => {
         const expected3 = [true, true, false, false, false, false, true, true];
         function validate(expected: boolean[]) {
             for (let i = -1; ++i < n;) {
-                expect(v.get(i)).toEqual(expected[i]);
+                expect(v.at(i)).toEqual(expected[i]);
             }
         }
         validate(expected1);

--- a/js/test/unit/vector/numeric-vector-tests.ts
+++ b/js/test/unit/vector/numeric-vector-tests.ts
@@ -337,10 +337,11 @@ function testAndValidateVector<T extends Int | Float>(vector: Vector<T>, typed: 
 function gets_expected_values<T extends Int | Float>(vector: Vector<T>, typed: T['TArray'], values: any[] = [...typed]) {
     test(`gets expected values`, () => {
         expect.hasAssertions();
-        let i = -1, n = vector.length;
+        let i = -1;
         try {
-            while (++i < n) {
-                expect(vector.at(i)).toEqual(values[i]);
+            while (++i < vector.length) {
+                expect(vector.at(i)).toEqual(values.at(i));
+                expect(vector.at(-i)).toEqual(values.at(-i));
             }
         } catch (e) { throw new Error(`${i}: ${e}`); }
     });

--- a/js/test/unit/vector/numeric-vector-tests.ts
+++ b/js/test/unit/vector/numeric-vector-tests.ts
@@ -340,7 +340,7 @@ function gets_expected_values<T extends Int | Float>(vector: Vector<T>, typed: T
         let i = -1, n = vector.length;
         try {
             while (++i < n) {
-                expect(vector.get(i)).toEqual(values[i]);
+                expect(vector.at(i)).toEqual(values[i]);
             }
         } catch (e) { throw new Error(`${i}: ${e}`); }
     });

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -73,7 +73,7 @@ describe(`StructVector`, () => {
 
     test(`get value`, () => {
         for (const [i, value] of values.entries()) {
-            expect(vector.get(i)!.toJSON()).toEqual(value);
+            expect(vector.at(i)!.toJSON()).toEqual(value);
         }
     });
 });
@@ -228,7 +228,7 @@ describe(`ListVector`, () => {
 
     test(`get value`, () => {
         for (const [i, value] of values.entries()) {
-            expect(vector.get(i)!.toJSON()).toEqual(value);
+            expect(vector.at(i)!.toJSON()).toEqual(value);
         }
     });
 });
@@ -272,7 +272,7 @@ function basicVectorTests(vector: Vector, values: any[], extras: any[]) {
     test(`gets expected values`, () => {
         let i = -1;
         while (++i < n) {
-            expect(vector.get(i)).toEqual(values[i]);
+            expect(vector.at(i)).toEqual(values[i]);
         }
     });
     test(`iterates expected values`, () => {


### PR DESCRIPTION
Arrays in JavaScript have `at` instead of `get` so here we are making our arrays more consistent. 

This PR still maintains support for `get` but deprecates it. We can remove `get` after one version of supporting both. 

* GitHub Issue: #39131