### PR TITLE
GH-40078: [C++] Import/Export ArrowDeviceArrayStream

### DIFF
--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -224,6 +224,8 @@ class ARROW_EXPORT Array {
   /// \return Status
   Status ValidateFull() const;
 
+  DeviceAllocationType device_type() const { return data_->device_type(); }
+
  protected:
   Array() = default;
   ARROW_DEFAULT_MOVE_AND_ASSIGN(Array);

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -224,6 +224,12 @@ class ARROW_EXPORT Array {
   /// \return Status
   Status ValidateFull() const;
 
+  /// \brief Return the device_type that this array's data is allocated on
+  ///
+  /// This just delegates to calling device_type on the underlying ArrayData
+  /// object which backs this Array.
+  ///
+  /// \return DeviceAllocationType
   DeviceAllocationType device_type() const { return data_->device_type(); }
 
  protected:

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -478,6 +478,7 @@ TEST_F(TestArray, TestMakeArrayOfNull) {
       ASSERT_EQ(array->type(), type);
       ASSERT_OK(array->ValidateFull());
       ASSERT_EQ(array->length(), length);
+      ASSERT_EQ(array->device_type(), DeviceAllocationType::kCPU);
       if (is_union(type->id())) {
         ASSERT_EQ(array->null_count(), 0);
         ASSERT_EQ(array->ComputeLogicalNullCount(), length);
@@ -719,6 +720,7 @@ TEST_F(TestArray, TestMakeArrayFromScalar) {
       ASSERT_OK(array->ValidateFull());
       ASSERT_EQ(array->length(), length);
       ASSERT_EQ(array->null_count(), 0);
+      ASSERT_EQ(array->device_type(), DeviceAllocationType::kCPU);
 
       // test case for ARROW-13321
       for (int64_t i : {int64_t{0}, length / 2, length - 1}) {
@@ -744,6 +746,7 @@ TEST_F(TestArray, TestMakeArrayFromScalarSliced) {
     auto sliced = array->Slice(1, 4);
     ASSERT_EQ(sliced->length(), 4);
     ASSERT_EQ(sliced->null_count(), 0);
+    ASSERT_EQ(array->device_type(), DeviceAllocationType::kCPU);
     ARROW_EXPECT_OK(sliced->ValidateFull());
   }
 }
@@ -758,7 +761,8 @@ TEST_F(TestArray, TestMakeArrayFromDictionaryScalar) {
   ASSERT_OK(array->ValidateFull());
   ASSERT_EQ(array->length(), 4);
   ASSERT_EQ(array->null_count(), 0);
-
+  ASSERT_EQ(array->device_type(), DeviceAllocationType::kCPU);
+  
   for (int i = 0; i < 4; i++) {
     ASSERT_OK_AND_ASSIGN(auto item, array->GetScalar(i));
     ASSERT_TRUE(item->Equals(scalar));
@@ -797,6 +801,7 @@ TEST_F(TestArray, TestMakeEmptyArray) {
     ASSERT_OK_AND_ASSIGN(auto array, MakeEmptyArray(type));
     ASSERT_OK(array->ValidateFull());
     ASSERT_EQ(array->length(), 0);
+    
     CheckSpanRoundTrip(*array);
   }
 }

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -762,7 +762,7 @@ TEST_F(TestArray, TestMakeArrayFromDictionaryScalar) {
   ASSERT_EQ(array->length(), 4);
   ASSERT_EQ(array->null_count(), 0);
   ASSERT_EQ(array->device_type(), DeviceAllocationType::kCPU);
-  
+
   for (int i = 0; i < 4; i++) {
     ASSERT_OK_AND_ASSIGN(auto item, array->GetScalar(i));
     ASSERT_TRUE(item->Equals(scalar));
@@ -801,7 +801,7 @@ TEST_F(TestArray, TestMakeEmptyArray) {
     ASSERT_OK_AND_ASSIGN(auto array, MakeEmptyArray(type));
     ASSERT_OK(array->ValidateFull());
     ASSERT_EQ(array->length(), 0);
-    
+
     CheckSpanRoundTrip(*array);
   }
 }

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -241,6 +241,7 @@ DeviceAllocationType ArrayData::device_type() const {
   }
 
   for (const auto& child : child_data) {
+    if (!child) continue;
     if (type == 0) {
       type = static_cast<int>(child->device_type());
     } else {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -224,6 +224,28 @@ int64_t ArrayData::ComputeLogicalNullCount() const {
   return ArraySpan(*this).ComputeLogicalNullCount();
 }
 
+DeviceAllocationType ArrayData::device_type() const {
+  int type = 0;
+  for (const auto& buf : buffers) {
+    if (!buf) continue;
+    if (type == 0) {
+      type = static_cast<int>(buf->device_type());
+    } else {
+      DCHECK_EQ(type, static_cast<int>(buf->device_type()));
+    }
+  }
+
+  for (const auto& child : child_data) {
+    if (type == 0) {
+      type = static_cast<int>(child->device_type());
+    } else {
+      DCHECK_EQ(type, static_cast<int>(child->device_type()));
+    }
+  }
+
+  return type == 0 ? DeviceAllocationType::kCPU : static_cast<DeviceAllocationType>(type);
+}
+
 // ----------------------------------------------------------------------
 // Methods for ArraySpan
 

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -225,6 +225,11 @@ int64_t ArrayData::ComputeLogicalNullCount() const {
 }
 
 DeviceAllocationType ArrayData::device_type() const {
+  // we're using 0 as a sentinel value for NOT YET ASSIGNED
+  // there is explicitly no constant DeviceAllocationType to represent
+  // the "UNASSIGNED" case as it is invalid for data to not have an
+  // assigned device type. If it's still 0 at the end, then we return
+  // CPU as the allocation device type
   int type = 0;
   for (const auto& buf : buffers) {
     if (!buf) continue;

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -243,6 +243,14 @@ DeviceAllocationType ArrayData::device_type() const {
     }
   }
 
+  if (dictionary) {
+    if (type == 0) {
+      type = static_cast<int>(dictionary->device_type());
+    } else {
+      DCHECK_EQ(type, static_cast<int>(dictionary->device_type()));
+    }
+  }
+
   return type == 0 ? DeviceAllocationType::kCPU : static_cast<DeviceAllocationType>(type);
 }
 

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -358,6 +358,14 @@ struct ARROW_EXPORT ArrayData {
   /// \see GetNullCount
   int64_t ComputeLogicalNullCount() const;
 
+  /// \brief Returns the device_type of the underlying buffers and children
+  ///
+  /// If there are no buffers in this ArrayData object, it just returns
+  /// DeviceAllocationType::kCPU as a default. We also assume that all buffers
+  /// should be allocated on the same device type and perform DCHECKs to confirm
+  /// this in debug mode.
+  ///
+  /// \return DeviceAllocationType
   DeviceAllocationType device_type() const;
 
   std::shared_ptr<DataType> type;

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -358,6 +358,8 @@ struct ARROW_EXPORT ArrayData {
   /// \see GetNullCount
   int64_t ComputeLogicalNullCount() const;
 
+  DeviceAllocationType device_type() const;
+
   std::shared_ptr<DataType> type;
   int64_t length = 0;
   mutable std::atomic<int64_t> null_count{0};

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -117,7 +117,7 @@ struct ARROW_EXPORT ArrayData {
     this->child_data = std::move(child_data);
 #ifndef NDEBUG
     // in debug mode, call the `device_type` function to trigger
-    // the DCHECKs that validate all the buffers (including children) 
+    // the DCHECKs that validate all the buffers (including children)
     // are on the same device
     ARROW_UNUSED(this->device_type());
 #endif

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -101,6 +101,11 @@ struct ARROW_EXPORT ArrayData {
             int64_t null_count = kUnknownNullCount, int64_t offset = 0)
       : ArrayData(std::move(type), length, null_count, offset) {
     this->buffers = std::move(buffers);
+#ifndef NDEBUG
+    // in debug mode, call the `device_type` function to trigger
+    // the DCHECKs that validate all the buffers are on the same device
+    ARROW_UNUSED(this->device_type());
+#endif
   }
 
   ArrayData(std::shared_ptr<DataType> type, int64_t length,
@@ -110,6 +115,12 @@ struct ARROW_EXPORT ArrayData {
       : ArrayData(std::move(type), length, null_count, offset) {
     this->buffers = std::move(buffers);
     this->child_data = std::move(child_data);
+#ifndef NDEBUG
+    // in debug mode, call the `device_type` function to trigger
+    // the DCHECKs that validate all the buffers (including children) 
+    // are on the same device
+    ARROW_UNUSED(this->device_type());
+#endif
   }
 
   static std::shared_ptr<ArrayData> Make(std::shared_ptr<DataType> type, int64_t length,

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -547,8 +547,8 @@ class NullArrayFactory {
     return Status::OK();
   }
 
-  Status Visit(const StructType& type) {
-    for (int i = 0; i < type_->num_fields(); ++i) {
+  Status Visit(const StructType& type) {    
+    for (int i = 0; i < type.num_fields(); ++i) {
       ARROW_ASSIGN_OR_RAISE(out_->child_data[i], CreateChild(type, i, length_));
     }
     return Status::OK();

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -547,7 +547,7 @@ class NullArrayFactory {
     return Status::OK();
   }
 
-  Status Visit(const StructType& type) {    
+  Status Visit(const StructType& type) {
     for (int i = 0; i < type.num_fields(); ++i) {
       ARROW_ASSIGN_OR_RAISE(out_->child_data[i], CreateChild(type, i, length_));
     }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2350,7 +2350,8 @@ class ArrayStreamBatchReader : public RecordBatchReader,
   using ArrayType = typename ArrayTraits::CType;
 
  public:
-  explicit ArrayStreamBatchReader(StreamType* stream, const DeviceMemoryMapper& mapper = DefaultDeviceMapper)
+  explicit ArrayStreamBatchReader(StreamType* stream,
+                                  const DeviceMemoryMapper& mapper = DefaultDeviceMapper)
       : ArrayStreamReader<StreamTraits, ArrayTraits>(stream, mapper) {}
 
   Status Init() {
@@ -2392,7 +2393,8 @@ class ArrayStreamArrayReader : public ArrayStreamReader<StreamTraits, ArrayTrait
   using ArrayType = typename ArrayTraits::CType;
 
  public:
-  explicit ArrayStreamArrayReader(StreamType* stream, const DeviceMemoryMapper& mapper = DefaultDeviceMapper)
+  explicit ArrayStreamArrayReader(StreamType* stream,
+                                  const DeviceMemoryMapper& mapper = DefaultDeviceMapper)
       : ArrayStreamReader<StreamTraits, ArrayTraits>(stream, mapper) {}
 
   Status Init() {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2400,7 +2400,7 @@ class ArrayStreamArrayReader : public ArrayStreamReader<StreamTraits, ArrayTrait
 
  public:
   explicit ArrayStreamArrayReader(StreamType* stream,
-                                  const DeviceMemoryMapper& mapper = DefaultDeviceMapper)
+                                  const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper)
       : ArrayStreamReader<StreamTraits, ArrayTraits>(stream, mapper) {}
 
   Status Init() {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1496,7 +1496,7 @@ struct ArrayImporter {
 
   Status Import(struct ArrowDeviceArray* src, const DeviceMemoryMapper& mapper) {
     ARROW_ASSIGN_OR_RAISE(memory_mgr_, mapper(src->device_type, src->device_id));
-    device_type_ = static_cast<DeviceAllocationType>(src->device_type);    
+    device_type_ = static_cast<DeviceAllocationType>(src->device_type);
     RETURN_NOT_OK(Import(&src->array));
     if (src->sync_event != nullptr) {
       ARROW_ASSIGN_OR_RAISE(import_->device_sync_, memory_mgr_->WrapDeviceSyncEvent(

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2073,7 +2073,7 @@ Status ExportDeviceStreamNext(const std::shared_ptr<ChunkedArray>& src, int64_t 
     ArrowArrayMarkReleased(&out_array->array);
     return Status::OK();
   } else {
-    return ExportDeviceArray(*src->chunk(static_cast<int>(i)), sync, out_array);
+    return ExportDeviceArray(*src->chunk(static_cast<int>(i)), std::move(sync), out_array);
   }
 }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2073,7 +2073,8 @@ Status ExportDeviceStreamNext(const std::shared_ptr<ChunkedArray>& src, int64_t 
     ArrowArrayMarkReleased(&out_array->array);
     return Status::OK();
   } else {
-    return ExportDeviceArray(*src->chunk(static_cast<int>(i)), std::move(sync), out_array);
+    return ExportDeviceArray(*src->chunk(static_cast<int>(i)), std::move(sync),
+                             out_array);
   }
 }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2336,7 +2336,7 @@ class ArrayStreamReader {
   }
 
   DeviceAllocationType get_device_type() const {
-    if constexpr (std::is_same_v<ArrayType, struct ArrowDeviceArray>) {
+    if constexpr (IsDevice) {
       return static_cast<DeviceAllocationType>(stream_.device_type);
     } else {
       return DeviceAllocationType::kCPU;

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2399,8 +2399,8 @@ class ArrayStreamArrayReader : public ArrayStreamReader<StreamTraits, ArrayTrait
   using ArrayType = typename ArrayTraits::CType;
 
  public:
-  explicit ArrayStreamArrayReader(StreamType* stream,
-                                  const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper)
+  explicit ArrayStreamArrayReader(
+      StreamType* stream, const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper)
       : ArrayStreamReader<StreamTraits, ArrayTraits>(stream, mapper) {}
 
   Status Init() {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2237,7 +2237,7 @@ class ArrayStreamReader {
 
  public:
   explicit ArrayStreamReader(StreamType* stream,
-                             const DeviceMemoryMapper& mapper = DefaultDeviceMapper)
+                             const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper)
       : mapper_{mapper} {
     StreamTraits::MoveFunc(stream, &stream_);
     DCHECK(!StreamTraits::IsReleasedFunc(&stream_));
@@ -2356,8 +2356,8 @@ class ArrayStreamBatchReader : public RecordBatchReader,
   using ArrayType = typename ArrayTraits::CType;
 
  public:
-  explicit ArrayStreamBatchReader(StreamType* stream,
-                                  const DeviceMemoryMapper& mapper = DefaultDeviceMapper)
+  explicit ArrayStreamBatchReader(
+      StreamType* stream, const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper)
       : ArrayStreamReader<StreamTraits, ArrayTraits>(stream, mapper) {}
 
   Status Init() {
@@ -2432,7 +2432,7 @@ class ArrayStreamArrayReader : public ArrayStreamReader<StreamTraits, ArrayTrait
 template <typename StreamTraits, typename ArrayTraits>
 Result<std::shared_ptr<RecordBatchReader>> ImportReader(
     typename StreamTraits::CType* stream,
-    const DeviceMemoryMapper& mapper = DefaultDeviceMapper) {
+    const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper) {
   if (StreamTraits::IsReleasedFunc(stream)) {
     return Status::Invalid("Cannot import released Arrow Stream");
   }
@@ -2446,7 +2446,7 @@ Result<std::shared_ptr<RecordBatchReader>> ImportReader(
 template <typename StreamTraits, typename ArrayTraits>
 Result<std::shared_ptr<ChunkedArray>> ImportChunked(
     typename StreamTraits::CType* stream,
-    const DeviceMemoryMapper& mapper = DefaultDeviceMapper) {
+    const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper) {
   if (StreamTraits::IsReleasedFunc(stream)) {
     return Status::Invalid("Cannot import released Arrow Stream");
   }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2048,7 +2048,7 @@ Status ExportStreamNext(const std::shared_ptr<RecordBatchReader>& src, int64_t i
 // overload of this with the version for ChunkedArrays. If we removed the int64_t
 // from the signature despite it being unused, we wouldn't be able to leverage the
 // overloading in the templated exporters.
-Status ExportDeviceStreamNext(const std::shared_ptr<RecordBatchReader>& src, int64_t i,
+Status ExportStreamNext(const std::shared_ptr<RecordBatchReader>& src, int64_t i,
                               struct ArrowDeviceArray* out_array) {
   std::shared_ptr<RecordBatch> batch;
   RETURN_NOT_OK(src->ReadNext(&batch));
@@ -2072,7 +2072,7 @@ Status ExportStreamNext(const std::shared_ptr<ChunkedArray>& src, int64_t i,
   }
 }
 
-Status ExportDeviceStreamNext(const std::shared_ptr<ChunkedArray>& src, int64_t i,
+Status ExportStreamNext(const std::shared_ptr<ChunkedArray>& src, int64_t i,
                               struct ArrowDeviceArray* out_array) {
   if (i >= src->num_chunks()) {
     // End of stream
@@ -2113,11 +2113,7 @@ class ExportedArrayStream {
   }
 
   Status GetNext(ArrayType* out_array) {
-    if constexpr (std::is_same_v<ArrayType, struct ArrowArray>) {
-      return ExportStreamNext(reader(), next_batch_num(), out_array);
-    } else {
-      return ExportDeviceStreamNext(reader(), next_batch_num(), out_array);
-    }
+    return ExportStreamNext(reader(), next_batch_num(), out_array);
   }
 
   const char* GetLastError() {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2255,7 +2255,7 @@ class ArrayStreamReader {
   Status ReadNextArrayInternal(ArrayType* array) {
     ArrayTraits::MarkReleased(array);
     Status status = StatusFromCError(stream_.get_next(&stream_, array));
-    if (!status.ok() && !ArrayTraits::IsReleasedFunc(array)) {
+    if (!status.ok()) {
       ArrayTraits::ReleaseFunc(array);
     }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2049,7 +2049,7 @@ Status ExportStreamNext(const std::shared_ptr<RecordBatchReader>& src, int64_t i
 // from the signature despite it being unused, we wouldn't be able to leverage the
 // overloading in the templated exporters.
 Status ExportStreamNext(const std::shared_ptr<RecordBatchReader>& src, int64_t i,
-                              struct ArrowDeviceArray* out_array) {
+                        struct ArrowDeviceArray* out_array) {
   std::shared_ptr<RecordBatch> batch;
   RETURN_NOT_OK(src->ReadNext(&batch));
   if (batch == nullptr) {
@@ -2073,7 +2073,7 @@ Status ExportStreamNext(const std::shared_ptr<ChunkedArray>& src, int64_t i,
 }
 
 Status ExportStreamNext(const std::shared_ptr<ChunkedArray>& src, int64_t i,
-                              struct ArrowDeviceArray* out_array) {
+                        struct ArrowDeviceArray* out_array) {
   if (i >= src->num_chunks()) {
     // End of stream
     ArrowArrayMarkReleased(&out_array->array);

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -321,6 +321,37 @@ ARROW_EXPORT
 Status ExportChunkedArray(std::shared_ptr<ChunkedArray> chunked_array,
                           struct ArrowArrayStream* out);
 
+/// \brief Export C++ RecordBatchReader using the C device stream interface
+///
+/// The resulting ArrowDeviceArrayStream struct keeps the record batch reader
+/// alive until its release callback is called by the consumer. The device
+/// type is determined by calling device_type() on the RecordBatchReader.
+///
+/// \note it is assumed that the output pointer has already be zeroed out before
+/// calling this function.
+///
+/// \param[in] reader RecordBatchReader object to export
+/// \param[out] out C struct to export the stream to
+ARROW_EXPORT
+Status ExportDeviceRecordBatchReader(std::shared_ptr<RecordBatchReader> reader,
+                                     struct ArrowDeviceArrayStream* out);
+
+/// \brief Export C++ ChunkedArray using the c device data interface format.
+///
+/// The resulting ArrowDeviceArrayStream keeps the chunked array data and buffers
+/// alive until its release callback is called by the consumer.
+///
+/// \note it is assumed that the output pointer has already been zeroed before
+/// calling this function.
+///
+/// \param[in] chunked_array ChunkedArray object to export
+/// \param[in] device_type the device type the data is located on
+/// \param[out] out C struct to export the stream to
+ARROW_EXPORT
+Status ExportDeviceChunkedArray(std::shared_ptr<ChunkedArray> chunked_array,
+                                DeviceAllocationType device_type,
+                                struct ArrowDeviceArrayStream* out);
+
 /// \brief Import C++ RecordBatchReader from the C stream interface.
 ///
 /// The ArrowArrayStream struct has its contents moved to a private object
@@ -342,6 +373,16 @@ Result<std::shared_ptr<RecordBatchReader>> ImportRecordBatchReader(
 /// \return Imported ChunkedArray object
 ARROW_EXPORT
 Result<std::shared_ptr<ChunkedArray>> ImportChunkedArray(struct ArrowArrayStream* stream);
+
+ARROW_EXPORT
+Result<std::shared_ptr<RecordBatchReader>> ImportDeviceRecordBatchReader(
+    struct ArrowDeviceArrayStream* stream,
+    const DeviceMemoryMapper& mapper = DefaultDeviceMapper);
+
+ARROW_EXPORT
+Result<std::shared_ptr<ChunkedArray>> ImportDeviceChunkedArray(
+    struct ArrowDeviceArrayStream* stream,
+    const DeviceMemoryMapper& mapper = DefaultDeviceMapper);
 
 /// @}
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -374,8 +374,8 @@ Result<std::shared_ptr<ChunkedArray>> ImportChunkedArray(struct ArrowArrayStream
 /// held alive by the resulting record batch reader.
 ///
 /// \note If there was a required sync event, sync events are accessible by individual
-/// buffers of columns. We are not yet bubbling the sync events from the buffers up to 
-/// the `GetSyncEvent` method of an imported RecordBatch. This will be added in a future 
+/// buffers of columns. We are not yet bubbling the sync events from the buffers up to
+/// the `GetSyncEvent` method of an imported RecordBatch. This will be added in a future
 /// update.
 ///
 /// \param[in,out] stream C device stream interface struct

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -384,7 +384,7 @@ Result<std::shared_ptr<ChunkedArray>> ImportChunkedArray(struct ArrowArrayStream
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatchReader>> ImportDeviceRecordBatchReader(
     struct ArrowDeviceArrayStream* stream,
-    const DeviceMemoryMapper& mapper = DefaultDeviceMapper);
+    const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper);
 
 /// \brief Import C++ ChunkedArray from the C device stream interface
 ///
@@ -402,7 +402,7 @@ Result<std::shared_ptr<RecordBatchReader>> ImportDeviceRecordBatchReader(
 ARROW_EXPORT
 Result<std::shared_ptr<ChunkedArray>> ImportDeviceChunkedArray(
     struct ArrowDeviceArrayStream* stream,
-    const DeviceMemoryMapper& mapper = DefaultDeviceMapper);
+    const DeviceMemoryMapper& mapper = DefaultDeviceMemoryMapper);
 
 /// @}
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -333,7 +333,7 @@ ARROW_EXPORT
 Status ExportDeviceRecordBatchReader(std::shared_ptr<RecordBatchReader> reader,
                                      struct ArrowDeviceArrayStream* out);
 
-/// \brief Export C++ ChunkedArray using the c device data interface format.
+/// \brief Export C++ ChunkedArray using the C device data interface format.
 ///
 /// The resulting ArrowDeviceArrayStream keeps the chunked array data and buffers
 /// alive until its release callback is called by the consumer.

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5227,7 +5227,8 @@ TEST_F(TestArrayDeviceStreamRoundtrip, SchemaError) {
       return EIO;
     }
 
-    static int GetNext(struct ArrowDeviceArrayStream* stream, struct ArrowDeviceArray* array) {
+    static int GetNext(struct ArrowDeviceArrayStream* stream,
+                       struct ArrowDeviceArray* array) {
       return EINVAL;
     }
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5208,7 +5208,8 @@ TEST_F(TestArrayDeviceStreamRoundtrip, Errors) {
       Status::Invalid("roundtrip error example"));
 
   Roundtrip(std::move(reader), [&](const std::shared_ptr<RecordBatchReader>& reader) {
-    EXPECT_THAT(reader->Next(), Raises(StatusCode::Invalid, ::testing::HasSubstr("roundtrip error example")));
+    EXPECT_THAT(reader->Next(), Raises(StatusCode::Invalid,
+                                       ::testing::HasSubstr("roundtrip error example")));
   });
 }
 
@@ -5218,13 +5219,9 @@ TEST_F(TestArrayDeviceStreamRoundtrip, SchemaError) {
     return "Expected error";
   };
   stream.get_schema = [](struct ArrowDeviceArrayStream* stream,
-                         struct ArrowSchema* schema) {
-    return EIO;
-  };
+                         struct ArrowSchema* schema) { return EIO; };
   stream.get_next = [](struct ArrowDeviceArrayStream* stream,
-                       struct ArrowDeviceArray* array) {
-    return EINVAL;
-  };
+                       struct ArrowDeviceArray* array) { return EINVAL; };
   stream.release = [](struct ArrowDeviceArrayStream* stream) {
     *static_cast<bool*>(stream->private_data) = true;
     std::memset(stream, 0, sizeof(*stream));
@@ -5234,7 +5231,7 @@ TEST_F(TestArrayDeviceStreamRoundtrip, SchemaError) {
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(IOError, ::testing::HasSubstr("Expected error"),
                                   ImportDeviceRecordBatchReader(&stream));
-  ASSERT_TRUE(state.released);
+  ASSERT_TRUE(released);
 }
 
 TEST_F(TestArrayDeviceStreamRoundtrip, ChunkedArrayRoundtrip) {

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -53,11 +53,15 @@
 
 namespace arrow {
 
+using internal::ArrayDeviceExportTraits;
+using internal::ArrayDeviceStreamExportTraits;
 using internal::ArrayExportGuard;
 using internal::ArrayExportTraits;
 using internal::ArrayStreamExportGuard;
 using internal::ArrayStreamExportTraits;
 using internal::checked_cast;
+using internal::DeviceArrayExportGuard;
+using internal::DeviceArrayStreamExportGuard;
 using internal::SchemaExportGuard;
 using internal::SchemaExportTraits;
 using internal::Zip;
@@ -4745,5 +4749,334 @@ TEST_F(TestArrayStreamRoundtrip, ChunkedArrayRoundtripEmpty) {
     AssertChunkedEqual(*dst, *src);
   });
 }
+
+////////////////////////////////////////////////////////////////////////////
+// Array device stream export tests
+
+class TestArrayDeviceStreamExport : public BaseArrayStreamTest {
+ public:
+  void AssertStreamSchema(struct ArrowDeviceArrayStream* c_stream,
+                          const Schema& expected) {
+    struct ArrowSchema c_schema;
+    ASSERT_EQ(0, c_stream->get_schema(c_stream, &c_schema));
+
+    SchemaExportGuard schema_guard(&c_schema);
+    ASSERT_FALSE(ArrowSchemaIsReleased(&c_schema));
+    ASSERT_OK_AND_ASSIGN(auto schema, ImportSchema(&c_schema));
+    AssertSchemaEqual(expected, *schema, /*check_metadata=*/true);
+  }
+
+  void AssertStreamEnd(struct ArrowDeviceArrayStream* c_stream) {
+    struct ArrowDeviceArray c_array;
+    ASSERT_EQ(0, c_stream->get_next(c_stream, &c_array));
+
+    DeviceArrayExportGuard guard(&c_array);
+    ASSERT_TRUE(ArrowDeviceArrayIsReleased(&c_array));
+  }
+
+  void AssertStreamNext(struct ArrowDeviceArrayStream* c_stream,
+                        const RecordBatch& expected) {
+    struct ArrowDeviceArray c_array;
+    ASSERT_EQ(0, c_stream->get_next(c_stream, &c_array));
+
+    DeviceArrayExportGuard guard(&c_array);
+    ASSERT_FALSE(ArrowDeviceArrayIsReleased(&c_array));
+
+    ASSERT_OK_AND_ASSIGN(auto batch,
+                         ImportDeviceRecordBatch(&c_array, expected.schema(),
+                                                 TestDeviceArrayRoundtrip::DeviceMapper));
+    AssertBatchesEqual(expected, *batch);
+  }
+
+  void AssertStreamNext(struct ArrowDeviceArrayStream* c_stream, const Array& expected) {
+    struct ArrowDeviceArray c_array;
+    ASSERT_EQ(0, c_stream->get_next(c_stream, &c_array));
+
+    DeviceArrayExportGuard guard(&c_array);
+    ASSERT_FALSE(ArrowDeviceArrayIsReleased(&c_array));
+
+    ASSERT_OK_AND_ASSIGN(auto array,
+                         ImportDeviceArray(&c_array, expected.type(),
+                                           TestDeviceArrayRoundtrip::DeviceMapper));
+    AssertArraysEqual(expected, *array);
+  }
+
+  static Result<std::shared_ptr<ArrayData>> ToDeviceData(
+      const std::shared_ptr<MemoryManager>& mm, const ArrayData& data) {
+    arrow::BufferVector buffers;
+    for (const auto& buf : data.buffers) {
+      if (buf) {
+        ARROW_ASSIGN_OR_RAISE(auto dest, mm->CopyBuffer(buf, mm));
+        buffers.push_back(dest);
+      } else {
+        buffers.push_back(nullptr);
+      }
+    }
+
+    arrow::ArrayDataVector children;
+    for (const auto& child : data.child_data) {
+      ARROW_ASSIGN_OR_RAISE(auto dest, ToDeviceData(mm, *child));
+      children.push_back(dest);
+    }
+
+    return ArrayData::Make(data.type, data.length, buffers, children, data.null_count,
+                           data.offset);
+  }
+
+  static Result<std::shared_ptr<Array>> ToDevice(const std::shared_ptr<MemoryManager>& mm,
+                                                 const ArrayData& data) {
+    ARROW_ASSIGN_OR_RAISE(auto result, ToDeviceData(mm, data));
+    return MakeArray(result);
+  }
+};
+
+TEST_F(TestArrayDeviceStreamExport, Empty) {
+  auto schema = arrow::schema({field("ints", int32())});
+  auto batches = MakeBatches(schema, {});
+  ASSERT_OK_AND_ASSIGN(
+      auto reader,
+      RecordBatchReader::Make(batches, schema,
+                              static_cast<DeviceAllocationType>(kMyDeviceType)));
+
+  struct ArrowDeviceArrayStream c_stream;
+  ASSERT_OK(ExportDeviceRecordBatchReader(reader, &c_stream));
+  DeviceArrayStreamExportGuard guard(&c_stream);
+
+  ASSERT_FALSE(ArrowDeviceArrayStreamIsReleased(&c_stream));
+  ASSERT_EQ(kMyDeviceType, c_stream.device_type);
+  AssertStreamSchema(&c_stream, *schema);
+  AssertStreamEnd(&c_stream);
+  AssertStreamEnd(&c_stream);
+}
+
+TEST_F(TestArrayDeviceStreamExport, Simple) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  ASSERT_OK_AND_ASSIGN(auto arr1,
+                       ToDevice(mm, *ArrayFromJSON(int32(), "[1, 2]")->data()));
+  ASSERT_EQ(device->device_type(), arr1->device_type());
+  ASSERT_OK_AND_ASSIGN(auto arr2,
+                       ToDevice(mm, *ArrayFromJSON(int32(), "[4, 5, null]")->data()));
+  ASSERT_EQ(device->device_type(), arr2->device_type());
+  auto schema = arrow::schema({field("ints", int32())});
+  auto batches = MakeBatches(schema, {arr1, arr2});
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       RecordBatchReader::Make(batches, schema, device->device_type()));
+
+  struct ArrowDeviceArrayStream c_stream;
+
+  ASSERT_OK(ExportDeviceRecordBatchReader(reader, &c_stream));
+  DeviceArrayStreamExportGuard guard(&c_stream);
+
+  ASSERT_FALSE(ArrowDeviceArrayStreamIsReleased(&c_stream));
+  AssertStreamSchema(&c_stream, *schema);
+  ASSERT_EQ(kMyDeviceType, c_stream.device_type);
+  AssertStreamNext(&c_stream, *batches[0]);
+  AssertStreamNext(&c_stream, *batches[1]);
+  AssertStreamEnd(&c_stream);
+  AssertStreamEnd(&c_stream);
+}
+
+TEST_F(TestArrayDeviceStreamExport, ArrayLifetime) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  ASSERT_OK_AND_ASSIGN(auto arr1,
+                       ToDevice(mm, *ArrayFromJSON(int32(), "[1, 2]")->data()));
+  ASSERT_EQ(device->device_type(), arr1->device_type());
+  ASSERT_OK_AND_ASSIGN(auto arr2,
+                       ToDevice(mm, *ArrayFromJSON(int32(), "[4, 5, null]")->data()));
+  ASSERT_EQ(device->device_type(), arr2->device_type());
+  auto schema = arrow::schema({field("ints", int32())});
+  auto batches = MakeBatches(schema, {arr1, arr2});
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       RecordBatchReader::Make(batches, schema, device->device_type()));
+
+  struct ArrowDeviceArrayStream c_stream;
+  struct ArrowSchema c_schema;
+  struct ArrowDeviceArray c_array0, c_array1;
+
+  ASSERT_OK(ExportDeviceRecordBatchReader(reader, &c_stream));
+  {
+    DeviceArrayStreamExportGuard guard(&c_stream);
+    ASSERT_FALSE(ArrowDeviceArrayStreamIsReleased(&c_stream));
+    ASSERT_EQ(kMyDeviceType, c_stream.device_type);
+
+    ASSERT_EQ(0, c_stream.get_schema(&c_stream, &c_schema));
+    ASSERT_EQ(0, c_stream.get_next(&c_stream, &c_array0));
+    ASSERT_EQ(0, c_stream.get_next(&c_stream, &c_array1));
+    AssertStreamEnd(&c_stream);
+  }
+
+  DeviceArrayExportGuard guard0(&c_array0), guard1(&c_array1);
+
+  {
+    SchemaExportGuard schema_guard(&c_schema);
+    ASSERT_OK_AND_ASSIGN(auto got_schema, ImportSchema(&c_schema));
+    AssertSchemaEqual(*schema, *got_schema, /*check_metadata=*/true);
+  }
+
+  ASSERT_EQ(kMyDeviceType, c_array0.device_type);
+  ASSERT_EQ(kMyDeviceType, c_array1.device_type);
+
+  ASSERT_GT(pool_->bytes_allocated(), orig_allocated_);
+  ASSERT_OK_AND_ASSIGN(
+      auto batch,
+      ImportDeviceRecordBatch(&c_array1, schema, TestDeviceArrayRoundtrip::DeviceMapper));
+  AssertBatchesEqual(*batches[1], *batch);
+  ASSERT_EQ(device->device_type(), batch->device_type());
+  ASSERT_OK_AND_ASSIGN(
+      batch,
+      ImportDeviceRecordBatch(&c_array0, schema, TestDeviceArrayRoundtrip::DeviceMapper));
+  AssertBatchesEqual(*batches[0], *batch);
+  ASSERT_EQ(device->device_type(), batch->device_type());
+}
+
+TEST_F(TestArrayDeviceStreamExport, Errors) {
+  auto reader =
+      std::make_shared<FailingRecordBatchReader>(Status::Invalid("some example error"));
+
+  struct ArrowDeviceArrayStream c_stream;
+
+  ASSERT_OK(ExportDeviceRecordBatchReader(reader, &c_stream));
+  DeviceArrayStreamExportGuard guard(&c_stream);
+
+  struct ArrowSchema c_schema;
+  ASSERT_EQ(0, c_stream.get_schema(&c_stream, &c_schema));
+  ASSERT_FALSE(ArrowSchemaIsReleased(&c_schema));
+  {
+    SchemaExportGuard schema_guard(&c_schema);
+    ASSERT_OK_AND_ASSIGN(auto schema, ImportSchema(&c_schema));
+    AssertSchemaEqual(schema, arrow::schema({}), /*check_metadata=*/true);
+  }
+
+  struct ArrowDeviceArray c_array;
+  ASSERT_EQ(EINVAL, c_stream.get_next(&c_stream, &c_array));
+}
+
+TEST_F(TestArrayDeviceStreamExport, ChunkedArrayExportEmpty) {
+  ASSERT_OK_AND_ASSIGN(auto chunked_array, ChunkedArray::Make({}, int32()));
+
+  struct ArrowDeviceArrayStream c_stream;
+  struct ArrowSchema c_schema;
+
+  ASSERT_OK(ExportDeviceChunkedArray(
+      chunked_array, static_cast<DeviceAllocationType>(kMyDeviceType), &c_stream));
+  DeviceArrayStreamExportGuard guard(&c_stream);
+
+  {
+    DeviceArrayStreamExportGuard guard(&c_stream);
+    ASSERT_FALSE(ArrowDeviceArrayStreamIsReleased(&c_stream));
+
+    ASSERT_EQ(kMyDeviceType, c_stream.device_type);
+    ASSERT_EQ(0, c_stream.get_schema(&c_stream, &c_schema));
+    AssertStreamEnd(&c_stream);
+  }
+
+  {
+    SchemaExportGuard schema_guard(&c_schema);
+    ASSERT_OK_AND_ASSIGN(auto got_type, ImportType(&c_schema));
+    AssertTypeEqual(*chunked_array->type(), *got_type);
+  }
+}
+
+TEST_F(TestArrayDeviceStreamExport, ChunkedArrayExport) {
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
+  auto mm = device->default_memory_manager();
+
+  ASSERT_OK_AND_ASSIGN(auto arr1,
+                       ToDevice(mm, *ArrayFromJSON(int32(), "[1, 2]")->data()));
+  ASSERT_EQ(device->device_type(), arr1->device_type());
+  ASSERT_OK_AND_ASSIGN(auto arr2,
+                       ToDevice(mm, *ArrayFromJSON(int32(), "[4, 5, null]")->data()));
+  ASSERT_EQ(device->device_type(), arr2->device_type());
+
+  ASSERT_OK_AND_ASSIGN(auto chunked_array, ChunkedArray::Make({arr1, arr2}));
+
+  struct ArrowDeviceArrayStream c_stream;
+  struct ArrowSchema c_schema;
+  struct ArrowDeviceArray c_array0, c_array1;
+
+  ASSERT_OK(ExportDeviceChunkedArray(chunked_array, device->device_type(), &c_stream));
+  DeviceArrayStreamExportGuard guard(&c_stream);
+
+  {
+    DeviceArrayStreamExportGuard guard(&c_stream);
+    ASSERT_FALSE(ArrowDeviceArrayStreamIsReleased(&c_stream));
+    ASSERT_EQ(kMyDeviceType, c_stream.device_type);
+
+    ASSERT_EQ(0, c_stream.get_schema(&c_stream, &c_schema));
+    ASSERT_EQ(0, c_stream.get_next(&c_stream, &c_array0));
+    ASSERT_EQ(0, c_stream.get_next(&c_stream, &c_array1));
+    AssertStreamEnd(&c_stream);
+  }
+
+  DeviceArrayExportGuard guard0(&c_array0), guard1(&c_array1);
+
+  {
+    SchemaExportGuard schema_guard(&c_schema);
+    ASSERT_OK_AND_ASSIGN(auto got_type, ImportType(&c_schema));
+    AssertTypeEqual(*chunked_array->type(), *got_type);
+  }
+
+  ASSERT_EQ(kMyDeviceType, c_array0.device_type);
+  ASSERT_EQ(kMyDeviceType, c_array1.device_type);
+
+  ASSERT_GT(pool_->bytes_allocated(), orig_allocated_);
+  ASSERT_OK_AND_ASSIGN(auto array,
+                       ImportDeviceArray(&c_array0, chunked_array->type(),
+                                         TestDeviceArrayRoundtrip::DeviceMapper));
+  ASSERT_EQ(device->device_type(), array->device_type());
+  AssertArraysEqual(*chunked_array->chunk(0), *array);
+  ASSERT_OK_AND_ASSIGN(array, ImportDeviceArray(&c_array1, chunked_array->type(),
+                                                TestDeviceArrayRoundtrip::DeviceMapper));
+  ASSERT_EQ(device->device_type(), array->device_type());
+  AssertArraysEqual(*chunked_array->chunk(1), *array);
+}
+
+////////////////////////////////////////////////////////////////////////////
+// Array device stream roundtrip tests
+
+class TestArrayDeviceStreamRoundtrip : public BaseArrayStreamTest {
+ public:
+  void Roundtrip(std::shared_ptr<RecordBatchReader>* reader,
+                 struct ArrowDeviceArrayStream* c_stream) {
+    ASSERT_OK(ExportDeviceRecordBatchReader(*reader, c_stream));
+    ASSERT_FALSE(ArrowDeviceArrayStreamIsReleased(c_stream));
+
+    ASSERT_OK_AND_ASSIGN(
+        auto got_reader,
+        ImportDeviceRecordBatchReader(c_stream, TestDeviceArrayRoundtrip::DeviceMapper));
+    *reader = std::move(got_reader);
+  }
+
+  void Roundtrip(
+      std::shared_ptr<RecordBatchReader> reader,
+      std::function<void(const std::shared_ptr<RecordBatchReader>&)> check_func) {
+    ArrowDeviceArrayStream c_stream;
+
+    // NOTE: ReleaseCallback<> is not immediately usable with ArrowDeviceArayStream
+    // because get_next and get_schema need the original private_data.
+    std::weak_ptr<RecordBatchReader> weak_reader(reader);
+    ASSERT_EQ(weak_reader.use_count(), 1);  // Expiration check will fail otherwise
+
+    ASSERT_OK(ExportDeviceRecordBatchReader(std::move(reader), &c_stream));
+    ASSERT_FALSE(ArrowDeviceArrayStreamIsReleased(&c_stream));
+
+    {
+      ASSERT_OK_AND_ASSIGN(auto new_reader,
+                           ImportDeviceRecordBatchReader(
+                               &c_stream, TestDeviceArrayRoundtrip::DeviceMapper));
+      // stream was moved
+      ASSERT_TRUE(ArrowDeviceArrayStreamIsReleased(&c_stream));
+      ASSERT_FALSE(weak_reader.expired());
+
+      check_func(new_reader);
+    }
+    // Stream was released when `new_reader` was destroyed
+    ASSERT_TRUE(weak_reader.expired());
+  }
+};
 
 }  // namespace arrow

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5208,9 +5208,7 @@ TEST_F(TestArrayDeviceStreamRoundtrip, Errors) {
       Status::Invalid("roundtrip error example"));
 
   Roundtrip(std::move(reader), [&](const std::shared_ptr<RecordBatchReader>& reader) {
-    auto status = reader->Next().status();
-    ASSERT_RAISES(Invalid, status);
-    ASSERT_THAT(status.message(), ::testing::HasSubstr("roundtrip error example"));
+    EXPECT_THAT(reader->Next(), Raises(StatusCode::Invalid, ::testing::HasSubstr("roundtrip error example")));
   });
 }
 

--- a/cpp/src/arrow/c/helpers.h
+++ b/cpp/src/arrow/c/helpers.h
@@ -92,11 +92,12 @@ inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dest) {
   ArrowArrayMarkReleased(src);
 }
 
-inline void ArrowDeviceArrayMove(struct ArrowDeviceArray* src, struct ArrowDeviceArray* dest) {
+inline void ArrowDeviceArrayMove(struct ArrowDeviceArray* src,
+                                 struct ArrowDeviceArray* dest) {
   assert(dest != src);
   assert(!ArrowDeviceArrayIsReleased(src));
   memcpy(dest, src, sizeof(struct ArrowDeviceArray));
-  ArrowDeviceArrayMarkReleased(src);  
+  ArrowDeviceArrayMarkReleased(src);
 }
 
 /// Release the C array, if necessary, by calling its release callback
@@ -146,8 +147,8 @@ inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
   ArrowArrayStreamMarkReleased(src);
 }
 
-inline void ArrowDeviceArrayStreamMove(struct ArrowDeviceArrayStream* src, 
-                                      struct ArrowDeviceArrayStream* dest) {
+inline void ArrowDeviceArrayStreamMove(struct ArrowDeviceArrayStream* src,
+                                       struct ArrowDeviceArrayStream* dest) {
   assert(dest != src);
   assert(!ArrowDeviceArrayStreamIsReleased(src));
   memcpy(dest, src, sizeof(struct ArrowDeviceArrayStream));

--- a/cpp/src/arrow/c/helpers.h
+++ b/cpp/src/arrow/c/helpers.h
@@ -70,8 +70,16 @@ inline int ArrowArrayIsReleased(const struct ArrowArray* array) {
   return array->release == NULL;
 }
 
+inline int ArrowDeviceArrayIsReleased(const struct ArrowDeviceArray* array) {
+  return ArrowArrayIsReleased(&array->array);
+}
+
 /// Mark the C array released (for use in release callbacks)
 inline void ArrowArrayMarkReleased(struct ArrowArray* array) { array->release = NULL; }
+
+inline void ArrowDeviceArrayMarkReleased(struct ArrowDeviceArray* array) {
+  ArrowArrayMarkReleased(&array->array);
+}
 
 /// Move the C array from `src` to `dest`
 ///
@@ -84,6 +92,13 @@ inline void ArrowArrayMove(struct ArrowArray* src, struct ArrowArray* dest) {
   ArrowArrayMarkReleased(src);
 }
 
+inline void ArrowDeviceArrayMove(struct ArrowDeviceArray* src, struct ArrowDeviceArray* dest) {
+  assert(dest != src);
+  assert(!ArrowDeviceArrayIsReleased(src));
+  memcpy(dest, src, sizeof(struct ArrowDeviceArray));
+  ArrowDeviceArrayMarkReleased(src);  
+}
+
 /// Release the C array, if necessary, by calling its release callback
 inline void ArrowArrayRelease(struct ArrowArray* array) {
   if (!ArrowArrayIsReleased(array)) {
@@ -93,13 +108,29 @@ inline void ArrowArrayRelease(struct ArrowArray* array) {
   }
 }
 
+inline void ArrowDeviceArrayRelease(struct ArrowDeviceArray* array) {
+  if (!ArrowDeviceArrayIsReleased(array)) {
+    array->array.release(&array->array);
+    ARROW_C_ASSERT(ArrowDeviceArrayIsReleased(array),
+                   "ArrowDeviceArrayRelease did not cleanup release callback");
+  }
+}
+
 /// Query whether the C array stream is released
 inline int ArrowArrayStreamIsReleased(const struct ArrowArrayStream* stream) {
   return stream->release == NULL;
 }
 
+inline int ArrowDeviceArrayStreamIsReleased(const struct ArrowDeviceArrayStream* stream) {
+  return stream->release == NULL;
+}
+
 /// Mark the C array stream released (for use in release callbacks)
 inline void ArrowArrayStreamMarkReleased(struct ArrowArrayStream* stream) {
+  stream->release = NULL;
+}
+
+inline void ArrowDeviceArrayStreamMarkReleased(struct ArrowDeviceArrayStream* stream) {
   stream->release = NULL;
 }
 
@@ -115,12 +146,28 @@ inline void ArrowArrayStreamMove(struct ArrowArrayStream* src,
   ArrowArrayStreamMarkReleased(src);
 }
 
+inline void ArrowDeviceArrayStreamMove(struct ArrowDeviceArrayStream* src, 
+                                      struct ArrowDeviceArrayStream* dest) {
+  assert(dest != src);
+  assert(!ArrowDeviceArrayStreamIsReleased(src));
+  memcpy(dest, src, sizeof(struct ArrowDeviceArrayStream));
+  ArrowDeviceArrayStreamMarkReleased(src);
+}
+
 /// Release the C array stream, if necessary, by calling its release callback
 inline void ArrowArrayStreamRelease(struct ArrowArrayStream* stream) {
   if (!ArrowArrayStreamIsReleased(stream)) {
     stream->release(stream);
     ARROW_C_ASSERT(ArrowArrayStreamIsReleased(stream),
                    "ArrowArrayStreamRelease did not cleanup release callback");
+  }
+}
+
+inline void ArrowDeviceArrayStreamRelease(struct ArrowDeviceArrayStream* stream) {
+  if (!ArrowDeviceArrayStreamIsReleased(stream)) {
+    stream->release(stream);
+    ARROW_C_ASSERT(ArrowDeviceArrayStreamIsReleased(stream),
+                   "ArrowDeviceArrayStreamRelease did not cleanup release callback");
   }
 }
 

--- a/cpp/src/arrow/c/helpers.h
+++ b/cpp/src/arrow/c/helpers.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/cpp/src/arrow/c/util_internal.h
+++ b/cpp/src/arrow/c/util_internal.h
@@ -32,12 +32,32 @@ struct ArrayExportTraits {
   typedef struct ArrowArray CType;
   static constexpr auto IsReleasedFunc = &ArrowArrayIsReleased;
   static constexpr auto ReleaseFunc = &ArrowArrayRelease;
+  static constexpr auto MoveFunc = &ArrowArrayMove;
+  static constexpr auto MarkReleased = &ArrowArrayMarkReleased;
+};
+
+struct ArrayDeviceExportTraits {
+  typedef struct ArrowDeviceArray CType;
+  static constexpr auto IsReleasedFunc = &ArrowDeviceArrayIsReleased;
+  static constexpr auto ReleaseFunc = &ArrowDeviceArrayRelease;
+  static constexpr auto MoveFunc = &ArrowDeviceArrayMove;
+  static constexpr auto MarkReleased = &ArrowDeviceArrayMarkReleased;
 };
 
 struct ArrayStreamExportTraits {
   typedef struct ArrowArrayStream CType;
   static constexpr auto IsReleasedFunc = &ArrowArrayStreamIsReleased;
   static constexpr auto ReleaseFunc = &ArrowArrayStreamRelease;
+  static constexpr auto MoveFunc = &ArrowArrayStreamMove;
+  static constexpr auto MarkReleased = &ArrowArrayStreamMarkReleased;
+};
+
+struct ArrayDeviceStreamExportTraits {
+  typedef struct ArrowDeviceArrayStream CType;
+  static constexpr auto IsReleasedFunc = &ArrowDeviceArrayStreamIsReleased;
+  static constexpr auto ReleaseFunc = &ArrowDeviceArrayStreamRelease;
+  static constexpr auto MoveFunc = &ArrowDeviceArrayStreamMove;
+  static constexpr auto MarkReleased = &ArrowDeviceArrayStreamMarkReleased;
 };
 
 // A RAII-style object to release a C Array / Schema struct at block scope exit.

--- a/cpp/src/arrow/c/util_internal.h
+++ b/cpp/src/arrow/c/util_internal.h
@@ -99,7 +99,9 @@ class ExportGuard {
 
 using SchemaExportGuard = ExportGuard<SchemaExportTraits>;
 using ArrayExportGuard = ExportGuard<ArrayExportTraits>;
+using DeviceArrayExportGuard = ExportGuard<ArrayDeviceExportTraits>;
 using ArrayStreamExportGuard = ExportGuard<ArrayStreamExportTraits>;
+using DeviceArrayStreamExportGuard = ExportGuard<ArrayDeviceStreamExportTraits>;
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -623,6 +623,10 @@ Status RecordBatch::ValidateFull() const {
   return ValidateBatch(*this, /*full_validation=*/true);
 }
 
+std::shared_ptr<Device::SyncEvent> RecordBatch::GetSyncEvent() {
+  return nullptr;
+}
+
 // ----------------------------------------------------------------------
 // Base record batch reader
 

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -623,9 +623,7 @@ Status RecordBatch::ValidateFull() const {
   return ValidateBatch(*this, /*full_validation=*/true);
 }
 
-std::shared_ptr<Device::SyncEvent> RecordBatch::GetSyncEvent() {
-  return nullptr;
-}
+std::shared_ptr<Device::SyncEvent> RecordBatch::GetSyncEvent() { return nullptr; }
 
 // ----------------------------------------------------------------------
 // Base record batch reader

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -667,16 +667,6 @@ Status RecordBatch::ValidateFull() const {
   return ValidateBatch(*this, /*full_validation=*/true);
 }
 
-const std::shared_ptr<Device::SyncEvent>& RecordBatch::GetSyncEvent() const {
-  return null_sync_event_;
-}
-
-DeviceAllocationType RecordBatch::device_type() const {
-  return DeviceAllocationType::kCPU;
-}
-
-const std::shared_ptr<Device::SyncEvent> RecordBatch::null_sync_event_{nullptr};
-
 // ----------------------------------------------------------------------
 // Base record batch reader
 

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -188,7 +188,7 @@ class SimpleRecordBatch : public RecordBatch {
     return RecordBatch::Validate();
   }
 
-  std::shared_ptr<Device::SyncEvent> GetSyncEvent() const override { return sync_event_; }
+  const std::shared_ptr<Device::SyncEvent>& GetSyncEvent() const override { return sync_event_; }
 
   DeviceAllocationType device_type() const override { return device_type_; }
 
@@ -213,7 +213,7 @@ std::shared_ptr<RecordBatch> RecordBatch::Make(
     std::shared_ptr<Device::SyncEvent> sync_event) {
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
   return std::make_shared<SimpleRecordBatch>(std::move(schema), num_rows,
-                                             std::move(columns), sync_event);
+                                             std::move(columns), std::move(sync_event));
 }
 
 std::shared_ptr<RecordBatch> RecordBatch::Make(
@@ -222,7 +222,7 @@ std::shared_ptr<RecordBatch> RecordBatch::Make(
     std::shared_ptr<Device::SyncEvent> sync_event) {
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
   return std::make_shared<SimpleRecordBatch>(std::move(schema), num_rows,
-                                             std::move(columns), device_type, sync_event);
+                                             std::move(columns), device_type, std::move(sync_event));
 }
 
 Result<std::shared_ptr<RecordBatch>> RecordBatch::MakeEmpty(
@@ -664,7 +664,7 @@ Status RecordBatch::ValidateFull() const {
   return ValidateBatch(*this, /*full_validation=*/true);
 }
 
-std::shared_ptr<Device::SyncEvent> RecordBatch::GetSyncEvent() const { return nullptr; }
+const std::shared_ptr<Device::SyncEvent>& RecordBatch::GetSyncEvent() const { return nullptr; }
 
 DeviceAllocationType RecordBatch::device_type() const {
   return DeviceAllocationType::kCPU;

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -668,12 +668,14 @@ Status RecordBatch::ValidateFull() const {
 }
 
 const std::shared_ptr<Device::SyncEvent>& RecordBatch::GetSyncEvent() const {
-  return nullptr;
+  return null_sync_event_;
 }
 
 DeviceAllocationType RecordBatch::device_type() const {
   return DeviceAllocationType::kCPU;
 }
+
+const std::shared_ptr<Device::SyncEvent> RecordBatch::null_sync_event_{nullptr};
 
 // ----------------------------------------------------------------------
 // Base record batch reader

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -188,7 +188,9 @@ class SimpleRecordBatch : public RecordBatch {
     return RecordBatch::Validate();
   }
 
-  const std::shared_ptr<Device::SyncEvent>& GetSyncEvent() const override { return sync_event_; }
+  const std::shared_ptr<Device::SyncEvent>& GetSyncEvent() const override {
+    return sync_event_;
+  }
 
   DeviceAllocationType device_type() const override { return device_type_; }
 
@@ -222,7 +224,8 @@ std::shared_ptr<RecordBatch> RecordBatch::Make(
     std::shared_ptr<Device::SyncEvent> sync_event) {
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
   return std::make_shared<SimpleRecordBatch>(std::move(schema), num_rows,
-                                             std::move(columns), device_type, std::move(sync_event));
+                                             std::move(columns), device_type,
+                                             std::move(sync_event));
 }
 
 Result<std::shared_ptr<RecordBatch>> RecordBatch::MakeEmpty(
@@ -664,7 +667,9 @@ Status RecordBatch::ValidateFull() const {
   return ValidateBatch(*this, /*full_validation=*/true);
 }
 
-const std::shared_ptr<Device::SyncEvent>& RecordBatch::GetSyncEvent() const { return nullptr; }
+const std::shared_ptr<Device::SyncEvent>& RecordBatch::GetSyncEvent() const {
+  return nullptr;
+}
 
 DeviceAllocationType RecordBatch::device_type() const {
   return DeviceAllocationType::kCPU;

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -59,17 +59,31 @@ int RecordBatch::num_columns() const { return schema_->num_fields(); }
 class SimpleRecordBatch : public RecordBatch {
  public:
   SimpleRecordBatch(std::shared_ptr<Schema> schema, int64_t num_rows,
-                    std::vector<std::shared_ptr<Array>> columns)
-      : RecordBatch(std::move(schema), num_rows), boxed_columns_(std::move(columns)) {
+                    std::vector<std::shared_ptr<Array>> columns,
+                    std::shared_ptr<Device::SyncEvent> sync_event = nullptr)
+      : RecordBatch(std::move(schema), num_rows),
+        boxed_columns_(std::move(columns)),
+        device_type_(DeviceAllocationType::kCPU),
+        sync_event_(std::move(sync_event)) {
+    if (boxed_columns_.size() > 0) {
+      device_type_ = boxed_columns_[0]->device_type();
+    }
+
     columns_.resize(boxed_columns_.size());
     for (size_t i = 0; i < columns_.size(); ++i) {
       columns_[i] = boxed_columns_[i]->data();
+      DCHECK_EQ(device_type_, columns_[i]->device_type());
     }
   }
 
   SimpleRecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows,
-                    std::vector<std::shared_ptr<ArrayData>> columns)
-      : RecordBatch(std::move(schema), num_rows), columns_(std::move(columns)) {
+                    std::vector<std::shared_ptr<ArrayData>> columns,
+                    DeviceAllocationType device_type = DeviceAllocationType::kCPU,
+                    std::shared_ptr<Device::SyncEvent> sync_event = nullptr)
+      : RecordBatch(std::move(schema), num_rows),
+        columns_(std::move(columns)),
+        device_type_(device_type),
+        sync_event_(std::move(sync_event)) {
     boxed_columns_.resize(schema_->num_fields());
   }
 
@@ -99,6 +113,7 @@ class SimpleRecordBatch : public RecordBatch {
       const std::shared_ptr<Array>& column) const override {
     ARROW_CHECK(field != nullptr);
     ARROW_CHECK(column != nullptr);
+    ARROW_CHECK(column->device_type() == device_type_);
 
     if (!field->type()->Equals(column->type())) {
       return Status::TypeError("Column data type ", field->type()->name(),
@@ -113,7 +128,8 @@ class SimpleRecordBatch : public RecordBatch {
 
     ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->AddField(i, field));
     return RecordBatch::Make(std::move(new_schema), num_rows_,
-                             internal::AddVectorElement(columns_, i, column->data()));
+                             internal::AddVectorElement(columns_, i, column->data()),
+                             device_type_, sync_event_);
   }
 
   Result<std::shared_ptr<RecordBatch>> SetColumn(
@@ -121,6 +137,7 @@ class SimpleRecordBatch : public RecordBatch {
       const std::shared_ptr<Array>& column) const override {
     ARROW_CHECK(field != nullptr);
     ARROW_CHECK(column != nullptr);
+    ARROW_CHECK(column->device_type() == device_type_);
 
     if (!field->type()->Equals(column->type())) {
       return Status::TypeError("Column data type ", field->type()->name(),
@@ -135,19 +152,22 @@ class SimpleRecordBatch : public RecordBatch {
 
     ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->SetField(i, field));
     return RecordBatch::Make(std::move(new_schema), num_rows_,
-                             internal::ReplaceVectorElement(columns_, i, column->data()));
+                             internal::ReplaceVectorElement(columns_, i, column->data()),
+                             device_type_, sync_event_);
   }
 
   Result<std::shared_ptr<RecordBatch>> RemoveColumn(int i) const override {
     ARROW_ASSIGN_OR_RAISE(auto new_schema, schema_->RemoveField(i));
     return RecordBatch::Make(std::move(new_schema), num_rows_,
-                             internal::DeleteVectorElement(columns_, i));
+                             internal::DeleteVectorElement(columns_, i), device_type_,
+                             sync_event_);
   }
 
   std::shared_ptr<RecordBatch> ReplaceSchemaMetadata(
       const std::shared_ptr<const KeyValueMetadata>& metadata) const override {
     auto new_schema = schema_->WithMetadata(metadata);
-    return RecordBatch::Make(std::move(new_schema), num_rows_, columns_);
+    return RecordBatch::Make(std::move(new_schema), num_rows_, columns_, device_type_,
+                             sync_event_);
   }
 
   std::shared_ptr<RecordBatch> Slice(int64_t offset, int64_t length) const override {
@@ -157,7 +177,8 @@ class SimpleRecordBatch : public RecordBatch {
       arrays.emplace_back(field->Slice(offset, length));
     }
     int64_t num_rows = std::min(num_rows_ - offset, length);
-    return std::make_shared<SimpleRecordBatch>(schema_, num_rows, std::move(arrays));
+    return std::make_shared<SimpleRecordBatch>(schema_, num_rows, std::move(arrays),
+                                               device_type_, sync_event_);
   }
 
   Status Validate() const override {
@@ -167,11 +188,20 @@ class SimpleRecordBatch : public RecordBatch {
     return RecordBatch::Validate();
   }
 
+  std::shared_ptr<Device::SyncEvent> GetSyncEvent() const override { return sync_event_; }
+
+  DeviceAllocationType device_type() const override { return device_type_; }
+
  private:
   std::vector<std::shared_ptr<ArrayData>> columns_;
 
   // Caching boxed array data
   mutable std::vector<std::shared_ptr<Array>> boxed_columns_;
+
+  // the type of device that the buffers for columns are allocated on.
+  // all columns should be on the same type of device.
+  DeviceAllocationType device_type_;
+  std::shared_ptr<Device::SyncEvent> sync_event_;
 };
 
 RecordBatch::RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows)
@@ -179,18 +209,20 @@ RecordBatch::RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows
 
 std::shared_ptr<RecordBatch> RecordBatch::Make(
     std::shared_ptr<Schema> schema, int64_t num_rows,
-    std::vector<std::shared_ptr<Array>> columns) {
+    std::vector<std::shared_ptr<Array>> columns,
+    std::shared_ptr<Device::SyncEvent> sync_event) {
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
   return std::make_shared<SimpleRecordBatch>(std::move(schema), num_rows,
-                                             std::move(columns));
+                                             std::move(columns), sync_event);
 }
 
 std::shared_ptr<RecordBatch> RecordBatch::Make(
     std::shared_ptr<Schema> schema, int64_t num_rows,
-    std::vector<std::shared_ptr<ArrayData>> columns) {
+    std::vector<std::shared_ptr<ArrayData>> columns, DeviceAllocationType device_type,
+    std::shared_ptr<Device::SyncEvent> sync_event) {
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
   return std::make_shared<SimpleRecordBatch>(std::move(schema), num_rows,
-                                             std::move(columns));
+                                             std::move(columns), device_type, sync_event);
 }
 
 Result<std::shared_ptr<RecordBatch>> RecordBatch::MakeEmpty(
@@ -505,7 +537,7 @@ Result<std::shared_ptr<RecordBatch>> RecordBatch::ReplaceSchema(
           ", did not match new schema field type: ", replace_type->ToString());
     }
   }
-  return RecordBatch::Make(std::move(schema), num_rows(), columns());
+  return RecordBatch::Make(std::move(schema), num_rows(), columns(), GetSyncEvent());
 }
 
 std::vector<std::string> RecordBatch::ColumnNames() const {
@@ -534,7 +566,7 @@ Result<std::shared_ptr<RecordBatch>> RecordBatch::RenameColumns(
   }
 
   return RecordBatch::Make(::arrow::schema(std::move(fields)), num_rows(),
-                           std::move(columns));
+                           std::move(columns), GetSyncEvent());
 }
 
 Result<std::shared_ptr<RecordBatch>> RecordBatch::SelectColumns(
@@ -555,7 +587,8 @@ Result<std::shared_ptr<RecordBatch>> RecordBatch::SelectColumns(
 
   auto new_schema =
       std::make_shared<arrow::Schema>(std::move(fields), schema()->metadata());
-  return RecordBatch::Make(std::move(new_schema), num_rows(), std::move(columns));
+  return RecordBatch::Make(std::move(new_schema), num_rows(), std::move(columns),
+                           GetSyncEvent());
 }
 
 std::shared_ptr<RecordBatch> RecordBatch::Slice(int64_t offset) const {
@@ -623,7 +656,11 @@ Status RecordBatch::ValidateFull() const {
   return ValidateBatch(*this, /*full_validation=*/true);
 }
 
-std::shared_ptr<Device::SyncEvent> RecordBatch::GetSyncEvent() { return nullptr; }
+std::shared_ptr<Device::SyncEvent> RecordBatch::GetSyncEvent() const { return nullptr; }
+
+DeviceAllocationType RecordBatch::device_type() const {
+  return DeviceAllocationType::kCPU;
+}
 
 // ----------------------------------------------------------------------
 // Base record batch reader
@@ -649,12 +686,16 @@ Result<std::shared_ptr<Table>> RecordBatchReader::ToTable() {
 class SimpleRecordBatchReader : public RecordBatchReader {
  public:
   SimpleRecordBatchReader(Iterator<std::shared_ptr<RecordBatch>> it,
-                          std::shared_ptr<Schema> schema)
-      : schema_(std::move(schema)), it_(std::move(it)) {}
+                          std::shared_ptr<Schema> schema,
+                          DeviceAllocationType device_type = DeviceAllocationType::kCPU)
+      : schema_(std::move(schema)), it_(std::move(it)), device_type_(device_type) {}
 
   SimpleRecordBatchReader(std::vector<std::shared_ptr<RecordBatch>> batches,
-                          std::shared_ptr<Schema> schema)
-      : schema_(std::move(schema)), it_(MakeVectorIterator(std::move(batches))) {}
+                          std::shared_ptr<Schema> schema,
+                          DeviceAllocationType device_type = DeviceAllocationType::kCPU)
+      : schema_(std::move(schema)),
+        it_(MakeVectorIterator(std::move(batches))),
+        device_type_(device_type) {}
 
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override {
     return it_.Next().Value(batch);
@@ -662,13 +703,17 @@ class SimpleRecordBatchReader : public RecordBatchReader {
 
   std::shared_ptr<Schema> schema() const override { return schema_; }
 
+  DeviceAllocationType device_type() const override { return device_type_; }
+
  protected:
   std::shared_ptr<Schema> schema_;
   Iterator<std::shared_ptr<RecordBatch>> it_;
+  DeviceAllocationType device_type_;
 };
 
 Result<std::shared_ptr<RecordBatchReader>> RecordBatchReader::Make(
-    std::vector<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema) {
+    std::vector<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema,
+    DeviceAllocationType device_type) {
   if (schema == nullptr) {
     if (batches.size() == 0 || batches[0] == nullptr) {
       return Status::Invalid("Cannot infer schema from empty vector or nullptr");
@@ -677,16 +722,19 @@ Result<std::shared_ptr<RecordBatchReader>> RecordBatchReader::Make(
     schema = batches[0]->schema();
   }
 
-  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), std::move(schema));
+  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), std::move(schema),
+                                                   device_type);
 }
 
 Result<std::shared_ptr<RecordBatchReader>> RecordBatchReader::MakeFromIterator(
-    Iterator<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema) {
+    Iterator<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema,
+    DeviceAllocationType device_type) {
   if (schema == nullptr) {
     return Status::Invalid("Schema cannot be nullptr");
   }
 
-  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), std::move(schema));
+  return std::make_shared<SimpleRecordBatchReader>(std::move(batches), std::move(schema),
+                                                   device_type);
 }
 
 RecordBatchReader::~RecordBatchReader() {
@@ -703,6 +751,10 @@ Result<std::shared_ptr<RecordBatch>> ConcatenateRecordBatches(
   int cols = batches[0]->num_columns();
   auto schema = batches[0]->schema();
   for (size_t i = 0; i < batches.size(); ++i) {
+    if (auto sync = batches[i]->GetSyncEvent()) {
+      ARROW_RETURN_NOT_OK(sync->Wait());
+    }
+
     length += batches[i]->num_rows();
     if (!schema->Equals(batches[i]->schema())) {
       return Status::Invalid(

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -498,6 +498,10 @@ bool RecordBatch::Equals(const RecordBatch& other, bool check_metadata,
     return false;
   }
 
+  if (device_type() != other.device_type()) {
+    return false;
+  }
+
   for (int i = 0; i < num_columns(); ++i) {
     if (!column(i)->Equals(other.column(i), opts)) {
       return false;
@@ -509,6 +513,10 @@ bool RecordBatch::Equals(const RecordBatch& other, bool check_metadata,
 
 bool RecordBatch::ApproxEquals(const RecordBatch& other, const EqualOptions& opts) const {
   if (num_columns() != other.num_columns() || num_rows_ != other.num_rows()) {
+    return false;
+  }
+
+  if (device_type() != other.device_type()) {
     return false;
   }
 

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "arrow/compare.h"
+#include "arrow/device.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
@@ -260,6 +261,16 @@ class ARROW_EXPORT RecordBatch {
   /// \return Status
   virtual Status ValidateFull() const;
 
+  /// \brief Return a top-level sync event object for this record batch
+  ///
+  /// If all of the data for this record batch is in host memory, then this
+  /// should return null (the default impl). If the data for this batch is
+  /// on a device, then if synchronization is needed before accessing the
+  /// data the returned sync event will allow for it.
+  ///
+  /// \return null or a Device::SyncEvent
+  virtual std::shared_ptr<Device::SyncEvent> GetSyncEvent();
+
  protected:
   RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows);
 
@@ -305,6 +316,11 @@ class ARROW_EXPORT RecordBatchReader {
 
   /// \brief finalize reader
   virtual Status Close() { return Status::OK(); }
+
+  /// \brief Get the device type for record batches this reader produces
+  ///
+  /// default implementation is to return ARROW_DEVICE_CPU
+  virtual DeviceAllocationType device_type() const { return DeviceAllocationType::kCPU; }
 
   class RecordBatchReaderIterator {
    public:

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -49,7 +49,7 @@ class ARROW_EXPORT RecordBatch {
   static std::shared_ptr<RecordBatch> Make(
       std::shared_ptr<Schema> schema, int64_t num_rows,
       std::vector<std::shared_ptr<Array>> columns,
-      std::shared_ptr<Device::SyncEvent> sync_event = nullptr);
+      std::shared_ptr<Device::SyncEvent> sync_event = NULLPTR);
 
   /// \brief Construct record batch from vector of internal data structures
   /// \since 0.5.0
@@ -64,7 +64,7 @@ class ARROW_EXPORT RecordBatch {
       std::shared_ptr<Schema> schema, int64_t num_rows,
       std::vector<std::shared_ptr<ArrayData>> columns,
       DeviceAllocationType device_type = DeviceAllocationType::kCPU,
-      std::shared_ptr<Device::SyncEvent> sync_event = nullptr);
+      std::shared_ptr<Device::SyncEvent> sync_event = NULLPTR);
 
   /// \brief Create an empty RecordBatch of a given schema
   ///

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -278,7 +278,7 @@ class ARROW_EXPORT RecordBatch {
   /// data the returned sync event will allow for it.
   ///
   /// \return null or a Device::SyncEvent
-  virtual std::shared_ptr<Device::SyncEvent> GetSyncEvent() const;
+  virtual const std::shared_ptr<Device::SyncEvent>& GetSyncEvent() const;
 
   virtual DeviceAllocationType device_type() const;
 

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -290,6 +290,8 @@ class ARROW_EXPORT RecordBatch {
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(RecordBatch);
+
+  static const std::shared_ptr<Device::SyncEvent> null_sync_event_;
 };
 
 struct ARROW_EXPORT RecordBatchWithMetadata {

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -261,7 +261,7 @@ class ARROW_EXPORT RecordBatch {
   /// \return Status
   virtual Status ValidateFull() const;
 
-  /// \brief Return a top-level sync event object for this record batch
+  /// \brief EXPERIMENTAL: Return a top-level sync event object for this record batch
   ///
   /// If all of the data for this record batch is in CPU memory, then this
   /// will return null. If the data for this batch is
@@ -317,9 +317,9 @@ class ARROW_EXPORT RecordBatchReader {
   /// \brief finalize reader
   virtual Status Close() { return Status::OK(); }
 
-  /// \brief Get the device type for record batches this reader produces
+  /// \brief EXPERIMENTAL: Get the device type for record batches this reader produces
   ///
-  /// default implementation is to return ARROW_DEVICE_CPU
+  /// default implementation is to return DeviceAllocationType::kCPU
   virtual DeviceAllocationType device_type() const { return DeviceAllocationType::kCPU; }
 
   class RecordBatchReaderIterator {

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -46,6 +46,8 @@ class ARROW_EXPORT RecordBatch {
   /// \param[in] num_rows length of fields in the record batch. Each array
   /// should have the same length as num_rows
   /// \param[in] columns the record batch fields as vector of arrays
+  /// \param[in] sync_event optional synchronization event for non-CPU device
+  /// memory used by buffers
   static std::shared_ptr<RecordBatch> Make(
       std::shared_ptr<Schema> schema, int64_t num_rows,
       std::vector<std::shared_ptr<Array>> columns,
@@ -60,6 +62,8 @@ class ARROW_EXPORT RecordBatch {
   /// \param num_rows the number of semantic rows in the record batch. This
   /// should be equal to the length of each field
   /// \param columns the data for the batch's columns
+  /// \param[in] sync_event optional synchronization event for non-CPU device
+  /// memory used by buffers
   static std::shared_ptr<RecordBatch> Make(
       std::shared_ptr<Schema> schema, int64_t num_rows,
       std::vector<std::shared_ptr<ArrayData>> columns,

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -46,9 +46,10 @@ class ARROW_EXPORT RecordBatch {
   /// \param[in] num_rows length of fields in the record batch. Each array
   /// should have the same length as num_rows
   /// \param[in] columns the record batch fields as vector of arrays
-  static std::shared_ptr<RecordBatch> Make(std::shared_ptr<Schema> schema,
-                                           int64_t num_rows,
-                                           std::vector<std::shared_ptr<Array>> columns);
+  static std::shared_ptr<RecordBatch> Make(
+      std::shared_ptr<Schema> schema, int64_t num_rows,
+      std::vector<std::shared_ptr<Array>> columns,
+      std::shared_ptr<Device::SyncEvent> sync_event = nullptr);
 
   /// \brief Construct record batch from vector of internal data structures
   /// \since 0.5.0
@@ -61,7 +62,9 @@ class ARROW_EXPORT RecordBatch {
   /// \param columns the data for the batch's columns
   static std::shared_ptr<RecordBatch> Make(
       std::shared_ptr<Schema> schema, int64_t num_rows,
-      std::vector<std::shared_ptr<ArrayData>> columns);
+      std::vector<std::shared_ptr<ArrayData>> columns,
+      DeviceAllocationType device_type = DeviceAllocationType::kCPU,
+      std::shared_ptr<Device::SyncEvent> sync_event = nullptr);
 
   /// \brief Create an empty RecordBatch of a given schema
   ///
@@ -269,7 +272,9 @@ class ARROW_EXPORT RecordBatch {
   /// data the returned sync event will allow for it.
   ///
   /// \return null or a Device::SyncEvent
-  virtual std::shared_ptr<Device::SyncEvent> GetSyncEvent();
+  virtual std::shared_ptr<Device::SyncEvent> GetSyncEvent() const;
+
+  virtual DeviceAllocationType device_type() const;
 
  protected:
   RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows);
@@ -396,14 +401,16 @@ class ARROW_EXPORT RecordBatchReader {
   /// \param[in] schema schema to conform to. Will be inferred from the first
   ///            element if not provided.
   static Result<std::shared_ptr<RecordBatchReader>> Make(
-      RecordBatchVector batches, std::shared_ptr<Schema> schema = NULLPTR);
+      RecordBatchVector batches, std::shared_ptr<Schema> schema = NULLPTR,
+      DeviceAllocationType device_type = DeviceAllocationType::kCPU);
 
   /// \brief Create a RecordBatchReader from an Iterator of RecordBatch.
   ///
   /// \param[in] batches an iterator of RecordBatch to read from.
   /// \param[in] schema schema that each record batch in iterator will conform to.
   static Result<std::shared_ptr<RecordBatchReader>> MakeFromIterator(
-      Iterator<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema);
+      Iterator<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema,
+      DeviceAllocationType device_type = DeviceAllocationType::kCPU);
 };
 
 /// \brief Concatenate record batches

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -62,7 +62,9 @@ class ARROW_EXPORT RecordBatch {
   /// \param num_rows the number of semantic rows in the record batch. This
   /// should be equal to the length of each field
   /// \param columns the data for the batch's columns
-  /// \param[in] sync_event optional synchronization event for non-CPU device
+  /// \param device_type the type of the device that the Arrow columns are 
+  /// allocated on
+  /// \param sync_event optional synchronization event for non-CPU device
   /// memory used by buffers
   static std::shared_ptr<RecordBatch> Make(
       std::shared_ptr<Schema> schema, int64_t num_rows,
@@ -404,6 +406,7 @@ class ARROW_EXPORT RecordBatchReader {
   /// \param[in] batches the vector of RecordBatch to read from
   /// \param[in] schema schema to conform to. Will be inferred from the first
   ///            element if not provided.
+  /// \param[in] device_type the type of device that the batches are allocated on
   static Result<std::shared_ptr<RecordBatchReader>> Make(
       RecordBatchVector batches, std::shared_ptr<Schema> schema = NULLPTR,
       DeviceAllocationType device_type = DeviceAllocationType::kCPU);
@@ -412,6 +415,7 @@ class ARROW_EXPORT RecordBatchReader {
   ///
   /// \param[in] batches an iterator of RecordBatch to read from.
   /// \param[in] schema schema that each record batch in iterator will conform to.
+  /// \param[in] device_type the type of device that the batches are allocated on
   static Result<std::shared_ptr<RecordBatchReader>> MakeFromIterator(
       Iterator<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema,
       DeviceAllocationType device_type = DeviceAllocationType::kCPU);

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -263,7 +263,7 @@ class ARROW_EXPORT RecordBatch {
 
   /// \brief Return a top-level sync event object for this record batch
   ///
-  /// If all of the data for this record batch is in host memory, then this
+  /// If all of the data for this record batch is in CPU memory, then this
   /// should return null (the default impl). If the data for this batch is
   /// on a device, then if synchronization is needed before accessing the
   /// data the returned sync event will allow for it.

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -278,9 +278,9 @@ class ARROW_EXPORT RecordBatch {
   /// data the returned sync event will allow for it.
   ///
   /// \return null or a Device::SyncEvent
-  virtual const std::shared_ptr<Device::SyncEvent>& GetSyncEvent() const;
+  virtual const std::shared_ptr<Device::SyncEvent>& GetSyncEvent() const = 0;
 
-  virtual DeviceAllocationType device_type() const;
+  virtual DeviceAllocationType device_type() const = 0;
 
  protected:
   RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows);
@@ -290,8 +290,6 @@ class ARROW_EXPORT RecordBatch {
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(RecordBatch);
-
-  static const std::shared_ptr<Device::SyncEvent> null_sync_event_;
 };
 
 struct ARROW_EXPORT RecordBatchWithMetadata {

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -264,7 +264,7 @@ class ARROW_EXPORT RecordBatch {
   /// \brief Return a top-level sync event object for this record batch
   ///
   /// If all of the data for this record batch is in CPU memory, then this
-  /// should return null (the default impl). If the data for this batch is
+  /// will return null. If the data for this batch is
   /// on a device, then if synchronization is needed before accessing the
   /// data the returned sync event will allow for it.
   ///

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -62,7 +62,7 @@ class ARROW_EXPORT RecordBatch {
   /// \param num_rows the number of semantic rows in the record batch. This
   /// should be equal to the length of each field
   /// \param columns the data for the batch's columns
-  /// \param device_type the type of the device that the Arrow columns are 
+  /// \param device_type the type of the device that the Arrow columns are
   /// allocated on
   /// \param sync_event optional synchronization event for non-CPU device
   /// memory used by buffers

--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -45,7 +45,7 @@ assert_array_released = pytest.raises(
     ValueError, match="Cannot import released ArrowArray")
 
 assert_stream_released = pytest.raises(
-    ValueError, match="Cannot import released ArrowArrayStream")
+    ValueError, match="Cannot import released Arrow Stream")
 
 
 def PyCapsule_IsValid(capsule, name):


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
The original PRs for adding support for importing and exporting the new C Device interface (#36488 / #36489) only added support for the Arrays themselves, not for the stream structure. We should support both.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Adding parallel functions for Import/Export of streams that accept `ArrowDeviceArrayStream`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Test writing in progress, wanted to get this up for review while I write tests.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No, only new functions have been added.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40078