### PR TITLE
MINOR: [Java] Reduce enum array allocation

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
@@ -38,6 +38,9 @@ import org.apache.calcite.avatica.ConnectionProperty;
  * A {@link ConnectionConfig} for the {@link ArrowFlightConnection}.
  */
 public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl {
+  private static final ArrowFlightConnectionProperty[] ARROW_FLIGHT_CONNECTION_PROPERTY_VALUES
+      = ArrowFlightConnectionProperty.values();
+
   public ArrowFlightConnectionConfigImpl(final Properties properties) {
     super(properties);
   }
@@ -179,11 +182,10 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
    */
   public Map<String, String> getHeaderAttributes() {
     Map<String, String> headers = new HashMap<>();
-    ArrowFlightConnectionProperty[] builtInProperties = ArrowFlightConnectionProperty.values();
     properties.forEach(
         (key, val) -> {
           // For built-in properties before adding new headers
-          if (Arrays.stream(builtInProperties)
+          if (Arrays.stream(ARROW_FLIGHT_CONNECTION_PROPERTY_VALUES)
               .noneMatch(builtInProperty -> builtInProperty.camelName.equalsIgnoreCase(key.toString()))) {
             headers.put(key.toString(), val.toString());
           }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

reduce Java object allocation

context: https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

cache  ArrowFlightConnectionProperty.values() in a static variable.

### Are these changes tested?

ArrowFlightConnectionConfigImplTest unit test passes.

### Are there any user-facing changes?

no

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
