### PR TITLE
GH-40858: [R] Remove dangling commas from codegen.R

### DIFF
--- a/r/data-raw/codegen.R
+++ b/r/data-raw/codegen.R
@@ -145,7 +145,7 @@ cpp_functions_definitions <- arrow_exports %>%
     // {basename(file)}
     {ifdef_wrap(cpp11_wrapped, name, sexp_signature, decoration)}
     ",
-      sep = "\n",
+      sep = "\n"
     )
   }) %>%
   glue_collapse(sep = "\n")
@@ -176,7 +176,7 @@ arrow_exports_cpp <- paste0(
 static const R_CallMethodDef CallEntries[] = {
 ",
   glue::glue_collapse(glue::glue(
-    '\t\t{{ "_{features}_available", (DL_FUNC)& _{features}_available, 0 }},',
+    '\t\t{{ "_{features}_available", (DL_FUNC)& _{features}_available, 0 }},'
   ), sep = "\n"),
   glue::glue("\n
 {cpp_functions_registration}
@@ -217,7 +217,7 @@ r_functions <- arrow_exports %>%
 
     ",
       list_params = glue_collapse_data(args, "{name}"),
-      sep = "\n",
+      sep = "\n"
     )
   }) %>%
   glue_collapse(sep = "\n")


### PR DESCRIPTION
### Rationale for this change

This is a draft PR fixing https://github.com/apache/arrow/issues/40858, though I'm not sure how or why this broke (or worked correctly).

Fixes #40858

### Are these changes tested?

These have been tested locally.
* GitHub Issue: #40858