### PR TITLE
GH-41016: [C++] Fix null count check in BooleanArray.true_count()

### DIFF
--- a/cpp/src/arrow/array/array_primitive.cc
+++ b/cpp/src/arrow/array/array_primitive.cc
@@ -56,7 +56,7 @@ int64_t BooleanArray::false_count() const {
 }
 
 int64_t BooleanArray::true_count() const {
-  if (data_->null_count.load() != 0) {
+  if (data_->GetNullCount() != 0) {
     DCHECK(data_->buffers[0]);
     return internal::CountAndSetBits(data_->buffers[0]->data(), data_->offset,
                                      data_->buffers[1]->data(), data_->offset,

--- a/cpp/src/arrow/array/array_primitive.cc
+++ b/cpp/src/arrow/array/array_primitive.cc
@@ -56,7 +56,7 @@ int64_t BooleanArray::false_count() const {
 }
 
 int64_t BooleanArray::true_count() const {
-  if (data_->GetNullCount() != 0) {
+  if (data_->MayHaveNulls()) {
     DCHECK(data_->buffers[0]);
     return internal::CountAndSetBits(data_->buffers[0]->data(), data_->offset,
                                      data_->buffers[1]->data(), data_->offset,

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1311,10 +1311,10 @@ TEST(TestBooleanArray, TrueCountFalseCount) {
   // GH-41016 true_count() with array without validity buffer with null_count of -1
   auto data = ArrayFromJSON(boolean(), "[true, false, true]")->data();
   data->null_count = -1;
-  std::shared_ptr<BooleanArray> arr2(new BooleanArray(data));
-  ASSERT_EQ(arr2->data()->null_count.load(), -1);
-  ASSERT_EQ(arr2->null_bitmap(), nullptr);
-  ASSERT_EQ(arr2->true_count(), 2);
+  auto arr_unknown_null_count = std::make_shared<BooleanArray>(data);
+  ASSERT_EQ(arr_unknown_null_count->data()->null_count.load(), -1);
+  ASSERT_EQ(arr_unknown_null_count->null_bitmap(), nullptr);
+  ASSERT_EQ(arr_unknown_null_count->true_count(), 2);
 }
 
 TEST(TestPrimitiveAdHoc, TestType) {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1309,12 +1309,11 @@ TEST(TestBooleanArray, TrueCountFalseCount) {
   CheckArray(checked_cast<const BooleanArray&>(*arr->Slice(0, 0)));
 
   // GH-41016 true_count() with array without validity buffer with null_count of -1
-  auto data = ArrayFromJSON(boolean(), "[true, false, true]")->data();
-  data->null_count = -1;
-  auto arr_unknown_null_count = std::make_shared<BooleanArray>(data);
+  auto arr_unknown_null_count = ArrayFromJSON(boolean(), "[true, false, true]");
+  arr_unknown_null_count->data()->null_count = kUnknownNullCount;
   ASSERT_EQ(arr_unknown_null_count->data()->null_count.load(), -1);
   ASSERT_EQ(arr_unknown_null_count->null_bitmap(), nullptr);
-  ASSERT_EQ(arr_unknown_null_count->true_count(), 2);
+  ASSERT_EQ(checked_pointer_cast<BooleanArray>(arr_unknown_null_count)->true_count(), 2);
 }
 
 TEST(TestPrimitiveAdHoc, TestType) {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1307,6 +1307,14 @@ TEST(TestBooleanArray, TrueCountFalseCount) {
   CheckArray(checked_cast<const BooleanArray&>(*arr));
   CheckArray(checked_cast<const BooleanArray&>(*arr->Slice(5)));
   CheckArray(checked_cast<const BooleanArray&>(*arr->Slice(0, 0)));
+
+  // GH-41016 true_count() with array without validity buffer with null_count of -1
+  auto data = ArrayFromJSON(boolean(), "[true, false, true]")->data();
+  data->null_count = -1;
+  std::shared_ptr<BooleanArray> arr2(new BooleanArray(data));
+  ASSERT_EQ(arr2->data()->null_count.load(), -1);
+  ASSERT_EQ(arr2->null_bitmap(), nullptr);
+  ASSERT_EQ(arr2->true_count(), 2);
 }
 
 TEST(TestPrimitiveAdHoc, TestType) {


### PR DESCRIPTION
### Rationale for this change

Loading the `null_count` attribute doesn't take into account the possible value of -1, leading to a code path where the validity buffer is accessed, but which is not necessarily present in that case.

### What changes are included in this PR?

Use `data->MayHaveNulls()` instead of `data->null_count.load()`

### Are these changes tested?

Yes

* GitHub Issue: #41016