### PR TITLE
GH-39440: [Python] Calling pyarrow.dataset.ParquetFileFormat.make_write_options as a class method results in a segfault

### DIFF
--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -198,6 +198,9 @@ cdef class ParquetFileFormat(FileFormat):
         -------
         pyarrow.dataset.FileWriteOptions
         """
+        if not isinstance(self, ParquetFileFormat):
+            raise TypeError("pyarrow.dataset.ParquetFileFormat() must be initiated"
+                            " before calling make_write_options()")
         opts = FileFormat.make_write_options(self)
         (<ParquetFileWriteOptions> opts).update(**kwargs)
         return opts

--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -200,8 +200,8 @@ cdef class ParquetFileFormat(FileFormat):
         """
         # Safeguard from calling make_write_options as a static class method
         if not isinstance(self, ParquetFileFormat):
-            raise TypeError("pyarrow.dataset.ParquetFileFormat() must be initiated"
-                            " before calling make_write_options()")
+            raise TypeError("make_write_options() should be called on "
+                            "an instance of ParquetFileFormat")
         opts = FileFormat.make_write_options(self)
         (<ParquetFileWriteOptions> opts).update(**kwargs)
         return opts

--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -198,6 +198,7 @@ cdef class ParquetFileFormat(FileFormat):
         -------
         pyarrow.dataset.FileWriteOptions
         """
+        # Safeguard from calling make_write_options as a static class method
         if not isinstance(self, ParquetFileFormat):
             raise TypeError("pyarrow.dataset.ParquetFileFormat() must be initiated"
                             " before calling make_write_options()")

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5630,3 +5630,16 @@ def test_checksum_write_dataset_read_dataset_to_table(tempdir):
             corrupted_dir_path,
             format=pq_read_format_crc
         ).to_table()
+
+
+def test_make_write_options_error():
+    # GH-39440
+    msg = ("make_write_options\\(\\) should be called on an "
+           "instance of ParquetFileFormat")
+    with pytest.raises(TypeError, match=msg):
+        pa.dataset.ParquetFileFormat.make_write_options(43)
+
+    pformat = pa.dataset.ParquetFileFormat()
+    msg = "make_write_options\\(\\) takes exactly 0 positional arguments"
+    with pytest.raises(TypeError, match=msg):
+        pformat.make_write_options(43)

--- a/python/pyarrow/tests/test_dataset_encryption.py
+++ b/python/pyarrow/tests/test_dataset_encryption.py
@@ -215,15 +215,3 @@ def test_large_row_encryption_decryption():
     dataset = ds.dataset(path, format=file_format, filesystem=mockfs)
     new_table = dataset.to_table()
     assert table == new_table
-
-
-def test_make_write_options_error():
-    # GH-39440
-    msg = "ParquetFileFormat\\(\\) must be initiated before calling make_write_options"
-    with pytest.raises(TypeError, match=msg):
-        pa.dataset.ParquetFileFormat.make_write_options(43)
-
-    pformat = pa.dataset.ParquetFileFormat()
-    msg = "make_write_options\\(\\) takes exactly 0 positional arguments"
-    with pytest.raises(TypeError, match=msg):
-        pformat.make_write_options(43)

--- a/python/pyarrow/tests/test_dataset_encryption.py
+++ b/python/pyarrow/tests/test_dataset_encryption.py
@@ -215,3 +215,15 @@ def test_large_row_encryption_decryption():
     dataset = ds.dataset(path, format=file_format, filesystem=mockfs)
     new_table = dataset.to_table()
     assert table == new_table
+
+
+def test_make_write_options_error():
+    # GH-39440
+    msg = "ParquetFileFormat\\(\\) must be initiated before calling make_write_options"
+    with pytest.raises(TypeError, match=msg):
+        pa.dataset.ParquetFileFormat.make_write_options(43)
+
+    pformat = pa.dataset.ParquetFileFormat()
+    msg = "make_write_options\\(\\) takes exactly 0 positional arguments"
+    with pytest.raises(TypeError, match=msg):
+        pformat.make_write_options(43)


### PR DESCRIPTION
### Rationale for this change

Calling `make_write_options()` method as class instead of instance method results in segfault.

### What changes are included in this PR?

Adds a type check on `self` and raises an error if not `ParquetFileFormat`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #39440