### PR TITLE
GH-41227: [CI][Release][GLib][Conda] Unpin gobject-introspection

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -831,9 +831,7 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
-  # We can unpin gobject-introspection after
-  # https://github.com/conda-forge/glib-feedstock/pull/174 is merged.
-  maybe_setup_conda glib gobject-introspection=1.78.1 meson ninja ruby
+  maybe_setup_conda glib gobject-introspection meson ninja ruby
   maybe_setup_virtualenv meson
 
   # Install bundler if doesn't exist


### PR DESCRIPTION
### Rationale for this change

Upstream problem https://github.com/conda-forge/glib-feedstock/pull/174 has been fixed.

### What changes are included in this PR?

Revert pinning.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41227