### PR TITLE
GH-36057: [C#] Allow C Data Interface export of ReadOnlyMemory backed buffers

### DIFF
--- a/csharp/src/Apache.Arrow/ArrowBuffer.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.cs
@@ -89,6 +89,13 @@ namespace Apache.Arrow
                 return true;
             }
 
+            if (_memoryOwner == null)
+            {
+                var handle = _memory.Pin();
+                ptr = newOwner.Reference(handle);
+                return true;
+            }
+
             ptr = IntPtr.Zero;
             return false;
         }

--- a/csharp/src/Apache.Arrow/Memory/ExportedAllocationOwner.cs
+++ b/csharp/src/Apache.Arrow/Memory/ExportedAllocationOwner.cs
@@ -21,7 +21,7 @@ using System.Threading;
 
 namespace Apache.Arrow.Memory
 {
-    internal sealed class ExportedAllocationOwner : INativeAllocationOwner, IDisposable
+    internal sealed class ExportedAllocationOwner : IDisposable
     {
         private readonly List<IntPtr> _pointers = new List<IntPtr>();
         private int _allocationSize;
@@ -44,11 +44,6 @@ namespace Apache.Arrow.Memory
             _pointers.Add(ptr);
             _allocationSize += length;
             return ptr;
-        }
-
-        public void Release(IntPtr ptr, int offset, int length)
-        {
-            throw new InvalidOperationException();
         }
 
         public void IncRef()

--- a/csharp/src/Apache.Arrow/Memory/NativeMemoryManager.cs
+++ b/csharp/src/Apache.Arrow/Memory/NativeMemoryManager.cs
@@ -80,6 +80,7 @@ namespace Apache.Arrow.Memory
                     // If disposed from the finalizer, that means there can be no MemoryHandles to this memory.
                     if (_pinCount > 0)
                     {
+                        _ptr = ptr;
                         throw new InvalidOperationException("Cannot free native memory while it is pinned");
                     }
                 }

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfacePythonTests.cs
@@ -933,11 +933,6 @@ namespace Apache.Arrow.Tests
         [SkippableFact]
         public async Task ExportBatchReadFromIpc()
         {
-            // Reading IPC data from a Stream creates Arrow buffers backed by ReadOnlyMemory that point
-            // to slices of a single memory buffer owned by the RecordBach (unless compression is used).
-            // Using the exported data after the RecordBatch has been disposed can cause
-            // memory corruption or access violations.
-
             var originalBatch = GetTestRecordBatch();
             dynamic pyBatch = GetPythonRecordBatch();
 
@@ -950,7 +945,7 @@ namespace Apache.Arrow.Tests
                 stream.Seek(0, SeekOrigin.Begin);
 
                 var reader = new ArrowStreamReader(stream);
-                var batch = await reader.ReadNextRecordBatchAsync();
+                using var batch = await reader.ReadNextRecordBatchAsync();
 
                 Assert.NotNull(batch);
                 Assert.Equal(originalBatch.Length, batch.Length);
@@ -966,14 +961,55 @@ namespace Apache.Arrow.Tests
                     long arrayPtr = ((IntPtr)cArray).ToInt64();
                     long schemaPtr = ((IntPtr)cSchema).ToInt64();
 
-                    batch.Dispose();
-
                     using (Py.GIL())
                     {
                         dynamic pa = Py.Import("pyarrow");
                         dynamic exportedPyArray = pa.RecordBatch._import_from_c(arrayPtr, schemaPtr);
                         Assert.True(exportedPyArray == pyBatch);
+
+                        // Dispose to unpin memory
+                        exportedPyArray.Dispose();
                     }
+
+                    CArrowArray.Free(cArray);
+                    CArrowSchema.Free(cSchema);
+                }
+            }
+        }
+
+        [SkippableFact]
+        public async Task EarlyDisposeOfExportedBatch()
+        {
+            // Reading IPC data from a Stream creates Arrow buffers backed by ReadOnlyMemory that point
+            // to slices of a single memory buffer owned by the RecordBach (unless compression is used).
+            // Using the exported data after the RecordBatch has been disposed could cause
+            // memory corruption or access violations.
+
+            var originalBatch = GetTestRecordBatch();
+
+            using (var stream = new MemoryStream())
+            {
+                var writer = new ArrowStreamWriter(stream, originalBatch.Schema);
+                await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                var reader = new ArrowStreamReader(stream);
+                using var batch = await reader.ReadNextRecordBatchAsync();
+
+                Assert.NotNull(batch);
+                Assert.Equal(originalBatch.Length, batch.Length);
+
+                unsafe
+                {
+                    CArrowArray* cArray = CArrowArray.Create();
+                    CArrowArrayExporter.ExportRecordBatch(batch, cArray);
+
+                    CArrowSchema* cSchema = CArrowSchema.Create();
+                    CArrowSchemaExporter.ExportSchema(batch.Schema, cSchema);
+
+                    Assert.Throws<InvalidOperationException>(() => batch.Dispose());
 
                     CArrowArray.Free(cArray);
                     CArrowSchema.Free(cSchema);


### PR DESCRIPTION
### Rationale for this change

This PR partly addresses #36057, by allowing C Data Interface export of buffers backed by `ReadOnlyMemory` rather than an `IMemoryOwner`. This is useful if you want to export data that has been read from an IPC file or stream for example. Previously you would need to first copy all buffers for this to work.

### What changes are included in this PR?

Updates the `ExportedAllocationOwner` class to allow it to hold pinned `MemoryHandle`s.

### Are these changes tested?

Yes, I've added new unit tests.

### Are there any user-facing changes?

Yes, this is a user-facing change, as export of arrays backed by `ReadOnlyMemory` would previously throw an exception but will now succeed.

### Safety

I can't see a way to do this completely safely, as there's always the possibility that a buffer is backed by a `MemoryManager` that frees or modifies memory after it is exported but before the exported data is disposed and the memory is unpinned.

Users are able to create buffers from arbitrary `ReadOnlyMemory` so there's no limit to how the underlying memory might be managed, but the only situation I'm aware of where `ReadOnlyMemory` is used for buffers created within the C# Arrow library itself is when reading IPC data. This might be read from an arbitrary `ReadOnlyMemory` object, but when reading uncompressed buffers from a `Stream`, the buffer data ends up being backed by slices of memory allocated using a `NativeMemoryAllocator`, and the `RecordBatch` holds a reference to the `IMemoryOwner` that owns this memory so it can all be freed at once.

In order to protect from users disposing a `RecordBatch` that is backed by native memory while it is still in use after export, I've made a change to throw an exception if a `NativeMemoryManager` is disposed while its memory is still pinned.

I'm not sure whether this is really safe enough to merge as is though, given the possibility of buffers using other `MemoryManager` implementations that don't have similar checks. Maybe it would make sense to require using separate export methods to allow export of `ReadOnlyMemory` buffers, eg. `CArrowArrayExporter.ExportArrayUnsafe`? By using this method instead of the normal `ExportArray` method, the user would be aware that they're responsible for verifying that the backing memory won't be disposed before the export client is done with the data.

I'm creating this as a draft PR initially as I think this safety aspect needs some discussion.
* GitHub Issue: #36057