### PR TITLE
GH-40806: [C++] Correctly report asimd/neon in GetRuntimeInfo

### DIFF
--- a/cpp/src/arrow/config.cc
+++ b/cpp/src/arrow/config.cc
@@ -58,6 +58,8 @@ std::string MakeSimdLevelString(QueryFlagFunction&& query_flag) {
     return "avx";
   } else if (query_flag(CpuInfo::SSE4_2)) {
     return "sse4_2";
+  } else if (query_flag(CpuInfo::ASIMD)) {
+    return "asimd";
   } else {
     return "none";
   }

--- a/cpp/src/arrow/config.cc
+++ b/cpp/src/arrow/config.cc
@@ -59,7 +59,7 @@ std::string MakeSimdLevelString(QueryFlagFunction&& query_flag) {
   } else if (query_flag(CpuInfo::SSE4_2)) {
     return "sse4_2";
   } else if (query_flag(CpuInfo::ASIMD)) {
-    return "asimd";
+    return "neon";
   } else {
     return "none";
   }


### PR DESCRIPTION
### What changes are included in this PR?

New case to conditional in `MakeSimdLevelString` which makes `GetRuntimeInfo` report correctly on respective CPUs. I chose to have it report "neon". Lowercase to match other strings and "neon" instead of "asimd" because I think that makes more sense to users. I'm not 100% sure which is more correct.

Fixes #40806

### Are these changes tested?

We don't have automated tests for this. I did install the R package and, on my M1 laptop it reports 'neon' now instead of 'none' before:

```r
> arrow_info()
...
SIMD Level          neon
Detected SIMD Level neon
```

### Are there any user-facing changes?

No.
* GitHub Issue: #40806