### PR TITLE
GH-40893: [Java][FlightRPC] Support IntervalMonthDayNanoVector in FlightSQL JDBC Driver

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactory.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactory.java
@@ -51,6 +51,7 @@ import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.IntervalMonthDayNanoVector;
 import org.apache.arrow.vector.IntervalYearVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
 import org.apache.arrow.vector.LargeVarCharVector;
@@ -175,6 +176,9 @@ public class ArrowFlightJdbcAccessorFactory {
           setCursorWasNull);
     } else if (vector instanceof IntervalYearVector) {
       return new ArrowFlightJdbcIntervalVectorAccessor(((IntervalYearVector) vector), getCurrentRow,
+          setCursorWasNull);
+    } else if (vector instanceof IntervalMonthDayNanoVector) {
+      return new ArrowFlightJdbcIntervalVectorAccessor(((IntervalMonthDayNanoVector) vector), getCurrentRow,
           setCursorWasNull);
     } else if (vector instanceof StructVector) {
       return new ArrowFlightJdbcStructVectorAccessor((StructVector) vector, getCurrentRow,

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessor.java
@@ -30,8 +30,11 @@ import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.IntervalMonthDayNanoVector;
 import org.apache.arrow.vector.IntervalYearVector;
+import org.apache.arrow.vector.PeriodDuration;
 import org.apache.arrow.vector.holders.NullableIntervalDayHolder;
+import org.apache.arrow.vector.holders.NullableIntervalMonthDayNanoHolder;
 import org.apache.arrow.vector.holders.NullableIntervalYearHolder;
 
 /**
@@ -94,6 +97,35 @@ public class ArrowFlightJdbcIntervalVectorAccessor extends ArrowFlightJdbcAccess
       }
     };
     objectClass = java.time.Period.class;
+  }
+
+  /**
+   * Instantiate an accessor for a {@link IntervalMonthDayNanoVector}.
+   *
+   * @param vector             an instance of a IntervalMonthDayNanoVector.
+   * @param currentRowSupplier the supplier to track the rows.
+   * @param setCursorWasNull   the consumer to set if value was null.
+   */
+  public ArrowFlightJdbcIntervalVectorAccessor(IntervalMonthDayNanoVector vector,
+                                               IntSupplier currentRowSupplier,
+                                               ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+    super(currentRowSupplier, setCursorWasNull);
+    this.vector = vector;
+    stringGetter = (index) -> {
+      final NullableIntervalMonthDayNanoHolder holder = new NullableIntervalMonthDayNanoHolder();
+      vector.get(index, holder);
+      if (holder.isSet == 0) {
+        return null;
+      } else {
+        final int months = holder.months;
+        final int days = holder.days;
+        final long nanos = holder.nanoseconds;
+        final Period period = Period.ofMonths(months).plusDays(days);
+        final Duration duration = Duration.ofNanos(nanos);
+        return new PeriodDuration(period, duration).toString();
+      }
+    };
+    objectClass = PeriodDuration.class;
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessor.java
@@ -122,7 +122,7 @@ public class ArrowFlightJdbcIntervalVectorAccessor extends ArrowFlightJdbcAccess
         final long nanos = holder.nanoseconds;
         final Period period = Period.ofMonths(months).plusDays(days);
         final Duration duration = Duration.ofNanos(nanos);
-        return new PeriodDuration(period, duration).toString();
+        return new PeriodDuration(period, duration).toISO8601IntervalString();
       }
     };
     objectClass = PeriodDuration.class;

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactoryTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactoryTest.java
@@ -41,6 +41,7 @@ import org.apache.arrow.driver.jdbc.accessor.impl.text.ArrowFlightJdbcVarCharVec
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.DurationVector;
 import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.IntervalMonthDayNanoVector;
 import org.apache.arrow.vector.IntervalYearVector;
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.ValueVector;
@@ -395,6 +396,19 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   @Test
   public void createAccessorForIntervalYearVector() {
     try (ValueVector valueVector = new IntervalYearVector("",
+        rootAllocatorTestRule.getRootAllocator())) {
+      ArrowFlightJdbcAccessor accessor =
+          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
+              (boolean wasNull) -> {
+              });
+
+      Assert.assertTrue(accessor instanceof ArrowFlightJdbcIntervalVectorAccessor);
+    }
+  }
+
+  @Test
+  public void createAccessorForIntervalMonthDayNanoVector() {
+    try (ValueVector valueVector = new IntervalMonthDayNanoVector("",
         rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
           ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessorTest.java
@@ -154,16 +154,16 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
   }
 
   private String getStringOnVector(ValueVector vector, int index) {
-    String object = getExpectedObject(vector, index).toString();
+    Object object = getExpectedObject(vector, index);
     if (object == null) {
       return null;
     } else if (vector instanceof IntervalDayVector) {
-      return formatIntervalDay(Duration.parse(object));
+      return formatIntervalDay(Duration.parse(object.toString()));
     } else if (vector instanceof IntervalYearVector) {
-      return formatIntervalYear(Period.parse(object));
+      return formatIntervalYear(Period.parse(object.toString()));
     } else if (vector instanceof IntervalMonthDayNanoVector) {
-      // This is the inverse of PeriodDuration#toISO8601IntervalString
-      String[] periodAndDuration = object.split("T");
+      String iso8601IntervalString = ((PeriodDuration) object).toISO8601IntervalString();
+      String[] periodAndDuration = iso8601IntervalString.split("T");
       if (periodAndDuration.length == 1) {
         // If there is no 'T', then either Period or Duration is zero, and the other one will successfully parse it
         String periodOrDuration = periodAndDuration[0];
@@ -173,10 +173,10 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
           return new PeriodDuration(Period.ZERO, Duration.parse(periodOrDuration)).toISO8601IntervalString();
         }
       } else {
-        // If there is a 'T', both Period and Duration are non-zero, and we just need to prepend the 'P' to the duration
-        // for both to parse successfully
+        // If there is a 'T', both Period and Duration are non-zero, and we just need to prepend the 'PT' to the
+        // duration for both to parse successfully
         Period parse = Period.parse(periodAndDuration[0]);
-        Duration duration = Duration.parse("P" + periodAndDuration[1]);
+        Duration duration = Duration.parse("PT" + periodAndDuration[1]);
         return new PeriodDuration(parse, duration).toISO8601IntervalString();
       }
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/PeriodDuration.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/PeriodDuration.java
@@ -43,6 +43,24 @@ public class PeriodDuration {
     return duration;
   }
 
+  /**
+   * Format this PeriodDuration as an ISO-8601 interval.
+   *
+   * @return An ISO-8601 formatted string representing the interval.
+   */
+  public String toISO8601IntervalString() {
+    if (duration.isZero()) {
+      return period.toString();
+    }
+    String durationString = duration.toString();
+    if (period.isZero()) {
+      return durationString;
+    }
+
+    // Remove 'P' from duration string and concatenate to produce an ISO-8601 representation
+    return period + durationString.substring(1);
+  }
+
   @Override
   public String toString() {
     return period.toString() + " " + duration.toString();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
@@ -21,7 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Period;
+import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
@@ -68,5 +71,23 @@ public class TestPeriodDuration {
             new PeriodDuration(Period.ZERO, Duration.ofSeconds(-86461).withNanos(123)).toISO8601IntervalString());
     assertEquals("P-1Y-2M-3DT-0.999999877S",
             new PeriodDuration(Period.of(-1, -2, -3), Duration.ofSeconds(-1).withNanos(123)).toISO8601IntervalString());
+  }
+
+  @Test
+  public void testTemporalAccessor() {
+    LocalDate date = LocalDate.of(2024, 1, 2);
+    PeriodDuration pd1 = new PeriodDuration(Period.ofYears(1), Duration.ZERO);
+    assertEquals(LocalDate.of(2025, 1, 2), pd1.addTo(date));
+
+    LocalDateTime dateTime = LocalDateTime.of(2024, 1, 2, 3, 4);
+    PeriodDuration pd2 = new PeriodDuration(Period.ZERO, Duration.ofMinutes(1));
+    assertEquals(LocalDateTime.of(2024, 1, 2, 3, 3), pd2.subtractFrom(dateTime));
+
+    PeriodDuration pd3 = new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(86461).withNanos(123));
+    assertEquals(pd3.get(ChronoUnit.YEARS), 1);
+    assertEquals(pd3.get(ChronoUnit.MONTHS), 2);
+    assertEquals(pd3.get(ChronoUnit.DAYS), 3);
+    assertEquals(pd3.get(ChronoUnit.SECONDS), 86461);
+    assertEquals(pd3.get(ChronoUnit.NANOS), 123);
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
@@ -43,4 +43,30 @@ public class TestPeriodDuration {
     assertNotEquals(pd1.hashCode(), pd3.hashCode());
   }
 
+  @Test
+  public void testToISO8601IntervalString() {
+    assertEquals("P0D",
+            new PeriodDuration(Period.ZERO, Duration.ZERO).toISO8601IntervalString());
+    assertEquals("P1Y2M3D",
+            new PeriodDuration(Period.of(1, 2, 3), Duration.ZERO).toISO8601IntervalString());
+    assertEquals("PT0.000000123S",
+            new PeriodDuration(Period.ZERO, Duration.ofNanos(123)).toISO8601IntervalString());
+    assertEquals("PT1.000000123S",
+            new PeriodDuration(Period.ZERO, Duration.ofSeconds(1).withNanos(123)).toISO8601IntervalString());
+    assertEquals("PT1H1.000000123S",
+            new PeriodDuration(Period.ZERO, Duration.ofSeconds(3601).withNanos(123)).toISO8601IntervalString());
+    assertEquals("PT24H1M1.000000123S",
+            new PeriodDuration(Period.ZERO, Duration.ofSeconds(86461).withNanos(123)).toISO8601IntervalString());
+    assertEquals("P1Y2M3DT24H1M1.000000123S",
+            new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(86461).withNanos(123)).toISO8601IntervalString());
+
+    assertEquals("P-1Y-2M-3D",
+            new PeriodDuration(Period.of(-1, -2, -3), Duration.ZERO).toISO8601IntervalString());
+    assertEquals("PT-0.000000123S",
+            new PeriodDuration(Period.ZERO, Duration.ofNanos(-123)).toISO8601IntervalString());
+    assertEquals("PT-24H-1M-0.999999877S",
+            new PeriodDuration(Period.ZERO, Duration.ofSeconds(-86461).withNanos(123)).toISO8601IntervalString());
+    assertEquals("P-1Y-2M-3DT-0.999999877S",
+            new PeriodDuration(Period.of(-1, -2, -3), Duration.ofSeconds(-1).withNanos(123)).toISO8601IntervalString());
+  }
 }


### PR DESCRIPTION
### Rationale for this change

Fixes https://github.com/apache/arrow/issues/40893.

### What changes are included in this PR?

 - Support IntervalMonthDayNanoVector in FlightSQL JDBC Driver
 - Return PeriodDuration as JDBC Object type, because there is no good java.time type for this interval
 - Return an ISO-8601 interval as the stringified version of PeriodDuration
 - Make PeriodDuration implement TemporalAccessor for standardization

### Are these changes tested?

Unit tests have been added that match those for other interval types.  I'm unaware of any other types of tests worth adding to, but I'd be happy to if pointed there.

### Are there any user-facing changes?

The only change users should noticed is that the FlightSQL JDBC Driver can now handle more query responses.
* GitHub Issue: #40893