### PR TITLE
GH-41728:[Java][Vector] Add ExtensionWriter and fix StructVector construction with ExtensionTypes

### DIFF
--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -215,6 +215,18 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   }
 
   @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    fail("Extension");
+    return null;
+  }
+
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    fail("Extension");
+    return null;
+  }
+
+  @Override
   public MapWriter map(String name, boolean keysSorted) {
     fail("Map");
     return null;

--- a/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -273,6 +273,11 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   }
 
   @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    return getWriter(MinorType.EXTENSIONTYPE).extension(arrowType);
+  }
+
+  @Override
   public MapWriter map(boolean keysSorted) {
     return getWriter(MinorType.MAP, new ArrowType.Map(keysSorted));
   }
@@ -291,6 +296,12 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   public MapWriter map(String name) {
     return getWriter(MinorType.STRUCT).map(name);
   }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    return getWriter(MinorType.EXTENSIONTYPE).extension(name, arrowType);
+  }
+
 
   @Override
   public MapWriter map(String name, boolean keysSorted) {

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -61,11 +61,15 @@ public interface BaseWriter extends AutoCloseable, Positionable {
 
     void copyReaderToField(String name, FieldReader reader);
     StructWriter struct(String name);
+    ExtensionWriter extension(String name, ArrowType arrowType);
     ListWriter list(String name);
     MapWriter map(String name);
     MapWriter map(String name, boolean keysSorted);
     void start();
     void end();
+  }
+
+  public interface ExtensionWriter extends StructWriter {
   }
 
   public interface ListWriter extends BaseWriter {
@@ -75,6 +79,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     ListWriter list();
     MapWriter map();
     MapWriter map(boolean keysSorted);
+    ExtensionWriter extension(ArrowType arrowType);
     void copyReader(FieldReader reader);
 
     <#list vv.types as type><#list type.minor as minor>

--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -193,6 +193,18 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   }
 
   @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    writer.extension(arrowType);
+    return writer;
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    ExtensionWriter extensionWriter = writer.extension(name, arrowType);
+    return extensionWriter;
+  }
+
+  @Override
   public void startList() {
     int start = vector.startNewValue(idx());
     writer.setPosition(start);

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -179,6 +179,18 @@ public class Union${listName}Writer extends AbstractFieldWriter {
     return mapWriter;
   }
 
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    writer.extension(arrowType);
+    return writer;
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    ExtensionWriter extensionWriter = writer.extension(name, arrowType);
+    return extensionWriter;
+  }
+
   <#if listName == "LargeList">
   @Override
   public void startList() {

--- a/java/vector/src/main/codegen/templates/UnionWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionWriter.java
@@ -165,6 +165,10 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     }
     return mapWriter;
   }
+  
+  private ExtensionWriter getExtensionWriter(ArrowType arrowType) {
+    throw new UnsupportedOperationException("ExtensionTypes are not supported yet.");
+  }
 
   public MapWriter asMap(ArrowType arrowType) {
     data.setType(idx(), MinorType.MAP);
@@ -183,6 +187,8 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
       return getListWriter();
     case MAP:
       return getMapWriter(arrowType);
+    case EXTENSIONTYPE:
+      return getExtensionWriter(arrowType);
     <#list vv.types as type>
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
@@ -400,6 +406,20 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     data.setType(idx(), MinorType.MAP);
     getStructWriter().setPosition(idx());
     return getStructWriter().map(name, keysSorted);
+  }
+
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    data.setType(idx(), MinorType.EXTENSIONTYPE);
+    getListWriter().setPosition(idx());
+    return getListWriter().extension(arrowType);
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    data.setType(idx(), MinorType.EXTENSIONTYPE);
+    getStructWriter().setPosition(idx());
+    return getStructWriter().extension(name, arrowType);
   }
 
   <#list vv.types as type><#list type.minor as minor>

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Locale;
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
@@ -224,6 +225,9 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
       case UNION:
         writer = new UnionWriter((UnionVector) vector, nullableStructWriterFactory);
         break;
+      case EXTENSIONTYPE:
+        writer = new UnionExtensionWriter((ExtensionTypeVector) vector);
+        break;
       default:
         writer = type.getNewFieldWriter(vector);
         break;
@@ -255,6 +259,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
         type == MinorType.MAP ||
         type == MinorType.DURATION ||
         type == MinorType.FIXEDSIZEBINARY ||
