### PR TITLE
GH-41356: [Release][Docs] Update post release documentation task to remove the warnings banner for stable version

### DIFF
--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -60,21 +60,6 @@ for versioned_path in docs/*.0/; do
   versioned_paths+=(${versioned_path})
   rm -rf ${versioned_path}
 done
-
-# Update DOCUMENTATION_OPTIONS.show_version_warning_banner
-# for dev docs (becoming stable docs)
-pushd docs/dev
-find ./ \
-  -type f \
-  -exec \
-    sed -i.bak \
-      -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
-      {} \;
-find ./ -name '*.bak' -delete
-popd
-git add docs/dev
-git commit -m "[Website] Update warning banner for dev docs"
-
 # add to list and remove dev docs
 versioned_paths+=("docs/dev/")
 rm -rf docs/dev/
@@ -94,6 +79,29 @@ curl \
   https://apache.jfrog.io/artifactory/arrow/docs/${version}/docs.tar.gz
 tar xvf docs.tar.gz
 rm -f docs.tar.gz
+
+# Update DOCUMENTATION_OPTIONS.show_version_warning_banner for stable docs
+pushd docs
+find ./ \
+  -maxdepth 1 \
+  -type f \
+  -exec \
+    sed -i.bak \
+      -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
+      {} \;
+find ./ -name '*.bak' -delete
+find /c_glib /cpp /developers /format /java /python  \
+  -type f \
+  -exec \
+    sed -i.bak \
+      -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
+      {} \;
+find ./ -name '*.bak' -delete
+popd
+git add docs
+git commit -m "[Website] Update warning banner for stable docs"
+
+git checkout docs/c_glib/index.html
 if [ "$is_major_release" = "yes" ] ; then
   previous_series=${previous_version%.*}
   mv docs_temp docs/${previous_series}

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -72,25 +72,18 @@ fi
 # delete current stable docs and restore all previous versioned docs
 rm -rf docs/*
 git checkout "${versioned_paths[@]}"
+# Download and untare released docs in a temp folder
+rm -rf docs_new
+mkdir docs_new
+pushd docs_new
 curl \
   --fail \
   --location \
   --remote-name \
   https://apache.jfrog.io/artifactory/arrow/docs/${version}/docs.tar.gz
 tar xvf docs.tar.gz
-rm -f docs.tar.gz
-
-# Update DOCUMENTATION_OPTIONS.show_version_warning_banner for stable docs
-pushd docs
-find ./ \
-  -maxdepth 1 \
-  -type f \
-  -exec \
-    sed -i.bak \
-      -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
-      {} \;
-find ./ -name '*.bak' -delete
-find /c_glib /cpp /developers /format /java /python  \
+# Update DOCUMENTATION_OPTIONS.show_version_warning_banner
+find docs \
   -type f \
   -exec \
     sed -i.bak \
@@ -98,8 +91,8 @@ find /c_glib /cpp /developers /format /java /python  \
       {} \;
 find ./ -name '*.bak' -delete
 popd
-git add docs
-git commit -m "[Website] Update warning banner for stable docs"
+mv docs_new/docs/* docs/
+rm -rf docs_new
 
 if [ "$is_major_release" = "yes" ] ; then
   previous_series=${previous_version%.*}

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -60,6 +60,21 @@ for versioned_path in docs/*.0/; do
   versioned_paths+=(${versioned_path})
   rm -rf ${versioned_path}
 done
+
+# Update DOCUMENTATION_OPTIONS.show_version_warning_banner
+# for dev docs (becoming stable docs)
+pushd docs/dev
+find ./ \
+  -type f \
+  -exec \
+    sed -i.bak \
+      -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
+      {} \;
+find ./ -name '*.bak' -delete
+popd
+git add docs/dev
+git commit -m "[Website] Update warning banner for dev docs"
+
 # add to list and remove dev docs
 versioned_paths+=("docs/dev/")
 rm -rf docs/dev/

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -72,7 +72,7 @@ fi
 # delete current stable docs and restore all previous versioned docs
 rm -rf docs/*
 git checkout "${versioned_paths[@]}"
-# Download and untare released docs in a temp folder
+# Download and untar released docs in a temp folder
 rm -rf docs_new
 mkdir docs_new
 pushd docs_new

--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -101,7 +101,6 @@ popd
 git add docs
 git commit -m "[Website] Update warning banner for stable docs"
 
-git checkout docs/c_glib/index.html
 if [ "$is_major_release" = "yes" ] ; then
   previous_series=${previous_version%.*}
   mv docs_temp docs/${previous_series}


### PR DESCRIPTION
### Rationale for this change

With every release dev documentation is moved to `docs/` and becomes stable version of the documentation but the  version warnings banner is still present.

### What changes are included in this PR?

This PR removes the banner before the dev docs are copied to the `docs/` folder.

### Are these changes tested?

Not yet.

### Are there any user-facing changes?

No.
* GitHub Issue: #41356