### PR TITLE
GH-41176: [C++] Stop defining ARROW_TEST_MEMCHECK in config.h.cmake

### DIFF
--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -33,7 +33,6 @@
 #include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/async_generator.h"
-#include "arrow/util/config.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/vector.h"
@@ -753,7 +752,7 @@ void GenericFileSystemTest::TestGetFileInfoSelector(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestGetFileInfoGenerator(FileSystem* fs) {
-#if defined(ADDRESS_SANITIZER) || defined(ARROW_TEST_MEMCHECK)
+#if defined(ADDRESS_SANITIZER) || defined(ARROW_VALGRIND)
   if (have_false_positive_memory_leak_with_generator()) {
     GTEST_SKIP() << "Filesystem have false positive memory leak with generator";
   }

--- a/cpp/src/arrow/util/config.h.cmake
+++ b/cpp/src/arrow/util/config.h.cmake
@@ -57,7 +57,6 @@
 #cmakedefine ARROW_GCS
 #cmakedefine ARROW_HDFS
 #cmakedefine ARROW_S3
-#cmakedefine ARROW_TEST_MEMCHECK
 #cmakedefine ARROW_USE_GLOG
 #cmakedefine ARROW_USE_NATIVE_INT128
 #cmakedefine ARROW_WITH_BROTLI


### PR DESCRIPTION
### Rationale for this change

We already have `ARROW_VALGRIND`.

### What changes are included in this PR?

Remove redundant macro.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41176