### PR TITLE
GH-41529: [C++][Compute] Remove redundant logic for ArrayData as ExecResults in ExecScalarCaseWhen

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1483,39 +1483,21 @@ Status ExecScalarCaseWhen(KernelContext* ctx, const ExecSpan& batch, ExecResult*
     result = temp.get();
   }
 
-  // TODO(wesm): clean this up to have less duplication
-  if (out->is_array_data()) {
-    ArrayData* output = out->array_data().get();
-    if (is_dictionary_type<Type>::value) {
-      const ExecValue& dict_from = has_result ? result : batch[1];
-      if (dict_from.is_scalar()) {
-        output->dictionary = checked_cast<const DictionaryScalar&>(*dict_from.scalar)
-                                 .value.dictionary->data();
-      } else {
-        output->dictionary = dict_from.array.ToArrayData()->dictionary;
-      }
+  ArraySpan* output = out->array_span_mutable();
+  if (is_dictionary_type<Type>::value) {
+    const ExecValue& dict_from = has_result ? result : batch[1];
+    output->child_data.resize(1);
+    if (dict_from.is_scalar()) {
+      output->child_data[0].SetMembers(
+          *checked_cast<const DictionaryScalar&>(*dict_from.scalar)
+               .value.dictionary->data());
+    } else {
+      output->child_data[0] = dict_from.array;
     }
-    CopyValues<Type>(result, /*in_offset=*/0, batch.length,
-                     output->GetMutableValues<uint8_t>(0, 0),
-                     output->GetMutableValues<uint8_t>(1, 0), output->offset);
-  } else {
-    // ArraySpan
-    ArraySpan* output = out->array_span_mutable();
-    if (is_dictionary_type<Type>::value) {
-      const ExecValue& dict_from = has_result ? result : batch[1];
-      output->child_data.resize(1);
-      if (dict_from.is_scalar()) {
-        output->child_data[0].SetMembers(
-            *checked_cast<const DictionaryScalar&>(*dict_from.scalar)
-                 .value.dictionary->data());
-      } else {
-        output->child_data[0] = dict_from.array;
-      }
-    }
-    CopyValues<Type>(result, /*in_offset=*/0, batch.length,
-                     output->GetValues<uint8_t>(0, 0), output->GetValues<uint8_t>(1, 0),
-                     output->offset);
   }
+  CopyValues<Type>(result, /*in_offset=*/0, batch.length,
+                   output->GetValues<uint8_t>(0, 0), output->GetValues<uint8_t>(1, 0),
+                   output->offset);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1483,6 +1483,12 @@ Status ExecScalarCaseWhen(KernelContext* ctx, const ExecSpan& batch, ExecResult*
     result = temp.get();
   }
 
+  // Only input types of non-fixed length (which cannot be pre-allocated)
+  // will save the output data in ArrayData. And make sure the FixedLength
+  // types must be output in ArraySpan.
+  static_assert(is_fixed_width(Type::type_id));
+  DCHECK(out->is_array_span());
+
   ArraySpan* output = out->array_span_mutable();
   if (is_dictionary_type<Type>::value) {
     const ExecValue& dict_from = has_result ? result : batch[1];


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Remove useless path in `ExecScalarCaseWhen`

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Refactor : remove processing logic for ArrayData as ExecResults in ExecScalarCaseWhen.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes, by exists.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41529