### PR TITLE
GH-40790: [C#] Account for offset and length when getting fields of a StructArray

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/MapArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/MapArray.cs
@@ -155,13 +155,11 @@ namespace Apache.Arrow
             // Get key values
             int start = offsets[index];
             int end = offsets[index + 1];
-            int length = end - start;
-            StructArray array = KeyValues.Slice(start, length) as StructArray;
 
-            TKeyArray keyArray = array.Fields[0] as TKeyArray;
-            TValueArray valueArray = array.Fields[1] as TValueArray;
+            TKeyArray keyArray = KeyValues.Fields[0] as TKeyArray;
+            TValueArray valueArray = KeyValues.Fields[1] as TValueArray;
 
-            for (int i = 0; i < length; i++)
+            for (int i = start; i < end; i++)
             {
                 yield return new Tuple<K, V>(getKey(keyArray, i), getValue(valueArray, i));
             }
@@ -174,13 +172,11 @@ namespace Apache.Arrow
             // Get key values
             int start = offsets[index];
             int end = offsets[index + 1];
-            int length = end - start;
-            StructArray array = KeyValues.Slice(start, length) as StructArray;
 
-            TKeyArray keyArray = array.Fields[0] as TKeyArray;
-            TValueArray valueArray = array.Fields[1] as TValueArray;
+            TKeyArray keyArray = KeyValues.Fields[0] as TKeyArray;
+            TValueArray valueArray = KeyValues.Fields[1] as TValueArray;
 
-            for (int i = 0; i < length; i++)
+            for (int i = start; i < end; i++)
             {
                 yield return new KeyValuePair<K,V>(getKey(keyArray, i), getValue(valueArray, i));
             }

--- a/csharp/src/Apache.Arrow/Arrays/MapArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/MapArray.cs
@@ -155,12 +155,13 @@ namespace Apache.Arrow
             // Get key values
             int start = offsets[index];
             int end = offsets[index + 1];
-            StructArray array = KeyValues.Slice(start, end - start) as StructArray;
+            int length = end - start;
+            StructArray array = KeyValues.Slice(start, length) as StructArray;
 
             TKeyArray keyArray = array.Fields[0] as TKeyArray;
             TValueArray valueArray = array.Fields[1] as TValueArray;
 
-            for (int i = start; i < end; i++)
+            for (int i = 0; i < length; i++)
             {
                 yield return new Tuple<K, V>(getKey(keyArray, i), getValue(valueArray, i));
             }
@@ -173,12 +174,13 @@ namespace Apache.Arrow
             // Get key values
             int start = offsets[index];
             int end = offsets[index + 1];
-            StructArray array = KeyValues.Slice(start, end - start) as StructArray;
+            int length = end - start;
+            StructArray array = KeyValues.Slice(start, length) as StructArray;
 
             TKeyArray keyArray = array.Fields[0] as TKeyArray;
             TValueArray valueArray = array.Fields[1] as TValueArray;
 
-            for (int i = start; i < end; i++)
+            for (int i = 0; i < length; i++)
             {
                 yield return new KeyValuePair<K,V>(getKey(keyArray, i), getValue(valueArray, i));
             }

--- a/csharp/src/Apache.Arrow/Arrays/StructArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StructArray.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Apache.Arrow.Types;
 using System.Collections.Generic;
 using System.Linq;

--- a/csharp/test/Apache.Arrow.Tests/StructArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/StructArrayTests.cs
@@ -18,7 +18,6 @@ using Apache.Arrow.Types;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Emit;
 using Xunit;
 
 namespace Apache.Arrow.Tests

--- a/csharp/test/Apache.Arrow.Tests/StructArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/StructArrayTests.cs
@@ -17,6 +17,8 @@ using Apache.Arrow.Ipc;
 using Apache.Arrow.Types;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace Apache.Arrow.Tests
@@ -119,6 +121,85 @@ namespace Apache.Arrow.Tests
 
             RecordBatch batch = new RecordBatch(schema, new[] { listArray }, 3);
             TestRoundTripRecordBatch(batch);
+        }
+
+        [Fact]
+        public void TestSliceStructArray()
+        {
+            const int numRows = 10;
+            var fields = new List<Field>
+            {
+                new Field.Builder().Name("ints").DataType(new Int32Type()).Nullable(true).Build(),
+                new Field.Builder().Name("doubles").DataType(new DoubleType()).Nullable(true).Build(),
+            };
+            var arrays = new List<IArrowArray>
+            {
+                new Int32Array.Builder().AppendRange(Enumerable.Range(0, numRows)).Build(),
+                new DoubleArray.Builder().AppendRange(Enumerable.Range(0, numRows).Select(i => i * 0.1)).Build(),
+            };
+
+            var nullBitmap = new ArrowBuffer.BitmapBuilder().AppendRange(true, numRows).Build();
+            var array = new StructArray(new StructType(fields), numRows, arrays, nullBitmap, nullCount: 0);
+
+            var slicedArray = (StructArray) array.Slice(3, 4);
+
+            Assert.Equal(4, slicedArray.Length);
+            Assert.Equal(2, slicedArray.Fields.Count);
+
+            var slicedInts = slicedArray.Fields[0];
+            var expectedInts = Enumerable.Range(3, 4).Select(val => (int?) val).ToArray();
+            Assert.Equal(expectedInts, (IReadOnlyList<int?>) slicedInts);
+
+            var slicedDoubles = slicedArray.Fields[1];
+            var expectedDoubles = Enumerable.Range(3, 4).Select(val => (double?) (val * 0.1)).ToArray();
+            Assert.Equal(expectedDoubles, (IReadOnlyList<double?>) slicedDoubles);
+        }
+
+        [Fact]
+        public void TestStructArrayConstructedWithOffset()
+        {
+            const int dataNumRows = 10;
+            const int arrayLength = 4;
+            const int arrayOffset = 3;
+
+            var fields = new List<Field>
+            {
+                new Field.Builder().Name("ints").DataType(new Int32Type()).Nullable(true).Build(),
+                new Field.Builder().Name("doubles").DataType(new DoubleType()).Nullable(true).Build(),
+            };
+            var arrays = new List<IArrowArray>
+            {
+                new Int32Array.Builder().AppendRange(Enumerable.Range(0, dataNumRows)).Build(),
+                new DoubleArray.Builder().AppendRange(Enumerable.Range(0, dataNumRows).Select(i => i * 0.1)).Build(),
+            };
+
+            var nullBitmap = new ArrowBuffer.BitmapBuilder().AppendRange(true, dataNumRows).Build();
+            var array = new StructArray(
+                new StructType(fields), arrayLength, arrays, nullBitmap, nullCount: 0, offset: arrayOffset);
+
+            Assert.Equal(4, array.Length);
+            Assert.Equal(3, array.Offset);
+            Assert.Equal(2, array.Fields.Count);
+
+            var slicedInts = array.Fields[0];
+            var expectedInts = Enumerable.Range(3, 4).Select(val => (int?) val).ToArray();
+            Assert.Equal(expectedInts, (IReadOnlyList<int?>) slicedInts);
+
+            var slicedDoubles = array.Fields[1];
+            var expectedDoubles = Enumerable.Range(3, 4).Select(val => (double?) (val * 0.1)).ToArray();
+            Assert.Equal(expectedDoubles, (IReadOnlyList<double?>) slicedDoubles);
+
+            var subSlice = (StructArray) array.Slice(1, 2);
+            Assert.Equal(2, subSlice.Length);
+            Assert.Equal(2, subSlice.Fields.Count);
+
+            var subSlicedInts = subSlice.Fields[0];
+            var expectedSubSliceInts = Enumerable.Range(4, 2).Select(val => (int?) val).ToArray();
+            Assert.Equal(expectedSubSliceInts, (IReadOnlyList<int?>) subSlicedInts);
+
+            var subSlicedDoubles = subSlice.Fields[1];
+            var expectedSubSliceDoubles = Enumerable.Range(4, 2).Select(val => (double?) (val * 0.1)).ToArray();
+            Assert.Equal(expectedSubSliceDoubles, (IReadOnlyList<double?>) subSlicedDoubles);
         }
 
         private static void TestRoundTripRecordBatch(RecordBatch originalBatch)


