### PR TITLE
GH-41418: [C++] Add [Large]ListView and Map nested types for scalar_if_else's kernel functions

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -284,8 +284,11 @@ static void CaseWhenBench(benchmark::State& state) {
   state.SetItemsProcessed(state.iterations() * (len - offset));
 }
 
-static void CaseWhenBenchList(benchmark::State& state) {
-  auto type = list(int64());
+template <typename Type>
+static void CaseWhenBenchList(benchmark::State& state,
+                              const std::shared_ptr<DataType>& type) {
+  using ArrayType = typename TypeTraits<Type>::ArrayType;
+
   auto fld = field("", type);
 
   int64_t len = state.range(0);
@@ -295,17 +298,17 @@ static void CaseWhenBenchList(benchmark::State& state) {
 
   auto cond_field =
       field("cond", boolean(), key_value_metadata({{"null_probability", "0.01"}}));
-  auto cond = rand.ArrayOf(*field("", struct_({cond_field, cond_field, cond_field}),
-                                  key_value_metadata({{"null_probability", "0.0"}})),
-                           len);
-  auto val1 = rand.ArrayOf(*fld, len);
-  auto val2 = rand.ArrayOf(*fld, len);
-  auto val3 = rand.ArrayOf(*fld, len);
-  auto val4 = rand.ArrayOf(*fld, len);
+  auto cond = std::static_pointer_cast<BooleanArray>(
+                  rand.ArrayOf(*field("", struct_({cond_field, cond_field, cond_field}),
+                                      key_value_metadata({{"null_probability", "0.0"}})),
+                               len))
+                  ->Slice(offset);
+  auto val1 = std::static_pointer_cast<ArrayType>(rand.ArrayOf(*fld, len))->Slice(offset);
+  auto val2 = std::static_pointer_cast<ArrayType>(rand.ArrayOf(*fld, len))->Slice(offset);
+  auto val3 = std::static_pointer_cast<ArrayType>(rand.ArrayOf(*fld, len))->Slice(offset);
+  auto val4 = std::static_pointer_cast<ArrayType>(rand.ArrayOf(*fld, len))->Slice(offset);
   for (auto _ : state) {
-    ABORT_NOT_OK(
-        CaseWhen(cond->Slice(offset), {val1->Slice(offset), val2->Slice(offset),
-                                       val3->Slice(offset), val4->Slice(offset)}));
+    ABORT_NOT_OK(CaseWhen(cond, {val1, val2, val3, val4}));
   }
 
   // Set bytes processed to ~length of output
@@ -370,6 +373,21 @@ static void CaseWhenBenchString(benchmark::State& state) {
 
 static void CaseWhenBenchStringContiguous(benchmark::State& state) {
   return CaseWhenBenchContiguous<StringType>(state);
+}
+
+template <typename ListType, typename ValueType>
+static void CaseWhenBenchVarLengthListLike(benchmark::State& state) {
+  auto value_type = TypeTraits<ValueType>::type_singleton();
+  auto list_type = std::make_shared<ListType>(value_type);
+  return CaseWhenBenchList<ListType>(state, list_type);
+}
+
+static void CaseWhenBenchListInt64(benchmark::State& state) {
+  return CaseWhenBenchVarLengthListLike<ListType, Int64Type>(state);
+}
+
+static void CaseWhenBenchListViewInt64(benchmark::State& state) {
+  CaseWhenBenchVarLengthListLike<ListViewType, Int64Type>(state);
 }
 
 struct CoalesceParams {
@@ -533,9 +551,11 @@ BENCHMARK(CaseWhenBench64)->Args({kNumItems, 99});
 BENCHMARK(CaseWhenBench64Contiguous)->Args({kNumItems, 0});
 BENCHMARK(CaseWhenBench64Contiguous)->Args({kNumItems, 99});
 
-// CaseWhen: Lists
-BENCHMARK(CaseWhenBenchList)->Args({kFewItems, 0});
-BENCHMARK(CaseWhenBenchList)->Args({kFewItems, 99});
+// CaseWhen: List-like types
+BENCHMARK(CaseWhenBenchListInt64)->Args({kFewItems, 0});
+BENCHMARK(CaseWhenBenchListInt64)->Args({kFewItems, 99});
+BENCHMARK(CaseWhenBenchListViewInt64)->Args({kFewItems, 0});
+BENCHMARK(CaseWhenBenchListViewInt64)->Args({kFewItems, 99});
 
 // CaseWhen: Strings
 BENCHMARK(CaseWhenBenchString)->Args({kFewItems, 0});

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -896,6 +896,21 @@ TEST_F(TestIfElseKernel, ParameterizedTypes) {
                    {cond, ArrayFromJSON(type0, "[0]"), ArrayFromJSON(type1, "[1]")}));
 }
 
+TEST_F(TestIfElseKernel, MapNested) {
+  auto type = map(int64(), utf8());
+  CheckWithDifferentShapes(
+      ArrayFromJSON(boolean(), "[true, true, false, false]"),
+      ArrayFromJSON(type, R"([null, [[2, "foo"], [4, null]], [[3, "test"]], []])"),
+      ArrayFromJSON(type, R"([[[1, "b"]], [[2, "c"]], [[7, "abc"]], null])"),
+      ArrayFromJSON(type, R"([null, [[2, "foo"], [4, null]], [[7, "abc"]], null])"));
+
+  CheckWithDifferentShapes(
+      ArrayFromJSON(boolean(), "[null, null, null, null]"),
+      ArrayFromJSON(type, R"([null, [[1, "c"]], [[4, null]], [[6, "ok"]]])"),
+      ArrayFromJSON(type, R"([[[-1, null]], [[3, "c"]], null, [[6, "ok"]]])"),
+      ArrayFromJSON(type, R"([null, null, null, null])"));
+}
+
 template <typename Type>
 class TestIfElseUnion : public ::testing::Test {};
 
@@ -1920,7 +1935,7 @@ TYPED_TEST(TestCaseWhenBinary, Random) {
 template <typename Type>
 class TestCaseWhenList : public ::testing::Test {};
 
-TYPED_TEST_SUITE(TestCaseWhenList, ListArrowTypes);
+TYPED_TEST_SUITE(TestCaseWhenList, ListAndListViewArrowTypes);
 
 TYPED_TEST(TestCaseWhenList, ListOfString) {
   auto type = std::make_shared<TypeParam>(utf8());
@@ -2555,7 +2570,7 @@ class TestCoalesceList : public ::testing::Test {};
 
 TYPED_TEST_SUITE(TestCoalesceNumeric, IfElseNumericBasedTypes);
 TYPED_TEST_SUITE(TestCoalesceBinary, BaseBinaryArrowTypes);
-TYPED_TEST_SUITE(TestCoalesceList, ListArrowTypes);
+TYPED_TEST_SUITE(TestCoalesceList, ListAndListViewArrowTypes);
 
 TYPED_TEST(TestCoalesceNumeric, Basics) {
   auto type = default_type_instance<TypeParam>();


### PR DESCRIPTION



<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Add [Large]ListView and Map nested types for scalar_if_else's kernel functions

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
1. Add the list-view related types to `case_when`, `coalesce`'s kernel function and move the nested-types's added
   logic to a unified function for better management.
2. Add the `MapType` and related test for `if_else`


<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41418