### PR TITLE
GH-41531: [MATLAB][Packaging] Bump `matlab-actions/setup-matlab` and `matlab-actions/run-command` from `v1` to `v2` in the `crossbow` job

### DIFF
--- a/dev/tasks/matlab/github.yml
+++ b/dev/tasks/matlab/github.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install ninja-build
         run: sudo apt-get update && sudo apt-get install ninja-build
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: R2024a
       - name: Build MATLAB Interface
@@ -66,7 +66,7 @@ jobs:
       - name: Install ninja-build
         run: brew install ninja
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: R2024a
       - name: Build MATLAB Interface
@@ -101,7 +101,7 @@ jobs:
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: R2024a
       - name: Install sccache
@@ -147,7 +147,7 @@ jobs:
           cp arrow/LICENSE.txt arrow/matlab/install/arrow_matlab/LICENSE.txt
           cp arrow/NOTICE.txt arrow/matlab/install/arrow_matlab/NOTICE.txt
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
         with:
           release: R2024a
       - name: Run commands
@@ -156,7 +156,7 @@ jobs:
           ARROW_MATLAB_TOOLBOX_FOLDER: arrow/matlab/install/arrow_matlab
           ARROW_MATLAB_TOOLBOX_OUTPUT_FOLDER: artifacts/matlab-dist
           ARROW_MATLAB_TOOLBOX_VERSION: {{ arrow.no_rc_version }}
-        uses: matlab-actions/run-command@v1
+        uses: matlab-actions/run-command@v2
         with:
           command: packageMatlabInterface
       {{ macros.github_upload_releases(["artifacts/matlab-dist/*.mltbx"])|indent }}


### PR DESCRIPTION
### Rationale for this change

I noticed `dev/tasks/matlab/github.yml` is still using `matlab-actions/setup-matlab@v1`, which is no longer supported. See this [log](https://github.com/ursacomputing/crossbow/actions/runs/8928507510/job/24524230971#step:4:11) file. We should use `matlab-actions/setup-matlab@v2` instead. We should also use `matlab-actions/run-command@v2` instead of `matlab-actions/run-command@v1`.

### What changes are included in this PR?

1. Replaced `matlab-actions/setup-matlab@v1` with `matlab-actions/setup-matlab@v2` in `dev/tasks/matlab/github.yml`

2. Replaced `matlab-actions/run-command@v1` with `matlab-actions/run-command@v2` in `dev/tasks/matlab/github.yml`


### Are these changes tested?

N/A (I will trigger a crossbow job to verify the packaging workflow works as expected still). 

### Are there any user-facing changes?

No.


* GitHub Issue: #41531