### PR TITLE
GH-40719: [Go] Make `arrow.Null` non-null for `arrow.TypeEqual` to work properly with `new(arrow.NullType)`

### DIFF
--- a/go/arrow/compare_test.go
+++ b/go/arrow/compare_test.go
@@ -43,6 +43,9 @@ func TestTypeEqual(t *testing.T) {
 			Null, Null, true, false,
 		},
 		{
+			Null, new(NullType), true, false,
+		},
+		{
 			&BinaryType{}, &StringType{}, false, false,
 		},
 		{

--- a/go/arrow/datatype_null.go
+++ b/go/arrow/datatype_null.go
@@ -27,7 +27,5 @@ func (*NullType) Layout() DataTypeLayout {
 	return DataTypeLayout{Buffers: []BufferSpec{SpecAlwaysNull()}}
 }
 
-var (
-	Null *NullType
-	_    DataType = Null
-)
+// Null gives us both the compile-time assertion of DataType interface as well as serving a good element for use in schemas.
+var Null DataType = new(NullType)


### PR DESCRIPTION
### Rationale for this change

Currently creating a record with a `null` type via `new(arrow.NullType)` in the schema will fail the schema validation.

### What changes are included in this PR?

Made `arrow.Null` a non-null value instead of just a declaration.

### Are these changes tested?

Yes, see cd4253a24e6d828128fbb7854da3c37951d74885

### Are there any user-facing changes?

`arrow.Null` became non-null, but the type is the same.
* GitHub Issue: #40719