### PR TITLE
GH-41371: [CI][Release] Use the latest Ruby on macOS

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -109,9 +109,9 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install Ruby
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: ruby
       - name: Install .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:


### PR DESCRIPTION
### Rationale for this change

Ruby 2.7 doesn't exist on `macos-latest` (`macos-14`).

### What changes are included in this PR?

Use `ruby` as the Ruby version to use the latest Ruby.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41371