### PR TITLE
GH-40900: [Go] Fix Mallocator Weirdness

### DIFF
--- a/go/arrow/memory/mallocator/mallocator.go
+++ b/go/arrow/memory/mallocator/mallocator.go
@@ -60,10 +60,19 @@ func (alloc *Mallocator) Allocate(size int) []byte {
 	}
 	ptr, err := C.calloc(C.size_t(size), 1)
 	if err != nil {
-		panic(err)
+		// under some circumstances and allocation patterns, we can end up in a scenario
+		// where for some reason calloc return ENOMEM even though there is definitely memory
+		// available for use. So we attempt to fallback to simply doing malloc + memset in
+		// this case. If malloc returns a nil pointer, then we know we're out of memory
+		// and will surface the error.
+		if ptr = C.malloc(C.size_t(size)); ptr == nil {
+			panic(err)
+		}
+		C.memset(ptr, 0, C.size_t(size))
 	} else if ptr == nil {
 		panic("mallocator: out of memory")
 	}
+
 	atomic.AddUint64(&alloc.allocatedBytes, uint64(size))
 	return unsafe.Slice((*byte)(ptr), size)
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
With help from @lidavidm and @bkietz digging into the linked issue, we found the following:

* Using `mtrace` and `strace` didn't produce much enlightenment to what was happening.
* If the python adbc_driver_manager was built so that the cython lib is built using `CMAKE_BUILD_TYPE=Debug` then the crash/failure goes away
* If the env var `MALLOC_MMAP_THRESHOLD_` is set to 128MB, the crash/failure goes away
* It is only reproducible when calling through python, I haven't been able to reproduce it using pure Go
* Calling `calloc` again after it fails, still fails
* Calling `malloc` + `memset` immediately after the failing `calloc` works perfectly and doesn't fail anymore

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Adding a comment describing the situation and falling back to `malloc` + `memset` if `calloc` returns an error. If the pointer returned from `malloc` is `nil` then we surface the error.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


* GitHub Issue: #40900