### PR TITLE
GH-38692: [C#] Implement ICollection<T?> on scalar arrays

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -22,7 +22,7 @@ using System.Collections;
 
 namespace Apache.Arrow
 {
-    public class BinaryArray : Array, IReadOnlyList<byte[]>
+    public class BinaryArray : Array, IReadOnlyList<byte[]>, ICollection<byte[]>
     {
         public class Builder : BuilderBase<BinaryArray, Builder>
         {
@@ -380,5 +380,40 @@ namespace Apache.Arrow
         }
 
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<byte[]>)this).GetEnumerator();
+
+        int ICollection<byte[]>.Count => Length;
+        bool ICollection<byte[]>.IsReadOnly => true;
+        void ICollection<byte[]>.Add(byte[]? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<byte[]>.Remove(byte[]? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<byte[]>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<byte[]>.Contains(byte[] item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                var foo = GetBytes(index);
+                if(IsSpanDataEqual(foo, item))
+                //if (foo == item)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsSpanDataEqual(ReadOnlySpan<byte> span1, ReadOnlySpan<byte> span2)
+        {
+            if (span1.Length != span2.Length)
+                return false;
+
+            return span1.SequenceEqual(span2);
+        }
+
+        void ICollection<byte[]>.CopyTo(byte[][] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetBytes(srcIndex).ToArray();
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -391,21 +391,11 @@ namespace Apache.Arrow
         {
             for (int index = 0; index < Length; index++)
             {
-                var foo = GetBytes(index);
-                if(IsSpanDataEqual(foo, item))
-                //if (foo == item)
+                if (GetBytes(index).SequenceEqual(item))
                     return true;
             }
 
             return false;
-        }
-
-        private static bool IsSpanDataEqual(ReadOnlySpan<byte> span1, ReadOnlySpan<byte> span2)
-        {
-            if (span1.Length != span2.Length)
-                return false;
-
-            return span1.SequenceEqual(span2);
         }
 
         void ICollection<byte[]>.CopyTo(byte[][] array, int arrayIndex)

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 
 namespace Apache.Arrow
 {
-    public class BooleanArray: Array, IReadOnlyList<bool?>
+    public class BooleanArray: Array, IReadOnlyList<bool?>, ICollection<bool?>
     {
         public class Builder : IArrowArrayBuilder<bool, BooleanArray, Builder>
         {
@@ -188,7 +188,7 @@ namespace Apache.Arrow
         public bool? GetValue(int index)
         {
             return IsNull(index)
-                ? (bool?)null
+                ? null
                 : BitUtility.GetBit(ValueBuffer.Span, index + Offset);
         }
 
@@ -205,5 +205,30 @@ namespace Apache.Arrow
         }
 
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<bool?>)this).GetEnumerator();
+
+        int ICollection<bool?>.Count => Length;
+        bool ICollection<bool?>.IsReadOnly => true;
+        void ICollection<bool?>.Add(bool? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<bool?>.Remove(bool? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<bool?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<bool?>.Contains(bool? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetValue(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<bool?>.CopyTo(bool?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetValue(srcIndex);
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
@@ -23,9 +23,9 @@ namespace Apache.Arrow
     /// The <see cref="Date32Array"/> class holds an array of dates in the <c>Date32</c> format, where each date is
     /// stored as the number of days since the dawn of (UNIX) time.
     /// </summary>
-    public class Date32Array : PrimitiveArray<int>, IReadOnlyList<DateTime?>
+    public class Date32Array : PrimitiveArray<int>, IReadOnlyList<DateTime?>, ICollection<DateTime?>
 #if NET6_0_OR_GREATER
-        , IReadOnlyList<DateOnly?>
+        , IReadOnlyList<DateOnly?>, ICollection<DateOnly?>
 #endif
     {
         private static readonly DateTime _epochDate = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
@@ -40,10 +40,9 @@ namespace Apache.Arrow
         {
             private class DateBuilder : PrimitiveArrayBuilder<int, Date32Array, DateBuilder>
             {
-                protected override Date32Array Build(
-                    ArrowBuffer valueBuffer, ArrowBuffer nullBitmapBuffer,
-                    int length, int nullCount, int offset) =>
-                    new Date32Array(valueBuffer, nullBitmapBuffer, length, nullCount, offset);
+                protected override Date32Array Build(ArrowBuffer valueBuffer, ArrowBuffer nullBitmapBuffer, int length,
+                    int nullCount, int offset) =>
+                    new(valueBuffer, nullBitmapBuffer, length, nullCount, offset);
             }
 
             /// <summary>
@@ -149,6 +148,31 @@ namespace Apache.Arrow
                 yield return GetDateOnly(index);
             };
         }
+
+        int ICollection<DateOnly?>.Count => Length;
+        bool ICollection<DateOnly?>.IsReadOnly => true;
+        void ICollection<DateOnly?>.Add(DateOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<DateOnly?>.Remove(DateOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<DateOnly?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<DateOnly?>.Contains(DateOnly? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetDateOnly(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<DateOnly?>.CopyTo(DateOnly?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetDateOnly(srcIndex);
+            }
+        }
 #endif
 
         int IReadOnlyCollection<DateTime?>.Count => Length;
@@ -160,7 +184,32 @@ namespace Apache.Arrow
             for (int index = 0; index < Length; index++)
             {
                 yield return GetDateTime(index);
-            };
+            }
+        }
+
+        int ICollection<DateTime?>.Count => Length;
+        bool ICollection<DateTime?>.IsReadOnly => true;
+        void ICollection<DateTime?>.Add(DateTime? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<DateTime?>.Remove(DateTime? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<DateTime?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<DateTime?>.Contains(DateTime? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetDateTime(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<DateTime?>.CopyTo(DateTime?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetDateTime(srcIndex);
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -24,9 +24,9 @@ namespace Apache.Arrow
     /// stored as the number of milliseconds since the dawn of (UNIX) time, excluding leap seconds, in multiples of
     /// 86400000.
     /// </summary>
-    public class Date64Array : PrimitiveArray<long>, IReadOnlyList<DateTime?>
+    public class Date64Array : PrimitiveArray<long>, IReadOnlyList<DateTime?>, ICollection<DateTime?>
 #if NET6_0_OR_GREATER
-        , IReadOnlyList<DateOnly?>
+        , IReadOnlyList<DateOnly?>, ICollection<DateOnly?>
 #endif
     {
         private const long MillisecondsPerDay = 86400000;
@@ -45,10 +45,9 @@ namespace Apache.Arrow
         {
             private class DateBuilder : PrimitiveArrayBuilder<long, Date64Array, DateBuilder>
             {
-                protected override Date64Array Build(
-                    ArrowBuffer valueBuffer, ArrowBuffer nullBitmapBuffer,
-                    int length, int nullCount, int offset) =>
-                    new Date64Array(valueBuffer, nullBitmapBuffer, length, nullCount, offset);
+                protected override Date64Array Build(ArrowBuffer valueBuffer, ArrowBuffer nullBitmapBuffer, int length,
+                    int nullCount, int offset) =>
+                    new(valueBuffer, nullBitmapBuffer, length, nullCount, offset);
             }
 
             /// <summary>
@@ -151,6 +150,31 @@ namespace Apache.Arrow
                 yield return GetDateOnly(index);
             };
         }
+
+        int ICollection<DateOnly?>.Count => Length;
+        bool ICollection<DateOnly?>.IsReadOnly => true;
+        void ICollection<DateOnly?>.Add(DateOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<DateOnly?>.Remove(DateOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<DateOnly?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<DateOnly?>.Contains(DateOnly? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetDateOnly(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<DateOnly?>.CopyTo(DateOnly?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetDateOnly(srcIndex);
+            }
+        }
 #endif
 
         int IReadOnlyCollection<DateTime?>.Count => Length;
@@ -162,7 +186,32 @@ namespace Apache.Arrow
             for (int index = 0; index < Length; index++)
             {
                 yield return GetDateTime(index);
-            };
+            }
+        }
+
+        int ICollection<DateTime?>.Count => Length;
+        bool ICollection<DateTime?>.IsReadOnly => true;
+        void ICollection<DateTime?>.Add(DateTime? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<DateTime?>.Remove(DateTime? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<DateTime?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<DateTime?>.Contains(DateTime? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetDateTime(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<DateTime?>.CopyTo(DateTime?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetDateTime(srcIndex);
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/IntervalArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/IntervalArray.cs
@@ -31,7 +31,7 @@ namespace Apache.Arrow
     }
 
     public abstract class IntervalArray<T> : PrimitiveArray<T>
-        where T : struct
+        where T : struct, IEquatable<T>
     {
         protected IntervalArray(ArrayData data)
             : base(data)

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -20,7 +20,7 @@ using System.Runtime.CompilerServices;
 
 namespace Apache.Arrow
 {
-    public abstract class PrimitiveArray<T> : Array, IReadOnlyList<T?>
+    public abstract class PrimitiveArray<T> : Array, IReadOnlyList<T?>, ICollection<T?>
         where T : struct
     {
         protected PrimitiveArray(ArrayData data)
@@ -40,7 +40,7 @@ namespace Apache.Arrow
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
-            return IsValid(index) ? Values[index] : (T?)null;
+            return IsValid(index) ? Values[index] : null;
         }
 
         public IList<T?> ToList(bool includeNulls = false)
@@ -84,6 +84,31 @@ namespace Apache.Arrow
             for (int index = 0; index < Length; index++)
             {
                 yield return IsValid(index) ? Values[index] : null;
+            }
+        }
+
+        int ICollection<T?>.Count => Length;
+        bool ICollection<T?>.IsReadOnly => true;
+        void ICollection<T?>.Add(T? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<T?>.Remove(T? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<T?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<T?>.Contains(T? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetValue(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<T?>.CopyTo(T?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetValue(srcIndex);
             }
         }
     }

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 namespace Apache.Arrow
 {
     public abstract class PrimitiveArray<T> : Array, IReadOnlyList<T?>, ICollection<T?>
-        where T : struct
+        where T : struct, IEquatable<T>
     {
         protected PrimitiveArray(ArrayData data)
             : base(data)
@@ -95,13 +95,12 @@ namespace Apache.Arrow
 
         bool ICollection<T?>.Contains(T? item)
         {
-            for (int index = 0; index < Length; index++)
+            if (item == null)
             {
-                if (GetValue(index).Equals(item))
-                    return true;
+                return NullCount > 0;
             }
 
-            return false;
+            return Values.IndexOf(item.Value) >= 0;
         }
 
         void ICollection<T?>.CopyTo(T?[] array, int arrayIndex)

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -100,7 +100,14 @@ namespace Apache.Arrow
                 return NullCount > 0;
             }
 
-            return Values.IndexOf(item.Value) >= 0;
+            ReadOnlySpan<T> values = Values;
+            while (values.Length > 0)
+            {
+                int index = Values.IndexOf(item.Value);
+                if (index < 0 || IsValid(index)) { return index >= 0; }
+                values = values.Slice(index + 1);
+            }
+            return false;
         }
 
         void ICollection<T?>.CopyTo(T?[] array, int arrayIndex)

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Apache.Arrow
 {
-    public abstract class PrimitiveArrayBuilder<TFrom, TTo, TArray, TBuilder> : IArrowArrayBuilder<TArray, TBuilder>
+    public abstract class PrimitiveArrayBuilder<TFrom, TTo, TArray, TBuilder> : IArrowArrayBuilder<TFrom, TArray, TBuilder>
         where TTo : struct
         where TArray : IArrowArray
         where TBuilder : class, IArrowArrayBuilder<TArray>

--- a/csharp/src/Apache.Arrow/Arrays/StringArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StringArray.cs
@@ -22,7 +22,7 @@ using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {
-    public class StringArray: BinaryArray, IReadOnlyList<string>
+    public class StringArray: BinaryArray, IReadOnlyList<string>, ICollection<string>
     {
         public static readonly Encoding DefaultEncoding = Encoding.UTF8;
 
@@ -164,5 +164,30 @@ namespace Apache.Arrow
         }
 
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<string>)this).GetEnumerator();
+
+        int ICollection<string>.Count => Length;
+        bool ICollection<string>.IsReadOnly => true;
+        void ICollection<string>.Add(string item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<string>.Remove(string item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<string>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<string>.Contains(string item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetString(index) == item)
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<string>.CopyTo(string[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetString(srcIndex);
+            }
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time32Array.cs
@@ -26,7 +26,7 @@ namespace Apache.Arrow
     /// </summary>
     public class Time32Array : PrimitiveArray<int>
 #if NET6_0_OR_GREATER
-        , IReadOnlyList<TimeOnly?>
+        , IReadOnlyList<TimeOnly?>, ICollection<TimeOnly?>
 #endif
     {
         /// <summary>
@@ -170,6 +170,31 @@ namespace Apache.Arrow
             {
                 yield return GetTime(index);
             };
+        }
+
+        int ICollection<TimeOnly?>.Count => Length;
+        bool ICollection<TimeOnly?>.IsReadOnly => true;
+        void ICollection<TimeOnly?>.Add(TimeOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<TimeOnly?>.Remove(TimeOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<TimeOnly?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<TimeOnly?>.Contains(TimeOnly? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetTime(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<TimeOnly?>.CopyTo(TimeOnly?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetTime(srcIndex);
+            }
         }
 #endif
     }

--- a/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Time64Array.cs
@@ -26,7 +26,7 @@ namespace Apache.Arrow
     /// </summary>
     public class Time64Array : PrimitiveArray<long>
 #if NET6_0_OR_GREATER
-        , IReadOnlyList<TimeOnly?>
+        , IReadOnlyList<TimeOnly?>, ICollection<TimeOnly?>
 #endif
     {
         /// <summary>
@@ -161,6 +161,31 @@ namespace Apache.Arrow
             {
                 yield return GetTime(index);
             };
+        }
+
+        int ICollection<TimeOnly?>.Count => Length;
+        bool ICollection<TimeOnly?>.IsReadOnly => true;
+        void ICollection<TimeOnly?>.Add(TimeOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<TimeOnly?>.Remove(TimeOnly? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<TimeOnly?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<TimeOnly?>.Contains(TimeOnly? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetTime(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<TimeOnly?>.CopyTo(TimeOnly?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetTime(srcIndex);
+            }
         }
 #endif
     }

--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -21,7 +21,7 @@ using System.IO;
 
 namespace Apache.Arrow
 {
-    public class TimestampArray : PrimitiveArray<long>, IReadOnlyList<DateTimeOffset?>
+    public class TimestampArray : PrimitiveArray<long>, IReadOnlyList<DateTimeOffset?>, ICollection<DateTimeOffset?>
     {
         private static readonly DateTimeOffset s_epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
 
@@ -156,6 +156,31 @@ namespace Apache.Arrow
             {
                 yield return GetTimestamp(index);
             };
+        }
+
+        int ICollection<DateTimeOffset?>.Count => Length;
+        bool ICollection<DateTimeOffset?>.IsReadOnly => true;
+        void ICollection<DateTimeOffset?>.Add(DateTimeOffset? item) => throw new NotSupportedException("Collection is read-only.");
+        bool ICollection<DateTimeOffset?>.Remove(DateTimeOffset? item) => throw new NotSupportedException("Collection is read-only.");
+        void ICollection<DateTimeOffset?>.Clear() => throw new NotSupportedException("Collection is read-only.");
+
+        bool ICollection<DateTimeOffset?>.Contains(DateTimeOffset? item)
+        {
+            for (int index = 0; index < Length; index++)
+            {
+                if (GetTimestamp(index).Equals(item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<DateTimeOffset?>.CopyTo(DateTimeOffset?[] array, int arrayIndex)
+        {
+            for (int srcIndex = 0, destIndex = arrayIndex; srcIndex < Length; srcIndex++, destIndex++)
+            {
+                array[destIndex] = GetTimestamp(srcIndex);
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -148,7 +148,7 @@ namespace Apache.Arrow.Ipc
             public void Visit(MonthDayNanosecondIntervalArray array) => VisitPrimitiveArray(array);
 
             private void VisitPrimitiveArray<T>(PrimitiveArray<T> array)
-                where T : struct
+                where T : struct, IEquatable<T>
             {
                 _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
                 _buffers.Add(CreateSlicedBuffer<T>(array.ValueBuffer, array.Offset, array.Length));

--- a/csharp/test/Apache.Arrow.IntegrationTest/JsonFile.cs
+++ b/csharp/test/Apache.Arrow.IntegrationTest/JsonFile.cs
@@ -908,8 +908,8 @@ namespace Apache.Arrow.IntegrationTest
             };
 
             private void GenerateArray<T, TArray>(Func<ArrowBuffer, ArrowBuffer, int, int, int, TArray> createArray)
+                where T : struct, IEquatable<T>
                 where TArray : PrimitiveArray<T>
-                where T : struct
             {
                 ArrowBuffer validityBuffer = GetValidityBuffer(out int nullCount);
 
@@ -929,8 +929,8 @@ namespace Apache.Arrow.IntegrationTest
             }
 
             private void GenerateLongArray<T, TArray>(Func<ArrowBuffer, ArrowBuffer, int, int, int, TArray> createArray, Func<string, T> parse)
+                where T : struct, IEquatable<T>
                 where TArray : PrimitiveArray<T>
-                where T : struct
             {
                 ArrowBuffer validityBuffer = GetValidityBuffer(out int nullCount);
 
@@ -950,8 +950,8 @@ namespace Apache.Arrow.IntegrationTest
             }
 
             private void GenerateArray<T, TArray>(Func<ArrowBuffer, ArrowBuffer, int, int, int, TArray> createArray, Func<JsonElement, T> construct)
+                where T : struct, IEquatable<T>
                 where TArray : PrimitiveArray<T>
-                where T : struct
             {
                 ArrowBuffer validityBuffer = GetValidityBuffer(out int nullCount);
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -118,7 +118,11 @@ namespace Apache.Arrow.Tests
             TestArrayAsReadOnlyList<byte, UInt8Array, UInt8Array.Builder>(new byte[] { 1, 2 });
             TestArrayAsReadOnlyList<long, Int64Array, Int64Array.Builder>(new long[] { 1, 2 });
             TestArrayAsReadOnlyList<DateTime, Date32Array, Date32Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date });
+            TestArrayAsReadOnlyList<DateTime, Date64Array, Date64Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date });
+
 #if NET5_0_OR_GREATER
+            TestArrayAsReadOnlyList<TimeOnly, Time32Array, Time32Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MinValue.AddHours(23) });
+            TestArrayAsReadOnlyList<TimeOnly, Time64Array, Time64Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MaxValue });
             TestArrayAsReadOnlyList<Half, HalfFloatArray, HalfFloatArray.Builder>(new[] { (Half)1.1, (Half)2.2f });
 #endif
         }
@@ -153,6 +157,8 @@ namespace Apache.Arrow.Tests
 #if NET5_0_OR_GREATER
             TestArrayAsCollection<DateOnly, Date32Array, Date32Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue, DateOnly.FromDayNumber(1), DateOnly.FromDayNumber(2) });
             TestArrayAsCollection<DateOnly, Date64Array, Date64Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue, DateOnly.FromDayNumber(1), DateOnly.FromDayNumber(2) });
+            TestArrayAsCollection<TimeOnly, Time32Array, Time32Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MinValue.AddHours(23), TimeOnly.MinValue.AddHours(1), TimeOnly.MinValue.AddHours(2) });
+            TestArrayAsCollection<TimeOnly, Time64Array, Time64Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.MinValue.AddHours(1), TimeOnly.MinValue.AddHours(2) });
             TestArrayAsCollection<Half, HalfFloatArray, HalfFloatArray.Builder>(new[] { (Half)1.1, (Half)2.2f, (Half)3.3f, (Half)4.4f });
 #endif
         }
@@ -160,7 +166,7 @@ namespace Apache.Arrow.Tests
         // Parameter 'values' must contain four values. The last value must be distinct from the rest.
         private static void TestArrayAsCollection<T, TArray, TArrayBuilder>(IReadOnlyList<T> values)
             where T : struct
-            where TArray : IArrowArray
+            where TArray : IArrowArray, ICollection<T?>
             where TArrayBuilder : IArrowArrayBuilder<T, TArray, TArrayBuilder>, new()
         {
             Assert.Equal(4, values.Count);

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -115,12 +115,16 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void ArrayAsReadOnlyList()
         {
-            TestArrayAsReadOnlyList<byte, UInt8Array, UInt8Array.Builder>(new byte[] { 1, 2 });
             TestArrayAsReadOnlyList<long, Int64Array, Int64Array.Builder>(new long[] { 1, 2 });
+            TestArrayAsReadOnlyList<byte, UInt8Array, UInt8Array.Builder>(new byte[] { 1, 2 });
+            TestArrayAsReadOnlyList<bool, BooleanArray, BooleanArray.Builder>(new[] { true, false });
             TestArrayAsReadOnlyList<DateTime, Date32Array, Date32Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date });
             TestArrayAsReadOnlyList<DateTime, Date64Array, Date64Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date });
+            TestArrayAsReadOnlyList<DateTimeOffset, TimestampArray, TimestampArray.Builder>(new[] { DateTimeOffset.MinValue, DateTimeOffset.MinValue.AddYears(100) });
 
 #if NET5_0_OR_GREATER
+            TestArrayAsReadOnlyList<DateOnly, Date32Array, Date32Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue });
+            TestArrayAsReadOnlyList<DateOnly, Date64Array, Date64Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue});
             TestArrayAsReadOnlyList<TimeOnly, Time32Array, Time32Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MinValue.AddHours(23) });
             TestArrayAsReadOnlyList<TimeOnly, Time64Array, Time64Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MaxValue });
             TestArrayAsReadOnlyList<Half, HalfFloatArray, HalfFloatArray.Builder>(new[] { (Half)1.1, (Half)2.2f });
@@ -163,10 +167,11 @@ namespace Apache.Arrow.Tests
             TestPrimitiveArrayAsCollection<Half, HalfFloatArray, HalfFloatArray.Builder>(new[] { (Half)1.1, (Half)2.2f, (Half)3.3f, (Half)4.4f });
 #endif
 
-            var builder = new BinaryArray.Builder();
-            byte[][] values = { new byte[1], System.Array.Empty<byte>(), new byte[] { 255 }, new byte[2] };
-            BinaryArray array = builder.Append(values[0].AsEnumerable()).AppendNull().Append(values[1].AsEnumerable()).Append(values[0].AsEnumerable()).Build();
-            TestObjectArrayAsCollection(array, System.Array.Empty<byte>(), values);
+            byte[][] byteArrs = { new byte[1], System.Array.Empty<byte>(), new byte[] { 255 }, new byte[2] };
+            TestObjectArrayAsCollection(new BinaryArray.Builder().Append(byteArrs[0].AsEnumerable()).AppendNull().Append(byteArrs[1].AsEnumerable()).Append(byteArrs[0].AsEnumerable()).Build(), System.Array.Empty<byte>(), byteArrs);
+
+            string[] strings = { "abc", "abd", "acd", "adc" };
+            TestObjectArrayAsCollection(new StringArray.Builder().Append(strings[0]).AppendNull().Append(strings[1]).Append(strings[0]).Build(), null, strings);
         }
 
         // Parameter 'values' must contain four values. The last value must be distinct from the rest.

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -124,6 +124,35 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
+        public void ArrayAsCollection()
+        {
+            Int64Array array = new Int64Array.Builder().Append(1).Append((long?)null).Append(2).Append(1).Build();
+            var collection = (ICollection<long?>)array;
+
+            Assert.Equal(array.Length, collection.Count);
+            Assert.Equal(4, collection.Count);
+            Assert.True(collection.IsReadOnly);
+
+            Assert.Equal("Collection is read-only.", Assert.Throws<NotSupportedException>(() => collection.Add(3)).Message);
+            Assert.Equal("Collection is read-only.", Assert.Throws<NotSupportedException>(() => collection.Remove(3)).Message);
+            Assert.Equal("Collection is read-only.", Assert.Throws<NotSupportedException>(collection.Clear).Message);
+
+            Assert.True(collection.Contains(1));
+            Assert.True(collection.Contains(2));
+            Assert.True(collection.Contains(null));
+            Assert.False(collection.Contains(-1));
+
+            long?[] destArr = new long?[6] { -1, -1, -1, -1, -1, -1 };
+            collection.CopyTo(destArr, 1);
+            Assert.Equal(-1, destArr[0]);
+            Assert.Equal(1, destArr[1]);
+            Assert.Null(destArr[2]);
+            Assert.Equal(2, destArr[3]);
+            Assert.Equal(1, destArr[4]);
+            Assert.Equal(-1, destArr[0]);
+        }
+
+        [Fact]
         public void RecursiveArraySlice()
         {
             var initialValues = Enumerable.Range(0, 100).ToArray();

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -115,19 +115,19 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void ArrayAsReadOnlyList()
         {
-            TestArrayAsReadOnlyList<long, Int64Array, Int64Array.Builder>(new long[] { 1, 2 });
-            TestArrayAsReadOnlyList<byte, UInt8Array, UInt8Array.Builder>(new byte[] { 1, 2 });
-            TestArrayAsReadOnlyList<bool, BooleanArray, BooleanArray.Builder>(new[] { true, false });
-            TestArrayAsReadOnlyList<DateTime, Date32Array, Date32Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date });
-            TestArrayAsReadOnlyList<DateTime, Date64Array, Date64Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date });
-            TestArrayAsReadOnlyList<DateTimeOffset, TimestampArray, TimestampArray.Builder>(new[] { DateTimeOffset.MinValue, DateTimeOffset.MinValue.AddYears(100) });
+            TestArrayAsReadOnlyList<long, Int64Array, Int64Array.Builder>([1, 2]);
+            TestArrayAsReadOnlyList<byte, UInt8Array, UInt8Array.Builder>([1, 2]);
+            TestArrayAsReadOnlyList<bool, BooleanArray, BooleanArray.Builder>([true, false]);
+            TestArrayAsReadOnlyList<DateTime, Date32Array, Date32Array.Builder>([DateTime.MinValue.Date, DateTime.MaxValue.Date]);
+            TestArrayAsReadOnlyList<DateTime, Date64Array, Date64Array.Builder>([DateTime.MinValue.Date, DateTime.MaxValue.Date]);
+            TestArrayAsReadOnlyList<DateTimeOffset, TimestampArray, TimestampArray.Builder>([DateTimeOffset.MinValue, DateTimeOffset.MinValue.AddYears(100)]);
 
 #if NET5_0_OR_GREATER
-            TestArrayAsReadOnlyList<DateOnly, Date32Array, Date32Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue });
-            TestArrayAsReadOnlyList<DateOnly, Date64Array, Date64Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue});
-            TestArrayAsReadOnlyList<TimeOnly, Time32Array, Time32Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MinValue.AddHours(23) });
-            TestArrayAsReadOnlyList<TimeOnly, Time64Array, Time64Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MaxValue });
-            TestArrayAsReadOnlyList<Half, HalfFloatArray, HalfFloatArray.Builder>(new[] { (Half)1.1, (Half)2.2f });
+            TestArrayAsReadOnlyList<DateOnly, Date32Array, Date32Array.Builder>([DateOnly.MinValue, DateOnly.MaxValue]);
+            TestArrayAsReadOnlyList<DateOnly, Date64Array, Date64Array.Builder>([DateOnly.MinValue, DateOnly.MaxValue]);
+            TestArrayAsReadOnlyList<TimeOnly, Time32Array, Time32Array.Builder>([TimeOnly.MinValue, TimeOnly.MinValue.AddHours(23)]);
+            TestArrayAsReadOnlyList<TimeOnly, Time64Array, Time64Array.Builder>([TimeOnly.MinValue, TimeOnly.MaxValue]);
+            TestArrayAsReadOnlyList<Half, HalfFloatArray, HalfFloatArray.Builder>([(Half)1.1, (Half)2.2f]);
 #endif
         }
 
