### PR TITLE
GH-41085: [CI][Java] Add Spark integration tests to "java" group in Crossbow tasks

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -80,6 +80,7 @@ groups:
 
   java:
     - "*java*"
+    - test-*spark*
 
   python:
     - test-*python*


### PR DESCRIPTION
### Rationale for this change

Spark integration tests to related to our Java implementation.

### What changes are included in this PR?

Add `test-*spark*` task to `java` group.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41085