+        type == MinorType.EXTENSIONTYPE ||
         (type.name().startsWith("TIMESTAMP") && type.name().endsWith("TZ"));
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -15,20 +15,40 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.vector.complex.writer;
+package org.apache.arrow.vector.complex.impl;
 
-import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ScalarWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
+import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.types.pojo.Field;
 
-/**
- * Composite of all writer types.  Writers are convenience classes for incrementally
- * adding values to {@linkplain org.apache.arrow.vector.ValueVector}s.
- */
-public interface FieldWriter extends StructWriter, ListWriter, MapWriter, ScalarWriter, ExtensionWriter {
-  void allocate();
+public class UnionExtensionWriter extends AbstractFieldWriter {
+  protected ExtensionTypeVector vector;
 
-  void clear();
+  public UnionExtensionWriter(ExtensionTypeVector vector) {
+    this.vector = vector;
+  }
+
+  @Override
+  public void allocate() {
+    vector.allocateNew();
+  }
+
+  @Override
+  public void clear() {
+    vector.clear();
+  }
+
+  @Override
+  public int getValueCapacity() {
+    return vector.getValueCapacity();
+  }
+
+  @Override
+  public Field getField() {
+    return vector.getField();
+  }
+
+  @Override
+  public void close() throws Exception {
+    vector.close();
+  }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
@@ -17,12 +17,17 @@
 
 package org.apache.arrow.vector;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.AbstractStructVector;
@@ -35,9 +40,11 @@ import org.apache.arrow.vector.complex.writer.IntWriter;
 import org.apache.arrow.vector.holders.ComplexHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.TestExtensionType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.After;
 import org.junit.Assert;
@@ -81,6 +88,44 @@ public class TestStructVector {
       assertEquals(0, toChild.getValidityBuffer().capacity());
     }
   }
+
+  @Test
+  public void testStructVectorWithExtensionTypes() {
+    TestExtensionType.UuidType uuidType = new TestExtensionType.UuidType();
+    Field uuidField = new Field("struct_child", FieldType.nullable(uuidType), null);
+    Field structField = new Field("struct", FieldType.nullable(new ArrowType.Struct()), List.of(uuidField));
+    StructVector s1 = new StructVector(structField, allocator, null);
+    StructVector s2 = (StructVector) structField.createVector(allocator);
+    s1.close();
+    s2.close();
+  }
+
+  @Test
+  public void testStructVectorTransferPairWithExtensionType() {
+    TestExtensionType.UuidType uuidType = new TestExtensionType.UuidType();
+    Field uuidField = new Field("uuid_child", FieldType.nullable(uuidType), null);
+    Field structField = new Field("struct", FieldType.nullable(new ArrowType.Struct()), List.of(uuidField));
+
+    StructVector s1 = (StructVector) structField.createVector(allocator);
+    TestExtensionType.UuidVector uuidVector =
+        s1.addOrGet("uuid_child", FieldType.nullable(uuidType), TestExtensionType.UuidVector.class);
+    s1.setValueCount(1);
+    uuidVector.set(0, new UUID(1, 2));
+    s1.setIndexDefined(0);
+
+    TransferPair tp = s1.getTransferPair(structField, allocator);
+    final StructVector toVector = (StructVector) tp.getTo();
+    assertEquals(s1.getField(), toVector.getField());
+    assertEquals(s1.getField().getChildren().get(0), toVector.getField().getChildren().get(0));
+    // also fails but probably another issue
+    // assertEquals(s1.getValueCount(), toVector.getValueCount());
+    // assertEquals(s1, toVector);
+
+    s1.close();
+    toVector.close();
+  }
+
+
 
   @Test
   public void testAllocateAfterReAlloc() throws Exception {

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -41,6 +42,7 @@ import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
@@ -49,6 +51,7 @@ import org.apache.arrow.vector.ipc.ArrowFileReader;
 import org.apache.arrow.vector.ipc.ArrowFileWriter;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
+import org.apache.arrow.vector.util.TransferPair;
 import org.apache.arrow.vector.util.VectorBatchAppender;
 import org.apache.arrow.vector.validate.ValidateVectorVisitor;
 import org.junit.Assert;
@@ -85,21 +88,21 @@ public class TestExtensionType {
           final ArrowFileReader reader = new ArrowFileReader(channel, allocator)) {
         reader.loadNextBatch();
         final VectorSchemaRoot readerRoot = reader.getVectorSchemaRoot();
-        Assert.assertEquals(root.getSchema(), readerRoot.getSchema());
+        assertEquals(root.getSchema(), readerRoot.getSchema());
 
         final Field field = readerRoot.getSchema().getFields().get(0);
         final UuidType expectedType = new UuidType();
-        Assert.assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_NAME),
+        assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_NAME),
             expectedType.extensionName());
