### PR TITLE
MINOR: [Java] `DenseUnionVector.empty` should create not-nullable DUVs

### DIFF
--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -124,7 +124,7 @@ public class DenseUnionVector extends AbstractContainerVector implements FieldVe
           ArrowType.Struct.INSTANCE, /*dictionary*/ null, /*metadata*/ null);
 
   public static DenseUnionVector empty(String name, BufferAllocator allocator) {
-    FieldType fieldType = FieldType.nullable(new ArrowType.Union(
+    FieldType fieldType = FieldType.notNullable(new ArrowType.Union(
             UnionMode.Dense, null));
     return new DenseUnionVector(name, allocator, fieldType, null);
   }


### PR DESCRIPTION
### Rationale for this change

DUVs do not have a validity vector, so cannot be set to null - `isNull`, for example, always returns false. This change ensures vectors created through `DenseUnionVector.empty` reflect this in their FieldType.

### What changes are included in this PR?

`DenseUnionVector.empty` now creates DUVs with a not-nullable `FieldType`

### Are these changes tested?

I haven't added an explicit test for this as it would essentially be testing `FieldType.notNullable` - confirmed that it doesn't break any existing tests.

### Are there any user-facing changes?

Yes, strictly speaking this is a public change, correcting a bug in a public API.

**This PR includes breaking changes to public APIs.**