### PR TITLE
GH-41149: [C++][Acero] Fix asof join race

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -972,10 +972,9 @@ class AsofJoinNode : public ExecNode {
       // If LHS is finished or empty then there's nothing we can do here
       if (lhs.Finished() || lhs.Empty()) break;
 
-      ARROW_ASSIGN_OR_RAISE(auto pair, UpdateRhsAndCheckUpToDateWithLhs());
       bool any_rhs_advanced{};
       bool rhs_up_to_date_with_lhs{};
-      std::tie(any_rhs_advanced, rhs_up_to_date_with_lhs) = pair;
+      ARROW_ASSIGN_OR_RAISE(std::tie(any_rhs_advanced, rhs_up_to_date_with_lhs), UpdateRhsAndCheckUpToDateWithLhs());
 
       // If we have received enough inputs to produce the next output batch
       // (decided by IsUpToDateWithLhsRow), we will perform the join and

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -551,7 +551,7 @@ class InputState {
   // NOTE: The emptiness must be decided by an single call to Empty() in caller, due to
   // the potential race with Push(), see GH-41614.
   bool CurrentEmpty(bool empty) const {
-    return memo_.no_future_ ? empty : memo_.times_.empty() && empty;
+    return memo_.no_future_ ? empty : (memo_.times_.empty() && empty);
   }
 
   // in case memo may not have future entries (the case of a non-positive tolerance),

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -548,8 +548,8 @@ class InputState {
   // true when the queue is empty and, when memo may have future entries (the case of a
   // positive tolerance), when the memo is empty.
   // used when checking whether RHS is up to date with LHS.
-  // NOTE: The emptiness must be decided by an single call to Empty() in caller, due to
-  // the potential race with Push(), see GH-41614.
+  // NOTE: The emptiness must be decided by a single call to Empty() in caller, due to the
+  // potential race with Push(), see GH-41614.
   bool CurrentEmpty(bool empty) const {
     return memo_.no_future_ ? empty : (memo_.times_.empty() && empty);
   }
@@ -652,8 +652,8 @@ class InputState {
   // timestamp, update latest_time and latest_ref_row to the value that immediately pass
   // the horizon. Update the memo-store with any entries or future entries so observed.
   // Returns true if updates were made, false if not.
-  // NOTE: The emptiness must be decided by an single call to Empty() in caller, due to
-  // the potential race with Push(), see GH-41614.
+  // NOTE: The emptiness must be decided by a single call to Empty() in caller, due to the
+  // potential race with Push(), see GH-41614.
   Result<bool> AdvanceAndMemoize(OnType ts, bool empty) {
     // Advance the right side row index until we reach the latest right row (for each key)
     // for the given left timestamp.

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -548,8 +548,8 @@ class InputState {
   // true when the queue is empty and, when memo may have future entries (the case of a
   // positive tolerance), when the memo is empty.
   // used when checking whether RHS is up to date with LHS.
-  // NOTE: The emptiness must be decided by an atomic all to Empty() in caller, due to the
-  // potential race with Push(), see GH-41614.
+  // NOTE: The emptiness must be decided by an single call to Empty() in caller, due to
+  // the potential race with Push(), see GH-41614.
   bool CurrentEmpty(bool empty) const {
     return memo_.no_future_ ? empty : memo_.times_.empty() && empty;
   }
@@ -652,8 +652,8 @@ class InputState {
   // timestamp, update latest_time and latest_ref_row to the value that immediately pass
   // the horizon. Update the memo-store with any entries or future entries so observed.
   // Returns true if updates were made, false if not.
-  // NOTE: The emptiness must be decided by an atomic all to Empty() in caller, due to the
-  // potential race with Push(), see GH-41614.
+  // NOTE: The emptiness must be decided by an single call to Empty() in caller, due to
+  // the potential race with Push(), see GH-41614.
   Result<bool> AdvanceAndMemoize(OnType ts, bool empty) {
     // Advance the right side row index until we reach the latest right row (for each key)
     // for the given left timestamp.

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -974,7 +974,8 @@ class AsofJoinNode : public ExecNode {
 
       bool any_rhs_advanced{};
       bool rhs_up_to_date_with_lhs{};
-      ARROW_ASSIGN_OR_RAISE(std::tie(any_rhs_advanced, rhs_up_to_date_with_lhs), UpdateRhsAndCheckUpToDateWithLhs());
+      ARROW_ASSIGN_OR_RAISE(std::tie(any_rhs_advanced, rhs_up_to_date_with_lhs),
+                            UpdateRhsAndCheckUpToDateWithLhs());
 
       // If we have received enough inputs to produce the next output batch
       // (decided by IsUpToDateWithLhsRow), we will perform the join and

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -1394,7 +1394,10 @@ class AsofJoinNode : public ExecNode {
     DEBUG_SYNC(this, "received batch from input ", k, ":", DEBUG_MANIP(std::endl),
                rb->ToString(), DEBUG_MANIP(std::endl));
 
-    ARROW_RETURN_NOT_OK(state_.at(k)->Push(rb));
+    {
+      std::lock_guard<std::mutex> guard(gate_);
+      ARROW_RETURN_NOT_OK(state_.at(k)->Push(rb));
+    }
     process_.Push(true);
     return Status::OK();
   }

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1678,7 +1678,9 @@ TEST(AsofJoinTest, BackpressureWithBatchesGen) {
                           /*slow_r0=*/false);
 }
 
-TEST(AsofJoinTest, GH40675) {
+// Reproduction of GH-40675: A logical race between Process() and Push() that can be more
+// easily observed with single small batch.
+TEST(AsofJoinTest, RhsEmptinessRace) {
   auto left_batch = ExecBatchFromJSON(
       {int64(), utf8()}, R"([[1, "a"], [1, "b"], [5, "a"], [6, "b"], [7, "f"]])");
   auto right_batch = ExecBatchFromJSON(
@@ -1705,7 +1707,9 @@ TEST(AsofJoinTest, GH40675) {
   AssertExecBatchesEqualIgnoringOrder(result.schema, {exp_batch}, result.batches);
 }
 
-TEST(AsofJoinTest, GH41149) {
+// Reproduction of GH-41149: Another case of the same root cause as GH-40675, but with
+// empty "by" columns.
+TEST(AsofJoinTest, RhsEmptinessRaceEmptyBy) {
   auto left_batch = ExecBatchFromJSON({int64()}, R"([[1], [2], [3]])");
   auto right_batch =
       ExecBatchFromJSON({utf8(), int64()}, R"([["Z", 2], ["B", 3], ["A", 4]])");

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1678,14 +1678,11 @@ TEST(AsofJoinTest, BackpressureWithBatchesGen) {
                           /*slow_r0=*/false);
 }
 
-// GH-40675.
-TEST(AsofJoinTest, Flaky1) {
-  std::vector<TypeHolder> left_types = {int64(), utf8()};
+TEST(AsofJoinTest, GH40675) {
   auto left_batch = ExecBatchFromJSON(
-      left_types, R"([[1, "a"], [1, "b"], [5, "a"], [6, "b"], [7, "f"]])");
-  std::vector<TypeHolder> right_types = {int64(), utf8(), float64()};
-  auto right_batch =
-      ExecBatchFromJSON(right_types, R"([[2, "a", 1.0], [9, "b", 3.0], [15, "g", 5.0]])");
+      {int64(), utf8()}, R"([[1, "a"], [1, "b"], [5, "a"], [6, "b"], [7, "f"]])");
+  auto right_batch = ExecBatchFromJSON(
+      {int64(), utf8(), float64()}, R"([[2, "a", 1.0], [9, "b", 3.0], [15, "g", 5.0]])");
 
   Declaration left{
       "exec_batch_source",
@@ -1697,23 +1694,21 @@ TEST(AsofJoinTest, Flaky1) {
                                          field("colC", float64())}),
                                  {std::move(right_batch)})};
   AsofJoinNodeOptions asof_join_opts({{{"colA"}, {{"col2"}}}, {{"colB"}, {{"col3"}}}}, 1);
-  Declaration asof_join{"asofjoin", {left, right}, asof_join_opts};
+  Declaration asof_join{
+      "asofjoin", {std::move(left), std::move(right)}, std::move(asof_join_opts)};
 
-  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(asof_join));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(asof_join)));
 
-  std::vector<TypeHolder> exp_types = {int64(), utf8(), float64()};
   auto exp_batch = ExecBatchFromJSON(
-      exp_types,
+      {int64(), utf8(), float64()},
       R"([[1, "a", 1.0], [1, "b", null], [5, "a", null], [6, "b", null], [7, "f", null]])");
   AssertExecBatchesEqualIgnoringOrder(result.schema, {exp_batch}, result.batches);
 }
 
-// GH-41149.
-TEST(AsofJoinTest, Flaky2) {
-  std::vector<TypeHolder> left_types = {int64()};
-  auto left_batch = ExecBatchFromJSON(left_types, R"([[1], [2], [3]])");
-  std::vector<TypeHolder> right_types = {utf8(), int64()};
-  auto right_batch = ExecBatchFromJSON(right_types, R"([["Z", 2], ["B", 3], ["A", 4]])");
+TEST(AsofJoinTest, GH41149) {
+  auto left_batch = ExecBatchFromJSON({int64()}, R"([[1], [2], [3]])");
+  auto right_batch =
+      ExecBatchFromJSON({utf8(), int64()}, R"([["Z", 2], ["B", 3], ["A", 4]])");
 
   Declaration left{"exec_batch_source",
                    ExecBatchSourceNodeOptions(schema({field("on", int64())}),
@@ -1723,12 +1718,13 @@ TEST(AsofJoinTest, Flaky2) {
       ExecBatchSourceNodeOptions(schema({field("colVals", utf8()), field("on", int64())}),
                                  {std::move(right_batch)})};
   AsofJoinNodeOptions asof_join_opts({{{"on"}, {}}, {{"on"}, {}}}, 1);
-  Declaration asof_join{"asofjoin", {left, right}, asof_join_opts};
+  Declaration asof_join{
+      "asofjoin", {std::move(left), std::move(right)}, std::move(asof_join_opts)};
 
-  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(asof_join));
+  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToExecBatches(std::move(asof_join)));
 
-  std::vector<TypeHolder> exp_types = {int64(), utf8()};
-  auto exp_batch = ExecBatchFromJSON(exp_types, R"([[1, "Z"], [2, "Z"], [3, "B"]])");
+  auto exp_batch =
+      ExecBatchFromJSON({int64(), utf8()}, R"([[1, "Z"], [2, "Z"], [3, "B"]])");
   AssertExecBatchesEqualIgnoringOrder(result.schema, {exp_batch}, result.batches);
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Sporadic asof join test failures have been frequently and annoyingly observed in pyarrow CI, as recorded in #40675 and #41149.

Turns out the root causes are the same - a logical race (as opposed to physical race which can be detected by sanitizers). By injecting special delay in various places in asof join, as shown in https://github.com/zanmato1984/arrow/commit/ea3b24c5f7308fe42f60dad41f51dbcbc1a54929, the issue can be reproduced almost 100%. And I have put some descriptions in that commit to explain how the race happens.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Eliminate the logical race of emptiness by combining multiple call-sites of `Empty()`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Include the UT to reproduce the issue.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
**This PR contains a "Critical Fix".**
In #40675 and #41149 , incorrect results are produced.
* GitHub Issue: #41149 
* Also closes #40675