### PR TITLE
GH-41329: [C++][Gandiva] Fix gandiva cache size env var

### DIFF
--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -35,8 +35,15 @@ int GetCapacityFromEnvVar() {
   if (env_value.empty()) {
     return DEFAULT_CACHE_SIZE;
   }
-  int capacity = std::atoi(env_value.c_str());
-  if (capacity <= 0) {
+  int capacity = 0;
+  size_t length = 0;
+  bool exception = false;
+  try {
+    capacity = std::stoi(env_value.c_str(), &length);
+  } catch (const std::exception&) {
+    exception = true;
+  }
+  if (length != env_value.length() || exception || capacity <= 0) {
     ARROW_LOG(WARNING) << "Invalid cache size provided in GANDIVA_CACHE_SIZE. "
                        << "Using default cache size: " << DEFAULT_CACHE_SIZE;
     return DEFAULT_CACHE_SIZE;

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -26,7 +26,7 @@ namespace gandiva {
 static const int DEFAULT_CACHE_SIZE = 5000;
 
 namespace internal {
-int GetCapacityFromEnvVar() {
+int GetCacheCapacityFromEnvVar() {
   auto maybe_env_value = ::arrow::internal::GetEnvVar("GANDIVA_CACHE_SIZE");
   if (!maybe_env_value.ok()) {
     return DEFAULT_CACHE_SIZE;
@@ -52,8 +52,11 @@ int GetCapacityFromEnvVar() {
 }
 }  // namespace internal
 
-int GetCapacity() {
-  static const int capacity = internal::GetCapacityFromEnvVar();
+// Deprecated in 17.0.0. Use GetCacheCapacity instead.
+int GetCapacity() { return GetCacheCapacity(); }
+
+int GetCacheCapacity() {
+  static const int capacity = internal::GetCacheCapacityFromEnvVar();
   return capacity;
 }
 

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -42,7 +42,7 @@ int GetCacheCapacityFromEnvVar() {
       env_value.c_str(), env_value.size(), &capacity);
   if (!ok || capacity <= 0) {
     ARROW_LOG(WARNING) << "Invalid cache size provided in " << kCacheCapacityEnvVar
-                       << "Using default cache size: " << kDefaultCacheSize;
+                       << ". Using default cache size: " << kDefaultCacheSize;
     return kDefaultCacheSize;
   }
   return capacity;

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -26,7 +26,7 @@ namespace gandiva {
 static const int DEFAULT_CACHE_SIZE = 5000;
 
 namespace internal {
-int GetCapacityInternal() {
+int GetCapacityFromEnvVar() {
   auto maybe_env_value = ::arrow::internal::GetEnvVar("GANDIVA_CACHE_SIZE");
   if (!maybe_env_value.ok()) {
     return DEFAULT_CACHE_SIZE;
@@ -46,7 +46,7 @@ int GetCapacityInternal() {
 }  // namespace internal
 
 int GetCapacity() {
-  static const int capacity = internal::GetCapacityInternal();
+  static const int capacity = internal::GetCapacityFromEnvVar();
   return capacity;
 }
 

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -25,6 +25,11 @@
 
 namespace gandiva {
 
+namespace internal {
+// For testing purposes only.
+int GetCapacityInternal();
+}  // namespace internal
+
 GANDIVA_EXPORT
 int GetCapacity();
 

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -26,8 +26,10 @@
 namespace gandiva {
 
 namespace internal {
-// For testing purposes only.
-int GetCapacityInternal();
+// Only called once by GetCapacity().
+// Do the actual work of getting the capacity from env var.
+// Also makes the testing easier.
+int GetCapacityFromEnvVar();
 }  // namespace internal
 
 GANDIVA_EXPORT

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -20,21 +20,26 @@
 #include <cstdlib>
 #include <mutex>
 
+#include "arrow/util/macros.h"
 #include "gandiva/lru_cache.h"
 #include "gandiva/visibility.h"
 
 namespace gandiva {
 
 namespace internal {
-// Only called once by GetCapacity().
-// Do the actual work of getting the capacity from env var.
+// Only called once by GetCacheCapacity().
+// Do the actual work of getting the cache capacity from env var.
 // Also makes the testing easier.
 GANDIVA_EXPORT
-int GetCapacityFromEnvVar();
+int GetCacheCapacityFromEnvVar();
 }  // namespace internal
 
+ARROW_DEPRECATED("Deprecated in 17.0.0. Use GetCacheCapacity instead.")
 GANDIVA_EXPORT
 int GetCapacity();
+
+GANDIVA_EXPORT
+int GetCacheCapacity();
 
 GANDIVA_EXPORT
 void LogCacheSize(size_t capacity);
@@ -44,7 +49,7 @@ class Cache {
  public:
   explicit Cache(size_t capacity) : cache_(capacity) { LogCacheSize(capacity); }
 
-  Cache() : Cache(GetCapacity()) {}
+  Cache() : Cache(GetCacheCapacity()) {}
 
   ValueType GetObjectCode(const KeyType& cache_key) {
     std::optional<ValueType> result;

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -29,6 +29,7 @@ namespace internal {
 // Only called once by GetCapacity().
 // Do the actual work of getting the capacity from env var.
 // Also makes the testing easier.
+GANDIVA_EXPORT
 int GetCapacityFromEnvVar();
 }  // namespace internal
 

--- a/cpp/src/gandiva/cache_test.cc
+++ b/cpp/src/gandiva/cache_test.cc
@@ -46,7 +46,9 @@ constexpr auto capacity_env_var = "GANDIVA_CACHE_SIZE";
 constexpr auto default_capacity = 5000;
 }  // namespace
 
-TEST(TestCache, TestGetCacheCapacityDefault) { ASSERT_EQ(GetCapacity(), 5000); }
+TEST(TestCache, TestGetCacheCapacityDefault) {
+  ASSERT_EQ(GetCapacity(), default_capacity);
+}
 
 TEST(TestCache, TestGetCacheCapacityEnvVar) {
   // Empty.

--- a/cpp/src/gandiva/cache_test.cc
+++ b/cpp/src/gandiva/cache_test.cc
@@ -44,39 +44,42 @@ TEST(TestCache, TestGetPut) {
 TEST(TestCache, TestGetCacheCapacityDefault) { ASSERT_EQ(GetCapacity(), 5000); }
 
 TEST(TestCache, TestGetCacheCapacityEnvVar) {
+  constexpr auto capacity_env_var = "GANDIVA_CACHE_SIZE";
+  constexpr auto default_capacity = 5000;
+
   // Empty.
-  ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", ""));
-  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
+  ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, ""));
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
 
   // Non-number.
-  ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "invalid"));
-  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
+  ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, "invalid"));
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
 
   // Valid positive number.
-  ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "42"));
+  ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, "42"));
   ASSERT_EQ(internal::GetCapacityFromEnvVar(), 42);
 
   // Int max.
   {
     auto str = std::to_string(std::numeric_limits<int>::max());
-    ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", str));
+    ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, str));
     ASSERT_EQ(internal::GetCapacityFromEnvVar(), std::numeric_limits<int>::max());
   }
 
   // Over int max.
   {
     auto str = std::to_string(static_cast<int64_t>(std::numeric_limits<int>::max()) + 1);
-    ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", str));
-    ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
+    ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, str));
+    ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
   }
 
   // Zero.
-  ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "0"));
-  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
+  ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, "0"));
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
 
   // Negative number.
-  ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "-1"));
-  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
+  ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, "-1"));
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/cache_test.cc
+++ b/cpp/src/gandiva/cache_test.cc
@@ -76,6 +76,12 @@ TEST(TestCache, TestGetCacheCapacityEnvVar) {
     ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
   }
 
