### PR TITLE
GH-41124: [CI][C++] Don't use CMake 3.29.1 with vcpkg

### DIFF
--- a/ci/scripts/install_cmake.sh
+++ b/ci/scripts/install_cmake.sh
@@ -23,7 +23,8 @@ declare -A archs
 archs=([amd64]=x86_64
        [arch64]=aarch64
        [arm64]=aarch64
-       [arm64v8]=aarch64)
+       [arm64v8]=aarch64
+       [x86_64]=x86_64)
 
 declare -A platforms
 platforms=([linux]=linux
@@ -42,4 +43,4 @@ prefix=$4
 
 mkdir -p ${prefix}
 url="https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-${platform}-${arch}.tar.gz"
-curl -O - ${url} | tar -xzf - --directory ${prefix} --strip-components=1
+curl -L ${url} | tar -xzf - --directory ${prefix} --strip-components=1

--- a/ci/scripts/install_cmake.sh
+++ b/ci/scripts/install_cmake.sh
@@ -46,21 +46,20 @@ url="https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${vers
 case ${platform} in
   macos)
     url+="universal.tar.gz"
+    curl -L ${url} | tar -xzf - --directory ${prefix} --strip-components=1
+    ln -s CMake.app/Contents/bin ${prefix}/bin
     ;;
   windows)
     url+="${arch}.zip"
