### PR TITLE
GH-39565: [C++] Do not concatenate chunked values of fixed-width types to run "array_take"

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -294,6 +294,8 @@ std::shared_ptr<VectorFunction> MakeIndicesNonZeroFunction(std::string name,
   VectorKernel kernel;
   kernel.null_handling = NullHandling::OUTPUT_NOT_NULL;
   kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
+  // "array_take" ensures that the output will be be chunked when at least one
+  // input is chunked, so we need to set this to false.
   kernel.output_chunked = false;
   kernel.exec = IndicesNonZeroExec;
   kernel.exec_chunked = IndicesNonZeroExecChunked;
@@ -339,6 +341,7 @@ void RegisterVectorSelection(FunctionRegistry* registry) {
   VectorKernel take_base;
   take_base.init = TakeState::Init;
   take_base.can_execute_chunkwise = false;
+  take_base.output_chunked = false;
   RegisterSelectionFunction("array_take", array_take_doc, take_base,
                             std::move(take_kernels), GetDefaultTakeOptions(), registry);
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
@@ -60,6 +60,7 @@ void RegisterSelectionFunction(const std::string& name, FunctionDoc doc,
         {std::move(kernel_data.value_type), std::move(kernel_data.selection_type)},
         OutputType(FirstType));
     base_kernel.exec = kernel_data.exec;
+    base_kernel.exec_chunked = kernel_data.chunked_exec;
     DCHECK_OK(func->AddKernel(base_kernel));
   }
   kernels.clear();

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
@@ -19,6 +19,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/array/array_binary.h"
@@ -199,14 +200,28 @@ struct Selection {
   ArrayData* out;
   TypedBufferBuilder<bool> validity_builder;
 
+  Selection(KernelContext* ctx, ArraySpan values, ArraySpan selection,
+            int64_t output_length, ArrayData* out)
+      : ctx(ctx),
+        values(std::move(values)),
+        selection(std::move(selection)),
+        output_length(output_length),
+        out(out),
+        validity_builder(ctx->memory_pool()) {
+    // If the selection is an array of indices, the output length should
+    // match the number of indices in the selection array.
+    DCHECK(!is_integer(selection.type->id()) || output_length == selection.length);
+  }
+
   Selection(KernelContext* ctx, const ExecSpan& batch, int64_t output_length,
             ExecResult* out)
-      : ctx(ctx),
-        values(batch[0].array),
-        selection(batch[1].array),
-        output_length(output_length),
-        out(out->array_data().get()),
-        validity_builder(ctx->memory_pool()) {}
+      : Selection(ctx, batch[0].array, batch[1].array, output_length,
+                  out->array_data().get()) {}
+
+  Selection(KernelContext* ctx, const ValuesSpan& values, const ArraySpan& indices,
+            std::shared_ptr<ArrayData>* out)
+      : Selection(ctx, values.array(), indices, /*output_length=*/indices.length,
+                  out->get()) {}
 
   virtual ~Selection() = default;
 
@@ -484,9 +499,9 @@ struct VarBinarySelectionImpl : public Selection<VarBinarySelectionImpl<Type>, T
 
   static constexpr int64_t kOffsetLimit = std::numeric_limits<offset_type>::max() - 1;
 
-  VarBinarySelectionImpl(KernelContext* ctx, const ExecSpan& batch, int64_t output_length,
-                         ExecResult* out)
-      : Base(ctx, batch, output_length, out),
+  template <typename... Args>
+  explicit VarBinarySelectionImpl(KernelContext* ctx, Args... args)
+      : Base(ctx, std::forward<Args>(args)...),
         offset_builder(ctx->memory_pool()),
         data_builder(ctx->memory_pool()) {}
 
@@ -558,9 +573,9 @@ struct ListSelectionImpl : public Selection<ListSelectionImpl<Type>, Type> {
   TypedBufferBuilder<offset_type> offset_builder;
   typename TypeTraits<Type>::OffsetBuilderType child_index_builder;
 
-  ListSelectionImpl(KernelContext* ctx, const ExecSpan& batch, int64_t output_length,
-                    ExecResult* out)
-      : Base(ctx, batch, output_length, out),
+  template <typename... Args>
+  explicit ListSelectionImpl(KernelContext* ctx, Args... args)
+      : Base(ctx, std::forward<Args>(args)...),
         offset_builder(ctx->memory_pool()),
         child_index_builder(ctx->memory_pool()) {}
 
@@ -623,9 +638,9 @@ struct ListViewSelectionImpl : public Selection<ListViewSelectionImpl<Type>, Typ
   TypedBufferBuilder<offset_type> offsets_builder;
   TypedBufferBuilder<offset_type> sizes_builder;
 
-  ListViewSelectionImpl(KernelContext* ctx, const ExecSpan& batch, int64_t output_length,
-                        ExecResult* out)
-      : Base(ctx, batch, output_length, out),
+  template <typename... Args>
+  explicit ListViewSelectionImpl(KernelContext* ctx, Args... args)
+      : Base(ctx, std::forward<Args>(args)...),
         offsets_builder(ctx->memory_pool()),
         sizes_builder(ctx->memory_pool()) {}
 
@@ -680,9 +695,9 @@ struct DenseUnionSelectionImpl
   std::vector<int8_t> type_codes_;
   std::vector<Int32Builder> child_indices_builders_;
 
-  DenseUnionSelectionImpl(KernelContext* ctx, const ExecSpan& batch,
-                          int64_t output_length, ExecResult* out)
-      : Base(ctx, batch, output_length, out),
+  template <typename... Args>
+  explicit DenseUnionSelectionImpl(KernelContext* ctx, Args... args)
+      : Base(ctx, std::forward<Args>(args)...),
         value_offset_buffer_builder_(ctx->memory_pool()),
         child_id_buffer_builder_(ctx->memory_pool()),
         type_codes_(checked_cast<const UnionType&>(*this->values.type).type_codes()),
@@ -761,9 +776,9 @@ struct SparseUnionSelectionImpl
   TypedBufferBuilder<int8_t> child_id_buffer_builder_;
   const int8_t type_code_for_null_;
 
-  SparseUnionSelectionImpl(KernelContext* ctx, const ExecSpan& batch,
-                           int64_t output_length, ExecResult* out)
-      : Base(ctx, batch, output_length, out),
+  template <typename... Args>
+  explicit SparseUnionSelectionImpl(KernelContext* ctx, Args... args)
+      : Base(ctx, std::forward<Args>(args)...),
         child_id_buffer_builder_(ctx->memory_pool()),
         type_code_for_null_(
             checked_cast<const UnionType&>(*this->values.type).type_codes()[0]) {}
@@ -812,9 +827,9 @@ struct FSLSelectionImpl : public Selection<FSLSelectionImpl, FixedSizeListType> 
   using Base = Selection<FSLSelectionImpl, FixedSizeListType>;
   LIFT_BASE_MEMBERS();
 
-  FSLSelectionImpl(KernelContext* ctx, const ExecSpan& batch, int64_t output_length,
-                   ExecResult* out)
-      : Base(ctx, batch, output_length, out), child_index_builder(ctx->memory_pool()) {}
+  template <typename... Args>
+  explicit FSLSelectionImpl(KernelContext* ctx, Args... args)
+      : Base(ctx, std::forward<Args>(args)...), child_index_builder(ctx->memory_pool()) {}
 
   template <typename Adapter>
   Status GenerateOutput() {

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
@@ -193,8 +193,8 @@ struct Selection {
   };
 
   KernelContext* ctx;
-  const ArraySpan& values;
-  const ArraySpan& selection;
+  const ArraySpan values;
+  const ArraySpan selection;
   int64_t output_length;
   ArrayData* out;
   TypedBufferBuilder<bool> validity_builder;

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.h
@@ -33,11 +33,7 @@
 #include "arrow/compute/kernel.h"
 #include "arrow/compute/kernels/codegen_internal.h"
 
-namespace arrow {
-
-using internal::ChunkResolver;
-
-namespace compute::internal {
+namespace arrow::compute::internal {
 
 using FilterState = OptionsWrapper<FilterOptions>;
 using TakeState = OptionsWrapper<TakeOptions>;
@@ -191,5 +187,4 @@ Status StructTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
 Status MapTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
                    std::shared_ptr<ArrayData>*);
 
-}  // namespace compute::internal
-}  // namespace arrow
+}  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.h
@@ -100,6 +100,20 @@ class ValuesSpan {
   }
 };
 
+/// \brief Type for a single "array_take" kernel function.
+///
+/// Instead of implementing both `ArrayKernelExec` and `ChunkedExec` typed
+/// functions for each configurations of `array_take` parameters, we use
+/// templates wrapping `TakeKernelExec` functions to expose exec functions
+/// that can be registered in the kernel registry.
+///
+/// A `TakeKernelExec` always returns a single array, which is the result of
+/// taking values from a single array (AA->A) or multiple arrays (CA->A). The
+/// wrappers take care of converting the output of a CA call to C or calling
+/// the kernel multiple times to process a CC call.
+using TakeKernelExec = Status (*)(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                                  std::shared_ptr<ArrayData>*);
+
 struct SelectionKernelData {
   SelectionKernelData(InputType value_type, InputType selection_type,
                       ArrayKernelExec exec,
@@ -149,19 +163,33 @@ Status FSLFilterExec(KernelContext*, const ExecSpan&, ExecResult*);
 Status DenseUnionFilterExec(KernelContext*, const ExecSpan&, ExecResult*);
 Status MapFilterExec(KernelContext*, const ExecSpan&, ExecResult*);
 
-Status VarBinaryTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status LargeVarBinaryTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status FixedWidthTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status FixedWidthTakeChunkedExec(KernelContext*, const ExecBatch&, Datum*);
-Status ListTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status LargeListTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status ListViewTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status LargeListViewTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status FSLTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status DenseUnionTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status SparseUnionTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status StructTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
-Status MapTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
+// Take kernels compatible with the TakeKernelExec signature
+Status VarBinaryTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                         std::shared_ptr<ArrayData>*);
+Status LargeVarBinaryTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                              std::shared_ptr<ArrayData>*);
+Status FixedWidthTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                          std::shared_ptr<ArrayData>*);
+Status FixedWidthTakeChunkedExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                                 std::shared_ptr<ArrayData>*);
+Status ListTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                    std::shared_ptr<ArrayData>*);
+Status LargeListTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                         std::shared_ptr<ArrayData>*);
+Status ListViewTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                        std::shared_ptr<ArrayData>*);
+Status LargeListViewTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                             std::shared_ptr<ArrayData>*);
+Status FSLTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                   std::shared_ptr<ArrayData>*);
+Status DenseUnionTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                          std::shared_ptr<ArrayData>*);
+Status SparseUnionTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                           std::shared_ptr<ArrayData>*);
+Status StructTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                      std::shared_ptr<ArrayData>*);
+Status MapTakeExec(KernelContext*, const ValuesSpan&, const ArraySpan&,
+                   std::shared_ptr<ArrayData>*);
 
 }  // namespace compute::internal
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/array/data.h"
@@ -34,9 +35,18 @@ using FilterState = OptionsWrapper<FilterOptions>;
 using TakeState = OptionsWrapper<TakeOptions>;
 
 struct SelectionKernelData {
+  SelectionKernelData(InputType value_type, InputType selection_type,
+                      ArrayKernelExec exec,
+                      VectorKernel::ChunkedExec chunked_exec = NULLPTR)
+      : value_type(std::move(value_type)),
+        selection_type(std::move(selection_type)),
+        exec(exec),
+        chunked_exec(chunked_exec) {}
+
   InputType value_type;
   InputType selection_type;
   ArrayKernelExec exec;
+  VectorKernel::ChunkedExec chunked_exec;
 };
 
 void RegisterSelectionFunction(const std::string& name, FunctionDoc doc,

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.h
@@ -86,6 +86,7 @@ Status MapFilterExec(KernelContext*, const ExecSpan&, ExecResult*);
 Status VarBinaryTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
 Status LargeVarBinaryTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
 Status FixedWidthTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
+Status FixedWidthTakeChunkedExec(KernelContext*, const ExecBatch&, Datum*);
 Status ListTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
 Status LargeListTakeExec(KernelContext*, const ExecSpan&, ExecResult*);
 Status ListViewTakeExec(KernelContext*, const ExecSpan&, ExecResult*);

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -824,15 +824,9 @@ class TakeMetaFunction : public MetaFunction {
     const auto& take_opts = static_cast<const TakeOptions&>(*options);
     switch (args[0].kind()) {
       case Datum::ARRAY:
-        // "array_take" can handle AA->A and AC->C cases directly
-        // (via their VectorKernel::exec and VectorKernel::exec_chunked)
-        if (index_kind == Datum::ARRAY || index_kind == Datum::CHUNKED_ARRAY) {
-          return CallArrayTake(args, take_opts, ctx);
-        }
-        break;
       case Datum::CHUNKED_ARRAY:
-        // "array_take" can handle CA->C and CC->C cases directly
-        // (via their VectorKernel::exec_chunked)
+        // "array_take" can handle AA->A, AC->C, CA->C, CC->C cases directly
+        // (via their VectorKernel::exec and VectorKernel::exec_chunked)
         if (index_kind == Datum::ARRAY || index_kind == Datum::CHUNKED_ARRAY) {
           return CallArrayTake(args, take_opts, ctx);
         }

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -882,7 +882,10 @@ Status CallAAAKernel(ArrayKernelExec take_aaa_exec, KernelContext* ctx,
   ExecSpan exec_span{array_array_batch};
   ExecResult result;
   result.value = out->array();
-  return take_aaa_exec(ctx, exec_span, &result);
+  RETURN_NOT_OK(take_aaa_exec(ctx, exec_span, &result));
+  DCHECK(result.is_array_data());
+  out->value = result.array_data();
+  return Status::OK();
 }
 
 Status CallCAAKernel(VectorKernel::ChunkedExec take_caa_exec, KernelContext* ctx,

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -51,9 +51,7 @@ using internal::BinaryBitBlockCounter;
 using internal::BitBlockCount;
 using internal::BitBlockCounter;
 using internal::CheckIndexBounds;
-using internal::ChunkResolver;
 using internal::OptionalBitBlockCounter;
-using internal::TypedChunkLocation;
 
 namespace compute {
 namespace internal {

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -717,7 +717,7 @@ const FunctionDoc take_doc(
     {"input", "indices"}, "TakeOptions");
 
 // Metafunction for dispatching to different Take implementations other than
-// Array-Array.
+// [Chunked]Array-[Chunked]Array.
 class TakeMetaFunction : public MetaFunction {
  public:
   TakeMetaFunction()

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -397,8 +397,6 @@ struct ChunkedFixedWidthValuesSpan {
     }
   }
 
-  ~ChunkedFixedWidthValuesSpan() = default;
-
   const int* src_residual_bit_offsets_data() const {
     return src_residual_bit_offsets.empty() ? nullptr : src_residual_bit_offsets.data();
   }
@@ -932,12 +930,12 @@ Status GenericTakeChunkedExec(ArrayKernelExec take_aaa_exec, KernelContext* ctx,
                               const ExecBatch& batch, Datum* out) {
   const auto& args = batch.values;
   if (args[0].kind() == Datum::CHUNKED_ARRAY) {
-    auto& values_chunked = args[0].chunked_array();
+    const auto& values_chunked = args[0].chunked_array();
     ARROW_ASSIGN_OR_RAISE(auto values_array,
                           ChunkedArrayAsArray(values_chunked, ctx->memory_pool()));
     if (args[1].kind() == Datum::ARRAY) {
       // CA->C
-      auto& indices = args[1].array();
+      const auto& indices = args[1].array();
       DCHECK_EQ(values_array->length(), batch.length);
       {
         // AA->A
@@ -952,7 +950,7 @@ Status GenericTakeChunkedExec(ArrayKernelExec take_aaa_exec, KernelContext* ctx,
       std::vector<std::shared_ptr<Array>> new_chunks;
       for (int i = 0; i < indices->num_chunks(); i++) {
         // AA->A
-        auto& indices_chunk = indices->chunk(i)->data();
+        const auto& indices_chunk = indices->chunk(i)->data();
         Datum result = PrepareOutput(batch, values_array->length());
         RETURN_NOT_OK(CallAAAKernel(take_aaa_exec, ctx, values_array->data(),
                                     indices_chunk, &result));
@@ -1010,7 +1008,7 @@ Status SpecialTakeChunkedExec(const ArrayKernelExec take_aaa_exec,
   auto* pool = ctx->memory_pool();
   const auto& args = batch.values;
   if (args[0].kind() == Datum::CHUNKED_ARRAY) {
-    auto& values_chunked = args[0].chunked_array();
+    const auto& values_chunked = args[0].chunked_array();
     std::shared_ptr<Array> single_chunk = nullptr;
     if (values_chunked->num_chunks() == 0 || values_chunked->length() == 0) {
       ARROW_ASSIGN_OR_RAISE(single_chunk,
@@ -1021,7 +1019,7 @@ Status SpecialTakeChunkedExec(const ArrayKernelExec take_aaa_exec,
 
     if (args[1].kind() == Datum::ARRAY) {
       // CA->C
-      auto& indices = args[1].array();
+      const auto& indices = args[1].array();
       if (single_chunk) {
         // AA->A
         DCHECK_EQ(single_chunk->length(), batch.length);
@@ -1044,7 +1042,7 @@ Status SpecialTakeChunkedExec(const ArrayKernelExec take_aaa_exec,
       const auto& indices = args[1].chunked_array();
       std::vector<std::shared_ptr<Array>> new_chunks;
       for (int i = 0; i < indices->num_chunks(); i++) {
-        auto& indices_chunk = indices->chunk(i)->data();
+        const auto& indices_chunk = indices->chunk(i)->data();
         result = PrepareOutput(batch, values_chunked->length());
         if (single_chunk) {
           // If the ChunkedArray was cheaply converted to a single chunk,

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -375,7 +375,6 @@ struct ChunkedFixedWidthValuesSpan {
   std::vector<const uint8_t*> src_chunks;
 
  public:
-  ARROW_NOINLINE
   explicit ChunkedFixedWidthValuesSpan(const ChunkedArray& values) {
     const bool chunk_values_are_bit_sized = values.type()->id() == Type::BOOL;
     DCHECK_EQ(chunk_values_are_bit_sized, util::FixedWidthInBytes(*values.type()) == -1);
@@ -398,7 +397,6 @@ struct ChunkedFixedWidthValuesSpan {
     }
   }
 
-  ARROW_NOINLINE
   ~ChunkedFixedWidthValuesSpan() = default;
 
   const int* src_residual_bit_offsets_data() const {
@@ -413,7 +411,6 @@ struct ResolvedIndicesState {
  private:
   std::unique_ptr<Buffer> chunk_location_buffer = NULLPTR;
 
-  ARROW_NOINLINE
   Status AllocateBuffers(int64_t n_indices, int64_t sizeof_index_type, MemoryPool* pool) {
     ARROW_ASSIGN_OR_RAISE(chunk_location_buffer,
                           AllocateBuffer(2 * n_indices * sizeof_index_type, pool));
@@ -421,7 +418,6 @@ struct ResolvedIndicesState {
   }
 
  public:
-  ARROW_NOINLINE
   ~ResolvedIndicesState() = default;
 
   template <typename IndexCType>


### PR DESCRIPTION
### Rationale for this change

Concatenating a chunked array into a single array before running the `array_take` kernels is very inefficient and can lead to out-of-memory crashes. See also #25822.

### What changes are included in this PR?

 - Implementation of kernels for `"array_take"` that can receive a `ChunkedArray` as `values` and produce an output without concatenating these chunks
 - Improvements in the dispatching logic of `TakeMetaFunction`(`"take"`) to make `"array_take"` able to have a `chunked_exec` kernel for all types (some specialized and some based on concatenation)

### Are these changes tested?

By existing tests. Some tests were added in previous PRs that introduced some of the infrastructure to support this.


* GitHub Issue: #39565