### PR TITLE
GH-41154: [C++] Fix Valgrind error in string-to-float16 conversion

### DIFF
--- a/cpp/src/arrow/util/value_parsing.cc
+++ b/cpp/src/arrow/util/value_parsing.cc
@@ -53,8 +53,11 @@ bool StringToFloat(const char* s, size_t length, char decimal_point, uint16_t* o
   float temp_out;
   const auto res =
       ::arrow_vendored::fast_float::from_chars_advanced(s, s + length, temp_out, options);
-  *out = Float16::FromFloat(temp_out).bits();
-  return res.ec == std::errc() && res.ptr == s + length;
+  const bool ok = res.ec == std::errc() && res.ptr == s + length;
+  if (ok) {
+    *out = Float16::FromFloat(temp_out).bits();
+  }
+  return ok;
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
### Rationale for this change

Only do the final conversion to float16 on success, to avoid conditional jump on uninitialized values.

Note: this is a benign error. But we want our Valgrind CI job to be as successful as possible.

### Are these changes tested?

Yes, on CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #41154