### PR TITLE
GH-41389: [Python] Expose byte_width and bit_width of ExtensionType in terms of the storage type

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2801,6 +2801,8 @@ cdef extern from "arrow/extension_type.h" namespace "arrow":
     cdef cppclass CExtensionType" arrow::ExtensionType"(CDataType):
         c_string extension_name()
         shared_ptr[CDataType] storage_type()
+        int byte_width()
+        int bit_width()
 
         @staticmethod
         shared_ptr[CArray] WrapArray(shared_ptr[CDataType] ext_type,

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -290,7 +290,7 @@ def test_ext_type_bit_width():
     # Test for non fixed-size binary types
     ty = LabelType()
     with pytest.raises(ValueError, match="Non-fixed width type"):
-        _ = ty.byte_width
+        _ = ty.bit_width
 
 
 def test_ext_type_as_py():

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -277,20 +277,20 @@ def test_ext_type_byte_width():
     # Test for non fixed-size binary types
     ty = LabelType()
     with pytest.raises(ValueError, match="Non-fixed width type"):
-        _ = ty.storage_type.byte_width
+        _ = ty.byte_width
 
 
 def test_ext_type_bit_width():
     # Test for fixed-size binary types
     ty = UuidType()
-    assert ty.storage_type.bit_width == 128
+    assert ty.bit_width == 128
     ty = ParamExtType(5)
-    assert ty.storage_type.bit_width == 40
+    assert ty.bit_width == 40
 
     # Test for non fixed-size binary types
     ty = LabelType()
     with pytest.raises(ValueError, match="Non-fixed width type"):
-        _ = ty.storage_type.byte_width
+        _ = ty.byte_width
 
 
 def test_ext_type_as_py():

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -251,14 +251,14 @@ def test_ext_type_repr():
     assert repr(ty) == "IntegerType(DataType(int64))"
 
 
-def test_ext_type__lifetime():
+def test_ext_type_lifetime():
     ty = UuidType()
     wr = weakref.ref(ty)
     del ty
     assert wr() is None
 
 
-def test_ext_type__storage_type():
+def test_ext_type_storage_type():
     ty = UuidType()
     assert ty.storage_type == pa.binary(16)
     assert ty.__class__ is UuidType
@@ -267,14 +267,14 @@ def test_ext_type__storage_type():
     assert ty.__class__ is ParamExtType
 
 
-def test_ext_type__byte_width():
+def test_ext_type_byte_width():
     ty = UuidType()
     assert ty.storage_type.byte_width == 16
     ty = ParamExtType(5)
     assert ty.storage_type.byte_width == 5
 
 
-def test_ext_type__bit_width():
+def test_ext_type_bit_width():
     ty = UuidType()
     assert ty.storage_type.bit_width == 128
     ty = ParamExtType(5)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -268,17 +268,29 @@ def test_ext_type_storage_type():
 
 
 def test_ext_type_byte_width():
+    # Test for fixed-size binary types
     ty = UuidType()
     assert ty.storage_type.byte_width == 16
     ty = ParamExtType(5)
     assert ty.storage_type.byte_width == 5
 
+    # Test for non fixed-size binary types
+    ty = LabelType()
+    with pytest.raises(ValueError, match="Non-fixed width type"):
+        _ = ty.storage_type.byte_width
+
 
 def test_ext_type_bit_width():
+    # Test for fixed-size binary types
     ty = UuidType()
     assert ty.storage_type.bit_width == 128
     ty = ParamExtType(5)
     assert ty.storage_type.bit_width == 40
+
+    # Test for non fixed-size binary types
+    ty = LabelType()
+    with pytest.raises(ValueError, match="Non-fixed width type"):
+        _ = ty.storage_type.byte_width
 
 
 def test_ext_type_as_py():

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -267,6 +267,20 @@ def test_ext_type__storage_type():
     assert ty.__class__ is ParamExtType
 
 
+def test_ext_type__byte_width():
+    ty = UuidType()
+    assert ty.storage_type.byte_width == 16
+    ty = ParamExtType(5)
+    assert ty.storage_type.byte_width == 5
+
+
+def test_ext_type__bit_width():
+    ty = UuidType()
+    assert ty.storage_type.bit_width == 128
+    ty = ParamExtType(5)
+    assert ty.storage_type.bit_width == 40
+
+
 def test_ext_type_as_py():
     ty = UuidType()
     expected = uuid4()

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -270,9 +270,9 @@ def test_ext_type_storage_type():
 def test_ext_type_byte_width():
     # Test for fixed-size binary types
     ty = UuidType()
-    assert ty.storage_type.byte_width == 16
+    assert ty.byte_width == 16
     ty = ParamExtType(5)
-    assert ty.storage_type.byte_width == 5
+    assert ty.byte_width == 5
 
     # Test for non fixed-size binary types
     ty = LabelType()

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1524,6 +1524,8 @@ cdef class BaseExtensionType(DataType):
         """
         The byte width of the extension type.
         """
+        if self.ext_type.byte_width() == -1:
+            raise ValueError("Non-fixed width type")
         return self.ext_type.byte_width()
 
     @property
@@ -1531,6 +1533,8 @@ cdef class BaseExtensionType(DataType):
         """
         The bit width of the extension type.
         """
+        if self.ext_type.bit_width() == -1:
+            raise ValueError("Non-fixed width type")
         return self.ext_type.bit_width()
 
     def wrap_array(self, storage):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1519,6 +1519,20 @@ cdef class BaseExtensionType(DataType):
         """
         return pyarrow_wrap_data_type(self.ext_type.storage_type())
 
+    @property
+    def byte_width(self):
+        """
+        The byte width of the extension type.
+        """
+        return self.ext_type.byte_width()
+
+    @property
+    def bit_width(self):
+        """
+        The bit width of the extension type.
+        """
+        return self.ext_type.bit_width()
+
     def wrap_array(self, storage):
         """
         Wrap the given storage array as an extension array.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

This update aligns the Python API with Arrow C++ by exposing the actual byte and bit widths of extension types from their storage type.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Expose byte_width and bit_width properties for ExtensionType in Python, reflecting the underlying storage type.
- Add  unit tests to verify these properties

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41389