### PR TITLE
GH-41336: [C++][Compute] Fix the bug of decimal types skipping cast in IfElse related expression function calls

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -992,32 +992,6 @@ TEST(Expression, ExecuteCallWithDecimalIfElseOps) {
       {"a1": "45.3", "a2": -30, "a3": "0.00"}
     ])"));
   }
-
-  // choose
-  {
-    // decimal128(3,3), decimal256(2,1) --> output_type: decimal256(5, 3)
-    ExpectExecute(
-        call("coalesce", {field_ref("idx"), field_ref("a1"), field_ref("a2")}),
-        ArrayFromJSON(struct_({field("idx", int64()), field("a1", decimal128(3, 3)),
-                               field("a2", decimal128(2, 1))}),
-                      R"([
-      {"idx": 0, "a1": "1.123", "a2": "2.3"},
-      {"idx": 1, "a1": null, "a2": "-3.3"},
-      {"idx": 0, "a1": "-1.230", "a2": "0.0"},
-      {"idx": null, "a1": "-1.230", "a2": "0.0"}
-    ])"));
-
-    // decimal128(3,3), float32() --> output_type: decimal128(3, 3)
-    ExpectExecute(
-        call("coalesce", {field_ref("idx"), field_ref("a1"), field_ref("a2")}),
-        ArrayFromJSON(struct_({field("idx", int64()), field("a1", decimal128(3, 3)),
-                               field("a2", float32())}),
-                      R"([
-      {"idx": null, "a1": "1.123", "a2": 2.3},
-      {"idx": 1, "a1": null, "a2": -3.3},
-      {"idx": 0, "a1": "-1.230", "a2": 0.0}
-    ])"));
-  }
 }
 
 TEST(Expression, ExecuteCallWithNoArguments) {

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -2773,10 +2773,9 @@ void AddPrimitiveCoalesceKernels(const std::shared_ptr<ScalarFunction>& scalar_f
 
 void AddChooseKernel(const std::shared_ptr<ScalarFunction>& scalar_function,
                      detail::GetTypeId get_id, ArrayKernelExec exec) {
-  ScalarKernel kernel(
-      KernelSignature::Make({Type::INT64, InputType(get_id.id)}, ResolveOutputType,
-                            /*is_varargs=*/true),
-      exec);
+  ScalarKernel kernel(KernelSignature::Make({Type::INT64, InputType(get_id.id)}, LastType,
+                                            /*is_varargs=*/true),
+                      exec);
   kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
   kernel.mem_allocation = MemAllocation::PREALLOCATE;
   kernel.can_write_into_slices = is_fixed_width(get_id.id);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
 Fix the bug of decimal types skipping cast in IfElse related expression function calls

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
1. Added the output resolver for the IfElse related kernel functions : `if_else`, `case_when`, `coalesce`.
    Output resolver will make sure the input decimal types casted correctly by their `DispatchBest` in expression call.
2. Added the tests include the combination of the decimal types and other numeric types to make sure they can be
    cast and execute correctly as `CallFunction`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No

Co-authored-by ZhangHuiGui [2689496754@qq.com](mailto:2689496754@qq.com)
Co-authored-by laotan332 [qinpengxiang@outlook.com](mailto:qinpengxiang@outlook.com)
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41336