### PR TITLE
GH-40999: [Java] Fix AIOOBE trying to splitAndTransfer DUV within nullable struct 

### DIFF
--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -676,10 +676,12 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
 
       for (int i = startIndex; i < startIndex + length; i++) {
         byte typeId = typeBuffer.getByte(i);
-        to.offsetBuffer.setInt((long) (i - startIndex) * OFFSET_WIDTH, typeCounts[typeId]);
-        typeCounts[typeId] += 1;
-        if (typeStarts[typeId] == -1) {
-          typeStarts[typeId] = offsetBuffer.getInt((long) i * OFFSET_WIDTH);
+        if (typeId >= 0) {
+          to.offsetBuffer.setInt((long) (i - startIndex) * OFFSET_WIDTH, typeCounts[typeId]);
+          typeCounts[typeId] += 1;
+          if (typeStarts[typeId] == -1) {
+            typeStarts[typeId] = offsetBuffer.getInt((long) i * OFFSET_WIDTH);
+          }
         }
       }
 


### PR DESCRIPTION
We add a `typeId >= 0` guard to `DUV.TransferImpl.splitAndTransfer` to fix #40999.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #40999