### PR TITLE
GH-38575: [Python] Include metadata when creating pa.schema from PyCapsule

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -1331,10 +1331,12 @@ def test_schema_import_c_schema_interface():
         def __arrow_c_schema__(self):
             return self.schema.__arrow_c_schema__()
 
-    schema = pa.schema([pa.field("field_name", pa.int32())])
-    wrapped_schema = Wrapper(schema)
+    schema = pa.schema([pa.field("field_name", pa.int32())], metadata={"a": "b"})
+    assert schema.metadata == {b"a": b"b"}
 
+    wrapped_schema = Wrapper(schema)
     assert pa.schema(wrapped_schema) == schema
+    assert pa.schema(wrapped_schema, metadata={"a": "c"}).metadata == {b"a": b"c"}
 
 
 def test_field_import_c_schema_interface():

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -1333,9 +1333,10 @@ def test_schema_import_c_schema_interface():
 
     schema = pa.schema([pa.field("field_name", pa.int32())], metadata={"a": "b"})
     assert schema.metadata == {b"a": b"b"}
-
     wrapped_schema = Wrapper(schema)
+
     assert pa.schema(wrapped_schema) == schema
+    assert pa.schema(wrapped_schema).metadata == {b"a": b"b"}
     assert pa.schema(wrapped_schema, metadata={"a": "c"}).metadata == {b"a": b"c"}
 
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -5332,7 +5332,10 @@ def schema(fields, metadata=None):
     if isinstance(fields, Mapping):
         fields = fields.items()
     elif hasattr(fields, "__arrow_c_schema__"):
-        return Schema._import_from_c_capsule(fields.__arrow_c_schema__())
+        result = Schema._import_from_c_capsule(fields.__arrow_c_schema__())
+        if metadata is not None:
+            result = result.with_metadata(metadata)
+        return result
 
     for item in fields:
         if isinstance(item, tuple):


### PR DESCRIPTION
### Rationale for this change

Fixes the dropped `pa.schema` metadata reported in #38575, which was introduced in #37797.

### What changes are included in this PR?

Passes through the `metadata` to the short-circuited `Schema` created with `_import_from_c_capsule`.

### Are these changes tested?

Yes - added `metadata` to the existing test.

### Are there any user-facing changes?

I'm not sure this quite rises to the `(b) a bug that caused incorrect or invalid data to be produced,` condition, but I added that note to be safe since the resulting schema is "incorrect" (and broke some round-trip tests on my end after a pyarrow update):

**This PR contains a "Critical Fix".**

* GitHub Issue: #38575