### PR TITLE
GH-41688: [Dev] Include all relevant CMakeLists.txt files in cmake-format precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,11 +119,7 @@ repos:
           ?^ci/.*/.*\.cmake$|
           ?^cpp/.*/.*\.cmake\.in$|
           ?^cpp/.*/.*\.cmake$|
-          ?^cpp/.*/CMakeLists\.txt$|
-          ?^go/.*/CMakeLists\.txt$|
-          ?^java/.*/CMakeLists\.txt$|
-          ?^matlab/.*/CMakeLists\.txt$|
-          ?^python/.*/CMakeLists\.txt$|
+          ?.*CMakeLists\.txt$|
           )
         exclude: >-
           (
@@ -131,6 +127,7 @@ repos:
           ?^cpp/cmake_modules/FindPythonLibsNew\.cmake$|
           ?^cpp/cmake_modules/UseCython\.cmake$|
           ?^cpp/src/arrow/util/config\.h\.cmake$|
+          ?^ci/conan/all/.*CMakeLists\.txt$|
           )
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v0.9.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,18 +116,18 @@ repos:
         name: CMake Format
         files: >-
           (
+          ?.*CMakeLists\.txt$|
           ?^ci/.*/.*\.cmake$|
           ?^cpp/.*/.*\.cmake\.in$|
           ?^cpp/.*/.*\.cmake$|
-          ?.*CMakeLists\.txt$|
           )
         exclude: >-
           (
+          ?^ci/conan/all/.*CMakeLists\.txt$|
           ?^cpp/cmake_modules/FindNumPy\.cmake$|
           ?^cpp/cmake_modules/FindPythonLibsNew\.cmake$|
           ?^cpp/cmake_modules/UseCython\.cmake$|
           ?^cpp/src/arrow/util/config\.h\.cmake$|
-          ?^ci/conan/all/.*CMakeLists\.txt$|
           )
   - repo: https://github.com/sphinx-contrib/sphinx-lint
     rev: v0.9.1

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -157,7 +157,7 @@ def cmake_linter(src, fix=False):
             'go/**/CMakeLists.txt',
             'java/**/CMakeLists.txt',
             'matlab/**/CMakeLists.txt',
-            'python/CMakeLists.txt',
+            'python/**/CMakeLists.txt',
         ],
         exclude_patterns=[
             'cpp/cmake_modules/FindNumPy.cmake',


### PR DESCRIPTION
### Rationale for this change

Some CMakeLists.txt files are not included in the pre-commit hook (causing failures on CI through archery if you rely on the pre-commit hook locally)

### What changes are included in this PR?

Include all CMakeLists.txt files by default anywhere in the repo, and explicitly exclude the ones we don't want (vendored files).

In practice, compared to the current set of files covered by the hook, those new files are included in the search:

'cpp/CMakeLists.txt',
'java/CMakeLists.txt',
'matlab/CMakeLists.txt',
'python/CMakeLists.txt'


### Are these changes tested?

Yes
* GitHub Issue: #41688