### PR TITLE
GH-41183: [C++][Python] Expose recursive flatten for lists on list_flatten kernel function and pyarrow bindings

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -153,6 +153,8 @@ static auto kRankOptionsType = GetFunctionOptionsType<RankOptions>(
     DataMember("tiebreaker", &RankOptions::tiebreaker));
 static auto kPairwiseOptionsType = GetFunctionOptionsType<PairwiseOptions>(
     DataMember("periods", &PairwiseOptions::periods));
+static auto kListFlattenOptionsType = GetFunctionOptionsType<ListFlattenOptions>(
+    DataMember("recursively", &ListFlattenOptions::recursively));
 }  // namespace
 }  // namespace internal
 
@@ -224,6 +226,10 @@ PairwiseOptions::PairwiseOptions(int64_t periods)
     : FunctionOptions(internal::kPairwiseOptionsType), periods(periods) {}
 constexpr char PairwiseOptions::kTypeName[];
 
+ListFlattenOptions::ListFlattenOptions(bool recursively)
+    : FunctionOptions(internal::kListFlattenOptionsType), recursively(recursively) {}
+constexpr char ListFlattenOptions::kTypeName[];
+
 namespace internal {
 void RegisterVectorOptions(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunctionOptionsType(kFilterOptionsType));
@@ -237,6 +243,7 @@ void RegisterVectorOptions(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunctionOptionsType(kCumulativeOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kRankOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kPairwiseOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kListFlattenOptionsType));
 }
 }  // namespace internal
 

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -154,7 +154,7 @@ static auto kRankOptionsType = GetFunctionOptionsType<RankOptions>(
 static auto kPairwiseOptionsType = GetFunctionOptionsType<PairwiseOptions>(
     DataMember("periods", &PairwiseOptions::periods));
 static auto kListFlattenOptionsType = GetFunctionOptionsType<ListFlattenOptions>(
-    DataMember("recursively", &ListFlattenOptions::recursively));
+    DataMember("recursive", &ListFlattenOptions::recursive));
 }  // namespace
 }  // namespace internal
 
@@ -226,8 +226,8 @@ PairwiseOptions::PairwiseOptions(int64_t periods)
     : FunctionOptions(internal::kPairwiseOptionsType), periods(periods) {}
 constexpr char PairwiseOptions::kTypeName[];
 
