### PR TITLE
GH-29537: [R] Support mutate/summarize with implicit join

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -48,10 +48,7 @@ supported_dplyr_methods <- list(
   group_vars = NULL,
   group_by_drop_default = NULL,
   ungroup = NULL,
-  mutate = c(
-    "window functions (e.g. things that require aggregation within groups)",
-    "not currently supported"
-  ),
+  mutate = NULL,
   transmute = NULL,
   arrange = NULL,
   rename = NULL,

--- a/r/R/dplyr-funcs-agg.R
+++ b/r/R/dplyr-funcs-agg.R
@@ -164,7 +164,6 @@ set_agg <- function(...) {
     # like sum(x - mean(x)), i.e. window functions.
     # This will reject (sum(sum(x)) as well, but that's not a useful operation.
     if (any(expr$field_names_in_expression() %in% names(aggs))) {
-      # TODO: support in ARROW-13926
       arrow_not_supported("aggregate within aggregate expression")
     }
   })

--- a/r/R/dplyr-funcs-doc.R
+++ b/r/R/dplyr-funcs-doc.R
@@ -53,7 +53,7 @@
 #' * [`groups()`][dplyr::groups()]
 #' * [`inner_join()`][dplyr::inner_join()]: the `copy` argument is ignored
 #' * [`left_join()`][dplyr::left_join()]: the `copy` argument is ignored
-#' * [`mutate()`][dplyr::mutate()]: window functions (e.g. things that require aggregation within groups) not currently supported
+#' * [`mutate()`][dplyr::mutate()]
 #' * [`pull()`][dplyr::pull()]: the `name` argument is not supported; returns an R vector by default but this behavior is deprecated and will return an Arrow [ChunkedArray] in a future release. Provide `as_vector = TRUE/FALSE` to control this behavior, or set `options(arrow.pull_as_vector)` globally.
 #' * [`relocate()`][dplyr::relocate()]
 #' * [`rename()`][dplyr::rename()]

