### PR TITLE
GH-41390: [CI] Use setup-python GitHub action on csharp macOS job

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -94,7 +94,7 @@ jobs:
         run: ci/scripts/csharp_test.sh $(pwd)
 
   macos:
-    name: AMD64 macOS 11 C# ${{ matrix.dotnet }}
+    name: ARM64 macOS 14 C# ${{ matrix.dotnet }}
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -107,6 +107,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - name: Setup Python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: 3.12
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Rationale for this change

The new macos-latest GH runner has changed and jobs are currently failing.

### What changes are included in this PR?

Install python with setup-python.

### Are these changes tested?

Will be on CI

### Are there any user-facing changes?
No
* GitHub Issue: #41390