+  // Number with invalid suffix.
+  {
+    ScopedEnvVar env(capacity_env_var, "42MB");
+    ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
+  }
+
   // Valid positive number.
   {
     ScopedEnvVar env(capacity_env_var, "42");
@@ -98,6 +104,13 @@ TEST(TestCache, TestGetCacheCapacityEnvVar) {
   // Negative number.
   {
     ScopedEnvVar env(capacity_env_var, "-1");
+    ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
+  }
+
+  // Over int max.
+  {
+    auto str = std::to_string(static_cast<int64_t>(std::numeric_limits<int>::max()) + 1);
+    ScopedEnvVar env(capacity_env_var, str.c_str());
     ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);
   }
 }

--- a/cpp/src/gandiva/cache_test.cc
+++ b/cpp/src/gandiva/cache_test.cc
@@ -46,37 +46,37 @@ TEST(TestCache, TestGetCacheCapacityDefault) { ASSERT_EQ(GetCapacity(), 5000); }
 TEST(TestCache, TestGetCacheCapacityEnvVar) {
   // Empty.
   ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", ""));
-  ASSERT_EQ(internal::GetCapacityInternal(), 5000);
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
 
   // Non-number.
   ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "invalid"));
-  ASSERT_EQ(internal::GetCapacityInternal(), 5000);
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
 
   // Valid positive number.
   ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "42"));