-        Assert.assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_METADATA),
+        assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_METADATA),
             expectedType.serialize());
 
         final ExtensionTypeVector deserialized = (ExtensionTypeVector) readerRoot.getFieldVectors().get(0);
-        Assert.assertEquals(vector.getValueCount(), deserialized.getValueCount());
+        assertEquals(vector.getValueCount(), deserialized.getValueCount());
         for (int i = 0; i < vector.getValueCount(); i++) {
-          Assert.assertEquals(vector.isNull(i), deserialized.isNull(i));
+          assertEquals(vector.isNull(i), deserialized.isNull(i));
           if (!vector.isNull(i)) {
-            Assert.assertEquals(vector.getObject(i), deserialized.getObject(i));
+            assertEquals(vector.getObject(i), deserialized.getObject(i));
           }
         }
       }
@@ -138,23 +141,23 @@ public class TestExtensionType {
           final ArrowFileReader reader = new ArrowFileReader(channel, allocator)) {
         reader.loadNextBatch();
         final VectorSchemaRoot readerRoot = reader.getVectorSchemaRoot();
-        Assert.assertEquals(1, readerRoot.getSchema().getFields().size());
-        Assert.assertEquals("a", readerRoot.getSchema().getFields().get(0).getName());
-        Assert.assertTrue(readerRoot.getSchema().getFields().get(0).getType() instanceof ArrowType.FixedSizeBinary);
-        Assert.assertEquals(16,
+        assertEquals(1, readerRoot.getSchema().getFields().size());
+        assertEquals("a", readerRoot.getSchema().getFields().get(0).getName());
+        assertTrue(readerRoot.getSchema().getFields().get(0).getType() instanceof ArrowType.FixedSizeBinary);
+        assertEquals(16,
             ((ArrowType.FixedSizeBinary) readerRoot.getSchema().getFields().get(0).getType()).getByteWidth());
 
         final Field field = readerRoot.getSchema().getFields().get(0);
         final UuidType expectedType = new UuidType();
-        Assert.assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_NAME),
+        assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_NAME),
             expectedType.extensionName());
-        Assert.assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_METADATA),
+        assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_METADATA),
             expectedType.serialize());
 
         final FixedSizeBinaryVector deserialized = (FixedSizeBinaryVector) readerRoot.getFieldVectors().get(0);
-        Assert.assertEquals(vector.getValueCount(), deserialized.getValueCount());
+        assertEquals(vector.getValueCount(), deserialized.getValueCount());
         for (int i = 0; i < vector.getValueCount(); i++) {
-          Assert.assertEquals(vector.isNull(i), deserialized.isNull(i));
+          assertEquals(vector.isNull(i), deserialized.isNull(i));
           if (!vector.isNull(i)) {
             final UUID uuid = vector.getObject(i);
             final ByteBuffer bb = ByteBuffer.allocate(16);
@@ -210,26 +213,26 @@ public class TestExtensionType {
            final ArrowFileReader reader = new ArrowFileReader(channel, allocator)) {
         reader.loadNextBatch();
         final VectorSchemaRoot readerRoot = reader.getVectorSchemaRoot();
-        Assert.assertEquals(root.getSchema(), readerRoot.getSchema());
+        assertEquals(root.getSchema(), readerRoot.getSchema());
 
         final Field field = readerRoot.getSchema().getFields().get(0);
         final LocationType expectedType = new LocationType();
-        Assert.assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_NAME),
+        assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_NAME),
                 expectedType.extensionName());
-        Assert.assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_METADATA),
+        assertEquals(field.getMetadata().get(ExtensionType.EXTENSION_METADATA_KEY_METADATA),
                 expectedType.serialize());
 
         final ExtensionTypeVector deserialized = (ExtensionTypeVector) readerRoot.getFieldVectors().get(0);
