### PR TITLE
GH-41467: [CI][Release] Don't push conda-verify-rc image

### DIFF
--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -43,7 +43,7 @@ jobs:
             -e TEST_{{ target|upper }}=1 \
             {{ distro }}-verify-rc
 
-    {% if arrow.is_default_branch() %}
+    {% if distro != "conda" %}
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -43,7 +43,7 @@ jobs:
             -e TEST_{{ target|upper }}=1 \
             {{ distro }}-verify-rc
 
-    {% if distro != "conda" %}
+    {% if arrow.is_default_branch() and distro != "conda" %}
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash


### PR DESCRIPTION
### Rationale for this change

Because it uses ubuntu:20.04 image directly. We don't build our image for it.

### What changes are included in this PR?

Don't push an image for `conda-verify-rc`.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #41467