### PR TITLE
GH-41596: [C++] fixed_width_internal.h: Simplify docstring and support bit-sized types (BOOL)

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -163,7 +163,7 @@ class PrimitiveFilterImpl {
         values_is_valid_(values.buffers[0].data),
         // No offset applied for boolean because it's a bitmap
         values_data_(kIsBoolean ? values.buffers[1].data
-                                : util::OffsetPointerOfFixedWidthValues(values)),
+                                : util::OffsetPointerOfFixedByteWidthValues(values)),
         values_null_count_(values.null_count),
         values_offset_(values.offset),
         values_length_(values.length),
@@ -469,7 +469,7 @@ Status PrimitiveFilterExec(KernelContext* ctx, const ExecSpan& batch, ExecResult
   // validity bitmap.
   const bool allocate_validity = values.null_count != 0 || !filter_null_count_is_zero;
 
-  DCHECK(util::IsFixedWidthLike(values, /*force_null_count=*/false));
+  DCHECK(util::IsFixedWidthLike(values));
   const int64_t bit_width = util::FixedWidthInBits(*values.type);
   RETURN_NOT_OK(util::internal::PreallocateFixedWidthArrayData(
       ctx, output_length, /*source=*/values, allocate_validity, out_arr));

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
@@ -898,7 +898,7 @@ Status FSLFilterExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out)
   // PrimitiveFilterExec for a fixed-size list array.
   if (util::IsFixedWidthLike(values,
                              /*force_null_count=*/true,
-                             /*exclude_dictionary=*/true)) {
+                             /*exclude_bool_and_dictionary=*/true)) {
     const auto byte_width = util::FixedWidthInBytes(*values.type);
     // 0 is a valid byte width for FixedSizeList, but PrimitiveFilterExec
     // might not handle it correctly.
@@ -971,7 +971,7 @@ Status FSLTakeExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   // PrimitiveTakeExec for a fixed-size list array.
   if (util::IsFixedWidthLike(values,
                              /*force_null_count=*/true,
-                             /*exclude_dictionary=*/true)) {
+                             /*exclude_bool_and_dictionary=*/true)) {
     const auto byte_width = util::FixedWidthInBytes(*values.type);
     // Additionally, PrimitiveTakeExec is only implemented for specific byte widths.
     // TODO(GH-41301): Extend PrimitiveTakeExec for any fixed-width type.

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -347,7 +347,7 @@ struct PrimitiveTakeImpl {
   static void Exec(const ArraySpan& values, const ArraySpan& indices,
                    ArrayData* out_arr) {
     DCHECK_EQ(util::FixedWidthInBytes(*values.type), kValueWidth);
-    const auto* values_data = util::OffsetPointerOfFixedWidthValues(values);
+    const auto* values_data = util::OffsetPointerOfFixedByteWidthValues(values);
     const uint8_t* values_is_valid = values.buffers[0].data;
     auto values_offset = values.offset;
 
@@ -588,8 +588,7 @@ Status PrimitiveTakeExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* 
 
   ArrayData* out_arr = out->array_data().get();
 
-  DCHECK(util::IsFixedWidthLike(values, /*force_null_count=*/false,
-                                /*exclude_dictionary=*/true));
+  DCHECK(util::IsFixedWidthLike(values));
   const int64_t bit_width = util::FixedWidthInBits(*values.type);
 
   // TODO: When neither values nor indices contain nulls, we can skip

--- a/cpp/src/arrow/util/fixed_width_test.cc
+++ b/cpp/src/arrow/util/fixed_width_test.cc
@@ -80,10 +80,7 @@ TEST_F(TestFixedWidth, IsFixedWidth) {
 
 TEST_F(TestFixedWidth, IsFixedWidthLike) {
   auto arr = ArraySpan{*fsl_bool_array_->data()};
-  // bools wrapped by fixed-size-list are not fixed-width because the
-  // innermost data buffer is a bitmap and won't byte-align.
-  ASSERT_FALSE(IsFixedWidthLike(arr, /*force_null_count=*/false));
-  ASSERT_FALSE(IsFixedWidthLike(arr, /*force_null_count=*/true));
+  ASSERT_TRUE(IsFixedWidthLike(arr, /*force_null_count=*/false));
 
   arr = ArraySpan{*fsl_int_array_->data()};
   ASSERT_TRUE(IsFixedWidthLike(arr, /*force_null_count=*/false));
@@ -114,12 +111,12 @@ TEST_F(TestFixedWidth, IsFixedWidthLike) {
 
   arr = ArraySpan{*dict_string_array_->data()};
   // Dictionaries are considered fixed-width by is_fixed_width(), but excluded
-  // by IsFixedWidthLike if exclude_dictionary=true.
+  // by IsFixedWidthLike if exclude_bool_and_dictionary=true.
   ASSERT_TRUE(IsFixedWidthLike(arr));
-  ASSERT_TRUE(
-      IsFixedWidthLike(arr, /*force_null_count=*/false, /*exclude_dictionary=*/false));
-  ASSERT_FALSE(
-      IsFixedWidthLike(arr, /*force_null_count=*/false, /*exclude_dictionary=*/true));
+  ASSERT_TRUE(IsFixedWidthLike(arr, /*force_null_count=*/false,
+                               /*exclude_bool_and_dictionary=*/false));
+  ASSERT_FALSE(IsFixedWidthLike(arr, /*force_null_count=*/false,
+                                /*exclude_bool_and_dictionary=*/true));
 }
 
 TEST_F(TestFixedWidth, MeasureWidthInBytes) {
@@ -184,9 +181,9 @@ TEST_F(TestFixedWidth, MeasureWidthInBits) {
   ASSERT_EQ(FixedWidthInBits(*varlen), -1);
   ASSERT_EQ(FixedWidthInBits(*varlen), -1);
 
-  ASSERT_EQ(FixedWidthInBits(*fsl(0, b)), -1);
-  ASSERT_EQ(FixedWidthInBits(*fsl(3, b)), -1);
-  ASSERT_EQ(FixedWidthInBits(*fsl(5, b)), -1);
+  ASSERT_EQ(FixedWidthInBits(*fsl(0, b)), 0);
+  ASSERT_EQ(FixedWidthInBits(*fsl(3, b)), 3);
+  ASSERT_EQ(FixedWidthInBits(*fsl(5, b)), 5);
 
   ASSERT_EQ(FixedWidthInBits(*fsl(0, i8)), 0);
   ASSERT_EQ(FixedWidthInBits(*fsl(3, i8)), 3 * 8);


### PR DESCRIPTION
### Rationale for this change

Post-merge feedback from #41297.

### What changes are included in this PR?

 - Supporting `BOOL` as both a top-level and nested in FSL types
 - Removing the long example from the docstring of `IsFixedWidthLike`

These changes don't affect users because this header was added recently and not released.

### Are these changes tested?

Yes, by existing and new test cases.
* GitHub Issue: #41596