### PR TITLE
GH-40870: [C#] Update CompareValidityBuffer() to pass when unspecified final bits are not identical

### DIFF
--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -445,8 +445,8 @@ namespace Apache.Arrow.Tests
 
                     // Compare the last byte bitwise (because there is no guarantee about the value of
                     // bits outside the range [0, arrayLength])
-                    ReadOnlySpan<byte> expectedSpanFull = expectedValidityBuffer.Span.Slice(0, validityBitmapByteCount - 1);
-                    ReadOnlySpan<byte> actualSpanFull = actualValidityBuffer.Span.Slice(0, validityBitmapByteCount - 1);
+                    ReadOnlySpan<byte> expectedSpanFull = expectedValidityBuffer.Span.Slice(0, validityBitmapByteCount);
+                    ReadOnlySpan<byte> actualSpanFull = actualValidityBuffer.Span.Slice(0, validityBitmapByteCount);
                     for (int i = 8 * (validityBitmapByteCount - 1); i < arrayLength; i++)
                     {
                         Assert.True(

--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -432,12 +432,25 @@ namespace Apache.Arrow.Tests
                 {
                     Assert.True(expectedValidityBuffer.Span.SequenceEqual(actualValidityBuffer.Span));
                 }
-                else if (nullCount != 0)
+                else if (nullCount != 0 && arrayLength > 0)
                 {
                     int validityBitmapByteCount = BitUtility.ByteCount(arrayLength);
+                    ReadOnlySpan<byte> expectedSpan = expectedValidityBuffer.Span.Slice(0, validityBitmapByteCount);
+                    ReadOnlySpan<byte> actualSpan = actualValidityBuffer.Span.Slice(0, validityBitmapByteCount);
+
+                    // Compare the first validityBitmapByteCount - 1 bytes
                     Assert.True(
-                        expectedValidityBuffer.Span.Slice(0, validityBitmapByteCount).SequenceEqual(actualValidityBuffer.Span.Slice(0, validityBitmapByteCount)),
-                        "Validity buffers do not match.");
+                        expectedSpan.SequenceEqual(actualSpan),
+                        string.Format("First {0} bytes of validity buffer do not match", validityBitmapByteCount - 1));
+
+                    // Compare the last byte bitwise (because there is no guarantee about the value of
+                    // bits outside the range [0, arrayLength])
+                    for (int i = 8 * (validityBitmapByteCount - 1); i < arrayLength; i++)
+                    {
+                        Assert.True(
+                            BitUtility.GetBit(expectedSpan, i) == BitUtility.GetBit(actualSpan, i),
+                            string.Format("Bit at index {0}/{1} is not equal", i, arrayLength));
+                    }
                 }
             }
         }

--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -435,20 +435,22 @@ namespace Apache.Arrow.Tests
                 else if (nullCount != 0 && arrayLength > 0)
                 {
                     int validityBitmapByteCount = BitUtility.ByteCount(arrayLength);
-                    ReadOnlySpan<byte> expectedSpan = expectedValidityBuffer.Span.Slice(0, validityBitmapByteCount);
-                    ReadOnlySpan<byte> actualSpan = actualValidityBuffer.Span.Slice(0, validityBitmapByteCount);
+                    ReadOnlySpan<byte> expectedSpanPartial = expectedValidityBuffer.Span.Slice(0, validityBitmapByteCount - 1);
+                    ReadOnlySpan<byte> actualSpanPartial = actualValidityBuffer.Span.Slice(0, validityBitmapByteCount - 1);
 
                     // Compare the first validityBitmapByteCount - 1 bytes
                     Assert.True(
-                        expectedSpan.SequenceEqual(actualSpan),
+                        expectedSpanPartial.SequenceEqual(actualSpanPartial),
                         string.Format("First {0} bytes of validity buffer do not match", validityBitmapByteCount - 1));
 
                     // Compare the last byte bitwise (because there is no guarantee about the value of
                     // bits outside the range [0, arrayLength])
+                    ReadOnlySpan<byte> expectedSpanFull = expectedValidityBuffer.Span.Slice(0, validityBitmapByteCount - 1);
+                    ReadOnlySpan<byte> actualSpanFull = actualValidityBuffer.Span.Slice(0, validityBitmapByteCount - 1);
                     for (int i = 8 * (validityBitmapByteCount - 1); i < arrayLength; i++)
                     {
                         Assert.True(
-                            BitUtility.GetBit(expectedSpan, i) == BitUtility.GetBit(actualSpan, i),
+                            BitUtility.GetBit(expectedSpanFull, i) == BitUtility.GetBit(actualSpanFull, i),
                             string.Format("Bit at index {0}/{1} is not equal", i, arrayLength));
                     }
                 }


### PR DESCRIPTION

### Rationale for this change

Before fixing nanoarrow's testing JSON reader to align with other implementations and properly zero out the last few bits, integration tests failed because C#'s `CompareValidityBuffer()` was comparing the bytes of the validity buffer (including undefined final bits that are maybe not identical due to uninitialized memory or because the arrays are slices).

### What changes are included in this PR?

`CompareValidityBuffer()` now compares the memory for all except the last byte and compares the last byte bitwise.

### Are these changes tested?

They should be but I am not sure exactly where to add the test!

### Are there any user-facing changes?

No
* GitHub Issue: #40870