@@ -152,25 +152,25 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void ArrayAsCollection()
         {
-            TestPrimitiveArrayAsCollection<long, Int64Array, Int64Array.Builder>(new long[] { 1, 2, 3, 4 });
-            TestPrimitiveArrayAsCollection<byte, UInt8Array, UInt8Array.Builder>(new byte[] { 1, 2, 3, 4 });
-            TestPrimitiveArrayAsCollection<bool, BooleanArray, BooleanArray.Builder>(new[] { true, true, true, false });
-            TestPrimitiveArrayAsCollection<DateTime, Date32Array, Date32Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date, DateTime.Today, DateTime.Today });
-            TestPrimitiveArrayAsCollection<DateTime, Date64Array, Date64Array.Builder>(new[] { DateTime.MinValue.Date, DateTime.MaxValue.Date, DateTime.Today, DateTime.Today });
-            TestPrimitiveArrayAsCollection<DateTimeOffset, TimestampArray, TimestampArray.Builder>(new[] { DateTimeOffset.MinValue, DateTimeOffset.MinValue.AddYears(100), DateTimeOffset.Now, DateTimeOffset.UtcNow });
+            TestPrimitiveArrayAsCollection<long, Int64Array, Int64Array.Builder>([1, 2, 3, 4]);
+            TestPrimitiveArrayAsCollection<byte, UInt8Array, UInt8Array.Builder>([1, 2, 3, 4]);
+            TestPrimitiveArrayAsCollection<bool, BooleanArray, BooleanArray.Builder>([true, true, true, false]);
+            TestPrimitiveArrayAsCollection<DateTime, Date32Array, Date32Array.Builder>([DateTime.MinValue.Date, DateTime.MaxValue.Date, DateTime.Today, DateTime.Today]);
+            TestPrimitiveArrayAsCollection<DateTime, Date64Array, Date64Array.Builder>([DateTime.MinValue.Date, DateTime.MaxValue.Date, DateTime.Today, DateTime.Today]);
+            TestPrimitiveArrayAsCollection<DateTimeOffset, TimestampArray, TimestampArray.Builder>([DateTimeOffset.MinValue, DateTimeOffset.MinValue.AddYears(100), DateTimeOffset.Now, DateTimeOffset.UtcNow]);
 
 #if NET5_0_OR_GREATER
