### PR TITLE
GH-38889: [C++] Fix redundant move warnings

### DIFF
--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -80,7 +80,7 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     std::pair<Decimal128, Decimal128> result;
     auto dstatus = BasicDecimal128::Divide(divisor, &result.first, &result.second);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(result);
+    return result;
   }
 
   /// \brief Convert the Decimal128 value to a base 10 decimal string with the given
@@ -118,7 +118,7 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     Decimal128 out;
     auto dstatus = BasicDecimal128::Rescale(original_scale, new_scale, &out);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(out);
+    return out;
   }
 
   /// \brief Convert to a signed integer
@@ -218,7 +218,7 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
     Decimal256 out;
     auto dstatus = BasicDecimal256::Rescale(original_scale, new_scale, &out);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(out);
+    return out;
   }
 
   /// Divide this number by right and return the result.
@@ -235,7 +235,7 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
     std::pair<Decimal256, Decimal256> result;
     auto dstatus = BasicDecimal256::Divide(divisor, &result.first, &result.second);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(result);
+    return result;
   }
 
   /// \brief Convert from a big-endian byte representation. The length must be


### PR DESCRIPTION
Though the original issue was closed, I am also seeing this warning when compiling nanoarrow

```
[13/91] Compiling C++ object src/nanoarrow/utils_test.p/utils_test.cc.o
FAILED: src/nanoarrow/utils_test.p/utils_test.cc.o 
c++ -Isrc/nanoarrow/utils_test.p -Isrc/nanoarrow -I../src/nanoarrow -Isrc -I../src -I/home/arrow-nanoarrow/arrow/include -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c++17 -O3 -pthread -isystem../subprojects/googletest-1.14.0/googletest -isystemsubprojects/googletest-1.14.0/googletest -isystem../subprojects/googletest-1.14.0/googletest/include -MD -MQ src/nanoarrow/utils_test.p/utils_test.cc.o -MF src/nanoarrow/utils_test.p/utils_test.cc.o.d -o src/nanoarrow/utils_test.p/utils_test.cc.o -c ../src/nanoarrow/utils_test.cc
In file included from ../src/nanoarrow/utils_test.cc:21:
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h: In member function ‘arrow::Result<std::pair<arrow::Decimal128, arrow::Decimal128> > arrow::Decimal128::Divide(const arrow::Decimal128&) const’:
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:83:21: error: redundant move in return statement [-Werror=redundant-move]
   83 |     return std::move(result);
      |            ~~~~~~~~~^~~~~~~~
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:83:21: note: remove ‘std::move’ call
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h: In member function ‘arrow::Result<arrow::Decimal128> arrow::Decimal128::Rescale(int32_t, int32_t) const’:
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:121:21: error: redundant move in return statement [-Werror=redundant-move]
  121 |     return std::move(out);
      |            ~~~~~~~~~^~~~~
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:121:21: note: remove ‘std::move’ call
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h: In member function ‘arrow::Result<arrow::Decimal256> arrow::Decimal256::Rescale(int32_t, int32_t) const’:
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:221:21: error: redundant move in return statement [-Werror=redundant-move]
  221 |     return std::move(out);
      |            ~~~~~~~~~^~~~~
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:221:21: note: remove ‘std::move’ call
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h: In member function ‘arrow::Result<std::pair<arrow::Decimal256, arrow::Decimal256> > arrow::Decimal256::Divide(const arrow::Decimal256&) const’:
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:238:21: error: redundant move in return statement [-Werror=redundant-move]
  238 |     return std::move(result);
      |            ~~~~~~~~~^~~~~~~~
/home/arrow-nanoarrow/arrow/include/arrow/util/decimal.h:238:21: note: remove ‘std::move’ call
```
* GitHub Issue: #38889

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Helps clean up build warnings when compiling with -Wextra

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Removed std::move from some return statements

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
N/A - just ensured program compiles cleanly

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->