### PR TITLE
GH-40907: [Java][FlightSQL] Shade slf4j-api in JDBC driver

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
@@ -72,7 +72,7 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
   public Logger getParentLogger() {
     // Return the logger associated with the driver package ('org.apache.arrow.driver.jdbc')
     // When packaged in flight-sql-jdbc-driver, it will also apply to all shaded dependencies
-    return Logger.getLogger(getClass().getPackageName());
+    return Logger.getLogger(getClass().getPackage().getName());
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
 import org.apache.arrow.driver.jdbc.utils.UrlParser;
@@ -58,13 +59,20 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
     // Netty requires some extra properties to unlock some native memory management api
     // Setting this property if not already set externally
     // This has to be done before any netty class is being loaded
-    final String key = "cfjd.io.netty.tryReflectionSetAccessible";
+    final String key = "io.netty.tryReflectionSetAccessible";
     final String tryReflectionSetAccessible = System.getProperty(key);
     if (tryReflectionSetAccessible == null) {
       System.setProperty(key, Boolean.TRUE.toString());
     }
 
     new ArrowFlightJdbcDriver().register();
+  }
+
+  @Override
+  public Logger getParentLogger() {
+    // Return the logger associated with the driver package ('org.apache.arrow.driver.jdbc')
+    // When packaged in flight-sql-jdbc-driver, it will also apply to all shaded dependencies
+    return Logger.getLogger(getClass().getPackageName());
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -97,6 +97,11 @@
             <artifactId>slf4j-api</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>
@@ -190,17 +195,16 @@
                             <relocations>
                                 <relocation>
                                     <pattern>com.</pattern>
-                                    <shadedPattern>cfjd.com.</shadedPattern>
+                                    <shadedPattern>org.apache.arrow.driver.jdbc.shaded.com.</shadedPattern>
                                     <excludes>
                                         <exclude>com.sun.**</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.</pattern>
-                                    <shadedPattern>cfjd.org.</shadedPattern>
+                                    <shadedPattern>org.apache.arrow.driver.jdbc.shaded.org.</shadedPattern>
                                     <excludes>
                                         <exclude>org.apache.arrow.driver.jdbc.**</exclude>
-                                        <exclude>org.slf4j.**</exclude>
                                         <!-- Avoid shading Flight JDBC Properties -->
                                         <exclude>org.apache.arrow.flight.name</exclude>
                                         <exclude>org.apache.arrow.flight.version</exclude>
@@ -210,24 +214,24 @@
                                 </relocation>
                                 <relocation>
                                     <pattern>io.</pattern>
-                                    <shadedPattern>cfjd.io.</shadedPattern>
+                                    <shadedPattern>org.apache.arrow.driver.jdbc.shaded.io.</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>net.</pattern>
-                                    <shadedPattern>cfjd.net.</shadedPattern>
+                                    <shadedPattern>org.apache.arrow.driver.jdbc.shaded.net.</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>mozilla.</pattern>
-                                    <shadedPattern>cfjd.mozilla.</shadedPattern>
+                                    <shadedPattern>org.apache.arrow.driver.jdbc.shaded.mozilla.</shadedPattern>
                                 </relocation>
                                 <!-- Entries to relocate netty native libraries  -->
                                 <relocation>
                                     <pattern>META-INF.native.libnetty_</pattern>
-                                    <shadedPattern>META-INF.native.libcfjd_netty_</shadedPattern>
+                                    <shadedPattern>META-INF.native.liboaadj_netty_</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>META-INF.native.netty_</pattern>
-                                    <shadedPattern>META-INF.native.cfjd_netty_</shadedPattern>
+                                    <shadedPattern>META-INF.native.oaadj_netty_</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ITDriverJarValidation.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ITDriverJarValidation.java
@@ -42,8 +42,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Check the content of the JDBC driver jar
  *
- * After shading everything should be either under org.apache.arrow.driver.jdbc.,
- * org.slf4j., or cfjd. packages
+ * After shading everything should be either under org.apache.arrow.driver.jdbc. package
  */
 public class ITDriverJarValidation {
   /**
@@ -57,8 +56,6 @@ public class ITDriverJarValidation {
    */
   public static final Set<String> ALLOWED_PREFIXES = ImmutableSet.of(
       "org/apache/arrow/driver/jdbc/",
-      "cfjd/",
-      "org/slf4j/",
       "META-INF/");
 
   /**

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -682,6 +682,11 @@
         <version>${dep.slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>${dep.slf4j.version}</version>
+      </dependency>
+      <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>


### PR DESCRIPTION
### Rationale for this change

FlightSQL JDBC Driver does not shade slfj4 api which may come into conflict into the version used by an application. If the application uses slf4j 1.x, it may cause the application slf4j backend to not be loaded properly.

The change configured maven-shade-plugin to also shade slf4j-api. To make sure log messages are still visible, slf4j-jdk14 is included as well so that all messages will be redirected to `java.util.logging` framework. The application can use jul-to-slf4j adapter to redirect log messages back to slf4j.

### What changes are included in this PR?

Overrides `Driver#getParentLogger()` to return the root logger for the JDBC driver (which is `org.apache.arrow.driver.jdbc`). To make sure shaded dependencies loggers are included as well, change relocation from `cfjd.`  to `org.apache.arrow.driver.jdbc.shaded. `(or `oaadj` for native libraries)

### Are these changes tested?

Verifying that slf4j-api is shaded along with the other relocation changes are covered by `ITDriverJarValidation`

### Are there any user-facing changes?

Yes. Driver will not expose directly slf4j api and the logger names for the shaded dependencies have been updated. For applications which were relying on configuring directly a slf4j logging backend for the driver, they may need to include `org.slf4j:slf4-api` and `org.slf4j:jul-to-slf4j` for logging configuration to work.
* GitHub Issue: #40907