-  ASSERT_EQ(internal::GetCapacityInternal(), 42);
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 42);
 
   // Int max.
   {
     auto str = std::to_string(std::numeric_limits<int>::max());
     ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", str));
-    ASSERT_EQ(internal::GetCapacityInternal(), std::numeric_limits<int>::max());
+    ASSERT_EQ(internal::GetCapacityFromEnvVar(), std::numeric_limits<int>::max());
   }
 
   // Over int max.
   {
     auto str = std::to_string(static_cast<int64_t>(std::numeric_limits<int>::max()) + 1);
     ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", str));
-    ASSERT_EQ(internal::GetCapacityInternal(), 5000);
+    ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
   }
 
   // Zero.
   ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "0"));
-  ASSERT_EQ(internal::GetCapacityInternal(), 5000);
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
 
   // Negative number.
   ASSERT_OK(::arrow::internal::SetEnvVar("GANDIVA_CACHE_SIZE", "-1"));
-  ASSERT_EQ(internal::GetCapacityInternal(), 5000);
+  ASSERT_EQ(internal::GetCapacityFromEnvVar(), 5000);
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/cache_test.cc
+++ b/cpp/src/gandiva/cache_test.cc
@@ -41,12 +41,14 @@ TEST(TestCache, TestGetPut) {
   ASSERT_EQ(cache.GetObjectCode(TestCacheKey(2)), "world");
 }
 
+namespace {
+constexpr auto capacity_env_var = "GANDIVA_CACHE_SIZE";
+constexpr auto default_capacity = 5000;
+}  // namespace
+
 TEST(TestCache, TestGetCacheCapacityDefault) { ASSERT_EQ(GetCapacity(), 5000); }
 
 TEST(TestCache, TestGetCacheCapacityEnvVar) {
-  constexpr auto capacity_env_var = "GANDIVA_CACHE_SIZE";
-  constexpr auto default_capacity = 5000;
-
   // Empty.
   ASSERT_OK(::arrow::internal::SetEnvVar(capacity_env_var, ""));
   ASSERT_EQ(internal::GetCapacityFromEnvVar(), default_capacity);

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -180,8 +180,10 @@ that changing their value later will have an effect.
 
    The number of entries to keep in the Gandiva JIT compilation cache.
    The cache is in-memory and does not persist across processes.
-   The value of this variable is expected to be a positive number less or equal
-   than int32 max, defaults to 5000 otherwise.
+
+   The default cache size is 5000.  The value of this environment variable
+   should be a positive integer and should not exceed the maximum value
+   of int32.  Otherwise the default value is used.
 
 .. envvar:: HADOOP_HOME
 

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -180,6 +180,8 @@ that changing their value later will have an effect.
 
    The number of entries to keep in the Gandiva JIT compilation cache.
    The cache is in-memory and does not persist across processes.
+   The value of this variable is expected to be a positive number less or equal
+   than int32 max, defaults to 5000 otherwise.
 
 .. envvar:: HADOOP_HOME
 


### PR DESCRIPTION
### Rationale for this change

Gandiva cache size validity checks are not robust enough (the negativity test is broken), and they are not currently tested.

### What changes are included in this PR?

1. Fix checking gandiva cache size env var.
2. Make cache size static so it only gets evaluated once.
3. Add test cases.
4. Enrich the description in the document about this env var.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

UT included.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41329