### PR TITLE
GH-41573: [Java] VectorSchemaRoot uses inefficient stream to copy fieldVectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -128,7 +128,7 @@ public class VectorSchemaRoot implements AutoCloseable {
     }
     if (fieldVectors.size() != schema.getFields().size()) {
       throw new IllegalArgumentException("The root vector did not create the right number of children. found " +
-              fieldVectors.size() + " expected " + schema.getFields().size());
+          fieldVectors.size() + " expected " + schema.getFields().size());
     }
     return new VectorSchemaRoot(schema, fieldVectors, 0);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -121,14 +121,14 @@ public class VectorSchemaRoot implements AutoCloseable {
    * Creates a new set of empty vectors corresponding to the given schema.
    */
   public static VectorSchemaRoot create(Schema schema, BufferAllocator allocator) {
-    List<FieldVector> fieldVectors = new ArrayList<>();
+    List<FieldVector> fieldVectors = new ArrayList<>(schema.getFields().size());
     for (Field field : schema.getFields()) {
       FieldVector vector = field.createVector(allocator);
       fieldVectors.add(vector);
     }
     if (fieldVectors.size() != schema.getFields().size()) {
       throw new IllegalArgumentException("The root vector did not create the right number of children. found " +
-          fieldVectors.size() + " expected " + schema.getFields().size());
+              fieldVectors.size() + " expected " + schema.getFields().size());
     }
     return new VectorSchemaRoot(schema, fieldVectors, 0);
   }
@@ -160,7 +160,7 @@ public class VectorSchemaRoot implements AutoCloseable {
   }
 
   public List<FieldVector> getFieldVectors() {
-    return fieldVectors.stream().collect(Collectors.toList());
+    return new ArrayList<>(fieldVectors);
   }
 
   /**
@@ -236,7 +236,7 @@ public class VectorSchemaRoot implements AutoCloseable {
    */
   public void setRowCount(int rowCount) {
     this.rowCount = rowCount;
-    for (FieldVector v : getFieldVectors()) {
+    for (FieldVector v : fieldVectors) {
       v.setValueCount(rowCount);
     }
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -160,7 +161,7 @@ public class VectorSchemaRoot implements AutoCloseable {
   }
 
   public List<FieldVector> getFieldVectors() {
-    return new ArrayList<>(fieldVectors);
+    return Collections.unmodifiableList(fieldVectors);
   }
 
   /**


### PR DESCRIPTION
### Rationale for this change

While reviewing allocation profiling of an Arrow intensive application, I noticed significant allocations due to `ArrayList#grow()` originating from `org.apache.arrow.vector.VectorSchemaRoot#getFieldVectors()`. The `org.apache.arrow.vector.VectorSchemaRoot#getFieldVectors()` method uses an inefficient `fieldVectors.stream().collect(Collectors.toList())` to create a list copy, leading to reallocations as the target list is collected. This could be replaced with a more efficent `new ArrayList<>(fieldVectors)` to make a pre-sized list copy, or even better an unmodifiable view via `Collections.unmodifiableList(fieldVectors)`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

* Use `Collections.unmodifiableList(List)` to return unmodifiable list view of `fieldVectors` from `getFieldVectors()`
* Pre-size the `fieldVectors` `ArrayList` in static factory `VectorSchemaRoot#create(Schema, BufferAllocator)`
* `VectorSchemaRoot#setRowCount(int)` iterates over instance `fieldVectors` instead of copied list (similar to existing `allocateNew()`, `clear()`, `contentToTSVString()`).

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

These changes are covered by existing unit and integration tests.


### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41573