### PR TITLE
GH-31186: [C++] file: Enable FIFO as an OSFile path.

### DIFF
--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -104,14 +104,14 @@ class OSFile {
     RETURN_NOT_OK(SetFileName(path));
 
     ARROW_ASSIGN_OR_RAISE(fd_, ::arrow::internal::FileOpenReadable(file_name_));
-    ARROW_ASSIGN_OR_RAISE(size_, ::arrow::internal::FileGetSize(fd_.fd()));
+    size_ = ::arrow::internal::FileGetSize(fd_.fd()).ValueOr(-1);
 
     mode_ = FileMode::READ;
     return Status::OK();
   }
 
   Status OpenReadable(int fd) {
-    ARROW_ASSIGN_OR_RAISE(size_, ::arrow::internal::FileGetSize(fd));
+    size_ = ::arrow::internal::FileGetSize(fd).ValueOr(-1);
     RETURN_NOT_OK(SetFileName(fd));
     mode_ = FileMode::READ;
     fd_ = FileDescriptor(fd);


### PR DESCRIPTION
### Rationale for this change

Allow reading from non-seekable FIFO paths (e.g. stdin).

Example: Currently the following code snippet is not allowed:

```
from pyarrow import csv, input_stream

stdin = input_stream('/dev/stdin')
data = csv.read_csv(stdin)
print(data)
```

Running this code will always trigger an OSError: 

```
# cat test.csv | python test2.py
Traceback (most recent call last):
  File "/mnt/nvme0n1/psp/arrow-test/test.py", line 4, in <module>
    stdin = input_stream('/dev/stdin')
  File "pyarrow/io.pxi", line 2690, in pyarrow.lib.input_stream
  File "pyarrow/io.pxi", line 1164, in pyarrow.lib.OSFile.__cinit__
  File "pyarrow/io.pxi", line 1176, in pyarrow.lib.OSFile._open_readable
  File "pyarrow/error.pxi", line 154, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 91, in pyarrow.lib.check_status
OSError: lseek failed
```

To get around this implementation one has to read stdin through a python file:

```
import sys
import os

from pyarrow import csv

stdin = os.fdopen(sys.stdin.fileno(), "rb")
data = csv.read_csv(stdin)
print(data)
```


Example csv:

```
customer_id,customer
1,customer1
2,customer2
```

### What changes are included in this PR?

Set the size of the OSFile to `-1` if the stream is not seekable. This has been used here to configure non-seekable file descriptors: https://github.com/pspoerri/arrow/blob/main/cpp/src/arrow/io/file.cc#L94-L95

### Are these changes tested?

I tested the code samples above.

### Are there any user-facing changes?

Not that I am aware of.
* GitHub Issue: #31186