### PR TITLE
GH-41566: [CI][Packaging] macOS wheel for Catalina fails to build on macOS arm64

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -409,7 +409,7 @@ tasks:
       arrow_jemalloc: "ON"
       python_version: "{{ python_version }}"
       macos_deployment_target: "{{ macos_version }}"
-      runs_on: "macos-latest"
+      runs_on: "macos-13"
       vcpkg_arch: "amd64"
     artifacts:
       - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-{{ platform_tag }}.whl


### PR DESCRIPTION
### Rationale for this change

Wheels for macOS catalina are failing

### What changes are included in this PR?

Use macos-13 instead of (latest) ARM

### Are these changes tested?

Yes, via archery

### Are there any user-facing changes?

No
* GitHub Issue: #41566