### PR TITLE
GH-41278: [C++][FS][Azure] Run TestGetFileInfoGenerator() with Valgrind again

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -49,3 +49,4 @@ thrift-cpp>=0.11.0
 xsimd
 zlib
 zstd
+

--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -49,4 +49,3 @@ thrift-cpp>=0.11.0
 xsimd
 zlib
 zstd
-

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -395,21 +395,6 @@ class TestGeneric : public ::testing::Test, public GenericFileSystemTest {
   bool have_directory_mtimes() const override { return true; }
   bool have_flaky_directory_tree_deletion() const override { return false; }
   bool have_file_metadata() const override { return true; }
-  // calloc() used in libxml2's xmlNewGlobalState() is detected as a
-  // memory leak like the following. But it's a false positive. It's
-  // used in ListBlobsByHierarchy() for GetFileInfo() and it's freed
-  // in the call. This is detected as a memory leak only with
-  // generator API (GetFileInfoGenerator()) and not detected with
-  // non-generator API (GetFileInfo()). So this is a false positive.
-  //
-  // ==2875409==ERROR: LeakSanitizer: detected memory leaks
-  //
-  // Direct leak of 968 byte(s) in 1 object(s) allocated from:
-  //     #0 0x55d02c967bdc in calloc (build/debug/arrow-azurefs-test+0x17bbdc) (BuildId:
-  //     520690d1b20e860cc1feef665dce8196e64f955e) #1 0x7fa914b1cd1e in xmlNewGlobalState
-  //     builddir/main/../../threads.c:580:10 #2 0x7fa914b1cd1e in xmlGetGlobalState
-  //     builddir/main/../../threads.c:666:31
-  bool have_false_positive_memory_leak_with_generator() const override { return true; }
 
   BaseAzureEnv* env_;
   std::shared_ptr<AzureFileSystem> azure_fs_;

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -752,12 +752,6 @@ void GenericFileSystemTest::TestGetFileInfoSelector(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestGetFileInfoGenerator(FileSystem* fs) {
-#if defined(ADDRESS_SANITIZER) || defined(ARROW_VALGRIND)
-  if (have_false_positive_memory_leak_with_generator()) {
-    GTEST_SKIP() << "Filesystem have false positive memory leak with generator";
-  }
-#endif
-
   ASSERT_OK(fs->CreateDir("AB/CD"));
   CreateFile(fs, "abc", "data");
   CreateFile(fs, "AB/def", "some data");

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -184,8 +184,6 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   virtual bool have_flaky_directory_tree_deletion() const { return false; }
   // - Whether the filesystem stores some metadata alongside files
   virtual bool have_file_metadata() const { return false; }
-  // - Whether the filesystem has a false positive memory leak with generator
-  virtual bool have_false_positive_memory_leak_with_generator() const { return false; }
 
   void TestEmpty(FileSystem* fs);
   void TestNormalizePath(FileSystem* fs);


### PR DESCRIPTION
### Rationale for this change

We use conda's libxml2. It didn't use `--with-tls` but 2.12.6-2 or later uses `--with-tls`. It may suppress a detected leak.

### What changes are included in this PR?

Remove `GTEST_SKIP()` for `TestGetFileInfoGenerator()`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #41278