### PR TITLE
GH-41370: [CI][MATLAB] MATLAB macOS CI workflow fails because of `macos-latest` change to `macos-14`

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -98,7 +98,7 @@ jobs:
           select-by-folder: matlab/test
   macos:
     name: AMD64 macOS 12 MATLAB
-    runs-on: macos-latest
+    runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
       - name: Check out repository

--- a/dev/tasks/matlab/github.yml
+++ b/dev/tasks/matlab/github.yml
@@ -60,7 +60,7 @@ jobs:
 
   macos:
     name: AMD64 macOS 12 MATLAB
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       - name: Install ninja-build


### PR DESCRIPTION
### Rationale for this change

* The MATLAB macOS CI workflow is failing because of the recent change to `macos-latest` from `macos-12` to `macos-14`.
* In https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/ it is mentioned that the transition to `macos-14` was planned for April-June 2024.
* As noted in the [Platform Road Map](https://www.mathworks.com/support/requirements/platform-road-map.html), MATLAB R2023a is not officially supported with `macos-14`.
* Until we can move to building against MATLAB R2024a (latest available version of MATLAB), it makes sense to pin back the macOS version to version 14.

### What changes are included in this PR?

1. Pin back MATLAB CI workflow to use `macos-12`.
2. Pin back MATLAB crossbow packaging workflow to use `macos-12`.

### Are these changes tested?

I will run a crossbow job and ensure that the MATLAB CI workflow passes successfully before merging this PR.

### Are there any user-facing changes?

No.

### Future Directions

1.  #41385

### Notes

1. Thanks @sgilmore10 for your help with this pull request!
* GitHub Issue: #41370