### PR TITLE
GH-40773: [Java] add `DENSEUNION` case to StructWriters, resolves #40773

### DIFF
--- a/java/vector/src/main/codegen/templates/StructWriters.java
+++ b/java/vector/src/main/codegen/templates/StructWriters.java
@@ -73,6 +73,12 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
         map(child.getName(), arrowType.getKeysSorted());
         break;
       }
+      case DENSEUNION: {
+        FieldType fieldType = new FieldType(addVectorAsNullable, MinorType.DENSEUNION.getType(), null, null);
+        DenseUnionWriter writer = new DenseUnionWriter(container.addOrGet(child.getName(), fieldType, DenseUnionVector.class), getNullableStructWriterFactory());
+        fields.put(handleCase(child.getName()), writer);
+        break;
+      }
       case UNION:
         FieldType fieldType = new FieldType(addVectorAsNullable, MinorType.UNION.getType(), null, null);
         UnionWriter writer = new UnionWriter(container.addOrGet(child.getName(), fieldType, UnionVector.class), getNullableStructWriterFactory());

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -60,6 +60,7 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -2971,6 +2972,20 @@ public class TestValueVector {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor();
       assertFalse(visitor.vectorEquals(vector1, vector2));
+    }
+  }
+
+  @Test
+  public void testStructVectorAcceptsDenseUnionChild() {
+    Field childField = new Field("child",
+             FieldType.notNullable(new ArrowType.Union(UnionMode.Dense, new int[] {})),
+             Collections.emptyList());
+    Field structField = new Field("struct",
+             FieldType.notNullable(ArrowType.Struct.INSTANCE),
+             Collections.singletonList(childField));
+
+    try (FieldVector structVec = structField.createVector(allocator)) {
+      assertEquals(structField, structVec.getField());
     }
   }
 


### PR DESCRIPTION
### What changes are included in this PR?

Adding a `DENSEUNION` case to the `StructWriters` template so that one can create StructVectors with a DenseUnionVector child.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #40773