### PR TITLE
GH-40249: [Java] Fix NPE in ArrowDatabaseMetadata

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadata.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadata.java
@@ -49,6 +49,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -197,31 +198,36 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
   @Override
   public String getSQLKeywords() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_KEYWORDS, List.class));
+        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_KEYWORDS, List.class))
+        .orElse("");
   }
 
   @Override
   public String getNumericFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_NUMERIC_FUNCTIONS, List.class));
+        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_NUMERIC_FUNCTIONS, List.class))
+        .orElse("");
   }
 
   @Override
   public String getStringFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_STRING_FUNCTIONS, List.class));
+        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_STRING_FUNCTIONS, List.class))
+        .orElse("");
   }
 
   @Override
   public String getSystemFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SYSTEM_FUNCTIONS, List.class));
+        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SYSTEM_FUNCTIONS, List.class))
+        .orElse("");
   }
 
   @Override
   public String getTimeDateFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DATETIME_FUNCTIONS, List.class));
+        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DATETIME_FUNCTIONS, List.class))
+        .orElse("");
   }
 
   @Override
@@ -753,8 +759,12 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
     return desiredType.cast(cachedSqlInfo.get(sqlInfoCommand));
   }
 
-  private String convertListSqlInfoToString(final List<?> sqlInfoList) {
-    return sqlInfoList.stream().map(Object::toString).collect(Collectors.joining(", "));
+  private Optional<String> convertListSqlInfoToString(final List<?> sqlInfoList) {
+    if (sqlInfoList == null) {
+      return Optional.empty();
+    } else {
+      return Optional.of(sqlInfoList.stream().map(Object::toString).collect(Collectors.joining(", ")));
+    }
   }
 
   private boolean getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(


### PR DESCRIPTION
### Rationale for this change

When retrieving database metadata using the JDBC driver, some data such as SQL keywords could be null. Before this change, an NPE would be thrown when trying to convert the list of SQL keywords into a String.

### What changes are included in this PR?

The following database metadata fields:

* SQL keywords
* Numeric functions
* String functions
* System functions
* Time/date functions

will convert to an empty string when they are null.

### Are these changes tested?

A unit test has been added to verify that the fields above are converted to the empty string when null, with no exceptions thrown.

### Are there any user-facing changes?

The fields above will now return an empty string rather than throw an NPE.
* GitHub Issue: #40249