### PR TITLE
GH-41507: [MATLAB][CI] Pass `strict: true` to `matlab-actions/run-tests@v2` 

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -95,8 +95,8 @@ jobs:
           MATLABPATH: matlab/install/arrow_matlab
         uses: matlab-actions/run-tests@v2
         with:
-          strict: true
           select-by-folder: matlab/test
+          strict: true
   macos:
     name: AMD64 macOS 12 MATLAB
     runs-on: macos-12
@@ -136,8 +136,8 @@ jobs:
           MATLABPATH: matlab/install/arrow_matlab
         uses: matlab-actions/run-tests@v2
         with:
+          select-by-folder: matlab/test
           strict: true
-          select-by-folder: matlab/test 
   windows:
     name: AMD64 Windows 2022 MATLAB
     runs-on: windows-2022
@@ -183,5 +183,5 @@ jobs:
           MATLABPATH: matlab/install/arrow_matlab
         uses: matlab-actions/run-tests@v2
         with:
+          select-by-folder: matlab/test
           strict: true
-          select-by-folder: matlab/test 

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -95,6 +95,7 @@ jobs:
           MATLABPATH: matlab/install/arrow_matlab
         uses: matlab-actions/run-tests@v2
         with:
+          strict: true
           select-by-folder: matlab/test
   macos:
     name: AMD64 macOS 12 MATLAB
@@ -135,6 +136,7 @@ jobs:
           MATLABPATH: matlab/install/arrow_matlab
         uses: matlab-actions/run-tests@v2
         with:
+          strict: true
           select-by-folder: matlab/test 
   windows:
     name: AMD64 Windows 2022 MATLAB
@@ -181,4 +183,5 @@ jobs:
           MATLABPATH: matlab/install/arrow_matlab
         uses: matlab-actions/run-tests@v2
         with:
+          strict: true
           select-by-folder: matlab/test 


### PR DESCRIPTION
### Rationale for this change

The MATLAB CI jobs should fail if any one of the unit tests issues a `warning`. Currently, the MATLAB CI jobs only fail if there is a verification failure. Passing the argument `strict: true` to `matlab-actions/run-tests@v2` will ensure MATLAB jobs will fail if a test warning is issued.

See the [`matlab-actions/run-tests@v2` documentation](https://github.com/matlab-actions/run-tests/?tab=readme-ov-file#run-matlab-tests) for more details.

### What changes are included in this PR?

1. Pass `strict: true` argument to `matlab-actions/setup-matlab@v2`

### Are these changes tested?

N/A (relying on existing tests).

### Are there any user-facing changes?

No.


* GitHub Issue: #41507