### PR TITLE
GH-41398: [R][CI] Windows job failing after R 4.4 release

### DIFF
--- a/r/src/extension-impl.cpp
+++ b/r/src/extension-impl.cpp
@@ -87,7 +87,7 @@ arrow::Result<std::shared_ptr<arrow::DataType>> RExtensionType::Deserialize(
   return std::shared_ptr<RExtensionType>(cloned.release());
 }
 
-std::string RExtensionType::ToString() const {
+std::string RExtensionType::ToString(bool show_metadata = false) const {
   arrow::Result<std::string> result = SafeCallIntoR<std::string>([&]() {
     cpp11::environment instance = r6_instance();
     cpp11::function instance_ToString(instance["ToString"]);
@@ -98,7 +98,7 @@ std::string RExtensionType::ToString() const {
   // In the event of an error (e.g., we are not on the main thread
   // and we are not inside RunWithCapturedR()), just call the default method
   if (!result.ok()) {
-    return ExtensionType::ToString();
+    return ExtensionType::ToString(show_metadata);
   } else {
     return result.ValueUnsafe();
   }

--- a/r/src/extension-impl.cpp
+++ b/r/src/extension-impl.cpp
@@ -87,11 +87,9 @@ arrow::Result<std::shared_ptr<arrow::DataType>> RExtensionType::Deserialize(
   return std::shared_ptr<RExtensionType>(cloned.release());
 }
 
-#if ARROW_VERSION_MAJOR >= 16
+std::string RExtensionType::ToString() const { return ToString(false); }
+
 std::string RExtensionType::ToString(bool show_metadata) const {
-#else
-std::string RExtensionType::ToString() const {
-#endif
   arrow::Result<std::string> result = SafeCallIntoR<std::string>([&]() {
     cpp11::environment instance = r6_instance();
     cpp11::function instance_ToString(instance["ToString"]);
@@ -102,7 +100,11 @@ std::string RExtensionType::ToString() const {
   // In the event of an error (e.g., we are not on the main thread
   // and we are not inside RunWithCapturedR()), just call the default method
   if (!result.ok()) {
+#if ARROW_VERSION_MAJOR >= 16
     return ExtensionType::ToString(show_metadata);
+#else
+    return ExtensionType::ToString();
+#endif
   } else {
     return result.ValueUnsafe();
   }

--- a/r/src/extension-impl.cpp
+++ b/r/src/extension-impl.cpp
@@ -87,7 +87,11 @@ arrow::Result<std::shared_ptr<arrow::DataType>> RExtensionType::Deserialize(
   return std::shared_ptr<RExtensionType>(cloned.release());
 }
 
+#if ARROW_VERSION_MAJOR >= 16
 std::string RExtensionType::ToString(bool show_metadata) const {
+#else
+std::string RExtensionType::ToString() const {
+#endif
   arrow::Result<std::string> result = SafeCallIntoR<std::string>([&]() {
     cpp11::environment instance = r6_instance();
     cpp11::function instance_ToString(instance["ToString"]);

--- a/r/src/extension-impl.cpp
+++ b/r/src/extension-impl.cpp
@@ -87,7 +87,7 @@ arrow::Result<std::shared_ptr<arrow::DataType>> RExtensionType::Deserialize(
   return std::shared_ptr<RExtensionType>(cloned.release());
 }
 
-std::string RExtensionType::ToString(bool show_metadata = false) const {
+std::string RExtensionType::ToString(bool show_metadata) const {
   arrow::Result<std::string> result = SafeCallIntoR<std::string>([&]() {
     cpp11::environment instance = r6_instance();
     cpp11::function instance_ToString(instance["ToString"]);

--- a/r/src/extension.h
+++ b/r/src/extension.h
@@ -52,11 +52,9 @@ class RExtensionType : public arrow::ExtensionType {
 
   std::string Serialize() const { return extension_metadata_; }
 
-#if ARROW_VERSION_MAJOR >= 16
   std::string ToString(bool show_metadata = false) const;
-#else
+  // wrapper for libarrow < 16
   std::string ToString() const;
-#endif
 
   cpp11::sexp Convert(const std::shared_ptr<arrow::ChunkedArray>& array) const;
 

--- a/r/src/extension.h
+++ b/r/src/extension.h
@@ -52,7 +52,11 @@ class RExtensionType : public arrow::ExtensionType {
 
   std::string Serialize() const { return extension_metadata_; }
 
+#if ARROW_VERSION_MAJOR >= 16
   std::string ToString(bool show_metadata = false) const;
+#else
+  std::string ToString() const;
+#endif
 
   cpp11::sexp Convert(const std::shared_ptr<arrow::ChunkedArray>& array) const;
 

--- a/r/src/extension.h
+++ b/r/src/extension.h
@@ -52,7 +52,7 @@ class RExtensionType : public arrow::ExtensionType {
 
   std::string Serialize() const { return extension_metadata_; }
 
-  std::string ToString() const;
+  std::string ToString(bool show_metadata = false) const;
 
   cpp11::sexp Convert(const std::shared_ptr<arrow::ChunkedArray>& array) const;
 


### PR DESCRIPTION
### Rationale for this change

We can't throw warnings on cran.

### What changes are included in this PR?

Update function to match changes in libarrow added in GH-39864

### Are these changes tested?

CI
### Are there any user-facing changes?

No

* GitHub Issue: #41398