### PR TITLE
GH-40898: [C#] Do not import length-zero buffers from C Data Interface Arrays

### DIFF
--- a/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using Apache.Arrow.Memory;
 using Apache.Arrow.Types;

--- a/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
+++ b/csharp/src/Apache.Arrow/C/CArrowArrayImporter.cs
@@ -262,8 +262,8 @@ namespace Apache.Arrow.C
             {
                 if (lengthBytes > 0)
                 {
-                    Debug.Assert(cArray->buffers[0] != null);
-                    return new ArrowBuffer(AddMemory((IntPtr)cArray->buffers[0], 0, lengthBytes));
+                    Debug.Assert(cArray->buffers[i] != null);
+                    return new ArrowBuffer(AddMemory((IntPtr)cArray->buffers[i], 0, lengthBytes));
                 }
                 else
                 {


### PR DESCRIPTION

### Rationale for this change

When implementing integration tests for nanoarrow, it was observed that C# never released arrays where `array->buffers[i]` was `NULL` (including any buffers of any recursive child arrays). This is allowed ( https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowArray.buffers ); however, every other implementation appears to allocate even for length zero buffers (including nanoarrow after https://github.com/apache/arrow-nanoarrow/pull/399 ).

### What changes are included in this PR?

`AddMemory()` is replaced with `ArrowBuffer.Empty` if the length of the imported buffer would have been 0 bytes. For other buffers (or anywhere I saw dereferencing a buffer pointer), I added a `Debug.Assert` just to be sure.

### Are these changes tested?

I'm not sure what the best way to test them is! They won't be tested in the nanoarrow integration tests since at the point that they run, nanoarrow will no longer export arrays that would trigger this.

### Are there any user-facing changes?

No
* GitHub Issue: #40898