### PR TITLE
GH-40788: [C#] Override Accept in MapArray

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/MapArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/MapArray.cs
@@ -135,6 +135,19 @@ namespace Apache.Arrow
         {
         }
 
+        public override void Accept(IArrowArrayVisitor visitor)
+        {
+            switch (visitor)
+            {
+                case IArrowArrayVisitor<MapArray> typedVisitor:
+                    typedVisitor.Visit(this);
+                    break;
+                default:
+                    base.Accept(visitor);
+                    break;
+            }
+        }
+
         public IEnumerable<Tuple<K, V>> GetTuples<TKeyArray, K, TValueArray, V>(int index, Func<TKeyArray, int, K> getKey, Func<TValueArray, int, V> getValue)
             where TKeyArray : Array where TValueArray : Array
         {


### PR DESCRIPTION
### Rationale for this change

This allows users to implement `IArrowArrayVisitor<MapArray>` and have the `Visit(MapArray)` method called instead of `Visit(ListArray)` or `Visit(IArrowArray)`.

### What changes are included in this PR?

Overrides the `Accept` method to check whether the visitor implements `Visit(MapArray)`, and if not, delegates to the base implementation to handle `IArrowArrayVisitor<ListArray>` or fall back to using an `IArrowArrayVisitor`.

### Are these changes tested?

Yes, I've added unit tests.

### Are there any user-facing changes?

Yes, this is a user-facing change.
* GitHub Issue: #40788