### PR TITLE
GH-38770: [C++][Python] RecordBatch.filter() segfaults if passed a ChunkedArray

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -22,6 +22,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "arrow/array/concatenate.h"
 #include "arrow/array/data.h"
 #include "arrow/buffer_builder.h"
 #include "arrow/chunked_array.h"
@@ -924,12 +925,26 @@ Result<std::shared_ptr<RecordBatch>> FilterRecordBatch(const RecordBatch& batch,
     return Status::Invalid("Filter inputs must all be the same length");
   }
 
-  // Convert filter to selection vector/indices and use Take
+  // Fetch filter
   const auto& filter_opts = *static_cast<const FilterOptions*>(options);
-  ARROW_ASSIGN_OR_RAISE(
-      std::shared_ptr<ArrayData> indices,
-      GetTakeIndices(*filter.array(), filter_opts.null_selection_behavior,
-                     ctx->memory_pool()));
+  ArrayData filter_array;
+  switch (filter.kind()) {
+    case Datum::ARRAY:
+      filter_array = *filter.array();
+      break;
+    case Datum::CHUNKED_ARRAY: {
+      ARROW_ASSIGN_OR_RAISE(auto combined, Concatenate(filter.chunked_array()->chunks()));
+      filter_array = *combined->data();
+      break;
+    }
+    default:
+      return Status::TypeError("Filter should be array-like");
+  }
+
+  // Convert filter to selection vector/indices and use Take
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<ArrayData> indices,
+                        GetTakeIndices(filter_array, filter_opts.null_selection_behavior,
+                                       ctx->memory_pool()));
   std::vector<std::shared_ptr<Array>> columns(batch.num_columns());
   for (int i = 0; i < batch.num_columns(); ++i) {
     ARROW_ASSIGN_OR_RAISE(Datum out, Take(batch.column(i)->data(), Datum(indices),
@@ -1038,18 +1053,10 @@ class FilterMetaFunction : public MetaFunction {
     }
 
     if (args[0].kind() == Datum::RECORD_BATCH) {
-      auto values_batch = args[0].record_batch();
-      if (args[1].kind() == Datum::ARRAY) {
-        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> out_batch,
-                              FilterRecordBatch(*values_batch, args[1], options, ctx));
-        return Datum(out_batch);
-      } else {
-        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Table> table,
-                              arrow::Table::FromRecordBatches({values_batch}));
-        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> out_table,
-                              FilterTable(*table, args[1], options, ctx));
-        return Datum(out_table);
-      }
+      ARROW_ASSIGN_OR_RAISE(
+          std::shared_ptr<RecordBatch> out_batch,
+          FilterRecordBatch(*args[0].record_batch(), args[1], options, ctx));
+      return Datum(out_batch);
     } else if (args[0].kind() == Datum::TABLE) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Table> out_table,
                             FilterTable(*args[0].table(), args[1], options, ctx));

--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -924,6 +924,10 @@ Result<std::shared_ptr<RecordBatch>> FilterRecordBatch(const RecordBatch& batch,
     return Status::Invalid("Filter inputs must all be the same length");
   }
 