-        Assert.assertTrue(deserialized instanceof LocationVector);
-        Assert.assertEquals("location", deserialized.getName());
+        assertTrue(deserialized instanceof LocationVector);
+        assertEquals("location", deserialized.getName());
         StructVector deserStruct = (StructVector) deserialized.getUnderlyingVector();
         Assert.assertNotNull(deserStruct.getChild("Latitude"));
         Assert.assertNotNull(deserStruct.getChild("Longitude"));
-        Assert.assertEquals(vector.getValueCount(), deserialized.getValueCount());
+        assertEquals(vector.getValueCount(), deserialized.getValueCount());
         for (int i = 0; i < vector.getValueCount(); i++) {
-          Assert.assertEquals(vector.isNull(i), deserialized.isNull(i));
+          assertEquals(vector.isNull(i), deserialized.isNull(i));
           if (!vector.isNull(i)) {
-            Assert.assertEquals(vector.getObject(i), deserialized.getObject(i));
+            assertEquals(vector.getObject(i), deserialized.getObject(i));
           }
         }
       }
@@ -278,11 +281,11 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidType extends ExtensionType {
+  public static class UuidType extends ExtensionType {
 
     @Override
     public ArrowType storageType() {
-      return new ArrowType.FixedSizeBinary(16);
+      return new FixedSizeBinary(16);
     }
 
     @Override
@@ -314,10 +317,17 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector> {
+  public static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector> {
+    private final Field field;
 
     public UuidVector(String name, BufferAllocator allocator, FixedSizeBinaryVector underlyingVector) {
       super(name, allocator, underlyingVector);
+      this.field = new Field(name, FieldType.nullable(new UuidType()), null);
+    }
+
+    @Override
+    public Field getField() {
+      return field;
     }
 
     @Override
@@ -341,6 +351,34 @@ public class TestExtensionType {
       bb.putLong(uuid.getMostSignificantBits());
       bb.putLong(uuid.getLeastSignificantBits());
       getUnderlyingVector().set(index, bb.array());
+    }
+
+    @Override
+    public TransferPair makeTransferPair(ValueVector to) {
+      ValueVector targetUnderlyingVector = ((UuidVector) to).getUnderlyingVector();
+      TransferPair tp = getUnderlyingVector().makeTransferPair(targetUnderlyingVector);
+
+      return new TransferPair() {
+        @Override
+        public void transfer() {
+          tp.transfer();
+        }
+
+        @Override
+        public void splitAndTransfer(int startIndex, int length) {
+          tp.splitAndTransfer(startIndex, length);
+        }
+
+        @Override
+        public ValueVector getTo() {
+          return to;
+        }
+
+        @Override
+        public void copyValueSafe(int fromIndex, int toIndex) {
+          tp.copyValueSafe(fromIndex, toIndex);
+        }
+      };
     }
   }
 
@@ -407,7 +445,7 @@ public class TestExtensionType {
     }
 
     @Override
-    public java.util.Map<String, ?> getObject(int index) {
+    public Map<String, ?> getObject(int index) {
       return getUnderlyingVector().getObject(index);
     }
 


### PR DESCRIPTION
### Rationale for this change

For me personally I mainly want to fix apache/arrow-java#87, but this change also includes some larger changes to the writer interface. This will likely include some design work and some back and forth as I can't make these decisions.

### What changes are included in this PR?

A commit that extends the writer interfaces with an `ExtensionWriter` as well as dealing with the `MinorType.EXTENSIONTYPE` in various places. The `ExtensionWriter` was left rather skeleton like as this needs some design decisions to be made before implementing the concrete details. I will leave some comments throughout the code of where I think stuff needs to be decided. 

This next bit are my 2cents (hence taken with a grain of salt) of how I would do things as I have the impression that one will eventually hit a wall with the current writer interfaces.  For example the `PromotableWriter` currently makes the assumption that the parent vector is a struct or a list vector, making it difficult to extend this to composite extension types. 
I would just create one single writer interface (`VectorWriter` or whatever you want to call) implemented by all concrete writers. If a writer doesn't support an operation just keep it abstract or throw an UOE. 

### Are these changes tested?

There are two tests that test the issue of apache/arrow-java#87. I have not tested (because of the lack of a concrete implementation) the `ExtensionWriter` interface.

### Are there any user-facing changes?

Yes. `ExtensionWriter` will be exposed for the first time. This is only an additive change and shouldn't break any existing API. 
* GitHub Issue: apache/arrow-java#87
* GitHub Issue: #87