-            TestPrimitiveArrayAsCollection<DateOnly, Date32Array, Date32Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue, DateOnly.FromDayNumber(1), DateOnly.FromDayNumber(2) });
-            TestPrimitiveArrayAsCollection<DateOnly, Date64Array, Date64Array.Builder>(new[] { DateOnly.MinValue, DateOnly.MaxValue, DateOnly.FromDayNumber(1), DateOnly.FromDayNumber(2) });
-            TestPrimitiveArrayAsCollection<TimeOnly, Time32Array, Time32Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MinValue.AddHours(23), TimeOnly.MinValue.AddHours(1), TimeOnly.MinValue.AddHours(2) });
-            TestPrimitiveArrayAsCollection<TimeOnly, Time64Array, Time64Array.Builder>(new[] { TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.MinValue.AddHours(1), TimeOnly.MinValue.AddHours(2) });
-            TestPrimitiveArrayAsCollection<Half, HalfFloatArray, HalfFloatArray.Builder>(new[] { (Half)1.1, (Half)2.2f, (Half)3.3f, (Half)4.4f });
+            TestPrimitiveArrayAsCollection<DateOnly, Date32Array, Date32Array.Builder>([DateOnly.MinValue, DateOnly.MaxValue, DateOnly.FromDayNumber(1), DateOnly.FromDayNumber(2)]);
+            TestPrimitiveArrayAsCollection<DateOnly, Date64Array, Date64Array.Builder>([DateOnly.MinValue, DateOnly.MaxValue, DateOnly.FromDayNumber(1), DateOnly.FromDayNumber(2)]);
+            TestPrimitiveArrayAsCollection<TimeOnly, Time32Array, Time32Array.Builder>([TimeOnly.MinValue, TimeOnly.MinValue.AddHours(23), TimeOnly.MinValue.AddHours(1), TimeOnly.MinValue.AddHours(2)]);
+            TestPrimitiveArrayAsCollection<TimeOnly, Time64Array, Time64Array.Builder>([TimeOnly.MinValue, TimeOnly.MaxValue, TimeOnly.MinValue.AddHours(1), TimeOnly.MinValue.AddHours(2)]);
+            TestPrimitiveArrayAsCollection<Half, HalfFloatArray, HalfFloatArray.Builder>([(Half)1.1, (Half)2.2f, (Half)3.3f, (Half)4.4f]);
 #endif
 