+  if (filter.is_chunked_array()) {
+    return Status::Invalid("Chunked filter not supported for RecordBatches.");
+  }
+
   // Convert filter to selection vector/indices and use Take
   const auto& filter_opts = *static_cast<const FilterOptions*>(options);
   ARROW_ASSIGN_OR_RAISE(

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2935,16 +2935,17 @@ cdef class RecordBatch(_Tabular):
 
         Parameters
         ----------
-        mask : Array or array-like
+        mask : Array, ChunkedArray or array-like
             The boolean mask to filter the record batch with.
         null_selection_behavior : str, default "drop"
             How nulls in the mask should be handled.
 
         Returns
         -------
-        filtered : RecordBatch
+        filtered : RecordBatch or Table
             A record batch of the same schema, with only the rows selected
-            by the boolean mask.
+            by the boolean mask. If mask is a chunked array the object returned
+            is a table.
 
         Examples
         --------
@@ -2977,7 +2978,10 @@ cdef class RecordBatch(_Tabular):
         2     4.0     Horse
         3     NaN      None
         """
-        return _pc().filter(self, mask, null_selection_behavior)
+        if isinstance(mask, ChunkedArray):
+            return Table.from_batches([self]).filter(mask, null_selection_behavior)
+        else:
+            return _pc().filter(self, mask, null_selection_behavior)
 
     def equals(self, object other, bint check_metadata=False):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2935,17 +2935,16 @@ cdef class RecordBatch(_Tabular):
 
         Parameters
         ----------
-        mask : Array, ChunkedArray or array-like
+        mask : Array or array-like
             The boolean mask to filter the record batch with.
         null_selection_behavior : str, default "drop"
             How nulls in the mask should be handled.
 
         Returns
         -------
-        filtered : RecordBatch or Table
+        filtered : RecordBatch
             A record batch of the same schema, with only the rows selected
-            by the boolean mask. If mask is a chunked array the object returned
-            is a table.
+            by the boolean mask.
 
         Examples
         --------
@@ -2978,10 +2977,7 @@ cdef class RecordBatch(_Tabular):
         2     4.0     Horse
         3     NaN      None
         """
-        if isinstance(mask, ChunkedArray):
-            return Table.from_batches([self]).filter(mask, null_selection_behavior)
-        else:
-            return _pc().filter(self, mask, null_selection_behavior)
+        return _pc().filter(self, mask, null_selection_behavior)
 
     def equals(self, object other, bint check_metadata=False):
         """

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1350,13 +1350,8 @@ def test_filter_record_batch():
 
     # GH-38770: mask is chunked array
     mask = pa.chunked_array([[True, False], [None], [False, True]])
-    result = batch.filter(mask)
-    expected = pa.table([pa.array(["a", "e"])], names=["a'"])
-    assert result.equals(expected)
-
-    result = batch.filter(mask, null_selection_behavior="emit_null")
-    expected = pa.table([pa.array(["a", None, "e"])], names=["a'"])
-    assert result.equals(expected)
+    with pytest.raises(pa.ArrowInvalid, match="Chunked filter not supported"):
+        batch.filter(mask)
 
 
 def test_filter_table():

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1344,14 +1344,13 @@ def test_filter_record_batch():
     expected = pa.record_batch([pa.array(["a", "e"])], names=["a'"])
     assert result.equals(expected)
 
-    result = batch.filter(mask, null_selection_behavior="emit_null")
-    expected = pa.record_batch([pa.array(["a", None, "e"])], names=["a'"])
+    # GH-38770: mask is chunked array
+    chunked_mask = pa.chunked_array([[True, False], [None], [False, True]])
+    result = batch.filter(chunked_mask)
     assert result.equals(expected)
 
-    # GH-38770: mask is chunked array
-    mask = pa.chunked_array([[True, False], [None], [False, True]])
-    result = batch.filter(mask)
-    expected = pa.table([pa.array(["a", "e"])], names=["a'"])
+    result = batch.filter(mask, null_selection_behavior="emit_null")
+    expected = pa.record_batch([pa.array(["a", None, "e"])], names=["a'"])
     assert result.equals(expected)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1348,6 +1348,16 @@ def test_filter_record_batch():
     expected = pa.record_batch([pa.array(["a", None, "e"])], names=["a'"])
     assert result.equals(expected)
 
+    # GH-38770: mask is chunked array
+    mask = pa.chunked_array([[True, False], [None], [False, True]])
+    result = batch.filter(mask)
+    expected = pa.table([pa.array(["a", "e"])], names=["a'"])
+    assert result.equals(expected)
+
+    result = batch.filter(mask, null_selection_behavior="emit_null")
+    expected = pa.table([pa.array(["a", None, "e"])], names=["a'"])
+    assert result.equals(expected)
+
 
 def test_filter_table():
     table = pa.table([pa.array(["a", None, "c", "d", "e"])], names=["a"])

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1350,8 +1350,9 @@ def test_filter_record_batch():
 
     # GH-38770: mask is chunked array
     mask = pa.chunked_array([[True, False], [None], [False, True]])
-    with pytest.raises(pa.ArrowInvalid, match="Chunked filter not supported"):
-        batch.filter(mask)
+    result = batch.filter(mask)
+    expected = pa.table([pa.array(["a", "e"])], names=["a'"])
+    assert result.equals(expected)
 
 
 def test_filter_table():


### PR DESCRIPTION
### Rationale for this change

Filtering a record batch with a boolean mask in the form of a `ChunkedArray` results in a segmentation fault.

### What changes are included in this PR?

In case chunked array is passed as a mask to filter record batch, the code path for `pa.Table.filter()` is taken resulting in a filtered table.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #38770