### PR TITLE
GH-41225: [C#] Slice value buffers when writing sliced list or binary arrays in IPC format

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -163,9 +163,18 @@ namespace Apache.Arrow.Ipc
             public void Visit(ListArray array)
             {
                 _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateSlicedBuffer<int>(array.ValueOffsetsBuffer, array.Offset, array.Length + 1));
+                _buffers.Add(CreateBuffer(GetZeroBasedValueOffsets(array)));
 
-                VisitArray(array.Values);
+                int valuesOffset = array.ValueOffsets[0];
+                int valuesLength = array.ValueOffsets[array.Length] - valuesOffset;
+
+                var values = array.Values;
+                if (valuesOffset > 0 || valuesLength < values.Length)
+                {
+                    values = ArrowArrayFactory.Slice(values, valuesOffset, valuesLength);
+                }
+
+                VisitArray(values);
             }
 
             public void Visit(ListViewArray array)
@@ -261,6 +270,40 @@ namespace Apache.Arrow.Ipc
             public void Visit(NullArray array)
             {
                 // There are no buffers for a NullArray
+            }
+
+            private ArrowBuffer GetZeroBasedValueOffsets(ListArray array)
+            {
+                var valueOffsetsBuffer = array.ValueOffsetsBuffer;
+                var requiredBytes = CalculatePaddedBufferLength(sizeof(int) * (array.Length + 1));
+
+                if (array.Offset != 0)
+                {
+                    // Array has been sliced, so we need to shift and adjust the offsets
+                    var originalOffsets = array.ValueOffsets;
+                    var firstOffset = array.Length > 0 ? originalOffsets[0] : 0;
+
+                    var newValueOffsetsBuffer = _allocator.Allocate(requiredBytes);
+                    var newValueOffsets = newValueOffsetsBuffer.Memory.Span.CastTo<int>();
+
+                    for (int i = 0; i < array.Length + 1; ++i)
+                    {
+                        newValueOffsets[i] = originalOffsets[i] - firstOffset;
+                    }
+
+                    return new ArrowBuffer(newValueOffsetsBuffer);
+                }
+                else if (valueOffsetsBuffer.Length > requiredBytes)
+                {
+                    // Array may have been sliced but the offset is zero,
+                    // so we can truncate the existing offsets
+                    return new ArrowBuffer(valueOffsetsBuffer.Memory.Slice(0, requiredBytes));
+                }
+                else
+                {
+                    // Use the full buffer
+                    return valueOffsetsBuffer;
+                }
             }
 
             private Buffer CreateBitmapBuffer(ArrowBuffer buffer, int offset, int length)

--- a/csharp/test/Apache.Arrow.Tests/ArrowFileWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowFileWriterTests.cs
@@ -113,6 +113,7 @@ namespace Apache.Arrow.Tests
         [InlineData(0, 45)]
         [InlineData(3, 45)]
         [InlineData(16, 45)]
+        [InlineData(10, 0)]
         public async Task WriteSlicedArrays(int sliceOffset, int sliceLength)
         {
             var originalBatch = TestData.CreateSampleRecordBatch(length: 100);

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -294,7 +294,18 @@ namespace Apache.Arrow.Tests
 
                 for (var i = 0; i < Length; i++)
                 {
-                    builder.Append(str);
+                    switch (i % 3)
+                    {
+                        case 0:
+                            builder.AppendNull();
+                            break;
+                        case 1:
+                            builder.Append(str);
+                            break;
+                        case 2:
+                            builder.Append(str + str);
+                            break;
+                    }
                 }
 
                 Array = builder.Build();
@@ -328,18 +339,20 @@ namespace Apache.Arrow.Tests
             {
                 var builder = new ListArray.Builder(type.ValueField).Reserve(Length);
 
-                var valueBuilder = (Int64Array.Builder)builder.ValueBuilder.Reserve(Length + 1);
+                var valueBuilder = (Int64Array.Builder)builder.ValueBuilder.Reserve(Length * 3 / 2);
 
                 for (var i = 0; i < Length; i++)
                 {
-                    builder.Append();
-                    valueBuilder.Append(i);
-                }
-
-                if (Length > 0)
-                {
-                    // Add a value to check if Values.Length can exceed ListArray.Length
-                    valueBuilder.Append(0);
+                    if (i % 10 == 2)
+                    {
+                        builder.AppendNull();
+                    }
+                    else
+                    {
+                        builder.Append();
+                        var listLength = i % 4;
+                        valueBuilder.AppendRange(Enumerable.Range(i, listLength).Select(x => (long)x));
+                    }
                 }
 
                 Array = builder.Build();

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -335,8 +335,12 @@ namespace Apache.Arrow.Tests
                     builder.Append();
                     valueBuilder.Append(i);
                 }
-                //Add a value to check if Values.Length can exceed ListArray.Length
-                valueBuilder.Append(0);
+
+                if (Length > 0)
+                {
+                    // Add a value to check if Values.Length can exceed ListArray.Length
+                    valueBuilder.Append(0);
+                }
 
                 Array = builder.Build();
             }
@@ -352,8 +356,12 @@ namespace Apache.Arrow.Tests
                     builder.Append();
                     valueBuilder.Append(i);
                 }
-                //Add a value to check if Values.Length can exceed ListArray.Length
-                valueBuilder.Append(0);
+
+                if (Length > 0)
+                {
+                    // Add a value to check if Values.Length can exceed ListArray.Length
+                    valueBuilder.Append(0);
+                }
 
                 Array = builder.Build();
             }
@@ -562,9 +570,13 @@ namespace Apache.Arrow.Tests
                     keyBuilder.Append(i.ToString());
                     valueBuilder.Append(i);
                 }
-                //Add a value to check if Values.Length can exceed MapArray.Length
-                keyBuilder.Append("0");
-                valueBuilder.Append(0);
+
+                if (Length > 0)
+                {
+                    // Add a value to check if Values.Length can exceed MapArray.Length
+                    keyBuilder.Append("0");
+                    valueBuilder.Append(0);
+                }
 
                 Array = builder.Build();
             }


### PR DESCRIPTION
### Rationale for this change

This reduces file sizes when writing sliced binary or list arrays to IPC format.

### What changes are included in this PR?

Changes `ArrowStreamWriter` to write only the subset of the values that is needed rather than the full value buffer when writing a `ListArray` or `BinaryArray`, and compute shifted value offset buffers.

### Are these changes tested?

This code is covered by existing tests and the change doesn't introduce any difference in the observed array values, so I haven't added new tests or checks.

I did change how list arrays are compared though as we can no longer compare the value and value offset buffers directly, so the tests now get list items as arrays and create a new `ArrayComparer` to compare them. This meant that array offsets are no longer always zero, so I've changed the offset assertions to only be used in strict mode.

### Are there any user-facing changes?

Yes, this might reduce IPC file sizes for users writing sliced data.
* GitHub Issue: #41225