### PR TITLE
GH-40954: [CI] Fix use of obsolete docker-compose command on Github Actions

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -32,7 +32,9 @@ on:
       - 'docker-compose.yml'
 
 env:
+  ARCHERY_DEBUG: 1
   ARCHERY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+  ARCHERY_USE_DOCKER_CLI: 1
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -154,7 +154,7 @@ jobs:
           sudo sysctl -w vm.mmap_rnd_bits=28
           sudo sysctl -w kernel.core_pattern="core.%e.%p"
           ulimit -c unlimited
-          archery --debug docker run ${{ matrix.image }}
+          archery docker run ${{ matrix.image }}
       - name: Docker Push
         if: >-
           success() &&

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -94,8 +94,8 @@ jobs:
             echo "," >> "$GITHUB_OUTPUT"
             cat <<JSON >> "$GITHUB_OUTPUT"
           {
-            "archery-use-docker-cli": "0",
             "arch": "arm64v8",
+            "archery-use-docker-cli": "0",
             "clang-tools": "10",
             "image": "ubuntu-cpp",
             "llvm": "10",

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -140,6 +140,8 @@ jobs:
           sudo apt install -y --no-install-recommends python3 python3-dev python3-pip
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]
+      - name: Find docker-compose
+        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -53,6 +53,7 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
   ARROW_ENABLE_TIMING_TESTS: OFF
   DOCKER_VOLUME_PREFIX: ".docker/"
 
@@ -93,6 +94,7 @@ jobs:
             echo "," >> "$GITHUB_OUTPUT"
             cat <<JSON >> "$GITHUB_OUTPUT"
           {
+            "archery-use-docker-cli": "0",
             "arch": "arm64v8",
             "clang-tools": "10",
             "image": "ubuntu-cpp",
@@ -118,6 +120,9 @@ jobs:
         include: ${{ fromJson(needs.docker-targets.outputs.targets) }}
     env:
       ARCH: ${{ matrix.arch }}
+      # By default, use Docker CLI because docker-compose v1 is obsolete,
+      # except where the Docker client version is too old.
+      ARCHERY_USE_DOCKER_CLI: ${{ matrix.archery-use-docker-cli || '1' }}
       ARROW_SIMD_LEVEL: ${{ matrix.simd-level }}
       CLANG_TOOLS: ${{ matrix.clang-tools }}
       LLVM: ${{ matrix.llvm }}
@@ -140,8 +145,6 @@ jobs:
           sudo apt install -y --no-install-recommends python3 python3-dev python3-pip
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]
-      - name: Find docker-compose
-        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
@@ -151,7 +154,7 @@ jobs:
           sudo sysctl -w vm.mmap_rnd_bits=28
           sudo sysctl -w kernel.core_pattern="core.%e.%p"
           ulimit -c unlimited
-          archery docker run ${{ matrix.image }}
+          archery --debug docker run ${{ matrix.image }}
       - name: Docker Push
         if: >-
           success() &&

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,6 +29,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
+
 jobs:
 
   lint:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   ARROW_ENABLE_TIMING_TESTS: OFF
   DOCKER_VOLUME_PREFIX: ".docker/"
 

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -33,6 +33,8 @@ permissions:
   contents: read
   
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   ARROW_ENABLE_TIMING_TESTS: OFF
   DOCKER_VOLUME_PREFIX: ".docker/"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  ARCHERY_DEBUG: 1
+
 jobs:
 
   docker-targets:
@@ -75,12 +78,14 @@ jobs:
           {
             "arch-label": "ARM64",
             "arch": "arm64v8",
+            "archery-use-docker-cli": "0",
             "go": "1.21",
             "runs-on": ["self-hosted", "arm", "linux"]
           },
           {
             "arch-label": "ARM64",
             "arch": "arm64v8",
+            "archery-use-docker-cli": "0",
             "go": "1.22",
             "runs-on": ["self-hosted", "arm", "linux"]
           }
@@ -101,6 +106,9 @@ jobs:
         include: ${{ fromJson(needs.docker-targets.outputs.targets) }}
     env:
       ARCH: ${{ matrix.arch }}
