### PR TITLE
GH-40796: [Java] set `lastSet` in `ListVector.setNull` to avoid O(n²) in ListVectors with lots of nulls

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -856,6 +856,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
       offsetBuffer.setInt((i + 1) * OFFSET_WIDTH, currentOffset);
     }
     BitVectorHelper.unsetBit(validityBuffer, index);
+    lastSet = index;
   }
 
   /**

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2860,6 +2860,29 @@ public class TestValueVector {
   }
 
   @Test
+  public void testListVectorSetNull() {
+    try (final ListVector vector = ListVector.empty("list", allocator)) {
+      UnionListWriter writer = vector.getWriter();
+      writer.allocate();
+
+      writeListVector(writer, new int[] {1, 2});
+      writeListVector(writer, new int[] {3, 4});
+      writeListVector(writer, new int[] {5, 6});
+      vector.setNull(3);
+      vector.setNull(4);
+      vector.setNull(5);
+      writer.setValueCount(6);
+
+      assertEquals(vector.getObject(0), Arrays.asList(1, 2));
+      assertEquals(vector.getObject(1), Arrays.asList(3, 4));
+      assertEquals(vector.getObject(2), Arrays.asList(5, 6));
+      assertTrue(vector.isNull(3));
+      assertTrue(vector.isNull(4));
+      assertTrue(vector.isNull(5));
+    }
+  }
+
+  @Test
   public void testStructVectorEqualsWithNull() {
 
     try (final StructVector vector1 = StructVector.empty("struct", allocator);


### PR DESCRIPTION
Would benefit from someone with knowledge of the context double-checking this doesn't have nuances I'm not aware of - particularly, there's a comment on the field: `the maximum index that is actually set` which one _could_ read to mean 'excluding nulls'?

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #40796