### PR TITLE
MINOR: [R] Replace use of show_query in test-duckdb.R with dbplyr::sql_build

### DIFF
--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -281,7 +281,7 @@ test_that("to_duckdb passing a connection", {
     to_duckdb(con = con_separate, auto_disconnect = FALSE)
 
   # Generates a query like SELECT * FROM arrow_xxx
-  table_four_query <- paste(show_query(table_four), collapse = "\n")
+  table_four_query <- paste(dbplyr::sql_build(table_four), collapse = "\n")
   table_four_name <- stringr::str_extract(table_four_query, "arrow_[0-9]{3}")
   expect_false(is.na(table_four_name))
 


### PR DESCRIPTION
### Rationale for this change

I just ran the R package tests and saw a printed query mixed amongst testthat output:

```
[ FAIL 0 | WARN 0 | SKIP 1 | PASS 15 ]<SQL>
SELECT *
FROM arrow_010
```

I thought it would be good to silence this in some way.

### What changes are included in this PR?

I silenced this by changing out the call to `dplyr::show_query` for `dbplyr::sql_build` which produces different output but (1) doesn't print as as side-effect, (2) is specifically made for testing, and (3) still produces output we can use in this test.

For reference, this is what show_query prints (assuming via `cat`):
```
> show_query(table_four)
<SQL>
SELECT *
FROM arrow_011
```

Whereas `sql_build`:
```
> dbplyr::sql_build(table_four)
<dbplyr_table_ident[1]>
[1] `arrow_011`
```

### Are these changes tested?

Yes, but just manually on my system.

### Are there any user-facing changes?

No.