### PR TITLE
GH-41029: [GLib] Add missing "no" to suppress warnings

### DIFF
--- a/c_glib/example/vala/meson.build
+++ b/c_glib/example/vala/meson.build
@@ -19,7 +19,7 @@
 
 if generate_vapi
   c_flags = [
-    '-Wunused-but-set-variable',
+    '-Wno-unused-but-set-variable',
   ]
   c_flags = meson.get_compiler('c').get_supported_arguments(c_flags)
   vala_example_executable_kwargs = {


### PR DESCRIPTION
### Rationale for this change

There are some `unused-but-set-variable` warnings for Vala examples on macOS:

```text
FAILED: example/vala/write-file.p/meson-generated_write-file.c.o
ccache cc -Iexample/vala/write-file.p -Iexample/vala -I../../c_glib/example/vala -I/Users/runner/work/arrow/arrow/build/c_glib -I/Users/runner/work/arrow/arrow/c_glib -Iarrow-glib -I../../c_glib/arrow-glib -I/usr/local/Cellar/glib/2.80.0_2/include -I/usr/local/Cellar/glib/2.80.0_2/include/glib-2.0 -I/usr/local/Cellar/glib/2.80.0_2/lib/glib-2.0/include -I/usr/local/opt/gettext/include -I/usr/local/Cellar/pcre2/10.43/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/ffi -fdiagnostics-color=always -Wall -Winvalid-pch -Werror -std=c99 -O0 -g -DARROW_NO_DEPRECATED_API -MD -MQ example/vala/write-file.p/meson-generated_write-file.c.o -MF example/vala/write-file.p/meson-generated_write-file.c.o.d -o example/vala/write-file.p/meson-generated_write-file.c.o -c example/vala/write-file.p/write-file.c
write-file.c:373:8: error: variable '_tmp45__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp45__length1;
                     ^
write-file.c:504:8: error: variable '_tmp57__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp57__length1;
                     ^
write-file.c:635:8: error: variable '_tmp69__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp69__length1;
                     ^
write-file.c:766:8: error: variable '_tmp81__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp81__length1;
                     ^
write-file.c:897:8: error: variable '_tmp93__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp93__length1;
                     ^
write-file.c:1028:8: error: variable '_tmp105__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp105__length1;
                     ^
write-file.c:1159:8: error: variable '_tmp117__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp117__length1;
                     ^
write-file.c:1290:8: error: variable '_tmp129__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp129__length1;
                     ^
write-file.c:1421:8: error: variable '_tmp141__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp141__length1;
                     ^
write-file.c:1552:8: error: variable '_tmp153__length1' set but not used [-Werror,-Wunused-but-set-variable]
                gint _tmp153__length1;
                     ^
10 errors generated.
```


### What changes are included in this PR?

Add missing `no` to option that suppress this warning:

    -Wunused-but-set-variable ->
    -Wno-unused-but-set-variable

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #41029