### PR DESCRIPTION
### Rationale for this change

See #40790. The `StructArray.Fields` property currently returns the child arrays without accounting for the array offset and length. This meant that consumers would need to know to account for the offset and length themselves when accessing the child arrays, and this is inconsistent with the behaviour of Arrow APIs in other languages.

### What changes are included in this PR?

Changes the behaviour of the `StructArray.Fields` property, so that the returned arrays are sliced if required. This behaviour is consistent with the C++ Arrow API, eg. see: https://github.com/apache/arrow/blob/f710ac52b049806515a14445b242c3ec819fb99d/cpp/src/arrow/array/array_nested.cc#L1019-L1020

I also checked that pyarrow behaves like this too:
```python
import pyarrow as pa

a = pa.array([0, 1, 2, 3, 4], type=pa.int32())
b = pa.array([0.0, 0.1, 0.2, 0.3, 0.4], type=pa.float32())

xs = pa.StructArray.from_arrays([a, b], names=["a", "b"])
slice = xs.slice(2, 3)

assert len(slice) == 3
assert len(slice.field(0)) == 3
assert len(slice.field(1)) == 3
```

### Are these changes tested?

Yes, I've added new unit tests.

### Are there any user-facing changes?

Yes, this is a user-facing bug fix and behaviour change.

**This PR includes breaking changes to public APIs.**

The behaviour of `StructArray.Fields` has changed. If users were previously accounting for the array offset and length themselves, this will break existing code.

I first tried to make this non-breaking, by introducing a new property to replace `Fields`, and marking that property as obsolete. But `StructArray` implements `IArrowRecord`, so the behaviour of the `IArrowRecord.Column` would either need to be kept as broken, or fixed with a breaking change. It seems simplest and most consistent to fix the behaviour for all methods.

If users need to maintain compatibility across different Arrow versions, I'd suggest using a pattern like:
```c#
var field = structArray.Fields[0];
if (field.Length != structArray.Length)
{
    field = ArrowArrayFactory.Slice(field, structArray.Offset, structArray.Length);
}
```

* GitHub Issue: #40790