### PR TITLE
GH-41100: [Python][Packaging] Update vcpkg to avoid compromised version of xz

### DIFF
--- a/.env
+++ b/.env
@@ -92,13 +92,13 @@ DEVTOOLSET_VERSION=
 # Used through docker-compose.yml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the
 # docker tags more readable.
-VCPKG="a42af01b72c28a8e1d7b48107b33e4f286a55ef6"    # 2023.11.20 Release
+VCPKG="a34c873a9717a888f58dc05268dea15592c2f0ff"    # 2024.03.25 Release
 
 # This must be updated when we update
 # ci/docker/python-wheel-windows-vs2019.dockerfile.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2024-03-19
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2024-04-09
 
 # Use conanio/${CONAN} for "docker-compose run --rm conan". See
 # https://github.com/conan-io/conan-docker-tools#readme for available


### PR DESCRIPTION
### Rationale for this change

New wheels are currently failing to build.

### What changes are included in this PR?

Updating vcpkg

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #41100