### PR TITLE
GH-41145: [R][CI] test-r-dev-duckdb fails installing duckdb

### DIFF
--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -27,6 +27,11 @@ ENV R_PRUNE_DEPS=${r_prune_deps}
 ARG r_duckdb_dev=FALSE
 ENV R_DUCKDB_DEV=${r_duckdb_dev}
 
+# This is needed to avoid errors with utf8 characters in some
+# R package's DESCRIPTION files
+# https://github.com/statnmap/HatchedPolygons/issues/4
+ENV LANG=C.UTF-8
+
 # Build R
 # [1] https://www.digitalocean.com/community/tutorials/how-to-install-r-on-ubuntu-18-04
 # [2] https://linuxize.com/post/how-to-install-r-on-ubuntu-18-04/#installing-r-packages-from-cran


### PR DESCRIPTION
### Rationale for this change

An error is received installing R duckdb:

```
#15 18.13 > remotes::install_github('duckdb/duckdb-r', build = FALSE)
#15 18.27 Error: Failed to install 'unknown package' from **GitHub:**
#15 18.27   Line starting 'Roxyg ...' is malformed!
```

Some searching seems to suggest that this is because R cannot process UTF-8 characters in DESCRIPTION files if the `LANG` is set to `C`.

### What changes are included in this PR?

The `LANG` is set to `C.UTF-8` in the dockerfile for this CI job

### Are these changes tested?

The change only affects a test

### Are there any user-facing changes?

No
* GitHub Issue: #41145