### PR TITLE
GH-41004: [C++][FS][Azure] Don't run TestGetFileInfoGenerator() with Valgrind

### DIFF
--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -33,6 +33,7 @@
 #include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/async_generator.h"
+#include "arrow/util/config.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/vector.h"
@@ -752,7 +753,7 @@ void GenericFileSystemTest::TestGetFileInfoSelector(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestGetFileInfoGenerator(FileSystem* fs) {
-#ifdef ADDRESS_SANITIZER
+#if defined(ADDRESS_SANITIZER) || defined(ARROW_TEST_MEMCHECK)
   if (have_false_positive_memory_leak_with_generator()) {
     GTEST_SKIP() << "Filesystem have false positive memory leak with generator";
   }

--- a/cpp/src/arrow/util/config.h.cmake
+++ b/cpp/src/arrow/util/config.h.cmake
@@ -57,6 +57,7 @@
 #cmakedefine ARROW_GCS
 #cmakedefine ARROW_HDFS
 #cmakedefine ARROW_S3
+#cmakedefine ARROW_TEST_MEMCHECK
 #cmakedefine ARROW_USE_GLOG
 #cmakedefine ARROW_USE_NATIVE_INT128
 #cmakedefine ARROW_WITH_BROTLI


### PR DESCRIPTION
### Rationale for this change

`GetFileInfo()` with generator reports false positive memory leak in Azure SDK for C++.

### What changes are included in this PR?

Don't run `TestGetFileInfoGenerator()` with Valgrind.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41004