### PR TITLE
GH-40888: [Go][FlightRPC] support conversion from array.Duration in FlightSQL driver

### DIFF
--- a/go/arrow/flight/flightsql/driver/utils.go
+++ b/go/arrow/flight/flightsql/driver/utils.go
@@ -104,6 +104,8 @@ func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
 		return v.ToTime(ts.TimeUnit()), nil
 	case *array.Date64:
 		return c.Value(idx).ToTime(), nil
+	case *array.Duration:
+		return c.Value(idx), nil
 	case *array.DayTimeInterval:
 		durationDays := time.Duration(c.Value(idx).Days*24) * time.Hour
 		duration := time.Duration(c.Value(idx).Milliseconds) * time.Millisecond

--- a/go/arrow/flight/flightsql/driver/utils.go
+++ b/go/arrow/flight/flightsql/driver/utils.go
@@ -105,7 +105,12 @@ func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
 	case *array.Date64:
 		return c.Value(idx).ToTime(), nil
 	case *array.Duration:
-		return c.Value(idx), nil
+    // according to
+    // https://github.com/apache/arrow/blob/50ca7a76d38e6ecf19589bc44f46bffd1db0d4c8/format/Schema.fbs#L420-L435
+    // the default "TimeUnit" for an arrow.Duration is in microseconds but
+    // golang Durations are int64 nanoseconds
+		duration := time.Duration(int64(c.Value(idx) * 1000))
+		return duration, nil
 	case *array.DayTimeInterval:
 		durationDays := time.Duration(c.Value(idx).Days*24) * time.Hour
 		duration := time.Duration(c.Value(idx).Milliseconds) * time.Millisecond

--- a/go/arrow/flight/flightsql/driver/utils.go
+++ b/go/arrow/flight/flightsql/driver/utils.go
@@ -105,11 +105,8 @@ func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
 	case *array.Date64:
 		return c.Value(idx).ToTime(), nil
 	case *array.Duration:
-    // according to
-    // https://github.com/apache/arrow/blob/50ca7a76d38e6ecf19589bc44f46bffd1db0d4c8/format/Schema.fbs#L420-L435
-    // the default "TimeUnit" for an arrow.Duration is in microseconds but
-    // golang Durations are int64 nanoseconds
-		duration := time.Duration(int64(c.Value(idx) * 1000))
+		dt := arr.DataType().(*arrow.DurationType)
+		duration := time.Duration(c.Value(idx)) * dt.Unit.Multiplier()
 		return duration, nil
 	case *array.DayTimeInterval:
 		durationDays := time.Duration(c.Value(idx).Days*24) * time.Hour

--- a/go/arrow/flight/flightsql/driver/utils_test.go
+++ b/go/arrow/flight/flightsql/driver/utils_test.go
@@ -131,8 +131,8 @@ func Test_fromArrowType(t *testing.T) {
 	tf(t, 14, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))  // "f15-ts_us"
 	tf(t, 15, testTime.In(time.UTC).Truncate(24*time.Hour))  // "f16-d64"
 	tf(t, 16, time.Duration(24*time.Hour+time.Second))       // "f17-dti"
-	tf(t, 17, time.Duration(1000000000))                     // "f17-duration_s"
-	tf(t, 18, time.Duration(1000000))                        // "f17-duration_ms"
-	tf(t, 19, time.Duration(1000))                           // "f17-duration_us"
-	tf(t, 20, time.Duration(1))                              // "f17-duration_ns"
+	tf(t, 17, time.Duration(1000000000))                     // "f18-duration_s"
+	tf(t, 18, time.Duration(1000000))                        // "f19-duration_ms"
+	tf(t, 19, time.Duration(1000))                           // "f20-duration_us"
+	tf(t, 20, time.Duration(1))                              // "f21-duration_ns"
 }

--- a/go/arrow/flight/flightsql/driver/utils_test.go
+++ b/go/arrow/flight/flightsql/driver/utils_test.go
@@ -50,7 +50,10 @@ func Test_fromArrowType(t *testing.T) {
 		{Name: "f15-ts_us", Type: arrow.FixedWidthTypes.Timestamp_ns},
 		{Name: "f16-d64", Type: arrow.FixedWidthTypes.Date64},
 		{Name: "f17-dti", Type: arrow.FixedWidthTypes.DayTimeInterval},
-		{Name: "f17-duration", Type: arrow.FixedWidthTypes.Duration_us},
+		{Name: "f18-duration_s", Type: arrow.FixedWidthTypes.Duration_s},
+		{Name: "f19-duration_ms", Type: arrow.FixedWidthTypes.Duration_ms},
+		{Name: "f20-duration_us", Type: arrow.FixedWidthTypes.Duration_us},
+		{Name: "f21-duration_ns", Type: arrow.FixedWidthTypes.Duration_ns},
 	}
 
 	schema := arrow.NewSchema(fields, nil)
