### PR TITLE
GH-41490: WIP: [Java] Use macos-12 for building C++ libraries

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runs_on: ["macos-13"], arch: "x86_64"}
+          - { runs_on: ["macos-12"], arch: "x86_64"}
           - { runs_on: ["macos-14"], arch: "aarch_64" }
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.15"


### PR DESCRIPTION
### Rationale for this change

`macos-latest` is `macos-14` and it's arm64 not x86_64. `java-jars` works well with `macos-12` that is the previous `macos-latset`.

### What changes are included in this PR?

Use `macos-12` that is the previous `macos-latest` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: apache/arrow-java#92
* GitHub Issue: #92