### PR TITLE
GH-41464: [Python] Fix StructArray.sort() for by=None

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3925,7 +3925,8 @@ cdef class StructArray(Array):
             tosort = self
         indices = _pc().sort_indices(
             tosort,
-            options=_pc().SortOptions(sort_keys=[("", order)], **kwargs)
+            options=_pc().SortOptions(
+                sort_keys=[(field.name, order) for field in self.type], **kwargs)
         )
         return self.take(indices)
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3920,13 +3920,11 @@ cdef class StructArray(Array):
         result : StructArray
         """
         if by is not None:
-            tosort = self._flattened_field(by)
+            tosort, sort_keys = self._flattened_field(by), [("", order)]
         else:
-            tosort = self
+            tosort, sort_keys = self, [(field.name, order) for field in self.type]
         indices = _pc().sort_indices(
-            tosort,
-            options=_pc().SortOptions(
-                sort_keys=[(field.name, order) for field in self.type], **kwargs)
+            tosort, options=_pc().SortOptions(sort_keys=sort_keys, **kwargs)
         )
         return self.take(indices)
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -3512,6 +3512,14 @@ def test_struct_array_sort():
         {"a": 5, "b": "foo"},
     ]
 
+    sorted_arr = arr.sort()
+    assert sorted_arr.to_pylist() == [
+        {"a": 5, "b": "foo"},
+        {"a": 7, "b": "bar"},
+        {"a": 7, "b": "car"},
+        {"a": 35, "b": "foobar"},
+    ]
+
     arr_with_nulls = pa.StructArray.from_arrays([
         pa.array([5, 7, 7, 35], type=pa.int64()),
         pa.array(["foo", "car", "bar", "foobar"])


### PR DESCRIPTION
### Rationale for this change
Closes issue https://github.com/apache/arrow/issues/41464. Fix `StructArray.sort` method's `by` param to work in the case of `by=None` which was documented to mean sort by all fields (the default), but would raise an exception.

### What changes are included in this PR?
* Add a unit test with by=None in `test_struct_array_sort` that fails on main
* Fix the sort method

### Are these changes tested?
yes

### Are there any user-facing changes?
yes
* GitHub Issue: #41464