### PR TITLE
GH-40882: [C++] Suppress shorten-64-to-32 warnings in CUDA/Skyhook codes

### DIFF
--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -494,7 +494,8 @@ Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType devic
     case ARROW_DEVICE_CUDA:
     case ARROW_DEVICE_CUDA_HOST:
     case ARROW_DEVICE_CUDA_MANAGED: {
-      ARROW_ASSIGN_OR_RAISE(auto device, arrow::cuda::CudaDevice::Make(device_id));
+      ARROW_ASSIGN_OR_RAISE(auto device,
+                            arrow::cuda::CudaDevice::Make(static_cast<int>(device_id)));
       return device->default_memory_manager();
     }
     default:
@@ -505,7 +506,8 @@ Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType devic
 namespace {
 
 Result<std::shared_ptr<MemoryManager>> DefaultCUDADeviceMapper(int64_t device_id) {
-  ARROW_ASSIGN_OR_RAISE(auto device, arrow::cuda::CudaDevice::Make(device_id));
+  ARROW_ASSIGN_OR_RAISE(auto device,
+                        arrow::cuda::CudaDevice::Make(static_cast<int>(device_id)));
   return device->default_memory_manager();
 }
 

--- a/cpp/src/skyhook/cls/cls_skyhook.cc
+++ b/cpp/src/skyhook/cls/cls_skyhook.cc
@@ -84,7 +84,7 @@ class RandomAccessObject : public arrow::io::RandomAccessFile {
 
     if (nbytes > 0) {
       std::shared_ptr<ceph::bufferlist> bl = std::make_shared<ceph::bufferlist>();
-      cls_cxx_read(hctx_, position, nbytes, bl.get());
+      cls_cxx_read(hctx_, static_cast<int>(position), static_cast<int>(nbytes), bl.get());
       chunks_.push_back(bl);
       return std::make_shared<arrow::Buffer>((uint8_t*)bl->c_str(), bl->length());
     }

--- a/cpp/src/skyhook/protocol/skyhook_protocol.cc
+++ b/cpp/src/skyhook/protocol/skyhook_protocol.cc
@@ -106,7 +106,8 @@ arrow::Status SerializeTable(const std::shared_ptr<arrow::Table>& table,
   ARROW_RETURN_NOT_OK(writer->Close());
 
   ARROW_ASSIGN_OR_RAISE(auto buffer, buffer_output_stream->Finish());
-  bl->append(reinterpret_cast<const char*>(buffer->data()), buffer->size());
+  bl->append(reinterpret_cast<const char*>(buffer->data()),
+             static_cast<unsigned int>(buffer->size()));
   return arrow::Status::OK();
 }
 


### PR DESCRIPTION
### Rationale for this change

```text
cpp/src/arrow/gpu/cuda_memory.cc:497:72: error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
      ARROW_ASSIGN_OR_RAISE(auto device, arrow::cuda::CudaDevice::Make(device_id));
                                         ~~~~~                         ^~~~~~~~~
```

```text
cpp/src/arrow/gpu/cuda_memory.cc:508:68: error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
  ARROW_ASSIGN_OR_RAISE(auto device, arrow::cuda::CudaDevice::Make(device_id));
                                     ~~~~~                         ^~~~~~~~~
```

```text
cpp/src/skyhook/protocol/skyhook_protocol.cc:109:69: error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'unsigned int' [-Werror,-Wshorten-64-to-32]
  bl->append(reinterpret_cast<const char*>(buffer->data()), buffer->size());
      ~~~~~~                                                ~~~~~~~~^~~~~~
```

```text
cpp/src/skyhook/cls/cls_skyhook.cc:87:37: error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
      cls_cxx_read(hctx_, position, nbytes, bl.get());
      ~~~~~~~~~~~~                  ^~~~~~
cpp/src/skyhook/cls/cls_skyhook.cc:87:27: error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
      cls_cxx_read(hctx_, position, nbytes, bl.get());
      ~~~~~~~~~~~~        ^~~~~~~~
```

```text
cpp/src/skyhook/protocol/skyhook_protocol.cc:109:69: error: implicit conversion loses integer precision: 'int64_t' (aka 'long') to 'unsigned int' [-Werror,-Wshorten-64-to-32]
  bl->append(reinterpret_cast<const char*>(buffer->data()), buffer->size());
      ~~~~~~
```

### What changes are included in this PR?

Add casts explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #40882