### PR TITLE
GH-40861: [C++][Python] Support null, binary_view and string_view types in type check

### DIFF
--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -2418,6 +2418,7 @@ TEST(TypesTest, TestMembership) {
   for (auto type : PrimitiveTypes()) {
     all_types.push_back(type);
   }
+  TEST_PREDICATE(all_types, is_null);
   TEST_PREDICATE(all_types, is_integer);
   TEST_PREDICATE(all_types, is_signed_integer);
   TEST_PREDICATE(all_types, is_unsigned_integer);
@@ -2430,6 +2431,8 @@ TEST(TypesTest, TestMembership) {
   TEST_PREDICATE(all_types, is_large_binary_like);
   TEST_PREDICATE(all_types, is_binary);
   TEST_PREDICATE(all_types, is_string);
+  TEST_PREDICATE(all_types, is_binary_view)
+  TEST_PREDICATE(all_types, is_string_view);
   TEST_PREDICATE(all_types, is_temporal);
   TEST_PREDICATE(all_types, is_interval);
   TEST_PREDICATE(all_types, is_dictionary);

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -955,6 +955,12 @@ using enable_if_physical_floating_point =
 /// \addtogroup runtime-type-predicates
 /// @{
 
+/// \brief Check for a null type
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id is a null type one
+constexpr bool is_null(Type::type type_id) { return type_id == Type::NA; }
+
 /// \brief Check for an integer type (signed or unsigned)
 ///
 /// \param[in] type_id the type-id to check
@@ -1193,6 +1199,34 @@ constexpr bool is_string(Type::type type_id) {
   switch (type_id) {
     case Type::STRING:
     case Type::LARGE_STRING:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+/// \brief Check for a binary-view type
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id is a binary-view type one
+constexpr bool is_binary_view(Type::type type_id) {
+  switch (type_id) {
+    case Type::BINARY_VIEW:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+/// \brief Check for a string-view type
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id is a string-view type one
+constexpr bool is_string_view(Type::type type_id) {
+  switch (type_id) {
+    case Type::STRING_VIEW:
       return true;
     default:
       break;
@@ -1517,6 +1551,14 @@ static inline int offset_bit_width(Type::type type_id) {
 /// \return the required value alignment in bytes (1 if no alignment required)
 int RequiredValueAlignmentForBuffer(Type::type type_id, int buffer_index);
 
+/// \brief Check for a null type
+///
+/// \param[in] type the type to check
+/// \return whether type is a null type
+///
+/// Convenience for checking using the type's id
+static inline bool is_null(const DataType& type) { return is_null(type.id()); }
+
 /// \brief Check for an integer type (signed or unsigned)
 ///
 /// \param[in] type the type to check
@@ -1622,6 +1664,26 @@ static inline bool is_binary(const DataType& type) { return is_binary(type.id())
 ///
 /// Convenience for checking using the type's id
 static inline bool is_string(const DataType& type) { return is_string(type.id()); }
+
+/// \brief Check for a binary-view type
+///
+/// \param[in] type the type to check
+/// \return whether type is a binary-view type
+///
+/// Convenience for checking using the type's id
+static inline bool is_binary_view(const DataType& type) {
+  return is_binary_view(type.id());
+}
+
+/// \brief Check for a string-view type
+///
+/// \param[in] type the type to check
+/// \return whether type is a string-view type
+///
+/// Convenience for checking using the type's id
+static inline bool is_string_view(const DataType& type) {
+  return is_string_view(type.id());
+}
 
 /// \brief Check for a temporal type, including time and timestamps for each unit
 ///

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -3019,3 +3019,9 @@ cdef extern from "arrow/python/udf.h" namespace "arrow::py" nogil:
 
 cdef extern from "arrow/compute/cast.h" namespace "arrow::compute":
     CResult[CDatum] Cast(const CDatum& value, const CCastOptions& options)
+
+cdef extern from "arrow/type_traits.h" namespace "arrow":
+    c_bool is_null(Type type_id)
+    c_bool is_binary_view(Type type_id)
+    c_bool is_string_view(Type type_id)
+

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -162,6 +162,9 @@ include "pandas-shim.pxi"
 # Memory pools and allocation
 include "memory.pxi"
 
+# TypeTraits
+include "type_traits.pxi"
+
 # DataType, Field, Schema
 include "types.pxi"
 

--- a/python/pyarrow/type_traits.pxi
+++ b/python/pyarrow/type_traits.pxi
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pyarrow.includes.libarrow cimport (is_null,
+is_binary_view,
+is_string_view)
+
+def _is_null(data_type):
+    """
+    This function checks whether the data type is null type.
+
+    Parameters
+    ----------
+    data_type: DataType
+        The data type to check against the null type.
+
+    Returns
+    -------
+    bool
+        True if the data type is null type, False otherwise.
+    """
+    return is_null(data_type.id)
+
+def _is_binary_view(data_type):
+    """
+    This function checks whether the data type is binary view type.
+
+    Parameters
+    ----------
+    data_type: DataType
+        The data type to check against the binary view type.
+
+    Returns
+    -------
+    bool
+        True if the data type is binary view type, False otherwise.
+    """
+    return is_binary_view(data_type.id)
+
+def _is_string_view(data_type):
+    """
+    This function checks whether the data type is string view type.
+
+    Parameters
+    ----------
+    data_type: DataType
+        The data type to check against the string view type.
+
+    Returns
+    -------
+    bool
+        True if the data type is string view type, False otherwise.
+    """
+    return is_string_view(data_type.id)

--- a/python/pyarrow/type_traits.pxi
+++ b/python/pyarrow/type_traits.pxi
@@ -16,8 +16,8 @@
 # under the License.
 
 from pyarrow.includes.libarrow cimport (is_null,
-is_binary_view,
-is_string_view)
+                                        is_binary_view,
+                                        is_string_view)
 
 def _is_null(data_type):
     """
@@ -35,6 +35,7 @@ def _is_null(data_type):
     """
     return is_null(data_type.id)
 
+
 def _is_binary_view(data_type):
     """
     This function checks whether the data type is binary view type.
@@ -50,6 +51,7 @@ def _is_binary_view(data_type):
         True if the data type is binary view type, False otherwise.
     """
     return is_binary_view(data_type.id)
+
 
 def _is_string_view(data_type):
     """

--- a/python/pyarrow/types.py
+++ b/python/pyarrow/types.py
@@ -20,7 +20,10 @@
 
 from pyarrow.lib import (is_boolean_value,  # noqa
                          is_integer_value,
-                         is_float_value)
+                         is_float_value,
+                         _is_null,
+                         _is_binary_view,
+                         _is_string_view)
 
 import pyarrow.lib as lib
 from pyarrow.util import doc
@@ -47,14 +50,7 @@ _NESTED_TYPES = {lib.Type_LIST, lib.Type_FIXED_SIZE_LIST, lib.Type_LARGE_LIST,
 
 @doc(datatype="null")
 def is_null(t):
-    """
-    Return True if value is an instance of type: {datatype}.
-
-    Parameters
-    ----------
-    t : DataType
-    """
-    return t.id == lib.Type_NA
+    return _is_null(t)
 
 
 @doc(is_null, datatype="boolean")
@@ -256,12 +252,12 @@ def is_fixed_size_binary(t):
 
 @doc(is_null, datatype="variable-length binary view")
 def is_binary_view(t):
-    return t.id == lib.Type_BINARY_VIEW
+    return _is_binary_view(t)
 
 
 @doc(is_null, datatype="variable-length string (utf-8) view")
 def is_string_view(t):
-    return t.id == lib.Type_STRING_VIEW
+    return _is_string_view(t)
 
 
 @doc(is_null, datatype="date")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Support `null`, `binary_view` and `string_view` types  in type checks within PyArrow

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- C++: Support `null`, `binary_view`, and `string_view` types into the type check functionality within `type_traits.h`.
- Python: Expose the `null`, `binary_view`, and `string_view` types to Python, enabling these types to be utilized effectively in Python-level type checks.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40861