### PR TITLE
GH-40978: [C++] Support UnsafeAppend{Values|Nulls} in ::arrow::BooleanBuilder

### DIFF
--- a/cpp/src/arrow/array/builder_primitive.cc
+++ b/cpp/src/arrow/array/builder_primitive.cc
@@ -89,9 +89,14 @@ Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,
 Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,
                                     const uint8_t* validity, int64_t offset) {
   RETURN_NOT_OK(Reserve(length));
+  UnsafeAppendValues(values, length, validity, offset);
+  return Status::OK();
+}
+
+void BooleanBuilder::UnsafeAppendValues(const uint8_t* values, int64_t length,
+                                        const uint8_t* validity, int64_t offset) {
   data_builder_.UnsafeAppend(values, offset, length);
   ArrayBuilder::UnsafeAppendToBitmap(validity, offset, length);
-  return Status::OK();
 }
 
 Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1212,15 +1212,10 @@ int PlainBooleanDecoder::DecodeArrow(
     while (value_position < num_values) {
       auto block = bit_counter.NextWord();
       if (block.AllSet()) {
-        // GH-40978: We don't have UnsafeAppendValues for booleans currently,
-        // so using `AppendValues` here.
-        PARQUET_THROW_NOT_OK(
-            builder->AppendValues(data_, block.length, NULLPTR, previous_value_offset));
+        builder->UnsafeAppendValues(data_, block.length, NULLPTR, previous_value_offset);
         previous_value_offset += block.length;
       } else if (block.NoneSet()) {
-        // GH-40978: We don't have UnsafeAppendNulls for booleans currently,
-        // so using `AppendNulls` here.
-        PARQUET_THROW_NOT_OK(builder->AppendNulls(block.length));
+        builder->UnsafeAppendNulls(block.length);
       } else {
         for (int64_t i = 0; i < block.length; ++i) {
           if (bit_util::GetBit(valid_bits, valid_bits_offset_position + i)) {

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -3169,8 +3169,7 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
       // Fast-path for not having nulls.
       do {
         next_boolean_batch();
-        PARQUET_THROW_NOT_OK(
-            out->AppendValues(values.begin(), values.begin() + current_batch_size));
+        out->UnsafeAppendValues(values.begin(), values.begin() + current_batch_size);
         num_values -= current_batch_size;
         current_index_in_batch = 0;
       } while (num_values > 0);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Currently, unsafe append only supports per-value appends. This patch supports "Unsafe" batch append to `::arrow::BooleanBuilder` and try to enhance the performance

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

 supports "Unsafe" batch append to `::arrow::BooleanBuilder` and try to enhance the performance

### Are these changes tested?

Not yet

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #40978