### PR TITLE
GH-36656: [Dev] Validate in merge script if issue has an assigned milestone already

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -689,7 +689,6 @@ def prompt_for_fix_version(cmd, issue, maintenance_branches=()):
         print("\n=== The assigned milestone is not the default ===")
         print(f"Assigned milestone: {current_fix_versions}")
         print(f"Current milestone: {default_fix_version}")
-        print("Please ensure to assign the correct milestone.")
         if issue.issue["milestone"].get("state") == 'closed':
             print("The assigned milestone state is closed. Contact the ")
             print("Release Manager if it has to be added to a closed Release")

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -685,7 +685,7 @@ def prompt_for_fix_version(cmd, issue, maintenance_branches=()):
 
     current_fix_versions = issue.current_fix_versions
     if (current_fix_versions and
-        current_fix_versions != default_fix_version):
+            current_fix_versions != default_fix_version):
         print("\n=== The assigned milestone is not the default ===")
         print(f"Assigned milestone: {current_fix_versions}")
         print(f"Current milestone: {default_fix_version}")

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -253,7 +253,10 @@ class GitHubIssue(object):
 
     @property
     def current_fix_versions(self):
-        return self.issue.get("milestone", {}).get("title")
+        try:
+            return self.issue.get("milestone", {}).get("title")
+        except AttributeError:
+            pass
 
     @property
     def current_versions(self):
@@ -679,6 +682,19 @@ def prompt_for_fix_version(cmd, issue, maintenance_branches=()):
         mainline_versions=issue.current_versions,
         maintenance_branches=maintenance_branches
     )
+
+    if (issue.current_fix_versions and
+        issue.current_fix_versions != default_fix_version):
+        print("\n=== The assigned milestone is not the default ===")
+        print(f"Assigned milestone: {issue.current_fix_versions}")
+        print(f"Current milestone: {default_fix_version}")
+        print("Please ensure to assign the correct milestone.")
+        if issue.issue["milestone"].get("state") == 'closed':
+            print("The assigned milestone state is closed. Contact the ")
+            print("Release Manager if it has to be added to a closed Release")
+        print("Please ensure to assign the correct milestone.")
+        # Default to existing assigned milestone
+        default_fix_version = issue.current_fix_versions
 
     issue_fix_version = cmd.prompt("Enter fix version [%s]: "
                                    % default_fix_version)

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -683,10 +683,11 @@ def prompt_for_fix_version(cmd, issue, maintenance_branches=()):
         maintenance_branches=maintenance_branches
     )
 
-    if (issue.current_fix_versions and
-        issue.current_fix_versions != default_fix_version):
+    current_fix_versions = issue.current_fix_versions
+    if (current_fix_versions and
+        current_fix_versions != default_fix_version):
         print("\n=== The assigned milestone is not the default ===")
-        print(f"Assigned milestone: {issue.current_fix_versions}")
+        print(f"Assigned milestone: {current_fix_versions}")
         print(f"Current milestone: {default_fix_version}")
         print("Please ensure to assign the correct milestone.")
         if issue.issue["milestone"].get("state") == 'closed':
@@ -694,7 +695,7 @@ def prompt_for_fix_version(cmd, issue, maintenance_branches=()):
             print("Release Manager if it has to be added to a closed Release")
         print("Please ensure to assign the correct milestone.")
         # Default to existing assigned milestone
-        default_fix_version = issue.current_fix_versions
+        default_fix_version = current_fix_versions
 
     issue_fix_version = cmd.prompt("Enter fix version [%s]: "
                                    % default_fix_version)

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -84,6 +84,10 @@ class FakeJIRA:
             v for v in all_versions if not v.raw.get("released")
         ] + ['0.11.0']
 
+    @property
+    def current_fix_versions(self):
+        return 'JS-0.4.0'
+
     def project_versions(self, project):
         return self._project_versions
 


### PR DESCRIPTION
### Rationale for this change

When we do the feature freeze for the releases or we are adding issues to patch releases we milestone the issues outside the merge script. The merge script should check and prompt if the issue already has a milestone assigned and should maintain the already assigned milestone to the issue.

### What changes are included in this PR?

The merge script checks whether the issue already contains a milestone and if the milestone is different than the current default one it prompts the user to double check that it is the correct one.

### Are these changes tested?

I've tested it locally.

If no milestone or default it prompts as usual
```
Would you like to update the associated issue? (y/n): y
Enter fix version [16.0.0]: 
```

If a different and closed milestone is assigned:
```
=== The assigned milestone is not the default ===
Assigned milestone: 15.0.2
Current milestone: 16.0.0
Please ensure to assign the correct milestone.
The assigned milestone state is closed. Contact the 
Release Manager if it has to be added to a closed Release
Please ensure to assign the correct milestone.
```


### Are there any user-facing changes?

No, only for committers and not relevant.
* GitHub Issue: #36656