### PR TITLE
GH-40727: [C++][Gandiva] 'ilike' function does not work

### DIFF
--- a/cpp/src/gandiva/function_holder_maker_registry.cc
+++ b/cpp/src/gandiva/function_holder_maker_registry.cc
@@ -58,6 +58,7 @@ arrow::Result<FunctionHolderPtr> FunctionHolderMakerRegistry::Make(
 FunctionHolderMakerRegistry::MakerMap FunctionHolderMakerRegistry::DefaultHolderMakers() {
   static const MakerMap maker_map = {
       {"like", HolderMaker<LikeHolder>},
+      {"ilike", HolderMaker<LikeHolder>},
       {"to_date", HolderMaker<ToDateHolder>},
       {"random", HolderMaker<RandomGeneratorHolder>},
       {"rand", HolderMaker<RandomGeneratorHolder>},

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -244,7 +244,7 @@ TEST_F(TestUtf8, TestIlike) {
 
   // Create a row-batch with some sample data
   int num_records = 4;
-  auto array_a = MakeArrowArrayUtf8({"park", "sparkle", "bright spark and fire", "spark"},
+  auto array_a = MakeArrowArrayUtf8({"park", "sParKle", "bright spark and fire", "spark"},
                                     {true, true, true, true});
 
   // expected output

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -230,10 +230,10 @@ TEST_F(TestUtf8, TestIlike) {
   auto res = field("res", boolean());
 
   // build expressions.
-  // like(literal(s), a)
+  // ilike(literal(s), a)
 
   auto node_a = TreeExprBuilder::MakeField(field_a);
-  auto literal_s = TreeExprBuilder::MakeStringLiteral("%spark%");
+  auto literal_s = TreeExprBuilder::MakeStringLiteral("%sparK%");
   auto is_like = TreeExprBuilder::MakeFunction("ilike", {node_a, literal_s}, boolean());
   auto expr = TreeExprBuilder::MakeExpression(is_like, res);
 

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -221,6 +221,47 @@ TEST_F(TestUtf8, TestLike) {
   EXPECT_ARROW_ARRAY_EQUALS(exp, outputs.at(0));
 }
 
+TEST_F(TestUtf8, TestIlike) {
+  // schema for input fields
+  auto field_a = field("a", utf8());
+  auto schema = arrow::schema({field_a});
+
+  // output fields
+  auto res = field("res", boolean());
+
+  // build expressions.
+  // like(literal(s), a)
+
+  auto node_a = TreeExprBuilder::MakeField(field_a);
+  auto literal_s = TreeExprBuilder::MakeStringLiteral("%spark%");
+  auto is_like = TreeExprBuilder::MakeFunction("ilike", {node_a, literal_s}, boolean());
+  auto expr = TreeExprBuilder::MakeExpression(is_like, res);
+
+  // Build a projector for the expressions.
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {expr}, TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+  auto array_a = MakeArrowArrayUtf8({"park", "sparkle", "bright spark and fire", "spark"},
+                                    {true, true, true, true});
+
+  // expected output
+  auto exp = MakeArrowArrayBool({false, true, true, true}, {true, true, true, true});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array_a});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp, outputs.at(0));
+}
+
 TEST_F(TestUtf8, TestLikeWithEscape) {
   // schema for input fields
   auto field_a = field("a", utf8());


### PR DESCRIPTION
### Rationale for this change

Bug fix for GH-40727

### What changes are included in this PR?

Register the 'ilike' function.
Added unit test.

### Are these changes tested?

Yes, unit test.

### Are there any user-facing changes?

No.

* GitHub Issue: #40727