### PR TITLE
GH-41243: [Release][Packaging] Avoid needless download by "archery crossbow download-artifacts"

### DIFF
--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -505,7 +505,17 @@ def download_artifacts(obj, job_name, target_dir, dry_run, fetch,
         if asset is not None:
             path = target_dir / task_name / asset.name
             path.parent.mkdir(exist_ok=True)
-            if not dry_run:
+
+            def need_download():
+                if dry_run:
+                    return False
+                if not path.exists():
+                    return True
+                if path.stat().st_size != asset.size:
+                    return True
+                return False
+
+            if need_download():
                 import github3
                 max_n_retries = 5
                 n_retries = 0


### PR DESCRIPTION
### Rationale for this change

We don't need to re-download already downloaded artifacts.

### What changes are included in this PR?

Check local path and skip download if there is downloaded artifact on local.
 
### Are these changes tested?

Yes. I've tested this with 16.0.0 RC0 release.

### Are there any user-facing changes?

No.
* GitHub Issue: #41243