### PR TITLE
GH-40952: [Java][FlightSQL] Clean up flight-sql-jdbc-driver dependencies

### DIFF
--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -115,6 +115,10 @@
                                     <shadedPattern>org.apache.arrow.driver.jdbc.shaded.io.</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>net.</pattern>
+                                    <shadedPattern>org.apache.arrow.driver.jdbc.shaded.net.</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>mozilla.</pattern>
                                     <shadedPattern>org.apache.arrow.driver.jdbc.shaded.mozilla.</shadedPattern>
                                 </relocation>
@@ -142,13 +146,6 @@
                                     <artifact>org.apache.calcite.avatica:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/services/java.sql.Driver</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.eclipse.collections:*</artifact>
-                                    <excludes>
-                                        <exclude>about.html</exclude>
-                                        <exclude>LICENSE-*-1.0.txt</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -28,14 +28,6 @@
     <url>https://arrow.apache.org</url>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>flight-sql-jdbc-core</artifactId>
@@ -43,110 +35,16 @@
         </dependency>
 
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.70</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-memory-core -->
-        <dependency>
-            <groupId>org.apache.arrow</groupId>
-            <artifactId>arrow-memory-core</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.arrow</groupId>
-            <artifactId>flight-sql</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.core.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.inline.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.arrow</groupId>
-            <artifactId>flight-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-kqueue</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-epoll</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.12.6</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.calcite.avatica</groupId>
-            <artifactId>avatica</artifactId>
-            <version>1.24.0</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.arrow</groupId>
-            <artifactId>arrow-vector</artifactId>
-            <classifier>${arrow.vector.classifier}</classifier>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <!-- Used for tests but need runtime scope. See MNG-4156 -->
             <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -215,10 +113,6 @@
                                 <relocation>
                                     <pattern>io.</pattern>
                                     <shadedPattern>org.apache.arrow.driver.jdbc.shaded.io.</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>net.</pattern>
-                                    <shadedPattern>org.apache.arrow.driver.jdbc.shaded.net.</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>mozilla.</pattern>


### PR DESCRIPTION
### Rationale for this change

Module `flight-sql-jdbc-driver` declares multiple dependencies, some (joda) are not used anymore (but still packaged).

### What changes are included in this PR?

Clean up list of dependencies declared in flight-sql-jdbc-driver modules as all of them are transitive dependencies from flight-sql-jdbc-core.

### Are these changes tested?

Yes: build + existing shading test

### Are there any user-facing changes?

No
* GitHub Issue: #40952