### PR TITLE
GH-40716: [Java][Integration] Fix test_package_java in verification scripts

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -642,8 +642,8 @@ test_package_java() {
         normalized_arch=x86_64
         ;;
     esac
-    mkdir -p ${dist_dir}/arrow_cdata_jni/${normalized_arch}/
-    mv ${install_dir}/lib/* ${dist_dir}/arrow_cdata_jni/${normalized_arch}/
+    mkdir -p ${dist_dir}
+    mv ${install_dir}/lib/* ${dist_dir}
     mvn install \
         -Darrow.c.jni.dist.dir=${dist_dir} \
         -Parrow-c-data

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -642,8 +642,8 @@ test_package_java() {
         normalized_arch=x86_64
         ;;
     esac
-    mkdir -p ${dist_dir}/${normalized_arch}/
-    mv ${install_dir}/lib/* ${dist_dir}/${normalized_arch}/
+    mkdir -p ${dist_dir}/arrow_cdata_jni/${normalized_arch}/
+    mv ${install_dir}/lib/* ${dist_dir}/arrow_cdata_jni/${normalized_arch}/
     mvn install \
         -Darrow.c.jni.dist.dir=${dist_dir} \
         -Parrow-c-data


### PR DESCRIPTION
### Rationale for this change

JPMS changed the location of JNI libs in the dist dir.

### What changes are included in this PR?

* Update the dist path in the verification script

### Are these changes tested?

CI

### Are there any user-facing changes?

No
* GitHub Issue: #40716