### PR TITLE
GH-41594: [Go] Support reading `date64` type & properly validate list-like types

### DIFF
--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -239,21 +239,31 @@ func WithStringsReplacer(replacer *strings.Replacer) Option {
 
 func validate(schema *arrow.Schema) {
 	for i, f := range schema.Fields() {
-		switch ft := f.Type.(type) {
-		case *arrow.BooleanType:
-		case *arrow.Int8Type, *arrow.Int16Type, *arrow.Int32Type, *arrow.Int64Type:
-		case *arrow.Uint8Type, *arrow.Uint16Type, *arrow.Uint32Type, *arrow.Uint64Type:
-		case *arrow.Float16Type, *arrow.Float32Type, *arrow.Float64Type:
-		case *arrow.StringType, *arrow.LargeStringType:
-		case *arrow.TimestampType:
-		case *arrow.Date32Type, *arrow.Date64Type:
-		case *arrow.Decimal128Type, *arrow.Decimal256Type:
-		case *arrow.ListType, *arrow.LargeListType, *arrow.FixedSizeListType:
-		case *arrow.BinaryType, *arrow.LargeBinaryType, *arrow.FixedSizeBinaryType:
-		case arrow.ExtensionType:
-		case *arrow.NullType:
-		default:
-			panic(fmt.Errorf("arrow/csv: field %d (%s) has invalid data type %T", i, f.Name, ft))
+		if !typeSupported(f.Type) {
+			panic(fmt.Errorf("arrow/csv: field %d (%s) has invalid data type %T", i, f.Name, f.Type))
 		}
 	}
+}
+
+func typeSupported(dt arrow.DataType) bool {
+	switch dt := dt.(type) {
+	case *arrow.BooleanType:
+	case *arrow.Int8Type, *arrow.Int16Type, *arrow.Int32Type, *arrow.Int64Type:
+	case *arrow.Uint8Type, *arrow.Uint16Type, *arrow.Uint32Type, *arrow.Uint64Type:
+	case *arrow.Float16Type, *arrow.Float32Type, *arrow.Float64Type:
+	case *arrow.StringType, *arrow.LargeStringType:
+	case *arrow.TimestampType:
+	case *arrow.Date32Type, *arrow.Date64Type:
+	case *arrow.Decimal128Type, *arrow.Decimal256Type:
+	case *arrow.MapType:
+		return false
+	case arrow.ListLikeType:
+		return typeSupported(dt.Elem())
+	case *arrow.BinaryType, *arrow.LargeBinaryType, *arrow.FixedSizeBinaryType:
+	case arrow.ExtensionType:
+	case *arrow.NullType:
+	default:
+		return false
+	}
+	return true
 }

--- a/go/arrow/csv/reader.go
+++ b/go/arrow/csv/reader.go
@@ -966,7 +966,7 @@ func (c conversionColumn) inferType(v string) arrow.DataType {
 			c.typ = arrow.FixedWidthTypes.Boolean
 		case *arrow.BooleanType:
 			c.typ = arrow.FixedWidthTypes.Date32
-		case *arrow.Date32Type, *arrow.Date64Type:
+		case *arrow.Date32Type:
 			c.typ = arrow.FixedWidthTypes.Time32s
 		case *arrow.Time32Type:
 			c.typ = &arrow.TimestampType{Unit: arrow.Second}
@@ -1001,7 +1001,7 @@ func tryParse(val string, dt arrow.DataType) error {
 	case *arrow.BooleanType:
 		_, err := strconv.ParseBool(val)
 		return err
-	case *arrow.Date32Type, *arrow.Date64Type:
+	case *arrow.Date32Type:
 		_, err := time.Parse("2006-01-02", val)
 		return err
 	case *arrow.Time32Type:

--- a/go/arrow/csv/reader_test.go
+++ b/go/arrow/csv/reader_test.go
@@ -357,6 +357,8 @@ func testCSVReader(t *testing.T, filepath string, withHeader bool, stringsCanBeN
 			{Name: "large_binary", Type: arrow.BinaryTypes.LargeBinary},
 			{Name: "fixed_size_binary", Type: &arrow.FixedSizeBinaryType{ByteWidth: 3}},
 			{Name: "uuid", Type: types.NewUUIDType()},
+			{Name: "date32", Type: arrow.PrimitiveTypes.Date32},
+			{Name: "date64", Type: arrow.PrimitiveTypes.Date64},
 		},
 		nil,
 	)
@@ -420,6 +422,8 @@ rec[0]["binary"]: ["\x00\x01\x02"]
 rec[0]["large_binary"]: ["\x00\x01\x02"]
 rec[0]["fixed_size_binary"]: ["\x00\x01\x02"]
 rec[0]["uuid"]: ["00000000-0000-0000-0000-000000000001"]
+rec[0]["date32"]: [19121]
+rec[0]["date64"]: [1652054400000]
 rec[1]["bool"]: [false]
 rec[1]["i8"]: [-2]
 rec[1]["i16"]: [-2]
@@ -442,6 +446,8 @@ rec[1]["binary"]: [(null)]
 rec[1]["large_binary"]: [(null)]
 rec[1]["fixed_size_binary"]: [(null)]
 rec[1]["uuid"]: ["00000000-0000-0000-0000-000000000002"]
+rec[1]["date32"]: [19121]
+rec[1]["date64"]: [1652054400000]
 rec[2]["bool"]: [(null)]
 rec[2]["i8"]: [(null)]
 rec[2]["i16"]: [(null)]
@@ -464,6 +470,8 @@ rec[2]["binary"]: [(null)]
 rec[2]["large_binary"]: [(null)]
 rec[2]["fixed_size_binary"]: [(null)]
 rec[2]["uuid"]: [(null)]
+rec[2]["date32"]: [(null)]
+rec[2]["date64"]: [(null)]
 `, str1Value, str1Value, str2Value, str2Value)
 	got, want := out.String(), want
 	require.Equal(t, want, got)

--- a/go/arrow/csv/testdata/header.csv
+++ b/go/arrow/csv/testdata/header.csv
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-bool;i8;i16;i32;i64;u8;u16;u32;u64;f16;f32;f64;str;large_str;ts;list(i64);large_list(i64);fixed_size_list(i64);binary;large_binary;fixed_size_binary;uuid
-true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;1.1;str-1;str-1;2022-05-09T00:01:01;{1,2,3};{1,2,3};{1,2,3};AAEC;AAEC;AAEC;00000000-0000-0000-0000-000000000001
-false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;2.2;;;2022-05-09T23:59:59;{};{};{4,5,6};;;;00000000-0000-0000-0000-000000000002
-null;NULL;null;N/A;;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null
+bool;i8;i16;i32;i64;u8;u16;u32;u64;f16;f32;f64;str;large_str;ts;list(i64);large_list(i64);fixed_size_list(i64);binary;large_binary;fixed_size_binary;uuid;date32;date64
+true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;1.1;str-1;str-1;2022-05-09T00:01:01;{1,2,3};{1,2,3};{1,2,3};AAEC;AAEC;AAEC;00000000-0000-0000-0000-000000000001;2022-05-09;2022-05-09
+false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;2.2;;;2022-05-09T23:59:59;{};{};{4,5,6};;;;00000000-0000-0000-0000-000000000002;2022-05-09;2022-05-09
+null;NULL;null;N/A;;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null

--- a/go/arrow/csv/testdata/types.csv
+++ b/go/arrow/csv/testdata/types.csv
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-## supported types: bool;int8;int16;int32;int64;uint8;uint16;uint32;uint64;float16;float32;float64;string;large_string;timestamp;list(i64);large_list(i64);fixed_size_list(i64);binary;large_binary;fixed_size_binary;uuid
-true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;1.1;str-1;str-1;2022-05-09T00:01:01;{1,2,3};{1,2,3};{1,2,3};AAEC;AAEC;AAEC;00000000-0000-0000-0000-000000000001
-false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;2.2;;;2022-05-09T23:59:59;{};{};{4,5,6};;;;00000000-0000-0000-0000-000000000002
-null;NULL;null;N/A;;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null
+## supported types: bool;int8;int16;int32;int64;uint8;uint16;uint32;uint64;float16;float32;float64;string;large_string;timestamp;list(i64);large_list(i64);fixed_size_list(i64);binary;large_binary;fixed_size_binary;uuid;date32;date64
+true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;1.1;str-1;str-1;2022-05-09T00:01:01;{1,2,3};{1,2,3};{1,2,3};AAEC;AAEC;AAEC;00000000-0000-0000-0000-000000000001;2022-05-09;2022-05-09
+false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;2.2;;;2022-05-09T23:59:59;{};{};{4,5,6};;;;00000000-0000-0000-0000-000000000002;2022-05-09;2022-05-09
+null;NULL;null;N/A;;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null;null


### PR DESCRIPTION
This PR includes 2 fixes:
1. support reading `date64` columns (as write is supported)
2. properly validate list-like data types (list of unsupported is unsupported)

### Rationale for this change

See #41594

### What changes are included in this PR?

1. Added `date64` reading & conversion funcs similar to `date32`
2. Refactored date type validation

### Are these changes tested?

a55cd5324d2c47932410b0c7a9c46075386645d2

### Are there any user-facing changes?

No.

* GitHub Issue: #41594