### PR TITLE
GH-41007: [CI][Archery] Correctly interpolate environment variables from docker compose when using docker cli on archery docker

### DIFF
--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -77,7 +77,9 @@ def docker(ctx, src, dry_run, using_docker_cli, using_docker_buildx):
     compose = DockerCompose(config_path, params=os.environ,
                             using_docker=using_docker_cli,
                             using_buildx=using_docker_buildx,
-                            debug=ctx.obj.get('debug', False))
+                            debug=ctx.obj.get('debug', False),
+                            compose_bin=("docker compose" if using_docker_cli
+                                         else "docker-compose"))
     if dry_run:
         _mock_compose_calls(compose)
     ctx.obj['compose'] = compose

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -402,6 +402,10 @@ class DockerCompose(Command):
                     # on the docker-compose yaml file.
                     if isinstance(cmd, list):
                         cmd = shlex.join(cmd)
+                    # Match behaviour from docker compose
+                    # to interpolate environment variables
+                    # https://docs.docker.com/compose/compose-file/12-interpolation/
+                    cmd = cmd.replace("$$", "$")
                     args.extend(shlex.split(cmd))
 
             # execute as a plain docker cli command


### PR DESCRIPTION
### Rationale for this change

Currently our verification jobs are failing due to environment variables not being correctly interpolated. docker compose expects a double `$$` sign on the command as explained here:
https://docs.docker.com/compose/compose-file/12-interpolation/
When we use `ARCHERY_USE_DOCKER_CLI=1` we are using `docker run` instead of `docker compose run`. The behaviour of the command changes and we have to update change the environment variable.

### What changes are included in this PR?

Use correct docker compose binary when using `docker cli` and remove double $$.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #41007