+      # By default, use Docker CLI because docker-compose v1 is obsolete,
+      # except where the Docker client version is too old.
+      ARCHERY_USE_DOCKER_CLI: ${{ matrix.archery-use-docker-cli || '1' }}
       GO: ${{ matrix.go }}
     steps:
       - name: Checkout Arrow

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,7 @@ permissions:
 
 env:
   ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
 
 jobs:
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,6 +51,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -80,6 +80,8 @@ jobs:
           python-version: 3.8
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
+      - name: Find docker-compose
+        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -45,6 +45,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
@@ -80,8 +82,6 @@ jobs:
           python-version: 3.8
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
-      - name: Find docker-compose
-        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -45,6 +45,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -38,6 +38,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
+
 jobs:
 
   docker:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -105,6 +105,8 @@ jobs:
           python-version: 3.8
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
+      - name: Find docker-compose
+        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,6 +41,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
@@ -105,8 +107,6 @@ jobs:
           python-version: 3.8
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
-      - name: Find docker-compose
-        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -51,6 +51,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -53,6 +53,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
@@ -87,8 +89,6 @@ jobs:
           python-version: 3.8
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
-      - name: Find docker-compose
-        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -87,6 +87,8 @@ jobs:
           python-version: 3.8
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
+      - name: Find docker-compose
+        run: which -a docker-compose
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -41,6 +41,8 @@ permissions:
   contents: read
 
 env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -44,6 +44,7 @@ BOOL = ArrowBool()
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--debug", type=BOOL, is_flag=True, default=False,
+              envvar='ARCHERY_DEBUG',
               help="Increase logging with debugging output.")
 @click.option("--pdb", type=BOOL, is_flag=True, default=False,
               help="Invoke pdb on uncaught exception.")

--- a/dev/archery/archery/docker/tests/test_docker_cli.py
+++ b/dev/archery/archery/docker/tests/test_docker_cli.py
@@ -33,14 +33,12 @@ def test_docker_run_with_custom_command(run, build, pull):
 
     assert result.exit_code == 0
     pull.assert_called_once_with(
-        "ubuntu-cpp", pull_leaf=True, using_docker=False
+        "ubuntu-cpp", pull_leaf=True,
     )
     build.assert_called_once_with(
         "ubuntu-cpp",
         use_cache=True,
         use_leaf_cache=True,
-        using_docker=False,
-        using_buildx=False
     )
     run.assert_called_once_with(
         "ubuntu-cpp",
@@ -48,7 +46,6 @@ def test_docker_run_with_custom_command(run, build, pull):
         env={},
         resource_limit=None,
         user=None,
-        using_docker=False,
         volumes=(),
     )
 
