### PR TITLE
GH-40974: [CI][Python] CI failures on Python builds due to pytest_cython

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -29,5 +29,8 @@ sphinx-copybutton
 sphinxcontrib-jquery
 sphinx==6.2
 # Requirement for doctest-cython
-pytest-cython
+# Needs upper pin of 0.3.0, see:
+# https://github.com/lgpage/pytest-cython/issues/67
+# With 0.3.* bug fix release, the pin can be removed
+pytest-cython==0.2.2
 pandas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -842,14 +842,9 @@ services:
       PYTEST_ARGS:  # inherit
     volumes: *conda-volumes
     command: &python-conda-command
-    # pytest-cython needs an upper pin of 0.3.0 due
-    # to an issue with typing annotiations
-    # https://github.com/lgpage/pytest-cython/issues/67
-    # With 0.3.* bug fix release, the pin can be removed
       ["
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
-        pip install pytest-cython~=0.2.2 &&
         /arrow/ci/scripts/python_test.sh /arrow"]
 
   ubuntu-cuda-python:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -842,9 +842,14 @@ services:
       PYTEST_ARGS:  # inherit
     volumes: *conda-volumes
     command: &python-conda-command
+    # pytest-cython needs an upper pin of 0.3.0 due
+    # to an issue with typing annotiations
+    # https://github.com/lgpage/pytest-cython/issues/67
+    # With 0.3.* bug fix release, the pin can be removed
       ["
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
+        pip install pytest-cython~=0.2.2 &&
         /arrow/ci/scripts/python_test.sh /arrow"]
 
   ubuntu-cuda-python:
@@ -1214,16 +1219,11 @@ services:
     # newer version breaks cython doctesting, see:
     # https://github.com/lgpage/pytest-cython/issues/58
     # Remove pip install pytest~=7 when upstream issue is resolved
-    # Also pytest-cython needs an upper pin of 0.3.0 due
-    # to an issue with typing annotiations
-    # https://github.com/lgpage/pytest-cython/issues/67
-    # With 0.3.* bug fix release, both pins can be removed
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         pip install -e /arrow/dev/archery[numpydoc] &&
         pip install pytest~=7.4 &&
-        pip install pytest-cython~=0.2.2 &&
         archery numpydoc --allow-rule GL10,PR01,PR03,PR04,PR05,PR10,RT03,YD01 &&
         /arrow/ci/scripts/python_test.sh /arrow"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1214,11 +1214,16 @@ services:
     # newer version breaks cython doctesting, see:
     # https://github.com/lgpage/pytest-cython/issues/58
     # Remove pip install pytest~=7 when upstream issue is resolved
+    # Also pytest-cython needs an upper pin of 0.3.0 due
+    # to an issue with typing annotiations
+    # https://github.com/lgpage/pytest-cython/issues/67
+    # With 0.3.* bug fix release, both pins can be removed
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         pip install -e /arrow/dev/archery[numpydoc] &&
         pip install pytest~=7.4 &&
+        pip install pytest-cython~=0.2.2 &&
         archery numpydoc --allow-rule GL10,PR01,PR03,PR04,PR05,PR10,RT03,YD01 &&
         /arrow/ci/scripts/python_test.sh /arrow"]
 


### PR DESCRIPTION
### Rationale for this change

We are seeing sporadic CI failures on Python builds due to `pytest_cython`.

### What changes are included in this PR?

Upper pin of 0.3.0 added for `pytest-cython`.

### Are these changes tested?

With a green CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #40974