### PR TITLE
GH-41626: [R][CI] Update OpenSUSE to 15.5 from 15.3

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1358,7 +1358,7 @@ tasks:
 {% for r_org, r_image, r_tag in [("rhub", "ubuntu-release", "latest"),
                                  ("rocker", "r-ver", "latest"),
                                  ("rstudio", "r-base", "4.2-focal"),
-                                 ("rstudio", "r-base", "4.1-opensuse153")] %}
+                                 ("rstudio", "r-base", "4.1-opensuse155")] %}
   test-r-{{ r_org }}-{{ r_image }}-{{ r_tag }}:
     ci: azure
     template: r/azure.linux.yml


### PR DESCRIPTION
### Rationale for this change

OpenSUSE 15.3 reached EOL and rstudio/r-builds dropped support for it: https://github.com/rstudio/r-builds/pull/177

### What changes are included in this PR?

Use `4.1-opensuse155` instead of `4.1-opensuse153`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41626