### PR TITLE
GH-40801: [Docs] Clarify device identifier documentation in the Arrow C Device data interface

### DIFF
--- a/docs/source/format/CDeviceDataInterface.rst
+++ b/docs/source/format/CDeviceDataInterface.rst
@@ -256,6 +256,10 @@ has the following fields:
     type are on the system. The semantics of the id will be hardware dependent,
     but we use an ``int64_t`` to future-proof the id as devices change over time.
 
+    For devices that do not have an intrinsic notion of a device identifier (e.g.,
+    ``ARROW_DEVICE_CPU``), it is recommended to use a ``device_id`` of -1 as a
+    convention.
+
 .. c:member:: ArrowDeviceType ArrowDeviceArray.device_type
 
     *Mandatory.* The type of the device which can access the buffers in the array.

--- a/docs/source/format/CDeviceDataInterface.rst
+++ b/docs/source/format/CDeviceDataInterface.rst
@@ -256,7 +256,7 @@ has the following fields:
     type are on the system. The semantics of the id will be hardware dependent,
     but we use an ``int64_t`` to future-proof the id as devices change over time.
 
-    For devices that do not have an intrinsic notion of a device identifier (e.g.,
+    For device types that do not have an intrinsic notion of a device identifier (e.g.,
     ``ARROW_DEVICE_CPU``), it is recommended to use a ``device_id`` of -1 as a
     convention.
 


### PR DESCRIPTION
### Rationale for this change

It is not explicit what the value of the `ArrowDeviceArray::device_id` should be when a given device type has no notion of a device identifier (e.g., there is always only one).

### What changes are included in this PR?

The text was clarified to recommend a value of -1. This was the value already used by Arrow C++.

### Are these changes tested?

No tests needed (documentation)

### Are there any user-facing changes?

No
* GitHub Issue: #40801