### PR TITLE
GH-41711: [C++] macros.h: Fix ARROW_FORCE_INLINE for MSVC

### DIFF
--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -102,7 +102,7 @@
 #elif defined(_MSC_VER)  // MSVC
 #define ARROW_NORETURN __declspec(noreturn)
 #define ARROW_NOINLINE __declspec(noinline)
-#define ARROW_FORCE_INLINE __declspec(forceinline)
+#define ARROW_FORCE_INLINE __forceinline
 #define ARROW_PREDICT_FALSE(x) (x)
 #define ARROW_PREDICT_TRUE(x) (x)
 #define ARROW_PREFETCH(addr)


### PR DESCRIPTION
### Rationale for this change

Define the macro correctly. Nothing is broken at the moment because the macro is not used within Arrow at the moment.

### What changes are included in this PR?

Correct definition of the macro.

### Are these changes tested?

Yes, by having this commit in other PRs that pass CI tests on Windows.
* GitHub Issue: #41711