### PR TITLE
GH-41282: [Dev] Always prompt next major version on merge script if it exists

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -306,15 +306,15 @@ def get_candidate_fix_version(mainline_versions,
 
     # Only suggest versions starting with a number, like 0.x but not JS-0.x
     mainline_versions = all_versions
-    mainline_non_patch_versions = []
+    major_versions = []
     for v in mainline_versions:
         (major, minor, patch) = v.split(".")
-        if patch == "0":
-            mainline_non_patch_versions.append(v)
+        if patch == "0" and minor == "0":
+            major_versions.append(v)
 
-    if len(mainline_versions) > len(mainline_non_patch_versions):
-        # If there is a non-patch release, suggest that instead
-        mainline_versions = mainline_non_patch_versions
+    if len(mainline_versions) > len(major_versions):
+        # If there is a future major release, suggest that
+        mainline_versions = major_versions
 
     mainline_versions = [v for v in mainline_versions
                          if f"maint-{v}" not in maintenance_branches]

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -306,11 +306,7 @@ def get_candidate_fix_version(mainline_versions,
 
     # Only suggest versions starting with a number, like 0.x but not JS-0.x
     mainline_versions = all_versions
-    major_versions = []
-    for v in mainline_versions:
-        (major, minor, patch) = v.split(".")
-        if patch == "0" and minor == "0":
-            major_versions.append(v)
+    major_versions = [v for v in mainline_versions if v.endswith('.0.0')]
 
     if len(mainline_versions) > len(major_versions):
         # If there is a future major release, suggest that

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -97,11 +97,9 @@ class FakeJIRA:
 
 class FakeGitHub:
 
-    def __init__(self, issue=None, project_versions=None, transitions=None,
-                 current_fix_versions=None):
+    def __init__(self, issue=None, project_versions=None):
         self._issue = issue
         self._project_versions = project_versions
-        self._transitions = transitions
 
     @property
     def issue(self):
@@ -253,8 +251,7 @@ def test_jira_resolve_non_mainline():
 def test_jira_resolve_released_fix_version():
     # ARROW-5083
     jira = FakeGitHub(issue=FAKE_ISSUE_1,
-                      project_versions=SOURCE_VERSIONS,
-                      transitions=TRANSITIONS)
+                      project_versions=SOURCE_VERSIONS)
 
     cmd = FakeCLI(responses=['1.0.0'])
     fix_versions_json = merge_arrow_pr.prompt_for_fix_version(cmd, jira)

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -159,7 +159,7 @@ def test_jira_fix_versions_filters_maintenance():
     assert fix_version == '2.0.0'
 
 
-def test_jira_only_suggest_major_elease():
+def test_jira_only_suggest_major_release():
     versions_json = [
         {'name': '0.9.1', 'released': False},
         {'name': '0.10.0', 'released': False},

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -26,14 +26,17 @@ import merge_arrow_pr
 
 FakeIssue = namedtuple('issue', ['fields'])
 FakeFields = namedtuple('fields', ['status', 'summary', 'assignee',
-                                   'components', 'fixVersions'])
+                                   'components', 'fixVersions', 'milestone'])
 FakeAssignee = namedtuple('assignee', ['displayName'])
 FakeStatus = namedtuple('status', ['name'])
 FakeComponent = namedtuple('component', ['name'])
 FakeVersion = namedtuple('version', ['name', 'raw'])
+FakeMilestone = namedtuple('milestone', ['state'])
 
 RAW_VERSION_JSON = [
     {'name': 'JS-0.4.0', 'released': False},
+    {'name': '1.0.0', 'released': False},
+    {'name': '2.0.0', 'released': False},
     {'name': '0.9.0', 'released': False},
     {'name': '0.10.0', 'released': False},
     {'name': '0.8.0', 'released': True},
@@ -50,7 +53,7 @@ jira_id = 'ARROW-1234'
 status = FakeStatus('In Progress')
 fields = FakeFields(status, 'issue summary', FakeAssignee('groundhog'),
                     [FakeComponent('C++'), FakeComponent('Format')],
-                    [])
+                    [], FakeMilestone('closed')._asdict())
 FAKE_ISSUE_1 = FakeIssue(fields)
 
 
@@ -92,6 +95,33 @@ class FakeJIRA:
         return self._project_versions
 
 
+class FakeGitHub:
+
+    def __init__(self, issue=None, project_versions=None, transitions=None,
+                 current_fix_versions=None):
+        self._issue = issue
+        self._project_versions = project_versions
+        self._transitions = transitions
+
+    @property
+    def issue(self):
+        return self._issue.fields._asdict()
+
+    @property
+    def current_versions(self):
+        all_versions = self._project_versions or SOURCE_VERSIONS
+        return [
+            v for v in all_versions if not v.raw.get("released")
+        ] + ['0.11.0']
+
+    @property
+    def current_fix_versions(self):
+        return 'JS-0.4.0'
+
+    def project_versions(self, project):
+        return self._project_versions
+
+
 class FakeCLI:
 
     def __init__(self, responses=()):
