### PR TITLE
GH-40674: [GLib] Don't assume gint64 and int64_t use the same type

### DIFF
--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -4995,7 +4995,8 @@ garrow_binary_dictionary_array_builder_append_indices(
   auto append_function = [&arrow_builder](const gint64 *values,
                                           gint64 values_length,
                                           const uint8_t *valid_bytes) -> arrow::Status {
-    return arrow_builder->AppendIndices(values, values_length, valid_bytes);
+    auto int64_t_values = reinterpret_cast<const int64_t *>(values);
+    return arrow_builder->AppendIndices(int64_t_values, values_length, valid_bytes);
   };
   return garrow_array_builder_append_values(values,
                                             values_length,
@@ -5226,7 +5227,8 @@ garrow_string_dictionary_array_builder_append_indices(
   auto append_function = [&arrow_builder](const gint64 *values,
                                           gint64 values_length,
                                           const uint8_t *valid_bytes) -> arrow::Status {
-    return arrow_builder->AppendIndices(values, values_length, valid_bytes);
+    auto int64_t_values = reinterpret_cast<const int64_t *>(values);
+    return arrow_builder->AppendIndices(int64_t_values, values_length, valid_bytes);
   };
   return garrow_array_builder_append_values(values,
                                             values_length,

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -591,9 +591,10 @@ garrow_large_list_array_get_value_length(GArrowLargeListArray *array, gint64 i)
 const gint64 *
 garrow_large_list_array_get_value_offsets(GArrowLargeListArray *array, gint64 *n_offsets)
 {
-  return garrow_base_list_array_get_value_offsets<arrow::LargeListArray>(
-    GARROW_ARRAY(array),
-    n_offsets);
+  auto value_offsets =
+    garrow_base_list_array_get_value_offsets<arrow::LargeListArray>(GARROW_ARRAY(array),
+                                                                    n_offsets);
+  return reinterpret_cast<const gint64 *>(value_offsets);
 }
 
 typedef struct GArrowStructArrayPrivate_

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -873,7 +873,8 @@ ggandiva_int64_literal_node_class_init(GGandivaInt64LiteralNodeClass *klass)
 GGandivaInt64LiteralNode *
 ggandiva_int64_literal_node_new(gint64 value)
 {
-  auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
+  auto int64_t_value = static_cast<int64_t>(value);
+  auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(int64_t_value);
   return GGANDIVA_INT64_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node, NULL));
 }
 
@@ -916,7 +917,8 @@ ggandiva_uint64_literal_node_class_init(GGandivaUInt64LiteralNodeClass *klass)
 GGandivaUInt64LiteralNode *
 ggandiva_uint64_literal_node_new(guint64 value)
 {
-  auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
+  auto uint64_t_value = static_cast<uint64_t>(value);
+  auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(uint64_t_value);
   return GGANDIVA_UINT64_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node, NULL));
 }
 


### PR DESCRIPTION
### Rationale for this change

GLib doesn't guarantee that `gint64` and `int64_t` use the same type:

https://docs.gtk.org/glib/types.html#gint64

> Note that on platforms with more than one 64-bit standard integer
> type, gint64 and int64_t are not necessarily implemented by the same
> 64-bit integer type. For example, on a platform where both long and
> long long are 64-bit, it might be the case that one of those types is
> used for gint64 and the other is used for int64_t.

### What changes are included in this PR?

Add explicit casts.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40674