### PR TITLE
GH-40839 [Java][Gandiva] Fix for Gandiva library loading flags in Java to use RTLD_GLOBAL

### DIFF
--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -26,6 +26,7 @@
   <properties>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <arrow.cpp.build.dir>../../../cpp/release-build</arrow.cpp.build.dir>
+    <jna.version>5.14.0</jna.version>
   </properties>
 
   <dependencies>
@@ -58,6 +59,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${jna.version}</version>
     </dependency>
   </dependencies>
 

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
@@ -24,17 +24,24 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.arrow.gandiva.exceptions.GandivaException;
 
+import com.sun.jna.Library;
+import com.sun.jna.NativeLibrary;
+
 /**
  * This class handles loading of the jni library, and acts as a bridge for the native functions.
  */
 class JniLoader {
   private static final String LIBRARY_NAME = "gandiva_jni";
+
+  private static final int RTLD_GLOBAL = 0x00100;
+  private static final int RTLD_LAZY = 0x00001; 
 
   private static volatile JniLoader INSTANCE;
   private static volatile long defaultConfiguration = 0L;
@@ -73,6 +80,10 @@ class JniLoader {
     final String libraryToLoad =
         LIBRARY_NAME + "/" + getNormalizedArch() + "/" + System.mapLibraryName(LIBRARY_NAME);
     final File libraryFile = moveFileFromJarToTemp(tmpDir, libraryToLoad, LIBRARY_NAME);
+    NativeLibrary.getInstance(
+        libraryFile.getAbsolutePath(),
+        Collections.singletonMap(Library.OPTION_OPEN_FLAGS, new Integer(RTLD_LAZY | RTLD_GLOBAL))
+    );
     System.load(libraryFile.getAbsolutePath());
   }
 


### PR DESCRIPTION
### Rationale for this change

Java does not use RTLD_GLOBAL flag when loading gandiva native library, this causes bug when llvm generated code tries to use one of functions imported by gandiva library as it is not visible to Java process (as example math functions from libgcc).

### What changes are included in this PR?

This change adds jna to be able to load gandiva library with RTLD_GLOBAL flag.

### Are these changes tested?

It is hard to test this specifc case as it only reproduces on some builds of JDK on Arm on specific OS (for example openjdk-11 arm docker image). 
 
### Are there any user-facing changes?

No.

* GitHub Issue: #40839