@@ -75,14 +72,12 @@ def test_docker_run_options(run, build, pull):
     result = CliRunner().invoke(docker, args)
     assert result.exit_code == 0
     pull.assert_called_once_with(
-        "ubuntu-cpp", pull_leaf=True, using_docker=False
+        "ubuntu-cpp", pull_leaf=True,
     )
     build.assert_called_once_with(
         "ubuntu-cpp",
         use_cache=True,
         use_leaf_cache=True,
-        using_docker=False,
-        using_buildx=False
     )
     run.assert_called_once_with(
         "ubuntu-cpp",
@@ -90,7 +85,6 @@ def test_docker_run_options(run, build, pull):
         env={"ARROW_GANDIVA": "OFF", "ARROW_FLIGHT": "ON"},
         resource_limit=None,
         user="root",
-        using_docker=False,
         volumes=(
             "./build:/build",
             "./ccache:/ccache:delegated",
@@ -126,7 +120,6 @@ def test_docker_limit_options(run):
         env={"ARROW_GANDIVA": "OFF", "ARROW_FLIGHT": "ON"},
         resource_limit="github",
         user="root",
-        using_docker=False,
         volumes=(
             "./build:/build",
             "./ccache:/ccache:delegated",
@@ -145,7 +138,6 @@ def test_docker_run_without_pulling_or_building(run):
         env={},
         resource_limit=None,
         user=None,
-        using_docker=False,
         volumes=(),
     )
 
@@ -157,14 +149,12 @@ def test_docker_run_only_pulling_and_building(build, pull):
     result = CliRunner().invoke(docker, args)
     assert result.exit_code == 0
     pull.assert_called_once_with(
-        "ubuntu-cpp", pull_leaf=True, using_docker=False
+        "ubuntu-cpp", pull_leaf=True,
     )
     build.assert_called_once_with(
         "ubuntu-cpp",
         use_cache=True,
         use_leaf_cache=True,
-        using_docker=False,
-        using_buildx=False
     )
 
 
@@ -187,8 +177,6 @@ def test_docker_run_without_build_cache(run, build):
         "ubuntu-cpp",
         use_cache=False,
         use_leaf_cache=False,
-        using_docker=False,
-        using_buildx=False
     )
     run.assert_called_once_with(
         "ubuntu-cpp",
@@ -196,6 +184,5 @@ def test_docker_run_without_build_cache(run, build):
         env={},
         resource_limit=None,
         user="me",
-        using_docker=False,
         volumes=(),
     )

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -30,6 +30,7 @@ jobs:
       ARCH: {{ '${{ matrix.platform.archery_arch }}' }}
       ARCH_ALIAS: {{ '${{ matrix.platform.archery_arch_alias }}' }}
       ARCH_SHORT: {{ '${{ matrix.platform.archery_arch_short }}' }}
+      ARCHERY_USE_DOCKER_CLI: {{ "${{matrix.platform.archery_use_docker_cli || '1'}}" }}
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +45,7 @@ jobs:
             archery_arch: "arm64v8"
             archery_arch_alias: "aarch64"
             archery_arch_short: "arm64"
+            archery_use_docker_cli: "0"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_free_space()|indent }}

--- a/dev/tasks/linux-packages/github.linux.yml
+++ b/dev/tasks/linux-packages/github.linux.yml
@@ -29,6 +29,7 @@ jobs:
     {% endif %}
     env:
       ARCHITECTURE: {{ architecture }}
+      ARCHERY_USE_DOCKER_CLI: {{ '0' if architecture == 'arm64' else '1' }}
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_login_dockerhub()|indent }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -23,6 +23,10 @@ on:
   push:
     branches:
       - "*-github-*"
+
+env:
+  ARCHERY_DEBUG: 1
+  ARCHERY_USE_DOCKER_CLI: 1
 {% endmacro %}
 
 {%- macro github_checkout_arrow(fetch_depth=1, submodules="recursive", action_v="4") -%}

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -31,8 +31,10 @@ jobs:
       # archery uses these environment variables
       {% if arch == "amd64" %}
       ARCH: amd64
+      ARCHERY_USE_DOCKER_CLI: 1
       {% else %}
       ARCH: arm64v8
+      ARCHERY_USE_DOCKER_CLI: 0
       {% endif %}
       PYTHON: "{{ python_version }}"
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1456,12 +1456,16 @@ tasks:
     ci: github
     template: docker-tests/github.cuda.yml
     params:
+      env:
+        ARCHERY_USE_DOCKER_CLI: 0
       image: ubuntu-cuda-cpp
 
   test-cuda-python:
     ci: github
     template: docker-tests/github.cuda.yml
     params:
+      env:
+        ARCHERY_USE_DOCKER_CLI: 0
       image: ubuntu-cuda-python
 
   ############################## Fuzz tests #################################


### PR DESCRIPTION
### Rationale for this change

The `docker-compose` utility is progressively being removed from GHA-provided runners:
https://github.com/actions/runner-images/issues/9557

### What changes are included in this PR?

Use `docker` client CLI directly instead of `docker-compose` where possible.

### Are these changes tested?

Yes, this should fix the sporadic CI failures because of the above migration.

### Are there any user-facing changes?

No, except additional optional env var `ARCHERY_DEBUG`.
* GitHub Issue: #40954