### PR TITLE
EXPERIMENTAL: [C++] Disable memory pool poisoning in non-debug mode

### DIFF
--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -444,12 +444,6 @@ int64_t MemoryPool::max_memory() const { return -1; }
 // MemoryPool implementation that delegates its core duty
 // to an Allocator class.
 
-#ifndef NDEBUG
-static constexpr uint8_t kAllocPoison = 0xBC;
-static constexpr uint8_t kReallocPoison = 0xBD;
-static constexpr uint8_t kDeallocPoison = 0xBE;
-#endif
-
 template <typename Allocator>
 class BaseMemoryPoolImpl : public MemoryPool {
  public:
@@ -463,14 +457,6 @@ class BaseMemoryPoolImpl : public MemoryPool {
       return Status::OutOfMemory("malloc size overflows size_t");
     }
     RETURN_NOT_OK(Allocator::AllocateAligned(size, alignment, out));
-#ifndef NDEBUG
-    // Poison data
-    if (size > 0) {
-      DCHECK_NE(*out, nullptr);
-      (*out)[0] = kAllocPoison;
-      (*out)[size - 1] = kAllocPoison;
-    }
-#endif
 
     stats_.DidAllocateBytes(size);
     return Status::OK();
@@ -485,28 +471,12 @@ class BaseMemoryPoolImpl : public MemoryPool {
       return Status::OutOfMemory("realloc overflows size_t");
     }
     RETURN_NOT_OK(Allocator::ReallocateAligned(old_size, new_size, alignment, ptr));
-#ifndef NDEBUG
-    // Poison data
-    if (new_size > old_size) {
-      DCHECK_NE(*ptr, nullptr);
-      (*ptr)[old_size] = kReallocPoison;
-      (*ptr)[new_size - 1] = kReallocPoison;
-    }
-#endif
 
     stats_.DidReallocateBytes(old_size, new_size);
     return Status::OK();
   }
 
   void Free(uint8_t* buffer, int64_t size, int64_t alignment) override {
-#ifndef NDEBUG
-    // Poison data
-    if (size > 0) {
-      DCHECK_NE(buffer, nullptr);
-      buffer[0] = kDeallocPoison;
-      buffer[size - 1] = kDeallocPoison;
-    }
-#endif
     Allocator::DeallocateAligned(buffer, size, alignment);
 
     stats_.DidFreeBytes(size);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Just checking that memory poisoning does not adversely affect performance on our benchmark suite (which might be too "micro" to exhibit such issues, however).

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->