### PR TITLE
GH-41010: [Java] Support extension vectors in JsonFileWriter/JsonFileReader

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -40,6 +40,7 @@ import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.Decimal256Vector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.DurationVector;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
@@ -209,6 +210,10 @@ public class JsonFileWriter implements AutoCloseable {
   }
 
   private void writeFromVectorIntoJson(Field field, FieldVector vector) throws IOException {
+    if (vector instanceof ExtensionTypeVector) {
+      writeFromVectorIntoJson(field, ((ExtensionTypeVector<?>) vector).getUnderlyingVector());
+      return;
+    }
     List<BufferType> vectorTypes = TypeLayout.getTypeLayout(field.getType()).getBufferTypes();
     List<ArrowBuf> vectorBuffers = vector.getFieldBuffers();
     if (vectorTypes.size() != vectorBuffers.size()) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -79,6 +79,7 @@ import org.apache.commons.codec.binary.Hex;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.NopIndenter;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
@@ -136,7 +137,7 @@ public class JsonFileWriter implements AutoCloseable {
       this.generator.setPrettyPrinter(prettyPrinter);
     }
     // Allow writing of floating point NaN values not as strings
-    this.generator.configure(JsonGenerator.Feature.QUOTE_NON_NUMERIC_NUMBERS, false);
+    this.generator.configure(JsonWriteFeature.WRITE_NAN_AS_STRINGS.mappedFeature(), false);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/ExtensionTypeRegistry.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/ExtensionTypeRegistry.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector.types.pojo;
 
+import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -38,5 +39,9 @@ public final class ExtensionTypeRegistry {
 
   public static ExtensionType lookup(String name) {
     return registry.get(name);
+  }
+
+  public static Collection<String> getExtensionNames() {
+    return registry.keySet();
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
@@ -429,6 +429,27 @@ public class TestJSONFile extends BaseFileTest {
     }
   }
 
+  @Test
+  public void testWriteReadExtensionData() throws IOException {
+    // write
+    try (VectorSchemaRoot root = writeUuidData(allocator)) {
+      File file = new File("target/mytest_extension.json");
+      writeJSON(file, root, null);
+    }
+
+    // read
+    try (BufferAllocator readerAllocator = allocator.newChildAllocator("reader", 0, Integer.MAX_VALUE);
+        JsonFileReader reader = new JsonFileReader(new File("target/mytest_extension.json"), readerAllocator)) {
+      Schema schema = reader.start();
+      LOGGER.debug("reading schema: " + schema);
+
+      // initialize vectors
+      try (VectorSchemaRoot root = reader.read()) {
+        validateUuidData(root);
+      }
+    }
+  }
+
   /** Regression test for ARROW-17107. */
   @Test
   public void testRoundtripEmptyVector() throws Exception {

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -278,7 +278,7 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidType extends ExtensionType {
+  public static class UuidType extends ExtensionType {
 
     @Override
     public ArrowType storageType() {
@@ -314,10 +314,15 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector> {
+  public static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector> {
 
     public UuidVector(String name, BufferAllocator allocator, FixedSizeBinaryVector underlyingVector) {
       super(name, allocator, underlyingVector);
+    }
+
+    @Override
+    public Field getField() {
+      return new Field(getName(), FieldType.nullable(new UuidType()), null);
     }
 
     @Override


### PR DESCRIPTION
### Rationale for this change

Extension vectors are unsupported in `JsonFileWriter`/`JsonFileReader`. We use these classes to test our Arrow support, but when we try to round-trip data with (e.g.) UUIDs it fails.

### What changes are included in this PR?

* `JsonFileWriter`: we delegate to the existing implementation for the underlying vector.
* `JsonFileReader`: we register all of the registered extension types as sub-types to the Jackson reader.

resolves apache/arrow-java#107 

### Are these changes tested?

Yes

### Are there any user-facing changes?

One: the addition of `ExtensionTypeRegistry.getExtensionNames()` so that the `JsonFileReader` can register them as sub-types with Jackson. Doesn't seem ideal to introduce a public method just to be called from `JsonFileReader` so (unless this is actually desirable, of course!), am open to other suggestions.
* GitHub Issue: apache/arrow-java#107
* GitHub Issue: #107