### PR TITLE
GH-41307: [Java] Use org.apache:apache parent pom version 31

### DIFF
--- a/java/adapter/avro/pom.xml
+++ b/java/adapter/avro/pom.xml
@@ -25,36 +25,27 @@
   <url>http://maven.apache.org</url>
 
   <dependencies>
-
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-memory-core -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>
     </dependency>
-
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-memory-netty -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-netty</artifactId>
       <scope>runtime</scope>
     </dependency>
-
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-vector -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${dep.avro.version}</version>
     </dependency>
   </dependencies>
-
 </project>

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -26,20 +26,17 @@
 
   <dependencies>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-memory-core -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-memory-netty -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-netty</artifactId>
       <scope>runtime</scope>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-vector -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
@@ -51,7 +48,6 @@
       <artifactId>value</artifactId>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
@@ -94,9 +90,6 @@
       <id>jdk11+</id>
       <activation>
         <jdk>[11,]</jdk>
-        <property>
-          <name>!m2e.version</name>
-        </property>
       </activation>
       <build>
         <plugins>

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -134,5 +134,22 @@
         </includes>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <configuration>
+              <ignoredDependencies combine.children="append">
+                <!-- indirect use of org.apache.arrow.flatbuf.Message in OrcStripeReader -->
+                <ignoredDependency>org.apache.arrow:arrow-format</ignoredDependency>
+              </ignoredDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>31</version>
   </parent>
 
   <groupId>org.apache.arrow</groupId>
@@ -27,6 +27,18 @@
 
   <properties>
     <arrow.vector.classifier></arrow.vector.classifier>
+    <!-- org.apache:apache overrides -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.plugin.tools.version>3.11.0</maven.plugin.tools.version>
+    <surefire.version>3.2.5</surefire.version>
+    <version.apache-rat-plugin>0.16.1</version.apache-rat-plugin>
+    <version.maven-assembly-plugin>3.7.1</version.maven-assembly-plugin>
+    <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
+    <version.maven-dependency-plugin>3.6.1</version.maven-dependency-plugin>
+    <version.maven-gpg-plugin>3.2.0</version.maven-gpg-plugin>
+    <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
+    <version.maven-project-info-reports-plugin>3.5.0</version.maven-project-info-reports-plugin>
   </properties>
 
   <dependencyManagement>
@@ -138,11 +150,9 @@
         <version>${project.version}</version>
       </dependency>
     </dependencies>
-
   </dependencyManagement>
 
   <build>
-
     <pluginManagement>
       <plugins>
         <plugin>
@@ -156,12 +166,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.12.1</version>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
@@ -188,12 +196,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.12.1</version>
       </plugin>
     </plugins>
   </reporting>

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -37,6 +37,7 @@
     <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
     <version.maven-dependency-plugin>3.6.1</version.maven-dependency-plugin>
     <version.maven-gpg-plugin>3.2.0</version.maven-gpg-plugin>
+    <version.maven-jar-plugin>3.2.2</version.maven-jar-plugin>
     <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
     <version.maven-project-info-reports-plugin>3.5.0</version.maven-project-info-reports-plugin>
   </properties>

--- a/java/c/pom.xml
+++ b/java/c/pom.xml
@@ -83,5 +83,4 @@
       </resource>
     </resources>
   </build>
-
 </project>

--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -23,7 +23,6 @@
   <description>Java implementation of Arrow Dataset API/Framework</description>
   <properties>
     <arrow.cpp.build.dir>../../../cpp/release-build/</arrow.cpp.build.dir>
-    <protobuf.version>2.5.0</protobuf.version>
     <parquet.version>1.13.1</parquet.version>
     <avro.version>1.11.3</avro.version>
   </properties>
@@ -195,21 +194,14 @@
       <id>jdk11+</id>
       <activation>
         <jdk>[11,]</jdk>
-        <property>
-          <name>!m2e.version</name>
-        </property>
       </activation>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <configuration combine.self="override">
