### PR TITLE
GH-41298: [Format][Docs] Add a canonical extension type specification for UUID

### DIFF
--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -272,6 +272,17 @@ JSON
   In the future, additional fields may be added, but they are not required
   to interpret the array.
 
+UUID
+====
+
+* Extension name: `arrow.uuid`.
+
+* The storage type of the extension is ``FixedSizeBinary`` with a length of 16 bytes.
+
+.. note::
+   A specific UUID version is not required or guaranteed. This extension represents
+   UUIDs as FixedSizeBinary(16) and does not interpret the bytes in any way.
+
 =========================
 Community Extension Types
 =========================

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -281,7 +281,7 @@ UUID
 
 .. note::
    A specific UUID version is not required or guaranteed. This extension represents
-   UUIDs as FixedSizeBinary(16) and does not interpret the bytes in any way.
+   UUIDs as FixedSizeBinary(16) with big-endian notation and does not interpret the bytes in any way.
 
 =========================
 Community Extension Types

--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -275,7 +275,7 @@ JSON
 UUID
 ====
 
-* Extension name: `arrow.uuid`.
+* Extension name: ``arrow.uuid``.
 
 * The storage type of the extension is ``FixedSizeBinary`` with a length of 16 bytes.
 


### PR DESCRIPTION
### Rationale for this change

Several users have expressed a need for a UUID type. This is to provide a canonical UUID extension type specification.

### What changes are included in this PR?

This adds to documentation of canonical extension types.

### Are these changes tested?

No as only docs are changed.

### Are there any user-facing changes?

No.
* GitHub Issue: #41298