### PR TITLE
GH-41577: [CI][Packaging] Use macOS amd64 to package jar files instead of arm64

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -183,7 +183,7 @@ jobs:
 
   package-jars:
     name: Build jar files
-    runs-on: macos-latest
+    runs-on: macos-13
     needs:
       - build-cpp-ubuntu
       - build-cpp-macos


### PR DESCRIPTION
### Rationale for this change

The java-jars job is currently failing when using macos-latest

### What changes are included in this PR?

Change from macos-latest to macos-13

### Are these changes tested?

Yes, via archery

### Are there any user-facing changes?

No
* GitHub Issue: #41577