-ListFlattenOptions::ListFlattenOptions(bool recursively)
-    : FunctionOptions(internal::kListFlattenOptionsType), recursively(recursively) {}
+ListFlattenOptions::ListFlattenOptions(bool recursive)
+    : FunctionOptions(internal::kListFlattenOptionsType), recursive(recursive) {}
 constexpr char ListFlattenOptions::kTypeName[];
 
 namespace internal {

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -245,6 +245,18 @@ class ARROW_EXPORT PairwiseOptions : public FunctionOptions {
   int64_t periods = 1;
 };
 
+/// \brief Options for list_flatten function
+class ARROW_EXPORT ListFlattenOptions : public FunctionOptions {
+ public:
+  explicit ListFlattenOptions(bool recursively = false);
+  static constexpr char const kTypeName[] = "ListFlattenOptions";
+  static ListFlattenOptions Defaults() { return ListFlattenOptions(); }
+
+  /// Control the version of 'Flatten' that keeps recursively flattening
+  /// until an array of non-list values is reached.
+  bool recursively = false;
+};
+
 /// @}
 
 /// \brief Filter with a boolean selection filter

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -248,7 +248,7 @@ class ARROW_EXPORT PairwiseOptions : public FunctionOptions {
 /// \brief Options for list_flatten function
 class ARROW_EXPORT ListFlattenOptions : public FunctionOptions {
  public:
-  explicit ListFlattenOptions(bool recursively = false);
+  explicit ListFlattenOptions(bool recursive = false);
   static constexpr char const kTypeName[] = "ListFlattenOptions";
   static ListFlattenOptions Defaults() { return ListFlattenOptions(); }
 

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -252,9 +252,9 @@ class ARROW_EXPORT ListFlattenOptions : public FunctionOptions {
   static constexpr char const kTypeName[] = "ListFlattenOptions";
   static ListFlattenOptions Defaults() { return ListFlattenOptions(); }
 
-  /// Control the version of 'Flatten' that keeps recursively flattening
-  /// until an array of non-list values is reached.
-  bool recursively = false;
+  /// \brief If true, the list is flattened recursively until a non-list
+  /// array is formed.
+  bool recursive = false;
 };
 
 /// @}

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <vector>
 
+#include "arrow/compute/api_vector.h"
 #include "arrow/type_fwd.h"
 
 namespace arrow {
@@ -60,6 +61,13 @@ Result<TypeHolder> ListValuesType(KernelContext* ctx,
                                   const std::vector<TypeHolder>& args) {
   auto list_type = checked_cast<const BaseListType*>(args[0].type);
   auto value_type = list_type->value_type().get();
+
+  auto recursive =
+      ctx->state() ? OptionsWrapper<ListFlattenOptions>::Get(ctx).recursive : false;
+  if (!recursive) {
+    return value_type;
+  }
+
   for (auto value_kind = value_type->id();
        is_list(value_kind) || is_list_view(value_kind); value_kind = value_type->id()) {
     list_type = checked_cast<const BaseListType*>(list_type->value_type().get());

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -57,8 +57,14 @@ Result<TypeHolder> LastType(KernelContext*, const std::vector<TypeHolder>& types
 }
 
 Result<TypeHolder> ListValuesType(KernelContext*, const std::vector<TypeHolder>& args) {
-  const auto& list_type = checked_cast<const BaseListType&>(*args[0].type);
-  return list_type.value_type().get();
+  auto list_type = checked_cast<const BaseListType*>(args[0].type);
+  auto value_type = list_type->value_type().get();
+  for (auto value_kind = value_type->id();
+       is_list(value_kind) || is_list_view(value_kind); value_kind = value_type->id()) {
+    list_type = checked_cast<const BaseListType*>(list_type->value_type().get());
+    value_type = list_type->value_type().get();
+  }
+  return value_type;
 }
 
 void EnsureDictionaryDecoded(std::vector<TypeHolder>* types) {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -56,7 +56,8 @@ Result<TypeHolder> LastType(KernelContext*, const std::vector<TypeHolder>& types
   return types.back();
 }
 
-Result<TypeHolder> ListValuesType(KernelContext*, const std::vector<TypeHolder>& args) {
+Result<TypeHolder> ListValuesType(KernelContext* ctx,
+                                  const std::vector<TypeHolder>& args) {
   auto list_type = checked_cast<const BaseListType*>(args[0].type);
   auto value_type = list_type->value_type().get();
   for (auto value_kind = value_type->id();

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -423,7 +423,8 @@ static void VisitTwoArrayValuesInline(const ArraySpan& arr0, const ArraySpan& ar
 
 Result<TypeHolder> FirstType(KernelContext*, const std::vector<TypeHolder>& types);
 Result<TypeHolder> LastType(KernelContext*, const std::vector<TypeHolder>& types);
-Result<TypeHolder> ListValuesType(KernelContext*, const std::vector<TypeHolder>& types);
+Result<TypeHolder> ListValuesType(KernelContext* ctx,
+                                  const std::vector<TypeHolder>& types);
 
 // ----------------------------------------------------------------------
 // Helpers for iterating over common DataType instances for adding kernels to

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -39,12 +39,26 @@ namespace {
 template <typename Type, typename offset_type = typename Type::offset_type>
 Status ListValueLength(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   const ArraySpan& arr = batch[0].array;
+  const auto kind = arr.type->id();
   ArraySpan* out_arr = out->array_span_mutable();
   auto out_values = out_arr->GetValues<offset_type>(1);
-  const offset_type* offsets = arr.GetValues<offset_type>(1);
-  // Offsets are always well-defined and monotonic, even for null values
-  for (int64_t i = 0; i < arr.length; ++i) {
-    *out_values++ = offsets[i + 1] - offsets[i];
+  if (is_list_view(kind)) {
+    // [Large]ListView's buffer layout:
+    //  buffer1 : valid bitmap
+    //  buffer2 : elements' start offset in current array
+    //  buffer3 : elements' size
+    //
+    // It's unnecessary to calculate according offsets.
+    const auto* sizes = arr.GetValues<offset_type>(2);
+    for (int64_t i = 0; i < arr.length; i++) {
+      *out_values++ = sizes[i];
+    }
+  } else {
+    const offset_type* offsets = arr.GetValues<offset_type>(1);
+    // Offsets are always well-defined and monotonic, even for null values
+    for (int64_t i = 0; i < arr.length; ++i) {
+      *out_values++ = offsets[i + 1] - offsets[i];
+    }
   }
   return Status::OK();
 }
@@ -57,6 +71,24 @@ Status FixedSizeListValueLength(KernelContext* ctx, const ExecSpan& batch,
   int32_t* out_values = out_arr->GetValues<int32_t>(1);
   std::fill(out_values, out_values + arr.length, width);
   return Status::OK();
+}
+
+template <typename InListType>
+void AddListValueLengthKernel(ScalarFunction* func,
+                              const std::shared_ptr<DataType>& out_type) {
+  auto in_type = {InputType(InListType::type_id)};
+  ScalarKernel kernel(in_type, out_type, ListValueLength<InListType>);
+  DCHECK_OK(func->AddKernel(std::move(kernel)));
+}
+
+void AddListValueLengthKernels(ScalarFunction* func) {
+  AddListValueLengthKernel<ListType>(func, int32());
+  AddListValueLengthKernel<LargeListType>(func, int64());
+  AddListValueLengthKernel<ListViewType>(func, int32());
+  AddListValueLengthKernel<LargeListViewType>(func, int64());
+
+  DCHECK_OK(func->AddKernel({InputType(Type::FIXED_SIZE_LIST)}, int32(),
+                            FixedSizeListValueLength));
 }
 
 const FunctionDoc list_value_length_doc{
@@ -399,6 +431,8 @@ void AddListElementKernels(ScalarFunction* func) {
 void AddListElementKernels(ScalarFunction* func) {
   AddListElementKernels<ListType, ListElement>(func);
   AddListElementKernels<LargeListType, ListElement>(func);
+  AddListElementKernels<ListViewType, ListElement>(func);
+  AddListElementKernels<LargeListViewType, ListElement>(func);
   AddListElementKernels<FixedSizeListType, FixedSizeListElement>(func);
 }
 
@@ -824,12 +858,7 @@ const FunctionDoc map_lookup_doc{
 void RegisterScalarNested(FunctionRegistry* registry) {
   auto list_value_length = std::make_shared<ScalarFunction>(
       "list_value_length", Arity::Unary(), list_value_length_doc);
-  DCHECK_OK(list_value_length->AddKernel({InputType(Type::LIST)}, int32(),
-                                         ListValueLength<ListType>));
-  DCHECK_OK(list_value_length->AddKernel({InputType(Type::FIXED_SIZE_LIST)}, int32(),
-                                         FixedSizeListValueLength));
-  DCHECK_OK(list_value_length->AddKernel({InputType(Type::LARGE_LIST)}, int64(),
-                                         ListValueLength<LargeListType>));
+  AddListValueLengthKernels(list_value_length.get());
   DCHECK_OK(registry->AddFunction(std::move(list_value_length)));
 
   auto list_element =

--- a/cpp/src/arrow/compute/kernels/vector_nested.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested.cc
@@ -113,12 +113,14 @@ struct ListParentIndicesArray {
 
 const FunctionDoc list_flatten_doc(
     "Flatten list values",
-    ("`lists` must have a logical list type like `[Large]ListType`, \n"
-     "`[Large]ListViewType` and `FixedSizeListType`. \n"
-     "Whether to flatten the top list level or the bottom list level \n"
-     "will be decided based on the `recursive` option specified in \n"
-     ":struct:`ListFlattenOptions`. \n"
-     "Top-level null values in `lists` do not emit anything in the input."),
+    ("`lists` must have a list-like type (lists, list-views, and\n"
+     "fixed-size lists).\n"
+     "Return an array with the top list level flattened unless\n"
+     "`recursive` is set to true in ListFlattenOptions. When that\n"
+     "is that case, flattening happens recursively until a non-list\n"
+     "array is formed.\n"
+     "\n"
+     "Null list values do not emit anything to the output."),
     {"lists"}, "ListFlattenOptions");
 
 const FunctionDoc list_parent_indices_doc(

--- a/cpp/src/arrow/compute/kernels/vector_nested.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested.cc
@@ -79,10 +79,6 @@ struct ListParentIndicesArray {
 
   Status Visit(const LargeListType& type) { return VisitList(type); }
 
-  Status Visit(const ListViewType& type) { return VisitList(type); }
-
-  Status Visit(const LargeListViewType& type) { return VisitList(type); }
-
   Status Visit(const FixedSizeListType& type) {
     using offset_type = typename FixedSizeListType::offset_type;
     const offset_type slot_length = type.list_size();

--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -19,6 +19,7 @@
 
 #include "arrow/chunked_array.h"
 #include "arrow/compute/api.h"
+#include "arrow/compute/api_vector.h"
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/result.h"
 #include "arrow/testing/gtest_util.h"
@@ -29,41 +30,143 @@ namespace compute {
 
 using arrow::internal::checked_cast;
 
-TEST(TestVectorNested, ListFlatten) {
-  for (auto ty : {list(int16()), large_list(int16())}) {
-    auto input = ArrayFromJSON(ty, "[[0, null, 1], null, [2, 3], []]");
-    auto expected = ArrayFromJSON(int16(), "[0, null, 1, 2, 3]");
+using ListAndListViewTypes =
+    ::testing::Types<ListType, LargeListType, ListViewType, LargeListViewType>;
+
+// ----------------------------------------------------------------------
+// [Large]List and [Large]ListView tests
+template <typename T>
+class TestVectorLogicalList : public ::testing::Test {
+ public:
+  using TypeClass = T;
+
+  void SetUp() override {
+    value_type_ = int16();
+    type_ = std::make_shared<T>(value_type_);
+  }
+
+ public:
+  void TestListFlatten() {
+    auto input = ArrayFromJSON(type_, "[[0, null, 1], null, [2, 3], []]");
+    auto expected = ArrayFromJSON(value_type_, "[0, null, 1, 2, 3]");
     CheckVectorUnary("list_flatten", input, expected);
 
     // Construct a list with a non-empty null slot
     auto tweaked = TweakValidityBit(input, 0, false);
-    expected = ArrayFromJSON(int16(), "[2, 3]");
+    expected = ArrayFromJSON(value_type_, "[2, 3]");
     CheckVectorUnary("list_flatten", tweaked, expected);
   }
-}
 
-TEST(TestVectorNested, ListFlattenNulls) {
-  const auto ty = list(int32());
-  auto input = ArrayFromJSON(ty, "[null, null]");
-  auto expected = ArrayFromJSON(int32(), "[]");
-  CheckVectorUnary("list_flatten", input, expected);
-}
+  void TestListFlattenNulls() {
+    value_type_ = int32();
+    type_ = std::make_shared<T>(value_type_);
+    auto input = ArrayFromJSON(type_, "[null, null]");
+    auto expected = ArrayFromJSON(value_type_, "[]");
+    CheckVectorUnary("list_flatten", input, expected);
+  }
 
-TEST(TestVectorNested, ListFlattenChunkedArray) {
-  for (auto ty : {list(int16()), large_list(int16())}) {
-    ARROW_SCOPED_TRACE(ty->ToString());
-    auto input = ChunkedArrayFromJSON(ty, {"[[0, null, 1], null]", "[[2, 3], []]"});
-    auto expected = ChunkedArrayFromJSON(int16(), {"[0, null, 1]", "[2, 3]"});
+  void TestListFlattenChunkedArray() {
+    ARROW_SCOPED_TRACE(type_->ToString());
+    auto input = ChunkedArrayFromJSON(type_, {"[[0, null, 1], null]", "[[2, 3], []]"});
+    auto expected = ChunkedArrayFromJSON(value_type_, {"[0, null, 1]", "[2, 3]"});
     CheckVectorUnary("list_flatten", input, expected);
 
     ARROW_SCOPED_TRACE("empty");
-    input = ChunkedArrayFromJSON(ty, {});
-    expected = ChunkedArrayFromJSON(int16(), {});
+    input = ChunkedArrayFromJSON(type_, {});
+    expected = ChunkedArrayFromJSON(value_type_, {});
     CheckVectorUnary("list_flatten", input, expected);
   }
+
+  void TestListFlattenRecursively() {
+    auto inner_type = std::make_shared<T>(value_type_);
+    type_ = std::make_shared<T>(inner_type);
+
+    ListFlattenOptions opts;
+    opts.recursively = true;
+
+    // List types with two nested level: list<list<int16>>
+    auto input = ArrayFromJSON(type_, R"([
+        [[0, 1, 2], null, [3, null]],
+        [null],
+        [[2, 9], [4], [], [6, 5]]
+      ])");
+    auto expected = ArrayFromJSON(value_type_, "[0, 1, 2, 3, null, 2, 9, 4, 6, 5]");
+    CheckVectorUnary("list_flatten", input, expected, &opts);
+
+    // Empty nested list should flatten until non-list type is reached
+    input = ArrayFromJSON(type_, R"([null])");
+    expected = ArrayFromJSON(value_type_, "[]");
+    CheckVectorUnary("list_flatten", input, expected, &opts);
+
+    // List types with three nested level: list<list<fixed_size_list<int32, 2>>>
+    type_ = std::make_shared<T>(std::make_shared<T>(fixed_size_list(value_type_, 2)));
+    input = ArrayFromJSON(type_, R"([
+        [
+          [[null, 0]],
+          [[3, 7], null]
+        ],
+        [
+          [[4, null], [5, 8]],
+          [[8, null]],
+          null
+        ],
+        [
+          null
+        ]
+      ])");
+    expected = ArrayFromJSON(value_type_, "[null, 0, 3, 7, 4, null, 5, 8, 8, null]");
+    CheckVectorUnary("list_flatten", input, expected, &opts);
+  }
+
+  void TestListParentIndices() {
+    auto input = ArrayFromJSON(type_, "[[0, null, 1], null, [2, 3], [], [4, 5]]");
+    auto expected = ArrayFromJSON(int64(), "[0, 0, 0, 2, 2, 4, 4]");
+    CheckVectorUnary("list_parent_indices", input, expected);
+
+    // Construct a list with a non-empty null slot
+    input = ArrayFromJSON(type_, "[[0, null, 1], [0, 0], [2, 3], [], [4, 5]]");
+    auto tweaked = TweakValidityBit(input, 1, false);
+    expected = ArrayFromJSON(int64(), "[0, 0, 0, 1, 1, 2, 2, 4, 4]");
+    CheckVectorUnary("list_parent_indices", tweaked, expected);
+  }
+
+  void TestListParentIndicesChunkedArray() {
+    auto input =
+        ChunkedArrayFromJSON(type_, {"[[0, null, 1], null]", "[[2, 3], [], [4, 5]]"});
+    auto expected = ChunkedArrayFromJSON(int64(), {"[0, 0, 0]", "[2, 2, 4, 4]"});
+    CheckVectorUnary("list_parent_indices", input, expected);
+
+    input = ChunkedArrayFromJSON(type_, {});
+    expected = ChunkedArrayFromJSON(int64(), {});
+    CheckVectorUnary("list_parent_indices", input, expected);
+  }
+
+ protected:
+  std::shared_ptr<DataType> type_;
+  std::shared_ptr<DataType> value_type_;
+};
+
+TYPED_TEST_SUITE(TestVectorLogicalList, ListAndListViewTypes);
+
+TYPED_TEST(TestVectorLogicalList, ListFlatten) { this->TestListFlatten(); }
+
+TYPED_TEST(TestVectorLogicalList, ListFlattenNulls) { this->TestListFlattenNulls(); }
+
+TYPED_TEST(TestVectorLogicalList, ListFlattenChunkedArray) {
+  this->TestListFlattenChunkedArray();
 }
 
-TEST(TestVectorNested, ListFlattenFixedSizeList) {
+TYPED_TEST(TestVectorLogicalList, ListFlattenRecursively) {
+  this->TestListFlattenRecursively();
+}
+
+TYPED_TEST(TestVectorLogicalList, ListParentIndices) { this->TestListParentIndices(); }
+
+TYPED_TEST(TestVectorLogicalList, ListParentIndicesChunkedArray) {
+  this->TestListParentIndicesChunkedArray();
+}
+
+TEST(TestVectorFixedSizeList, ListFlattenFixedSizeList) {
   for (auto ty : {fixed_size_list(int16(), 2), fixed_size_list(uint32(), 2)}) {
     const auto& out_ty = checked_cast<const FixedSizeListType&>(*ty).value_type();
     {
@@ -85,43 +188,29 @@ TEST(TestVectorNested, ListFlattenFixedSizeList) {
   }
 }
 
-TEST(TestVectorNested, ListFlattenFixedSizeListNulls) {
+TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListNulls) {
   const auto ty = fixed_size_list(int32(), 1);
   auto input = ArrayFromJSON(ty, "[null, null]");
   auto expected = ArrayFromJSON(int32(), "[]");
   CheckVectorUnary("list_flatten", input, expected);
 }
 
-TEST(TestVectorNested, ListParentIndices) {
-  for (auto ty : {list(int16()), large_list(int16())}) {
-    auto input = ArrayFromJSON(ty, "[[0, null, 1], null, [2, 3], [], [4, 5]]");
+TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListRecursively) {
+  ListFlattenOptions opts;
+  opts.recursively = true;
 
-    auto expected = ArrayFromJSON(int64(), "[0, 0, 0, 2, 2, 4, 4]");
-    CheckVectorUnary("list_parent_indices", input, expected);
-  }
-
-  // Construct a list with a non-empty null slot
-  auto input = ArrayFromJSON(list(int16()), "[[0, null, 1], [0, 0], [2, 3], [], [4, 5]]");
-  auto tweaked = TweakValidityBit(input, 1, false);
-  auto expected = ArrayFromJSON(int64(), "[0, 0, 0, 1, 1, 2, 2, 4, 4]");
-  CheckVectorUnary("list_parent_indices", tweaked, expected);
+  auto inner_type = fixed_size_list(int32(), 2);
+  auto type = fixed_size_list(inner_type, 2);
+  auto input = ArrayFromJSON(type, R"([
+    [[0, 1], [null, 3]],
+    [[7, null], [2, 5]],
+    [null, null]
+  ])");
+  auto expected = ArrayFromJSON(int32(), "[0, 1, null, 3, 7, null, 2, 5]");
+  CheckVectorUnary("list_flatten", input, expected, &opts);
 }
 
-TEST(TestVectorNested, ListParentIndicesChunkedArray) {
-  for (auto ty : {list(int16()), large_list(int16())}) {
-    auto input =
-        ChunkedArrayFromJSON(ty, {"[[0, null, 1], null]", "[[2, 3], [], [4, 5]]"});
-
-    auto expected = ChunkedArrayFromJSON(int64(), {"[0, 0, 0]", "[2, 2, 4, 4]"});
-    CheckVectorUnary("list_parent_indices", input, expected);
-
-    input = ChunkedArrayFromJSON(ty, {});
-    expected = ChunkedArrayFromJSON(int64(), {});
-    CheckVectorUnary("list_parent_indices", input, expected);
-  }
-}
-
-TEST(TestVectorNested, ListParentIndicesFixedSizeList) {
+TEST(TestVectorFixedSizeList, ListParentIndicesFixedSizeList) {
   for (auto ty : {fixed_size_list(int16(), 2), fixed_size_list(uint32(), 2)}) {
     {
       auto input = ArrayFromJSON(ty, "[[0, null], null, [1, 2], [3, 4], [null, 5]]");

--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -82,7 +82,7 @@ class TestVectorLogicalList : public ::testing::Test {
     type_ = std::make_shared<T>(inner_type);
 
     ListFlattenOptions opts;
-    opts.recursively = true;
+    opts.recursive = true;
 
     // List types with two nested level: list<list<int16>>
     auto input = ArrayFromJSON(type_, R"([
@@ -168,7 +168,7 @@ TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListNulls) {
 
 TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListRecursively) {
   ListFlattenOptions opts;
-  opts.recursively = true;
+  opts.recursive = true;
 
   auto inner_type = fixed_size_list(int32(), 2);
   auto type = fixed_size_list(inner_type, 2);
@@ -181,7 +181,7 @@ TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListRecursively) {
   CheckVectorUnary("list_flatten", input, expected, &opts);
 }
 
-TEST(TestVectorNested, ListParentIndices) {
+TEST(TestVectorListParentIndices, BasicListArray) {
   for (auto ty : {list(int16()), large_list(int16())}) {
     auto input = ArrayFromJSON(ty, "[[0, null, 1], null, [2, 3], [], [4, 5]]");
 
@@ -196,7 +196,7 @@ TEST(TestVectorNested, ListParentIndices) {
   CheckVectorUnary("list_parent_indices", tweaked, expected);
 }
 
-TEST(TestVectorNested, ListParentIndicesChunkedArray) {
+TEST(TestVectorListParentIndices, BasicListChunkedArray) {
   for (auto ty : {list(int16()), large_list(int16())}) {
     auto input =
         ChunkedArrayFromJSON(ty, {"[[0, null, 1], null]", "[[2, 3], [], [4, 5]]"});
@@ -210,7 +210,7 @@ TEST(TestVectorNested, ListParentIndicesChunkedArray) {
   }
 }
 
-TEST(TestVectorNested, ListParentIndicesFixedSizeList) {
+TEST(TestVectorListParentIndices, FixedSizeListArray) {
   for (auto ty : {fixed_size_list(int16(), 2), fixed_size_list(uint32(), 2)}) {
     {
       auto input = ArrayFromJSON(ty, "[[0, null], null, [1, 2], [3, 4], [null, 5]]");

--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -36,7 +36,7 @@ using ListAndListViewTypes =
 // ----------------------------------------------------------------------
 // [Large]List and [Large]ListView tests
 template <typename T>
-class TestVectorLogicalList : public ::testing::Test {
+class TestVectorNestedSpecialized : public ::testing::Test {
  public:
   using TypeClass = T;
 
@@ -84,7 +84,7 @@ class TestVectorLogicalList : public ::testing::Test {
     ListFlattenOptions opts;
     opts.recursive = true;
 
-    // List types with two nested level: list<list<int16>>
+    // List types with two nesting levels: list<list<int16>>
     auto input = ArrayFromJSON(type_, R"([
         [[0, 1, 2], null, [3, null]],
         [null],
@@ -98,7 +98,7 @@ class TestVectorLogicalList : public ::testing::Test {
     expected = ArrayFromJSON(value_type_, "[]");
     CheckVectorUnary("list_flatten", input, expected, &opts);
 
-    // List types with three nested level: list<list<fixed_size_list<int32, 2>>>
+    // List types with three nesting levels: list<list<fixed_size_list<int32, 2>>>
     type_ = std::make_shared<T>(std::make_shared<T>(fixed_size_list(value_type_, 2)));
     input = ArrayFromJSON(type_, R"([
         [
@@ -123,21 +123,23 @@ class TestVectorLogicalList : public ::testing::Test {
   std::shared_ptr<DataType> value_type_;
 };
 
-TYPED_TEST_SUITE(TestVectorLogicalList, ListAndListViewTypes);
+TYPED_TEST_SUITE(TestVectorNestedSpecialized, ListAndListViewTypes);
 
-TYPED_TEST(TestVectorLogicalList, ListFlatten) { this->TestListFlatten(); }
+TYPED_TEST(TestVectorNestedSpecialized, ListFlatten) { this->TestListFlatten(); }
 
-TYPED_TEST(TestVectorLogicalList, ListFlattenNulls) { this->TestListFlattenNulls(); }
+TYPED_TEST(TestVectorNestedSpecialized, ListFlattenNulls) {
+  this->TestListFlattenNulls();
+}
 
-TYPED_TEST(TestVectorLogicalList, ListFlattenChunkedArray) {
+TYPED_TEST(TestVectorNestedSpecialized, ListFlattenChunkedArray) {
   this->TestListFlattenChunkedArray();
 }
 
-TYPED_TEST(TestVectorLogicalList, ListFlattenRecursively) {
+TYPED_TEST(TestVectorNestedSpecialized, ListFlattenRecursively) {
   this->TestListFlattenRecursively();
 }
 
-TEST(TestVectorFixedSizeList, ListFlattenFixedSizeList) {
+TEST(TestVectorNested, ListFlattenFixedSizeList) {
   for (auto ty : {fixed_size_list(int16(), 2), fixed_size_list(uint32(), 2)}) {
     const auto& out_ty = checked_cast<const FixedSizeListType&>(*ty).value_type();
     {
@@ -159,14 +161,14 @@ TEST(TestVectorFixedSizeList, ListFlattenFixedSizeList) {
   }
 }
 
-TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListNulls) {
+TEST(TestVectorNested, ListFlattenFixedSizeListNulls) {
   const auto ty = fixed_size_list(int32(), 1);
   auto input = ArrayFromJSON(ty, "[null, null]");
   auto expected = ArrayFromJSON(int32(), "[]");
   CheckVectorUnary("list_flatten", input, expected);
 }
 
-TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListRecursively) {
+TEST(TestVectorNested, ListFlattenFixedSizeListRecursively) {
   ListFlattenOptions opts;
   opts.recursive = true;
 
@@ -181,7 +183,7 @@ TEST(TestVectorFixedSizeList, ListFlattenFixedSizeListRecursively) {
   CheckVectorUnary("list_flatten", input, expected, &opts);
 }
 
-TEST(TestVectorListParentIndices, BasicListArray) {
+TEST(TestVectorNested, ListParentIndices) {
   for (auto ty : {list(int16()), large_list(int16())}) {
     auto input = ArrayFromJSON(ty, "[[0, null, 1], null, [2, 3], [], [4, 5]]");
 
@@ -196,7 +198,7 @@ TEST(TestVectorListParentIndices, BasicListArray) {
   CheckVectorUnary("list_parent_indices", tweaked, expected);
 }
 
-TEST(TestVectorListParentIndices, BasicListChunkedArray) {
+TEST(TestVectorNested, ListParentIndicesChunkedArray) {
   for (auto ty : {list(int16()), large_list(int16())}) {
     auto input =
         ChunkedArrayFromJSON(ty, {"[[0, null, 1], null]", "[[2, 3], [], [4, 5]]"});
@@ -210,7 +212,7 @@ TEST(TestVectorListParentIndices, BasicListChunkedArray) {
   }
 }
 
-TEST(TestVectorListParentIndices, FixedSizeListArray) {
+TEST(TestVectorNested, ListParentIndicesFixedSizeList) {
   for (auto ty : {fixed_size_list(int16(), 2), fixed_size_list(uint32(), 2)}) {
     {
       auto input = ArrayFromJSON(ty, "[[0, null], null, [1, 2], [3, 4], [null, 5]]");

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2036,8 +2036,8 @@ class PairwiseOptions(_PairwiseOptions):
 
 
 cdef class _ListFlattenOptions(FunctionOptions):
-    def _set_options(self, recursively):
-        self.wrapped.reset(new CListFlattenOptions(recursively))
+    def _set_options(self, recursive):
+        self.wrapped.reset(new CListFlattenOptions(recursive))
 
 
 class ListFlattenOptions(_ListFlattenOptions):
@@ -2046,13 +2046,13 @@ class ListFlattenOptions(_ListFlattenOptions):
 
     Parameters
     ----------
-    recursively : bool, defalut false
+    recursive : bool, defalut false
         When true, do list flatten recursively until an array of
         non-list values is reached.
     """
 
-    def __init__(self, recursively=False):
-        self._set_options(recursively)
+    def __init__(self, recursive=False):
+        self._set_options(recursive)
 
 
 cdef class _ArraySortOptions(FunctionOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2046,9 +2046,9 @@ class ListFlattenOptions(_ListFlattenOptions):
 
     Parameters
     ----------
-    recursive : bool, defalut false
-        When true, do list flatten recursively until an array of
-        non-list values is reached.
+    recursive : bool, default False
+        When True, the list array is flattened recursively until an array
+        of non-list values is formed.
     """
 
     def __init__(self, recursive=False):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2035,6 +2035,26 @@ class PairwiseOptions(_PairwiseOptions):
         self._set_options(period)
 
 
+cdef class _ListFlattenOptions(FunctionOptions):
+    def _set_options(self, recursively):
+        self.wrapped.reset(new CListFlattenOptions(recursively))
+
+
+class ListFlattenOptions(_ListFlattenOptions):
+    """
+    Options for `list_flatten` function
+
+    Parameters
+    ----------
+    recursively : bool, defalut false
+        When true, do list flatten recursively until an array of
+        non-list values is reached.
+    """
+
+    def __init__(self, recursively=False):
+        self._set_options(recursively)
+
+
 cdef class _ArraySortOptions(FunctionOptions):
     def _set_options(self, order, null_placement):
         self.wrapped.reset(new CArraySortOptions(

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2202,34 +2202,34 @@ cdef class BaseListArray(Array):
         if we enable recursive=True.
 
         >>> array = pa.array([
-                None,
-                [
-                    [1, None, 2],
-                    None,
-                    [3, 4]
-                ],
-                [],
-                [
-                    [],
-                    [5, 6],
-                    None
-                ],
-                [
-                    [7, 8]
-                ]
-            ], type=pa.list_(pa.list_(pa.int64())))
+        ...    None,
+        ...    [
+        ...        [1, None, 2],
+        ...        None,
+        ...        [3, 4]
+        ...    ],
+        ...    [],
+        ...    [
+        ...        [],
+        ...        [5, 6],
+        ...        None
+        ...    ],
+        ...    [
+        ...        [7, 8]
+        ...    ]
+        ... ], type=pa.list_(pa.list_(pa.int64())))
         >>> array.flatten(True)
         <pyarrow.lib.Int64Array object at ...>
         [
-            1,
-            None,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8
+          1,
+          null,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
         ]
         """
         options = _pc().ListFlattenOptions(recursive)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2152,10 +2152,11 @@ cdef class BaseListArray(Array):
 
         Parameters
         ----------
-        recursive : bool, defalut false, optional
-            When true, flatten this logical list-array recursivey until an
-            array of non-list values is reached.
-            When false, flatten this logical list-array by one level
+        recursive : bool, default False, optional
+            When True, flatten this logical list-array recursively until an
+            array of non-list values is formed.
+
+            When False, flatten only the top level.
 
         Returns
         -------
@@ -2197,9 +2198,8 @@ cdef class BaseListArray(Array):
           2
         ]
 
-        If an logical list-array is nested with multi-level, the array will
-        be flattened recursively until an array of non-list values is reached
-        if we enable recursive=True.
+        When recursive=True, nested list arrays are flattened recursively
+        until an array of non-list values is formed.
 
         >>> array = pa.array([
         ...    None,

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2141,22 +2141,99 @@ cdef class Decimal256Array(FixedSizeBinaryArray):
 
 cdef class BaseListArray(Array):
 
-    def flatten(self):
+    def flatten(self, recursively=False):
         """
-        Unnest this ListArray/LargeListArray by one level.
-
-        The returned Array is logically a concatenation of all the sub-lists
-        in this Array.
+        Unnest this [Large]ListArray/[Large]ListViewArray/FixedSizeListArray
+        according to 'recursively'.
 
         Note that this method is different from ``self.values`` in that
         it takes care of the slicing offset as well as null elements backed
         by non-empty sub-lists.
 
+        Parameters
+        ----------
+        recursively : bool, defalut false, optional
+            When true, flatten this logical list-array recursively until an
+            array of non-list values is reached.
+            When false, flatten this logical list-array by one level
+
         Returns
         -------
         result : Array
+
+        Examples
+        --------
+
+        Basic logical list-array's flatten
+        >>> import pyarrow as pa
+        >>> values = [1, 2, 3, 4]
+        >>> offsets = [2, 1, 0]
+        >>> sizes = [2, 2, 2]
+        >>> array = pa.ListViewArray.from_arrays(offsets, sizes, values)
+        >>> array
+        <pyarrow.lib.ListViewArray object at ...>
+        [
+          [
+            3,
+            4
+          ],
+          [
+            2,
+            3
+          ],
+          [
+            1,
+            2
+          ]
+        ]
+        >>> array.flatten()
+        <pyarrow.lib.Int64Array object at ...>
+        [
+          3,
+          4,
+          2,
+          3,
+          1,
+          2
+        ]
+
+        If an logical list-array is nested with multi-level, the array will
+        be flattened recursively until an array of non-list values is reached
+        if we enable recursively=True.
+
+        >>> array = pa.array([
+                None,
+                [
+                    [1, None, 2],
+                    None,
+                    [3, 4]
+                ],
+                [],
+                [
+                    [],
+                    [5, 6],
+                    None
+                ],
+                [
+                    [7, 8]
+                ]
+            ], type=pa.list_(pa.list_(pa.int64())))
+        >>> array.flatten(True)
+        <pyarrow.lib.Int64Array object at ...>
+        [
+            1,
+            None,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8
+        ]
         """
-        return _pc().list_flatten(self)
+        options = _pc().ListFlattenOptions(recursively)
+        return _pc().list_flatten(self, options)
 
     def value_parent_indices(self):
         """
@@ -2527,7 +2604,7 @@ cdef class LargeListArray(BaseListArray):
         return pyarrow_wrap_array((<CLargeListArray*> self.ap).offsets())
 
 
-cdef class ListViewArray(Array):
+cdef class ListViewArray(BaseListArray):
     """
     Concrete class for Arrow arrays of a list view data type.
     """
@@ -2747,69 +2824,8 @@ cdef class ListViewArray(Array):
         """
         return pyarrow_wrap_array((<CListViewArray*> self.ap).sizes())
 
-    def flatten(self, memory_pool=None):
-        """
-        Unnest this ListViewArray by one level.
 
-        The returned Array is logically a concatenation of all the sub-lists
-        in this Array.
-
-        Note that this method is different from ``self.values`` in that
-        it takes care of the slicing offset as well as null elements backed
-        by non-empty sub-lists.
-
-        Parameters
-        ----------
-        memory_pool : MemoryPool, optional
-
-        Returns
-        -------
-        result : Array
-
-        Examples
-        --------
-
-        >>> import pyarrow as pa
-        >>> values = [1, 2, 3, 4]
-        >>> offsets = [2, 1, 0]
-        >>> sizes = [2, 2, 2]
-        >>> array = pa.ListViewArray.from_arrays(offsets, sizes, values)
-        >>> array
-        <pyarrow.lib.ListViewArray object at ...>
-        [
-          [
-            3,
-            4
-          ],
-          [
-            2,
-            3
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-        >>> array.flatten()
-        <pyarrow.lib.Int64Array object at ...>
-        [
-          3,
-          4,
-          2,
-          3,
-          1,
-          2
-        ]
-        """
-        cdef CMemoryPool* cpool = maybe_unbox_memory_pool(memory_pool)
-        with nogil:
-            out = GetResultValue((<CListViewArray*> self.ap).Flatten(cpool))
-        cdef Array result = pyarrow_wrap_array(out)
-        result.validate()
-        return result
-
-
-cdef class LargeListViewArray(Array):
+cdef class LargeListViewArray(BaseListArray):
     """
     Concrete class for Arrow arrays of a large list view data type.
 
@@ -3036,67 +3052,6 @@ cdef class LargeListViewArray(Array):
         ]
         """
         return pyarrow_wrap_array((<CLargeListViewArray*> self.ap).sizes())
-
-    def flatten(self, memory_pool=None):
-        """
-        Unnest this LargeListViewArray by one level.
-
-        The returned Array is logically a concatenation of all the sub-lists
-        in this Array.
-
-        Note that this method is different from ``self.values`` in that
-        it takes care of the slicing offset as well as null elements backed
-        by non-empty sub-lists.
-
-        Parameters
-        ----------
-        memory_pool : MemoryPool, optional
-
-        Returns
-        -------
-        result : Array
-
-        Examples
-        --------
-
-        >>> import pyarrow as pa
-        >>> values = [1, 2, 3, 4]
-        >>> offsets = [2, 1, 0]
-        >>> sizes = [2, 2, 2]
-        >>> array = pa.LargeListViewArray.from_arrays(offsets, sizes, values)
-        >>> array
-        <pyarrow.lib.LargeListViewArray object at ...>
-        [
-          [
-            3,
-            4
-          ],
-          [
-            2,
-            3
-          ],
-          [
-            1,
-            2
-          ]
-        ]
-        >>> array.flatten()
-        <pyarrow.lib.Int64Array object at ...>
-        [
-          3,
-          4,
-          2,
-          3,
-          1,
-          2
-        ]
-        """
-        cdef CMemoryPool* cpool = maybe_unbox_memory_pool(memory_pool)
-        with nogil:
-            out = GetResultValue((<CLargeListViewArray*> self.ap).Flatten(cpool))
-        cdef Array result = pyarrow_wrap_array(out)
-        result.validate()
-        return result
 
 
 cdef class MapArray(ListArray):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2141,10 +2141,10 @@ cdef class Decimal256Array(FixedSizeBinaryArray):
 
 cdef class BaseListArray(Array):
 
-    def flatten(self, recursively=False):
+    def flatten(self, recursive=False):
         """
         Unnest this [Large]ListArray/[Large]ListViewArray/FixedSizeListArray
-        according to 'recursively'.
+        according to 'recursive'.
 
         Note that this method is different from ``self.values`` in that
         it takes care of the slicing offset as well as null elements backed
@@ -2152,8 +2152,8 @@ cdef class BaseListArray(Array):
 
         Parameters
         ----------
-        recursively : bool, defalut false, optional
-            When true, flatten this logical list-array recursively until an
+        recursive : bool, defalut false, optional
+            When true, flatten this logical list-array recursivey until an
             array of non-list values is reached.
             When false, flatten this logical list-array by one level
 
@@ -2199,7 +2199,7 @@ cdef class BaseListArray(Array):
 
         If an logical list-array is nested with multi-level, the array will
         be flattened recursively until an array of non-list values is reached
-        if we enable recursively=True.
+        if we enable recursive=True.
 
         >>> array = pa.array([
                 None,
@@ -2232,8 +2232,8 @@ cdef class BaseListArray(Array):
             8
         ]
         """
-        options = _pc().ListFlattenOptions(recursively)
-        return _pc().list_flatten(self, options)
+        options = _pc().ListFlattenOptions(recursive)
+        return _pc().list_flatten(self, options=options)
 
     def value_parent_indices(self):
         """

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -44,6 +44,7 @@ from pyarrow._compute import (  # noqa
     IndexOptions,
     JoinOptions,
     ListSliceOptions,
+    ListFlattenOptions,
     MakeStructOptions,
     MapLookupOptions,
     MatchSubstringOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2591,8 +2591,8 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CListFlattenOptions\
             "arrow::compute::ListFlattenOptions"(CFunctionOptions):
-        CListFlattenOptions(c_bool recursively)
-        c_bool recursively
+        CListFlattenOptions(c_bool recursive)
+        c_bool recursive
 
     cdef cppclass CArraySortOptions \
             "arrow::compute::ArraySortOptions"(CFunctionOptions):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2591,8 +2591,8 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CListFlattenOptions\
             "arrow::compute::ListFlattenOptions"(CFunctionOptions):
-        CListFlattenOptions(bool recursively)
-        bool recursively
+        CListFlattenOptions(c_bool recursively)
+        c_bool recursively
 
     cdef cppclass CArraySortOptions \
             "arrow::compute::ArraySortOptions"(CFunctionOptions):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2589,6 +2589,11 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CPairwiseOptions(int64_t period)
         int64_t period
 
+    cdef cppclass CListFlattenOptions\
+            "arrow::compute::ListFlattenOptions"(CFunctionOptions):
+        CListFlattenOptions(bool recursively)
+        bool recursively
+
     cdef cppclass CArraySortOptions \
             "arrow::compute::ArraySortOptions"(CFunctionOptions):
         CArraySortOptions(CSortOrder, CNullPlacement)

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -437,11 +437,11 @@ cdef class LargeListArray(BaseListArray):
     pass
 
 
-cdef class ListViewArray(Array):
+cdef class ListViewArray(BaseListArray):
     pass
 
 
-cdef class LargeListViewArray(Array):
+cdef class LargeListViewArray(BaseListArray):
     pass
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2879,6 +2879,7 @@ def test_fixed_size_list_array_flatten():
     assert arr0.type.equals(typ0)
     assert arr1.flatten().equals(arr0)
     assert arr2.flatten().flatten().equals(arr0)
+    assert arr2.flatten().equals(arr1)
     assert arr2.flatten(True).equals(arr0)
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2704,8 +2704,7 @@ def test_invalid_tensor_construction():
 
 
 @pytest.mark.parametrize(('offset_type', 'list_type_factory'),
-                         [(pa.int32(), pa.list_), (pa.int64(), pa.large_list),
-                          (pa.int32(), pa.list_view), (pa.int64(), pa.large_list_view)])
+                         [(pa.int32(), pa.list_), (pa.int64(), pa.large_list)])
 def test_list_array_flatten(offset_type, list_type_factory):
     typ2 = list_type_factory(
         list_type_factory(
@@ -2764,9 +2763,7 @@ def test_list_array_flatten(offset_type, list_type_factory):
 @pytest.mark.parametrize('list_type', [
     pa.list_(pa.int32()),
     pa.list_(pa.int32(), list_size=2),
-    pa.large_list(pa.int32()),
-    pa.list_view(pa.int32()),
-    pa.large_list_view(pa.int32())])
+    pa.large_list(pa.int32())])
 def test_list_value_parent_indices(list_type):
     arr = pa.array(
         [

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2704,7 +2704,8 @@ def test_invalid_tensor_construction():
 
 
 @pytest.mark.parametrize(('offset_type', 'list_type_factory'),
-                         [(pa.int32(), pa.list_), (pa.int64(), pa.large_list)])
+                         [(pa.int32(), pa.list_), (pa.int64(), pa.large_list),
+                          (pa.int32(), pa.list_view), (pa.int64(), pa.large_list_view)])
 def test_list_array_flatten(offset_type, list_type_factory):
     typ2 = list_type_factory(
         list_type_factory(
@@ -2757,12 +2758,15 @@ def test_list_array_flatten(offset_type, list_type_factory):
     assert arr1.values.equals(arr0)
     assert arr2.flatten().flatten().equals(arr0)
     assert arr2.values.values.equals(arr0)
+    assert arr2.flatten(True).equals(arr0)
 
 
 @pytest.mark.parametrize('list_type', [
     pa.list_(pa.int32()),
     pa.list_(pa.int32(), list_size=2),
-    pa.large_list(pa.int32())])
+    pa.large_list(pa.int32()),
+    pa.list_view(pa.int32()),
+    pa.large_list_view(pa.int32())])
 def test_list_value_parent_indices(list_type):
     arr = pa.array(
         [
@@ -2778,7 +2782,9 @@ def test_list_value_parent_indices(list_type):
 @pytest.mark.parametrize(('offset_type', 'list_type'),
                          [(pa.int32(), pa.list_(pa.int32())),
                           (pa.int32(), pa.list_(pa.int32(), list_size=2)),
-                          (pa.int64(), pa.large_list(pa.int32()))])
+                          (pa.int64(), pa.large_list(pa.int32())),
+                          (pa.int32(), pa.list_view(pa.int32())),
+                          (pa.int64(), pa.large_list_view(pa.int32()))])
 def test_list_value_lengths(offset_type, list_type):
 
     # FixedSizeListArray needs fixed list sizes
@@ -2876,6 +2882,7 @@ def test_fixed_size_list_array_flatten():
     assert arr0.type.equals(typ0)
     assert arr1.flatten().equals(arr0)
     assert arr2.flatten().flatten().equals(arr0)
+    assert arr2.flatten(True).equals(arr0)
 
 
 def test_fixed_size_list_array_flatten_with_slice():
@@ -3844,6 +3851,7 @@ def test_list_view_flatten(list_array_type, list_type_factory, offset_type):
     assert arr2.values.equals(arr1)
     assert arr2.flatten().flatten().equals(arr0)
     assert arr2.values.values.equals(arr0)
+    assert arr2.flatten(True).equals(arr0)
 
     # test out of order offsets
     values = [1, 2, 3, 4]

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -152,6 +152,7 @@ def test_option_class_equality():
         pc.IndexOptions(pa.scalar(1)),
         pc.JoinOptions(),
         pc.ListSliceOptions(0, -1, 1, True),
+        pc.ListFlattenOptions(recursively=False),
         pc.MakeStructOptions(["field", "names"],
                              field_nullability=[True, True],
                              field_metadata=[pa.KeyValueMetadata({"a": "1"}),

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -152,7 +152,7 @@ def test_option_class_equality():
         pc.IndexOptions(pa.scalar(1)),
         pc.JoinOptions(),
         pc.ListSliceOptions(0, -1, 1, True),
-        pc.ListFlattenOptions(recursively=False),
+        pc.ListFlattenOptions(recursive=False),
         pc.MakeStructOptions(["field", "names"],
                              field_nullability=[True, True],
                              field_metadata=[pa.KeyValueMetadata({"a": "1"}),


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Expose recursive flatten for logical lists on list_flatten kernel function and pyarrow bindings.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
1. Expose recursive flatten for logical lists on `list_flatten` kernel function
2. Support [Large]ListView for some kernel functions: `list_flatten`,`list_value_length`, `list_element`
3. Support recursive flatten for pyarrow bindinds and simplify [Large]ListView's pyarrow bindings
4. Refactor vector_nested_test.cc for better support [Large]ListView types.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes.
1. Some kernel functions like: list_flatten, list_value_length, list_element would support [Large]ListView types
2. `list_flatten` and related pyarrow bindings could support flatten recursively with an ListFlattenOptions.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41183