### PR TITLE
GH-41169: [CI][Release] Specify --build-config explicitly on Windows

### DIFF
--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -122,7 +122,10 @@ cmake --build . --target INSTALL --config Release || exit /B 1
 @rem Needed so python-test.exe works
 set PYTHONPATH_ORIGINAL=%PYTHONPATH%
 set PYTHONPATH=%CONDA_PREFIX%\Lib;%CONDA_PREFIX%\Lib\site-packages;%CONDA_PREFIX%\DLLs;%CONDA_PREFIX%;%PYTHONPATH%
-ctest -j%NUMBER_OF_PROCESSORS% --output-on-failure  || exit /B 1
+ctest ^
+  --build-config Release ^
+  --output-on-failure ^
+  --parallel %NUMBER_OF_PROCESSORS% || exit /B 1
 set PYTHONPATH=%PYTHONPATH_ORIGINAL%
 popd
 


### PR DESCRIPTION
### Rationale for this change

#37821 changed to use `add_test()` usage from old style to new style:

https://github.com/apache/arrow/commit/1a1d2c87d11c48569fa603cc157e6bddc1f7d306?diff=unified&w=1#diff-1ce47eec54afaee769086e1a720c5ed65bc347cd8fc60a233de67fd895dda329L763-R764

MSVC generators multi-config generators. With old style, all tests are run without specifying `--build-config` explicitly. With new style, we need to specify `--build-config` explicitly.

See also: https://cmake.org/cmake/help/latest/command/add_test.html

### What changes are included in this PR?

Specify `--build-config` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41169