### PR TITLE
GH-41112: [C++] Clean up unused parameter warnings

### DIFF
--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -175,11 +175,9 @@ class ARROW_EXPORT ArrayBuilder {
   /// \brief Append a range of values from an array.
   ///
   /// The given array must be the same type as the builder.
-  virtual Status AppendArraySlice(const ArraySpan& array, int64_t offset,
-                                  int64_t length) {
-    ARROW_UNUSED(array);
-    ARROW_UNUSED(offset);
-    ARROW_UNUSED(length);
+  virtual Status AppendArraySlice(const ArraySpan& ARROW_ARG_UNUSED(array),
+                                  int64_t ARROW_ARG_UNUSED(offset),
+                                  int64_t ARROW_ARG_UNUSED(length)) {
     return Status::NotImplemented("AppendArraySlice for builder for ", *type());
   }
 

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -177,6 +177,9 @@ class ARROW_EXPORT ArrayBuilder {
   /// The given array must be the same type as the builder.
   virtual Status AppendArraySlice(const ArraySpan& array, int64_t offset,
                                   int64_t length) {
+    ARROW_UNUSED(array);
+    ARROW_UNUSED(offset);
+    ARROW_UNUSED(length);
     return Status::NotImplemented("AppendArraySlice for builder for ", *type());
   }
 

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -175,9 +175,9 @@ class ARROW_EXPORT ArrayBuilder {
   /// \brief Append a range of values from an array.
   ///
   /// The given array must be the same type as the builder.
-  virtual Status AppendArraySlice(const ArraySpan& ARROW_ARG_UNUSED(array),
-                                  int64_t ARROW_ARG_UNUSED(offset),
-                                  int64_t ARROW_ARG_UNUSED(length)) {
+  virtual Status AppendArraySlice([[maybe_unused]] const ArraySpan& array,
+                                  [[maybe_unused]] int64_t offset,
+                                  [[maybe_unused]] int64_t length) {
     return Status::NotImplemented("AppendArraySlice for builder for ", *type());
   }
 

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -250,7 +250,7 @@ class ARROW_EXPORT VarLengthListLikeBuilder : public ArrayBuilder {
   /// \brief Append dimensions for a single list slot.
   ///
   /// ListViewBuilder overrides this to also append the size.
-  virtual void UnsafeAppendDimensions(int64_t offset, [[maybe_unused]] int64_t size)) {
+  virtual void UnsafeAppendDimensions(int64_t offset, [[maybe_unused]] int64_t size) {
     offsets_builder_.UnsafeAppend(static_cast<offset_type>(offset));
   }
 

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -251,7 +251,8 @@ class ARROW_EXPORT VarLengthListLikeBuilder : public ArrayBuilder {
   ///
   /// ListViewBuilder overrides this to also append the size.
   virtual void UnsafeAppendDimensions(int64_t offset, int64_t size) {
-    offsets_builder_.UnsafeAppend(static_cast<offset_type>(offset), size);
+    ARROW_UNUSED(size);
+    offsets_builder_.UnsafeAppend(static_cast<offset_type>(offset));
   }
 
   TypedBufferBuilder<offset_type> offsets_builder_;

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -251,7 +251,7 @@ class ARROW_EXPORT VarLengthListLikeBuilder : public ArrayBuilder {
   ///
   /// ListViewBuilder overrides this to also append the size.
   virtual void UnsafeAppendDimensions(int64_t offset, int64_t size) {
-    offsets_builder_.UnsafeAppend(static_cast<offset_type>(offset));
+    offsets_builder_.UnsafeAppend(static_cast<offset_type>(offset), size);
   }
 
   TypedBufferBuilder<offset_type> offsets_builder_;

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -250,8 +250,7 @@ class ARROW_EXPORT VarLengthListLikeBuilder : public ArrayBuilder {
   /// \brief Append dimensions for a single list slot.
   ///
   /// ListViewBuilder overrides this to also append the size.
-  virtual void UnsafeAppendDimensions(int64_t offset, int64_t size) {
-    ARROW_UNUSED(size);
+  virtual void UnsafeAppendDimensions(int64_t offset, int64_t ARROW_ARG_UNUSED(size)) {
     offsets_builder_.UnsafeAppend(static_cast<offset_type>(offset));
   }
 

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -250,7 +250,7 @@ class ARROW_EXPORT VarLengthListLikeBuilder : public ArrayBuilder {
   /// \brief Append dimensions for a single list slot.
   ///
   /// ListViewBuilder overrides this to also append the size.
-  virtual void UnsafeAppendDimensions(int64_t offset, int64_t ARROW_ARG_UNUSED(size)) {
+  virtual void UnsafeAppendDimensions(int64_t offset, [[maybe_unused]] int64_t size)) {
     offsets_builder_.UnsafeAppend(static_cast<offset_type>(offset));
   }
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -33,11 +33,15 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
  public:
   explicit NullBuilder(MemoryPool* pool = default_memory_pool(),
                        int64_t alignment = kDefaultBufferAlignment)
-      : ArrayBuilder(pool) {}
+      : ArrayBuilder(pool) {
+    ARROW_UNUSED(alignment);
+  }
   explicit NullBuilder(const std::shared_ptr<DataType>& type,
                        MemoryPool* pool = default_memory_pool(),
                        int64_t alignment = kDefaultBufferAlignment)
-      : NullBuilder(pool, alignment) {}
+      : NullBuilder(pool, alignment) {
+    ARROW_UNUSED(type);
+  }
 
   /// \brief Append the specified number of null elements
   Status AppendNulls(int64_t length) final {

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -32,10 +32,10 @@ namespace arrow {
 class ARROW_EXPORT NullBuilder : public ArrayBuilder {
  public:
   explicit NullBuilder(MemoryPool* pool = default_memory_pool(),
-                       int64_t ARROW_ARG_UNUSED(alignment) = kDefaultBufferAlignment)
+                       [[maybe_unused]] int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool) {}
 
-  explicit NullBuilder(const std::shared_ptr<DataType>& ARROW_ARG_UNUSED(type),
+  explicit NullBuilder([[maybe_unused]] const std::shared_ptr<DataType>& type,
                        MemoryPool* pool = default_memory_pool(),
                        int64_t alignment = kDefaultBufferAlignment)
       : NullBuilder(pool, alignment) {}

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -32,16 +32,13 @@ namespace arrow {
 class ARROW_EXPORT NullBuilder : public ArrayBuilder {
  public:
   explicit NullBuilder(MemoryPool* pool = default_memory_pool(),
-                       int64_t alignment = kDefaultBufferAlignment)
-      : ArrayBuilder(pool) {
-    ARROW_UNUSED(alignment);
-  }
-  explicit NullBuilder(const std::shared_ptr<DataType>& type,
+                       int64_t ARROW_ARG_UNUSED(alignment) = kDefaultBufferAlignment)
+      : ArrayBuilder(pool) {}
+
+  explicit NullBuilder(const std::shared_ptr<DataType>& ARROW_ARG_UNUSED(type),
                        MemoryPool* pool = default_memory_pool(),
                        int64_t alignment = kDefaultBufferAlignment)
-      : NullBuilder(pool, alignment) {
-    ARROW_UNUSED(type);
-  }
+      : NullBuilder(pool, alignment) {}
 
   /// \brief Append the specified number of null elements
   Status AppendNulls(int64_t length) final {

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -139,8 +139,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// This should create the appropriate stream type for the device,
   /// derived from Device::Stream to allow for stream ordered events
   /// and memory allocations.
-  virtual Result<std::shared_ptr<Stream>> MakeStream(
-      unsigned int ARROW_ARG_UNUSED(flags)) {
+  virtual Result<std::shared_ptr<Stream>> MakeStream([[maybe_unused]] unsigned int flags) {
     return NULLPTR;
   }
 
@@ -150,10 +149,8 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// @param release_fn a function to call during destruction, `nullptr` or
   ///        a no-op function can be passed to indicate ownership is maintained
   ///        externally
-  virtual Result<std::shared_ptr<Stream>> WrapStream(void* device_stream,
-                                                     Stream::release_fn_t release_fn) {
-    ARROW_UNUSED(device_stream);
-    ARROW_UNUSED(release_fn);
+  virtual Result<std::shared_ptr<Stream>> WrapStream([[maybe_unused]] void* device_stream,
+                                                     [[maybe_unused]] Stream::release_fn_t release_fn) {
     return NULLPTR;
   }
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -140,6 +140,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// derived from Device::Stream to allow for stream ordered events
   /// and memory allocations.
   virtual Result<std::shared_ptr<Stream>> MakeStream(unsigned int flags) {
+    ARROW_UNUSED(flags);
     return NULLPTR;
   }
 
@@ -151,6 +152,8 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   ///        externally
   virtual Result<std::shared_ptr<Stream>> WrapStream(void* device_stream,
                                                      Stream::release_fn_t release_fn) {
+    ARROW_UNUSED(device_stream);
+    ARROW_UNUSED(release_fn);
     return NULLPTR;
   }
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -139,7 +139,8 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// This should create the appropriate stream type for the device,
   /// derived from Device::Stream to allow for stream ordered events
   /// and memory allocations.
-  virtual Result<std::shared_ptr<Stream>> MakeStream([[maybe_unused]] unsigned int flags) {
+  virtual Result<std::shared_ptr<Stream>> MakeStream(
+      [[maybe_unused]] unsigned int flags) {
     return NULLPTR;
   }
 
@@ -149,8 +150,9 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// @param release_fn a function to call during destruction, `nullptr` or
   ///        a no-op function can be passed to indicate ownership is maintained
   ///        externally
-  virtual Result<std::shared_ptr<Stream>> WrapStream([[maybe_unused]] void* device_stream,
-                                                     [[maybe_unused]] Stream::release_fn_t release_fn) {
+  virtual Result<std::shared_ptr<Stream>> WrapStream(
+      [[maybe_unused]] void* device_stream,
+      [[maybe_unused]] Stream::release_fn_t release_fn) {
     return NULLPTR;
   }
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -139,8 +139,8 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// This should create the appropriate stream type for the device,
   /// derived from Device::Stream to allow for stream ordered events
   /// and memory allocations.
-  virtual Result<std::shared_ptr<Stream>> MakeStream(unsigned int flags) {
-    ARROW_UNUSED(flags);
+  virtual Result<std::shared_ptr<Stream>> MakeStream(
+      unsigned int ARROW_ARG_UNUSED(flags)) {
     return NULLPTR;
   }
 
@@ -150,10 +150,9 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// @param release_fn a function to call during destruction, `nullptr` or
   ///        a no-op function can be passed to indicate ownership is maintained
   ///        externally
-  virtual Result<std::shared_ptr<Stream>> WrapStream(void* device_stream,
-                                                     Stream::release_fn_t release_fn) {
-    ARROW_UNUSED(device_stream);
-    ARROW_UNUSED(release_fn);
+  virtual Result<std::shared_ptr<Stream>> WrapStream(
+      void* ARROW_ARG_UNUSED(device) _stream,
+      Stream::release_fn_t ARROW_ARG_UNUSED(release_fn)) {
     return NULLPTR;
   }
 

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -151,7 +151,7 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   ///        a no-op function can be passed to indicate ownership is maintained
   ///        externally
   virtual Result<std::shared_ptr<Stream>> WrapStream(
-      void* ARROW_ARG_UNUSED(device) _stream,
+      void* ARROW_ARG_UNUSED(device_stream),
       Stream::release_fn_t ARROW_ARG_UNUSED(release_fn)) {
     return NULLPTR;
   }

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -150,9 +150,10 @@ class ARROW_EXPORT Device : public std::enable_shared_from_this<Device>,
   /// @param release_fn a function to call during destruction, `nullptr` or
   ///        a no-op function can be passed to indicate ownership is maintained
   ///        externally
-  virtual Result<std::shared_ptr<Stream>> WrapStream(
-      void* ARROW_ARG_UNUSED(device_stream),
-      Stream::release_fn_t ARROW_ARG_UNUSED(release_fn)) {
+  virtual Result<std::shared_ptr<Stream>> WrapStream(void* device_stream,
+                                                     Stream::release_fn_t release_fn) {
+    ARROW_UNUSED(device_stream);
+    ARROW_UNUSED(release_fn);
     return NULLPTR;
   }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1723,7 +1723,7 @@ class ARROW_EXPORT MonthIntervalType : public IntervalType {
 
   MonthIntervalType() : IntervalType(type_id) {}
 
-  std::string ToString(bool ARROW_ARG_UNUSED(show_metadata) = false) const override {
+  std::string ToString([[maybe_unused]] bool show_metadata = false) const override {
     return name();
   }
   std::string name() const override { return "month_interval"; }
@@ -1761,7 +1761,7 @@ class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  std::string ToString(bool ARROW_ARG_UNUSED(show_metadata) = false) const override {
+  std::string ToString([[maybe_unused]] bool show_metadata = false) const override {
     return name();
   }
   std::string name() const override { return "day_time_interval"; }
@@ -1803,7 +1803,7 @@ class ARROW_EXPORT MonthDayNanoIntervalType : public IntervalType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  std::string ToString(bool ARROW_ARG_UNUSED(show_metadata) = false) const override {
+  std::string ToString([[maybe_unused]] bool show_metadata = false) const override {
     return name();
   }
   std::string name() const override { return "month_day_nano_interval"; }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1723,7 +1723,10 @@ class ARROW_EXPORT MonthIntervalType : public IntervalType {
 
   MonthIntervalType() : IntervalType(type_id) {}
 
-  std::string ToString(bool show_metadata = false) const override { return name(); }
+  std::string ToString(bool show_metadata = false) const override {
+    ARROW_UNUSED(show_metadata);
+    return name();
+  }
   std::string name() const override { return "month_interval"; }
 };
 
@@ -1759,7 +1762,10 @@ class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  std::string ToString(bool show_metadata = false) const override { return name(); }
+  std::string ToString(bool show_metadata = false) const override {
+    ARROW_UNUSED(show_metadata);
+    return name();
+  }
   std::string name() const override { return "day_time_interval"; }
 };
 
@@ -1799,7 +1805,10 @@ class ARROW_EXPORT MonthDayNanoIntervalType : public IntervalType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  std::string ToString(bool show_metadata = false) const override { return name(); }
+  std::string ToString(bool show_metadata = false) const override {
+    ARROW_UNUSED(show_metadata);
+    return name();
+  }
   std::string name() const override { return "month_day_nano_interval"; }
 };
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1723,8 +1723,7 @@ class ARROW_EXPORT MonthIntervalType : public IntervalType {
 
   MonthIntervalType() : IntervalType(type_id) {}
 
-  std::string ToString(bool show_metadata = false) const override {
-    ARROW_UNUSED(show_metadata);
+  std::string ToString(bool ARROW_ARG_UNUSED(show_metadata) = false) const override {
     return name();
   }
   std::string name() const override { return "month_interval"; }
@@ -1762,8 +1761,7 @@ class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  std::string ToString(bool show_metadata = false) const override {
-    ARROW_UNUSED(show_metadata);
+  std::string ToString(bool ARROW_ARG_UNUSED(show_metadata) = false) const override {
     return name();
   }
   std::string name() const override { return "day_time_interval"; }
@@ -1805,8 +1803,7 @@ class ARROW_EXPORT MonthDayNanoIntervalType : public IntervalType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  std::string ToString(bool show_metadata = false) const override {
-    ARROW_UNUSED(show_metadata);
+  std::string ToString(bool ARROW_ARG_UNUSED(show_metadata) = false) const override {
     return name();
   }
   std::string name() const override { return "month_day_nano_interval"; }

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -80,7 +80,7 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     std::pair<Decimal128, Decimal128> result;
     auto dstatus = BasicDecimal128::Divide(divisor, &result.first, &result.second);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(result);
+    return result;
   }
 
   /// \brief Convert the Decimal128 value to a base 10 decimal string with the given
@@ -118,7 +118,7 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     Decimal128 out;
     auto dstatus = BasicDecimal128::Rescale(original_scale, new_scale, &out);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(out);
+    return out;
   }
 
   /// \brief Convert to a signed integer
@@ -218,7 +218,7 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
     Decimal256 out;
     auto dstatus = BasicDecimal256::Rescale(original_scale, new_scale, &out);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(out);
+    return out;
   }
 
   /// Divide this number by right and return the result.
@@ -235,7 +235,7 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
     std::pair<Decimal256, Decimal256> result;
     auto dstatus = BasicDecimal256::Divide(divisor, &result.first, &result.second);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return std::move(result);
+    return result;
   }
 
   /// \brief Convert from a big-endian byte representation. The length must be

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -80,7 +80,7 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     std::pair<Decimal128, Decimal128> result;
     auto dstatus = BasicDecimal128::Divide(divisor, &result.first, &result.second);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return result;
+    return std::move(result);
   }
 
   /// \brief Convert the Decimal128 value to a base 10 decimal string with the given
@@ -118,7 +118,7 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     Decimal128 out;
     auto dstatus = BasicDecimal128::Rescale(original_scale, new_scale, &out);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return out;
+    return std::move(out);
   }
 
   /// \brief Convert to a signed integer
@@ -218,7 +218,7 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
     Decimal256 out;
     auto dstatus = BasicDecimal256::Rescale(original_scale, new_scale, &out);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return out;
+    return std::move(out);
   }
 
   /// Divide this number by right and return the result.
@@ -235,7 +235,7 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
     std::pair<Decimal256, Decimal256> result;
     auto dstatus = BasicDecimal256::Divide(divisor, &result.first, &result.second);
     ARROW_RETURN_NOT_OK(ToArrowStatus(dstatus));
-    return result;
+    return std::move(result);
   }
 
   /// \brief Convert from a big-endian byte representation. The length must be


### PR DESCRIPTION
Noticed these when compiling the nanoarrow test suite with -Wextra
* GitHub Issue: #41112

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Helps clean up build warnings when compiling with -Wextra

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Used Arrow macros to mark some parameters as unused

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
N/A - just ensured program compiles cleanly

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->