### PR TITLE
GH-41405: [Release][Docs][GLib] Use Sphinx based GLib front page

### DIFF
--- a/dev/release/post-08-docs.sh
+++ b/dev/release/post-08-docs.sh
@@ -79,7 +79,6 @@ curl \
   https://apache.jfrog.io/artifactory/arrow/docs/${version}/docs.tar.gz
 tar xvf docs.tar.gz
 rm -f docs.tar.gz
-git checkout docs/c_glib/index.html
 if [ "$is_major_release" = "yes" ] ; then
   previous_series=${previous_version%.*}
   mv docs_temp docs/${previous_series}


### PR DESCRIPTION
### Rationale for this change

We should use the GLib front page generated by Sphinx.

### What changes are included in this PR?

Stop reverting the GLib front page change in release script.

### Are these changes tested?

No.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #41405