### PR TITLE
MINOR: [C++] Remove misleading comment on FileKeyUnwrapper constructor

### DIFF
--- a/cpp/src/parquet/encryption/file_key_unwrapper.h
+++ b/cpp/src/parquet/encryption/file_key_unwrapper.h
@@ -57,8 +57,7 @@ class PARQUET_EXPORT FileKeyUnwrapper : public DecryptionKeyRetriever {
 
   /// Constructor overload that takes a raw pointer to the KeyToolkit and
   /// accepts an existing key_material_store rather than using
-  /// the file path and file system to create one when needed. This is useful for key
-  /// rotation to allow accessing the key material store after it is used.
+  /// the file path and file system to create one when needed.
   FileKeyUnwrapper(KeyToolkit* key_toolkit,
                    const KmsConnectionConfig& kms_connection_config,
                    double cache_lifetime_seconds,


### PR DESCRIPTION
### Rationale for this change

I added this comment in #34181, but from the discussion in https://github.com/apache/arrow/pull/40732#discussion_r1535001401, I realised this comment was incorrect. The extra overload appears to just be a convenience as a `FileKeyMaterialStore` is already constructed in `KeyToolkit::RotateMasterKeys`, but the store isn't actually used by the `FileKeyUnwrapper` in that method, as only `FileKeyUnwrapper::GetDataEncryptionKey` is called, which bypasses the store.

`RotateMasterKeys` does however rely on the `temp_key_material_store` passed to the `FileKeyWrapper` being used, which is possibly where this confusion came from.

### What changes are included in this PR?

Removes an incorrect statement from a C++ header comment.

### Are these changes tested?

NA

### Are there any user-facing changes?

No