### PR TITLE
GH-41317: [C++] Fix crash on invalid Parquet file

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -649,6 +649,11 @@ Status TableBatchReader::ReadNext(std::shared_ptr<RecordBatch>* out) {
       std::min(table_.num_rows() - absolute_row_position_, max_chunksize_);
   std::vector<const Array*> chunks(table_.num_columns());
   for (int i = 0; i < table_.num_columns(); ++i) {
+    if (chunk_numbers_[i] >= column_data_[i]->num_chunks()) {
+      *out = nullptr;
+      return Status::Invalid("Requesting too large chunk number ", chunk_numbers_[i],
+                             " for column ", i);
+    }
     auto chunk = column_data_[i]->chunk(chunk_numbers_[i]).get();
     int64_t chunk_remaining = chunk->length() - chunk_offsets_[i];
 


### PR DESCRIPTION
### Rationale for this change

Fixes the crash detailed in #41317 in TableBatchReader::ReadNext() on a corrupted Parquet file

### What changes are included in this PR?

Add a validation on the chunk index requested in column_data_[i]->chunk() and return an error if out of obunds

### Are these changes tested?

I've tested on the reproducer I provided in #41317 that it now triggers a clean error:
```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    [_ for _ in parquet_file.iter_batches()]
  File "test.py", line 3, in <listcomp>
    [_ for _ in parquet_file.iter_batches()]
  File "pyarrow/_parquet.pyx", line 1587, in iter_batches
  File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Requesting too large chunk number 1 for column 18
```
I'm not sure if/how unit tests for corrupted datasets should be added

### Are there any user-facing changes?

No

**This PR contains a "Critical Fix".**
* GitHub Issue: #41317