-            byte[][] byteArrs = { new byte[1], System.Array.Empty<byte>(), new byte[] { 255 }, new byte[2] };
+            byte[][] byteArrs = [new byte[1], [], [255], new byte[2]];
             TestObjectArrayAsCollection(new BinaryArray.Builder().Append(byteArrs[0].AsEnumerable()).AppendNull().Append(byteArrs[1].AsEnumerable()).Append(byteArrs[0].AsEnumerable()).Build(), System.Array.Empty<byte>(), byteArrs);
 
-            string[] strings = { "abc", "abd", "acd", "adc" };
+            string[] strings = ["abc", "abd", "acd", "adc"];
             TestObjectArrayAsCollection(new StringArray.Builder().Append(strings[0]).AppendNull().Append(strings[1]).Append(strings[0]).Build(), null, strings);
         }
 
@@ -240,6 +240,20 @@ namespace Apache.Arrow.Tests
             Assert.Equal(values[1], destArr[3]);
             Assert.Equal(values[0], destArr[4]);
             Assert.Equal(sentinel, destArr[0]);
+        }
+
+        [Fact]
+        public void ContainsDoesNotMatchDefaultValueInArrayWithNullValue()
+        {
+            Int64Array array = new Int64Array.Builder().Append(1).Append(2).AppendNull().Build();
+            Assert.NotNull(array);
+            var collection = (ICollection<long?>)array;
+
+            Assert.True(collection.Contains(1));
+            Assert.True(collection.Contains(2));
+            Assert.True(collection.Contains(default));
+            // A null value is stored as a null bit in the null bitmap, and a default value in the value buffer. Check that we do not match the default value.
+            Assert.False(collection.Contains(0));
         }
 
         [Fact]

