### PR TITLE
GH-41253: [C++] Feature: support filter before agg for acero.

### DIFF
--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -515,11 +515,11 @@ TEST(ExecPlan, ToString) {
   });
   ASSERT_OK_AND_ASSIGN(std::string plan_str, DeclarationToString(declaration));
   EXPECT_EQ(plan_str, R"a(ExecPlan with 6 nodes:
-custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
+custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}, filter = true}
   :FilterNode{filter=(sum(multiply(i32, 2)) > 10)}
     :GroupByNode{keys=["bool"], aggregates=[
     	hash_sum(multiply(i32, 2)),
-    	hash_count(multiply(i32, 2), {mode=NON_NULL}),
+    	hash_count(multiply(i32, 2), {mode=NON_NULL}, filter = true),
     	hash_count_all(*),
     ]}
       :ProjectNode{projection=[bool, multiply(i32, 2)]}
@@ -551,8 +551,8 @@ custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32,
   EXPECT_EQ(plan_str, R"a(ExecPlan with 5 nodes:
 :SinkNode{}
   :ScalarAggregateNode{aggregates=[
-	count(i32, {mode=NON_NULL}),
-	count_all(*),
+	count(i32, {mode=NON_NULL}, filter = true),
+	count_all(*, {mode=NON_NULL}, filter = true),
 ]}
     :UnionNode{}
       rhs:SourceNode{}

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -106,40 +106,43 @@ static auto kIndexOptionsType =
 }  // namespace
 }  // namespace internal
 
-ScalarAggregateOptions::ScalarAggregateOptions(bool skip_nulls, uint32_t min_count)
-    : FunctionOptions(internal::kScalarAggregateOptionsType),
+ScalarAggregateOptions::ScalarAggregateOptions(bool skip_nulls, uint32_t min_count,
+                                               Expression filter)
+    : FunctionOptions(internal::kScalarAggregateOptionsType, filter),
       skip_nulls(skip_nulls),
       min_count(min_count) {}
 constexpr char ScalarAggregateOptions::kTypeName[];
 
-CountOptions::CountOptions(CountMode mode)
-    : FunctionOptions(internal::kCountOptionsType), mode(mode) {}
+CountOptions::CountOptions(CountMode mode, Expression filter)
+    : FunctionOptions(internal::kCountOptionsType, filter), mode(mode) {}
 constexpr char CountOptions::kTypeName[];
 
-ModeOptions::ModeOptions(int64_t n, bool skip_nulls, uint32_t min_count)
-    : FunctionOptions(internal::kModeOptionsType),
+ModeOptions::ModeOptions(int64_t n, bool skip_nulls, uint32_t min_count,
+                         Expression filter)
+    : FunctionOptions(internal::kModeOptionsType, filter),
       n{n},
       skip_nulls{skip_nulls},
       min_count{min_count} {}
 constexpr char ModeOptions::kTypeName[];
 
-VarianceOptions::VarianceOptions(int ddof, bool skip_nulls, uint32_t min_count)
-    : FunctionOptions(internal::kVarianceOptionsType),
+VarianceOptions::VarianceOptions(int ddof, bool skip_nulls, uint32_t min_count,
+                                 Expression filter)
+    : FunctionOptions(internal::kVarianceOptionsType, filter),
       ddof(ddof),
       skip_nulls(skip_nulls),
       min_count(min_count) {}
 constexpr char VarianceOptions::kTypeName[];
 
 QuantileOptions::QuantileOptions(double q, enum Interpolation interpolation,
-                                 bool skip_nulls, uint32_t min_count)
-    : FunctionOptions(internal::kQuantileOptionsType),
+                                 bool skip_nulls, uint32_t min_count, Expression filter)
+    : FunctionOptions(internal::kQuantileOptionsType, filter),
       q{q},
       interpolation{interpolation},
       skip_nulls{skip_nulls},
       min_count{min_count} {}
 QuantileOptions::QuantileOptions(std::vector<double> q, enum Interpolation interpolation,
-                                 bool skip_nulls, uint32_t min_count)
-    : FunctionOptions(internal::kQuantileOptionsType),
+                                 bool skip_nulls, uint32_t min_count, Expression filter)
+    : FunctionOptions(internal::kQuantileOptionsType, filter),
       q{std::move(q)},
       interpolation{interpolation},
       skip_nulls{skip_nulls},
@@ -147,16 +150,17 @@ QuantileOptions::QuantileOptions(std::vector<double> q, enum Interpolation inter
 constexpr char QuantileOptions::kTypeName[];
 
 TDigestOptions::TDigestOptions(double q, uint32_t delta, uint32_t buffer_size,
-                               bool skip_nulls, uint32_t min_count)
-    : FunctionOptions(internal::kTDigestOptionsType),
+                               bool skip_nulls, uint32_t min_count, Expression filter)
+    : FunctionOptions(internal::kTDigestOptionsType, filter),
       q{q},
       delta{delta},
       buffer_size{buffer_size},
       skip_nulls{skip_nulls},
       min_count{min_count} {}
 TDigestOptions::TDigestOptions(std::vector<double> q, uint32_t delta,
-                               uint32_t buffer_size, bool skip_nulls, uint32_t min_count)
-    : FunctionOptions(internal::kTDigestOptionsType),
+                               uint32_t buffer_size, bool skip_nulls, uint32_t min_count,
+                               Expression filter)
+    : FunctionOptions(internal::kTDigestOptionsType, filter),
       q{std::move(q)},
       delta{delta},
       buffer_size{buffer_size},
