### PR TITLE
MINOR: [C++][CMake] Remove unused CMAKE_SKIP_INSTALL_ALL_DEPENDENCY

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -256,9 +256,6 @@ if(ARROW_USE_CCACHE
 endif()
 
 if(ARROW_OPTIONAL_INSTALL)
-  # Don't make the "install" target depend on the "all" target
-  set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
-
   set(INSTALL_IS_OPTIONAL OPTIONAL)
 endif()
 


### PR DESCRIPTION
### Rationale for this change

CMAKE_SKIP_INSTALL_ALL_DEPENDENCY was removed in https://github.com/apache/arrow/pull/75 but it seems that there is still one line remaining.

### What changes are included in this PR?

Remove unused CMAKE_SKIP_INSTALL_ALL_DEPENDENCY.

### Are these changes tested?

Pass all CIs.

### Are there any user-facing changes?

No.