### PR TITLE
GH-41256: [Format][Docs] Add a canonical extension type specification for JSON

### DIFF
--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -259,7 +259,8 @@ JSON
 * Extension name: `arrow.json`.
 
 * The storage type of this extension is ``StringArray`` or
-  ``StringViewArray``.
+  or ``LargeStringArray`` or ``StringViewArray``.
+  Only UTF-8 encoded JSON is supported.
 
 * Extension type parameters:
 

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -251,32 +251,24 @@ Variable shape tensor
    Values inside each **data** tensor element are stored in row-major/C-contiguous
    order according to the corresponding **shape**.
 
-.. _text_data_format_extension:
+.. _json_extension:
 
-Text data format
-=================
+JSON
+====
 
-* Extension name: `arrow.text_data_format`.
+* Extension name: `arrow.json`.
 
-* The storage type of the extension is ``StringArray`` or
+* The storage type of this extension is ``StringArray`` or
   ``LargeStringArray``or ``StringViewArray``.
 
 * Extension type parameters:
 
-  * **media_type** must be a string specifying the
-    `IANA registered <https://www.iana.org/assignments/media-types/media-types.xhtml#application>`_
-    text data format stored in the array.
+  This type does not have any parameters.
 
 * Description of the serialization:
 
-  The metadata must be a valid JSON object providing a **"media_type"** key
-  plus an optional **"metadata"** key for additional application specific
-  information such as schema or notation dialect.
-
-  - Example: ``{ "media_type": "application/json" }``
-  - Example: ``{ "media_type": "application/xml" }``
-  - Example: ``{ "media_type": "application/yaml", "metadata": { "key": "value" } }``
-  - Example: ``{ "media_type": "text/csv" }``
+  Metadata is an empty string.
+  - Example: ``""``
 
 =========================
 Community Extension Types

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -258,8 +258,8 @@ JSON
 
 * Extension name: ``arrow.json``.
 
-* The storage type of this extension is ``StringArray`` or
-  or ``LargeStringArray`` or ``StringViewArray``.
+* The storage type of this extension is ``String`` or
+  or ``LargeString`` or ``StringView``.
   Only UTF-8 encoded JSON as specified in `rfc8259`_ is supported.
 
 * Extension type parameters:

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -256,7 +256,7 @@ Variable shape tensor
 JSON
 ====
 
-* Extension name: `arrow.json`.
+* Extension name: ``arrow.json``.
 
 * The storage type of this extension is ``StringArray`` or
   or ``LargeStringArray`` or ``StringViewArray``.

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -51,7 +51,7 @@ types:
 
   3) Its serialization *must* be described in the proposal and should
      not require unduly implementation work or unusual software dependencies
-     (for example, a trivial custom text format or JSON would be acceptable).
+     (for example, a trivial custom text format or YAML would be acceptable).
 
   4) Its expected semantics *should* be described as well and any
      potential ambiguities or pain points addressed or at least mentioned.

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -51,7 +51,7 @@ types:
 
   3) Its serialization *must* be described in the proposal and should
      not require unduly implementation work or unusual software dependencies
-     (for example, a trivial custom text format or YAML would be acceptable).
+     (for example, a trivial custom text format or a JSON-based format would be acceptable).
 
   4) Its expected semantics *should* be described as well and any
      potential ambiguities or pain points addressed or at least mentioned.

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -260,7 +260,7 @@ JSON
 
 * The storage type of this extension is ``StringArray`` or
   or ``LargeStringArray`` or ``StringViewArray``.
-  Only UTF-8 encoded JSON is supported.
+  Only UTF-8 encoded JSON as specified in `rfc8259`_ is supported.
 
 * Extension type parameters:
 
@@ -289,3 +289,5 @@ GeoArrow
 Arrow extension types for representing vector geometries. It is well known
 within the Arrow geospatial subcommunity. The GeoArrow specification is not yet
 finalized.
+
+.. _rfc8259: https://datatracker.ietf.org/doc/html/rfc8259

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -259,7 +259,7 @@ JSON
 * Extension name: `arrow.json`.
 
 * The storage type of this extension is ``StringArray`` or
-  ``LargeStringArray``or ``StringViewArray``.
+  ``StringViewArray``.
 
 * Extension type parameters:
 
@@ -268,7 +268,6 @@ JSON
 * Description of the serialization:
 
   Metadata is an empty string.
-  - Example: ``""``
 
 =========================
 Community Extension Types

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -251,6 +251,33 @@ Variable shape tensor
    Values inside each **data** tensor element are stored in row-major/C-contiguous
    order according to the corresponding **shape**.
 
+.. _text_data_format_extension:
+
+Text data format
+=================
+
+* Extension name: `arrow.text_data_format`.
+
+* The storage type of the extension is ``StringArray`` or
+  ``LargeStringArray``or ``StringViewArray``.
+
+* Extension type parameters:
+
+  * **media_type** must be a string specifying the
+    `IANA registered <https://www.iana.org/assignments/media-types/media-types.xhtml#application>`_
+    text data format stored in the array.
+
+* Description of the serialization:
+
+  The metadata must be a valid JSON object providing a **"media_type"** key
+  plus an optional **"metadata"** key for additional application specific
+  information such as schema or notation dialect.
+
+  - Example: ``{ "media_type": "application/json" }``
+  - Example: ``{ "media_type": "application/xml" }``
+  - Example: ``{ "media_type": "application/yaml", "metadata": { "key": "value" } }``
+  - Example: ``{ "media_type": "text/csv" }``
+
 =========================
 Community Extension Types
 =========================

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -267,7 +267,9 @@ JSON
 
 * Description of the serialization:
 
-  Metadata is an empty string.
+  Metadata is either an empty string or a JSON string with an empty object.
+  In the future, additional fields may be added, but they are not required
+  to interpret the array.
 
 =========================
 Community Extension Types


### PR DESCRIPTION
### Rationale for this change

As per #41256 this proposes a specification of a canonical extension type for JSON serialized data.

### What changes are included in this PR?

This adds to documentation of canonical extension types.

### Are these changes tested?

No as only docs are changed.

### Are there any user-facing changes?

No.
* GitHub Issue: #41256