### PR TITLE
GH-40866: [C++][Python] Basic conversion of RecordBatch to Arrow Tensor - add support for row-major

### DIFF
--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -297,13 +297,13 @@ struct ConvertColumnsToTensorRowMajorVisitor {
       auto in_values = ArraySpan(in_data).GetSpan<In>(1, in_data.length);
 
       if (in_data.null_count == 0) {
-        for (int64_t j = 0; j < in_data.length; ++j) {
-          out_values[j * num_cols + col_idx] = static_cast<Out>(in_values[j]);
+        for (int64_t i = 0; i < in_data.length; ++i) {
+          out_values[i * num_cols + col_idx] = static_cast<Out>(in_values[i]);
         }
       } else {
-        for (int64_t j = 0; j < in_data.length; ++j) {
-          out_values[j * num_cols + col_idx] =
-              in_data.IsNull(j) ? static_cast<Out>(NAN) : static_cast<Out>(in_values[j]);
+        for (int64_t i = 0; i < in_data.length; ++i) {
+          out_values[i * num_cols + col_idx] =
+              in_data.IsNull(i) ? static_cast<Out>(NAN) : static_cast<Out>(in_values[i]);
         }
       }
       return Status::OK();

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -284,8 +284,7 @@ struct ConvertColumnsToTensorVisitor {
 };
 
 template <typename DataType>
-inline void ConvertColumnsToTensor(const RecordBatch& batch, uint8_t* out,
-                                   bool null_to_nan) {
+inline void ConvertColumnsToTensor(const RecordBatch& batch, uint8_t* out) {
   using CType = typename arrow::TypeTraits<DataType>::CType;
   auto* out_values = reinterpret_cast<CType*>(out);
 
@@ -363,35 +362,35 @@ Result<std::shared_ptr<Tensor>> RecordBatch::ToTensor(bool null_to_nan,
   // Copy data
   switch (result_type->id()) {
     case Type::UINT8:
-      ConvertColumnsToTensor<UInt8Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<UInt8Type>(*this, result->mutable_data());
       break;
     case Type::UINT16:
     case Type::HALF_FLOAT:
-      ConvertColumnsToTensor<UInt16Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<UInt16Type>(*this, result->mutable_data());
       break;
     case Type::UINT32:
-      ConvertColumnsToTensor<UInt32Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<UInt32Type>(*this, result->mutable_data());
       break;
     case Type::UINT64:
-      ConvertColumnsToTensor<UInt64Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<UInt64Type>(*this, result->mutable_data());
       break;
     case Type::INT8:
-      ConvertColumnsToTensor<Int8Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<Int8Type>(*this, result->mutable_data());
       break;
     case Type::INT16:
-      ConvertColumnsToTensor<Int16Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<Int16Type>(*this, result->mutable_data());
       break;
     case Type::INT32:
-      ConvertColumnsToTensor<Int32Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<Int32Type>(*this, result->mutable_data());
       break;
     case Type::INT64:
-      ConvertColumnsToTensor<Int64Type>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<Int64Type>(*this, result->mutable_data());
       break;
     case Type::FLOAT:
-      ConvertColumnsToTensor<FloatType>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<FloatType>(*this, result->mutable_data());
       break;
     case Type::DOUBLE:
-      ConvertColumnsToTensor<DoubleType>(*this, result->mutable_data(), null_to_nan);
+      ConvertColumnsToTensor<DoubleType>(*this, result->mutable_data());
       break;
     default:
       return Status::TypeError("DataType is not supported: ", result_type->ToString());

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -283,18 +283,55 @@ struct ConvertColumnsToTensorVisitor {
   }
 };
 
+template <typename Out>
+struct ConvertColumnsToTensorRowMajorVisitor {
+  Out*& out_values;
+  const ArrayData& in_data;
+  int num_cols;
+  int i;
+
+  template <typename T>
+  Status Visit(const T&) {
+    if constexpr (is_numeric(T::type_id)) {
+      using In = typename T::c_type;
+      auto in_values = ArraySpan(in_data).GetSpan<In>(1, in_data.length);
+
+      if (in_data.null_count == 0) {
+        for (int64_t j = 0; j < in_data.length; ++j) {
+          out_values[j * num_cols + i] = static_cast<Out>(in_values[j]);
+        }
+      } else {
+        for (int64_t j = 0; j < in_data.length; ++j) {
+          out_values[j * num_cols + i] =
+              in_data.IsNull(j) ? static_cast<Out>(NAN) : static_cast<Out>(in_values[j]);
+        }
+      }
+      return Status::OK();
+    }
+    Unreachable();
+  }
+};
+
 template <typename DataType>
-inline void ConvertColumnsToTensor(const RecordBatch& batch, uint8_t* out) {
+inline void ConvertColumnsToTensor(const RecordBatch& batch, uint8_t* out,
+                                   bool row_major) {
   using CType = typename arrow::TypeTraits<DataType>::CType;
   auto* out_values = reinterpret_cast<CType*>(out);
 
+  int i = 0;
   for (const auto& column : batch.columns()) {
-    ConvertColumnsToTensorVisitor<CType> visitor{out_values, *column->data()};
-    DCHECK_OK(VisitTypeInline(*column->type(), &visitor));
+    if (row_major) {
+      ConvertColumnsToTensorRowMajorVisitor<CType> visitor{out_values, *column->data(),
+                                                           batch.num_columns(), i++};
+      DCHECK_OK(VisitTypeInline(*column->type(), &visitor));
+    } else {
+      ConvertColumnsToTensorVisitor<CType> visitor{out_values, *column->data()};
+      DCHECK_OK(VisitTypeInline(*column->type(), &visitor));
+    }
   }
 }
 
-Result<std::shared_ptr<Tensor>> RecordBatch::ToTensor(bool null_to_nan,
+Result<std::shared_ptr<Tensor>> RecordBatch::ToTensor(bool null_to_nan, bool row_major,
                                                       MemoryPool* pool) const {
   if (num_columns() == 0) {
     return Status::TypeError(
@@ -362,35 +399,35 @@ Result<std::shared_ptr<Tensor>> RecordBatch::ToTensor(bool null_to_nan,
   // Copy data
   switch (result_type->id()) {
     case Type::UINT8:
-      ConvertColumnsToTensor<UInt8Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt8Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::UINT16:
     case Type::HALF_FLOAT:
-      ConvertColumnsToTensor<UInt16Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt16Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::UINT32:
-      ConvertColumnsToTensor<UInt32Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt32Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::UINT64:
-      ConvertColumnsToTensor<UInt64Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt64Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::INT8:
-      ConvertColumnsToTensor<Int8Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int8Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::INT16:
-      ConvertColumnsToTensor<Int16Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int16Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::INT32:
-      ConvertColumnsToTensor<Int32Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int32Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::INT64:
-      ConvertColumnsToTensor<Int64Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int64Type>(*this, result->mutable_data(), row_major);
       break;
     case Type::FLOAT:
-      ConvertColumnsToTensor<FloatType>(*this, result->mutable_data());
+      ConvertColumnsToTensor<FloatType>(*this, result->mutable_data(), row_major);
       break;
     case Type::DOUBLE:
-      ConvertColumnsToTensor<DoubleType>(*this, result->mutable_data());
+      ConvertColumnsToTensor<DoubleType>(*this, result->mutable_data(), row_major);
       break;
     default:
       return Status::TypeError("DataType is not supported: ", result_type->ToString());
@@ -401,11 +438,17 @@ Result<std::shared_ptr<Tensor>> RecordBatch::ToTensor(bool null_to_nan,
       internal::checked_cast<const FixedWidthType&>(*result_type);
   std::vector<int64_t> shape = {num_rows(), num_columns()};
   std::vector<int64_t> strides;
-  ARROW_RETURN_NOT_OK(
-      internal::ComputeColumnMajorStrides(fixed_width_type, shape, &strides));
-  ARROW_ASSIGN_OR_RAISE(auto tensor,
-                        Tensor::Make(result_type, std::move(result), shape, strides));
+  std::shared_ptr<Tensor> tensor;
 
+  if (row_major) {
+    ARROW_RETURN_NOT_OK(
+        internal::ComputeRowMajorStrides(fixed_width_type, shape, &strides));
+  } else {
+    ARROW_RETURN_NOT_OK(
+        internal::ComputeColumnMajorStrides(fixed_width_type, shape, &strides));
+  }
+  ARROW_ASSIGN_OR_RAISE(tensor,
+                        Tensor::Make(result_type, std::move(result), shape, strides));
   return tensor;
 }
 

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -288,7 +288,7 @@ struct ConvertColumnsToTensorRowMajorVisitor {
   Out*& out_values;
   const ArrayData& in_data;
   int num_cols;
-  int i;
+  int col_idx;
 
   template <typename T>
   Status Visit(const T&) {
@@ -298,11 +298,11 @@ struct ConvertColumnsToTensorRowMajorVisitor {
 
       if (in_data.null_count == 0) {
         for (int64_t j = 0; j < in_data.length; ++j) {
-          out_values[j * num_cols + i] = static_cast<Out>(in_values[j]);
+          out_values[j * num_cols + col_idx] = static_cast<Out>(in_values[j]);
         }
       } else {
         for (int64_t j = 0; j < in_data.length; ++j) {
-          out_values[j * num_cols + i] =
+          out_values[j * num_cols + col_idx] =
               in_data.IsNull(j) ? static_cast<Out>(NAN) : static_cast<Out>(in_values[j]);
         }
       }

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -284,7 +284,8 @@ struct ConvertColumnsToTensorVisitor {
 };
 
 template <typename DataType>
-inline void ConvertColumnsToTensor(const RecordBatch& batch, uint8_t* out) {
+inline void ConvertColumnsToTensor(const RecordBatch& batch, uint8_t* out,
+                                   bool null_to_nan) {
   using CType = typename arrow::TypeTraits<DataType>::CType;
   auto* out_values = reinterpret_cast<CType*>(out);
 
@@ -362,35 +363,35 @@ Result<std::shared_ptr<Tensor>> RecordBatch::ToTensor(bool null_to_nan,
   // Copy data
   switch (result_type->id()) {
     case Type::UINT8:
-      ConvertColumnsToTensor<UInt8Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt8Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::UINT16:
     case Type::HALF_FLOAT:
-      ConvertColumnsToTensor<UInt16Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt16Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::UINT32:
-      ConvertColumnsToTensor<UInt32Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt32Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::UINT64:
-      ConvertColumnsToTensor<UInt64Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<UInt64Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::INT8:
-      ConvertColumnsToTensor<Int8Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int8Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::INT16:
-      ConvertColumnsToTensor<Int16Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int16Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::INT32:
-      ConvertColumnsToTensor<Int32Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int32Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::INT64:
-      ConvertColumnsToTensor<Int64Type>(*this, result->mutable_data());
+      ConvertColumnsToTensor<Int64Type>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::FLOAT:
-      ConvertColumnsToTensor<FloatType>(*this, result->mutable_data());
+      ConvertColumnsToTensor<FloatType>(*this, result->mutable_data(), null_to_nan);
       break;
     case Type::DOUBLE:
-      ConvertColumnsToTensor<DoubleType>(*this, result->mutable_data());
+      ConvertColumnsToTensor<DoubleType>(*this, result->mutable_data(), null_to_nan);
       break;
     default:
       return Status::TypeError("DataType is not supported: ", result_type->ToString());

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -87,10 +87,12 @@ class ARROW_EXPORT RecordBatch {
   /// Generated Tensor will have column-major layout.
   ///
   /// \param[in] null_to_nan if true, convert nulls to NaN
+  /// \param[in] row_major if true, create row-major Tensor else column-major Tensor
   /// \param[in] pool the memory pool to allocate the tensor buffer
   /// \return the resulting Tensor
   Result<std::shared_ptr<Tensor>> ToTensor(
-      bool null_to_nan = false, MemoryPool* pool = default_memory_pool()) const;
+      bool null_to_nan = false, bool row_major = false,
+      MemoryPool* pool = default_memory_pool()) const;
 
   /// \brief Construct record batch from struct array
   ///

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -91,7 +91,7 @@ class ARROW_EXPORT RecordBatch {
   /// \param[in] pool the memory pool to allocate the tensor buffer
   /// \return the resulting Tensor
   Result<std::shared_ptr<Tensor>> ToTensor(
-      bool null_to_nan = false, bool row_major = false,
+      bool null_to_nan = false, bool row_major = true,
       MemoryPool* pool = default_memory_pool()) const;
 
   /// \brief Construct record batch from struct array

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -803,7 +803,7 @@ TEST_F(TestRecordBatch, ToTensorSupportedNullToNan) {
   auto a4 = ArrayFromJSON(int8(), "[10, 20, 30, 40, null, 60, 70, 80, 90]");
   auto batch2 = RecordBatch::Make(schema2, length, {a3, a4});
 
-  ASSERT_OK_AND_ASSIGN(auto tensor2, batch2->ToTensor(/*null_to_nan=*/true));
+  ASSERT_OK_AND_ASSIGN(auto tensor2, batch2->ToTensor(/*null_to_nan=*/true, /*row_major=*/false));
   ASSERT_OK(tensor2->Validate());
 
   const int64_t f32_size = sizeof(float);

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -682,15 +682,20 @@ TEST_F(TestRecordBatch, ToTensorEmptyBatch) {
   ASSERT_OK_AND_ASSIGN(std::shared_ptr<RecordBatch> empty,
                        RecordBatch::MakeEmpty(schema));
 
-  ASSERT_OK_AND_ASSIGN(auto tensor,
+  ASSERT_OK_AND_ASSIGN(auto tensor_column,
                        empty->ToTensor(/*null_to_nan=*/false, /*row_major=*/false));
-  ASSERT_OK(tensor->Validate());
+  ASSERT_OK(tensor_column->Validate());
+
+  ASSERT_OK_AND_ASSIGN(auto tensor_row, empty->ToTensor());
+  ASSERT_OK(tensor_row->Validate());
 
   const std::vector<int64_t> strides = {4, 4};
   const std::vector<int64_t> shape = {0, 2};
 
-  EXPECT_EQ(strides, tensor->strides());
-  EXPECT_EQ(shape, tensor->shape());
+  EXPECT_EQ(strides, tensor_column->strides());
+  EXPECT_EQ(shape, tensor_column->shape());
+  EXPECT_EQ(strides, tensor_row->strides());
+  EXPECT_EQ(shape, tensor_row->shape());
 
   auto batch_no_columns =
       RecordBatch::Make(::arrow::schema({}), 10, std::vector<std::shared_ptr<Array>>{});

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -803,7 +803,8 @@ TEST_F(TestRecordBatch, ToTensorSupportedNullToNan) {
   auto a4 = ArrayFromJSON(int8(), "[10, 20, 30, 40, null, 60, 70, 80, 90]");
   auto batch2 = RecordBatch::Make(schema2, length, {a3, a4});
 
-  ASSERT_OK_AND_ASSIGN(auto tensor2, batch2->ToTensor(/*null_to_nan=*/true, /*row_major=*/false));
+  ASSERT_OK_AND_ASSIGN(auto tensor2,
+                       batch2->ToTensor(/*null_to_nan=*/true, /*row_major=*/false));
   ASSERT_OK(tensor2->Validate());
 
   const int64_t f32_size = sizeof(float);

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -984,7 +984,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CRecordBatch] Slice(int64_t offset)
         shared_ptr[CRecordBatch] Slice(int64_t offset, int64_t length)
 
-        CResult[shared_ptr[CTensor]] ToTensor(c_bool null_to_nan, CMemoryPool* pool) const
+        CResult[shared_ptr[CTensor]] ToTensor(c_bool null_to_nan, c_bool row_major,
+                                              CMemoryPool* pool) const
 
     cdef cppclass CRecordBatchWithMetadata" arrow::RecordBatchWithMetadata":
         shared_ptr[CRecordBatch] batch

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3394,10 +3394,13 @@ cdef class RecordBatch(_Tabular):
         Convert to a :class:`~pyarrow.Tensor`.
 
         RecordBatches that can be converted have fields of type signed or unsigned
-        integer or float, including all bit-widths. RecordBatches with validity bitmask
-        for any of the arrays can be converted with ``null_to_nan``turned to ``True``.
-        In this case null values are converted to NaN and signed or unsigned integer
-        type arrays are promoted to appropriate float type.
+        integer or float, including all bit-widths.
+
+        ``null_to_nan`` is ``False`` by default and will raise an error in case
+        validity bitmask exists. RecordBatches with validity bitmask for any of the
+        arrays can be converted with ``null_to_nan`` turned to ``True``. In this case
+        null values are converted to ``NaN`` and signed or unsigned integer type arrays
+        are promoted to appropriate float type.
 
         Parameters
         ----------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3398,7 +3398,7 @@ cdef class RecordBatch(_Tabular):
 
         ``null_to_nan`` is ``False`` by default and this method will raise an error in case
         any nulls are present. RecordBatches with nulls
-        arrays can be converted with ``null_to_nan`` set to ``True``. In this case
+        can be converted with ``null_to_nan`` set to ``True``. In this case
         null values are converted to ``NaN`` and integer type arrays
         are promoted to the appropriate float type.
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3396,11 +3396,11 @@ cdef class RecordBatch(_Tabular):
         RecordBatches that can be converted have fields of type signed or unsigned
         integer or float, including all bit-widths.
 
-        ``null_to_nan`` is ``False`` by default and will raise an error in case
-        validity bitmask exists. RecordBatches with validity bitmask for any of the
-        arrays can be converted with ``null_to_nan`` turned to ``True``. In this case
-        null values are converted to ``NaN`` and signed or unsigned integer type arrays
-        are promoted to appropriate float type.
+        ``null_to_nan`` is ``False`` by default and this method will raise an error in case
+        any nulls are present. RecordBatches with nulls
+        arrays can be converted with ``null_to_nan`` set to ``True``. In this case
+        null values are converted to ``NaN`` and integer type arrays
+        are promoted to the appropriate float type.
 
         Parameters
         ----------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3397,10 +3397,9 @@ cdef class RecordBatch(_Tabular):
         integer or float, including all bit-widths.
 
         ``null_to_nan`` is ``False`` by default and this method will raise an error in case
-        any nulls are present. RecordBatches with nulls
-        can be converted with ``null_to_nan`` set to ``True``. In this case
-        null values are converted to ``NaN`` and integer type arrays
-        are promoted to the appropriate float type.
+        any nulls are present. RecordBatches with nulls can be converted with ``null_to_nan``
+        set to ``True``. In this case null values are converted to ``NaN`` and integer type
+        arrays are promoted to the appropriate float type.
 
         Parameters
         ----------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -3434,7 +3434,6 @@ cdef class RecordBatch(_Tabular):
         type: double
         shape: (5, 2)
         strides: (16, 8)
-
         >>> batch.to_tensor(null_to_nan=True).to_numpy()
         array([[ 1., 10.],
                [ 2., 20.],
@@ -3451,10 +3450,10 @@ cdef class RecordBatch(_Tabular):
         strides: (8, 40)
         >>> batch.to_tensor(null_to_nan=True, row_major=False).to_numpy()
         array([[ 1., 10.],
-            [ 2., 20.],
-            [ 3., 30.],
-            [ 4., 40.],
-            [nan, nan]])
+               [ 2., 20.],
+               [ 3., 30.],
+               [ 4., 40.],
+               [nan, nan]])
         """
         cdef:
             shared_ptr[CRecordBatch] c_record_batch

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -928,12 +928,12 @@ def test_recordbatch_to_tensor_uniform_type(typ):
     )
 
     result = batch.to_tensor(row_major=False)
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order=F")
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
     result = batch.to_tensor()
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order=C")
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
@@ -944,12 +944,12 @@ def test_recordbatch_to_tensor_uniform_type(typ):
     arr3 = [100, 100, 100, 100, 100, 100, 100, 100]
 
     result = batch1.to_tensor(row_major=False)
-    x = np.array([arr1, arr2, arr3], typ).transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
     result = batch1.to_tensor()
-    x = np.array([arr1, arr2, arr3], typ, order='F').transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
@@ -959,12 +959,12 @@ def test_recordbatch_to_tensor_uniform_type(typ):
     arr3 = [100, 100, 100, 100, 100]
 
     result = batch2.to_tensor(row_major=False)
-    x = np.array([arr1, arr2, arr3], typ).transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
     result = batch2.to_tensor()
-    x = np.array([arr1, arr2, arr3], typ, order='F').transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
@@ -982,12 +982,12 @@ def test_recordbatch_to_tensor_uniform_float_16():
     )
 
     result = batch.to_tensor(row_major=False)
-    x = np.array([arr1, arr2, arr3], np.float16).transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(np.float16, order="F")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.float16(), 27)
 
     result = batch.to_tensor()
-    x = np.array([arr1, arr2, arr3], np.float16, order='F').transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(np.float16, order="C")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.float16(), 27)
 
@@ -1005,12 +1005,12 @@ def test_recordbatch_to_tensor_mixed_type():
     )
 
     result = batch.to_tensor(row_major=False)
-    x = np.array([arr1, arr2], np.int32).transpose()
+    x = np.column_stack([arr1, arr2]).astype(np.int32, order="F")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.int32(), 18)
 
     result = batch.to_tensor()
-    x = np.array([arr1, arr2], np.int32, order='F').transpose()
+    x = np.column_stack([arr1, arr2]).astype(np.int32, order="C")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.int32(), 18)
 
@@ -1023,8 +1023,7 @@ def test_recordbatch_to_tensor_mixed_type():
         ], ["a", "b", "c"]
     )
     result = batch.to_tensor(row_major=False)
-
-    x = np.array([arr1, arr2, arr3], np.float64).transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(np.float64, order="F")
     expected = pa.Tensor.from_numpy(x)
 
     np.testing.assert_equal(result.to_numpy(), x)
@@ -1034,8 +1033,7 @@ def test_recordbatch_to_tensor_mixed_type():
     assert result.strides == expected.strides
 
     result = batch.to_tensor()
-
-    x = np.array([arr1, arr2, arr3], order='F').transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(np.float64, order="C")
     expected = pa.Tensor.from_numpy(x)
 
     np.testing.assert_equal(result.to_numpy(), x)
@@ -1074,8 +1072,7 @@ def test_recordbatch_to_tensor_nan():
         ], ["a", "b"]
     )
     result = batch.to_tensor(row_major=False)
-
-    x = np.array([arr1, arr2], np.float32).transpose()
+    x = np.column_stack([arr1, arr2]).astype(np.float32, order="F")
     expected = pa.Tensor.from_numpy(x)
 
     np.testing.assert_equal(result.to_numpy(), x)
@@ -1101,8 +1098,7 @@ def test_recordbatch_to_tensor_null():
         batch.to_tensor()
 
     result = batch.to_tensor(null_to_nan=True, row_major=False)
-
-    x = np.array([arr1, arr2], np.float64).transpose()
+    x = np.column_stack([arr1, arr2]).astype(np.float64, order="F")
     expected = pa.Tensor.from_numpy(x)
 
     np.testing.assert_equal(result.to_numpy(), x)
@@ -1136,8 +1132,7 @@ def test_recordbatch_to_tensor_null():
     )
 
     result = batch.to_tensor(null_to_nan=True, row_major=False)
-
-    x = np.array([arr1, arr2], np.float32).transpose()
+    x = np.column_stack([arr1, arr2]).astype(np.float32, order="F")
     expected = pa.Tensor.from_numpy(x)
 
     np.testing.assert_equal(result.to_numpy(), x)
@@ -1156,7 +1151,7 @@ def test_recordbatch_to_tensor_empty():
     )
     result = batch.to_tensor()
 
-    x = np.array([[], []], np.float32).transpose()
+    x = np.column_stack([[], []]).astype(np.float32, order="F")
     expected = pa.Tensor.from_numpy(x)
 
     assert result.size == expected.size

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -926,36 +926,46 @@ def test_recordbatch_to_tensor_uniform_type(typ):
             pa.array(arr3, type=pa.from_numpy_dtype(typ)),
         ], ["a", "b", "c"]
     )
-    result = batch.to_tensor()
 
+    result = batch.to_tensor(row_major=False)
     x = np.array([arr1, arr2, arr3], typ).transpose()
     expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
+    result = batch.to_tensor()
+    x = np.array([arr1, arr2, arr3], typ, order='F').transpose()
+    expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
     # Test offset
     batch1 = batch.slice(1)
-    result = batch1.to_tensor()
-
     arr1 = [2, 3, 4, 5, 6, 7, 8, 9]
     arr2 = [20, 30, 40, 50, 60, 70, 80, 90]
     arr3 = [100, 100, 100, 100, 100, 100, 100, 100]
 
+    result = batch1.to_tensor(row_major=False)
     x = np.array([arr1, arr2, arr3], typ).transpose()
     expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
+    result = batch1.to_tensor()
+    x = np.array([arr1, arr2, arr3], typ, order='F').transpose()
+    expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
     batch2 = batch.slice(1, 5)
-    result = batch2.to_tensor()
-
     arr1 = [2, 3, 4, 5, 6]
     arr2 = [20, 30, 40, 50, 60]
     arr3 = [100, 100, 100, 100, 100]
 
+    result = batch2.to_tensor(row_major=False)
     x = np.array([arr1, arr2, arr3], typ).transpose()
     expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
+    result = batch2.to_tensor()
+    x = np.array([arr1, arr2, arr3], typ, order='F').transpose()
+    expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
 
@@ -970,11 +980,15 @@ def test_recordbatch_to_tensor_uniform_float_16():
             pa.array(np.array(arr3, dtype=np.float16), type=pa.float16()),
         ], ["a", "b", "c"]
     )
-    result = batch.to_tensor()
 
+    result = batch.to_tensor(row_major=False)
     x = np.array([arr1, arr2, arr3], np.float16).transpose()
     expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.float16(), 27)
 
+    result = batch.to_tensor()
+    x = np.array([arr1, arr2, arr3], np.float16, order='F').transpose()
+    expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.float16(), 27)
 
 
@@ -989,11 +1003,15 @@ def test_recordbatch_to_tensor_mixed_type():
             pa.array(arr2, type=pa.int16()),
         ], ["a", "b"]
     )
-    result = batch.to_tensor()
 
+    result = batch.to_tensor(row_major=False)
     x = np.array([arr1, arr2], np.int32).transpose()
     expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.int32(), 18)
 
+    result = batch.to_tensor()
+    x = np.array([arr1, arr2], np.int32, order='F').transpose()
+    expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.int32(), 18)
 
     # uint16 + int16 + float32 = float64
@@ -1004,9 +1022,20 @@ def test_recordbatch_to_tensor_mixed_type():
             pa.array(arr3, type=pa.float32()),
         ], ["a", "b", "c"]
     )
-    result = batch.to_tensor()
+    result = batch.to_tensor(row_major=False)
 
     x = np.array([arr1, arr2, arr3], np.float64).transpose()
+    expected = pa.Tensor.from_numpy(x)
+
+    np.testing.assert_equal(result.to_numpy(), x)
+    assert result.size == 27
+    assert result.type == pa.float64()
+    assert result.shape == expected.shape
+    assert result.strides == expected.strides
+
+    result = batch.to_tensor()
+
+    x = np.array([arr1, arr2, arr3], order='F').transpose()
     expected = pa.Tensor.from_numpy(x)
 
     np.testing.assert_equal(result.to_numpy(), x)
@@ -1044,7 +1073,7 @@ def test_recordbatch_to_tensor_nan():
             pa.array(arr2, type=pa.float32()),
         ], ["a", "b"]
     )
-    result = batch.to_tensor()
+    result = batch.to_tensor(row_major=False)
 
     x = np.array([arr1, arr2], np.float32).transpose()
     expected = pa.Tensor.from_numpy(x)
@@ -1071,7 +1100,7 @@ def test_recordbatch_to_tensor_null():
     ):
         batch.to_tensor()
 
-    result = batch.to_tensor(null_to_nan=True)
+    result = batch.to_tensor(null_to_nan=True, row_major=False)
 
     x = np.array([arr1, arr2], np.float64).transpose()
     expected = pa.Tensor.from_numpy(x)
@@ -1090,7 +1119,7 @@ def test_recordbatch_to_tensor_null():
         ], ["a", "b"]
     )
 
-    result = batch.to_tensor(null_to_nan=True)
+    result = batch.to_tensor(null_to_nan=True, row_major=False)
 
     np.testing.assert_equal(result.to_numpy(), x)
     assert result.size == 18
@@ -1125,7 +1154,7 @@ def test_recordbatch_to_tensor_empty():
             pa.array([], type=pa.float32()),
         ], ["a", "b"]
     )
-    result = batch.to_tensor()
+    result = batch.to_tensor(row_major=False)
 
     x = np.array([[], []], np.float32).transpose()
     expected = pa.Tensor.from_numpy(x)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1156,7 +1156,7 @@ def test_recordbatch_to_tensor_empty():
     )
     result = batch.to_tensor()
 
-    x = np.array([[], []], np.float32)
+    x = np.array([[], []], np.float32).transpose()
     expected = pa.Tensor.from_numpy(x)
 
     assert result.size == expected.size

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1154,9 +1154,9 @@ def test_recordbatch_to_tensor_empty():
             pa.array([], type=pa.float32()),
         ], ["a", "b"]
     )
-    result = batch.to_tensor(row_major=False)
+    result = batch.to_tensor()
 
-    x = np.array([[], []], np.float32).transpose()
+    x = np.array([[], []], np.float32)
     expected = pa.Tensor.from_numpy(x)
 
     assert result.size == expected.size

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1135,7 +1135,7 @@ def test_recordbatch_to_tensor_null():
         ], ["a", "b"]
     )
 
-    result = batch.to_tensor(null_to_nan=True)
+    result = batch.to_tensor(null_to_nan=True, row_major=False)
 
     x = np.array([arr1, arr2], np.float32).transpose()
     expected = pa.Tensor.from_numpy(x)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -928,12 +928,12 @@ def test_recordbatch_to_tensor_uniform_type(typ):
     )
 
     result = batch.to_tensor(row_major=False)
-    x = np.array([arr1, arr2, arr3], typ).transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order=F")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
     result = batch.to_tensor()
-    x = np.array([arr1, arr2, arr3], typ, order='F').transpose()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order=C")
     expected = pa.Tensor.from_numpy(x)
     check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 


### PR DESCRIPTION
### Rationale for this change

The conversion from `RecordBatch` to `Tensor` class now exists but it doesn't support row-major `Tensor` as an output. This PR adds support for an option to construct row-major `Tensor`.

### What changes are included in this PR?

This PR adds a `row_major` option in `RecordBatch::ToTensor` so that row-major `Tensor` can be constructed. The default conversion will be row-major. This for example works:

```python
>>> import pyarrow as pa
>>> import numpy as np

>>> arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
>>> arr2 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
>>> batch = pa.RecordBatch.from_arrays(
...     [
...         pa.array(arr1, type=pa.uint16()),
...         pa.array(arr2, type=pa.int16()),
... 
...     ], ["a", "b"]
... )

# Row-major

>>> batch.to_tensor()
<pyarrow.Tensor>
type: int32
shape: (9, 2)
strides: (8, 4)

>>> batch.to_tensor().to_numpy().flags
  C_CONTIGUOUS : True
  F_CONTIGUOUS : False
  OWNDATA : False
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False

# Column-major

>>> batch.to_tensor(row_major=False)
<pyarrow.Tensor>
type: int32
shape: (9, 2)
strides: (4, 36)

>>> batch.to_tensor(row_major=False).to_numpy().flags
  C_CONTIGUOUS : False
  F_CONTIGUOUS : True
  OWNDATA : False
  WRITEABLE : True
  ALIGNED : True
  WRITEBACKIFCOPY : False
```

### Are these changes tested?

Yes, in C++ and Python.

### Are there any user-facing changes?

No.
* GitHub Issue: #40866