### PR TITLE
GH-41184: [CI][Release][Python] Canonicalize version in sdist filename

### DIFF
--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -82,11 +82,12 @@ class SourceTest < Test::Unit::TestCase
     source
     Dir.chdir("#{@tag_name}/python") do
       sh("python3", "setup.py", "sdist")
-      if on_release_branch?
-        pyarrow_source_archive = "dist/pyarrow-#{@release_version}.tar.gz"
-      else
-        pyarrow_source_archive = "dist/pyarrow-#{@release_version}a0.tar.gz"
+      pyarrow_source_archive =
+        "dist/pyarrow-#{@release_python_canonicalized_version}"
+      unless on_release_branch?
+        pyarrow_source_archive << "a0"
       end
+      pyarrow_source_archive << ".tar.gz"
       assert_equal([pyarrow_source_archive],
                    Dir.glob("dist/pyarrow-*.tar.gz"))
     end

--- a/dev/release/test-helper.rb
+++ b/dev/release/test-helper.rb
@@ -106,6 +106,8 @@ module VersionDetectable
     @snapshot_major_version = @snapshot_version.split(".")[0]
     @release_version = @snapshot_version.gsub(/-SNAPSHOT\z/, "")
     @release_compatible_version = @release_version.split(".")[0, 2].join(".")
+    @release_python_canonicalized_version =
+      @release_version.gsub(/(?:\.0)+\z/, "")
     @so_version = compute_so_version(@release_version)
     next_version_components = @release_version.split(".")
     case release_type


### PR DESCRIPTION
### Rationale for this change

setuptools 69.3.0 changed version in sdist filename.

See also: https://github.com/pypa/setuptools/pull/4286

### What changes are included in this PR?

Removing trailing `.0`s from version.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41184