### PR TITLE
GH-41188: [C++] Don't recursively produce nulls when appending nulls to a FixedSizeListBuilder

### DIFF
--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -213,13 +213,13 @@ Status FixedSizeListBuilder::AppendValues(int64_t length, const uint8_t* valid_b
 Status FixedSizeListBuilder::AppendNull() {
   RETURN_NOT_OK(Reserve(1));
   UnsafeAppendToBitmap(false);
-  return value_builder_->AppendNulls(list_size_);
+  return value_builder_->AppendEmptyValues(list_size_);
 }
 
 Status FixedSizeListBuilder::AppendNulls(int64_t length) {
   RETURN_NOT_OK(Reserve(length));
   UnsafeAppendToBitmap(length, false);
-  return value_builder_->AppendNulls(list_size_ * length);
+  return value_builder_->AppendEmptyValues(list_size_ * length);
 }
 
 Status FixedSizeListBuilder::ValidateOverflow(int64_t new_elements) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -157,7 +157,7 @@ template <typename DestType>
 struct CastFixedToVarList {
   using dest_offset_type = typename DestType::offset_type;
 
-  /// \pre values->length >= list_size * num_lists
+  /// \pre values->length == list_size * num_lists
   /// \pre values->offset >= 0
   ///
   /// \param num_lists The number of fixed-size lists in the input and lists in the
@@ -170,7 +170,7 @@ struct CastFixedToVarList {
       KernelContext* ctx, int64_t num_lists, const uint8_t* list_validity,
       int32_t list_size, std::shared_ptr<ArrayData>&& values,
       const std::shared_ptr<DataType>& to_type) {
-    DCHECK_GE(values->length, list_size * num_lists);
+    DCHECK_EQ(values->length, list_size * num_lists);
     // XXX: is it OK to use options recursively without modifying it?
     const CastOptions& options = CastState::Get(ctx);
     ARROW_ASSIGN_OR_RAISE(Datum cast_values,
@@ -204,7 +204,7 @@ struct CastFixedToVarList {
 
     // Handle child values
     std::shared_ptr<ArrayData> child_values = in_array.child_data[0].ToArrayData();
-    if (in_array.offset > 0) {
+    if (in_array.offset > 0 || child_values->length > in_array.length * list_size) {
       child_values =
           child_values->Slice(in_array.offset * list_size, in_array.length * list_size);
     }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -27,11 +27,14 @@
 #include "arrow/compute/cast.h"
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/scalar_cast_internal.h"
+#include "arrow/util/bit_block_counter.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/int_util.h"
 
 namespace arrow {
 
+using internal::BitBlockCount;
+using internal::BitBlockCounter;
 using internal::CopyBitmap;
 
 namespace compute::internal {
@@ -173,8 +176,61 @@ struct CastFixedToVarList {
     DCHECK_EQ(values->length, list_size * num_lists);
     // XXX: is it OK to use options recursively without modifying it?
     const CastOptions& options = CastState::Get(ctx);
-    ARROW_ASSIGN_OR_RAISE(Datum cast_values,
-                          Cast(std::move(values), to_type, options, ctx->exec_context()));
+    Datum cast_values;
+    if (list_validity && list_size > 0) {
+      const int64_t full_values_length = values->offset + values->length;
+      // If the fixed_size_list array has nulls, the child values aligned with
+      // those null lists are unspecified (could be anything). We don't want the
+      // casting of the child values array to fail because of values in these slots
+      // (e.g. empty strings will fail a cast to numbers).
+      auto original_values_validity = values->buffers[0];
+      // So we need to create a new validity bitmap that is the same size as the
+      // child values array, but with validity bits zeroed out for the null lists.
+      std::shared_ptr<Buffer> combined_values_validity;
+      if (original_values_validity) {
+        ARROW_ASSIGN_OR_RAISE(
+            combined_values_validity,
+            original_values_validity->CopySlice(
+                0, bit_util::BytesForBits(full_values_length), ctx->memory_pool()));
+      } else {
+        ARROW_ASSIGN_OR_RAISE(combined_values_validity,
+                              AllocateBitmap(full_values_length, ctx->memory_pool()));
+        auto* bitmap = combined_values_validity->mutable_data();
+        bitmap[bit_util::BytesForBits(full_values_length) - 1] = 0;
+        bit_util::SetBitsTo(bitmap, 0, values->offset, false);
+        bit_util::SetBitsTo(bitmap, values->offset, values->length, true);
+      }
+      // Expand every 0 in list_validity into list_size 0s in combined_values_validity.
+      auto* combined_values_validity_data = combined_values_validity->mutable_data();
+      BitBlockCounter bit_counter{list_validity, 0, num_lists};
+      for (int64_t list_idx = 0; list_idx < num_lists;) {
+        BitBlockCount block = bit_counter.NextWord();
+        if (block.NoneSet()) {
+          bit_util::SetBitsTo(combined_values_validity_data,
+                              values->offset + list_idx * list_size,
+                              block.length * list_size, false);
+        } else if (!block.AllSet()) {
+          for (int64_t i = 0; i < block.length; i++) {
+            if (!bit_util::GetBit(list_validity, list_idx + i)) {
+              bit_util::SetBitsTo(combined_values_validity_data,
+                                  values->offset + (list_idx + i) * list_size, list_size,
+                                  false);
+            }
+          }
+        }
+        list_idx += block.length;
+      }
+
+      // Use the combined validity bitmap before casting the child values so
+      // casting ignores the unspecified values in the null slots.
+      values->null_count.store(kUnknownNullCount);
+      values->buffers[0] = combined_values_validity;
+      ARROW_ASSIGN_OR_RAISE(
+          cast_values, Cast(std::move(values), to_type, options, ctx->exec_context()));
+    } else {
+      ARROW_ASSIGN_OR_RAISE(
+          cast_values, Cast(std::move(values), to_type, options, ctx->exec_context()));
+    }
     DCHECK(cast_values.is_array());
     return cast_values.array();
   }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2376,17 +2376,25 @@ void CheckCastList(const std::shared_ptr<DataType>& from_type,
 TEST(Cast, FSLToList) {
   CheckCastList(fixed_size_list(int16(), 2), list(int16()),
                 "[[0, 1], [2, 3], [null, 5], null]");
+  CheckCastList(fixed_size_list(int16(), 2), list(int16()),
+                "[[0, 1], [2, 3],      null, [6, 7]]");
   // Large variant
   CheckCastList(fixed_size_list(int16(), 2), large_list(int16()),
                 "[[0, 1], [2, 3], [null, 5], null]");
+  CheckCastList(fixed_size_list(int16(), 2), large_list(int16()),
+                "[[0, 1], [2, 3],      null, [6, 7]]");
   // Different child types
   CheckCastList(fixed_size_list(int16(), 2), list(int32()),
                 "[[0, 1], [2, 3], [null, 5], null]");
+  CheckCastList(fixed_size_list(int16(), 2), list(int32()),
+                "[[0, 1], [2, 3],      null, [6, 7]]");
   // No nulls
   CheckCastList(fixed_size_list(int16(), 2), list(int32()), "[[0, 1], [2, 3], [4, 5]]");
   // Nested lists
   CheckCastList(fixed_size_list(list(int16()), 2), list(list(int32())),
                 "[[[0, 1], [2, 3]], [[4, 5], null]]");
+  CheckCastList(fixed_size_list(list(int16()), 2), list(list(int32())),
+                "[[[0, 1], [2, 3]],          null, [[6, 7], [8, 9]]]");
   // Sliced children (top-level slicing handled in CheckCast)
   auto children_src = ArrayFromJSON(int32(), "[1, 2, null, 4, 5, null]");
   children_src = children_src->Slice(2);

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3313,7 +3313,7 @@ cdef class FixedSizeListArray(BaseListArray):
         Note even null elements are included.
 
         Compare with :meth:`flatten`, which returns only the non-null
-        sub-list values.
+        sub-list values from non-null lists.
 
         Returns
         -------
@@ -3335,8 +3335,8 @@ cdef class FixedSizeListArray(BaseListArray):
         [
           1,
           2,
-          null,
-          null,
+          0,
+          0,
           3,
           null
         ]


### PR DESCRIPTION
### Rationale for this change

Old behavior is not required by the Arrow spec and is wasteful. It's also theoretically incorrect if the fixed size list's child field is marked non-nullable.

### What changes are included in this PR?

`FixedSizeListBuilder` now appends empty values to the child when appending nulls to itself.

### Are these changes tested?

By existing tests.

### Are there any user-facing changes?

`FixedSizeListBuilder::AppendNull()` and `AppendNulls()` don't append nulls to the underlying value builder and call `AppendEmptyValues(fixed_list_size)` instead.
* GitHub Issue: #41188