@@ -164,8 +168,8 @@ TDigestOptions::TDigestOptions(std::vector<double> q, uint32_t delta,
       min_count{min_count} {}
 constexpr char TDigestOptions::kTypeName[];
 
-IndexOptions::IndexOptions(std::shared_ptr<Scalar> value)
-    : FunctionOptions(internal::kIndexOptionsType), value{std::move(value)} {}
+IndexOptions::IndexOptions(std::shared_ptr<Scalar> value, Expression filter)
+    : FunctionOptions(internal::kIndexOptionsType, filter), value{std::move(value)} {}
 IndexOptions::IndexOptions() : IndexOptions(std::make_shared<NullScalar>()) {}
 constexpr char IndexOptions::kTypeName[];
 

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -22,6 +22,7 @@
 
 #include <vector>
 
+#include "arrow/compute/expression.h"
 #include "arrow/compute/function_options.h"
 #include "arrow/datum.h"
 #include "arrow/result.h"
@@ -47,7 +48,8 @@ class ExecContext;
 /// By default, null values are ignored (skip_nulls = true).
 class ARROW_EXPORT ScalarAggregateOptions : public FunctionOptions {
  public:
-  explicit ScalarAggregateOptions(bool skip_nulls = true, uint32_t min_count = 1);
+  explicit ScalarAggregateOptions(bool skip_nulls = true, uint32_t min_count = 1,
+                                  Expression filter = literal(true));
   static constexpr char const kTypeName[] = "ScalarAggregateOptions";
   static ScalarAggregateOptions Defaults() { return ScalarAggregateOptions{}; }
 
@@ -71,7 +73,8 @@ class ARROW_EXPORT CountOptions : public FunctionOptions {
     /// Count both non-null and null values.
     ALL,
   };
-  explicit CountOptions(CountMode mode = CountMode::ONLY_VALID);
+  explicit CountOptions(CountMode mode = CountMode::ONLY_VALID,
+                        Expression filter = literal(true));
   static constexpr char const kTypeName[] = "CountOptions";
   static CountOptions Defaults() { return CountOptions{}; }
 
@@ -84,7 +87,8 @@ class ARROW_EXPORT CountOptions : public FunctionOptions {
 /// By default, returns the most common value and count.
 class ARROW_EXPORT ModeOptions : public FunctionOptions {
  public:
-  explicit ModeOptions(int64_t n = 1, bool skip_nulls = true, uint32_t min_count = 0);
+  explicit ModeOptions(int64_t n = 1, bool skip_nulls = true, uint32_t min_count = 0,
+                       Expression filter = literal(true));
   static constexpr char const kTypeName[] = "ModeOptions";
   static ModeOptions Defaults() { return ModeOptions{}; }
 
@@ -102,7 +106,8 @@ class ARROW_EXPORT ModeOptions : public FunctionOptions {
 /// By default, ddof is zero, and population variance or stddev is returned.
 class ARROW_EXPORT VarianceOptions : public FunctionOptions {
  public:
-  explicit VarianceOptions(int ddof = 0, bool skip_nulls = true, uint32_t min_count = 0);
+  explicit VarianceOptions(int ddof = 0, bool skip_nulls = true, uint32_t min_count = 0,
+                           Expression filter = literal(true));
   static constexpr char const kTypeName[] = "VarianceOptions";
   static VarianceOptions Defaults() { return VarianceOptions{}; }
 
@@ -129,11 +134,13 @@ class ARROW_EXPORT QuantileOptions : public FunctionOptions {
   };
 
   explicit QuantileOptions(double q = 0.5, enum Interpolation interpolation = LINEAR,
-                           bool skip_nulls = true, uint32_t min_count = 0);
+                           bool skip_nulls = true, uint32_t min_count = 0,
+                           Expression filter = literal(true));
 
   explicit QuantileOptions(std::vector<double> q,
                            enum Interpolation interpolation = LINEAR,
-                           bool skip_nulls = true, uint32_t min_count = 0);
+                           bool skip_nulls = true, uint32_t min_count = 0,
+                           Expression filter = literal(true));
 
   static constexpr char const kTypeName[] = "QuantileOptions";
   static QuantileOptions Defaults() { return QuantileOptions{}; }
@@ -155,10 +162,10 @@ class ARROW_EXPORT TDigestOptions : public FunctionOptions {
  public:
   explicit TDigestOptions(double q = 0.5, uint32_t delta = 100,
                           uint32_t buffer_size = 500, bool skip_nulls = true,
-                          uint32_t min_count = 0);
+                          uint32_t min_count = 0, Expression filter = literal(true));
   explicit TDigestOptions(std::vector<double> q, uint32_t delta = 100,
                           uint32_t buffer_size = 500, bool skip_nulls = true,
-                          uint32_t min_count = 0);
+                          uint32_t min_count = 0, Expression filter = literal(true));
   static constexpr char const kTypeName[] = "TDigestOptions";
   static TDigestOptions Defaults() { return TDigestOptions{}; }
 
@@ -178,7 +185,7 @@ class ARROW_EXPORT TDigestOptions : public FunctionOptions {
 /// \brief Control Index kernel behavior
 class ARROW_EXPORT IndexOptions : public FunctionOptions {
  public:
-  explicit IndexOptions(std::shared_ptr<Scalar> value);
+  explicit IndexOptions(std::shared_ptr<Scalar> value, Expression filter = literal(true));
   // Default constructor for serialization
   IndexOptions();
   static constexpr char const kTypeName[] = "IndexOptions";
@@ -210,6 +217,10 @@ struct ARROW_EXPORT Aggregate {
       : Aggregate(std::move(function), /*options=*/NULLPTR,
                   /*target=*/std::vector<FieldRef>{}, std::move(name)) {}
 
+  Aggregate(std::string function, std::string name,
+            std::shared_ptr<FunctionOptions> options)
+      : Aggregate(std::move(function), std::move(options),
+                  /*target=*/std::vector<FieldRef>{}, std::move(name)) {}
   /// the name of the aggregation function
   std::string function;
 

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -876,7 +876,6 @@ Result<ExecBatch> ExecuteFilterWithIdBatch(const Expression& expr, const ExecBat
   DCHECK(!std::all_of(input.values.begin(), input.values.end(),
                       [](const Datum& value) { return value.is_scalar(); }));
 
-
   std::vector<Datum> values;
   for (const int field : agg_src_fieldset) {
     auto agg_value = input.values[field];

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -252,7 +252,8 @@ ARROW_EXPORT
 Result<Datum> ExecuteScalarExpression(const Expression&, const Schema& full_schema,
                                       const Datum& partial_input, ExecContext* = NULLPTR);
 
-/// Filter the input batch according to the passed filter expression and generate a new batch
+/// Filter the input batch according to the passed filter expression and generate a new
+/// batch
 ARROW_EXPORT
 Result<ExecBatch> ExecuteFilterBatch(const Expression&, const ExecBatch& input,
                                      ExecContext* = NULLPTR);

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -252,6 +252,25 @@ ARROW_EXPORT
 Result<Datum> ExecuteScalarExpression(const Expression&, const Schema& full_schema,
                                       const Datum& partial_input, ExecContext* = NULLPTR);
 
+/// Filter the input batch according to the passed filter expression and generate a new batch
+ARROW_EXPORT
+Result<ExecBatch> ExecuteFilterBatch(const Expression&, const ExecBatch& input,
+                                     ExecContext* = NULLPTR);
+
+/// Similar to ExecuteFilterBatch, but the difference is:
+/// 1.id_batch is a grouped batch (only one column). For details, see the return value of
+/// the Grouper.Consume function.
+/// 2.agg_src_fieldsets indicates which column to extract and participate in the agg
+/// calculation of group by.
+/// 3.filter the original batch and use mask to filter the
+/// id_batch of group by. 4.The returned batch is the corresponding input column plus
+/// id_batch.
+ARROW_EXPORT
+Result<ExecBatch> ExecuteFilterWithIdBatch(const Expression& expr, const ExecBatch& input,
+                                           const Datum& id_batch,
+                                           const std::vector<int>& agg_src_fieldset,
+                                           ExecContext* exec_context);
+
 // Serialization
 
 ARROW_EXPORT

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -263,9 +263,9 @@ TEST(Expression, ToString) {
   auto in_12 = call("index_in", {field_ref("beta")},
                     compute::SetLookupOptions{ArrayFromJSON(int32(), "[1,2]")});
 
-  EXPECT_EQ(
-      in_12.ToString(),
-      "index_in(beta, {value_set=int32:[\n  1,\n  2\n], null_matching_behavior=MATCH}, filter = true)");
+  EXPECT_EQ(in_12.ToString(),
+            "index_in(beta, {value_set=int32:[\n  1,\n  2\n], "
+            "null_matching_behavior=MATCH}, filter = true)");
 
   EXPECT_EQ(and_(field_ref("a"), field_ref("b")).ToString(), "(a and b)");
   EXPECT_EQ(or_(field_ref("a"), field_ref("b")).ToString(), "(a or b)");

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -265,7 +265,7 @@ TEST(Expression, ToString) {
 
   EXPECT_EQ(
       in_12.ToString(),
-      "index_in(beta, {value_set=int32:[\n  1,\n  2\n], null_matching_behavior=MATCH})");
+      "index_in(beta, {value_set=int32:[\n  1,\n  2\n], null_matching_behavior=MATCH}, filter = true)");
 
   EXPECT_EQ(and_(field_ref("a"), field_ref("b")).ToString(), "(a and b)");
   EXPECT_EQ(or_(field_ref("a"), field_ref("b")).ToString(), "(a or b)");
@@ -275,17 +275,17 @@ TEST(Expression, ToString) {
       cast(field_ref("a"), int32()).ToString(),
       "cast(a, {to_type=int32, allow_int_overflow=false, allow_time_truncate=false, "
       "allow_time_overflow=false, allow_decimal_truncate=false, "
-      "allow_float_truncate=false, allow_invalid_utf8=false})");
+      "allow_float_truncate=false, allow_invalid_utf8=false}, filter = true)");
   EXPECT_EQ(
       cast(field_ref("a"), nullptr).ToString(),
       "cast(a, {to_type=<NULLPTR>, allow_int_overflow=false, allow_time_truncate=false, "
       "allow_time_overflow=false, allow_decimal_truncate=false, "
-      "allow_float_truncate=false, allow_invalid_utf8=false})");
+      "allow_float_truncate=false, allow_invalid_utf8=false}, filter = true)");
 
   EXPECT_EQ(call("widgetify", {}).ToString(), "widgetify()");
   EXPECT_EQ(
       call("widgetify", {literal(1)}, std::make_shared<WidgetifyOptions>()).ToString(),
-      "widgetify(1, widgetify)");
+      "widgetify(1, widgetify, filter = true)");
 
   EXPECT_EQ(equal(field_ref("a"), literal(1)).ToString(), "(a == 1)");
   EXPECT_EQ(less(field_ref("a"), literal(2)).ToString(), "(a < 2)");
@@ -311,9 +311,9 @@ TEST(Expression, ToString) {
             "{a=a, renamed_a=a, three=3, b=" + in_12.ToString() + "}");
 
   EXPECT_EQ(call("round", {literal(3.14)}, compute::RoundOptions()).ToString(),
-            "round(3.14, {ndigits=0, round_mode=HALF_TO_EVEN})");
+            "round(3.14, {ndigits=0, round_mode=HALF_TO_EVEN}, filter = true)");
   EXPECT_EQ(call("random", {}, compute::RandomOptions()).ToString(),
-            "random({initializer=SystemRandom, seed=0})");
+            "random({initializer=SystemRandom, seed=0}, filter = true)");
 }
 
 TEST(Expression, Equality) {

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -49,7 +49,9 @@ Result<std::unique_ptr<FunctionOptions>> FunctionOptionsType::Deserialize(
   return Status::NotImplemented("Deserialize for ", type_name());
 }
 
-std::string FunctionOptions::ToString() const { return options_type()->Stringify(*this); }
+std::string FunctionOptions::ToString() const {
+  return options_type()->Stringify(*this) + ", filter = " + get_filter().ToString();
+}
 
 bool FunctionOptions::Equals(const FunctionOptions& other) const {
   if (this == &other) return true;

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -688,6 +688,7 @@ const FunctionOptionsType* GetFunctionOptionsType(const Properties&... propertie
     }
     std::unique_ptr<FunctionOptions> Copy(const FunctionOptions& options) const override {
       auto out = std::make_unique<Options>();
+      out->set_filter(options.get_filter());
       CopyImpl<Options>(out.get(), checked_cast<const Options&>(options), properties_);
       return std::move(out);
     }

--- a/cpp/src/arrow/compute/function_options.h
+++ b/cpp/src/arrow/compute/function_options.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "arrow/compute/expression.h"
 #include "arrow/compute/type_fwd.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
@@ -55,6 +56,8 @@ class ARROW_EXPORT FunctionOptions : public util::EqualityComparable<FunctionOpt
 
   const FunctionOptionsType* options_type() const { return options_type_; }
   const char* type_name() const { return options_type()->type_name(); }
+  const Expression& get_filter() const { return filter_; };
+  void set_filter(const Expression& filter) { filter_ = filter; }
 
   bool Equals(const FunctionOptions& other) const;
   std::string ToString() const;
@@ -69,8 +72,11 @@ class ARROW_EXPORT FunctionOptions : public util::EqualityComparable<FunctionOpt
       const std::string& type_name, const Buffer& buffer);
 
  protected:
-  explicit FunctionOptions(const FunctionOptionsType* type) : options_type_(type) {}
+  explicit FunctionOptions(const FunctionOptionsType* type,
+                           Expression filter = literal(true))
+      : options_type_(type), filter_(std::move(filter)) {}
   const FunctionOptionsType* options_type_;
+  Expression filter_;
 };
 
 ARROW_EXPORT void PrintTo(const FunctionOptions&, std::ostream*);

--- a/cpp/src/arrow/compute/function_options.h
+++ b/cpp/src/arrow/compute/function_options.h
@@ -56,7 +56,7 @@ class ARROW_EXPORT FunctionOptions : public util::EqualityComparable<FunctionOpt
 
   const FunctionOptionsType* options_type() const { return options_type_; }
   const char* type_name() const { return options_type()->type_name(); }
-  const Expression& get_filter() const { return filter_; };
+  const Expression& get_filter() const { return filter_; }
   void set_filter(const Expression& filter) { filter_ = filter; }
 
   bool Equals(const FunctionOptions& other) const;

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -314,6 +314,9 @@ Result<std::unique_ptr<KernelState>> NoopInit(KernelContext*, const KernelInitAr
   return nullptr;
 }
 
+Status NoopFilter(KernelContext*, const ExecSpan&, const Expression&) {
+  return Status::OK();
+}
 Status NoopConsume(KernelContext*, const ExecSpan&) { return Status::OK(); }
 Status NoopMerge(KernelContext*, KernelState&&, KernelState*) { return Status::OK(); }
 Status NoopFinalize(KernelContext*, Datum*) { return Status::OK(); }
@@ -322,8 +325,8 @@ TEST(ScalarAggregateFunction, DispatchExact) {
   ScalarAggregateFunction func("agg_test", Arity::Unary(), FunctionDoc::Empty());
 
   std::vector<InputType> in_args = {int8()};
-  ScalarAggregateKernel kernel(std::move(in_args), int64(), NoopInit, NoopConsume,
-                               NoopMerge, NoopFinalize, /*ordered=*/false);
+  ScalarAggregateKernel kernel(std::move(in_args), int64(), NoopInit, NoopFilter,
+                               NoopConsume, NoopMerge, NoopFinalize, /*ordered=*/false);
   ASSERT_OK(func.AddKernel(kernel));
 
   in_args = {float64()};

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -94,6 +94,10 @@ struct ScalarAggregator : public KernelState {
   virtual Status Consume(KernelContext* ctx, const ExecSpan& batch) = 0;
   virtual Status MergeFrom(KernelContext* ctx, KernelState&& src) = 0;
   virtual Status Finalize(KernelContext* ctx, Datum* out) = 0;
+  Result<ExecBatch> FilterBatch(KernelContext* ctx, const ExecSpan& batch,
+                               const Expression& expr) {
+    return ExecuteFilterBatch(expr, std::move(batch.ToExecBatch()), ctx->exec_context());
+  }
 };
 
 // Helper to differentiate between var/std calculation so we can fold

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -95,7 +95,7 @@ struct ScalarAggregator : public KernelState {
   virtual Status MergeFrom(KernelContext* ctx, KernelState&& src) = 0;
   virtual Status Finalize(KernelContext* ctx, Datum* out) = 0;
   Result<ExecBatch> FilterBatch(KernelContext* ctx, const ExecSpan& batch,
-                               const Expression& expr) {
+                                const Expression& expr) {
     return ExecuteFilterBatch(expr, std::move(batch.ToExecBatch()), ctx->exec_context());
   }
 };

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -637,7 +637,7 @@ cdef class FunctionOptions(_Weakrefable):
     def __repr__(self):
         type_name = self.__class__.__name__
         # Remove {} so we can use our own braces
-        string_repr = frombytes(self.get_options().ToString())[1:-1]
+        string_repr = frombytes(self.get_options().ToString())
         return f"{type_name}({string_repr})"
 
     def __eq__(self, FunctionOptions other):
@@ -829,6 +829,11 @@ def _min_count_doc(*, default):
     return f"""min_count : int, default {default}
         Minimum number of non-null values in the input.  If the number
         of non-null values is below `min_count`, the output is null.
+"""
+
+def _filter(*, default):
+    return f"""filter : Expression, default {default}
+        An expression that can be used to filter batch data.
 """
 
 
@@ -1493,8 +1498,14 @@ class StructFieldOptions(_StructFieldOptions):
 
 
 cdef class _ScalarAggregateOptions(FunctionOptions):
-    def _set_options(self, skip_nulls, min_count):
-        self.wrapped.reset(new CScalarAggregateOptions(skip_nulls, min_count))
+    def _set_options(self, skip_nulls, min_count, filter):
+        if isinstance(filter, Expression):
+            c_filter = (<Expression>filter).unwrap()
+        else:
+            c_filter = CMakeScalarExpression(
+                <shared_ptr[CScalar]> make_shared[CBooleanScalar](True)
+            )
+        self.wrapped.reset(new CScalarAggregateOptions(skip_nulls, min_count, c_filter))
 
 
 class ScalarAggregateOptions(_ScalarAggregateOptions):
@@ -1505,10 +1516,13 @@ class ScalarAggregateOptions(_ScalarAggregateOptions):
     ----------
     {_skip_nulls_doc()}
     {_min_count_doc(default=1)}
+    {_filter(default=None)}
     """
 
-    def __init__(self, *, skip_nulls=True, min_count=1):
-        self._set_options(skip_nulls, min_count)
+    def __init__(self, *, skip_nulls=True, min_count=1, filter=None):
+        if filter is None:
+            filter = Expression._scalar(True)
+        self._set_options(skip_nulls, min_count, filter)
 
 
 cdef class _CountOptions(FunctionOptions):
@@ -1518,9 +1532,11 @@ cdef class _CountOptions(FunctionOptions):
         "all": CCountMode_ALL,
     }
 
-    def _set_options(self, mode):
+    def _set_options(self, mode, filter):
         try:
-            self.wrapped.reset(new CCountOptions(self._mode_map[mode]))
+            if isinstance(filter, Expression):
+                c_filter = (<Expression>filter).unwrap()
+            self.wrapped.reset(new CCountOptions(self._mode_map[mode], c_filter))
         except KeyError:
             _raise_invalid_function_option(mode, "count mode")
 
@@ -1534,15 +1550,24 @@ class CountOptions(_CountOptions):
     mode : str, default "only_valid"
         Which values to count in the input.
         Accepted values are "only_valid", "only_null", "all".
+    filter : Expression, default literal(true).
     """
 
-    def __init__(self, mode="only_valid"):
-        self._set_options(mode)
+    def __init__(self, mode="only_valid", filter=None):
+        if filter is None:
+            filter = Expression._scalar(True)
+        self._set_options(mode, filter)
 
 
 cdef class _IndexOptions(FunctionOptions):
-    def _set_options(self, scalar):
-        self.wrapped.reset(new CIndexOptions(pyarrow_unwrap_scalar(scalar)))
+    def _set_options(self, scalar, filter):
+        if isinstance(filter, Expression):
+            c_filter = (<Expression>filter).unwrap()
+        else:
+            c_filter = CMakeScalarExpression(
+                <shared_ptr[CScalar]> make_shared[CBooleanScalar](True)
+            )
+        self.wrapped.reset(new CIndexOptions(pyarrow_unwrap_scalar(scalar), c_filter))
 
 
 class IndexOptions(_IndexOptions):
@@ -1553,10 +1578,14 @@ class IndexOptions(_IndexOptions):
     ----------
     value : Scalar
         The value to search for.
+    filter : Expression
+        The filter before agg.
     """
 
-    def __init__(self, value):
-        self._set_options(value)
+    def __init__(self, value, filter=None):
+        if filter is None:
+            filter = Expression._scalar(True)
+        self._set_options(value, filter)
 
 
 cdef class _MapLookupOptions(FunctionOptions):
@@ -1600,8 +1629,10 @@ class MapLookupOptions(_MapLookupOptions):
 
 
 cdef class _ModeOptions(FunctionOptions):
-    def _set_options(self, n, skip_nulls, min_count):
-        self.wrapped.reset(new CModeOptions(n, skip_nulls, min_count))
+    def _set_options(self, n, skip_nulls, min_count, filter):
+        if isinstance(filter, Expression):
+            c_filter = (<Expression>filter).unwrap()
+        self.wrapped.reset(new CModeOptions(n, skip_nulls, min_count, c_filter))
 
 
 class ModeOptions(_ModeOptions):
@@ -1614,10 +1645,13 @@ class ModeOptions(_ModeOptions):
         Number of distinct most-common values to return.
     {_skip_nulls_doc()}
     {_min_count_doc(default=0)}
+    {_filter(default=None)}
     """
 
-    def __init__(self, n=1, *, skip_nulls=True, min_count=0):
-        self._set_options(n, skip_nulls, min_count)
+    def __init__(self, n=1, *, skip_nulls=True, min_count=0, filter=None):
+        if filter is None:
+            filter = Expression._scalar(True)
+        self._set_options(n, skip_nulls, min_count, filter)
 
 
 cdef class _SetLookupOptions(FunctionOptions):
@@ -1843,8 +1877,14 @@ class NullOptions(_NullOptions):
 
 
 cdef class _VarianceOptions(FunctionOptions):
-    def _set_options(self, ddof, skip_nulls, min_count):
-        self.wrapped.reset(new CVarianceOptions(ddof, skip_nulls, min_count))
+    def _set_options(self, ddof, skip_nulls, min_count, filter):
+        if isinstance(filter, Expression):
+            c_filter = (<Expression>filter).unwrap()
+        else:
+            c_filter = CMakeScalarExpression(
+                <shared_ptr[CScalar]> make_shared[CBooleanScalar](True)
+            )
+        self.wrapped.reset(new CVarianceOptions(ddof, skip_nulls, min_count, c_filter))
 
 
 class VarianceOptions(_VarianceOptions):
@@ -1857,10 +1897,13 @@ class VarianceOptions(_VarianceOptions):
         Number of degrees of freedom.
     {_skip_nulls_doc()}
     {_min_count_doc(default=0)}
+    {_filter(default=None)}
     """
 
-    def __init__(self, *, ddof=0, skip_nulls=True, min_count=0):
-        self._set_options(ddof, skip_nulls, min_count)
+    def __init__(self, *, ddof=0, skip_nulls=True, min_count=0, filter=None):
+        if filter is None:
+            filter = Expression._scalar(True)
+        self._set_options(ddof, skip_nulls, min_count, filter)
 
 
 cdef class _SplitOptions(FunctionOptions):
@@ -2131,11 +2174,17 @@ cdef class _QuantileOptions(FunctionOptions):
         "midpoint": CQuantileInterp_MIDPOINT,
     }
 
-    def _set_options(self, quantiles, interp, skip_nulls, min_count):
+    def _set_options(self, quantiles, interp, skip_nulls, min_count, filter):
         try:
+            if isinstance(filter, Expression):
+                c_filter = (<Expression>filter).unwrap()
+            else:
+                c_filter = CMakeScalarExpression(
+                    <shared_ptr[CScalar]> make_shared[CBooleanScalar](True)
+                )
             self.wrapped.reset(
                 new CQuantileOptions(quantiles, self._interp_map[interp],
-                                     skip_nulls, min_count)
+                                     skip_nulls, min_count, c_filter)
             )
         except KeyError:
             _raise_invalid_function_option(interp, "quantile interpolation")
@@ -2161,21 +2210,30 @@ class QuantileOptions(_QuantileOptions):
         - "midpoint": compute the (unweighted) mean of the two data points
     {_skip_nulls_doc()}
     {_min_count_doc(default=0)}
+    {_filter(default=None)}
     """
 
     def __init__(self, q=0.5, *, interpolation="linear", skip_nulls=True,
-                 min_count=0):
+                 min_count=0, filter = None):
         if not isinstance(q, (list, tuple, np.ndarray)):
             q = [q]
-        self._set_options(q, interpolation, skip_nulls, min_count)
+        if filter is None:
+            filter = Expression._scalar(True)
+        self._set_options(q, interpolation, skip_nulls, min_count, filter)
 
 
 cdef class _TDigestOptions(FunctionOptions):
     def _set_options(self, quantiles, delta, buffer_size, skip_nulls,
-                     min_count):
+                     min_count, filter):
+        if isinstance(filter, Expression):
+            c_filter = (<Expression>filter).unwrap()
+        else:
+            c_filter = CMakeScalarExpression(
+                <shared_ptr[CScalar]> make_shared[CBooleanScalar](True)
+            )
         self.wrapped.reset(
             new CTDigestOptions(quantiles, delta, buffer_size, skip_nulls,
-                                min_count)
+                                min_count, c_filter)
         )
 
 
@@ -2194,13 +2252,16 @@ class TDigestOptions(_TDigestOptions):
         Buffer size for the T-digest algorithm.
     {_skip_nulls_doc()}
     {_min_count_doc(default=0)}
+    {_filter(default=None)}
     """
 
     def __init__(self, q=0.5, *, delta=100, buffer_size=500, skip_nulls=True,
-                 min_count=0):
+                 min_count=0, filter=None):
         if not isinstance(q, (list, tuple, np.ndarray)):
             q = [q]
-        self._set_options(q, delta, buffer_size, skip_nulls, min_count)
+        if filter is None:
+            filter = Expression._scalar(True)
+        self._set_options(q, delta, buffer_size, skip_nulls, min_count, filter)
 
 
 cdef class _Utf8NormalizeOptions(FunctionOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2432,7 +2432,7 @@ cdef class Expression(_Weakrefable):
       1,
       2,
       3
-    ], null_matching_behavior=MATCH})>
+    ], null_matching_behavior=MATCH}, filter = true)>
     """
 
     def __init__(self):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -831,6 +831,7 @@ def _min_count_doc(*, default):
         of non-null values is below `min_count`, the output is null.
 """
 
+
 def _filter(*, default):
     return f"""filter : Expression, default {default}
         An expression that can be used to filter batch data.
@@ -1550,7 +1551,8 @@ class CountOptions(_CountOptions):
     mode : str, default "only_valid"
         Which values to count in the input.
         Accepted values are "only_valid", "only_null", "all".
-    {_filter(default=None)}
+    filter : Expression, default None
+        An expression that can be used to filter batch data.
     """
 
     def __init__(self, mode="only_valid", filter=None):
@@ -1578,7 +1580,8 @@ class IndexOptions(_IndexOptions):
     ----------
     value : Scalar
         The value to search for.
-    {_filter(default=None)}
+    filter : Expression, default None
+        An expression that can be used to filter batch data.
     """
 
     def __init__(self, value, filter=None):
@@ -2213,7 +2216,7 @@ class QuantileOptions(_QuantileOptions):
     """
 
     def __init__(self, q=0.5, *, interpolation="linear", skip_nulls=True,
-                 min_count=0, filter = None):
+                 min_count=0, filter=None):
         if not isinstance(q, (list, tuple, np.ndarray)):
             q = [q]
         if filter is None:

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1550,7 +1550,7 @@ class CountOptions(_CountOptions):
     mode : str, default "only_valid"
         Which values to count in the input.
         Accepted values are "only_valid", "only_null", "all".
-    filter : Expression, default literal(true).
+    {_filter(default=None)}
     """
 
     def __init__(self, mode="only_valid", filter=None):
@@ -1578,8 +1578,7 @@ class IndexOptions(_IndexOptions):
     ----------
     value : Scalar
         The value to search for.
-    filter : Expression
-        The filter before agg.
+    {_filter(default=None)}
     """
 
     def __init__(self, value, filter=None):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2636,7 +2636,7 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
             "arrow::compute::TDigestOptions"(CFunctionOptions):
         CTDigestOptions(vector[double] q,
                         uint32_t delta, uint32_t buffer_size,
-                        c_bool skip_nulls, uint32_t min_count, 
+                        c_bool skip_nulls, uint32_t min_count,
                         CExpression filter)
         vector[double] q
         uint32_t delta

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2490,14 +2490,14 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CVarianceOptions \
             "arrow::compute::VarianceOptions"(CFunctionOptions):
-        CVarianceOptions(int ddof, c_bool skip_nulls, uint32_t min_count)
+        CVarianceOptions(int ddof, c_bool skip_nulls, uint32_t min_count, CExpression filter)
         int ddof
         c_bool skip_nulls
         uint32_t min_count
 
     cdef cppclass CScalarAggregateOptions \
             "arrow::compute::ScalarAggregateOptions"(CFunctionOptions):
-        CScalarAggregateOptions(c_bool skip_nulls, uint32_t min_count)
+        CScalarAggregateOptions(c_bool skip_nulls, uint32_t min_count, CExpression filter)
         c_bool skip_nulls
         uint32_t min_count
 
@@ -2508,19 +2508,19 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CCountOptions \
             "arrow::compute::CountOptions"(CFunctionOptions):
-        CCountOptions(CCountMode mode)
+        CCountOptions(CCountMode mode, CExpression filter)
         CCountMode mode
 
     cdef cppclass CModeOptions \
             "arrow::compute::ModeOptions"(CFunctionOptions):
-        CModeOptions(int64_t n, c_bool skip_nulls, uint32_t min_count)
+        CModeOptions(int64_t n, c_bool skip_nulls, uint32_t min_count, CExpression filter)
         int64_t n
         c_bool skip_nulls
         uint32_t min_count
 
     cdef cppclass CIndexOptions \
             "arrow::compute::IndexOptions"(CFunctionOptions):
-        CIndexOptions(shared_ptr[CScalar] value)
+        CIndexOptions(shared_ptr[CScalar] value, CExpression filter)
         shared_ptr[CScalar] value
 
     cdef cppclass CAggregate "arrow::compute::Aggregate":
@@ -2626,7 +2626,7 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
     cdef cppclass CQuantileOptions \
             "arrow::compute::QuantileOptions"(CFunctionOptions):
         CQuantileOptions(vector[double] q, CQuantileInterp interpolation,
-                         c_bool skip_nulls, uint32_t min_count)
+                         c_bool skip_nulls, uint32_t min_count, CExpression filter)
         vector[double] q
         CQuantileInterp interpolation
         c_bool skip_nulls
@@ -2636,7 +2636,8 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
             "arrow::compute::TDigestOptions"(CFunctionOptions):
         CTDigestOptions(vector[double] q,
                         uint32_t delta, uint32_t buffer_size,
-                        c_bool skip_nulls, uint32_t min_count)
+                        c_bool skip_nulls, uint32_t min_count, 
+                        CExpression filter)
         vector[double] q
         uint32_t delta
         uint32_t buffer_size

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -225,9 +225,9 @@ def test_option_class_equality():
     for option1, option2 in zip(options, options[1:]):
         assert option1 != option2
 
-    assert repr(pc.IndexOptions(pa.scalar(1))) == "IndexOptions(value=int64:1}, filter = tru)"
+    assert repr(pc.IndexOptions(pa.scalar(1))) == "IndexOptions({value=int64:1}, filter = true)"
     assert repr(pc.ArraySortOptions()) == \
-        "ArraySortOptions(order=Ascending, null_placement=AtEnd}, filter = tru)"
+        "ArraySortOptions({order=Ascending, null_placement=AtEnd}, filter = true)"
 
 
 def test_list_functions():
@@ -752,6 +752,8 @@ def test_generated_docstrings():
         min_count : int, default 1
             Minimum number of non-null values in the input.  If the number
             of non-null values is below `min_count`, the output is null.
+        filter : Expression, default None
+            An expression that can be used to filter batch data.
         options : pyarrow.compute.ScalarAggregateOptions, optional
             Alternative way of passing options.
         memory_pool : pyarrow.MemoryPool, optional
@@ -844,12 +846,12 @@ def test_generated_signatures():
     assert str(sig) == "(x, y, /, *, memory_pool=None)"
     # With options
     sig = inspect.signature(pc.min_max)
-    assert str(sig) == ("(array, /, *, skip_nulls=True, min_count=1, "
+    assert str(sig) == ("(array, /, *, skip_nulls=True, min_count=1, filter=None, "
                         "options=None, memory_pool=None)")
     # With positional options
     sig = inspect.signature(pc.quantile)
     assert str(sig) == ("(array, /, q=0.5, *, interpolation='linear', "
-                        "skip_nulls=True, min_count=0, "
+                        "skip_nulls=True, min_count=0, filter=None, "
                         "options=None, memory_pool=None)")
     # Varargs with options
     sig = inspect.signature(pc.binary_join_element_wise)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -225,7 +225,8 @@ def test_option_class_equality():
     for option1, option2 in zip(options, options[1:]):
         assert option1 != option2
 
-    assert repr(pc.IndexOptions(pa.scalar(1))) == "IndexOptions({value=int64:1}, filter = true)"
+    assert repr(pc.IndexOptions(pa.scalar(1))) == \
+        "IndexOptions({value=int64:1}, filter = true)"
     assert repr(pc.ArraySortOptions()) == \
         "ArraySortOptions({order=Ascending, null_placement=AtEnd}, filter = true)"
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -225,9 +225,9 @@ def test_option_class_equality():
     for option1, option2 in zip(options, options[1:]):
         assert option1 != option2
 
-    assert repr(pc.IndexOptions(pa.scalar(1))) == "IndexOptions(value=int64:1)"
+    assert repr(pc.IndexOptions(pa.scalar(1))) == "IndexOptions(value=int64:1}, filter = tru)"
     assert repr(pc.ArraySortOptions()) == \
-        "ArraySortOptions(order=Ascending, null_placement=AtEnd)"
+        "ArraySortOptions(order=Ascending, null_placement=AtEnd}, filter = tru)"
 
 
 def test_list_functions():
@@ -3516,7 +3516,7 @@ def test_expression_call_function():
     assert str(pc.round(field)) == "round(field)"
     # specified options
     assert str(pc.round(field, ndigits=1)) == \
-        "round(field, {ndigits=1, round_mode=HALF_TO_EVEN})"
+        "round(field, {ndigits=1, round_mode=HALF_TO_EVEN}, filter = true)"
 
     # Will convert non-expression arguments if possible
     assert str(pc.add(field, 1)) == "add(field, 1)"


### PR DESCRIPTION
### Rationale for this change

In order to support more grammatical features, improve the filter before agg.

https://www.postgresql.org/docs/current/tutorial-agg.html


### What changes are included in this PR?
1. Add filter expression to FunctionOption.
2. Support filter capabilities for ScalarAgg and GroupByAgg, and add filter function implementation before the three-stage consume.
3. Move the filter logic in filter_node.cc to expression.cc to facilitate other operators to use the common filter function.
4. count_all and hash_count_all add default options to allow filters.
5. Add unit tests for relevant modifications.

### Are these changes tested?
yes, include scalar and groupby agg.

### Are there any user-facing changes?
yes.
* GitHub Issue: #41253