### PR TITLE
GH-40806: [C++] Revert changes from PR #40857

### DIFF
--- a/cpp/src/arrow/config.cc
+++ b/cpp/src/arrow/config.cc
@@ -58,8 +58,6 @@ std::string MakeSimdLevelString(QueryFlagFunction&& query_flag) {
     return "avx";
   } else if (query_flag(CpuInfo::SSE4_2)) {
     return "sse4_2";
-  } else if (query_flag(CpuInfo::ASIMD)) {
-    return "neon";
   } else {
     return "none";
   }


### PR DESCRIPTION
Revert changes from https://github.com/apache/arrow/pull/40857.

`GetRuntimeInfo` returns the SIMD level for dynamic dispatch, but Neon currently does not participate in dynamic dispatch (actually, Neon should be available by default on all modern Arm CPUs AFAIU).

* GitHub Issue: #40806