### PR TITLE
GH-41167: [CI][Release][GLib][Conda] Pin gobject-introspection to 1.78.1

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -831,7 +831,9 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
-  maybe_setup_conda glib gobject-introspection meson ninja ruby
+  # We can unpin gobject-introspection after
+  # https://github.com/conda-forge/glib-feedstock/pull/174 is merged.
+  maybe_setup_conda glib gobject-introspection=1.78.1 meson ninja ruby
   maybe_setup_virtualenv meson
 
   # Install bundler if doesn't exist


### PR DESCRIPTION
### Rationale for this change

GObject Introspection is merging into GLib. It's not completed yet.

GLib related `.gir` files are moved to GLib from GObject Introspection since GLib/GObject Introspection 2.80.0. But glib 2.80.0 conda package doesn't support this merge yet:  https://github.com/conda-forge/glib-feedstock/pull/174

### What changes are included in this PR?

Pin gobject-introspection to 1.78.1 for now. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41167