### PR TITLE
GH-40792: [C#] Fix slicing a previously sliced array

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
@@ -104,14 +104,6 @@ namespace Apache.Arrow
 
         public static IArrowArray Slice(IArrowArray array, int offset, int length)
         {
-            if (offset > array.Length)
-            {
-                throw new ArgumentException($"Offset {offset} cannot be greater than Length {array.Length} for Array.Slice");
-            }
-
-            length = Math.Min(array.Data.Length - offset, length);
-            offset += array.Data.Offset;
-
             ArrayData newData = array.Data.Slice(offset, length);
             return BuildArray(newData);
         }

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using Xunit;
 
@@ -120,6 +121,22 @@ namespace Apache.Arrow.Tests
             Assert.Equal(array.Length, readOnlyList.Count);
             Assert.Equal(readOnlyList[0], 1);
             Assert.Equal(readOnlyList[1], 2);
+        }
+
+        [Fact]
+        public void RecursiveArraySlice()
+        {
+            var initialValues = Enumerable.Range(0, 100).ToArray();
+            var array = new Int32Array.Builder().AppendRange(initialValues).Build();
+
+            var sliced = (Int32Array) array.Slice(20, 30);
+            var slicedAgain = (Int32Array) sliced.Slice(5, 10);
+
+            Assert.Equal(25, slicedAgain.Offset);
+            Assert.Equal(10, slicedAgain.Length);
+            Assert.Equal(
+                initialValues.Skip(25).Take(10).Select(val => (int?) val).ToArray(),
+                (IReadOnlyList<int?>) slicedAgain);
         }
 
 #if NET5_0_OR_GREATER


### PR DESCRIPTION
### Rationale for this change

See #40792, slicing a previously sliced array would return incorrect results.

### What changes are included in this PR?

Removes the duplicated logic accounting for the current offset in `ArrowArrayFactory`, which is already handled by `ArrayData.Slice`.

### Are these changes tested?

Yes, I added a unit test.

### Are there any user-facing changes?

Yes, this is a user-facing bug fix.
* GitHub Issue: #40792