### PR TITLE
GH-40791: [Dev][CI] Use the official hadolint configuration

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,6 +35,7 @@ jobs:
     name: Lint C++, Python, R, Docker, RAT
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 15
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,11 @@ repos:
         entry: bash -c "git archive HEAD --prefix=apache-arrow/ --output=arrow-src.tar && ./dev/release/run-rat.sh arrow-src.tar"
         always_run: true
         pass_filenames: false
-      - id: hadolint
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint-docker
         name: Docker Format
-        language: docker_image
-        types:
-          - dockerfile
-        entry: --entrypoint /bin/hadolint hadolint/hadolint:latest -
         exclude: ^dev/.*$
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0


### PR DESCRIPTION
### Rationale for this change

We don't need to define it by ourselves.

Our configuration is blocked with pre-commit 3.7.0.

### What changes are included in this PR?

Use the official configuration.
See also: https://github.com/hadolint/hadolint/blob/master/docs/INTEGRATION.md#pre-commit

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40791