@@ -92,6 +95,9 @@ func Test_fromArrowType(t *testing.T) {
 	b.Field(15).(*array.Date64Builder).Append(arrow.Date64FromTime(testTime))
 	b.Field(16).(*array.DayTimeIntervalBuilder).Append(arrow.DayTimeInterval{Days: 1, Milliseconds: 1000})
 	b.Field(17).(*array.DurationBuilder).Append(1)
+	b.Field(18).(*array.DurationBuilder).Append(1)
+	b.Field(19).(*array.DurationBuilder).Append(1)
+	b.Field(20).(*array.DurationBuilder).Append(1)
 
 	rec := b.NewRecord()
 	defer rec.Release()
@@ -125,10 +131,8 @@ func Test_fromArrowType(t *testing.T) {
 	tf(t, 14, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))  // "f15-ts_us"
 	tf(t, 15, testTime.In(time.UTC).Truncate(24*time.Hour))  // "f16-d64"
 	tf(t, 16, time.Duration(24*time.Hour+time.Second))       // "f17-dti"
-	// according to
-	// https://github.com/apache/arrow/blob/50ca7a76d38e6ecf19589bc44f46bffd1db0d4c8/format/Schema.fbs#L420-L435
-	// the default "TimeUnit" for an arrow.Duration is in microseconds but golang
-	// Durations are int64 nanoseconds so we verify here that the
-	// array.Duration(1) we create above shows up as a 1000 nanoseconds
-	tf(t, 17, time.Duration(1000)) // "f18-duration_ms"
+	tf(t, 17, time.Duration(1000000000))                     // "f17-duration_s"
+	tf(t, 18, time.Duration(1000000))                        // "f17-duration_ms"
+	tf(t, 19, time.Duration(1000))                           // "f17-duration_us"
+	tf(t, 20, time.Duration(1))                              // "f17-duration_ns"
 }

--- a/go/arrow/flight/flightsql/driver/utils_test.go
+++ b/go/arrow/flight/flightsql/driver/utils_test.go
@@ -50,6 +50,7 @@ func Test_fromArrowType(t *testing.T) {
 		{Name: "f15-ts_us", Type: arrow.FixedWidthTypes.Timestamp_ns},
 		{Name: "f16-d64", Type: arrow.FixedWidthTypes.Date64},
 		{Name: "f17-dti", Type: arrow.FixedWidthTypes.DayTimeInterval},
+		{Name: "f17-duration", Type: arrow.FixedWidthTypes.Duration_ms},
 	}
 
 	schema := arrow.NewSchema(fields, nil)
@@ -90,6 +91,7 @@ func Test_fromArrowType(t *testing.T) {
 	testTime := time.Now()
 	b.Field(15).(*array.Date64Builder).Append(arrow.Date64FromTime(testTime))
 	b.Field(16).(*array.DayTimeIntervalBuilder).Append(arrow.DayTimeInterval{Days: 1, Milliseconds: 1000})
+	b.Field(17).(*array.DurationBuilder).Append(1)
 
 	rec := b.NewRecord()
 	defer rec.Release()
@@ -123,4 +125,10 @@ func Test_fromArrowType(t *testing.T) {
 	tf(t, 14, time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC))  // "f15-ts_us"
 	tf(t, 15, testTime.In(time.UTC).Truncate(24*time.Hour))  // "f16-d64"
 	tf(t, 16, time.Duration(24*time.Hour+time.Second))       // "f17-dti"
+	// according to
+	// https://github.com/apache/arrow/blob/50ca7a76d38e6ecf19589bc44f46bffd1db0d4c8/format/Schema.fbs#L420-L435
+	// the default "TimeUnit" for an arrow.Duration is in microseconds but golang
+	// Durations are int64 nanoseconds so we verify here that the
+	// array.Duration(1) we create above shows up as a 1000 nanoseconds
+	tf(t, 17, time.Duration(1000)) // "f18-duration_ms"
 }

--- a/go/arrow/flight/flightsql/driver/utils_test.go
+++ b/go/arrow/flight/flightsql/driver/utils_test.go
@@ -50,7 +50,7 @@ func Test_fromArrowType(t *testing.T) {
 		{Name: "f15-ts_us", Type: arrow.FixedWidthTypes.Timestamp_ns},
 		{Name: "f16-d64", Type: arrow.FixedWidthTypes.Date64},
 		{Name: "f17-dti", Type: arrow.FixedWidthTypes.DayTimeInterval},
-		{Name: "f17-duration", Type: arrow.FixedWidthTypes.Duration_ms},
+		{Name: "f17-duration", Type: arrow.FixedWidthTypes.Duration_us},
 	}
 
 	schema := arrow.NewSchema(fields, nil)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To enable the use of the flightsql driver's implementation of golang sql interfaces.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

A new switch branch for handling `array.Duration`.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I manually tested and didn't add new unit tests because none of the other types handled in the same switch block are unit tested.

### Are there any user-facing changes?

Just a more complete set of types handled by the sql driver.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

* GitHub Issue: #40888