### PR TITLE
GH-40816: [C++] Security checks and relaxing hashjoin batch rows size.

### DIFF
--- a/cpp/src/arrow/acero/partition_util.h
+++ b/cpp/src/arrow/acero/partition_util.h
@@ -62,7 +62,7 @@ class PartitionSort {
   template <class INPUT_PRTN_ID_FN, class OUTPUT_POS_FN>
   static void Eval(int64_t num_rows, int num_prtns, uint16_t* prtn_ranges,
                    INPUT_PRTN_ID_FN prtn_id_impl, OUTPUT_POS_FN output_pos_impl) {
-    ARROW_DCHECK(num_rows > 0 && num_rows <= (1 << 15));
+    ARROW_DCHECK(num_rows > 0 && num_rows <= ((1 << 16) - 1));
     ARROW_DCHECK(num_prtns >= 1 && num_prtns <= (1 << 15));
 
     memset(prtn_ranges, 0, (num_prtns + 1) * sizeof(uint16_t));

--- a/cpp/src/arrow/acero/partition_util.h
+++ b/cpp/src/arrow/acero/partition_util.h
@@ -62,8 +62,8 @@ class PartitionSort {
   template <class INPUT_PRTN_ID_FN, class OUTPUT_POS_FN>
   static void Eval(int64_t num_rows, int num_prtns, uint16_t* prtn_ranges,
                    INPUT_PRTN_ID_FN prtn_id_impl, OUTPUT_POS_FN output_pos_impl) {
-    ARROW_DCHECK(num_rows > 0 && num_rows <= ((1 << 16) - 1));
-    ARROW_DCHECK(num_prtns >= 1 && num_prtns <= (1 << 15));
+    ARROW_DCHECK(num_rows > 0 && num_rows <= std::numeric_limits<uint16_t>::max());
+    ARROW_DCHECK(num_prtns >= 1 && num_prtns <= std::numeric_limits<uint16_t>::max());
 
     memset(prtn_ranges, 0, (num_prtns + 1) * sizeof(uint16_t));
 

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -1283,6 +1283,7 @@ Status SwissTableForJoinBuild::ProcessPartition(int64_t thread_id,
   // Insert new keys into hash table associated with the current partition
   // and map existing keys to integer ids.
   //
+  ARROW_DCHECK(num_rows_new >= 0);
   prtn_state.key_ids.resize(num_rows_before + num_rows_new);
   SwissTableWithKeys::Input input(&key_batch, num_rows_new, row_ids, temp_stack,
                                   &locals.temp_column_arrays, &locals.temp_group_ids);


### PR DESCRIPTION

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
swiss_join and partition has been changed.

add an assertion to ensure that batch_prtn_ranges is incremented and relax the rows check of partition eval.

### What changes are included in this PR?

swiss_join.cc
partition_util.h

### Are these changes tested?

yes

### Are there any user-facing changes?

yes


* GitHub Issue: #40816