### PR TITLE
GH-41039: [Python] ListView pandas tests should use np.nan instead of None

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2571,7 +2571,7 @@ class TestConvertListTypes:
         )
 
         actual = arr.to_pandas()
-        expected = pd.Series([[1, None], [], None])
+        expected = pd.Series([[1, np.nan], [], None])
 
         tm.assert_series_equal(actual, expected)
 
@@ -2593,7 +2593,7 @@ class TestConvertListTypes:
         arr = pa.chunked_array([arr1, arr2])
 
         actual = arr.to_pandas()
-        expected = pd.Series([[3, 4], [2, 3], [1, 2], [5, 6, 7], [6, 7, None], None])
+        expected = pd.Series([[3, 4], [2, 3], [1, 2], [5, 6, 7], [6, 7, np.nan], None])
 
         tm.assert_series_equal(actual, expected)
 


### PR DESCRIPTION
### Rationale for this change

ListView pandas conversion tests are failing in upstream development branches of pandas/numpy.

### What changes are included in this PR?

* Use np.nan instead of None when comparing with an expected Pandas Series.

### Are these changes tested?

Yes, unit tests updated.

### Are there any user-facing changes?

No.
* GitHub Issue: #41039