### PR TITLE
MINOR: [Java] Bump com.fasterxml.jackson:jackson-bom from 2.16.1 to 2.17.0 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <dep.netty-bom.version>4.1.106.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.61.1</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
-    <dep.jackson-bom.version>2.16.1</dep.jackson-bom.version>
+    <dep.jackson-bom.version>2.17.0</dep.jackson-bom.version>
     <dep.hadoop.version>3.3.6</dep.hadoop.version>
     <dep.fbs.version>23.5.26</dep.fbs.version>
     <dep.avro.version>1.11.3</dep.avro.version>


### PR DESCRIPTION
See dependabot issue for more details https://github.com/apache/arrow/pull/40526#issue-2185246604