### PR TITLE
GH-41460: [C++] Use ASAN to poison temp vector stack memory

### DIFF
--- a/cpp/src/arrow/compute/util_internal.cc
+++ b/cpp/src/arrow/compute/util_internal.cc
@@ -20,16 +20,23 @@
 #include "arrow/compute/util.h"
 #include "arrow/memory_pool.h"
 
+#include <sanitizer/asan_interface.h>
+
 namespace arrow {
 namespace util {
+
+// TempVectorStack::~TempVectorStack() {
+//   if (buffer_) {
+//     ASAN_UNPOISON_MEMORY_REGION(buffer_->mutable_data(), buffer_size_);
+//   }
+// }
 
 Status TempVectorStack::Init(MemoryPool* pool, int64_t size) {
   num_vectors_ = 0;
   top_ = 0;
-  buffer_size_ = EstimatedAllocationSize(size);
+  buffer_size_ = PaddedAllocationSize(size);
   ARROW_ASSIGN_OR_RAISE(auto buffer, AllocateResizableBuffer(size, pool));
-  // Ensure later operations don't accidentally read uninitialized memory.
-  std::memset(buffer->mutable_data(), 0xFF, size);
+  ASAN_POISON_MEMORY_REGION(buffer->mutable_data(), size);
   buffer_ = std::move(buffer);
   return Status::OK();
 }
@@ -46,32 +53,35 @@ int64_t TempVectorStack::PaddedAllocationSize(int64_t num_bytes) {
 }
 
 void TempVectorStack::alloc(uint32_t num_bytes, uint8_t** data, int* id) {
-  int64_t estimated_alloc_size = EstimatedAllocationSize(num_bytes);
-  int64_t new_top = top_ + estimated_alloc_size;
+  // int64_t estimated_alloc_size = EstimatedAllocationSize(num_bytes);
+  int64_t alloc_size = PaddedAllocationSize(num_bytes);
+  int64_t new_top = top_ + alloc_size;
   // Stack overflow check (see GH-39582).
   // XXX cannot return a regular Status because most consumers do not either.
   ARROW_CHECK_LE(new_top, buffer_size_)
-      << "TempVectorStack::alloc overflow: allocating " << estimated_alloc_size
-      << " on top of " << top_ << " in stack of size " << buffer_size_;
-  *data = buffer_->mutable_data() + top_ + sizeof(uint64_t);
-  // We set 8 bytes before the beginning of the allocated range and
-  // 8 bytes after the end to check for stack overflow (which would
-  // result in those known bytes being corrupted).
-  reinterpret_cast<uint64_t*>(buffer_->mutable_data() + top_)[0] = kGuard1;
-  reinterpret_cast<uint64_t*>(buffer_->mutable_data() + new_top)[-1] = kGuard2;
+      << "TempVectorStack::alloc overflow: allocating " << alloc_size << " on top of "
+      << top_ << " in stack of size " << buffer_size_;
+  *data = buffer_->mutable_data() + top_;
+  ASAN_UNPOISON_MEMORY_REGION(*data, alloc_size);
+  // // We set 8 bytes before the beginning of the allocated range and
+  // // 8 bytes after the end to check for stack overflow (which would
+  // // result in those known bytes being corrupted).
+  // reinterpret_cast<uint64_t*>(buffer_->mutable_data() + top_)[0] = kGuard1;
+  // reinterpret_cast<uint64_t*>(buffer_->mutable_data() + new_top)[-1] = kGuard2;
   *id = num_vectors_++;
   top_ = new_top;
 }
 
 void TempVectorStack::release(int id, uint32_t num_bytes) {
   ARROW_DCHECK(num_vectors_ == id + 1);
-  int64_t size = EstimatedAllocationSize(num_bytes);
-  ARROW_DCHECK(reinterpret_cast<const uint64_t*>(buffer_->mutable_data() + top_)[-1] ==
-               kGuard2);
+  int64_t size = PaddedAllocationSize(num_bytes);
+  // ARROW_DCHECK(reinterpret_cast<const uint64_t*>(buffer_->mutable_data() + top_)[-1] ==
+  //              kGuard2);
   ARROW_DCHECK(top_ >= size);
   top_ -= size;
-  ARROW_DCHECK(reinterpret_cast<const uint64_t*>(buffer_->mutable_data() + top_)[0] ==
-               kGuard1);
+  ASAN_POISON_MEMORY_REGION(buffer_->mutable_data() + top_, size);
+  // ARROW_DCHECK(reinterpret_cast<const uint64_t*>(buffer_->mutable_data() + top_)[0] ==
+  //              kGuard1);
   --num_vectors_;
 }
 

--- a/cpp/src/arrow/compute/util_internal.cc
+++ b/cpp/src/arrow/compute/util_internal.cc
@@ -38,7 +38,7 @@ TempVectorStack::~TempVectorStack() {
 Status TempVectorStack::Init(MemoryPool* pool, int64_t size) {
   num_vectors_ = 0;
   top_ = 0;
-  buffer_size_ = PaddedAllocationSize(size);
+  buffer_size_ = EstimatedAllocationSize(size);
   ARROW_ASSIGN_OR_RAISE(auto buffer, AllocateResizableBuffer(size, pool));
 #ifdef ADDRESS_SANITIZER
   ASAN_POISON_MEMORY_REGION(buffer->mutable_data(), size);
@@ -59,16 +59,23 @@ int64_t TempVectorStack::PaddedAllocationSize(int64_t num_bytes) {
 }
 
 void TempVectorStack::alloc(uint32_t num_bytes, uint8_t** data, int* id) {
-  int64_t alloc_size = PaddedAllocationSize(num_bytes);
-  int64_t new_top = top_ + alloc_size;
+  int64_t estimated_alloc_size = EstimatedAllocationSize(num_bytes);
+  int64_t new_top = top_ + estimated_alloc_size;
   // Stack overflow check (see GH-39582).
   // XXX cannot return a regular Status because most consumers do not either.
   ARROW_CHECK_LE(new_top, buffer_size_)
-      << "TempVectorStack::alloc overflow: allocating " << alloc_size << " on top of "
-      << top_ << " in stack of size " << buffer_size_;
-  *data = buffer_->mutable_data() + top_;
+      << "TempVectorStack::alloc overflow: allocating " << estimated_alloc_size
+      << " on top of " << top_ << " in stack of size " << buffer_size_;
 #ifdef ADDRESS_SANITIZER
-  ASAN_UNPOISON_MEMORY_REGION(*data, alloc_size);
+  ASAN_UNPOISON_MEMORY_REGION(buffer_->mutable_data() + top_, estimated_alloc_size);
+#endif
+  *data = buffer_->mutable_data() + top_ + /*one guard*/ sizeof(uint64_t);
+#ifndef NDEBUG
+  // We set 8 bytes before the beginning of the allocated range and
+  // 8 bytes after the end to check for stack overflow (which would
+  // result in those known bytes being corrupted).
+  reinterpret_cast<uint64_t*>(buffer_->mutable_data() + top_)[0] = kGuard1;
+  reinterpret_cast<uint64_t*>(buffer_->mutable_data() + new_top)[-1] = kGuard2;
 #endif
   *id = num_vectors_++;
   top_ = new_top;
@@ -76,9 +83,13 @@ void TempVectorStack::alloc(uint32_t num_bytes, uint8_t** data, int* id) {
 
 void TempVectorStack::release(int id, uint32_t num_bytes) {
   ARROW_DCHECK(num_vectors_ == id + 1);
-  int64_t size = PaddedAllocationSize(num_bytes);
+  int64_t size = EstimatedAllocationSize(num_bytes);
+  ARROW_DCHECK(reinterpret_cast<const uint64_t*>(buffer_->mutable_data() + top_)[-1] ==
+               kGuard2);
   ARROW_DCHECK(top_ >= size);
   top_ -= size;
+  ARROW_DCHECK(reinterpret_cast<const uint64_t*>(buffer_->mutable_data() + top_)[0] ==
+               kGuard1);
 #ifdef ADDRESS_SANITIZER
   ASAN_POISON_MEMORY_REGION(buffer_->mutable_data() + top_, size);
 #endif

--- a/cpp/src/arrow/compute/util_internal.cc
+++ b/cpp/src/arrow/compute/util_internal.cc
@@ -20,7 +20,9 @@
 #include "arrow/compute/util.h"
 #include "arrow/memory_pool.h"
 
+#ifdef ADDRESS_SANITIZER
 #include <sanitizer/asan_interface.h>
+#endif
 
 namespace arrow {
 namespace util {

--- a/cpp/src/arrow/compute/util_internal.cc
+++ b/cpp/src/arrow/compute/util_internal.cc
@@ -38,8 +38,6 @@ Status TempVectorStack::Init(MemoryPool* pool, int64_t size) {
   ARROW_ASSIGN_OR_RAISE(auto buffer, AllocateResizableBuffer(size, pool));
   ASAN_POISON_MEMORY_REGION(buffer->mutable_data(), size);
   buffer_ = std::move(buffer);
-  // buffer_cure_.buffer = buffer_->mutable_data();
-  // buffer_cure_.size = buffer_size_;
   return Status::OK();
 }
 

--- a/cpp/src/arrow/compute/util_internal.h
+++ b/cpp/src/arrow/compute/util_internal.h
@@ -38,16 +38,22 @@ class ARROW_EXPORT TempVectorStack {
   friend class TempVectorHolder;
 
  public:
-  // ~TempVectorStack() = default;
+  TempVectorStack() = default;
+  ~TempVectorStack();
+
+  TempVectorStack(const TempVectorStack&) = delete;
+  TempVectorStack& operator=(const TempVectorStack&) = delete;
+  TempVectorStack(TempVectorStack&&) = default;
+  TempVectorStack& operator=(TempVectorStack&&) = default;
 
   Status Init(MemoryPool* pool, int64_t size);
 
   int64_t AllocatedSize() const { return top_; }
 
  private:
-  static int64_t EstimatedAllocationSize(int64_t size) {
-    return PaddedAllocationSize(size) + 2 * sizeof(uint64_t);
-  }
+  // static int64_t EstimatedAllocationSize(int64_t size) {
+  //   return PaddedAllocationSize(size) + 2 * sizeof(uint64_t);
+  // }
 
   static int64_t PaddedAllocationSize(int64_t num_bytes);
 
@@ -58,6 +64,15 @@ class ARROW_EXPORT TempVectorStack {
   int64_t top_;
   std::unique_ptr<Buffer> buffer_;
   int64_t buffer_size_;
+
+  // #ifdef ADDRESS_SANITIZER
+  //   struct BufferCure {
+  //     uint8_t* buffer = nullptr;
+  //     int64_t size = 0;
+  //     ~BufferCure();
+  //   };
+  //   BufferCure buffer_cure_;
+  // #endif
 };
 
 template <typename T>

--- a/cpp/src/arrow/compute/util_internal.h
+++ b/cpp/src/arrow/compute/util_internal.h
@@ -43,6 +43,7 @@ class ARROW_EXPORT TempVectorStack {
 
   TempVectorStack(const TempVectorStack&) = delete;
   TempVectorStack& operator=(const TempVectorStack&) = delete;
+
   TempVectorStack(TempVectorStack&&) = default;
   TempVectorStack& operator=(TempVectorStack&&) = default;
 
@@ -51,10 +52,6 @@ class ARROW_EXPORT TempVectorStack {
   int64_t AllocatedSize() const { return top_; }
 
  private:
-  // static int64_t EstimatedAllocationSize(int64_t size) {
-  //   return PaddedAllocationSize(size) + 2 * sizeof(uint64_t);
-  // }
-
   static int64_t PaddedAllocationSize(int64_t num_bytes);
 
   void alloc(uint32_t num_bytes, uint8_t** data, int* id);
@@ -64,15 +61,6 @@ class ARROW_EXPORT TempVectorStack {
   int64_t top_;
   std::unique_ptr<Buffer> buffer_;
   int64_t buffer_size_;
-
-  // #ifdef ADDRESS_SANITIZER
-  //   struct BufferCure {
-  //     uint8_t* buffer = nullptr;
-  //     int64_t size = 0;
-  //     ~BufferCure();
-  //   };
-  //   BufferCure buffer_cure_;
-  // #endif
 };
 
 template <typename T>

--- a/cpp/src/arrow/compute/util_internal.h
+++ b/cpp/src/arrow/compute/util_internal.h
@@ -38,6 +38,8 @@ class ARROW_EXPORT TempVectorStack {
   friend class TempVectorHolder;
 
  public:
+  // ~TempVectorStack() = default;
+
   Status Init(MemoryPool* pool, int64_t size);
 
   int64_t AllocatedSize() const { return top_; }
@@ -51,8 +53,6 @@ class ARROW_EXPORT TempVectorStack {
 
   void alloc(uint32_t num_bytes, uint8_t** data, int* id);
   void release(int id, uint32_t num_bytes);
-  static constexpr uint64_t kGuard1 = 0x3141592653589793ULL;
-  static constexpr uint64_t kGuard2 = 0x0577215664901532ULL;
   static constexpr int64_t kPadding = 64;
   int num_vectors_;
   int64_t top_;

--- a/cpp/src/arrow/compute/util_internal.h
+++ b/cpp/src/arrow/compute/util_internal.h
@@ -20,6 +20,7 @@
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
 
 namespace arrow {
 namespace util {
@@ -41,11 +42,9 @@ class ARROW_EXPORT TempVectorStack {
   TempVectorStack() = default;
   ~TempVectorStack();
 
-  TempVectorStack(const TempVectorStack&) = delete;
-  TempVectorStack& operator=(const TempVectorStack&) = delete;
+  ARROW_DISALLOW_COPY_AND_ASSIGN(TempVectorStack);
 
-  TempVectorStack(TempVectorStack&&) = default;
-  TempVectorStack& operator=(TempVectorStack&&) = default;
+  ARROW_DEFAULT_MOVE_AND_ASSIGN(TempVectorStack);
 
   Status Init(MemoryPool* pool, int64_t size);
 

--- a/cpp/src/arrow/compute/util_internal.h
+++ b/cpp/src/arrow/compute/util_internal.h
@@ -51,10 +51,16 @@ class ARROW_EXPORT TempVectorStack {
   int64_t AllocatedSize() const { return top_; }
 
  private:
+  static int64_t EstimatedAllocationSize(int64_t size) {
+    return PaddedAllocationSize(size) + /*two guards*/ 2 * sizeof(uint64_t);
+  }
+
   static int64_t PaddedAllocationSize(int64_t num_bytes);
 
   void alloc(uint32_t num_bytes, uint8_t** data, int* id);
   void release(int id, uint32_t num_bytes);
+  static constexpr uint64_t kGuard1 = 0x3141592653589793ULL;
+  static constexpr uint64_t kGuard2 = 0x0577215664901532ULL;
   static constexpr int64_t kPadding = 64;
   int num_vectors_;
   int64_t top_;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

See #41460. And reduce the overhead of current manual poisoning (filling the entire stack space with `0xFF`s) that happens even in release mode.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Use ASAN API to replace the current manual poisoning of the temp vector stack memory.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Wanted to add cases to assert that ASAN poison/unpoison is functioning. However I found it too tricky to catch an ASAN error because ASAN directly uses signals that are hard to interoperate in C++/gtest. So I just manually checked poisoning is working in my local, e.g. by intentionally not unpoisoning the allocated buffer and seeing ASAN unhappy.

Just leveraging existing cases that use temp stack such as acero tests, which should cover this change well.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41460