### PR TITLE
GH-41353: [C++] Define bit_width and byte_width of ExtensionType in terms of the storage type

### DIFF
--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -54,6 +54,9 @@ class ARROW_EXPORT ExtensionType : public DataType {
 
   std::string name() const override { return "extension"; }
 
+  int32_t byte_width() const override { return storage_type_->byte_width(); }
+  int bit_width() const override { return storage_type_->bit_width(); }
+
   /// \brief Unique name of extension type used to identify type for
   /// serialization
   /// \return the string name of the extension

--- a/cpp/src/arrow/extension_type_test.cc
+++ b/cpp/src/arrow/extension_type_test.cc
@@ -196,6 +196,8 @@ TEST_F(TestExtensionType, ExtensionTypeTest) {
 
   auto type = uuid();
   ASSERT_EQ(type->id(), Type::EXTENSION);
+  ASSERT_EQ(type->bit_width(), 128);
+  ASSERT_EQ(type->byte_width(), 16);
 
   const auto& ext_type = static_cast<const ExtensionType&>(*type);
   std::string serialized = ext_type.Serialize();
@@ -204,6 +206,9 @@ TEST_F(TestExtensionType, ExtensionTypeTest) {
                        ext_type.Deserialize(fixed_size_binary(16), serialized));
   ASSERT_TRUE(deserialized->Equals(*type));
   ASSERT_FALSE(deserialized->Equals(*fixed_size_binary(16)));
+  ASSERT_EQ(deserialized->id(), Type::EXTENSION);
+  ASSERT_EQ(deserialized->bit_width(), 128);
+  ASSERT_EQ(deserialized->byte_width(), 16);
 }
 
 auto RoundtripBatch = [](const std::shared_ptr<RecordBatch>& batch,


### PR DESCRIPTION
### Rationale for this change

Users and other classes within Arrow itself (e.g. array builders) expect extension types to behave like their underlying storage type.

As it is now, `ExtensionType::bit_width()` is the default `DataType::bit_width()` implementation which returns `-1`. It should return the storage type's bit-width.

### What changes are included in this PR?

Definition of `ExtensionType::bit_width/byte_width` functions.

### Are these changes tested?

Tests added and confirmed to fail prior to these changes.

### Are there any user-facing changes?

`ExtensionType` now define `bit_width` and `byte_width` according to their storage type.
* GitHub Issue: #41353