### PR TITLE
GH-40636: [C++][Parquet] Improve fallback encoding choice in column writer.

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4210,7 +4210,7 @@ TEST_P(TestArrowWriteDictionary, Statistics) {
       {{true, true}, {true, true}},
       {{true, false}, {true, false}},
       {{true, true}, {true, true}},
-      {{false}, {false}}};
+      {{false, false}, {false, false}}};
 
   for (std::size_t case_index = 0; case_index < test_dictionaries.size(); case_index++) {
     SCOPED_TRACE(test_dictionaries[case_index]->type()->ToString());

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4195,7 +4195,8 @@ TEST_P(TestArrowWriteDictionary, Statistics) {
   std::vector<int> expected_num_data_pages = {2, 2, 2, 2};
   std::vector<std::vector<int32_t>> expected_valid_by_page = {
       {1, 1}, {2, 0}, {2, 1}, {0, 0}};
-  std::vector<std::vector<int64_t>> expected_null_by_page = {{1, 0}, {0, 1}, {0, 0}, {2, 1}};
+  std::vector<std::vector<int64_t>> expected_null_by_page = {
+      {1, 0}, {0, 1}, {0, 0}, {2, 1}};
   std::vector<int32_t> expected_dict_counts = {4, 4, 4, 3};
   // Pairs of (min, max)
   std::vector<std::vector<std::string>> expected_min_max_ = {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4192,10 +4192,10 @@ TEST_P(TestArrowWriteDictionary, Statistics) {
   // row groups are identical for ease of testing.
   std::vector<int32_t> expected_valid_counts = {2, 2, 3, 0};
   std::vector<int32_t> expected_null_counts = {1, 1, 0, 3};
-  std::vector<int> expected_num_data_pages = {2, 2, 2, 1};
+  std::vector<int> expected_num_data_pages = {2, 2, 2, 2};
   std::vector<std::vector<int32_t>> expected_valid_by_page = {
-      {1, 1}, {2, 0}, {2, 1}, {0}};
-  std::vector<std::vector<int64_t>> expected_null_by_page = {{1, 0}, {0, 1}, {0, 0}, {3}};
+      {1, 1}, {2, 0}, {2, 1}, {0, 0}};
+  std::vector<std::vector<int64_t>> expected_null_by_page = {{1, 0}, {0, 1}, {0, 0}, {2, 1}};
   std::vector<int32_t> expected_dict_counts = {4, 4, 4, 3};
   // Pairs of (min, max)
   std::vector<std::vector<std::string>> expected_min_max_ = {

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1206,7 +1206,7 @@ Status ConvertDictionaryToDense(const ::arrow::Array& array, MemoryPool* pool,
 }
 
 static inline bool IsDictionaryEncoding(Encoding::type encoding) {
-  return encoding == Encoding::PLAIN_DICTIONARY;
+  return encoding == Encoding::PLAIN_DICTIONARY || encoding == Encoding::RLE_DICTIONARY;
 }
 
 template <typename DType>

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1571,7 +1571,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
       FlushBufferedDataPages();
       fallback_ = true;
 
-      Encoding::type fallback_encoding = ChooseFallbackEncoding(
+      Encoding::type fallback_encoding = ChooseNonDictEncoding(
           DType::type_num, properties_->version(), properties_->data_page_version());
 
       current_encoder_ = MakeEncoder(DType::type_num, fallback_encoding, false, descr_,
@@ -2377,8 +2377,8 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* met
                               descr->physical_type() != Type::BOOLEAN;
   Encoding::type encoding = properties->encoding(descr->path());
   if (encoding == Encoding::UNKNOWN) {
-    encoding = ChooseFallbackEncoding(descr->physical_type(), properties->version(),
-                                      properties->data_page_version());
+    encoding = ChooseNonDictEncoding(descr->physical_type(), properties->version(),
+                                     properties->data_page_version());
   }
   if (use_dictionary) {
     encoding = properties->dictionary_index_encoding();

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1608,7 +1608,7 @@ TEST_F(ColumnWriterTestSizeEstimated, NonBufferedDictionary) {
   EXPECT_EQ(0, required_writer->total_compressed_bytes());
   EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
   // write a huge batch to trigger page flush
-  for (int32_t i = 0; i < 50; i++) {
+  for (int32_t i = 0; i < 50000; i++) {
     required_writer->WriteBatch(1, nullptr, nullptr, &dict_value);
   }
   // Page flushed, check size

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -223,17 +223,19 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
       }
       ASSERT_EQ(encodings, expected);
     } else if (version == ParquetVersion::PARQUET_1_0) {
-      // There are 3 encodings (PLAIN_DICTIONARY, PLAIN, RLE) in a fallback case
-      // for version 1.0
-      std::set<Encoding::type> expected(
-          {Encoding::PLAIN_DICTIONARY, Encoding::PLAIN, Encoding::RLE});
-      ASSERT_EQ(encodings, expected);
+      // There are 4 encodings (PLAIN_DICTIONARY, PLAIN, RLE, DELTA_LENGTH_BYTE_ARRAY) in
+      // a fallback case for version 1.0, dependent on data type
+      std::set<Encoding::type> expected({Encoding::PLAIN_DICTIONARY, Encoding::PLAIN,
+                                         Encoding::RLE,
+                                         Encoding::DELTA_LENGTH_BYTE_ARRAY});
+      ASSERT_THAT(encodings, testing::IsSubsetOf(expected));
     } else {
-      // There are 3 encodings (RLE_DICTIONARY, PLAIN, RLE) in a fallback case for
-      // version 2.0
-      std::set<Encoding::type> expected(
-          {Encoding::RLE_DICTIONARY, Encoding::PLAIN, Encoding::RLE});
-      ASSERT_EQ(encodings, expected);
+      // There are 4 encodings (RLE_DICTIONARY, PLAIN, RLE, DELTA_LENGTH_BYTE_ARRAY) in a
+      // fallback case for version 2.0, dependent on data type
+      std::set<Encoding::type> expected({Encoding::RLE_DICTIONARY, Encoding::PLAIN,
+                                         Encoding::RLE,
+                                         Encoding::DELTA_LENGTH_BYTE_ARRAY});
+      ASSERT_THAT(encodings, testing::IsSubsetOf(expected));
     }
 
     std::vector<parquet::PageEncodingStats> encoding_stats =
@@ -246,21 +248,31 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
                     : Encoding::PLAIN);
       ASSERT_EQ(encoding_stats[0].page_type, PageType::DATA_PAGE);
     } else if (version == ParquetVersion::PARQUET_1_0) {
-      std::vector<Encoding::type> expected(
-          {Encoding::PLAIN_DICTIONARY, Encoding::PLAIN, Encoding::PLAIN_DICTIONARY});
-      ASSERT_EQ(encoding_stats[0].encoding, expected[0]);
+      std::vector<std::set<Encoding::type>> expected(
+          {{Encoding::PLAIN_DICTIONARY},
+           {Encoding::PLAIN, Encoding::PLAIN_DICTIONARY},
+           {Encoding::PLAIN_DICTIONARY, Encoding::DELTA_LENGTH_BYTE_ARRAY}});
+      std::set<Encoding::type> actual = {encoding_stats[0].encoding};
+      ASSERT_THAT(actual, testing::IsSubsetOf(expected[0]));
       ASSERT_EQ(encoding_stats[0].page_type, PageType::DICTIONARY_PAGE);
       for (size_t i = 1; i < encoding_stats.size(); i++) {
-        ASSERT_EQ(encoding_stats[i].encoding, expected[i]);
+        actual = {encoding_stats[i].encoding};
+        // It seems like having DELTA_LENGTH_BYTE_ARRAY as a fallback option
+        // can cause this test to *not* fallback and stick with PLAIN_DICTIONARY. 
+        ASSERT_THAT(actual, testing::IsSubsetOf(expected[i]));
         ASSERT_EQ(encoding_stats[i].page_type, PageType::DATA_PAGE);
       }
     } else {
-      std::vector<Encoding::type> expected(
-          {Encoding::PLAIN, Encoding::PLAIN, Encoding::RLE_DICTIONARY});
-      ASSERT_EQ(encoding_stats[0].encoding, expected[0]);
+      std::vector<std::set<Encoding::type>> expected(
+          {{Encoding::PLAIN, Encoding::DELTA_LENGTH_BYTE_ARRAY},
+           {Encoding::PLAIN, Encoding::DELTA_LENGTH_BYTE_ARRAY},
+           {Encoding::RLE_DICTIONARY}});
+      std::set<Encoding::type> actual = {encoding_stats[0].encoding};
+      ASSERT_THAT(actual, testing::IsSubsetOf(expected[0]));
       ASSERT_EQ(encoding_stats[0].page_type, PageType::DICTIONARY_PAGE);
       for (size_t i = 1; i < encoding_stats.size(); i++) {
-        ASSERT_EQ(encoding_stats[i].encoding, expected[i]);
+        actual = {encoding_stats[i].encoding};
+        ASSERT_THAT(actual, testing::IsSubsetOf(expected[i]));
         ASSERT_EQ(encoding_stats[i].page_type, PageType::DATA_PAGE);
       }
     }

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -258,7 +258,7 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
       for (size_t i = 1; i < encoding_stats.size(); i++) {
         actual = {encoding_stats[i].encoding};
         // It seems like having DELTA_LENGTH_BYTE_ARRAY as a fallback option
-        // can cause this test to *not* fallback and stick with PLAIN_DICTIONARY. 
+        // can cause this test to *not* fallback and stick with PLAIN_DICTIONARY.
         ASSERT_THAT(actual, testing::IsSubsetOf(expected[i]));
         ASSERT_EQ(encoding_stats[i].page_type, PageType::DATA_PAGE);
       }

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1493,7 +1493,7 @@ class ColumnWriterTestSizeEstimated : public ::testing::Test {
     node_ = std::static_pointer_cast<GroupNode>(
         GroupNode::Make("schema", Repetition::REQUIRED,
                         {
-                            schema::Int32("required", Repetition::REQUIRED),
+                            schema::Float("required", Repetition::REQUIRED),
                         }));
     std::vector<schema::NodePtr> fields;
     schema_descriptor_ = std::make_unique<SchemaDescriptor>();
@@ -1538,7 +1538,7 @@ TEST_F(ColumnWriterTestSizeEstimated, NonBuffered) {
   auto required_writer =
       this->BuildWriter(Compression::UNCOMPRESSED, /* buffered*/ false);
   // Write half page, page will not be flushed after loop
-  for (int32_t i = 0; i < 127; i++) {
+  for (int32_t i = 0; i < 50; i++) {
     required_writer->WriteBatch(1, nullptr, nullptr, &i);
   }
   // Page not flushed, check size
@@ -1546,16 +1546,13 @@ TEST_F(ColumnWriterTestSizeEstimated, NonBuffered) {
   EXPECT_EQ(0, required_writer->total_compressed_bytes());  // unbuffered
   EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
   // Write half page, page be flushed after loop
-  for (int32_t i = 0; i < 127; i++) {
+  for (int32_t i = 0; i < 50; i++) {
     required_writer->WriteBatch(1, nullptr, nullptr, &i);
   }
   // Page flushed, check size
-  /* FIXME: For whatever reason, despite being flushed, this does not actually
-   * cause the data page to be written when the encoder is DELTA_BINARY_PACKED.
   EXPECT_LT(400, required_writer->total_bytes_written());
   EXPECT_EQ(0, required_writer->total_compressed_bytes());
   EXPECT_LT(400, required_writer->total_compressed_bytes_written());
-  */
 
   // Test after closed
   int64_t written_size = required_writer->Close();
@@ -1568,7 +1565,7 @@ TEST_F(ColumnWriterTestSizeEstimated, NonBuffered) {
 TEST_F(ColumnWriterTestSizeEstimated, Buffered) {
   auto required_writer = this->BuildWriter(Compression::UNCOMPRESSED, /* buffered*/ true);
   // Write half page, page will not be flushed after loop
-  for (int32_t i = 0; i < 127; i++) {
+  for (int32_t i = 0; i < 50; i++) {
     required_writer->WriteBatch(1, nullptr, nullptr, &i);
   }
   // Page not flushed, check size
@@ -1576,16 +1573,13 @@ TEST_F(ColumnWriterTestSizeEstimated, Buffered) {
   EXPECT_EQ(0, required_writer->total_compressed_bytes());  // buffered
   EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
   // Write half page, page be flushed after loop
-  for (int32_t i = 0; i < 127; i++) {
+  for (int32_t i = 0; i < 50; i++) {
     required_writer->WriteBatch(1, nullptr, nullptr, &i);
   }
   // Page flushed, check size
-  /* FIXME: For whatever reason, despite being flushed, this does not actually
-   * cause the data page to be written when the encoder is DELTA_BINARY_PACKED.
   EXPECT_LT(400, required_writer->total_bytes_written());
   EXPECT_EQ(0, required_writer->total_compressed_bytes());
   EXPECT_LT(400, required_writer->total_compressed_bytes_written());
-  */
 
   // Test after closed
   int64_t written_size = required_writer->Close();
@@ -1612,12 +1606,9 @@ TEST_F(ColumnWriterTestSizeEstimated, NonBufferedDictionary) {
     required_writer->WriteBatch(1, nullptr, nullptr, &dict_value);
   }
   // Page flushed, check size
-  /* FIXME: For whatever reason, despite being flushed, this does not actually
-   * cause the data page to be written when the encoder is DELTA_BINARY_PACKED.
   EXPECT_EQ(0, required_writer->total_bytes_written());
   EXPECT_LT(400, required_writer->total_compressed_bytes());
   EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
-  */
 
   required_writer->Close();
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -4059,9 +4059,9 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
 // Informed heavily by https://github.com/apache/parquet-format/blob/master/Encodings.md
 // Should we also consider if we're in dictionary encoding mode? or assume no for the
 // moment?
-Encoding::type ChooseFallbackEncoding(Type::type data_type,
-                                      ParquetVersion::type parquet_version,
-                                      ParquetDataPageVersion datapage_version) {
+Encoding::type ChooseNonDictEncoding(Type::type data_type,
+                                     ParquetVersion::type parquet_version,
+                                     ParquetDataPageVersion datapage_version) {
   if (data_type == Type::BOOLEAN && parquet_version != ParquetVersion::PARQUET_1_0 &&
       datapage_version == ParquetDataPageVersion::V2) {
     return Encoding::RLE;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -4055,4 +4055,7 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
 }
 
 }  // namespace detail
+
+Encoding::type ChooseFallbackEncoding() { return Encoding::PLAIN; }
+
 }  // namespace parquet

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -4055,8 +4055,7 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
 }
 
 }  // namespace detail
-   //
-   //
+
 bool IsParquetVersionAtLeast2_0(ParquetVersion::type parquet_version) {
   switch (parquet_version) {
     case ParquetVersion::PARQUET_1_0:

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -4062,7 +4062,6 @@ bool IsParquetVersionAtLeast2_0(ParquetVersion::type parquet_version) {
     case ParquetVersion::PARQUET_1_0:
       return false;
     case ParquetVersion::PARQUET_2_4:
-      return true;
     case ParquetVersion::PARQUET_2_6:
       return true;
     default:
@@ -4098,7 +4097,10 @@ Encoding::type ChooseNonDictEncoding(Type::type data_type,
       return Encoding::PLAIN;
 
     case Type::BYTE_ARRAY:
-      return Encoding::DELTA_LENGTH_BYTE_ARRAY;
+      if (IsParquetVersionAtLeast2_0(parquet_version)) {
+        return Encoding::DELTA_LENGTH_BYTE_ARRAY;
+      }
+      break;
 
     case Type::FIXED_LEN_BYTE_ARRAY:
     default:

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -4057,15 +4057,11 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
 }  // namespace detail
 
 // Informed heavily by https://github.com/apache/parquet-format/blob/master/Encodings.md
+// Should we also consider if we're in dictionary encoding mode? or assume no for the
+// moment?
 Encoding::type ChooseFallbackEncoding(Type::type data_type,
                                       ParquetVersion::type parquet_version,
                                       ParquetDataPageVersion datapage_version) {
-  // WriterProperties data used to make encoding decision
-  //  physical type - some encodings don't support certain types.
-  //  current encoding - not sure if we actually need this.
-  //  parquet version
-  //  data page version
-  //
   if (data_type == Type::BOOLEAN && parquet_version != ParquetVersion::PARQUET_1_0 &&
       datapage_version == ParquetDataPageVersion::V2) {
     return Encoding::RLE;
@@ -4075,9 +4071,5 @@ Encoding::type ChooseFallbackEncoding(Type::type data_type,
   }
   return Encoding::PLAIN;
 }
-
-//  IsDictionaryEncoding - I think we should handle this separately
-//  differences between data page and dictionary page
-//
 
 }  // namespace parquet

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -4056,6 +4056,28 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
 
 }  // namespace detail
 
-Encoding::type ChooseFallbackEncoding() { return Encoding::PLAIN; }
+// Informed heavily by https://github.com/apache/parquet-format/blob/master/Encodings.md
+Encoding::type ChooseFallbackEncoding(Type::type data_type,
+                                      ParquetVersion::type parquet_version,
+                                      ParquetDataPageVersion datapage_version) {
+  // WriterProperties data used to make encoding decision
+  //  physical type - some encodings don't support certain types.
+  //  current encoding - not sure if we actually need this.
+  //  parquet version
+  //  data page version
+  //
+  if (data_type == Type::BOOLEAN && parquet_version != ParquetVersion::PARQUET_1_0 &&
+      datapage_version == ParquetDataPageVersion::V2) {
+    return Encoding::RLE;
+  } else if (data_type == Type::BYTE_ARRAY) {
+    // BYTE_ARRAYs should always default to DELTA_LENGTH_BYTE_ARRAY
+    return Encoding::DELTA_LENGTH_BYTE_ARRAY;
+  }
+  return Encoding::PLAIN;
+}
+
+//  IsDictionaryEncoding - I think we should handle this separately
+//  differences between data page and dictionary page
+//
 
 }  // namespace parquet

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -469,6 +469,7 @@ std::unique_ptr<typename EncodingTraits<DType>::Decoder> MakeTypedDecoder(
   return std::unique_ptr<OutType>(dynamic_cast<OutType*>(base.release()));
 }
 
+PARQUET_EXPORT
 Encoding::type ChooseNonDictEncoding(Type::type data_type,
                                      ParquetVersion::type parquet_version,
                                      ParquetDataPageVersion datapage_version);

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -468,4 +468,6 @@ std::unique_ptr<typename EncodingTraits<DType>::Decoder> MakeTypedDecoder(
   return std::unique_ptr<OutType>(dynamic_cast<OutType*>(base.release()));
 }
 
+Encoding::type ChooseFallbackEncoding();
+
 }  // namespace parquet

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -26,6 +26,7 @@
 
 #include "parquet/exception.h"
 #include "parquet/platform.h"
+#include "parquet/properties.h"
 #include "parquet/types.h"
 
 namespace arrow {
@@ -468,6 +469,8 @@ std::unique_ptr<typename EncodingTraits<DType>::Decoder> MakeTypedDecoder(
   return std::unique_ptr<OutType>(dynamic_cast<OutType*>(base.release()));
 }
 
-Encoding::type ChooseFallbackEncoding();
+Encoding::type ChooseFallbackEncoding(Type::type data_type,
+                                      ParquetVersion::type parquet_version,
+                                      ParquetDataPageVersion datapage_version);
 
 }  // namespace parquet

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -469,8 +469,8 @@ std::unique_ptr<typename EncodingTraits<DType>::Decoder> MakeTypedDecoder(
   return std::unique_ptr<OutType>(dynamic_cast<OutType*>(base.release()));
 }
 
-Encoding::type ChooseFallbackEncoding(Type::type data_type,
-                                      ParquetVersion::type parquet_version,
-                                      ParquetDataPageVersion datapage_version);
+Encoding::type ChooseNonDictEncoding(Type::type data_type,
+                                     ParquetVersion::type parquet_version,
+                                     ParquetDataPageVersion datapage_version);
 
 }  // namespace parquet

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2524,7 +2524,34 @@ TEST(DeltaByteArrayEncodingAdHoc, ArrowDirectPut) {
 }
 
 TEST(TestFallbackEncodingSuite, TestChooseFallbackEncoding) {
-  auto encoding = ChooseFallbackEncoding();
-  ASSERT_EQ(encoding, Encoding::PLAIN);
+  struct TestCase {
+    Type::type data_type;
+    ParquetVersion::type parquet_version;
+    ParquetDataPageVersion datapage_version;
+    Encoding::type expected_encoding;
+  };
+  TestCase cases[] = {
+      {Type::BOOLEAN, ParquetVersion::PARQUET_1_0, ParquetDataPageVersion::V2,
+       Encoding::PLAIN},
+      {Type::BOOLEAN, ParquetVersion::PARQUET_2_4, ParquetDataPageVersion::V1,
+       Encoding::PLAIN},
+      {Type::BOOLEAN, ParquetVersion::PARQUET_2_4, ParquetDataPageVersion::V2,
+       Encoding::RLE},
+      {Type::BOOLEAN, ParquetVersion::PARQUET_2_6, ParquetDataPageVersion::V2,
+       Encoding::RLE},
+      // Only BYTE_ARRAY type matters for producing Encoding::DELTA_LENGTH_BYTE_ARRAY
+      {Type::BYTE_ARRAY, ParquetVersion::PARQUET_1_0, ParquetDataPageVersion::V1,
+       Encoding::DELTA_LENGTH_BYTE_ARRAY},
+      {Type::BYTE_ARRAY, ParquetVersion::PARQUET_1_0, ParquetDataPageVersion::V2,
+       Encoding::DELTA_LENGTH_BYTE_ARRAY},
+      {Type::BYTE_ARRAY, ParquetVersion::PARQUET_2_4, ParquetDataPageVersion::V2,
+       Encoding::DELTA_LENGTH_BYTE_ARRAY},
+  };
+
+  for (auto test_case : cases) {
+    auto encoding = ChooseFallbackEncoding(test_case.data_type, test_case.parquet_version,
+                                           test_case.datapage_version);
+    ASSERT_EQ(encoding, test_case.expected_encoding);
+  }
 }
 }  // namespace parquet::test

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2523,7 +2523,7 @@ TEST(DeltaByteArrayEncodingAdHoc, ArrowDirectPut) {
   }
 }
 
-TEST(TestFallbackEncodingSuite, TestChooseFallbackEncoding) {
+TEST(TestFallbackEncodingSuite, TestChooseNonDictEncoding) {
   struct TestCase {
     Type::type data_type;
     ParquetVersion::type parquet_version;
@@ -2549,8 +2549,8 @@ TEST(TestFallbackEncodingSuite, TestChooseFallbackEncoding) {
   };
 
   for (auto test_case : cases) {
-    auto encoding = ChooseFallbackEncoding(test_case.data_type, test_case.parquet_version,
-                                           test_case.datapage_version);
+    auto encoding = ChooseNonDictEncoding(test_case.data_type, test_case.parquet_version,
+                                          test_case.datapage_version);
     ASSERT_EQ(encoding, test_case.expected_encoding);
   }
 }

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2539,13 +2539,24 @@ TEST(TestFallbackEncodingSuite, TestChooseNonDictEncoding) {
        Encoding::RLE},
       {Type::BOOLEAN, ParquetVersion::PARQUET_2_6, ParquetDataPageVersion::V2,
        Encoding::RLE},
-      // Only BYTE_ARRAY type matters for producing Encoding::DELTA_LENGTH_BYTE_ARRAY
       {Type::BYTE_ARRAY, ParquetVersion::PARQUET_1_0, ParquetDataPageVersion::V1,
-       Encoding::DELTA_LENGTH_BYTE_ARRAY},
+       Encoding::PLAIN},
       {Type::BYTE_ARRAY, ParquetVersion::PARQUET_1_0, ParquetDataPageVersion::V2,
-       Encoding::DELTA_LENGTH_BYTE_ARRAY},
+       Encoding::PLAIN},
       {Type::BYTE_ARRAY, ParquetVersion::PARQUET_2_4, ParquetDataPageVersion::V2,
        Encoding::DELTA_LENGTH_BYTE_ARRAY},
+      {Type::INT32, ParquetVersion::PARQUET_1_0, ParquetDataPageVersion::V1,
+       Encoding::PLAIN},
+      {Type::INT32, ParquetVersion::PARQUET_2_4, ParquetDataPageVersion::V1,
+       Encoding::DELTA_BINARY_PACKED},
+      {Type::FLOAT, ParquetVersion::PARQUET_1_0, ParquetDataPageVersion::V1,
+       Encoding::PLAIN},
+      {Type::FLOAT, ParquetVersion::PARQUET_2_4, ParquetDataPageVersion::V2,
+       Encoding::PLAIN},
+      {Type::FIXED_LEN_BYTE_ARRAY, ParquetVersion::PARQUET_1_0,
+       ParquetDataPageVersion::V1, Encoding::PLAIN},
+      {Type::FIXED_LEN_BYTE_ARRAY, ParquetVersion::PARQUET_2_4,
+       ParquetDataPageVersion::V2, Encoding::PLAIN},
   };
 
   for (auto test_case : cases) {

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2522,4 +2522,9 @@ TEST(DeltaByteArrayEncodingAdHoc, ArrowDirectPut) {
     CheckEncodeDecode(values, prefix_lengths, suffix_lengths, suffix_data);
   }
 }
+
+TEST(TestFallbackEncodingSuite, TestChooseFallbackEncoding) {
+  auto encoding = ChooseFallbackEncoding();
+  ASSERT_EQ(encoding, Encoding::PLAIN);
+}
 }  // namespace parquet::test


### PR DESCRIPTION
TODO

- [ ] Check for other possible fallback encoding improvements.
- [ ] Investigate existing tests for `ColumnWriter` and `TypeColumnWriterImpl` to determine if current testing is adequate or if more should be written in light of this change.

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Trying to improve fallback encoding choice for parquet files.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Adds a function `ChooseFallbackEncoding` which chooses the encoding based on the following: 
-  data type
- parquet version
- parquet data page version

And calls to it from appropriate places within `column_writer.cc`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Added a unit test for `ChooseFallbackEncoding` but more tests may be necessary in order to fully vet how this change impacts `ColumnWriter` and `TypedColumnWriterImpl`.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Will modify how parquet encoding fallback selection happens, which may be pertinent to end users.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40636