### PR TITLE
WIP: GH-41169: [CI][Release] Pin CMake temporary to test Windows verification

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -26,7 +26,7 @@ boost-cpp>=1.68.0
 brotli
 bzip2
 c-ares
-cmake
+cmake==3.29.0
 gflags
 glog
 gmock>=1.10.0


### PR DESCRIPTION
### Rationale for this change
I am testing if the issue on the verification job is due to CMake 3.29.2

### What changes are included in this PR?

Only pinning to test the Windows verification

### Are these changes tested?

Archery job

### Are there any user-facing changes?
No
* GitHub Issue: #41169