### PR TITLE
GH-39664: [C++][Acero] Ensure Acero benchmarks present a metric for identifying throughput

### DIFF
--- a/cpp/src/arrow/acero/asof_join_benchmark.cc
+++ b/cpp/src/arrow/acero/asof_join_benchmark.cc
@@ -91,7 +91,7 @@ static void TableJoinOverhead(benchmark::State& state,
     ASSERT_OK(DeclarationToStatus(std::move(join_node), /*use_threads=*/false));
   }
 
-  state.counters["input_rows_per_second"] = benchmark::Counter(
+  state.counters["rows_per_second"] = benchmark::Counter(
       static_cast<double>(state.iterations() * (left_table_stats.rows + right_hand_rows)),
       benchmark::Counter::kIsRate);
 

--- a/cpp/src/arrow/acero/expression_benchmark.cc
+++ b/cpp/src/arrow/acero/expression_benchmark.cc
@@ -41,9 +41,6 @@ std::shared_ptr<Scalar> ninety_nine_dict =
     DictionaryScalar::Make(MakeScalar(0), ArrayFromJSON(int64(), "[99]"));
 
 static void BindAndEvaluate(benchmark::State& state, Expression expr) {
-  const auto rows_per_batch = static_cast<int32_t>(state.range(0));
-  const auto num_batches = 1000000 / rows_per_batch;
-
   ExecContext ctx;
   auto struct_type = struct_({
       field("int", int64()),
@@ -69,34 +66,17 @@ static void BindAndEvaluate(benchmark::State& state, Expression expr) {
     ASSIGN_OR_ABORT(auto bound, expr.Bind(*dataset_schema));
     ABORT_NOT_OK(ExecuteScalarExpression(bound, input, &ctx).status());
   }
-
-  state.counters["rows_per_second"] = benchmark::Counter(
-      static_cast<double>(state.iterations() * num_batches * rows_per_batch),
-      benchmark::Counter::kIsRate);
-
-  state.counters["batches_per_second"] = benchmark::Counter(
-      static_cast<double>(state.iterations() * num_batches), benchmark::Counter::kIsRate);
 }
 
 // A benchmark of SimplifyWithGuarantee using expressions arising from partitioning.
 static void SimplifyFilterWithGuarantee(benchmark::State& state, Expression filter,
                                         Expression guarantee) {
-  const auto rows_per_batch = static_cast<int32_t>(state.range(0));
-  const auto num_batches = 1000000 / rows_per_batch;
-
   auto dataset_schema = schema({field("a", int64()), field("b", int64())});
   ASSIGN_OR_ABORT(filter, filter.Bind(*dataset_schema));
 
   for (auto _ : state) {
     ABORT_NOT_OK(SimplifyWithGuarantee(filter, guarantee));
   }
-
-  state.counters["rows_per_second"] = benchmark::Counter(
-      static_cast<double>(state.iterations() * num_batches * rows_per_batch),
-      benchmark::Counter::kIsRate);
-
-  state.counters["batches_per_second"] = benchmark::Counter(
-      static_cast<double>(state.iterations() * num_batches), benchmark::Counter::kIsRate);
 }
 
 static void ExecuteScalarExpressionOverhead(benchmark::State& state, Expression expr) {
@@ -183,103 +163,31 @@ auto ref_only_expression = field_ref("x");
 
 // Negative queries (partition expressions that fail the filter)
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee, negative_filter_simple_guarantee_simple,
-                  filter_simple_negative, guarantee)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  filter_simple_negative, guarantee);
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee, negative_filter_cast_guarantee_simple,
-                  filter_cast_negative, guarantee)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  filter_cast_negative, guarantee);
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee,
                   negative_filter_simple_guarantee_dictionary, filter_simple_negative,
-                  guarantee_dictionary)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  guarantee_dictionary);
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee, negative_filter_cast_guarantee_dictionary,
-                  filter_cast_negative, guarantee_dictionary)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  filter_cast_negative, guarantee_dictionary);
 // Positive queries (partition expressions that pass the filter)
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee, positive_filter_simple_guarantee_simple,
-                  filter_simple_positive, guarantee)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  filter_simple_positive, guarantee);
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee, positive_filter_cast_guarantee_simple,
-                  filter_cast_positive, guarantee)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  filter_cast_positive, guarantee);
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee,
                   positive_filter_simple_guarantee_dictionary, filter_simple_positive,
-                  guarantee_dictionary)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  guarantee_dictionary);
 BENCHMARK_CAPTURE(SimplifyFilterWithGuarantee, positive_filter_cast_guarantee_dictionary,
-                  filter_cast_positive, guarantee_dictionary)
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  filter_cast_positive, guarantee_dictionary);
 
-BENCHMARK_CAPTURE(BindAndEvaluate, simple_array, field_ref("int_arr"))
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
-BENCHMARK_CAPTURE(BindAndEvaluate, simple_scalar, field_ref("int_scalar"))
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+BENCHMARK_CAPTURE(BindAndEvaluate, simple_array, field_ref("int_arr"));
+BENCHMARK_CAPTURE(BindAndEvaluate, simple_scalar, field_ref("int_scalar"));
 BENCHMARK_CAPTURE(BindAndEvaluate, nested_array,
-                  field_ref(FieldRef("struct_arr", "float")))
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  field_ref(FieldRef("struct_arr", "float")));
 BENCHMARK_CAPTURE(BindAndEvaluate, nested_scalar,
-                  field_ref(FieldRef("struct_scalar", "float")))
-    ->ArgNames({"rows_per_batch"})
-    ->RangeMultiplier(10)
-    ->Range(1000, 1000000)
-    ->DenseThreadRange(1, std::thread::hardware_concurrency(),
-                       std::thread::hardware_concurrency())
-    ->UseRealTime();
+                  field_ref(FieldRef("struct_scalar", "float")));
 
 /// \brief Baseline benchmark for complex_expression implemented without arrow
 struct ComplexExpressionBaseline {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Acero benchmarks sometimes output metrics such as `items/s`, `bytes/s`, `batches/s`, and `rows/s`. However, there is inconsistency in how these metrics are presented across different benchmarks. We are undertaking an effort to standardize the output of these metrics to ensure uniformity and clarity in performance measurement across all Acero benchmarks. 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

`rows/s` has a similar meaning to `items/s`.

- `bytes/s` and `items/s`: aggregate
- `bytes/s` and `rows/s`: asof_join
- `batches/s` and `rows/s`: project, filter, expression

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #39664