### PR TITLE
GH-41043: [CI][Python] check message in test_make_write_options_error for Cython 2

### DIFF
--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5643,7 +5643,7 @@ def test_make_write_options_error():
              "doesn't apply to a 'int'")
     with pytest.raises(TypeError) as excinfo:
         pa.dataset.ParquetFileFormat.make_write_options(43)
-    assert (msg_1 or msg_2) in str(excinfo.value)
+    assert msg_1 in str(excinfo.value) or msg_2 in str(excinfo.value)
 
     pformat = pa.dataset.ParquetFileFormat()
     msg = "make_write_options\\(\\) takes exactly 0 positional arguments"

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5633,11 +5633,17 @@ def test_checksum_write_dataset_read_dataset_to_table(tempdir):
 
 
 def test_make_write_options_error():
-    # GH-39440
-    msg = ("make_write_options\\(\\) should be called on an "
-           "instance of ParquetFileFormat")
-    with pytest.raises(TypeError, match=msg):
+    # GH-39440: calling make_write_options as a static class method
+    msg_1 = ("make_write_options() should be called on an "
+             "instance of ParquetFileFormat")
+    # GH-41043: In Cython2 all Cython methods were "regular" C extension methods
+    # see: https://github.com/cython/cython/issues/6127#issuecomment-2038153359
+    msg_2 = ("descriptor 'make_write_options' for "
+             "'pyarrow._dataset_parquet.ParquetFileFormat' objects "
+             "doesn't apply to a 'int'")
+    with pytest.raises(TypeError) as excinfo:
         pa.dataset.ParquetFileFormat.make_write_options(43)
+    assert (msg_1 or msg_2) in str(excinfo.value)
 
     pformat = pa.dataset.ParquetFileFormat()
     msg = "make_write_options\\(\\) takes exactly 0 positional arguments"


### PR DESCRIPTION
### Rationale for this change

`test_make_write_options_error` has been failing on Cython 2 crossbow build because in older versions of Cython the methods were "regular" C extension method had type check automatically built in. In Cython 3 that is not the case, see https://github.com/cython/cython/issues/6127 and so the check for `ParquetFileFormat` was added in https://github.com/apache/arrow/pull/40976.

### What changes are included in this PR?

Checking the error raised for both messages, type check and the check for `ParquetFileFormat` added in https://github.com/apache/arrow/pull/40976.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41043