--- a/csharp/test/Apache.Arrow.Tests/Date32ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Date32ArrayTests.cs
@@ -131,7 +131,7 @@ namespace Apache.Arrow.Tests
         public class AppendDateOnly
         {
             [Theory]
-            [MemberData(nameof(GetDateOnlyData), MemberType = typeof(Date64ArrayTests))]
+            [MemberData(nameof(GetDateOnlyData), MemberType = typeof(Date32ArrayTests))]
             public void AppendDateGivesSameDate(DateOnly date)
             {
                 // Arrange

--- a/csharp/test/Apache.Arrow.Tests/Extensions/DateTimeOffsetExtensions.cs
+++ b/csharp/test/Apache.Arrow.Tests/Extensions/DateTimeOffsetExtensions.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Apache.Arrow.Tests
 {

--- a/csharp/test/Apache.Arrow.Tests/UnionArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/UnionArrayTests.cs
@@ -110,7 +110,7 @@ public class UnionArrayTests
     }
 
     private static void CompareFieldValue<T, TArray>(byte typeId, UnionArray originalArray, int originalIndex, UnionArray slicedArray, int sliceIndex)
-        where T: struct
+        where T : struct, IEquatable<T>
         where TArray : PrimitiveArray<T>
     {
         if (originalArray is DenseUnionArray denseOriginalArray)


### PR DESCRIPTION
### What changes are included in this PR?

This PR makes the following array types support ICollection<T?> :
- PrimitiveArray
- BooleanArray
- Date32Array
- Date64Array
- Time32Array
- Time64Array
- BinaryArray
- TimestampArray
- StringArray

### Are these changes tested?

Yes

### Are there any user-facing changes?

No



Closes #38692
* GitHub Issue: #38692