--- a/r/R/dplyr-mutate.R
+++ b/r/R/dplyr-mutate.R
@@ -89,7 +89,28 @@ mutate.arrow_dplyr_query <- function(.data,
     agg_query$aggregations <- ..aggregations
     agg_query <- collapse.arrow_dplyr_query(agg_query)
     if (length(grv)) {
-      out <- left_join(out, agg_query, by = grv)
+      # First, hack around #41358
+      # We need to fill in missing values in the join keys with something valid.
+      # To reduce the number of types we have to deal with, and to allow us to
+      # insert a value for NA that we can very reasonably assume not to be in
+      # the actual data, we'll make copies of the join key columns in both
+      # tables, cast them to string, and coalesce to fill the NA with a sentinel.
+      # We'll prefix the column names with "..temp" so that they get cleaned up
+      # after, along with the aggregation columns, and we'll keep the original
+      # copy of the key columns in `out` but drop them from `agg_query` to
+      # avoid collisions.
+      na_sentinel <- Expression$scalar(paste0("..temp", Sys.time()))
+      make_joinable <- function(x) {
+        Expression$create("coalesce", args = list(x$cast(utf8()), na_sentinel))
+      }
+      for (group_var in grv) {
+        tempname <- paste0("..temp", group_var)
+        out$selected_columns[[tempname]] <- make_joinable(out$selected_columns[[group_var]])
+        agg_query$selected_columns[[tempname]] <- make_joinable(agg_query$selected_columns[[group_var]])
+        agg_query$selected_columns[[group_var]] <- NULL
+      }
+      # Now we can join
+      out <- left_join(out, agg_query, by = paste0("..temp", grv))
     } else {
       # If there are no group_by vars, add a scalar column to both and join on that
       agg_query$selected_columns[["..tempjoin"]] <- Expression$scalar(1L)

--- a/r/R/dplyr-mutate.R
+++ b/r/R/dplyr-mutate.R
@@ -45,17 +45,16 @@ mutate.arrow_dplyr_query <- function(.data,
     return(out)
   }
 
-  # Restrict the cases we support for now
-  has_aggregations <- any(unlist(lapply(exprs, all_funs)) %in% names(agg_funcs))
-  if (has_aggregations) {
-    # ARROW-13926
-    # mutate() on a grouped dataset does calculations within groups
-    # This doesn't matter on scalar ops (arithmetic etc.) but it does
-    # for things with aggregations (e.g. subtracting the mean)
-    return(abandon_ship(call, .data, "window functions not currently supported in Arrow"))
-  }
+  # Create a mask with aggregation functions in it
+  # If there are any aggregations, we will need to compute them and
+  # and join the results back in, for "window functions" like x - mean(x)
+  mask <- arrow_mask(out, aggregation = TRUE)
+  # As in summarize(), we need to track the aggregations here.
+  # If this list is not empty after we evaluate the exprs, we will need to
+  # compute the aggregations and join them back in.
+  ..aggregations <- empty_named_list()
 
-  mask <- arrow_mask(out)
+  # Evaluate the mutate expressions
   results <- list()
   for (i in seq_along(exprs)) {
     # Iterate over the indices and not the names because names may be repeated
@@ -81,6 +80,24 @@ mutate.arrow_dplyr_query <- function(.data,
     mask[[new_var]] <- mask$.data[[new_var]] <- results[[new_var]]
   }
 
+  if (length(..aggregations)) {
+    # Make a copy of .data, do the aggregations on it, and then left_join on
+    # the group_by variables.
+    agg_query <- as_adq(.data)
+    # These may be computed by .by, make sure they're set
+    agg_query$group_by_vars <- grv
+    agg_query$aggregations <- ..aggregations
+    agg_query <- collapse.arrow_dplyr_query(agg_query)
+    if (length(grv)) {
+      out <- left_join(out, agg_query, by = grv)
+    } else {
+      # If there are no group_by vars, add a scalar column to both and join on that
+      agg_query$selected_columns[["..tempjoin"]] <- Expression$scalar(1L)
+      out$selected_columns[["..tempjoin"]] <- Expression$scalar(1L)
+      out <- left_join(out, agg_query, by = "..tempjoin")
+    }
+  }
+
   old_vars <- names(out$selected_columns)
   # Note that this is names(exprs) not names(results):
   # if results$new_var is NULL, that means we are supposed to remove it
@@ -90,6 +107,11 @@ mutate.arrow_dplyr_query <- function(.data,
   for (new_var in new_vars) {
     out$selected_columns[[new_var]] <- results[[new_var]]
   }
+
+  # Prune any ..temp columns from the result, which would have come from
+  # ..aggregations
+  temps <- grepl("^\\.\\.temp", names(out$selected_columns))
+  out$selected_columns <- out$selected_columns[!temps]
 
   # Deduplicate new_vars and remove NULL columns from new_vars
   new_vars <- intersect(union(new_vars, grv), names(out$selected_columns))

--- a/r/man/acero.Rd
+++ b/r/man/acero.Rd
@@ -40,7 +40,7 @@ Table into an R \code{tibble}.
 \item \code{\link[dplyr:group_data]{groups()}}
 \item \code{\link[dplyr:mutate-joins]{inner_join()}}: the \code{copy} argument is ignored
 \item \code{\link[dplyr:mutate-joins]{left_join()}}: the \code{copy} argument is ignored
-\item \code{\link[dplyr:mutate]{mutate()}}: window functions (e.g. things that require aggregation within groups) not currently supported
+\item \code{\link[dplyr:mutate]{mutate()}}
 \item \code{\link[dplyr:pull]{pull()}}: the \code{name} argument is not supported; returns an R vector by default but this behavior is deprecated and will return an Arrow \link{ChunkedArray} in a future release. Provide \code{as_vector = TRUE/FALSE} to control this behavior, or set \code{options(arrow.pull_as_vector)} globally.
 \item \code{\link[dplyr:relocate]{relocate()}}
 \item \code{\link[dplyr:rename]{rename()}}

--- a/r/tests/testthat/test-dataset-dplyr.R
+++ b/r/tests/testthat/test-dataset-dplyr.R
@@ -163,17 +163,6 @@ See $.data for the source Arrow object",
   )
 })
 
-test_that("mutate() features not yet implemented", {
-  ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
-  expect_error(
-    ds %>%
-      group_by(int) %>%
-      mutate(avg = mean(int)),
-    "window functions not currently supported in Arrow\nCall collect() first to pull data into R.",
-    fixed = TRUE
-  )
-})
-
 test_that("filter scalar validation doesn't crash (ARROW-7772)", {
   ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
   expect_error(

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -422,8 +422,6 @@ test_that("Can mutate after group_by, including with some aggregations", {
       mutate(avg_int = mean(int)) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
-      # And joins currently don't join on NAs
-      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )
@@ -436,8 +434,6 @@ test_that("Can mutate after group_by, including with some aggregations", {
       mutate(avg_int = mean(mean)) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
-      # And joins currently don't join on NAs
-      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )
@@ -487,8 +483,6 @@ test_that("Can mutate with .by argument, even with some aggregations", {
       mutate(avg_int = mean(int), .by = chr) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
-      # And joins currently don't join on NAs
-      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )
@@ -500,8 +494,6 @@ test_that("Can mutate with .by argument, even with some aggregations", {
       mutate(avg_int = mean(mean), .by = chr) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
-      # And joins currently don't join on NAs
-      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -422,6 +422,8 @@ test_that("Can mutate after group_by, including with some aggregations", {
       mutate(avg_int = mean(int)) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )
@@ -434,6 +436,8 @@ test_that("Can mutate after group_by, including with some aggregations", {
       mutate(avg_int = mean(mean)) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )
@@ -483,6 +487,8 @@ test_that("Can mutate with .by argument, even with some aggregations", {
       mutate(avg_int = mean(int), .by = chr) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )
@@ -494,6 +500,8 @@ test_that("Can mutate with .by argument, even with some aggregations", {
       mutate(avg_int = mean(mean), .by = chr) %>%
       # Because this silently does a join, the rows can get unsorted
       arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
     tbl
   )

--- a/r/tests/testthat/test-dplyr-mutate.R
+++ b/r/tests/testthat/test-dplyr-mutate.R
@@ -378,18 +378,16 @@ test_that("dplyr::mutate's examples", {
   # The mutate operation may yield different results on grouped
   # tibbles because the expressions are computed within groups.
   # The following normalises `mass` by the global average:
-  # TODO(ARROW-13926): support window functions
   compare_dplyr_binding(
     .input %>%
       select(name, mass, species) %>%
       mutate(mass_norm = mass / mean(mass, na.rm = TRUE)) %>%
       collect(),
-    starwars,
-    warning = "window function"
+    starwars
   )
 })
 
-test_that("Can mutate after group_by as long as there are no aggregations", {
+test_that("Can mutate after group_by, including with some aggregations", {
   compare_dplyr_binding(
     .input %>%
       select(int, chr) %>%
@@ -417,31 +415,35 @@ test_that("Can mutate after group_by as long as there are no aggregations", {
       collect(),
     tbl
   )
-  expect_warning(
-    tbl %>%
-      Table$create() %>%
+  compare_dplyr_binding(
+    .input %>%
       select(int, chr) %>%
       group_by(chr) %>%
       mutate(avg_int = mean(int)) %>%
+      # Because this silently does a join, the rows can get unsorted
+      arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
-    "window functions not currently supported in Arrow; pulling data into R",
-    fixed = TRUE
+    tbl
   )
-  expect_warning(
-    tbl %>%
-      Table$create() %>%
+  compare_dplyr_binding(
+    .input %>%
       select(mean = int, chr) %>%
       # rename `int` to `mean` and use `mean(mean)` in `mutate()` to test that
       # `all_funs()` detects `mean()` despite the collision with a column name
       group_by(chr) %>%
       mutate(avg_int = mean(mean)) %>%
+      # Because this silently does a join, the rows can get unsorted
+      arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
-    "window functions not currently supported in Arrow; pulling data into R",
-    fixed = TRUE
+    tbl
   )
 })
 
-test_that("Can mutate with .by argument as long as there are no aggregations", {
+test_that("Can mutate with .by argument, even with some aggregations", {
   compare_dplyr_binding(
     .input %>%
       select(int, chr) %>%
@@ -479,25 +481,29 @@ test_that("Can mutate with .by argument as long as there are no aggregations", {
       collect(),
     tbl
   )
-  expect_warning(
-    tbl %>%
-      Table$create() %>%
+  compare_dplyr_binding(
+    .input %>%
       select(int, chr) %>%
       mutate(avg_int = mean(int), .by = chr) %>%
+      # Because this silently does a join, the rows can get unsorted
+      arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
-    "window functions not currently supported in Arrow; pulling data into R",
-    fixed = TRUE
+    tbl
   )
-  expect_warning(
-    tbl %>%
-      Table$create() %>%
+  compare_dplyr_binding(
+    .input %>%
       select(mean = int, chr) %>%
       # rename `int` to `mean` and use `mean(mean)` in `mutate()` to test that
       # `all_funs()` detects `mean()` despite the collision with a column name
       mutate(avg_int = mean(mean), .by = chr) %>%
+      # Because this silently does a join, the rows can get unsorted
+      arrange(chr) %>%
+      # And joins currently don't join on NAs
+      filter(!is.na(chr)) %>%
       collect(),
-    "window functions not currently supported in Arrow; pulling data into R",
-    fixed = TRUE
+    tbl
   )
 })
 
@@ -682,7 +688,6 @@ test_that("mutate() and transmute() with namespaced functions", {
 })
 
 test_that("Can use across() within mutate()", {
-
   # expressions work in the right order
   compare_dplyr_binding(
     .input %>%
@@ -717,17 +722,15 @@ test_that("Can use across() within mutate()", {
     example_data
   )
 
-  # gives the right error with window functions
-  expect_warning(
-    arrow_table(example_data) %>%
+  compare_dplyr_binding(
+    .input %>%
       mutate(
         x = int + 2,
         across(c("int", "dbl"), list(mean = mean, sd = sd, round)),
         exp(dbl2)
       ) %>%
       collect(),
-    "window functions not currently supported in Arrow; pulling data into R",
-    fixed = TRUE
+    example_data
   )
 })
 

--- a/r/vignettes/data_wrangling.Rmd
+++ b/r/vignettes/data_wrangling.Rmd
@@ -165,33 +165,7 @@ sw2 %>%
   transmute(name, height, mass, res = residuals(lm(mass ~ height)))
 ```
 
-Because window functions are not supported, computing an aggregation like `mean()` on a grouped table or within a rowwise operation like `filter()` is not supported:
-
-```{r}
-sw %>%
-  select(1:4) %>%
-  filter(!is.na(hair_color)) %>%
-  group_by(hair_color) %>%
-  filter(height < mean(height, na.rm = TRUE))
-```
-
-This operation is sometimes referred to as a windowed aggregate and can be accomplished in Arrow by computing the aggregation separately, for example within a join operation:
-
-```{r}
-sw %>%
-  select(1:4) %>%
-  filter(!is.na(hair_color)) %>%
-  left_join(
-    sw %>%
-      group_by(hair_color) %>%
-      summarize(mean_height = mean(height, na.rm = TRUE))
-    ) %>%
-  filter(height < mean_height) %>%
-  select(!mean_height) %>%
-  collect()
-```
-
-Alternatively, [DuckDB](https:\www.duckdb.org) supports Arrow natively, so you can pass the `Table` object to DuckDB without paying a performance penalty using the helper function `to_duckdb()` and pass the object back to Arrow with `to_arrow()`:
+For some operations, you can use [DuckDB](https://www.duckdb.org). It supports Arrow natively, so you can pass the `Dataset` or query object to DuckDB without paying a performance penalty using the helper function `to_duckdb()` and pass the object back to Arrow with `to_arrow()`:
 
 ```{r}
 sw %>%


### PR DESCRIPTION
### Rationale for this change

Since it doesn't look like Acero will be getting window functions any time soon, implement support in `mutate()` for transformations that involve aggregations, like `x - mean(x)`, via left_join.

### What changes are included in this PR?

Following #41223, I realized I could reuse that evaluation path in `mutate()`. Evaluating expressions accumulates `..aggregations` and `mutate_stuff`; in summarize() we apply aggregations and then mutate on the result. If expressions in the `mutate_stuff` reference columns in the original data and not just the result of aggregations, we reject it.

Here, if there are aggregations, we apply them on a copy of the query up to that point, and join the result back onto the query, then apply the mutations on that. It's not a problem for those mutate expressions to reference both columns in the original data and the results of the aggregations because both are present.

There are ~three~ two caveats:

* Join has non-deterministic order, so while `mutate()` doesn't generally affect row order, if this code path is activated, row order may not be stable. With datasets, it's not guaranteed anyway.
* ~Acero's join seems to have a limitation currently where missing values are not joined to each other. If your join key has NA in it, and you do a left_join, your new columns will all be NA, even if there is a corresponding value in the right dataset. I made https://github.com/apache/arrow/issues/41358 to address that, and in the meantime, I've added a workaround (https://github.com/apache/arrow/pull/41350/commits/b9de50452e926fe5f39aeb3887a04e203302b960) that's not awesome but has the right behavior.~ Fixed and rebased.
* I believe it is possible in dplyr to get this behavior in other verbs: filter, arrange, even summarize. I've only done this for mutate. Are we ok with that? 

### Are these changes tested?

Yes

### Are there any user-facing changes?

This works now:

``` r
library(arrow)
library(dplyr)

mtcars |>
  arrow_table() |>
  select(cyl, mpg, hp) |>
  group_by(cyl) |>
  mutate(stdize_mpg = (mpg - mean(mpg)) / sd(mpg)) |>
  collect()
#> # A tibble: 32 × 4
#> # Groups:   cyl [3]
#>      cyl   mpg    hp stdize_mpg
#>    <dbl> <dbl> <dbl>      <dbl>
#>  1     6  21     110      0.865
#>  2     6  21     110      0.865
#>  3     4  22.8    93     -0.857
#>  4     6  21.4   110      1.14 
#>  5     8  18.7   175      1.41 
#>  6     6  18.1   105     -1.13 
#>  7     8  14.3   245     -0.312
#>  8     4  24.4    62     -0.502
#>  9     4  22.8    95     -0.857
#> 10     6  19.2   123     -0.373
#> # ℹ 22 more rows
```

<sup>Created on 2024-04-23 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

* GitHub Issue: #29537