### PR TITLE
GH-41247: [Release] Use LC_ALL in binary upload scripts

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -22,16 +22,7 @@ set -u
 set -o pipefail
 
 export LANG=C.UTF-8
-export LC_ADDRESS=C.UTF-8
-export LC_CTYPE=C.UTF-8
-export LC_IDENTIFICATION=C.UTF-8
-export LC_MEASUREMENT=C.UTF-8
-export LC_MONETARY=C.UTF-8
-export LC_NAME=C.UTF-8
-export LC_NUMERIC=C.UTF-8
-export LC_PAPER=C.UTF-8
-export LC_TELEPHONE=C.UTF-8
-export LC_TIME=C.UTF-8
+export LC_ALL=C.UTF-8
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/dev/release/binary/runner.sh
+++ b/dev/release/binary/runner.sh
@@ -20,16 +20,7 @@
 set -u
 
 export LANG=C.UTF-8
-export LC_ADDRESS=C.UTF-8
-export LC_CTYPE=C.UTF-8
-export LC_IDENTIFICATION=C.UTF-8
-export LC_MEASUREMENT=C.UTF-8
-export LC_MONETARY=C.UTF-8
-export LC_NAME=C.UTF-8
-export LC_NUMERIC=C.UTF-8
-export LC_PAPER=C.UTF-8
-export LC_TELEPHONE=C.UTF-8
-export LC_TIME=C.UTF-8
+export LC_ALL=C.UTF-8
 
 target_dir=/host/binary/tmp
 original_owner=$(stat --format=%u ${target_dir})


### PR DESCRIPTION
### Rationale for this change

Setting all `LC_*` explicitly is redundant.

### What changes are included in this PR?

Use `LC_ALL` instead.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #41247