### PR TITLE
MINOR: [Java] Bump org.apache.hadoop dependencies from 3.3.6 to 3.4.0 in /java

### DIFF
--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-runtime</artifactId>
-            <version>3.4.0</version>
+            <version>${dep.hadoop.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -70,12 +70,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-api</artifactId>
-            <version>3.4.0</version>
+            <version>${dep.hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.4.0</version>
+            <version>${dep.hadoop.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-runtime</artifactId>
-            <version>3.3.6</version>
+            <version>3.4.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -70,12 +70,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-api</artifactId>
-            <version>3.3.6</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.3.6</version>
+            <version>3.4.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,7 +37,7 @@
     <dep.grpc-bom.version>1.61.1</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.17.0</dep.jackson-bom.version>
-    <dep.hadoop.version>3.3.6</dep.hadoop.version>
+    <dep.hadoop.version>3.4.0</dep.hadoop.version>
     <dep.fbs.version>23.5.26</dep.fbs.version>
     <dep.avro.version>1.11.3</dep.avro.version>
     <arrow.vector.classifier />


### PR DESCRIPTION
Updates the Hadoop version to 3.4.0 to address vulnerabilities identified in https://deps.dev/maven/org.apache.hadoop%3Ahadoop-common/3.3.6