### PR TITLE
GH-41347: [FlightRPC][C#] Allow hosting flight server in pre-Kestrel .net versions

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Apache.Arrow.Flight.csproj
+++ b/csharp/src/Apache.Arrow.Flight/Apache.Arrow.Flight.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>
@@ -12,6 +12,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
+    <PackageReference Include="Grpc.Core" Version="2.46.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/src/Apache.Arrow.Flight/Server/GrpcCoreFlightServerExtensions.cs
+++ b/csharp/src/Apache.Arrow.Flight/Server/GrpcCoreFlightServerExtensions.cs
@@ -1,0 +1,24 @@
+﻿#if NET46_OR_GREATER
+
+using Apache.Arrow.Flight.Protocol;
+using Apache.Arrow.Flight.Server.Internal;
+using Grpc.Core;
+
+namespace Apache.Arrow.Flight.Server
+{
+    public static class GrpcCoreFlightServerExtensions
+    {
+        /// <summary>
+        /// Create a ServerServiceDefinition for use with a <see href="https://grpc.github.io/grpc/csharp/api/Grpc.Core.Server.html">Grpc.Core Server</see>
+        //  This allows running a flight server on pre-Kestrel .net Framework versions
+        /// </summary>
+        /// <param name="flightServer"></param>
+        /// <returns></returns>
+        public static ServerServiceDefinition CreateServiceDefinition(this FlightServer flightServer)
+        {
+            return FlightService.BindService(new FlightServerImplementation(flightServer));
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
### Rationale for this change

With the existing structure it is not possible to create a flight RPC service as a regular GRPC service, outside of AspNet.Core/Kestrel.

This can be supported by changing the protection level of the generated classes and FlightServiceImplementation.cs 

### What changes are included in this PR?

Change protection level from internal to public for generated protocol files and FlightServiceImplementation.cs

### Are these changes tested?

Confirmed that classes are public in the built assembly.

### Are there any user-facing changes?

Generated protocol classes will become visible to end users.

* GitHub Issue: #41347