### PR TITLE
MINOR: Increase the open-pull-requests-limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,30 +23,35 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [CI] "
+    open-pull-requests-limit: 10
   - package-ecosystem: "gomod"
     directory: "/go/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [Go] "
+    open-pull-requests-limit: 10
   - package-ecosystem: "maven"
     directory: "/java/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [Java] "
+    open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/js/"
     schedule:
       interval: "monthly"
     commit-message:
       prefix: "MINOR: [JS] "
+    open-pull-requests-limit: 10
   - package-ecosystem: "nuget"
     directory: "/csharp/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "MINOR: [C#] "
+    open-pull-requests-limit: 10
     ignore:
       - dependency-name: "Microsoft.Extensions.*"
         update-types:


### PR DESCRIPTION
### Rationale for this change

By default, dependabot opens a maximum of five pull requests for version updates. Once there are five open pull requests from dependabot, dependabot will not open any new requests until some of those open requests are merged or closed. With this change, dependabot can open up to 50 pull requests for Maven, and 10 pull requests for other systems.

### What changes are included in this PR?

Update configuration for dependabot.

### Are these changes tested?

Tested on other ASF projects 😄 

### Are there any user-facing changes?

No