-              <enableAssertions>false</enableAssertions>
-              <systemPropertyVariables>
-                <arrow.test.dataRoot>${project.basedir}/../../testing/data</arrow.test.dataRoot>
-              </systemPropertyVariables>
-              <argLine>--add-reads=org.apache.arrow.dataset=com.fasterxml.jackson.databind --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
+            <configuration>
+              <argLine combine.self="override">--add-reads=org.apache.arrow.dataset=com.fasterxml.jackson.databind --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -15,7 +15,6 @@
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
     <version>17.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flight-core</artifactId>
@@ -151,13 +150,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <!--
-          Downgrade maven-shade-plugin specifically for this module.
-          Using a newer version up to at least 3.5.1 will cause
-          issues in the arrow-tools tests looking up FlatBuffer
-          dependencies.
-         -->
-        <version>3.2.4</version>
         <executions>
           <execution>
             <id>shade-main</id>
@@ -244,7 +236,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.3.0</version>
         <executions>
           <execution>
             <id>analyze</id>
@@ -264,7 +255,6 @@
         <!-- add generated sources to classpath -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
         <executions>
           <execution>
             <id>add-generated-sources-to-classpath</id>
@@ -282,7 +272,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.7.1</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -299,13 +288,6 @@
         </executions>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
-      </extension>
-    </extensions>
   </build>
 
   <profiles>
@@ -313,18 +295,14 @@
       <id>jdk11+</id>
       <activation>
         <jdk>[11,]</jdk>
-        <property>
-          <name>!m2e.version</name>
-        </property>
       </activation>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <configuration combine.self="override">
-              <argLine>--add-opens=org.apache.arrow.flight.core/org.apache.arrow.flight.perf.impl=protobuf.java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
-              <enableAssertions>false</enableAssertions>
+            <configuration>
+              <argLine combine.self="override">--add-opens=org.apache.arrow.flight.core/org.apache.arrow.flight.perf.impl=protobuf.java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
               <systemPropertyVariables>
                 <arrow.test.dataRoot>${project.basedir}/../../../testing/data</arrow.test.dataRoot>
               </systemPropertyVariables>
@@ -334,5 +312,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/java/flight/flight-integration-tests/pom.xml
+++ b/java/flight/flight-integration-tests/pom.xml
@@ -15,7 +15,6 @@
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
     <version>17.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flight-integration-tests</artifactId>
@@ -63,7 +62,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.7.1</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -15,7 +15,6 @@
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
     <version>17.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flight-sql-jdbc-core</artifactId>
@@ -47,20 +46,17 @@
       </exclusions>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-memory-core -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-memory-netty -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-netty</artifactId>
       <scope>runtime</scope>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.apache.arrow/arrow-vector -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
@@ -136,11 +132,6 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -154,7 +145,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
-        <version>1.2.1</version>
         <executions>
           <execution>
             <id>write-project-properties-to-file</id>

--- a/java/flight/flight-sql-jdbc-driver/pom.xml
+++ b/java/flight/flight-sql-jdbc-driver/pom.xml
@@ -15,7 +15,6 @@
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
     <version>17.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flight-sql-jdbc-driver</artifactId>

--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -15,7 +15,6 @@
     <groupId>org.apache.arrow</groupId>
     <artifactId>arrow-flight</artifactId>
     <version>17.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>flight-sql</artifactId>
@@ -119,9 +118,6 @@
       <id>jdk11+</id>
       <activation>
         <jdk>[11,]</jdk>
-        <property>
-          <name>!m2e.version</name>
-        </property>
       </activation>
       <build>
         <plugins>
@@ -136,5 +132,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -31,7 +31,6 @@
   </dependencies>
 
   <build>
-
     <plugins>
       <plugin>
         <!-- no checkstyle on the generated code -->
@@ -42,6 +41,5 @@
         </configuration>
       </plugin>
     </plugins>
