### PR TITLE
GH-40911: [C++] Remove decimal division's precision and scale calculate logic from implicit casts

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -428,13 +428,9 @@ Status CastBinaryDecimalArgs(DecimalPromotion promotion, std::vector<TypeHolder>
       right_scaleup = std::max(s1, s2) - s2;
       break;
     }
-    case DecimalPromotion::kMultiply: {
-      left_scaleup = right_scaleup = 0;
-      break;
-    }
+    case DecimalPromotion::kMultiply:
     case DecimalPromotion::kDivide: {
-      left_scaleup = std::max(4, s1 + p2 - s2 + 1) + s2 - s1;
-      right_scaleup = 0;
+      left_scaleup = right_scaleup = 0;
       break;
     }
     default:

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -541,13 +541,8 @@ Result<TypeHolder> ResolveDecimalDivisionOutput(KernelContext*,
       types,
       [](int32_t p1, int32_t s1, int32_t p2,
          int32_t s2) -> Result<std::pair<int32_t, int32_t>> {
-        if (s1 < s2) {
-          return Status::Invalid("Division of two decimal types scale1 < scale2. ", "(",
-                                 s1, s2, ").");
-        }
-        DCHECK_GE(s1, s2);
-        const int32_t scale = s1 - s2;
-        const int32_t precision = p1;
+        const int32_t scale = std::max(4, s1 + p2 - s2 + 1);
+        const int32_t precision = p1 - s1 + s2 + scale;
         return std::make_pair(precision, scale);
       });
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fix decimal divide results wrong when scale1 >= scale2 between CallFunction and expression execute.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
 Remove decimal division's precision and scale calculate logic from implicit casts.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes, decimal divide with scale1>=scale2 in ExecuteScalarExpression's results will be different with before.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40911