### PR TITLE
GH-41005: [CI] HDFS and skyhook tests require docker compose usage because they require multiple containers

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1528,6 +1528,7 @@ tasks:
       env:
         PYTHON: "3.10"
         HDFS: "{{ hdfs_version }}"
+        ARCHERY_USE_DOCKER_CLI: 0
       image: conda-python-hdfs
 {% endfor %}
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1090,8 +1090,8 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 20.04
         ARCHERY_USE_DOCKER_CLI: 0
+        UBUNTU: 20.04
       flags: -e ARROW_SKYHOOK=ON
       image: ubuntu-cpp
 
@@ -1527,9 +1527,9 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        PYTHON: "3.10"
-        HDFS: "{{ hdfs_version }}"
         ARCHERY_USE_DOCKER_CLI: 0
+        HDFS: "{{ hdfs_version }}"
+        PYTHON: "3.10"
       image: conda-python-hdfs
 {% endfor %}
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1091,6 +1091,7 @@ tasks:
     params:
       env:
         UBUNTU: 20.04
+        ARCHERY_USE_DOCKER_CLI: 0
       flags: -e ARROW_SKYHOOK=ON
       image: ubuntu-cpp
 


### PR DESCRIPTION
### Rationale for this change

We are currently using docker run but we require linked containers to be also started.

### What changes are included in this PR?

Use docker compose instead of docker 

### Are these changes tested?

Via archery

### Are there any user-facing changes?
No
* GitHub Issue: #41005