-
   </build>
 </project>

--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -22,13 +22,12 @@
   <packaging>jar</packaging>
   <name>Arrow Gandiva</name>
   <description>Java wrappers around the native Gandiva SQL expression compiler.</description>
+
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <protobuf.version>3.25.1</protobuf.version>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <arrow.cpp.build.dir>../../../cpp/release-build</arrow.cpp.build.dir>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.arrow</groupId>
@@ -51,7 +50,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -62,6 +60,7 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
+
   <build>
     <resources>
       <resource>
@@ -88,14 +87,6 @@
         </executions>
       </plugin>
     </plugins>
-
-    <extensions>
-      <extension>
-        <groupId>kr.motd.maven</groupId>
-        <artifactId>os-maven-plugin</artifactId>
-        <version>1.7.1</version>
-      </extension>
-    </extensions>
   </build>
   <profiles>
     <profile>
@@ -105,7 +96,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -118,7 +108,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -131,7 +120,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.2</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -146,5 +134,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/java/maven/module-info-compiler-maven-plugin/pom.xml
+++ b/java/maven/module-info-compiler-maven-plugin/pom.xml
@@ -64,39 +64,14 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.11.0</version>
+      <version>${maven.plugin.tools.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
 
   <build>
     <pluginManagement>
-      <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.12.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
         <plugin>
           <groupId>com.gradle</groupId>
           <artifactId>gradle-enterprise-maven-extension</artifactId>
@@ -118,7 +93,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.12.0</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -15,6 +15,13 @@
     Note: Do not inherit from the Arrow parent POM as plugins can be referenced
     during the parent POM, introducing circular dependencies.
   -->
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>31</version>
+    <relativePath></relativePath>
+  </parent>
+
   <groupId>org.apache.arrow.maven.plugins</groupId>
   <artifactId>arrow-maven-plugins</artifactId>
   <version>17.0.0-SNAPSHOT</version>
@@ -27,25 +34,37 @@
 
   <properties>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
+    <!-- org.apache:apache overrides -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.plugin.tools.version>3.12.0</maven.plugin.tools.version>
+    <surefire.version>3.2.5</surefire.version>
+    <version.apache-rat-plugin>0.16.1</version.apache-rat-plugin>
+    <version.maven-assembly-plugin>3.7.1</version.maven-assembly-plugin>
+    <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
+    <version.maven-dependency-plugin>3.6.1</version.maven-dependency-plugin>
+    <version.maven-gpg-plugin>3.2.0</version.maven-gpg-plugin>
+    <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
+    <version.maven-project-info-reports-plugin>3.5.0</version.maven-project-info-reports-plugin>
   </properties>
 
   <build>
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.5.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.12.1</version>
-        </plugin>
-        <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>2.30.0</version>
+        </plugin>
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>4.0.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>2.7.11</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -145,41 +164,15 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <configuration>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <encoding>UTF-8</encoding>
-          <source>1.8</source>
-          <target>1.8</target>
           <maxmem>2048m</maxmem>
-          <useIncrementalCompilation>false</useIncrementalCompilation>
           <fork>true</fork>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
-          <execution>
-            <id>validate_java_and_maven_version</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>verify</phase>
-            <inherited>false</inherited>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>[3.3.0,4)</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
           <execution>
             <id>avoid_bad_dependencies</id>
             <goals>
@@ -205,8 +198,6 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>4.0.5</version>
-
         <configuration>
           <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
           <verbose>false</verbose>
@@ -248,7 +239,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
         <configuration>
           <configLocation>../dev/checkstyle/checkstyle.xml</configLocation>
           <headerLocation>../dev/checkstyle/checkstyle.license</headerLocation>
@@ -288,7 +278,6 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.11</version>
         <executions>
           <execution>
             <goals>
@@ -353,12 +342,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.12.1</version>
       </plugin>
     </plugins>
   </reporting>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -44,6 +44,7 @@
     <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
     <version.maven-dependency-plugin>3.6.1</version.maven-dependency-plugin>
     <version.maven-gpg-plugin>3.2.0</version.maven-gpg-plugin>
+    <version.maven-jar-plugin>3.2.2</version.maven-jar-plugin>
     <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
     <version.maven-project-info-reports-plugin>3.5.0</version.maven-project-info-reports-plugin>
   </properties>
@@ -138,11 +139,6 @@
             <exclude>**/logback.xml</exclude>
           </excludes>
           <archive>
-            <index>true</index>
-            <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-            </manifest>
             <manifestEntries>
               <Extension-Name>org.apache.arrow</Extension-Name>
               <Built-By>${username}</Built-By>

--- a/java/memory/memory-core/pom.xml
+++ b/java/memory/memory-core/pom.xml
@@ -61,9 +61,6 @@
       <id>jdk11+</id>
       <activation>
         <jdk>[11,]</jdk>
-        <property>
-          <name>!m2e.version</name>
-        </property>
       </activation>
       <build>
         <plugins>
@@ -92,7 +89,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-
             <executions>
               <execution>
                 <id>opens-tests</id>
@@ -101,12 +97,9 @@
                 </goals>
                 <phase>test</phase>
                 <configuration>
-                  <!-- Dummy value to stop inheriting the default add-opens flag -->
-                  <argLine>-Dfoo=bar</argLine>
-                  <excludes>
-                    <!-- Need something (anything) here to make Maven not inherit the value above -->
-                    <exclude>**/TestArrowBuf.java</exclude>
-                  </excludes>
+                  <!-- Do not inherit the default add-opens flag and excludes -->
+                  <argLine combine.self="override"></argLine>
+                  <excludes combine.self="override"></excludes>
                   <includes>
                     <include>**/TestOpens.java</include>
                   </includes>
@@ -129,9 +122,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <source>8</source>
-              <target>8</target>
-              <encoding>UTF-8</encoding>
               <compilerArgs combine.children="append">
                 <arg>-Xmaxerrs</arg>
                 <!-- javac only reports the first 100 errors or warnings -->
@@ -150,12 +140,6 @@
                   <version>${checker.framework.version}</version>
                 </path>
               </annotationProcessorPaths>
-              <annotationProcessors>
-                <!-- To support @Value.Immutable processors -->
-                <annotationProcessor>org.immutables.value.internal.$processor$.$Processor</annotationProcessor>
-                <!-- Add all the checkers you want to enable here -->
-                <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
-              </annotationProcessors>
             </configuration>
           </plugin>
         </plugins>

--- a/java/performance/pom.xml
+++ b/java/performance/pom.xml
@@ -22,9 +22,7 @@
   <description>JMH Performance benchmarks for other Arrow libraries.</description>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmh.version>1.37</jmh.version>
-    <javac.target>1.8</javac.target>
     <uberjar.name>benchmarks</uberjar.name>
     <skip.perf.benchmarks>true</skip.perf.benchmarks>
     <benchmark.filter>.*</benchmark.filter>
@@ -96,52 +94,7 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.3</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.self="override">
-          <compilerVersion>${javac.target}</compilerVersion>
-          <source>${javac.target}</source>
-          <target>${javac.target}</target>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -175,7 +128,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.2.0</version>
         <configuration>
           <skip>${skip.perf.benchmarks}</skip>
           <classpathScope>test</classpathScope>
@@ -212,5 +164,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>31</version>
   </parent>
 
   <groupId>org.apache.arrow</groupId>
@@ -85,7 +85,7 @@
     <dep.guava-bom.version>33.0.0-jre</dep.guava-bom.version>
     <dep.netty-bom.version>4.1.108.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.63.0</dep.grpc-bom.version>
-    <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
+    <dep.protobuf-bom.version>3.25.1</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.17.0</dep.jackson-bom.version>
     <dep.hadoop.version>3.4.0</dep.hadoop.version>
     <dep.fbs.version>23.5.26</dep.fbs.version>
@@ -95,10 +95,23 @@
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     <error_prone_core.version>2.24.0</error_prone_core.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <mockito.core.version>5.11.0</mockito.core.version>
     <mockito.inline.version>5.2.0</mockito.inline.version>
     <checker.framework.version>3.42.0</checker.framework.version>
+    <doclint>none</doclint>
+    <additionalparam>-Xdoclint:none</additionalparam>
+    <!-- org.apache:apache overrides -->
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.plugin.tools.version>3.11.0</maven.plugin.tools.version>
+    <surefire.version>3.2.5</surefire.version>
+    <version.apache-rat-plugin>0.16.1</version.apache-rat-plugin>
+    <version.maven-assembly-plugin>3.7.1</version.maven-assembly-plugin>
+    <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
+    <version.maven-dependency-plugin>3.6.1</version.maven-dependency-plugin>
+    <version.maven-gpg-plugin>3.2.0</version.maven-gpg-plugin>
+    <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
+    <version.maven-project-info-reports-plugin>3.5.0</version.maven-project-info-reports-plugin>
   </properties>
 
   <dependencyManagement>
@@ -268,40 +281,16 @@
       <version>8.3.0</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
-  <repositories></repositories>
-
   <build>
-
     <pluginManagement>
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <!--
-            This appears to report a false positive with versions
-            greater than 3.1.2 (tested up to 3.6.0) when compiling
-            arrow-tools about Jackson being only used for tests.
-          -->
-          <version>3.1.2</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <version>0.16.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
           <configuration>
+            <fork>true</fork>
             <excludes>**/module-info.java</excludes>
             <testExcludes>**/module-info.java</testExcludes>
             <useModulePath>false</useModulePath>
@@ -315,17 +304,7 @@
           </configuration>
         </plugin>
         <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.1</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
           <configuration>
             <enableAssertions>true</enableAssertions>
             <childDelegation>true</childDelegation>
@@ -340,22 +319,9 @@
               <arrow.vector.max_allocation_bytes>1048576</arrow.vector.max_allocation_bytes>
             </systemPropertyVariables>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.junit.jupiter</groupId>
-              <artifactId>junit-jupiter-engine</artifactId>
-              <version>${dep.junit.jupiter.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.maven.surefire</groupId>
-              <artifactId>surefire-junit-platform</artifactId>
-              <version>3.2.5</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.5</version>
           <configuration>
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
@@ -444,6 +410,22 @@
                     <ignore></ignore>
                   </action>
                 </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.drill.tools</groupId>
+                    <artifactId>drill-fmpp-maven-plugin</artifactId>
+                    <versionRange>[1.0,)</versionRange>
+                    <goals>
+                      <goal>generate</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                      <runOnConfiguration>true</runOnConfiguration>
+                    </execute>
+                  </action>
+                </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
@@ -451,9 +433,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.3</version>
           <configuration>
-            <source>8</source>
             <sourceFileExcludes>
               <sourceFileExclude>**/module-info.java</sourceFileExclude>
             </sourceFileExcludes>
@@ -463,16 +443,6 @@
           <groupId>org.apache.arrow.maven.plugins</groupId>
           <artifactId>module-info-compiler-maven-plugin</artifactId>
           <version>${project.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.5.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.12.1</version>
         </plugin>
         <plugin>
           <groupId>com.gradle</groupId>
@@ -520,6 +490,36 @@
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>2.30.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>1.9.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>properties-maven-plugin</artifactId>
+          <version>1.2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>4.0.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <version>2.7.11</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.drill.tools</groupId>
+          <artifactId>drill-fmpp-maven-plugin</artifactId>
+          <version>1.21.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -620,40 +620,15 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <configuration>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <maxmem>2048m</maxmem>
-          <useIncrementalCompilation>false</useIncrementalCompilation>
           <fork>true</fork>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
-          <execution>
-            <id>validate_java_and_maven_version</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>verify</phase>
-            <inherited>false</inherited>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>[3.3.0,4)</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
           <execution>
             <id>avoid_bad_dependencies</id>
             <goals>
@@ -679,8 +654,6 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>4.0.5</version>
-
         <configuration>
           <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
           <verbose>false</verbose>
@@ -722,7 +695,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.0</version>
         <configuration>
           <excludes>**/module-info.java</excludes>
           <configLocation>dev/checkstyle/checkstyle.xml</configLocation>
@@ -786,7 +758,6 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.11</version>
         <executions>
           <execution>
             <goals>
@@ -817,12 +788,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.12.1</version>
       </plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
@@ -857,7 +826,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
         <configuration>
           <sourceFileExcludes>
             <sourceFileExclude>**/module-info.java</sourceFileExclude>
@@ -885,28 +853,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.5.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.12.1</version>
       </plugin>
     </plugins>
   </reporting>
 
   <profiles>
-    <profile>
-      <id>java-nodoclint</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <doclint>none</doclint>
-        <additionalparam>-Xdoclint:none</additionalparam>
-      </properties>
-    </profile>
-
     <profile>
       <!-- C data interface depends on building a native library -->
       <id>arrow-c-data</id>
@@ -954,7 +909,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <fork>true</fork>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne</arg>
@@ -987,9 +941,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <source>8</source>
-              <target>8</target>
-              <encoding>UTF-8</encoding>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/(target/generated-sources)/.*</arg>
@@ -1013,9 +964,26 @@
               </annotationProcessorPaths>
             </configuration>
           </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk11+</id>
+      <activation>
+        <jdk>[11,]</jdk>
+      </activation>
+      <build>
+        <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
             </configuration>
@@ -1060,7 +1028,6 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.11</version>
             <reportSets>
               <reportSet>
                 <!-- don't run aggregate in child modules -->
@@ -1106,7 +1073,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>cdata-cmake</id>
@@ -1163,7 +1129,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>jni-cpp-cmake</id>
@@ -1270,7 +1235,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>jni-cpp-cmake</id>
@@ -1360,5 +1324,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -110,6 +110,11 @@
     <version.maven-compiler-plugin>3.12.1</version.maven-compiler-plugin>
     <version.maven-dependency-plugin>3.6.1</version.maven-dependency-plugin>
     <version.maven-gpg-plugin>3.2.0</version.maven-gpg-plugin>
+    <!--
+      Downgrade maven-jar-plugin until https://github.com/codehaus-plexus/plexus-archiver/issues/332
+      is addressed
+    -->
+    <version.maven-jar-plugin>3.2.2</version.maven-jar-plugin>
     <version.maven-javadoc-plugin>3.6.3</version.maven-javadoc-plugin>
     <version.maven-project-info-reports-plugin>3.5.0</version.maven-project-info-reports-plugin>
   </properties>
@@ -594,11 +599,6 @@
             <exclude>**/logback.xml</exclude>
           </excludes>
           <archive>
-            <index>true</index>
-            <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-            </manifest>
             <manifestEntries>
               <Extension-Name>org.apache.arrow</Extension-Name>
               <Built-By>${username}</Built-By>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -54,6 +54,11 @@
       <version>1.3.14</version>
       <scope>test</scope>
     </dependency>
+    <!--
+        Adding jackson as a compile dependency although only directly used in tests.
+        Using <scope>test</scope> however would cause the final scope to be test instead of
+        compile because of MNG-4156
+    -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -85,7 +90,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.7.1</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -101,7 +105,21 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <phase>verify</phase>
+            <configuration>
+              <ignoredNonTestScopedDependencies>
+                <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:*</ignoredNonTestScopedDependency>
+              </ignoredNonTestScopedDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
-
 </project>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -76,64 +76,7 @@
     </dependency>
   </dependencies>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>apache</id>
-      <name>apache</name>
-      <url>https://repo.maven.apache.org/maven2/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
-
-    <resources>
-      <resource>
-        <targetPath>codegen</targetPath>
-        <!-- Copy freemarker template and fmpp configuration files of Vector's
-          to allow clients to leverage definitions. -->
-        <directory>${basedir}/src/main/codegen</directory>
-      </resource>
-    </resources>
-    <pluginManagement>
-      <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings
-          only. It has no influence on the Maven build itself. -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.drill.tools</groupId>
-                    <artifactId>drill-fmpp-maven-plugin</artifactId>
-                    <versionRange>[1.0,)</versionRange>
-                    <goals>
-                      <goal>generate</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <execute>
-                      <runOnIncremental>false</runOnIncremental>
-                      <runOnConfiguration>true</runOnConfiguration>
-                    </execute>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -164,32 +107,9 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- copy all templates in the same location to compile them at once -->
-            <id>copy-fmpp-resources</id>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <phase>initialize</phase>
-            <configuration>
-              <outputDirectory>${project.build.directory}/codegen</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>src/main/codegen</directory>
-                  <filtering>false</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <!-- generate sources from fmpp -->
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
-        <version>1.21.1</version>
         <executions>
           <execution>
             <id>generate-fmpp</id>
@@ -200,7 +120,7 @@
             <configuration>
               <config>src/main/codegen/config.fmpp</config>
               <output>${project.build.directory}/generated-sources</output>
-              <templates>${project.build.directory}/codegen/templates</templates>
+              <templates>src/main/codegen/templates</templates>
             </configuration>
           </execution>
         </executions>
@@ -208,13 +128,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <!--
-          Downgrade maven-shade-plugin specifically for this module.
-          Using a newer version up to at least 3.5.1 will cause
-          issues in the arrow-tools tests looking up FlatBuffer
-          dependencies.
-         -->
-        <version>3.2.4</version>
         <executions>
           <execution>
             <goals>
@@ -243,7 +156,6 @@
         </executions>
       </plugin>
     </plugins>
-
   </build>
 
   <profiles>
@@ -276,5 +188,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
### Rationale for this change

Use/update Maven modules to `org.apache:parent:31` and clean up Maven modules to remove unnecessary configuration or outdated workarounds

### What changes are included in this PR?

* Add `org.apache:parent:31` to `org.apache.arrow:arrow-bom` and `org.apache.arrow.maven.plugins:arrow-maven-plugins` to make them conformant with ASF standards
* Update `org.apache.arrow:arrow-java-root` parent to `org.apache:parent:31`
* Use `version.*` and other properties to override plugin versions defined by `org.apache:parent`
* Move standalone plugin versions under pluginManagement at the top level
* Cleanup redundant plugin version or configuration declaration
* Update `maven-dependency-plugin` to 3.6.1 and add the required overrides when necessary
* Update `maven-shade-plugin` to 3.5.1 (via `org.apache:parent`)
* Remove enforcer check for java and maven version (handled by `org.apache:parent`)
* Remove unnecessary `mvnrepository` link comments
* Remove `m2e.version` property check in profiles (only needed for errorprone plugin configuration which is incompatible with M2E)
* Cleanup `argLine` overrides for surefire/failsafe plugins
* Remove unnecessary `../pom.xml` `<relativePath>` directives
* Remove source/target/encoding configuration properties for `maven-compiler-plugin`, `maven-javadoc-plugin` and `maven-resources-plugin` as it is handled by `org.apache:parent` and plugin themselves
* Remove unnecessary copy of codegen templates in `arrow-vector` module
* Remove unnecessary junit jupiter engine dependencies for surefire/failsafe plugins.

### Are these changes tested?

No net new code. tested via CI jobs

### Are there any user-facing changes?

None
* GitHub Issue: #41307