### PR TITLE
MINOR: [Docs] Correct a small typo in archery docs

### DIFF
--- a/dev/archery/README.md
+++ b/dev/archery/README.md
@@ -23,7 +23,7 @@ Archery is documented on the Arrow website:
 
 * [Daily development using Archery](https://arrow.apache.org/docs/developers/continuous_integration/archery.html)
 * [Using Archery and Crossbow](https://arrow.apache.org/docs/developers/continuous_integration/crossbow.html)
-* [Using Archer and Docker](https://arrow.apache.org/docs/developers/continuous_integration/docker.html)
+* [Using Archery and Docker](https://arrow.apache.org/docs/developers/continuous_integration/docker.html)
 
 # Installing Archery
 


### PR DESCRIPTION
### Rationale for this change

The name is archery not archer 

### What changes are included in this PR?

`s/archer /archery/` 

### Are these changes tested?

No, docs only

### Are there any user-facing changes?

Yes, to the docs