### PR TITLE
GH-41323: [R] Redo how summarize() evaluates expressions

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,7 +19,7 @@
 
 # arrow 16.0.0.9000
 
-* R functions that users write that use functions that Arrow supports in dataset queries now can be used in queries too. Previously, only functions that used arithmetic operators worked. For example, `time_hours <- function(mins) mins / 60` worked, but `time_hours_rounded <- function(mins) round(mins / 60)` did not; now both work. (#41223)
+* R functions that users write that use functions that Arrow supports in dataset queries now can be used in queries too. Previously, only functions that used arithmetic operators worked. For example, `time_hours <- function(mins) mins / 60` worked, but `time_hours_rounded <- function(mins) round(mins / 60)` did not; now both work. These are not true user-defined functions (UDFs); for those, see `register_scalar_function()`. (#41223)
 * `summarize()` supports more complex expressions, and correctly handles cases where column names are reused in expressions. 
 
 # arrow 16.0.0

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,6 +19,9 @@
 
 # arrow 16.0.0.9000
 
+* R functions that users write that use functions that Arrow supports in dataset queries now can be used in queries too. Previously, only functions that used arithmetic operators worked. For example, `time_hours <- function(mins) mins / 60` worked, but `time_hours_rounded <- function(mins) round(mins / 60)` did not; now both work. (#41223)
+* `summarize()` supports more complex expressions, and correctly handles cases where column names are reused in expressions. 
+
 # arrow 16.0.0
 
 # arrow 15.0.2

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1132,6 +1132,10 @@ compute___expr__get_field_ref_name <- function(x) {
   .Call(`_arrow_compute___expr__get_field_ref_name`, x)
 }
 
+compute___expr__field_names_in_expression <- function(x) {
+  .Call(`_arrow_compute___expr__field_names_in_expression`, x)
+}
+
 compute___expr__field_ref <- function(name) {
   .Call(`_arrow_compute___expr__field_ref`, name)
 }

--- a/r/R/dplyr-across.R
+++ b/r/R/dplyr-across.R
@@ -145,7 +145,6 @@ across_setup <- function(cols, fns, names, .caller_env, mask, inline = FALSE, ex
     fns <- call_args(fns)
   }
 
-  # ARROW-14071
   if (all(map_lgl(fns, is_call, name = "function"))) {
     abort("Anonymous functions are not yet supported in Arrow")
   }

--- a/r/R/dplyr-eval.R
+++ b/r/R/dplyr-eval.R
@@ -125,8 +125,7 @@ arrow_mask <- function(.data, aggregation = FALSE) {
   if (aggregation) {
     # Add the aggregation functions to the environment, and set the enclosing
     # environment to the parent frame so that, when called from summarize_eval(),
-    # they can reference and assign into `..aggregations` and `..post_mutate`
-    # defined there.
+    # they can reference and assign into `..aggregations` defined there.
     pf <- parent.frame()
     for (f in names(agg_funcs)) {
       f_env[[f]] <- agg_funcs[[f]]

--- a/r/R/dplyr-eval.R
+++ b/r/R/dplyr-eval.R
@@ -17,8 +17,8 @@
 
 # filter(), mutate(), etc. work by evaluating the quoted `exprs` to generate Expressions
 arrow_eval <- function(expr, mask) {
-  # Look for R functions referenced in expr that are not in the mask and add them
-  # If they call other functions in the mask, this will let them find them
+  # Look for R functions referenced in expr that are not in the mask and add
+  # them. If they call other functions in the mask, this will let them find them
   # and just work. (If they call things not supported in Arrow, it won't work,
   # but it wouldn't have worked anyway!)
   # Note this is *not* true UDFs.
@@ -57,8 +57,10 @@ add_user_functions_to_mask <- function(expr, mask) {
   # see if we can add them to the mask and set their parent env to the mask
   # so that they can reference other functions in the mask.
   if (is_quosure(expr)) {
-    # case_when evaluates regular formulas not quosures, which don't have
-    # their own environment, so let's just skip them for now
+    # case_when calls arrow_eval() on regular formulas not quosures, which don't
+    # have their own environment. But, we've already walked those expressions
+    # when calling arrow_eval() on the case_when expression itself, so we don't
+    # need to worry about adding them again.
     function_env <- parent.env(parent.env(mask))
     quo_expr <- quo_get_expr(expr)
     funs_in_expr <- all_funs(quo_expr)

--- a/r/R/dplyr-eval.R
+++ b/r/R/dplyr-eval.R
@@ -88,10 +88,14 @@ arrow_mask <- function(.data, aggregation = FALSE) {
   }
 
   if (aggregation) {
+    pf <- parent.frame()
     # This should probably be done with an environment inside an environment
     # but a first attempt at that had scoping problems (ARROW-13499)
     for (f in names(agg_funcs)) {
       f_env[[f]] <- agg_funcs[[f]]
+      # Make sure that ..aggregations and ..post_mutate are in the search path
+      # This assumes being called from summarize
+      environment(f_env[[f]]) <- pf
     }
   }
 

--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -471,26 +471,6 @@ summarize_eval <- function(name, quosure, mask, hash) {
     expr <- wrap_hash_quantile(expr)
     quosure <- as_quosure(expr, quo_env)
   }
-  function_env <- parent.env(parent.env(mask))
-  unknown <- setdiff(funs_in_expr, ls(function_env, all.names = TRUE))
-  if (length(unknown)) {
-    for (i in unknown) {
-      if (exists(i, quo_env)) {
-        user_fun <- get(i, quo_env)
-        if (!is.null(environment(user_fun))) {
-          # Primitives don't have an environment
-          if (getOption("arrow.debug", FALSE)) {
-            print(paste("Adding", i, "to the function environment"))
-          }
-          function_env[[i]] <- user_fun
-          # Also set the enclosing environment to be the function environment.
-          # This allows the function to reference other functions in the env.
-          # This may have other undesired side effects?
-          environment(function_env[[i]]) <- function_env
-        }
-      }
-    }
-  }
 
   # Add previous aggregations to the mask
   agg_field_types <- aggregate_types(starting_aggs, hash)

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -60,6 +60,9 @@ Expression <- R6Class("Expression",
     is_field_ref = function() {
       compute___expr__is_field_ref(self)
     },
+    field_names_in_expression = function() {
+      compute___expr__field_names_in_expression(self)
+    },
     cast = function(to_type, safe = TRUE, ...) {
       opts <- cast_options(safe, ...)
       opts$to_type <- as_type(to_type)

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2980,6 +2980,14 @@ BEGIN_CPP11
 END_CPP11
 }
 // expression.cpp
+std::vector<std::string> compute___expr__field_names_in_expression(const std::shared_ptr<compute::Expression>& x);
+extern "C" SEXP _arrow_compute___expr__field_names_in_expression(SEXP x_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<compute::Expression>&>::type x(x_sexp);
+	return cpp11::as_sexp(compute___expr__field_names_in_expression(x));
+END_CPP11
+}
+// expression.cpp
 std::shared_ptr<compute::Expression> compute___expr__field_ref(std::string name);
 extern "C" SEXP _arrow_compute___expr__field_ref(SEXP name_sexp){
 BEGIN_CPP11
@@ -5951,6 +5959,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_compute___expr__call", (DL_FUNC) &_arrow_compute___expr__call, 3}, 
 		{ "_arrow_compute___expr__is_field_ref", (DL_FUNC) &_arrow_compute___expr__is_field_ref, 1}, 
 		{ "_arrow_compute___expr__get_field_ref_name", (DL_FUNC) &_arrow_compute___expr__get_field_ref_name, 1}, 
+		{ "_arrow_compute___expr__field_names_in_expression", (DL_FUNC) &_arrow_compute___expr__field_names_in_expression, 1}, 
 		{ "_arrow_compute___expr__field_ref", (DL_FUNC) &_arrow_compute___expr__field_ref, 1}, 
 		{ "_arrow_compute___expr__nested_field_ref", (DL_FUNC) &_arrow_compute___expr__nested_field_ref, 2}, 
 		{ "_arrow_compute___expr__scalar", (DL_FUNC) &_arrow_compute___expr__scalar, 1}, 

--- a/r/src/expression.cpp
+++ b/r/src/expression.cpp
@@ -71,7 +71,8 @@ std::vector<std::string> compute___expr__field_names_in_expression(
   for (const auto& ref : compute::FieldsInExpression(*x)) {
     if (ref.IsNested()) {
       // Slight hack: this isn't the field's "name", but it's good enough
-      // for my current purposes. A nested field ref doesn't have a name property
+      // for my current purposes. A nested field ref doesn't have a name property.
+      // Alternatively, we could skip nested refs like in get_field_ref_name
       names.push_back(ref.ToString());
     } else {
       names.push_back(*ref.name());

--- a/r/src/expression.cpp
+++ b/r/src/expression.cpp
@@ -65,6 +65,16 @@ std::string compute___expr__get_field_ref_name(
 }
 
 // [[arrow::export]]
+std::vector<std::string> compute___expr__field_names_in_expression(
+    const std::shared_ptr<compute::Expression>& x) {
+  std::vector<std::string> names;
+  for (const auto& ref : compute::FieldsInExpression(*x)) {
+    names.push_back(*ref.name());
+  }
+  return names;
+}
+
+// [[arrow::export]]
 std::shared_ptr<compute::Expression> compute___expr__field_ref(std::string name) {
   return std::make_shared<compute::Expression>(compute::field_ref(std::move(name)));
 }

--- a/r/src/expression.cpp
+++ b/r/src/expression.cpp
@@ -69,7 +69,13 @@ std::vector<std::string> compute___expr__field_names_in_expression(
     const std::shared_ptr<compute::Expression>& x) {
   std::vector<std::string> names;
   for (const auto& ref : compute::FieldsInExpression(*x)) {
-    names.push_back(*ref.name());
+    if (ref.IsNested()) {
+      // Slight hack: this isn't the field's "name", but it's good enough
+      // for my current purposes. A nested field ref doesn't have a name property
+      names.push_back(ref.ToString());
+    } else {
+      names.push_back(*ref.name());
+    }
   }
   return names;
 }

--- a/r/tests/testthat/test-dplyr-across.R
+++ b/r/tests/testthat/test-dplyr-across.R
@@ -18,7 +18,6 @@
 library(dplyr, warn.conflicts = FALSE)
 
 test_that("expand_across correctly expands quosures", {
-
   # single unnamed function
   expect_across_equal(
     quos(across(c(dbl, dbl2), round)),
@@ -236,7 +235,6 @@ test_that("expand_across correctly expands quosures", {
 })
 
 test_that("purrr-style lambda functions are supported", {
-
   # using `.x` inside lambda functions
   expect_across_equal(
     quos(across(c(dbl, dbl2), ~ round(.x, digits = 0))),
@@ -279,7 +277,17 @@ test_that("purrr-style lambda functions are supported", {
   )
 })
 
-test_that("ARROW-14071 - function(x)-style lambda functions are not supported", {
+test_that("ARROW-14071 - user-defined R functions", {
+  makeWhole <- function(x) round(x, digits = 0)
+  compare_dplyr_binding(
+    .input %>%
+      mutate(across(c(int, dbl), makeWhole)) %>%
+      collect(),
+    example_data
+  )
+})
+
+test_that("function(x)-style lambda functions are not supported", {
   expect_error(
     expand_across(as_adq(example_data), quos(across(.cols = c(dbl, dbl2), list(function(x) {
       head(x, 1)
@@ -301,17 +309,15 @@ test_that("ARROW-14071 - function(x)-style lambda functions are not supported", 
 })
 
 test_that("if_all() and if_any() are supported", {
-
   expect_across_equal(
-    quos(if_any(everything(), ~is.na(.x))),
+    quos(if_any(everything(), ~ is.na(.x))),
     quos(is.na(int) | is.na(dbl) | is.na(dbl2) | is.na(lgl) | is.na(false) | is.na(chr) | is.na(fct)),
     example_data
   )
 
   expect_across_equal(
-    quos(if_all(everything(), ~is.na(.x))),
+    quos(if_all(everything(), ~ is.na(.x))),
     quos(is.na(int) & is.na(dbl) & is.na(dbl2) & is.na(lgl) & is.na(false) & is.na(chr) & is.na(fct)),
     example_data
   )
-
 })

--- a/r/tests/testthat/test-dplyr-across.R
+++ b/r/tests/testthat/test-dplyr-across.R
@@ -277,7 +277,7 @@ test_that("purrr-style lambda functions are supported", {
   )
 })
 
-test_that("ARROW-14071 - user-defined R functions", {
+test_that("ARROW-14071 - R functions from a user's environment", {
   makeWhole <- function(x) round(x, digits = 0)
   compare_dplyr_binding(
     .input %>%

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -277,7 +277,6 @@ test_that("filter environment scope", {
     tbl
   )
   isShortString <- function(x) nchar(x) < 10
-  skip("TODO: ARROW-14071")
   compare_dplyr_binding(
     .input %>%
       select(-fct) %>%

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -192,6 +192,21 @@ test_that("case_when()", {
       collect(),
     tbl
   )
+
+  # Test finding R functions from the user's environment
+  isIn <- function(x, y) x %in% y
+  withr::with_options(list(arrow.debug = TRUE), {
+    expect_output(
+      compare_dplyr_binding(
+        .input %>%
+          transmute(cw = case_when(isIn(chr, letters[1:3]) ~ 1L) + 41L) %>%
+          collect(),
+        tbl
+      ),
+      "Adding isIn to the function environment"
+    )
+  })
+
   compare_dplyr_binding(
     .input %>%
       filter(case_when(

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -967,7 +967,7 @@ test_that("Not (yet) supported: implicit join", {
       collect(),
     data.frame(x = 1, y = 2),
     warning = paste(
-      "Expression y is not an aggregate expression",
+      "Expression y is not a valid aggregation expression",
       "or is not supported in Arrow; pulling data into R"
     )
   )
@@ -980,7 +980,7 @@ test_that("Not (yet) supported: implicit join", {
       collect(),
     data.frame(x = 1, y = 2, z = 3),
     warning = paste(
-      "Expression x - y is not an aggregate expression",
+      "Expression x - y is not a valid aggregation expression",
       "or is not supported in Arrow; pulling data into R"
     )
   )
@@ -1222,7 +1222,7 @@ test_that("Can use across() within summarise()", {
       group_by(x) %>%
       summarise(across(everything())) %>%
       collect(),
-    regexp = "Expression y is not an aggregate expression or is not supported in Arrow; pulling data into R"
+    regexp = "Expression y is not a valid aggregation expression or is not supported in Arrow; pulling data into R"
   )
 })
 

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -857,6 +857,64 @@ test_that("Expressions on aggregations", {
   )
 })
 
+test_that("Re-using/overwriting column names", {
+  compare_dplyr_binding(
+    .input %>%
+      summarize(
+        # These are both aggregations
+        y = sum(int, na.rm = TRUE),
+        y = sum(dbl, na.rm = TRUE)
+      ) %>%
+      collect(),
+    tbl
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      summarize(
+        # This is just aggregation
+        y = sum(int, na.rm = TRUE),
+        # This is aggregations and a projection after
+        y = mean(int, na.rm = TRUE) * n()
+      ) %>%
+      collect(),
+    tbl
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      summarize(
+        # Same thing, but in the other order
+        y = mean(int, na.rm = TRUE) * n(),
+        y = sum(dbl, na.rm = TRUE),
+      ) %>%
+      collect(),
+    tbl
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      summarize(
+        int = sum(int, na.rm = TRUE),
+        # This needs to pick up *that* int, not the column in the data
+        y = int / n()
+      ) %>%
+      collect(),
+    tbl
+  )
+
+  compare_dplyr_binding(
+    .input %>%
+      summarize(
+        # No one should do this! But it's valid right?
+        int = sum(int, na.rm = TRUE),
+        int = int / n()
+      ) %>%
+      collect(),
+    tbl
+  )
+})
+
 test_that("Weighted mean", {
   compare_dplyr_binding(
     .input %>%
@@ -907,7 +965,7 @@ test_that("Summarize with 0 arguments", {
   )
 })
 
-test_that("Not (yet) supported: implicit join", {
+test_that("Not (yet) supported: window functions", {
   compare_dplyr_binding(
     .input %>%
       group_by(some_grouping) %>%

--- a/r/tests/testthat/test-dplyr-summarize.R
+++ b/r/tests/testthat/test-dplyr-summarize.R
@@ -948,7 +948,6 @@ test_that("Not (yet) supported: implicit join", {
     )
   )
 
-  options(arrow.debug = TRUE)
   compare_dplyr_binding(
     .input %>%
       group_by(x) %>%
@@ -960,7 +959,6 @@ test_that("Not (yet) supported: implicit join", {
       "or is not supported in Arrow; pulling data into R"
     )
   )
-  options(arrow.debug = FALSE)
 
   compare_dplyr_binding(
     .input %>%


### PR DESCRIPTION
### Rationale for this change

Previously, the NSE expression handling in `summarize()` worked differently from filter/mutate/etc. Among the implications, it would not have been possible to define bindings for other aggregation functions that can be translated into some combination of supported aggregations, such as `weighted.mean()`.  

### What changes are included in this PR?

* Expressions in `summarize()` can now be evaluated with "regular" `arrow_eval()`. Aggregation bindings stick the contents of the aggregation data they previously returned into an `..aggregations` list that lives in an enclosing environment, and then return a FieldRef pointing to that. This makes the code in e.g. `summarize_eval()` a little harder to follow, since it's grabbing and pointing to objects out of its immediate scope, but I've tried to comment thoroughly and am happy to add more.
* `arrow_eval()` inspects the expression it receives for any functions that are not in the NSE mask and not in some other package's namespace (i.e. hopefully just user functions) and inserts them into the NSE mask, setting the enclosing environment for that copy of the function to be the mask, so that if the function calls other functions that we do have bindings for, the bindings get called. This is the approach I suggested back in https://github.com/apache/arrow/issues/29667#issuecomment-1378049226, and it is what fixes #29667 and #40938.

### Are these changes tested?

Existing tests, which are pretty comprehensive, pass. But it would be good to try to be more evil in manual testing with the user-defined R function support.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #41323