### PR TITLE
MINOR: [Docs] Fix broken link in acero/options.h docstring

### DIFF
--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -105,7 +105,7 @@ class ARROW_ACERO_EXPORT SourceNodeOptions : public ExecNodeOptions {
 /// \brief a node that generates data from a table already loaded in memory
 ///
 /// The table source node will slice off chunks, defined by `max_batch_size`
-/// for parallel processing.  The source node extends source node and so these
+/// for parallel processing.  The table source node extends source node and so these
 /// chunks will be iteratively processed in small batches.  \see SourceNodeOptions
 /// for details.
 class ARROW_ACERO_EXPORT TableSourceNodeOptions : public ExecNodeOptions {

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -106,7 +106,7 @@ class ARROW_ACERO_EXPORT SourceNodeOptions : public ExecNodeOptions {
 ///
 /// The table source node will slice off chunks, defined by `max_batch_size`
 /// for parallel processing.  The source node extends source node and so these
-/// chunks will be iteratively processed in small batches.  \see SourceNode
+/// chunks will be iteratively processed in small batches.  \see SourceNodeOptions
 /// for details.
 class ARROW_ACERO_EXPORT TableSourceNodeOptions : public ExecNodeOptions {
  public:


### PR DESCRIPTION
### Rationale for this change

A "See also" link at https://arrow.apache.org/docs/cpp/api/acero.html#_CPPv4N5arrow5acero22TableSourceNodeOptionsE isn't automatically linked, probably because SourceNode itself isn't documented.

### What changes are included in this PR?

I updated the string to be "SourceNodeOptions" so it links there, which I'm pretty sure is what was intended because TableSourceNode inherits from SourceNode and the docs for SourceNodeOptions documents the behavior of SourceNode.

### Are these changes tested?

Yes, locally.

### Are there any user-facing changes?

Just docs.