### PR TITLE
GH-41609: [Java] Initialize non empty offset buffer for variable-size layout before exporting

### DIFF
--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -524,10 +524,11 @@ public class RoundtripTest {
     }
   }
 
-  @Test
+  0@Test
   public void testEmptyVarCharVector() {
     try (final VarCharVector vector = new VarCharVector("v", allocator)) {
-      setVector(vector);
+      vector.allocateNewSafe();
+      vector.setValueCount(0);
       assertTrue(roundtrip(vector, VarCharVector.class));
     }
   }
@@ -535,7 +536,8 @@ public class RoundtripTest {
   @Test
   public void testEmptyLargeVarCharVector() {
     try (final LargeVarCharVector vector = new LargeVarCharVector("v", allocator)) {
-      setVector(vector);
+      vector.allocateNewSafe();
+      vector.setValueCount(0);
       assertTrue(roundtrip(vector, LargeVarCharVector.class));
     }
   }
@@ -543,7 +545,8 @@ public class RoundtripTest {
   @Test
   public void testEmptyVarBinaryVector() {
     try (final VarBinaryVector vector = new VarBinaryVector("v", allocator)) {
-      setVector(vector);
+      vector.allocateNewSafe();
+      vector.setValueCount(0);
       assertTrue(roundtrip(vector, VarBinaryVector.class));
     }
   }
@@ -551,7 +554,8 @@ public class RoundtripTest {
   @Test
   public void testEmptyLargeVarBinaryVector() {
     try (final LargeVarBinaryVector vector = new LargeVarBinaryVector("v", allocator)) {
-      setVector(vector);
+      vector.allocateNewSafe();
+      vector.setValueCount(0);
       assertTrue(roundtrip(vector, LargeVarBinaryVector.class));
     }
   }

--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -525,6 +525,38 @@ public class RoundtripTest {
   }
 
   @Test
+  public void testEmptyVarCharVector() {
+    try (final VarCharVector vector = new VarCharVector("v", allocator)) {
+      setVector(vector);
+      assertTrue(roundtrip(vector, VarCharVector.class));
+    }
+  }
+
+  @Test
+  public void testEmptyLargeVarCharVector() {
+    try (final LargeVarCharVector vector = new LargeVarCharVector("v", allocator)) {
+      setVector(vector);
+      assertTrue(roundtrip(vector, LargeVarCharVector.class));
+    }
+  }
+
+  @Test
+  public void testEmptyVarBinaryVector() {
+    try (final VarBinaryVector vector = new VarBinaryVector("v", allocator)) {
+      setVector(vector);
+      assertTrue(roundtrip(vector, VarBinaryVector.class));
+    }
+  }
+
+  @Test
+  public void testEmptyLargeVarBinaryVector() {
+    try (final LargeVarBinaryVector vector = new LargeVarBinaryVector("v", allocator)) {
+      setVector(vector);
+      assertTrue(roundtrip(vector, LargeVarBinaryVector.class));
+    }
+  }
+
+  @Test
   public void testLargeVarBinaryVector() {
     try (final LargeVarBinaryVector vector = new LargeVarBinaryVector("", allocator)) {
       vector.allocateNew(5, 1);

--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -524,7 +524,7 @@ public class RoundtripTest {
     }
   }
 
-  0@Test
+  @Test
   public void testEmptyVarCharVector() {
     try (final VarCharVector vector = new VarCharVector("v", allocator)) {
       vector.allocateNewSafe();


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This is a follow up of https://github.com/apache/arrow/issues/40038. In https://github.com/apache/arrow/issues/40038, we fixed null offset buffer issue for BaseVariableWidthVector. For empty vector, instead of a empty offset buffer which turns to be a null buffer through C Data Interface, we export a non-empty offset which is supposed to contain zero value.

But the initialization code has a bug in the PR https://github.com/apache/arrow/pull/40043, so the offset buffer is not initialized. Note that this is not a regression because the exported vector never works due to null offset buffer.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fixed the uninitialized offset buffer of empty `BaseVariableWidthVector`.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Added test cases.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->

No

<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41609