@@ -115,11 +145,11 @@ def test_jira_fix_versions():
     fix_version = merge_arrow_pr.get_candidate_fix_version(
         issue.current_versions
     )
-    assert fix_version == '0.9.0'
+    assert fix_version == '1.0.0'
 
 
 def test_jira_fix_versions_filters_maintenance():
-    maintenance_branches = ["maint-0.9.0"]
+    maintenance_branches = ["maint-1.0.0"]
     jira = FakeJIRA(project_versions=SOURCE_VERSIONS,
                     transitions=TRANSITIONS)
 
@@ -128,13 +158,14 @@ def test_jira_fix_versions_filters_maintenance():
         issue.current_versions,
         maintenance_branches=maintenance_branches
     )
-    assert fix_version == '0.10.0'
+    assert fix_version == '2.0.0'
 
 
-def test_jira_no_suggest_patch_release():
+def test_jira_only_suggest_major_elease():
     versions_json = [
         {'name': '0.9.1', 'released': False},
         {'name': '0.10.0', 'released': False},
+        {'name': '1.0.0', 'released': False},
     ]
 
     versions = [FakeVersion(raw['name'], raw) for raw in versions_json]
@@ -144,7 +175,7 @@ def test_jira_no_suggest_patch_release():
     fix_version = merge_arrow_pr.get_candidate_fix_version(
         issue.current_versions
     )
-    assert fix_version == '0.10.0'
+    assert fix_version == '1.0.0'
 
 
 def test_jira_parquet_no_suggest_non_cpp():
@@ -153,8 +184,10 @@ def test_jira_parquet_no_suggest_non_cpp():
         {'name': 'cpp-1.5.0', 'released': True},
         {'name': 'cpp-1.6.0', 'released': False},
         {'name': 'cpp-1.7.0', 'released': False},
+        {'name': 'cpp-2.0.0', 'released': False},
         {'name': '1.11.0', 'released': False},
-        {'name': '1.12.0', 'released': False}
+        {'name': '1.12.0', 'released': False},
+        {'name': '2.0.0', 'released': False}
     ]
 
     versions = [FakeVersion(raw['name'], raw)
@@ -166,7 +199,7 @@ def test_jira_parquet_no_suggest_non_cpp():
     fix_version = merge_arrow_pr.get_candidate_fix_version(
         issue.current_versions
     )
-    assert fix_version == 'cpp-1.6.0'
+    assert fix_version == 'cpp-2.0.0'
 
 
 def test_jira_invalid_issue():
@@ -219,13 +252,13 @@ def test_jira_resolve_non_mainline():
 
 def test_jira_resolve_released_fix_version():
     # ARROW-5083
-    jira = FakeJIRA(issue=FAKE_ISSUE_1,
-                    project_versions=SOURCE_VERSIONS,
-                    transitions=TRANSITIONS)
+    jira = FakeGitHub(issue=FAKE_ISSUE_1,
+                      project_versions=SOURCE_VERSIONS,
+                      transitions=TRANSITIONS)
 
-    cmd = FakeCLI(responses=['0.7.0'])
+    cmd = FakeCLI(responses=['1.0.0'])
     fix_versions_json = merge_arrow_pr.prompt_for_fix_version(cmd, jira)
-    assert fix_versions_json == "0.7.0"
+    assert fix_versions_json == "1.0.0"
 
 
 def test_multiple_authors_bad_input():
@@ -256,7 +289,7 @@ def test_multiple_authors_bad_input():
 def test_jira_already_resolved():
     status = FakeStatus('Resolved')
     fields = FakeFields(status, 'issue summary', FakeAssignee('groundhog'),
-                        [FakeComponent('Java')], [])
+                        [FakeComponent('Java')], [], None)
     issue = FakeIssue(fields)
 
     jira = FakeJIRA(issue=issue,
@@ -287,7 +320,7 @@ def test_no_unset_point_release_fix_version():
     fields = FakeFields(status, 'summary', FakeAssignee('someone'),
                         [FakeComponent('Java')],
                         [FakeVersion(v, versions_json[v])
-                         for v in ['0.17.0', '0.15.1', '0.14.2']])
+                         for v in ['0.17.0', '0.15.1', '0.14.2']], None)
     issue = FakeIssue(fields)
 
     jira = FakeJIRA(


### PR DESCRIPTION
### Rationale for this change

When we created the `16.1.0` milestone the merge script started prompting it instead of `17.0.0` we want to default to the next major release.

### What changes are included in this PR?

Update archery logic to default to major versions online.

### Are these changes tested?
I've tested locally and now it defaults to `17.0.0`:

```
Enter fix version [17.0.0]: 
```

### Are there any user-facing changes?
No
* GitHub Issue: #41282