### PR TITLE
GH-33484: [C++][Compute] Implement `Grouper::Reset`

### DIFF
--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -592,6 +592,11 @@ void TestSegments(std::unique_ptr<RowSegmenter>& segmenter, const ExecSpan& batc
     ASSERT_EQ(expected_segment, segment);
     offset = segment.offset + segment.length;
   }
+  // Assert next is the last (empty) segment.
+  ASSERT_OK_AND_ASSIGN(auto segment, segmenter->GetNextSegment(batch, offset));
+  ASSERT_TRUE(segment.offset >= batch.length);
+  ASSERT_TRUE(segment.is_open);
+  ASSERT_TRUE(segment.extends);
 }
 
 Result<std::unique_ptr<Grouper>> MakeGrouper(const std::vector<TypeHolder>& key_types) {
@@ -682,48 +687,142 @@ TEST(RowSegmenter, Basics) {
 }
 
 TEST(RowSegmenter, NonOrdered) {
-  std::vector<TypeHolder> types = {int32()};
-  auto batch = ExecBatchFromJSON(types, "[[1], [1], [2], [1], [2]]");
-  ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
-  TestSegments(segmenter, ExecSpan(batch),
-               {{0, 2, false, true},
-                {2, 1, false, false},
-                {3, 1, false, false},
-                {4, 1, true, false},
-                {5, 0, true, true}});
+  {
+    std::vector<TypeHolder> types = {int32()};
+    auto batch = ExecBatchFromJSON(types, "[[1], [1], [2], [1], [2]]");
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batch),
+                 {{0, 2, false, true},
+                  {2, 1, false, false},
+                  {3, 1, false, false},
+                  {4, 1, true, false},
+                  {5, 0, true, true}});
+  }
+  {
+    std::vector<TypeHolder> types = {int32(), int32()};
+    auto batch = ExecBatchFromJSON(types, "[[1, 1], [1, 1], [2, 2], [1, 2], [2, 2]]");
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batch),
+                 {{0, 2, false, true},
+                  {2, 1, false, false},
+                  {3, 1, false, false},
+                  {4, 1, true, false},
+                  {5, 0, true, true}});
+  }
 }
 
 TEST(RowSegmenter, EmptyBatches) {
-  std::vector<TypeHolder> types = {int32()};
-  std::vector<ExecBatch> batches = {
-      ExecBatchFromJSON(types, "[]"),         ExecBatchFromJSON(types, "[]"),
-      ExecBatchFromJSON(types, "[[1]]"),      ExecBatchFromJSON(types, "[]"),
-      ExecBatchFromJSON(types, "[[1]]"),      ExecBatchFromJSON(types, "[]"),
-      ExecBatchFromJSON(types, "[[2], [2]]"), ExecBatchFromJSON(types, "[]"),
-  };
-  ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
-  TestSegments(segmenter, ExecSpan(batches[0]), {});
-  TestSegments(segmenter, ExecSpan(batches[1]), {});
-  TestSegments(segmenter, ExecSpan(batches[2]), {{0, 1, true, true}});
-  TestSegments(segmenter, ExecSpan(batches[3]), {});
-  TestSegments(segmenter, ExecSpan(batches[4]), {{0, 1, true, true}});
-  TestSegments(segmenter, ExecSpan(batches[5]), {});
-  TestSegments(segmenter, ExecSpan(batches[6]), {{0, 2, true, false}});
-  TestSegments(segmenter, ExecSpan(batches[7]), {});
+  {
+    std::vector<TypeHolder> types = {int32()};
+    std::vector<ExecBatch> batches = {
+        ExecBatchFromJSON(types, "[]"),         ExecBatchFromJSON(types, "[]"),
+        ExecBatchFromJSON(types, "[[1]]"),      ExecBatchFromJSON(types, "[]"),
+        ExecBatchFromJSON(types, "[[1]]"),      ExecBatchFromJSON(types, "[]"),
+        ExecBatchFromJSON(types, "[[2], [2]]"), ExecBatchFromJSON(types, "[]"),
+    };
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batches[0]), {});
+    TestSegments(segmenter, ExecSpan(batches[1]), {});
+    TestSegments(segmenter, ExecSpan(batches[2]), {{0, 1, true, true}});
+    TestSegments(segmenter, ExecSpan(batches[3]), {});
+    TestSegments(segmenter, ExecSpan(batches[4]), {{0, 1, true, true}});
+    TestSegments(segmenter, ExecSpan(batches[5]), {});
+    TestSegments(segmenter, ExecSpan(batches[6]), {{0, 2, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[7]), {});
+  }
+  {
+    std::vector<TypeHolder> types = {int32(), int32()};
+    std::vector<ExecBatch> batches = {
+        ExecBatchFromJSON(types, "[]"),
+        ExecBatchFromJSON(types, "[]"),
+        ExecBatchFromJSON(types, "[[1, 1]]"),
+        ExecBatchFromJSON(types, "[]"),
+        ExecBatchFromJSON(types, "[[1, 1]]"),
+        ExecBatchFromJSON(types, "[]"),
+        ExecBatchFromJSON(types, "[[2, 2], [2, 2]]"),
+        ExecBatchFromJSON(types, "[]"),
+    };
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batches[0]), {});
+    TestSegments(segmenter, ExecSpan(batches[1]), {});
+    TestSegments(segmenter, ExecSpan(batches[2]), {{0, 1, true, true}});
+    TestSegments(segmenter, ExecSpan(batches[3]), {});
+    TestSegments(segmenter, ExecSpan(batches[4]), {{0, 1, true, true}});
+    TestSegments(segmenter, ExecSpan(batches[5]), {});
+    TestSegments(segmenter, ExecSpan(batches[6]), {{0, 2, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[7]), {});
+  }
 }
 
 TEST(RowSegmenter, MultipleSegments) {
-  std::vector<TypeHolder> types = {int32()};
-  auto batch = ExecBatchFromJSON(types, "[[1], [1], [2], [5], [3], [3], [5], [5], [4]]");
-  ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
-  TestSegments(segmenter, ExecSpan(batch),
-               {{0, 2, false, true},
-                {2, 1, false, false},
-                {3, 1, false, false},
-                {4, 2, false, false},
-                {6, 2, false, false},
-                {8, 1, true, false},
-                {9, 0, true, true}});
+  {
+    std::vector<TypeHolder> types = {int32()};
+    auto batch =
+        ExecBatchFromJSON(types, "[[1], [1], [2], [5], [3], [3], [5], [5], [4]]");
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batch),
+                 {{0, 2, false, true},
+                  {2, 1, false, false},
+                  {3, 1, false, false},
+                  {4, 2, false, false},
+                  {6, 2, false, false},
+                  {8, 1, true, false},
+                  {9, 0, true, true}});
+  }
+  {
+    std::vector<TypeHolder> types = {int32(), int32()};
+    auto batch = ExecBatchFromJSON(
+        types,
+        "[[1, 1], [1, 1], [2, 2], [5, 5], [3, 3], [3, 3], [5, 5], [5, 5], [4, 4]]");
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batch),
+                 {{0, 2, false, true},
+                  {2, 1, false, false},
+                  {3, 1, false, false},
+                  {4, 2, false, false},
+                  {6, 2, false, false},
+                  {8, 1, true, false},
+                  {9, 0, true, true}});
+  }
+}
+
+TEST(RowSegmenter, MultipleSegmentsMultipleBatches) {
+  {
+    std::vector<TypeHolder> types = {int32()};
+    std::vector<ExecBatch> batches = {
+        ExecBatchFromJSON(types, "[[1]]"), ExecBatchFromJSON(types, "[[1], [2]]"),
+        ExecBatchFromJSON(types, "[[5], [3]]"),
+        ExecBatchFromJSON(types, "[[3], [5], [5]]"), ExecBatchFromJSON(types, "[[4]]")};
+
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batches[0]), {{0, 1, true, true}});
+    TestSegments(segmenter, ExecSpan(batches[1]),
+                 {{0, 1, false, true}, {1, 1, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[2]),
+                 {{0, 1, false, false}, {1, 1, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[3]),
+                 {{0, 1, false, true}, {1, 2, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[4]), {{0, 1, true, false}});
+  }
+  {
+    std::vector<TypeHolder> types = {int32(), int32()};
+    std::vector<ExecBatch> batches = {
+        ExecBatchFromJSON(types, "[[1, 1]]"),
+        ExecBatchFromJSON(types, "[[1, 1], [2, 2]]"),
+        ExecBatchFromJSON(types, "[[5, 5], [3, 3]]"),
+        ExecBatchFromJSON(types, "[[3, 3], [5, 5], [5, 5]]"),
+        ExecBatchFromJSON(types, "[[4, 4]]")};
+
+    ASSERT_OK_AND_ASSIGN(auto segmenter, MakeRowSegmenter(types));
+    TestSegments(segmenter, ExecSpan(batches[0]), {{0, 1, true, true}});
+    TestSegments(segmenter, ExecSpan(batches[1]),
+                 {{0, 1, false, true}, {1, 1, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[2]),
+                 {{0, 1, false, false}, {1, 1, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[3]),
+                 {{0, 1, false, true}, {1, 2, true, false}});
+    TestSegments(segmenter, ExecSpan(batches[4]), {{0, 1, true, false}});
+  }
 }
 
 namespace {

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -594,7 +594,7 @@ void TestSegments(std::unique_ptr<RowSegmenter>& segmenter, const ExecSpan& batc
   }
   // Assert next is the last (empty) segment.
   ASSERT_OK_AND_ASSIGN(auto segment, segmenter->GetNextSegment(batch, offset));
-  ASSERT_TRUE(segment.offset >= batch.length);
+  ASSERT_GE(segment.offset, batch.length);
   ASSERT_TRUE(segment.is_open);
   ASSERT_TRUE(segment.extends);
 }

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -595,6 +595,7 @@ void TestSegments(std::unique_ptr<RowSegmenter>& segmenter, const ExecSpan& batc
   // Assert next is the last (empty) segment.
   ASSERT_OK_AND_ASSIGN(auto segment, segmenter->GetNextSegment(batch, offset));
   ASSERT_GE(segment.offset, batch.length);
+  ASSERT_EQ(segment.length, 0);
   ASSERT_TRUE(segment.is_open);
   ASSERT_TRUE(segment.extends);
 }

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -223,12 +223,11 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
 
   AnyKeysSegmenter(const std::vector<TypeHolder>& key_types, ExecContext* ctx)
       : BaseRowSegmenter(key_types),
-        ctx_(ctx),
-        grouper_(nullptr),
+        grouper_(Grouper::Make(key_types, ctx).ValueOrDie()),
         save_group_id_(kNoGroupId) {}
 
   Status Reset() override {
-    grouper_ = nullptr;
+    ARROW_RETURN_NOT_OK(grouper_->Reset());
     save_group_id_ = kNoGroupId;
     return Status::OK();
   }
@@ -245,7 +244,6 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
   // first row of a new segment to see if it extends the previous segment.
   template <typename Batch>
   Result<group_id_t> MapGroupIdAt(const Batch& batch, int64_t offset) {
-    if (!grouper_) return kNoGroupId;
     ARROW_ASSIGN_OR_RAISE(auto datum, grouper_->Consume(batch, offset,
                                                         /*length=*/1));
     if (!datum.is_array()) {
@@ -264,9 +262,6 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
     if (offset == batch.length) {
       return MakeSegment(batch.length, offset, 0, kEmptyExtends);
     }
-    // ARROW-18311: make Grouper support Reset()
-    // so it can be reset instead of recreated below
-    //
     // the group id must be computed prior to resetting the grouper, since it is compared
     // to save_group_id_, and after resetting the grouper produces incomparable group ids
     ARROW_ASSIGN_OR_RAISE(auto group_id, MapGroupIdAt(batch, offset));
@@ -276,7 +271,7 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
       return extends;
     };
     // resetting drops grouper's group-ids, freeing-up memory for the next segment
-    ARROW_ASSIGN_OR_RAISE(grouper_, Grouper::Make(key_types_, ctx_));  // TODO: reset it
+    ARROW_RETURN_NOT_OK(grouper_->Reset());
     // GH-34475: cache the grouper-consume result across invocations of GetNextSegment
     ARROW_ASSIGN_OR_RAISE(auto datum, grouper_->Consume(batch, offset));
     if (datum.is_array()) {
@@ -299,7 +294,6 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
   }
 
  private:
-  ExecContext* const ctx_;
   std::unique_ptr<Grouper> grouper_;
   group_id_t save_group_id_;
 };
@@ -354,6 +348,7 @@ struct GrouperNoKeysImpl : Grouper {
     RETURN_NOT_OK(builder->Finish(&array));
     return std::move(array);
   }
+  Status Reset() override { return Status::OK(); }
   Result<Datum> Consume(const ExecSpan& batch, int64_t offset, int64_t length) override {
     ARROW_ASSIGN_OR_RAISE(auto array, MakeConstantGroupIdArray(length, 0));
     return Datum(array);
@@ -417,6 +412,14 @@ struct GrouperImpl : public Grouper {
     }
 
     return std::move(impl);
+  }
+
+  Status Reset() override {
+    map_.clear();
+    offsets_.clear();
+    key_bytes_.clear();
+    num_groups_ = 0;
+    return Status::OK();
   }
 
   Result<Datum> Consume(const ExecSpan& batch, int64_t offset, int64_t length) override {
@@ -595,7 +598,13 @@ struct GrouperFastImpl : public Grouper {
     return std::move(impl);
   }
 
-  ~GrouperFastImpl() { map_.cleanup(); }
+  Status Reset() override {
+    rows_.Clean();
+    rows_minibatch_.Clean();
+    map_.cleanup();
+    RETURN_NOT_OK(map_.init(encode_ctx_.hardware_flags, ctx_->memory_pool()));
+    return Status::OK();
+  }
 
   Result<Datum> Consume(const ExecSpan& batch, int64_t offset, int64_t length) override {
     ARROW_RETURN_NOT_OK(CheckAndCapLengthForConsume(batch.length, offset, &length));
@@ -838,8 +847,7 @@ struct GrouperFastImpl : public Grouper {
     return out;
   }
 
-  static constexpr int log_minibatch_max_ = 10;
-  static constexpr int minibatch_size_max_ = 1 << log_minibatch_max_;
+  static constexpr int minibatch_size_max_ = arrow::util::MiniBatch::kMiniBatchLength;
   static constexpr int minibatch_size_min_ = 128;
   int minibatch_size_;
 

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -604,6 +604,10 @@ struct GrouperFastImpl : public Grouper {
     rows_minibatch_.Clean();
     map_.cleanup();
     RETURN_NOT_OK(map_.init(encode_ctx_.hardware_flags, ctx_->memory_pool()));
+    // TODO: It is now assumed that the dictionaries_ are identical to the first batch
+    // throughout the grouper's lifespan so no resetting is needed. But if we want to
+    // support different dictionaries for different batches, we need to reset the
+    // dictionaries_ here.
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/row/grouper.h
+++ b/cpp/src/arrow/compute/row/grouper.h
@@ -109,6 +109,10 @@ class ARROW_EXPORT Grouper {
   static Result<std::unique_ptr<Grouper>> Make(const std::vector<TypeHolder>& key_types,
                                                ExecContext* ctx = default_exec_context());
 
+  /// Reset all intermidiate state, make the grouper logically as just `Make`ed.
+  /// The underlying buffers, if any, may or may not be released though.
+  virtual Status Reset() = 0;
+
   /// Consume a batch of keys, producing the corresponding group ids as an integer array,
   /// over a slice defined by an offset and length, which defaults to the batch length.
   /// Currently only uint32 indices will be produced, eventually the bit width will only

--- a/cpp/src/arrow/compute/row/grouper.h
+++ b/cpp/src/arrow/compute/row/grouper.h
@@ -109,7 +109,7 @@ class ARROW_EXPORT Grouper {
   static Result<std::unique_ptr<Grouper>> Make(const std::vector<TypeHolder>& key_types,
                                                ExecContext* ctx = default_exec_context());
 
-  /// Reset all intermidiate state, make the grouper logically as just `Make`ed.
+  /// Reset all intermediate state, make the grouper logically as just `Make`ed.
   /// The underlying buffers, if any, may or may not be released though.
   virtual Status Reset() = 0;
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Recently I've been working on some improvement for `Grouper` and I found adding `Reset` function could be beneficial. Then I trace down to #33484 from a TODO in code. Here comes this PR.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Add `Reset` function for all the concrete `Grouper` implementations, and eliminate the recreation of `Grouper` in `AnyKeysSegmenter`.

Also add more `RowSegmenter` cases covering `AnyKeysSegmenter`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. Legacy UTs should cover it well. Also added some new UTs.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #33484