### PR TITLE
GH-40623: [Python][Docs] Add workaround for autosummary

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -208,8 +208,14 @@ templates_path = ['_templates']
 #
 
 source_suffix = {
-    '.md': 'markdown',
+    # We need to keep "'.rst': 'restructuredtext'" as the first item.
+    # This is a workaround of
+    # https://github.com/sphinx-doc/sphinx/issues/12147 .
+    #
+    # We can sort these items in alphabetical order with Sphinx 7.3.0
+    # or later that will include the fix of this problem.
     '.rst': 'restructuredtext',
+    '.md': 'markdown',
 }
 
 autosummary_generate = True


### PR DESCRIPTION
### Rationale for this change

Sphinx < 7.3.0 has a problem that auto generated files may use wrong suffix.

See https://github.com/sphinx-doc/sphinx/issues/12147 for details.

### What changes are included in this PR?

Use `.rst` as the first `source_suffix` item as a workaround of this problem.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40623