### PR TITLE
GH-40680: [Java] Test JDK 22 in CI

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -58,8 +58,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 11, 17, 21]
-        maven: [3.9.5]
+        jdk: [8, 11, 17, 21, 22]
+        maven: [3.9.6]
         image: [java]
     env:
       JDK: ${{ matrix.jdk }}

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -29,8 +29,8 @@ Java modules are regularly built and tested on macOS and Linux distributions.
 Java Compatibility
 ==================
 
-Java modules are compatible with JDK 8 and above.
-Currently, JDK 8, 11, 17, and 21 are tested in CI.
+Java modules are compatible with JDK 8 and above. Currently, JDK versions
+8, 11, 17, and 21 are tested in CI. The latest JDK is also tested in CI.
 
 When using Java 9 or later, some JDK internals must be exposed by
 adding ``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`` to the ``java`` command:
@@ -61,7 +61,7 @@ Modifying the command above for Flight:
    $ env _JAVA_OPTIONS="--add-reads=org.apache.arrow.flight.core=ALL-UNNAMED --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
 
 Otherwise, you may see errors like ``java.lang.IllegalAccessError: superclass access check failed: class
-org.apache.arrow.flight.ArrowMessage$ArrowBufRetainingCompositeByteBuf (in module org.apache.arrow.flight.core) 
+org.apache.arrow.flight.ArrowMessage$ArrowBufRetainingCompositeByteBuf (in module org.apache.arrow.flight.core)
 cannot access class io.netty.buffer.CompositeByteBuf (in unnamed module ...) because module
 org.apache.arrow.flight.core does not read unnamed module ...
 
@@ -74,8 +74,8 @@ Modifying the command above for arrow-memory:
    # Indirectly via environment variables
    $ env _JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.dataset,org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
 
-Otherwise you may see errors such as ``java.lang.RuntimeException: java.lang.reflect.InaccessibleObjectException: 
-Unable to make static void java.nio.Bits.reserveMemory(long,long) accessible: module 
+Otherwise you may see errors such as ``java.lang.RuntimeException: java.lang.reflect.InaccessibleObjectException:
+Unable to make static void java.nio.Bits.reserveMemory(long,long) accessible: module
 java.base does not "opens java.nio" to module org.apache.arrow.dataset``
 
 If using Maven and Surefire for unit testing, :ref:`this argument must

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -46,7 +46,7 @@
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     <error_prone_core.version>2.24.0</error_prone_core.version>
     <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
-    <mockito.core.version>5.5.0</mockito.core.version>
+    <mockito.core.version>5.11.0</mockito.core.version>
     <mockito.inline.version>5.2.0</mockito.inline.version>
     <checker.framework.version>3.42.0</checker.framework.version>
   </properties>


### PR DESCRIPTION
### Rationale for this change

JDK 22 is released. Let's ensure Arrow java CI tests this version successfully.

### What changes are included in this PR?

* Add JDK 22 to CI

### Are these changes tested?

Tested by CI jobs

### Are there any user-facing changes?

No
* GitHub Issue: #40680