### PR TITLE
GH-40634: [C#] ArrowStreamReader should not be null

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/FlightRecordBatchStreamReader.cs
+++ b/csharp/src/Apache.Arrow.Flight/FlightRecordBatchStreamReader.cs
@@ -45,12 +45,12 @@ namespace Apache.Arrow.Flight
             _arrowReaderImplementation = new RecordBatchReaderImplementation(flightDataStream);
         }
 
-        public ValueTask<Schema> Schema => _arrowReaderImplementation.ReadSchema();
+        public ValueTask<Schema> Schema => _arrowReaderImplementation.GetSchemaAsync();
 
         internal ValueTask<FlightDescriptor> GetFlightDescriptor()
         {
             return _arrowReaderImplementation.ReadFlightDescriptor();
-        }        
+        }
 
         /// <summary>
         /// Get the application metadata from the latest received record batch

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
@@ -52,7 +52,7 @@ namespace Apache.Arrow.Ipc
             return _footer.RecordBatchCount;
         }
 
-        protected override async ValueTask ReadSchemaAsync(CancellationToken cancellationToken = default)
+        public override async ValueTask ReadSchemaAsync(CancellationToken cancellationToken = default)
         {
             if (HasReadSchema)
             {
@@ -85,7 +85,7 @@ namespace Apache.Arrow.Ipc
             }
         }
 
-        protected override void ReadSchema()
+        public override void ReadSchema()
         {
             if (HasReadSchema)
             {
@@ -139,7 +139,7 @@ namespace Apache.Arrow.Ipc
             // Deserialize the footer from the footer flatbuffer
             _footer = new ArrowFooter(Flatbuf.Footer.GetRootAsFooter(CreateByteBuffer(buffer)), ref _dictionaryMemo);
 
-            Schema = _footer.Schema;
+            _schema = _footer.Schema;
         }
 
         public async ValueTask<RecordBatch> ReadRecordBatchAsync(int index, CancellationToken cancellationToken)

--- a/csharp/src/Apache.Arrow/Ipc/ArrowMemoryReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowMemoryReaderImplementation.cs
@@ -33,6 +33,13 @@ namespace Apache.Arrow.Ipc
             _buffer = buffer;
         }
 
+        public override ValueTask ReadSchemaAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ReadSchema();
+            return default;
+        }
+
         public override ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -93,7 +100,7 @@ namespace Apache.Arrow.Ipc
             return batch;
         }
 
-        private void ReadSchema()
+        public override void ReadSchema()
         {
             if (HasReadSchema)
             {
@@ -117,7 +124,7 @@ namespace Apache.Arrow.Ipc
             }
 
             ByteBuffer schemaBuffer = CreateByteBuffer(_buffer.Slice(_bufferPosition));
-            Schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemaBuffer), ref _dictionaryMemo);
+            _schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemaBuffer), ref _dictionaryMemo);
             _bufferPosition += schemaMessageLength;
         }
     }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
@@ -30,13 +30,25 @@ namespace Apache.Arrow.Ipc
 {
     internal abstract class ArrowReaderImplementation : IDisposable
     {
-        public Schema Schema { get; protected set; }
-        protected bool HasReadSchema => Schema != null;
+        public Schema Schema
+        {
+            get
+            {
+                if (!HasReadSchema)
+                {
+                    ReadSchema();
+                }
+                return _schema;
+            }
+        }
+
+        protected internal bool HasReadSchema => _schema != null;
 
         private protected DictionaryMemo _dictionaryMemo;
         private protected DictionaryMemo DictionaryMemo => _dictionaryMemo ??= new DictionaryMemo();
         private protected readonly MemoryAllocator _allocator;
         private readonly ICompressionCodecFactory _compressionCodecFactory;
+        private protected Schema _schema;
 
         private protected ArrowReaderImplementation() : this(null, null)
         { }
@@ -56,6 +68,9 @@ namespace Apache.Arrow.Ipc
         protected virtual void Dispose(bool disposing)
         {
         }
+
+        public abstract ValueTask ReadSchemaAsync(CancellationToken cancellationToken);
+        public abstract void ReadSchema();
 
         public abstract ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken);
         public abstract RecordBatch ReadNextRecordBatch();

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -28,6 +28,9 @@ namespace Apache.Arrow.Ipc
     {
         private protected readonly ArrowReaderImplementation _implementation;
 
+        /// <summary>
+        /// May block if the schema hasn't yet been read. To avoid blocking, use GetSchemaAsync.
+        /// </summary>
         public Schema Schema => _implementation.Schema;
 
         public ArrowStreamReader(Stream stream)
@@ -95,6 +98,15 @@ namespace Apache.Arrow.Ipc
             {
                 _implementation.Dispose();
             }
+        }
+
+        public async ValueTask<Schema> GetSchema(CancellationToken cancellationToken = default)
+        {
+            if (!_implementation.HasReadSchema)
+            {
+                await _implementation.ReadSchemaAsync(cancellationToken);
+            }
+            return _implementation.Schema;
         }
 
         public ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -146,7 +146,7 @@ namespace Apache.Arrow.Ipc
             return new ReadResult(messageLength, result);
         }
 
-        protected virtual async ValueTask ReadSchemaAsync(CancellationToken cancellationToken = default)
+        public override async ValueTask ReadSchemaAsync(CancellationToken cancellationToken = default)
         {
             if (HasReadSchema)
             {
@@ -164,11 +164,11 @@ namespace Apache.Arrow.Ipc
                 EnsureFullRead(buff, bytesRead);
 
                 Google.FlatBuffers.ByteBuffer schemabb = CreateByteBuffer(buff);
-                Schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemabb), ref _dictionaryMemo);
+                _schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemabb), ref _dictionaryMemo);
             }
         }
 
-        protected virtual void ReadSchema()
+        public override void ReadSchema()
         {
             if (HasReadSchema)
             {
@@ -184,7 +184,7 @@ namespace Apache.Arrow.Ipc
                 EnsureFullRead(buff, bytesRead);
 
                 Google.FlatBuffers.ByteBuffer schemabb = CreateByteBuffer(buff);
-                Schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemabb), ref _dictionaryMemo);
+                _schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemabb), ref _dictionaryMemo);
             }
         }
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -38,6 +38,9 @@ namespace Apache.Arrow.Tests
 
         public static async Task VerifyReaderAsync(ArrowStreamReader reader, RecordBatch originalBatch)
         {
+            Schema schema = await reader.GetSchema();
+            Assert.NotNull(schema);
+
             RecordBatch readBatch = await reader.ReadNextRecordBatchAsync();
             CompareBatches(originalBatch, readBatch);
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -94,6 +94,8 @@ namespace Apache.Arrow.Tests
         {
             await TestReaderFromMemory((reader, originalBatch) =>
             {
+                Assert.NotNull(reader.Schema);
+
                 ArrowReaderVerifier.VerifyReader(reader, originalBatch);
                 return Task.CompletedTask;
             }, writeEnd);


### PR DESCRIPTION
### What changes are included in this PR?

Small refactoring in the IPC reader implementation classes of how the schema is read in order to support getting the schema asynchronously through ArrowStreamReader and avoiding the case where ArrowStreamReader.Schema returns null because no record batches have yet been read.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

A new method ArrowStreamReader.GetSchema has been added to allow the schema to be gotten asynchronously.

Closes #40634 
* GitHub Issue: #40634