### PR TITLE
GH-41462: [CI] Temporary pin azurite to v3.29.0

### DIFF
--- a/ci/scripts/install_azurite.sh
+++ b/ci/scripts/install_azurite.sh
@@ -19,6 +19,7 @@
 
 set -e
 
+# Pin azurite to 3.29.0 due to https://github.com/apache/arrow/issues/41505
 case "$(uname)" in
   Darwin)
     npm install -g azurite@v3.29.0

--- a/ci/scripts/install_azurite.sh
+++ b/ci/scripts/install_azurite.sh
@@ -21,15 +21,15 @@ set -e
 
 case "$(uname)" in
   Darwin)
-    npm install -g azurite
+    npm install -g azurite@v3.29.0
     which azurite
     ;;
   MINGW*)
     choco install nodejs.install
-    npm install -g azurite
+    npm install -g azurite@v3.29.0
     ;;
   Linux)
-    npm install -g azurite
+    npm install -g azurite@v3.29.0
     which azurite
     ;;
 esac


### PR DESCRIPTION
### Rationale for this change

install_azurite.sh is failing to install the latest version of Azurite and azure tests were failing.

### What changes are included in this PR?

Temporarily pin azurite to v3.29.0 to unblock 16.1.0 release. A follow up issue is tracked here: https://github.com/apache/arrow/issues/41505

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No
* GitHub Issue: #41462