### PR TITLE
GH-41238: [Release] Use UTF-8 as the default encoding to upload binary

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -21,8 +21,17 @@ set -e
 set -u
 set -o pipefail
 
-export LANG=C
-export LC_CTYPE=C
+export LANG=C.UTF-8
+export LC_ADDRESS=C.UTF-8
+export LC_CTYPE=C.UTF-8
+export LC_IDENTIFICATION=C.UTF-8
+export LC_MEASUREMENT=C.UTF-8
+export LC_MONETARY=C.UTF-8
+export LC_NAME=C.UTF-8
+export LC_NUMERIC=C.UTF-8
+export LC_PAPER=C.UTF-8
+export LC_TELEPHONE=C.UTF-8
+export LC_TIME=C.UTF-8
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/dev/release/binary/runner.sh
+++ b/dev/release/binary/runner.sh
@@ -19,7 +19,7 @@
 
 set -u
 
-export LANG=C
+export LANG=C.UTF-8
 
 target_dir=/host/binary/tmp
 original_owner=$(stat --format=%u ${target_dir})

--- a/dev/release/binary/runner.sh
+++ b/dev/release/binary/runner.sh
@@ -20,6 +20,16 @@
 set -u
 
 export LANG=C.UTF-8
+export LC_ADDRESS=C.UTF-8
+export LC_CTYPE=C.UTF-8
+export LC_IDENTIFICATION=C.UTF-8
+export LC_MEASUREMENT=C.UTF-8
+export LC_MONETARY=C.UTF-8
+export LC_NAME=C.UTF-8
+export LC_NUMERIC=C.UTF-8
+export LC_PAPER=C.UTF-8
+export LC_TELEPHONE=C.UTF-8
+export LC_TIME=C.UTF-8
 
 target_dir=/host/binary/tmp
 original_owner=$(stat --format=%u ${target_dir})


### PR DESCRIPTION
### Rationale for this change

We may have non ASCII characters in the process. For example, PGP uid may include non ASCII characters.

### What changes are included in this PR?

Use `LANG=C.UTF-8` and `LC_*=C.UTF-8` to use UTF-8 as the default encoding.

### Are these changes tested?

Yes. I used this for 16.0.0 RC0.

### Are there any user-facing changes?

No.
* GitHub Issue: #41238