### PR TITLE
GH-41240: [Release][Packaging] Use Debian bookworm for uploading binaries

### DIFF
--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
### Rationale for this change

Debian bullseye will reach EOL on 2024-07:
https://wiki.debian.org/DebianReleases

### What changes are included in this PR?

Use bookworm instead.

### Are these changes tested?

Yes. I used this for 16.0.0 RC0.

### Are there any user-facing changes?

No.
* GitHub Issue: #41240