### PR TITLE
MINOR: [CI] Avoid docker-compose on Azure

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5.1.0
         with:
-          python-version: '3.12'
+          python-version: '3.9'
       - name: Install pygit2 binary wheel
         run: pip install pygit2 --only-binary pygit2
       - name: Install Archery, Crossbow- and Test Dependencies

--- a/dev/archery/requirements-test.txt
+++ b/dev/archery/requirements-test.txt
@@ -1,2 +1,3 @@
+docker-compose
 pytest
 responses

--- a/dev/tasks/docker-tests/azure.linux.yml
+++ b/dev/tasks/docker-tests/azure.linux.yml
@@ -46,7 +46,7 @@ jobs:
     displayName: Setup Archery
 
   - script: |
-      archery docker run \
+      archery --debug docker --using-docker-cli run \
         -e ARROW_DOCS_VERSION="{{ arrow.no_rc_version }}" \
         -e SETUPTOOLS_SCM_PRETEND_VERSION="{{ arrow.no_rc_version }}" \
         {{ flags|default("") }} \


### PR DESCRIPTION
### Rationale for this change

Same as PR #40949, but for Crossbow builds hosted on Azure Pipelines.

### Are these changes tested?

Yes, they fix CI tests.

### Are there any user-facing changes?

No.