### PR TITLE
GH-41280: [Release][Java] Make Maven version detection more robust

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -502,7 +502,8 @@ maybe_setup_conda() {
 install_maven() {
   MAVEN_VERSION=3.8.7
   if command -v mvn > /dev/null; then
-    SYSTEM_MAVEN_VERSION=$(mvn --color=never -v | head -n 1 | awk '{print $3}')
+    # --batch-mode is for disabling output color.
+    SYSTEM_MAVEN_VERSION=$(mvn --batch-mode -v | head -n 1 | awk '{print $3}')
     show_info "Found Maven version ${SYSTEM_MAVEN_VERSION} at $(command -v mvn)."
   else
     SYSTEM_MAVEN_VERSION=0.0.0
@@ -523,7 +524,8 @@ install_maven() {
         ${APACHE_MIRROR}/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
       tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz
       export PATH=$(pwd)/apache-maven-${MAVEN_VERSION}/bin:$PATH
-      show_info "Installed Maven version $(mvn --color=never -v | head -n 1 | awk '{print $3}')"
+      # --batch-mode is for disabling output color.
+      show_info "Installed Maven version $(mvn --batch-mode -v | head -n 1 | awk '{print $3}')"
     else
       show_info "System Maven version ${SYSTEM_MAVEN_VERSION} is newer than minimum version ${MAVEN_VERSION}. Skipping installation."
     fi

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -502,7 +502,7 @@ maybe_setup_conda() {
 install_maven() {
   MAVEN_VERSION=3.8.7
   if command -v mvn > /dev/null; then
-    SYSTEM_MAVEN_VERSION=$(mvn -v | head -n 1 | awk '{print $3}')
+    SYSTEM_MAVEN_VERSION=$(mvn --color=never -v | head -n 1 | awk '{print $3}')
     show_info "Found Maven version ${SYSTEM_MAVEN_VERSION} at $(command -v mvn)."
   else
     SYSTEM_MAVEN_VERSION=0.0.0
@@ -523,7 +523,7 @@ install_maven() {
         ${APACHE_MIRROR}/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
       tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz
       export PATH=$(pwd)/apache-maven-${MAVEN_VERSION}/bin:$PATH
-      show_info "Installed Maven version $(mvn -v | head -n 1 | awk '{print $3}')"
+      show_info "Installed Maven version $(mvn --color=never -v | head -n 1 | awk '{print $3}')"
     else
       show_info "System Maven version ${SYSTEM_MAVEN_VERSION} is newer than minimum version ${MAVEN_VERSION}. Skipping installation."
     fi


### PR DESCRIPTION
### Rationale for this change

If `mvn -v` uses escape sequence, our verification script detects wrong version information.

### What changes are included in this PR?

Ensure disabling escape sequence of `mvn -v`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41280