+    archive_name=$(basename ${url})
+    curl -L -o ${archive_name} ${url}
+    unzip ${archive_name}
+    base_name=$(basename ${archive_name} .zip)
+    mv ${base_name}/* ${prefix}
+    rm -rf ${base_name} ${archive_name}
     ;;
   *)
     url+="${arch}.tar.gz"
+    curl -L ${url} | tar -xzf - --directory ${prefix} --strip-components=1
     ;;
 esac
-if [ ${platform} = windows ]; then
-  archive_name=$(basename ${url})
-  curl -L -o ${archive_name} ${url}
-  unzip ${archive_name}
-  base_name=$(basename ${archive_name} .zip)
-  mv ${base_name}/* ${prefix}
-  rm -rf ${base_name} ${archive_name}
-else
-  curl -L ${url} | tar -xzf - --directory ${prefix} --strip-components=1
-fi

--- a/ci/scripts/install_cmake.sh
+++ b/ci/scripts/install_cmake.sh
@@ -42,5 +42,25 @@ version=$3
 prefix=$4
 
 mkdir -p ${prefix}
-url="https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-${platform}-${arch}.tar.gz"
-curl -L ${url} | tar -xzf - --directory ${prefix} --strip-components=1
+url="https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-${platform}-"
+case ${platform} in
+  macos)
+    url+="universal.tar.gz"
+    ;;
+  windows)
+    url+="${arch}.zip"
+    ;;
+  *)
+    url+="${arch}.tar.gz"
+    ;;
+esac
+if [ ${platform} = windows ]; then
+  archive_name=$(basename ${url})
+  curl -L -o ${archive_name} ${url}
+  unzip ${archive_name}
+  base_name=$(basename ${archive_name} .zip)
+  mv ${base_name}/* ${prefix}
+  rm -rf ${base_name} ${archive_name}
+else
+  curl -L ${url} | tar -xzf - --directory ${prefix} --strip-components=1
+fi

--- a/ci/scripts/install_cmake.sh
+++ b/ci/scripts/install_cmake.sh
@@ -40,5 +40,6 @@ platform=${platforms[$2]}
 version=$3
 prefix=$4
 
+mkdir -p ${prefix}
 url="https://github.com/Kitware/CMake/releases/download/v${version}/cmake-${version}-${platform}-${arch}.tar.gz"
-wget -q ${url} -O - | tar -xzf - --directory ${prefix} --strip-components=1
+curl -O - ${url} | tar -xzf - --directory ${prefix} --strip-components=1

--- a/ci/scripts/install_cmake.sh
+++ b/ci/scripts/install_cmake.sh
@@ -21,6 +21,8 @@ set -e
 
 declare -A archs
 archs=([amd64]=x86_64
+       [arch64]=aarch64
+       [arm64]=aarch64
        [arm64v8]=aarch64)
 
 declare -A platforms

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -86,7 +86,7 @@ env:
 
 {%- macro github_upload_releases(pattern) -%}
   - name: Set up Python by actions/setup-python
-    if: runner.arch == 'X64'
+    if: !(runner.os == 'Linux' && runner.arch != 'X64')
     uses: actions/setup-python@v4
     with:
       python-version: 3.12

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -86,7 +86,8 @@ env:
 
 {%- macro github_upload_releases(pattern) -%}
   - name: Set up Python by actions/setup-python
-    if: !(runner.os == 'Linux' && runner.arch != 'X64')
+    if: |
+      !(runner.os == 'Linux' && runner.arch != 'X64')
     uses: actions/setup-python@v4
     with:
       python-version: 3.12

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -59,7 +59,7 @@ env:
 
 {%- macro github_install_archery() -%}
   - name: Set up Python by actions/setup-python
-    if: runner.arch == 'X64'
+    if: !(runner.os == 'Linux' && runner.arch != 'X64')
     uses: actions/setup-python@v4
     with:
       cache: 'pip'

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -59,7 +59,8 @@ env:
 
 {%- macro github_install_archery() -%}
   - name: Set up Python by actions/setup-python
-    if: !(runner.os == 'Linux' && runner.arch != 'X64')
+    if: |
+      !(runner.os == 'Linux' && runner.arch != 'X64')
     uses: actions/setup-python@v4
     with:
       cache: 'pip'

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Retrieve VCPKG version from arrow/.env
         run: |
+          which cmake
+          cmake --version
           vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -57,13 +57,9 @@ jobs:
         run: |
           arrow/ci/scripts/install_cmake.sh $(arch) macos 3.29.0 ${PWD}/local
           echo "${PWD}/local/bin" >> $GITHUB_PATH
-          ${PWD}/local/bin/cmake --version
 
       - name: Retrieve VCPKG version from arrow/.env
         run: |
-          echo $PATH
-          which cmake
-          cmake --version
           vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -50,6 +50,14 @@ jobs:
         run: |
           brew list
 
+      # CMake 3.29.1 that is pre-installed on the Windows image has a problem.
+      # See also: https://github.com/microsoft/vcpkg/issues/37968
+      - name: Install CMake 3.29.0
+        shell: bash
+        run: |
+          arrow/ci/scripts/install_cmake.sh $(arch) macos 3.29.0 ${PWD}/local
+          echo "${PWD}/local/bin" >> $GITHUB_PATH
+
       - name: Retrieve VCPKG version from arrow/.env
         run: |
           vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -57,9 +57,11 @@ jobs:
         run: |
           arrow/ci/scripts/install_cmake.sh $(arch) macos 3.29.0 ${PWD}/local
           echo "${PWD}/local/bin" >> $GITHUB_PATH
+          ${PWD/local/bin/cmake --version
 
       - name: Retrieve VCPKG version from arrow/.env
         run: |
+          echo $PATH
           which cmake
           cmake --version
           vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           brew list
 
-      # CMake 3.29.1 that is pre-installed on the Windows image has a problem.
+      # CMake 3.29.1 that is pre-installed on the macOS image has a problem.
       # See also: https://github.com/microsoft/vcpkg/issues/37968
       - name: Install CMake 3.29.0
         shell: bash

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           arrow/ci/scripts/install_cmake.sh $(arch) macos 3.29.0 ${PWD}/local
           echo "${PWD}/local/bin" >> $GITHUB_PATH
-          ${PWD/local/bin/cmake --version
+          ${PWD}/local/bin/cmake --version
 
       - name: Retrieve VCPKG version from arrow/.env
         run: |

--- a/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
+++ b/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
@@ -78,7 +78,8 @@ cmake --build . --target INSTALL --config Release || exit /B 1
 
 @rem Test Arrow C++ library
 
-ctest --output-on-failure ^
+ctest --build-config Release ^
+      --output-on-failure ^
       --parallel %NUMBER_OF_PROCESSORS% ^
       --timeout 300 || exit /B 1
 

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -45,8 +45,6 @@ jobs:
         # to remove and reinstall it.
         shell: cmd
         run: |
-          echo %PATH%
-          cmake --version
           CALL vcpkg integrate remove 2>NUL
           CALL C:
           CALL cd \

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -15,14 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# NOTE: must set "Crossbow" as name to have the badge links working in the
-# github comment reports!
-name: Crossbow
+{% import 'macros.jinja' as macros with context %}
 
-on:
-  push:
-    branches:
-      - "*-github-*"
+{{ macros.github_header() }}
 
 jobs:
   test-vcpkg-win:
@@ -31,12 +26,12 @@ jobs:
     env:
       VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
     steps:
-      - name: Checkout Arrow
-        run: |
-          git clone --no-checkout {{ arrow.remote }} arrow
-          git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-          git -C arrow checkout FETCH_HEAD
-          git -C arrow submodule update --init --recursive
+      {{ macros.github_checkout_arrow()|indent }}
+      # CMake 3.29.1 that is pre-installed on the Windows image has a problem.
+      # See also: https://github.com/microsoft/vcpkg/issues/37968
+      - name: Install CMake 3.29.0
+        shell: bash
+        run: arrow/ci/scripts/install_cmake.sh 3.29.0
       - name: Download Timezone Database
         shell: bash
         run: arrow/ci/scripts/download_tz_database.sh
@@ -59,7 +54,7 @@ jobs:
           CALL setx PATH "%PATH%;C:\vcpkg"
       - name: Setup NuGet Credentials
         shell: bash
-        env: 
+        env:
           GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
         run: |
           `vcpkg fetch nuget | tail -n 1` \

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -45,6 +45,8 @@ jobs:
         # to remove and reinstall it.
         shell: cmd
         run: |
+          echo %PATH%
+          cmake --version
           CALL vcpkg integrate remove 2>NUL
           CALL C:
           CALL cd \

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -31,7 +31,9 @@ jobs:
       # See also: https://github.com/microsoft/vcpkg/issues/37968
       - name: Install CMake 3.29.0
         shell: bash
-        run: arrow/ci/scripts/install_cmake.sh 3.29.0
+        run: |
+          arrow/ci/scripts/install_cmake.sh amd64 windows 3.29.0 /c/cmake
+          echo "c:\\cmake\\bin" >> $GITHUB_PATH
       - name: Download Timezone Database
         shell: bash
         run: arrow/ci/scripts/download_tz_database.sh


### PR DESCRIPTION
### Rationale for this change

vcpkg doesn't work with CMake 3.29.1.

See also: https://github.com/microsoft/vcpkg/issues/37968

### What changes are included in this PR?

Use CMake 3.29.0 temporary.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41124