### PR TITLE
GH-40549: [Java] Revert bump org.apache.maven.plugins:maven-shade-plugin from 3.2.4 to 3.5.2 in /java (#40462)"

### DIFF
--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -164,7 +164,7 @@
           issues in the arrow-tools tests looking up FlatBuffer
           dependencies.
          -->
-        <version>3.5.2</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <id>shade-main</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -449,7 +449,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.2</version>
+          <version>3.5.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -179,7 +179,7 @@
           issues in the arrow-tools tests looking up FlatBuffer
           dependencies.
          -->
-        <version>3.5.2</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
This reverts commit 8ee9679d401183220a4566681ca7ef9e887ba4d2.

### Rationale for this change

Spark integration tests are failing due to this bump.

### What changes are included in this PR?

Revert bump org.apache.maven.plugins:maven-shade-plugin from 3.2.4 to 3.5.2 

### Are these changes tested?
Via CI.

### Are there any user-facing changes?

They shouldn't
* GitHub Issue: #40549