### PR TITLE
GH-41015: [JS] [Benchmarking] allow JS benchmarks to run more portably

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -11,7 +11,7 @@
     "build": "cross-env NODE_NO_WARNINGS=1 gulp build",
     "clean": "cross-env NODE_NO_WARNINGS=1 gulp clean",
     "debug": "cross-env NODE_NO_WARNINGS=1 gulp debug",
-    "perf": "perf/index.ts",
+    "perf": "node --no-warnings --loader ts-node/esm/transpile-only perf/index.ts",
     "test:integration": "bin/integration.ts --mode validate",
     "release": "./npm-release.sh",
     "clean:all": "yarn clean && yarn clean:testdata",


### PR DESCRIPTION
Fixes #41015. This PR allows users to run `yarn perf` to run the JS benchmarks on more machines; in particular, machines that do not support `env -S` like Amazon Linux.
* GitHub Issue: #41015