### PR TITLE
GH-41435: [CI][MATLAB] Add job to build and test MATLAB Interface on `macos-14`

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -102,11 +102,12 @@ jobs:
     runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
-      include:
-          - architecture: AMD64
-            macos-version: "12"
-          - architecture: ARM64
-            macos-version: "14"
+      matrix:
+        include:
+            - architecture: AMD64
+              macos-version: "12"
+            - architecture: ARM64
+              macos-version: "14"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -98,9 +98,15 @@ jobs:
           select-by-folder: matlab/test
           strict: true
   macos:
-    name: AMD64 macOS 12 MATLAB
+    name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} MATLAB
     runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    strategy:
+      include:
+          - architecture: AMD64
+            macos-version: "12"
+          - architecture: ARM64
+            macos-version: "14"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -99,7 +99,7 @@ jobs:
           strict: true
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} MATLAB
-    runs-on: macos-12
+    runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       matrix:


### PR DESCRIPTION
### Rationale for this change

Currently, the MATLAB interface is built and tested on `macos-12` - not `macos-14` - because the version of `mathworks/libmexclass` depends on used to not support `macos-14`. However, now that https://github.com/apache/arrow/issues/41400 is closed, the version of `mathworks/libmexclass` the MATLAB interface depends on works on `macos-14`, so we will be able to build and test the MATLAB interface on `macos-14`.

**Note**: When adding support for ARM-based macOS builds, we discovered an issue with the way in which we package the MLTBX files for the MATLAB Interface to Arrow.
 
Currently, we bundle all shared libraries for all platforms (.dll, .dylib, and .so) into one large "monolithic" MLTBX file.
 
Unfortunately, putting all platform-specific files into one MLTBX file poses an issue when we support multiple ISAs (e.g. x86 and ARM) because builds for the same operating system with different ISAs will have the same shared library file names. In other words, we will have a library named libarrowproxy.dylib for both ARM and x86 macOS builds.
 
Therefore, we are going to hold off on adding ARM-based macOS builds to the crossbow packaging workflow for now until we have a chance to properly explore alternative packaging approaches. For example, we may want to consider having platform-specific MLTBX files. However, we still think it is worthwhile to add CI support for `macos-14` in the meantime.

### What changes are included in this PR?

1. Added workflow to build and test the MATLAB interface on `macos-14` as well as `macos-12`.

### Are these changes tested?

N/A. 


### Are there any user-facing changes?

No.

### Future Directions

1. Add crossbow packaging workflow on `macos-14` once we determine how to package the interface for both ARM-based and Intel-based mac ISAs.

* GitHub Issue: #41435