### PR TITLE
GH-41310: [C++] S3FS Read file using the version id obtained with HEAD call 

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1258,7 +1258,8 @@ Result<S3Model::GetObjectResult> GetObjectRange(Aws::S3::S3Client* client,
   S3Model::GetObjectRequest req;
   req.SetBucket(ToAwsString(path.bucket));
   req.SetKey(ToAwsString(path.key));
-  req.SetVersionId(version);
+  if(!version.empty())
+    req.SetVersionId(version);
   req.SetRange(ToAwsString(FormatRange(start, length)));
   req.SetResponseStreamFactory(AwsWriteableStreamFactory(out, length));
   return OutcomeToResult("GetObject", client->GetObject(req));
@@ -1417,7 +1418,8 @@ class ObjectInputFile final : public io::RandomAccessFile {
     }
     content_length_ = outcome.GetResult().GetContentLength();
     DCHECK_GE(content_length_, 0);
-    version_ = outcome.GetResult().GetVersionId();
+    if(!outcome.GetResult().GetVersionId().empty())
+      version_ = outcome.GetResult().GetVersionId();
     metadata_ = GetObjectMetadata(outcome.GetResult());
     return Status::OK();
   }


### PR DESCRIPTION

### Rationale for this change

GET calls to s3 is not made using the version id (if available) from the HEAD call (which is used to get the content-length). If the version is available, using that makes the GET call more reliably return the file data without running in to race condition, if a write was intercepted between the HEAD and GET. 

### What changes are included in this PR?

s3fs.cc 
The changes include capturing the version if available from the HEAD call and using it subsequently in the GET requests.

This doesnt need any specific tests. The existing tests should cover for regression.

* GitHub Issue: #41310