### PR TITLE
GH-39204: [Format][FlightRPC][Docs] Stabilize Flight SQL

### DIFF
--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// \brief Implementation of Flight RPC client. API should be
-/// considered experimental for now
+/// \brief Implementation of Flight RPC client.
 
 #pragma once
 
@@ -177,7 +176,6 @@ class ARROW_FLIGHT_EXPORT FlightMetadataReader {
 };
 
 /// \brief Client class for Arrow Flight RPC services.
-/// API experimental for now
 class ARROW_FLIGHT_EXPORT FlightClient {
  public:
   ~FlightClient();
@@ -275,8 +273,6 @@ class ARROW_FLIGHT_EXPORT FlightClient {
   /// \param[in] options Per-RPC options
   /// \param[in] descriptor the dataset request
   /// \param[in] listener Callbacks for response and RPC completion
-  ///
-  /// This API is EXPERIMENTAL.
   void GetFlightInfoAsync(const FlightCallOptions& options,
                           const FlightDescriptor& descriptor,
                           std::shared_ptr<AsyncListener<FlightInfo>> listener);
@@ -288,8 +284,6 @@ class ARROW_FLIGHT_EXPORT FlightClient {
   /// \brief Asynchronous GetFlightInfo returning a Future.
   /// \param[in] options Per-RPC options
   /// \param[in] descriptor the dataset request
-  ///
-  /// This API is EXPERIMENTAL.
   arrow::Future<FlightInfo> GetFlightInfoAsync(const FlightCallOptions& options,
                                                const FlightDescriptor& descriptor);
   arrow::Future<FlightInfo> GetFlightInfoAsync(const FlightDescriptor& descriptor) {

--- a/cpp/src/arrow/flight/cookie_internal.cc
+++ b/cpp/src/arrow/flight/cookie_internal.cc
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Interfaces for defining middleware for Flight clients. Currently
-// experimental.
+// Interfaces for defining middleware for Flight clients.
 
 #include "arrow/flight/cookie_internal.h"
 #include "arrow/flight/client.h"

--- a/cpp/src/arrow/flight/middleware.h
+++ b/cpp/src/arrow/flight/middleware.h
@@ -16,7 +16,7 @@
 // under the License.
 
 // Interfaces for defining middleware for Flight clients and
-// servers. Currently experimental.
+// servers.
 
 #pragma once
 

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Interfaces to use for defining Flight RPC servers. API should be considered
-// experimental for now
+// Interfaces to use for defining Flight RPC servers.
 
 #pragma once
 

--- a/cpp/src/arrow/flight/server_middleware.h
+++ b/cpp/src/arrow/flight/server_middleware.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Interfaces for defining middleware for Flight servers. Currently
-// experimental.
+// Interfaces for defining middleware for Flight servers.
 
 #pragma once
 

--- a/cpp/src/arrow/flight/sql/server.cc
+++ b/cpp/src/arrow/flight/sql/server.cc
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Interfaces to use for defining Flight RPC servers. API should be considered
-// experimental for now
+// Interfaces to use for defining Flight RPC servers.
 
 // Platform-specific defines
 #include "arrow/flight/platform.h"

--- a/cpp/src/arrow/flight/sql/server.h
+++ b/cpp/src/arrow/flight/sql/server.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Interfaces to use for defining Flight RPC servers. API should be considered
-// experimental for now
+// Interfaces to use for defining Flight RPC servers.
 
 #pragma once
 

--- a/cpp/src/arrow/flight/sql/server_session_middleware.h
+++ b/cpp/src/arrow/flight/sql/server_session_middleware.h
@@ -16,7 +16,6 @@
 // under the License.
 
 // Middleware for handling Flight SQL Sessions including session cookie handling.
-// Currently experimental.
 
 #pragma once
 

--- a/cpp/src/arrow/flight/transport.h
+++ b/cpp/src/arrow/flight/transport.h
@@ -19,8 +19,6 @@
 /// Internal (but not private) interface for implementing
 /// alternate network transports in Flight.
 ///
-/// \warning EXPERIMENTAL. Subject to change.
-///
 /// To implement a transport, implement ServerTransport and
 /// ClientTransport, and register the desired URI schemes with
 /// TransportRegistry. Flight takes care of most of the per-RPC
@@ -248,8 +246,6 @@ TransportRegistry* GetDefaultTransportRegistry();
 /// Transport implementations may subclass this to store their own
 /// state, and stash an instance in a user-supplied AsyncListener via
 /// ClientTransport::GetAsyncRpc and ClientTransport::SetAsyncRpc.
-///
-/// This API is EXPERIMENTAL.
 class ARROW_FLIGHT_EXPORT AsyncRpc {
  public:
   virtual ~AsyncRpc() = default;

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Data structure for Flight RPC. API should be considered experimental for now
+// Data structure for Flight RPC.
 
 #pragma once
 
@@ -1115,8 +1115,6 @@ std::string ToString(TransportStatusCode code);
 ///   instead of trying to translate to Arrow Status.
 ///
 /// Currently, only attached to the Status passed to AsyncListener::OnFinish.
-///
-/// This API is EXPERIMENTAL.
 class ARROW_FLIGHT_EXPORT TransportStatusDetail : public StatusDetail {
  public:
   constexpr static const char* kTypeId = "flight::TransportStatusDetail";

--- a/cpp/src/arrow/flight/types_async.h
+++ b/cpp/src/arrow/flight/types_async.h
@@ -31,8 +31,6 @@ namespace arrow::flight {
 /// @{
 
 /// \brief Non-templated state for an async RPC.
-///
-/// This API is EXPERIMENTAL.
 class ARROW_FLIGHT_EXPORT AsyncListenerBase {
  public:
   AsyncListenerBase();
@@ -57,8 +55,6 @@ class ARROW_FLIGHT_EXPORT AsyncListenerBase {
 /// A single listener may not be used for multiple concurrent RPC
 /// calls.  The application MUST hold the listener alive until
 /// OnFinish() is called and has finished.
-///
-/// This API is EXPERIMENTAL.
 template <typename T>
 class ARROW_FLIGHT_EXPORT AsyncListener : public AsyncListenerBase {
  public:

--- a/docs/source/cpp/api/flightsql.rst
+++ b/docs/source/cpp/api/flightsql.rst
@@ -22,8 +22,6 @@
 Arrow Flight SQL
 ================
 
-.. note:: Flight SQL is currently experimental and APIs are subject to change.
-
 Common Types
 ============
 

--- a/docs/source/format/FlightSql.rst
+++ b/docs/source/format/FlightSql.rst
@@ -32,9 +32,6 @@ with any database that supports the necessary endpoints. Flight SQL
 clients wrap the underlying Flight client to provide methods for the
 new RPC methods described here.
 
-.. warning:: Flight SQL is **experimental** and changes to the
-             protocol may still be made.
-
 RPC Methods
 ===========
 

--- a/docs/source/java/overview.rst
+++ b/docs/source/java/overview.rst
@@ -54,10 +54,10 @@ but some modules are JNI bindings to the C++ library.
      - (Experimental) A library for converting JDBC data to Arrow data.
      - Native
    * - flight-core
-     - (Experimental) An RPC mechanism for transferring ValueVectors.
+     - An RPC mechanism for transferring ValueVectors.
      - Native
    * - flight-sql
-     - (Experimental) Contains utility classes to expose Flight SQL semantics for clients and servers over Arrow Flight.
+     - Contains utility classes to expose Flight SQL semantics for clients and servers over Arrow Flight.
      - Native
    * - flight-integration-tests
      - Integration tests for Flight RPC.

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -43,7 +43,6 @@ package arrow.flight.protocol.sql;
  * where there is one row per requested piece of metadata information.
  */
 message CommandGetSqlInfo {
-  option (experimental) = true;
 
   /*
    * Values are modelled after ODBC's SQLGetInfo() function. This information is intended to provide
@@ -1131,7 +1130,6 @@ enum Searchable {
  * The returned data should be ordered by data_type and then by type_name.
  */
 message CommandGetXdbcTypeInfo {
-  option (experimental) = true;
 
   /*
    * Specifies the data type to search for the info.
@@ -1153,7 +1151,6 @@ message CommandGetXdbcTypeInfo {
  * The returned data should be ordered by catalog_name.
  */
 message CommandGetCatalogs {
-  option (experimental) = true;
 }
 
 /*
@@ -1171,7 +1168,6 @@ message CommandGetCatalogs {
  * The returned data should be ordered by catalog_name, then db_schema_name.
  */
 message CommandGetDbSchemas {
-  option (experimental) = true;
 
   /*
    * Specifies the Catalog to search for the tables.
@@ -1219,7 +1215,6 @@ message CommandGetDbSchemas {
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
  */
 message CommandGetTables {
-  option (experimental) = true;
 
   /*
    * Specifies the Catalog to search for the tables.
@@ -1272,7 +1267,6 @@ message CommandGetTables {
  * The returned data should be ordered by table_type.
  */
 message CommandGetTableTypes {
-  option (experimental) = true;
 }
 
 /*
@@ -1293,7 +1287,6 @@ message CommandGetTableTypes {
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, key_name, then key_sequence.
  */
 message CommandGetPrimaryKeys {
-  option (experimental) = true;
 
   /*
    * Specifies the catalog to search for the table.
@@ -1348,7 +1341,6 @@ enum UpdateDeleteRules {
  * update_rule and delete_rule returns a byte that is equivalent to actions declared on UpdateDeleteRules enum.
  */
 message CommandGetExportedKeys {
-  option (experimental) = true;
 
   /*
    * Specifies the catalog to search for the foreign key table.
@@ -1399,7 +1391,6 @@ message CommandGetExportedKeys {
  *    - 4 = SET DEFAULT
  */
 message CommandGetImportedKeys {
-  option (experimental) = true;
 
   /*
    * Specifies the catalog to search for the primary key table.
@@ -1452,7 +1443,6 @@ message CommandGetImportedKeys {
  *    - 4 = SET DEFAULT
  */
 message CommandGetCrossReference {
-  option (experimental) = true;
 
   /**
    * The catalog name where the parent table is.
@@ -1499,7 +1489,6 @@ message CommandGetCrossReference {
  * Request message for the "CreatePreparedStatement" action on a Flight SQL enabled backend.
  */
 message ActionCreatePreparedStatementRequest {
-  option (experimental) = true;
 
   // The valid SQL string to create a prepared statement for.
   string query = 1;
@@ -1512,7 +1501,6 @@ message ActionCreatePreparedStatementRequest {
  * An embedded message describing a Substrait plan to execute.
  */
 message SubstraitPlan {
-  option (experimental) = true;
 
   // The serialized substrait.Plan to create a prepared statement for.
   // XXX(ARROW-16902): this is bytes instead of an embedded message
@@ -1529,7 +1517,6 @@ message SubstraitPlan {
  * Request message for the "CreatePreparedSubstraitPlan" action on a Flight SQL enabled backend.
  */
 message ActionCreatePreparedSubstraitPlanRequest {
-  option (experimental) = true;
 
   // The serialized substrait.Plan to create a prepared statement for.
   SubstraitPlan plan = 1;
@@ -1548,7 +1535,6 @@ message ActionCreatePreparedSubstraitPlanRequest {
  * The result should be wrapped in a google.protobuf.Any message.
  */
 message ActionCreatePreparedStatementResult {
-  option (experimental) = true;
 
   // Opaque handle for the prepared statement on the server.
   bytes prepared_statement_handle = 1;
@@ -1570,7 +1556,6 @@ message ActionCreatePreparedStatementResult {
  * Closes server resources associated with the prepared statement handle.
  */
 message ActionClosePreparedStatementRequest {
-  option (experimental) = true;
 
   // Opaque handle for the prepared statement on the server.
   bytes prepared_statement_handle = 1;
@@ -1581,7 +1566,6 @@ message ActionClosePreparedStatementRequest {
  * Begins a transaction.
  */
 message ActionBeginTransactionRequest {
-  option (experimental) = true;
 }
 
 /*
@@ -1592,7 +1576,6 @@ message ActionBeginTransactionRequest {
  * FLIGHT_SQL_TRANSACTION_SUPPORT_SAVEPOINT.
  */
 message ActionBeginSavepointRequest {
-  option (experimental) = true;
 
   // The transaction to which a savepoint belongs.
   bytes transaction_id = 1;
@@ -1610,7 +1593,6 @@ message ActionBeginSavepointRequest {
  * The result should be wrapped in a google.protobuf.Any message.
  */
 message ActionBeginTransactionResult {
-  option (experimental) = true;
 
   // Opaque handle for the transaction on the server.
   bytes transaction_id = 1;
@@ -1626,7 +1608,6 @@ message ActionBeginTransactionResult {
  * The result should be wrapped in a google.protobuf.Any message.
  */
 message ActionBeginSavepointResult {
-  option (experimental) = true;
 
   // Opaque handle for the savepoint on the server.
   bytes savepoint_id = 1;
@@ -1641,7 +1622,6 @@ message ActionBeginSavepointResult {
  * invalidated, as are all associated savepoints.
  */
 message ActionEndTransactionRequest {
-  option (experimental) = true;
 
   enum EndTransaction {
     END_TRANSACTION_UNSPECIFIED = 0;
@@ -1667,7 +1647,6 @@ message ActionEndTransactionRequest {
  * savepoints created after the current savepoint.
  */
 message ActionEndSavepointRequest {
-  option (experimental) = true;
 
   enum EndSavepoint {
     END_SAVEPOINT_UNSPECIFIED = 0;
@@ -1702,7 +1681,6 @@ message ActionEndSavepointRequest {
  *  - GetFlightInfo: execute the query.
  */
 message CommandStatementQuery {
-  option (experimental) = true;
 
   // The SQL syntax.
   string query = 1;
@@ -1729,7 +1707,6 @@ message CommandStatementQuery {
  *  - DoPut: execute the query.
  */
 message CommandStatementSubstraitPlan {
-  option (experimental) = true;
 
   // A serialized substrait.Plan
   SubstraitPlan plan = 1;
@@ -1742,7 +1719,6 @@ message CommandStatementSubstraitPlan {
  * This should be used only once and treated as an opaque value, that is, clients should not attempt to parse this.
  */
 message TicketStatementQuery {
-  option (experimental) = true;
 
   // Unique identifier for the instance of the statement to execute.
   bytes statement_handle = 1;
@@ -1770,7 +1746,6 @@ message TicketStatementQuery {
  *  - GetFlightInfo: execute the prepared statement instance.
  */
 message CommandPreparedStatementQuery {
-  option (experimental) = true;
 
   // Opaque handle for the prepared statement on the server.
   bytes prepared_statement_handle = 1;
@@ -1781,7 +1756,6 @@ message CommandPreparedStatementQuery {
  * for the RPC call DoPut to cause the server to execute the included SQL update.
  */
 message CommandStatementUpdate {
-  option (experimental) = true;
 
   // The SQL syntax.
   string query = 1;
@@ -1795,7 +1769,6 @@ message CommandStatementUpdate {
  * prepared statement handle as an update.
  */
 message CommandPreparedStatementUpdate {
-  option (experimental) = true;
 
   // Opaque handle for the prepared statement on the server.
   bytes prepared_statement_handle = 1;
@@ -1807,7 +1780,6 @@ message CommandPreparedStatementUpdate {
  * FlightData into the target destination.
  */
 message CommandStatementIngest {
-  option (experimental) = true;
 
   // Options for table definition behavior
   message TableDefinitionOptions {
@@ -1866,7 +1838,6 @@ message CommandStatementIngest {
  * in the request, containing results from the update.
  */
 message DoPutUpdateResult {
-  option (experimental) = true;
 
   // The number of records updated. A return value of -1 represents
   // an unknown updated record count.
@@ -1880,7 +1851,6 @@ message DoPutUpdateResult {
  * can continue as though the fields in this message were not provided or set to sensible default values.
  */
 message DoPutPreparedStatementResult {
-  option (experimental) = true;
 
   // Represents a (potentially updated) opaque handle for the prepared statement on the server.
   // Because the handle could potentially be updated, any previous handles for this prepared
@@ -1912,7 +1882,6 @@ message DoPutPreparedStatementResult {
  */
 message ActionCancelQueryRequest {
   option deprecated = true;
-  option (experimental) = true;
 
   // The result of the GetFlightInfo RPC that initiated the query.
   // XXX(ARROW-16902): this must be a serialized FlightInfo, but is
@@ -1931,7 +1900,6 @@ message ActionCancelQueryRequest {
  */
 message ActionCancelQueryResult {
   option deprecated = true;
-  option (experimental) = true;
 
   enum CancelResult {
     // The cancellation status is unknown. Servers should avoid using

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>flight-core</artifactId>
   <packaging>jar</packaging>
   <name>Arrow Flight Core</name>
-  <description>(Experimental)An RPC mechanism for transferring ValueVectors.</description>
+  <description>An RPC mechanism for transferring ValueVectors.</description>
 
   <properties>
     <forkCount>1</forkCount>

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
@@ -26,8 +26,6 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * Middleware for handling Flight SQL Sessions including session cookie handling.
- *
- * Currently experimental.
  */
 public class ServerSessionMiddleware implements FlightServerMiddleware {
   Factory factory;

--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -20,7 +20,7 @@
   <artifactId>flight-sql</artifactId>
   <packaging>jar</packaging>
   <name>Arrow Flight SQL</name>
-  <description>(Experimental)Contains utility classes to expose Flight SQL semantics for clients and servers over Arrow Flight</description>
+  <description>Contains utility classes to expose Flight SQL semantics for clients and servers over Arrow Flight</description>
 
   <properties>
     <forkCount>1</forkCount>

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1249,6 +1249,8 @@ class AsyncioCall:
 cdef class AsyncioFlightClient:
     """
     A FlightClient with an asyncio-based async interface.
+
+    This interface is EXPERIMENTAL.
     """
 
     cdef:

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1249,8 +1249,6 @@ class AsyncioCall:
 cdef class AsyncioFlightClient:
     """
     A FlightClient with an asyncio-based async interface.
-
-    This interface is EXPERIMENTAL.
     """
 
     cdef:


### PR DESCRIPTION
Update documentation, protobufs, and class documentation to remove experimental tags from Flight and Flight SQL documentation.

### Rationale for this change
Flight SQL has been used by multiple databases now and has been voted as stable per the
mailing list discussion: [https://lists.apache.org/thread/qoshg8mln3t2ovr90o1yklz4yrpv503h](url)

### What changes are included in this PR?
Update protobuf, class comments, and user documentation to remove references to Flight and Flight SQL being experimental. This change excludes the UCX transport and the session option messages


### Are these changes tested?
No, documentation only.

### Are there any user-facing changes?
User documentation.
* GitHub Issue: #39204