### PR TITLE
MINOR: [Java] Fix maven-checkstyle-plugin configuration

### DIFF
--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -257,13 +257,12 @@
           <headerLocation>../dev/checkstyle/checkstyle.license</headerLocation>
           <suppressionsLocation>../dev/checkstyle/suppressions.xml</suppressionsLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <encoding>UTF-8</encoding>
+          <inputEncoding>UTF-8</inputEncoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>${checkstyle.failOnViolation}</failsOnError>
           <failOnViolation>${checkstyle.failOnViolation}</failOnViolation>
           <violationSeverity>warning</violationSeverity>
-          <format>xml</format>
-          <format>html</format>
+          <outputFileFormat>xml</outputFileFormat>
           <outputFile>${project.build.directory}/test/checkstyle-errors.xml</outputFile>
           <linkXRef>false</linkXRef>
         </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -327,13 +327,12 @@
           <headerLocation>dev/checkstyle/checkstyle.license</headerLocation>
           <suppressionsLocation>dev/checkstyle/suppressions.xml</suppressionsLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <encoding>UTF-8</encoding>
+          <inputEncoding>UTF-8</inputEncoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>${checkstyle.failOnViolation}</failsOnError>
           <failOnViolation>${checkstyle.failOnViolation}</failOnViolation>
           <violationSeverity>warning</violationSeverity>
-          <format>xml</format>
-          <format>html</format>
+          <outputFileFormat>xml</outputFileFormat>
           <outputFile>${project.build.directory}/test/checkstyle-errors.xml</outputFile>
           <linkXRef>false</linkXRef>
         </configuration>


### PR DESCRIPTION
### Rationale for this change

`maven-checkstyle-plugin` configuration refers to several unrecognized properties, causing build output to print several messages like:
> [WARNING] Parameter 'format' is unknown for plugin 'maven-checkstyle-plugin:3.1.0:check (validate)'

### What changes are included in this PR?

Fix checkstyle configuration and use the correct outputFileFormat and inputEncoding properties in place of the unrecognized format and encoding ones.

### Are these changes tested?

As this is a build change with no code change, only via a local build + visual inspection of the build output

### Are there any user-facing changes?
No