### PR TITLE
GH-41730: [Java] Adding variadicBufferCounts to RecordBatch

### DIFF
--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
@@ -114,7 +114,7 @@ public class StructVectorLoader {
     if (variadicBufferCounts != null) {
       variadicBufferLayoutCount = variadicBufferCounts.next();
     }
-    int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType(), vector));
+    int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType()));
     List<ArrowBuf> ownBuffers = new ArrayList<>(bufferLayoutCount);
     for (int j = 0; j < bufferLayoutCount; j++) {
       ArrowBuf nextBuf = buffers.next();

--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
@@ -90,8 +90,12 @@ public class StructVectorLoader {
         .fromCompressionType(recordBatch.getBodyCompression().getCodec());
     decompressionNeeded = codecType != CompressionUtil.CodecType.NO_COMPRESSION;
     CompressionCodec codec = decompressionNeeded ? factory.createCodec(codecType) : NoCompressionCodec.INSTANCE;
+    Iterator<Long> variadicBufferCounts = null;
+    if (recordBatch.getVariadicBufferCounts() != null && !recordBatch.getVariadicBufferCounts().isEmpty()) {
+      variadicBufferCounts = recordBatch.getVariadicBufferCounts().iterator();
+    }
     for (FieldVector fieldVector : result.getChildrenFromFields()) {
-      loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes, codec);
+      loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes, codec, variadicBufferCounts);
     }
     result.loadFieldBuffers(new ArrowFieldNode(recordBatch.getLength(), 0), Collections.singletonList(null));
     if (nodes.hasNext() || buffers.hasNext()) {
@@ -102,10 +106,15 @@ public class StructVectorLoader {
   }
 
   private void loadBuffers(FieldVector vector, Field field, Iterator<ArrowBuf> buffers, Iterator<ArrowFieldNode> nodes,
-      CompressionCodec codec) {
+      CompressionCodec codec, Iterator<Long> variadicBufferCounts) {
     checkArgument(nodes.hasNext(), "no more field nodes for field %s and vector %s", field, vector);
     ArrowFieldNode fieldNode = nodes.next();
-    int bufferLayoutCount = TypeLayout.getTypeBufferCount(field.getType());
+    // variadicBufferLayoutCount will be 0 for vectors of type except BaseVariableWidthViewVector
+    long variadicBufferLayoutCount = 0;
+    if (variadicBufferCounts != null) {
+      variadicBufferLayoutCount = variadicBufferCounts.next();
+    }
+    int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType(), vector));
     List<ArrowBuf> ownBuffers = new ArrayList<>(bufferLayoutCount);
     for (int j = 0; j < bufferLayoutCount; j++) {
       ArrowBuf nextBuf = buffers.next();
@@ -138,7 +147,7 @@ public class StructVectorLoader {
       for (int i = 0; i < childrenFromFields.size(); i++) {
         Field child = children.get(i);
         FieldVector fieldVector = childrenFromFields.get(i);
-        loadBuffers(fieldVector, child, buffers, nodes, codec);
+        loadBuffers(fieldVector, child, buffers, nodes, codec, variadicBufferCounts);
       }
     }
   }

--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorUnloader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorUnloader.java
@@ -107,8 +107,9 @@ public class StructVectorUnloader {
       List<Long> variadicBufferCounts) {
     nodes.add(new ArrowFieldNode(vector.getValueCount(), includeNullCount ? vector.getNullCount() : -1));
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
-    int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType(), vector);
-    variadicBufferCounts.add(getVariadicBufferCount(vector));
+    long variadicBufferCount = getVariadicBufferCount(vector);
+    int expectedBufferCount = (int) (TypeLayout.getTypeBufferCount(vector.getField().getType()) + variadicBufferCount);
+    variadicBufferCounts.add(variadicBufferCount);
     if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format("wrong number of buffers for field %s in vector %s. found: %s",
           vector.getField(), vector.getClass().getSimpleName(), fieldBuffers));

--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorUnloader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorUnloader.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.BaseVariableWidthViewVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TypeLayout;
 import org.apache.arrow.vector.complex.StructVector;
@@ -87,17 +88,27 @@ public class StructVectorUnloader {
   public ArrowRecordBatch getRecordBatch() {
     List<ArrowFieldNode> nodes = new ArrayList<>();
     List<ArrowBuf> buffers = new ArrayList<>();
+    List<Long> variadicBufferCounts = new ArrayList<>();
     for (FieldVector vector : root.getChildrenFromFields()) {
-      appendNodes(vector, nodes, buffers);
+      appendNodes(vector, nodes, buffers, variadicBufferCounts);
     }
     return new ArrowRecordBatch(root.getValueCount(), nodes, buffers, CompressionUtil.createBodyCompression(codec),
-        alignBuffers);
+        variadicBufferCounts, alignBuffers);
   }
 
-  private void appendNodes(FieldVector vector, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers) {
+  private long getVariadicBufferCount(FieldVector vector) {
+    if (vector instanceof BaseVariableWidthViewVector) {
+      return ((BaseVariableWidthViewVector) vector).getDataBuffers().size();
+    }
+    return 0L;
+  }
+
+  private void appendNodes(FieldVector vector, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
+      List<Long> variadicBufferCounts) {
     nodes.add(new ArrowFieldNode(vector.getValueCount(), includeNullCount ? vector.getNullCount() : -1));
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
-    int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType());
+    int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType(), vector);
+    variadicBufferCounts.add(getVariadicBufferCount(vector));
     if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format("wrong number of buffers for field %s in vector %s. found: %s",
           vector.getField(), vector.getClass().getSimpleName(), fieldBuffers));
@@ -106,7 +117,7 @@ public class StructVectorUnloader {
       buffers.add(codec.compress(vector.getAllocator(), buf));
     }
     for (FieldVector child : vector.getChildrenFromFields()) {
-      appendNodes(child, nodes, buffers);
+      appendNodes(child, nodes, buffers, variadicBufferCounts);
     }
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -161,7 +161,7 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
   /**
    * Get the buffers that store the data for views in the vector.
    *
-   * @return buffer
+   * @return list of ArrowBuf
    */
   public List<ArrowBuf> getDataBuffers() {
     return dataBuffers;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -368,8 +368,21 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
    */
   @Override
   public void loadFieldBuffers(ArrowFieldNode fieldNode, List<ArrowBuf> ownBuffers) {
-    // TODO: https://github.com/apache/arrow/issues/40931
-    throw new UnsupportedOperationException("loadFieldBuffers is not supported for BaseVariableWidthViewVector");
+    ArrowBuf bitBuf = ownBuffers.get(0);
+    ArrowBuf viewBuf = ownBuffers.get(1);
+    List<ArrowBuf> dataBufs = ownBuffers.subList(2, ownBuffers.size());
+
+    this.clear();
+
+    this.viewBuffer = viewBuf.getReferenceManager().retain(viewBuf, allocator);
+    this.validityBuffer = BitVectorHelper.loadValidityBuffer(fieldNode, bitBuf, allocator);
+
+    for (ArrowBuf dataBuf : dataBufs) {
+      this.dataBuffers.add(dataBuf.getReferenceManager().retain(dataBuf, allocator));
+    }
+
+    lastSet = fieldNode.getLength() - 1;
+    valueCount = fieldNode.getLength();
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -58,6 +58,7 @@ public class TypeLayout {
 
   /**
    * Constructs a new {@link TypeLayout} for the given <code>arrowType</code>.
+   * This method is deprecated and will be removed in a future release.
    */
   @Deprecated
   public static TypeLayout getTypeLayout(final ArrowType arrowType) {
@@ -501,6 +502,7 @@ public class TypeLayout {
 
   /**
    * Gets the number of {@link BufferLayout}s for the given <code>arrowType</code>.
+   * This method is deprecated and will be removed in a future release.
    */
   @Deprecated
   public static int getTypeBufferCount(final ArrowType arrowType) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -40,6 +40,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType.Int;
 import org.apache.arrow.vector.types.pojo.ArrowType.Interval;
 import org.apache.arrow.vector.types.pojo.ArrowType.LargeBinary;
 import org.apache.arrow.vector.types.pojo.ArrowType.LargeUtf8;
+import org.apache.arrow.vector.types.pojo.ArrowType.ListView;
 import org.apache.arrow.vector.types.pojo.ArrowType.Map;
 import org.apache.arrow.vector.types.pojo.ArrowType.Null;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
@@ -496,6 +497,16 @@ public class TypeLayout {
         return newFixedWidthTypeLayout(BufferLayout.dataBuffer(64));
       }
 
+      @Override
+      public TypeLayout visit(ListView type) {
+        List<BufferLayout> vectors = asList(
+            BufferLayout.validityVector(),
+            BufferLayout.offsetBuffer(),
+            BufferLayout.sizeBuffer()
+        );
+        return new TypeLayout(vectors);
+      }
+
     });
     return layout;
   }
@@ -808,6 +819,12 @@ public class TypeLayout {
       @Override
       public Integer visit(Duration type) {
         return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(ListView type) {
+        // validity buffer + offset buffer + size buffer
+        return 3;
       }
 
     });

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -28,6 +28,7 @@ import org.apache.arrow.vector.BufferLayout.BufferType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeVisitor;
 import org.apache.arrow.vector.types.pojo.ArrowType.Binary;
+import org.apache.arrow.vector.types.pojo.ArrowType.BinaryView;
 import org.apache.arrow.vector.types.pojo.ArrowType.Bool;
 import org.apache.arrow.vector.types.pojo.ArrowType.Date;
 import org.apache.arrow.vector.types.pojo.ArrowType.Decimal;
@@ -58,6 +59,7 @@ public class TypeLayout {
   /**
    * Constructs a new {@link TypeLayout} for the given <code>arrowType</code>.
    */
+  @Deprecated
   public static TypeLayout getTypeLayout(final ArrowType arrowType) {
     TypeLayout layout = arrowType.accept(new ArrowTypeVisitor<TypeLayout>() {
 
@@ -186,7 +188,6 @@ public class TypeLayout {
 
       @Override
       public TypeLayout visit(ArrowType.BinaryView type) {
-        // TODO: https://github.com/apache/arrow/issues/40934
         throw new UnsupportedOperationException("BinaryView not supported");
       }
 
@@ -197,7 +198,6 @@ public class TypeLayout {
 
       @Override
       public TypeLayout visit(Utf8View type) {
-        // TODO: https://github.com/apache/arrow/issues/40934
         throw new UnsupportedOperationException("Utf8View not supported");
       }
 
@@ -275,8 +275,234 @@ public class TypeLayout {
   }
 
   /**
+   * Constructs a new {@link TypeLayout}.
+   *
+   * @param arrowType the type to create the layout for
+   * @param vector the vector to create the layout for
+   * @return the layout for the given type and vector
+   * @throws UnsupportedOperationException if the ArrowType is not supported
+   */
+  public static TypeLayout getTypeLayout(final ArrowType arrowType, FieldVector vector) {
+    TypeLayout layout = arrowType.accept(new ArrowTypeVisitor<TypeLayout>() {
+
+      @Override
+      public TypeLayout visit(Int type) {
+        return newFixedWidthTypeLayout(BufferLayout.dataBuffer(type.getBitWidth()));
+      }
+
+      @Override
+      public TypeLayout visit(Union type) {
+        List<BufferLayout> vectors;
+        switch (type.getMode()) {
+          case Dense:
+            vectors = asList(
+                BufferLayout.typeBuffer(),
+                BufferLayout.offsetBuffer() // offset to find the vector
+            );
+            break;
+          case Sparse:
+            vectors = asList(
+                BufferLayout.typeBuffer() // type of the value at the index or 0 if null
+            );
+            break;
+          default:
+            throw new UnsupportedOperationException("Unsupported Union Mode: " + type.getMode());
+        }
+        return new TypeLayout(vectors);
+      }
+
+      @Override
+      public TypeLayout visit(Struct type) {
+        List<BufferLayout> vectors = asList(
+            BufferLayout.validityVector()
+        );
+        return new TypeLayout(vectors);
+      }
+
+      @Override
+      public TypeLayout visit(Timestamp type) {
+        return newFixedWidthTypeLayout(BufferLayout.dataBuffer(64));
+      }
+
+      @Override
+      public TypeLayout visit(org.apache.arrow.vector.types.pojo.ArrowType.List type) {
+        List<BufferLayout> vectors = asList(
+            BufferLayout.validityVector(),
+            BufferLayout.offsetBuffer()
+        );
+        return new TypeLayout(vectors);
+      }
+
+      @Override
+      public TypeLayout visit(ArrowType.LargeList type) {
+        List<BufferLayout> vectors = asList(
+            BufferLayout.validityVector(),
+            BufferLayout.largeOffsetBuffer()
+        );
+        return new TypeLayout(vectors);
+      }
+
+      @Override
+      public TypeLayout visit(FixedSizeList type) {
+        List<BufferLayout> vectors = asList(
+            BufferLayout.validityVector()
+        );
+        return new TypeLayout(vectors);
+      }
+
+      @Override
+      public TypeLayout visit(Map type) {
+        List<BufferLayout> vectors = asList(
+            BufferLayout.validityVector(),
+            BufferLayout.offsetBuffer()
+        );
+        return new TypeLayout(vectors);
+      }
+
+      @Override
+      public TypeLayout visit(FloatingPoint type) {
+        int bitWidth;
+        switch (type.getPrecision()) {
+          case HALF:
+            bitWidth = 16;
+            break;
+          case SINGLE:
+            bitWidth = 32;
+            break;
+          case DOUBLE:
+            bitWidth = 64;
+            break;
+          default:
+            throw new UnsupportedOperationException("Unsupported Precision: " + type.getPrecision());
+        }
+        return newFixedWidthTypeLayout(BufferLayout.dataBuffer(bitWidth));
+      }
+
+      @Override
+      public TypeLayout visit(Decimal type) {
+        return newFixedWidthTypeLayout(BufferLayout.dataBuffer(type.getBitWidth()));
+      }
+
+      @Override
+      public TypeLayout visit(FixedSizeBinary type) {
+        return newFixedWidthTypeLayout(new BufferLayout(BufferType.DATA, type.getByteWidth() * 8));
+      }
+
+      @Override
+      public TypeLayout visit(Bool type) {
+        return newFixedWidthTypeLayout(BufferLayout.booleanVector());
+      }
+
+      @Override
+      public TypeLayout visit(Binary type) {
+        return newVariableWidthTypeLayout();
+      }
+
+      @Override
+      public TypeLayout visit(BinaryView type) {
+        return newVariableWidthViewTypeLayout((ViewVarBinaryVector) vector);
+      }
+
+      @Override
+      public TypeLayout visit(Utf8 type) {
+        return newVariableWidthTypeLayout();
+      }
+
+      @Override
+      public TypeLayout visit(Utf8View type) {
+        return newVariableWidthViewTypeLayout((ViewVarCharVector) vector);
+      }
+
+      @Override
+      public TypeLayout visit(LargeUtf8 type) {
+        return newLargeVariableWidthTypeLayout();
+      }
+
+      @Override
+      public TypeLayout visit(LargeBinary type) {
+        return newLargeVariableWidthTypeLayout();
+      }
+
+      private TypeLayout newVariableWidthTypeLayout() {
+        return newPrimitiveTypeLayout(BufferLayout.validityVector(), BufferLayout.offsetBuffer(),
+            BufferLayout.byteVector());
+      }
+
+      private TypeLayout newVariableWidthViewTypeLayout(BaseVariableWidthViewVector vector) {
+        final int numDataBuffers = vector.getDataBuffers().size();
+        List<BufferLayout> bufferLayouts = new ArrayList<>(numDataBuffers + 2);
+        bufferLayouts.add(BufferLayout.validityVector());
+        bufferLayouts.add(BufferLayout.byteVector());
+
+        for (int i = 0; i < numDataBuffers; i++) {
+          bufferLayouts.add(BufferLayout.byteVector());
+        }
+
+        return new TypeLayout(bufferLayouts);
+      }
+
+      private TypeLayout newLargeVariableWidthTypeLayout() {
+        return newPrimitiveTypeLayout(BufferLayout.validityVector(), BufferLayout.largeOffsetBuffer(),
+            BufferLayout.byteVector());
+      }
+
+      private TypeLayout newPrimitiveTypeLayout(BufferLayout... vectors) {
+        return new TypeLayout(asList(vectors));
+      }
+
+      public TypeLayout newFixedWidthTypeLayout(BufferLayout dataVector) {
+        return newPrimitiveTypeLayout(BufferLayout.validityVector(), dataVector);
+      }
+
+      @Override
+      public TypeLayout visit(Null type) {
+        return new TypeLayout(Collections.<BufferLayout>emptyList());
+      }
+
+      @Override
+      public TypeLayout visit(Date type) {
+        switch (type.getUnit()) {
+          case DAY:
+            return newFixedWidthTypeLayout(BufferLayout.dataBuffer(32));
+          case MILLISECOND:
+            return newFixedWidthTypeLayout(BufferLayout.dataBuffer(64));
+          default:
+            throw new UnsupportedOperationException("Unknown unit " + type.getUnit());
+        }
+      }
+
+      @Override
+      public TypeLayout visit(Time type) {
+        return newFixedWidthTypeLayout(BufferLayout.dataBuffer(type.getBitWidth()));
+      }
+
+      @Override
+      public TypeLayout visit(Interval type) {
+        switch (type.getUnit()) {
+          case DAY_TIME:
+            return newFixedWidthTypeLayout(BufferLayout.dataBuffer(64));
+          case YEAR_MONTH:
+            return newFixedWidthTypeLayout(BufferLayout.dataBuffer(32));
+          case MONTH_DAY_NANO:
+            return newFixedWidthTypeLayout(BufferLayout.dataBuffer(128));
+          default:
+            throw new UnsupportedOperationException("Unknown unit " + type.getUnit());
+        }
+      }
+
+      @Override
+      public TypeLayout visit(Duration type) {
+        return newFixedWidthTypeLayout(BufferLayout.dataBuffer(64));
+      }
+
+    });
+    return layout;
+  }
+
+  /**
    * Gets the number of {@link BufferLayout}s for the given <code>arrowType</code>.
    */
+  @Deprecated
   public static int getTypeBufferCount(final ArrowType arrowType) {
     return arrowType.accept(new ArrowTypeVisitor<Integer>() {
 
@@ -377,9 +603,8 @@ public class TypeLayout {
       }
 
       @Override
-      public Integer visit(ArrowType.BinaryView type) {
-        // TODO: https://github.com/apache/arrow/issues/40935
-        return VARIABLE_WIDTH_BUFFER_COUNT;
+      public Integer visit(BinaryView type) {
+        throw new UnsupportedOperationException("BinaryView not supported");
       }
 
       @Override
@@ -389,8 +614,163 @@ public class TypeLayout {
 
       @Override
       public Integer visit(Utf8View type) {
-        // TODO: https://github.com/apache/arrow/issues/40935
+        throw new UnsupportedOperationException("Utf8View not supported");
+      }
+
+      @Override
+      public Integer visit(LargeUtf8 type) {
         return VARIABLE_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(LargeBinary type) {
+        return VARIABLE_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Null type) {
+        return 0;
+      }
+
+      @Override
+      public Integer visit(Date type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Time type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Interval type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Duration type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+    });
+  }
+
+
+  /**
+   * Gets the number of {@link BufferLayout}s.
+   *
+   * @param arrowType the ArrowType for which the buffer count is to be determined
+   * @param vector the FieldVector associated with the ArrowType
+   * @return the number of BufferLayouts for the given ArrowType and FieldVector
+   * @throws UnsupportedOperationException if the ArrowType is not supported
+   */
+  public static int getTypeBufferCount(final ArrowType arrowType, FieldVector vector) {
+
+    return arrowType.accept(new ArrowTypeVisitor<Integer>() {
+
+      /**
+       * All fixed width vectors have a common number of buffers 2: one validity buffer, plus a data buffer.
+       */
+      static final int FIXED_WIDTH_BUFFER_COUNT = 2;
+
+      /**
+       * All variable width vectors have a common number of buffers 3: a validity buffer,
+       * an offset buffer, and a data buffer.
+       */
+      static final int VARIABLE_WIDTH_BUFFER_COUNT = 3;
+
+      @Override
+      public Integer visit(Int type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Union type) {
+        switch (type.getMode()) {
+          case Dense:
+            // TODO: validate this
+            return 2;
+          case Sparse:
+            // type buffer
+            return 1;
+          default:
+            throw new UnsupportedOperationException("Unsupported Union Mode: " + type.getMode());
+        }
+      }
+
+      @Override
+      public Integer visit(Struct type) {
+        // validity buffer
+        return 1;
+      }
+
+      @Override
+      public Integer visit(Timestamp type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(org.apache.arrow.vector.types.pojo.ArrowType.List type) {
+        // validity buffer + offset buffer
+        return 2;
+      }
+
+      @Override
+      public Integer visit(ArrowType.LargeList type) {
+        // validity buffer + offset buffer
+        return 2;
+      }
+
+      @Override
+      public Integer visit(FixedSizeList type) {
+        // validity buffer
+        return 1;
+      }
+
+      @Override
+      public Integer visit(Map type) {
+        // validity buffer + offset buffer
+        return 2;
+      }
+
+      @Override
+      public Integer visit(FloatingPoint type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Decimal type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(FixedSizeBinary type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Bool type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Binary type) {
+        return VARIABLE_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(BinaryView type) {
+        return 2 + ((ViewVarBinaryVector) vector).getDataBuffers().size();
+      }
+
+      @Override
+      public Integer visit(Utf8 type) {
+        return VARIABLE_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Utf8View type) {
+        return 2 + ((ViewVarCharVector) vector).getDataBuffers().size();
       }
 
       @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -109,7 +109,7 @@ public class VectorLoader {
     if (variadicBufferCounts != null) {
       variadicBufferLayoutCount = variadicBufferCounts.next();
     }
-    int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType(), vector));
+    int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType()));
     List<ArrowBuf> ownBuffers = new ArrayList<>(bufferLayoutCount);
     for (int j = 0; j < bufferLayoutCount; j++) {
       ArrowBuf nextBuf = buffers.next();

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -98,7 +98,7 @@ public class VectorLoader {
       CompressionCodec codec) {
     checkArgument(nodes.hasNext(), "no more field nodes for field %s and vector %s", field, vector);
     ArrowFieldNode fieldNode = nodes.next();
-    int bufferLayoutCount = TypeLayout.getTypeBufferCount(field.getType());
+    int bufferLayoutCount = TypeLayout.getTypeBufferCount(field.getType(), vector);
     List<ArrowBuf> ownBuffers = new ArrayList<>(bufferLayoutCount);
     for (int j = 0; j < bufferLayoutCount; j++) {
       ArrowBuf nextBuf = buffers.next();

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -80,8 +80,13 @@ public class VectorLoader {
         CompressionUtil.CodecType.fromCompressionType(recordBatch.getBodyCompression().getCodec());
     decompressionNeeded = codecType != CompressionUtil.CodecType.NO_COMPRESSION;
     CompressionCodec codec = decompressionNeeded ? factory.createCodec(codecType) : NoCompressionCodec.INSTANCE;
+    Iterator<Long> variadicBufferCounts = null;
+    if (recordBatch.getVariadicBufferCounts() != null && !recordBatch.getVariadicBufferCounts().isEmpty()) {
+      variadicBufferCounts = recordBatch.getVariadicBufferCounts().iterator();
+    }
+
     for (FieldVector fieldVector : root.getFieldVectors()) {
-      loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes, codec);
+      loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes, codec, variadicBufferCounts);
     }
     root.setRowCount(recordBatch.getLength());
     if (nodes.hasNext() || buffers.hasNext()) {
@@ -95,10 +100,16 @@ public class VectorLoader {
       Field field,
       Iterator<ArrowBuf> buffers,
       Iterator<ArrowFieldNode> nodes,
-      CompressionCodec codec) {
+      CompressionCodec codec,
+      Iterator<Long> variadicBufferCounts) {
     checkArgument(nodes.hasNext(), "no more field nodes for field %s and vector %s", field, vector);
     ArrowFieldNode fieldNode = nodes.next();
-    int bufferLayoutCount = TypeLayout.getTypeBufferCount(field.getType(), vector);
+    // variadicBufferLayoutCount will be 0 for vectors of type except BaseVariableWidthViewVector
+    long variadicBufferLayoutCount = 0;
+    if (variadicBufferCounts != null) {
+      variadicBufferLayoutCount = variadicBufferCounts.next();
+    }
+    int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType(), vector));
     List<ArrowBuf> ownBuffers = new ArrayList<>(bufferLayoutCount);
     for (int j = 0; j < bufferLayoutCount; j++) {
       ArrowBuf nextBuf = buffers.next();
@@ -130,7 +141,7 @@ public class VectorLoader {
       for (int i = 0; i < childrenFromFields.size(); i++) {
         Field child = children.get(i);
         FieldVector fieldVector = childrenFromFields.get(i);
-        loadBuffers(fieldVector, child, buffers, nodes, codec);
+        loadBuffers(fieldVector, child, buffers, nodes, codec, variadicBufferCounts);
       }
     }
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -101,8 +101,9 @@ public class VectorUnloader {
       List<Long> variadicBufferCounts) {
     nodes.add(new ArrowFieldNode(vector.getValueCount(), includeNullCount ? vector.getNullCount() : -1));
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
-    int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType(), vector);
-    variadicBufferCounts.add(getVariadicBufferCount(vector));
+    long variadicBufferCount = getVariadicBufferCount(vector);
+    int expectedBufferCount = (int) (TypeLayout.getTypeBufferCount(vector.getField().getType()) + variadicBufferCount);
+    variadicBufferCounts.add(variadicBufferCount);
     if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format(
           "wrong number of buffers for field %s in vector %s. found: %s",

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -80,19 +80,29 @@ public class VectorUnloader {
   public ArrowRecordBatch getRecordBatch() {
     List<ArrowFieldNode> nodes = new ArrayList<>();
     List<ArrowBuf> buffers = new ArrayList<>();
+    List<Long> variadicBufferCounts = new ArrayList<>();
     for (FieldVector vector : root.getFieldVectors()) {
-      appendNodes(vector, nodes, buffers);
+      appendNodes(vector, nodes, buffers, variadicBufferCounts);
     }
     // Do NOT retain buffers in ArrowRecordBatch constructor since we have already retained them.
     return new ArrowRecordBatch(
-        root.getRowCount(), nodes, buffers, CompressionUtil.createBodyCompression(codec), alignBuffers,
-        /*retainBuffers*/ false);
+        root.getRowCount(), nodes, buffers, CompressionUtil.createBodyCompression(codec),
+        variadicBufferCounts, alignBuffers, /*retainBuffers*/ false);
   }
 
-  private void appendNodes(FieldVector vector, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers) {
+  private long getVariadicBufferCount(FieldVector vector) {
+    if (vector instanceof BaseVariableWidthViewVector) {
+      return ((BaseVariableWidthViewVector) vector).getDataBuffers().size();
+    }
+    return 0L;
+  }
+
+  private void appendNodes(FieldVector vector, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
+      List<Long> variadicBufferCounts) {
     nodes.add(new ArrowFieldNode(vector.getValueCount(), includeNullCount ? vector.getNullCount() : -1));
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
     int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType(), vector);
+    variadicBufferCounts.add(getVariadicBufferCount(vector));
     if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format(
           "wrong number of buffers for field %s in vector %s. found: %s",
@@ -107,7 +117,7 @@ public class VectorUnloader {
       buffers.add(codec.compress(vector.getAllocator(), buf));
     }
     for (FieldVector child : vector.getChildrenFromFields()) {
-      appendNodes(child, nodes, buffers);
+      appendNodes(child, nodes, buffers, variadicBufferCounts);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -92,7 +92,7 @@ public class VectorUnloader {
   private void appendNodes(FieldVector vector, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers) {
     nodes.add(new ArrowFieldNode(vector.getValueCount(), includeNullCount ? vector.getNullCount() : -1));
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
-    int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType());
+    int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType(), vector);
     if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format(
           "wrong number of buffers for field %s in vector %s. found: %s",

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -48,7 +48,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector {
    * @param allocator allocator for memory management.
    */
   public ViewVarCharVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(MinorType.VARCHAR.getType()), allocator);
+    this(name, FieldType.nullable(MinorType.VIEWVARCHAR.getType()), allocator);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -715,7 +715,9 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
 
   private void readFromJsonIntoVector(Field field, FieldVector vector) throws JsonParseException, IOException {
     ArrowType type = field.getType();
-    TypeLayout typeLayout = TypeLayout.getTypeLayout(type, vector);
+    // TODO: update the `getTypeLayout` method to take a FieldVector as an argument.
+    //  In relation, the metadata must be used to determine the buffer count for views.
+    TypeLayout typeLayout = TypeLayout.getTypeLayout(type);
     List<BufferType> vectorTypes = typeLayout.getBufferTypes();
     ArrowBuf[] vectorBuffers = new ArrowBuf[vectorTypes.size()];
     /*

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -715,8 +715,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
 
   private void readFromJsonIntoVector(Field field, FieldVector vector) throws JsonParseException, IOException {
     ArrowType type = field.getType();
-    // TODO: update the `getTypeLayout` method to take a FieldVector as an argument.
-    //  In relation, the metadata must be used to determine the buffer count for views.
+    // TODO: https://github.com/apache/arrow/issues/41733
     TypeLayout typeLayout = TypeLayout.getTypeLayout(type);
     List<BufferType> vectorTypes = typeLayout.getBufferTypes();
     ArrowBuf[] vectorBuffers = new ArrowBuf[vectorTypes.size()];

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -715,7 +715,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
 
   private void readFromJsonIntoVector(Field field, FieldVector vector) throws JsonParseException, IOException {
     ArrowType type = field.getType();
-    TypeLayout typeLayout = TypeLayout.getTypeLayout(type);
+    TypeLayout typeLayout = TypeLayout.getTypeLayout(type, vector);
     List<BufferType> vectorTypes = typeLayout.getBufferTypes();
     ArrowBuf[] vectorBuffers = new ArrowBuf[vectorTypes.size()];
     /*

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -208,7 +208,7 @@ public class JsonFileWriter implements AutoCloseable {
   }
 
   private void writeFromVectorIntoJson(Field field, FieldVector vector) throws IOException {
-    List<BufferType> vectorTypes = TypeLayout.getTypeLayout(field.getType()).getBufferTypes();
+    List<BufferType> vectorTypes = TypeLayout.getTypeLayout(field.getType(), vector).getBufferTypes();
     List<ArrowBuf> vectorBuffers = vector.getFieldBuffers();
     if (vectorTypes.size() != vectorBuffers.size()) {
       throw new IllegalArgumentException("vector types and inner vector buffers are not the same size: " +

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -208,7 +208,8 @@ public class JsonFileWriter implements AutoCloseable {
   }
 
   private void writeFromVectorIntoJson(Field field, FieldVector vector) throws IOException {
-    List<BufferType> vectorTypes = TypeLayout.getTypeLayout(field.getType(), vector).getBufferTypes();
+    // TODO: https://github.com/apache/arrow/issues/41733
+    List<BufferType> vectorTypes = TypeLayout.getTypeLayout(field.getType()).getBufferTypes();
     List<ArrowBuf> vectorBuffers = vector.getFieldBuffers();
     if (vectorTypes.size() != vectorBuffers.size()) {
       throw new IllegalArgumentException("vector types and inner vector buffers are not the same size: " +

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -99,8 +99,7 @@ public class ArrowRecordBatch implements ArrowMessage {
    */
   public ArrowRecordBatch(
       int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
-      ArrowBodyCompression bodyCompression, boolean alignBuffers,
-      boolean retainBuffers) {
+      ArrowBodyCompression bodyCompression, boolean alignBuffers, boolean retainBuffers) {
     super();
     this.length = length;
     this.nodes = nodes;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -93,22 +93,6 @@ public class ArrowRecordBatch implements ArrowMessage {
    * @param nodes   field level info
    * @param buffers will be retained until this recordBatch is closed
    * @param bodyCompression compression info.
-   * @param variadicBufferCounts the number of buffers in each variadic section.
-   * @param alignBuffers Whether to align buffers to an 8 byte boundary.
-   */
-  public ArrowRecordBatch(
-      int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
-      ArrowBodyCompression bodyCompression, List<Long> variadicBufferCounts, boolean alignBuffers) {
-    this(length, nodes, buffers, bodyCompression, variadicBufferCounts, alignBuffers, /*retainBuffers*/ true);
-  }
-
-  /**
-   * Construct a record batch from nodes.
-   *
-   * @param length  how many rows in this batch
-   * @param nodes   field level info
-   * @param buffers will be retained until this recordBatch is closed
-   * @param bodyCompression compression info.
    * @param alignBuffers Whether to align buffers to an 8 byte boundary.
    * @param retainBuffers Whether to retain() each source buffer in the constructor. If false, the caller is
    *                      responsible for retaining the buffers beforehand.
@@ -141,6 +125,22 @@ public class ArrowRecordBatch implements ArrowMessage {
     }
     this.buffersLayout = Collections.unmodifiableList(arrowBuffers);
     this.variadicBufferCounts = null;
+  }
+
+  /**
+   * Construct a record batch from nodes.
+   *
+   * @param length  how many rows in this batch
+   * @param nodes   field level info
+   * @param buffers will be retained until this recordBatch is closed
+   * @param bodyCompression compression info.
+   * @param variadicBufferCounts the number of buffers in each variadic section.
+   * @param alignBuffers Whether to align buffers to an 8 byte boundary.
+   */
+  public ArrowRecordBatch(
+      int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
+      ArrowBodyCompression bodyCompression, List<Long> variadicBufferCounts, boolean alignBuffers) {
+    this(length, nodes, buffers, bodyCompression, variadicBufferCounts, alignBuffers, /*retainBuffers*/ true);
   }
 
   /**
@@ -343,8 +343,12 @@ public class ArrowRecordBatch implements ArrowMessage {
 
   @Override
   public String toString() {
+    int variadicBufCount = 0;
+    if (variadicBufferCounts != null && !variadicBufferCounts.isEmpty()) {
+      variadicBufCount = variadicBufferCounts.size();
+    }
     return "ArrowRecordBatch [length=" + length + ", nodes=" + nodes + ", #buffers=" + buffers.size() +
-        ", #variadicBufferCounts=" + variadicBufferCounts.size() + ", buffersLayout=" + buffersLayout +
+        ", #variadicBufferCounts=" + variadicBufCount + ", buffersLayout=" + buffersLayout +
         ", closed=" + closed + "]";
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -56,17 +56,19 @@ public class ArrowRecordBatch implements ArrowMessage {
 
   private final List<ArrowBuffer> buffersLayout;
 
+  private final List<Long> variadicBufferCounts;
+
   private boolean closed = false;
 
   public ArrowRecordBatch(
       int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers) {
-    this(length, nodes, buffers, NoCompressionCodec.DEFAULT_BODY_COMPRESSION, true);
+    this(length, nodes, buffers, NoCompressionCodec.DEFAULT_BODY_COMPRESSION, null, true);
   }
 
   public ArrowRecordBatch(
       int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
       ArrowBodyCompression bodyCompression) {
-    this(length, nodes, buffers, bodyCompression, true);
+    this(length, nodes, buffers, bodyCompression, null, true);
   }
 
   /**
@@ -76,12 +78,13 @@ public class ArrowRecordBatch implements ArrowMessage {
    * @param nodes   field level info
    * @param buffers will be retained until this recordBatch is closed
    * @param bodyCompression compression info.
+   * @param variadicBufferCounts the number of buffers in each variadic section.
    * @param alignBuffers Whether to align buffers to an 8 byte boundary.
    */
   public ArrowRecordBatch(
       int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
-      ArrowBodyCompression bodyCompression, boolean alignBuffers) {
-    this(length, nodes, buffers, bodyCompression, alignBuffers, /*retainBuffers*/ true);
+      ArrowBodyCompression bodyCompression, List<Long> variadicBufferCounts, boolean alignBuffers) {
+    this(length, nodes, buffers, bodyCompression, variadicBufferCounts, alignBuffers, /*retainBuffers*/ true);
   }
 
   /**
@@ -91,19 +94,22 @@ public class ArrowRecordBatch implements ArrowMessage {
    * @param nodes   field level info
    * @param buffers will be retained until this recordBatch is closed
    * @param bodyCompression compression info.
+   * @param variadicBufferCounts the number of buffers in each variadic section.
    * @param alignBuffers Whether to align buffers to an 8 byte boundary.
    * @param retainBuffers Whether to retain() each source buffer in the constructor. If false, the caller is
    *                      responsible for retaining the buffers beforehand.
    */
   public ArrowRecordBatch(
       int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
-      ArrowBodyCompression bodyCompression, boolean alignBuffers, boolean retainBuffers) {
+      ArrowBodyCompression bodyCompression, List<Long> variadicBufferCounts, boolean alignBuffers,
+      boolean retainBuffers) {
     super();
     this.length = length;
     this.nodes = nodes;
     this.buffers = buffers;
     Preconditions.checkArgument(bodyCompression != null, "body compression cannot be null");
     this.bodyCompression = bodyCompression;
+    this.variadicBufferCounts = variadicBufferCounts;
     List<ArrowBuffer> arrowBuffers = new ArrayList<>(buffers.size());
     long offset = 0;
     for (ArrowBuf arrowBuf : buffers) {
@@ -129,12 +135,14 @@ public class ArrowRecordBatch implements ArrowMessage {
   // to distinguish this from the public constructor.
   private ArrowRecordBatch(
       boolean dummy, int length, List<ArrowFieldNode> nodes,
-      List<ArrowBuf> buffers, ArrowBodyCompression bodyCompression) {
+      List<ArrowBuf> buffers, ArrowBodyCompression bodyCompression,
+      List<Long> variadicBufferCounts) {
     this.length = length;
     this.nodes = nodes;
     this.buffers = buffers;
     Preconditions.checkArgument(bodyCompression != null, "body compression cannot be null");
     this.bodyCompression = bodyCompression;
+    this.variadicBufferCounts = variadicBufferCounts;
     this.closed = false;
     List<ArrowBuffer> arrowBuffers = new ArrayList<>();
     long offset = 0;
@@ -180,6 +188,14 @@ public class ArrowRecordBatch implements ArrowMessage {
   }
 
   /**
+   * Get the record batch variadic buffer counts.
+   * @return the variadic buffer counts
+   */
+  public List<Long> getVariadicBufferCounts() {
+    return variadicBufferCounts;
+  }
+
+  /**
    * Create a new ArrowRecordBatch which has the same information as this batch but whose buffers
    * are owned by that Allocator.
    *
@@ -195,7 +211,7 @@ public class ArrowRecordBatch implements ArrowMessage {
             .writerIndex(buf.writerIndex()))
         .collect(Collectors.toList());
     close();
-    return new ArrowRecordBatch(false, length, nodes, newBufs, bodyCompression);
+    return new ArrowRecordBatch(false, length, nodes, newBufs, bodyCompression, variadicBufferCounts);
   }
 
   /**
@@ -217,6 +233,24 @@ public class ArrowRecordBatch implements ArrowMessage {
     if (bodyCompression.getCodec() != NoCompressionCodec.COMPRESSION_TYPE) {
       compressOffset = bodyCompression.writeTo(builder);
     }
+
+    // Start the variadicBufferCounts vector.
+    int variadicBufferCountsOffset = 0;
+    if (variadicBufferCounts != null && !variadicBufferCounts.isEmpty()) {
+      variadicBufferCountsOffset = variadicBufferCounts.size();
+      int elementSizeInBytes = 8; // Size of long in bytes
+      builder.startVector(elementSizeInBytes, variadicBufferCountsOffset, elementSizeInBytes);
+
+      // Add each long to the builder. Note that elements should be added in reverse order.
+      for (int i = variadicBufferCounts.size() - 1; i >= 0; i--) {
+        long value = variadicBufferCounts.get(i);
+        builder.addLong(value);
+      }
+
+      // End the vector. This returns an offset that you can use to refer to the vector.
+      variadicBufferCountsOffset = builder.endVector();
+    }
+
     RecordBatch.startRecordBatch(builder);
     RecordBatch.addLength(builder, length);
     RecordBatch.addNodes(builder, nodesOffset);
@@ -224,6 +258,12 @@ public class ArrowRecordBatch implements ArrowMessage {
     if (bodyCompression.getCodec() != NoCompressionCodec.COMPRESSION_TYPE) {
       RecordBatch.addCompression(builder, compressOffset);
     }
+
+    // Add the variadicBufferCounts to the RecordBatch
+    if (variadicBufferCounts != null && !variadicBufferCounts.isEmpty()) {
+      RecordBatch.addVariadicBufferCounts(builder, variadicBufferCountsOffset);
+    }
+
     return RecordBatch.endRecordBatch(builder);
   }
 
@@ -248,7 +288,8 @@ public class ArrowRecordBatch implements ArrowMessage {
   @Override
   public String toString() {
     return "ArrowRecordBatch [length=" + length + ", nodes=" + nodes + ", #buffers=" + buffers.size() +
-      ", buffersLayout=" + buffersLayout + ", closed=" + closed + "]";
+        ", #variadicBufferCounts=" + variadicBufferCounts.size() + ", buffersLayout=" + buffersLayout +
+        ", closed=" + closed + "]";
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -83,7 +83,7 @@ public class ArrowRecordBatch implements ArrowMessage {
   public ArrowRecordBatch(
       int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
       ArrowBodyCompression bodyCompression, boolean alignBuffers) {
-    this(length, nodes, buffers, bodyCompression, alignBuffers, /*retainBuffers*/ true);
+    this(length, nodes, buffers, bodyCompression, null, alignBuffers, /*retainBuffers*/ true);
   }
 
   /**
@@ -100,30 +100,7 @@ public class ArrowRecordBatch implements ArrowMessage {
   public ArrowRecordBatch(
       int length, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers,
       ArrowBodyCompression bodyCompression, boolean alignBuffers, boolean retainBuffers) {
-    super();
-    this.length = length;
-    this.nodes = nodes;
-    this.buffers = buffers;
-    Preconditions.checkArgument(bodyCompression != null, "body compression cannot be null");
-    this.bodyCompression = bodyCompression;
-    List<ArrowBuffer> arrowBuffers = new ArrayList<>(buffers.size());
-    long offset = 0;
-    for (ArrowBuf arrowBuf : buffers) {
-      if (retainBuffers) {
-        arrowBuf.getReferenceManager().retain();
-      }
-      long size = arrowBuf.readableBytes();
-      arrowBuffers.add(new ArrowBuffer(offset, size));
-      if (LOGGER.isTraceEnabled()) {
-        LOGGER.trace("Buffer in RecordBatch at {}, length: {}", offset, size);
-      }
-      offset += size;
-      if (alignBuffers) { // align on 8 byte boundaries
-        offset = DataSizeRoundingUtil.roundUpTo8Multiple(offset);
-      }
-    }
-    this.buffersLayout = Collections.unmodifiableList(arrowBuffers);
-    this.variadicBufferCounts = null;
+    this(length, nodes, buffers, bodyCompression, null, alignBuffers, retainBuffers);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
@@ -51,7 +51,7 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
 
     if (vector instanceof FieldVector) {
       FieldVector fieldVector = (FieldVector) vector;
-      // TODO: update the `getTypeBufferCount` method to use the `vector` (FieldVector).
+      // TODO: https://github.com/apache/arrow/issues/41734
       int typeBufferCount = TypeLayout.getTypeBufferCount(arrowType);
       validateOrThrow(fieldVector.getFieldBuffers().size() == typeBufferCount,
           "Expected %s buffers in vector of type %s, got %s.",

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
@@ -51,7 +51,7 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
 
     if (vector instanceof FieldVector) {
       FieldVector fieldVector = (FieldVector) vector;
-      int typeBufferCount = TypeLayout.getTypeBufferCount(arrowType);
+      int typeBufferCount = TypeLayout.getTypeBufferCount(arrowType, fieldVector);
       validateOrThrow(fieldVector.getFieldBuffers().size() == typeBufferCount,
           "Expected %s buffers in vector of type %s, got %s.",
               typeBufferCount, vector.getField().getType().toString(), fieldVector.getFieldBuffers().size());

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
@@ -51,7 +51,8 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
 
     if (vector instanceof FieldVector) {
       FieldVector fieldVector = (FieldVector) vector;
-      int typeBufferCount = TypeLayout.getTypeBufferCount(arrowType, fieldVector);
+      // TODO: update the `getTypeBufferCount` method to use the `vector` (FieldVector).
+      int typeBufferCount = TypeLayout.getTypeBufferCount(arrowType);
       validateOrThrow(fieldVector.getFieldBuffers().size() == typeBufferCount,
           "Expected %s buffers in vector of type %s, got %s.",
               typeBufferCount, vector.getField().getType().toString(), fieldVector.getFieldBuffers().size());

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -51,89 +51,89 @@ public class TestTypeLayout {
   @Test
   public void testTypeBufferCount() {
     ArrowType type = new ArrowType.Int(8, true);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Union(UnionMode.Sparse, new int[2]);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Union(UnionMode.Dense, new int[1]);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Struct();
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.List();
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.FixedSizeList(5);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Map(false);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Decimal(10, 10, 128);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Decimal(10, 10, 256);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
 
     type = new ArrowType.FixedSizeBinary(5);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Bool();
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Binary();
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Utf8();
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Null();
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Date(DateUnit.DAY);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Time(TimeUnit.MILLISECOND, 32);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Interval(IntervalUnit.DAY_TIME);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Duration(TimeUnit.MILLISECOND);
-    assertEquals(TypeLayout.getTypeBufferCount(type, null),
-        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type),
+        TypeLayout.getTypeLayout(type).getBufferLayouts().size());
   }
 
   private String generateRandomString(int length) {
@@ -150,8 +150,8 @@ public class TestTypeLayout {
     // empty vector
     try (ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
       ArrowType type = viewVarCharVector.getMinorType().getType();
-      assertEquals(TypeLayout.getTypeBufferCount(type, viewVarCharVector),
-          TypeLayout.getTypeLayout(type, viewVarCharVector).getBufferLayouts().size());
+      assertEquals(TypeLayout.getTypeBufferCount(type),
+          TypeLayout.getTypeLayout(type).getBufferLayouts().size());
     }
     // vector with long strings
     try (ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
@@ -167,8 +167,8 @@ public class TestTypeLayout {
       viewVarCharVector.setValueCount(6);
 
       ArrowType type = viewVarCharVector.getMinorType().getType();
-      assertEquals(TypeLayout.getTypeBufferCount(type, viewVarCharVector),
-          TypeLayout.getTypeLayout(type, viewVarCharVector).getBufferLayouts().size());
+      assertEquals(TypeLayout.getTypeBufferCount(type),
+          TypeLayout.getTypeLayout(type).getBufferLayouts().size());
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -17,82 +17,158 @@
 
 package org.apache.arrow.vector;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Random;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.IntervalUnit;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestTypeLayout {
+
+  private BufferAllocator allocator;
+
+  @BeforeEach
+  public void prepare() {
+    allocator = new RootAllocator(Integer.MAX_VALUE);
+  }
+
+  @AfterEach
+  public void shutdown() {
+    allocator.close();
+  }
+
 
   @Test
   public void testTypeBufferCount() {
     ArrowType type = new ArrowType.Int(8, true);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Union(UnionMode.Sparse, new int[2]);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Union(UnionMode.Dense, new int[1]);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Struct();
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.List();
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.FixedSizeList(5);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Map(false);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Decimal(10, 10, 128);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Decimal(10, 10, 256);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
 
     type = new ArrowType.FixedSizeBinary(5);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Bool();
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Binary();
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Utf8();
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Null();
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Date(DateUnit.DAY);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Time(TimeUnit.MILLISECOND, 32);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Interval(IntervalUnit.DAY_TIME);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
 
     type = new ArrowType.Duration(TimeUnit.MILLISECOND);
-    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+    assertEquals(TypeLayout.getTypeBufferCount(type, null),
+        TypeLayout.getTypeLayout(type, null).getBufferLayouts().size());
+  }
+
+  private String generateRandomString(int length) {
+    Random random = new Random();
+    StringBuilder sb = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      sb.append(random.nextInt(10)); // 0-9
+    }
+    return sb.toString();
+  }
+
+  @Test
+  public void testTypeBufferCountInVectorsWithVariadicBuffers() {
+    // empty vector
+    try (ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
+      ArrowType type = viewVarCharVector.getMinorType().getType();
+      assertEquals(TypeLayout.getTypeBufferCount(type, viewVarCharVector),
+          TypeLayout.getTypeLayout(type, viewVarCharVector).getBufferLayouts().size());
+    }
+    // vector with long strings
+    try (ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
+      viewVarCharVector.allocateNew(32, 6);
+
+      viewVarCharVector.setSafe(0, generateRandomString(8).getBytes());
+      viewVarCharVector.setSafe(1, generateRandomString(12).getBytes());
+      viewVarCharVector.setSafe(2, generateRandomString(14).getBytes());
+      viewVarCharVector.setSafe(3, generateRandomString(18).getBytes());
+      viewVarCharVector.setSafe(4, generateRandomString(22).getBytes());
+      viewVarCharVector.setSafe(5, generateRandomString(24).getBytes());
+
+      viewVarCharVector.setValueCount(6);
+
+      ArrowType type = viewVarCharVector.getMinorType().getType();
+      assertEquals(TypeLayout.getTypeBufferCount(type, viewVarCharVector),
+          TypeLayout.getTypeLayout(type, viewVarCharVector).getBufferLayouts().size());
+    }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -37,14 +37,6 @@ import org.junit.jupiter.api.Test;
 
 public class TestTypeLayout {
 
-  private static final Charset utf8Charset = StandardCharsets.UTF_8;
-  private static final byte[] STR1 = "AAAAA1".getBytes(utf8Charset);
-  private static final byte[] STR2 = "BBBBBBBBB2".getBytes(utf8Charset);
-  private static final byte[] STR3 = "CCCC3".getBytes(utf8Charset);
-  private static final byte[] STR4 = "DDDDDDDD4".getBytes(utf8Charset);
-  private static final byte[] STR5 = "EEE5".getBytes(utf8Charset);
-  private static final byte[] STR6 = "0123456789123456".getBytes(utf8Charset);
-
   private BufferAllocator allocator;
 
   @BeforeEach

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -19,8 +19,6 @@ package org.apache.arrow.vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 import org.apache.arrow.memory.BufferAllocator;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -17,23 +17,49 @@
 
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.testing.ValueVectorDataPopulator.setVector;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.impl.ComplexWriterImpl;
+import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.complex.writer.BaseWriter.ComplexWriter;
+import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
+import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
+import org.apache.arrow.vector.complex.writer.IntWriter;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.IntervalUnit;
 import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class TestTypeLayout {
+
+  private static final Charset utf8Charset = StandardCharsets.UTF_8;
+  private static final byte[] STR1 = "AAAAA1".getBytes(utf8Charset);
+  private static final byte[] STR2 = "BBBBBBBBB2".getBytes(utf8Charset);
+  private static final byte[] STR3 = "CCCC3".getBytes(utf8Charset);
+  private static final byte[] STR4 = "DDDDDDDD4".getBytes(utf8Charset);
+  private static final byte[] STR5 = "EEE5".getBytes(utf8Charset);
+  private static final byte[] STR6 = "0123456789123456".getBytes(utf8Charset);
 
   private BufferAllocator allocator;
 
@@ -170,5 +196,212 @@ public class TestTypeLayout {
       assertEquals(TypeLayout.getTypeBufferCount(type, viewVarCharVector),
           TypeLayout.getTypeLayout(type, viewVarCharVector).getBufferLayouts().size());
     }
+  }
+
+  @Test
+  public void testVectorLoadUnload() {
+
+    try (final ViewVarCharVector vector1 = new ViewVarCharVector("myvector", allocator)) {
+
+      setVector(vector1, STR1, STR2, STR3, STR4, STR5, STR6);
+
+      assertEquals(5, vector1.getLastSet());
+      vector1.setValueCount(15);
+      assertEquals(14, vector1.getLastSet());
+
+      /* Check the vector output */
+      assertArrayEquals(STR1, vector1.get(0));
+      assertArrayEquals(STR2, vector1.get(1));
+      assertArrayEquals(STR3, vector1.get(2));
+      assertArrayEquals(STR4, vector1.get(3));
+      assertArrayEquals(STR5, vector1.get(4));
+      assertArrayEquals(STR6, vector1.get(5));
+
+      Field field = vector1.getField();
+      String fieldName = field.getName();
+
+      List<Field> fields = new ArrayList<>();
+      List<FieldVector> fieldVectors = new ArrayList<>();
+
+      fields.add(field);
+      fieldVectors.add(vector1);
+
+      Schema schema = new Schema(fields);
+
+      VectorSchemaRoot schemaRoot1 = new VectorSchemaRoot(schema, fieldVectors, vector1.getValueCount());
+      VectorUnloader vectorUnloader = new VectorUnloader(schemaRoot1);
+
+      try (
+          ArrowRecordBatch recordBatch = vectorUnloader.getRecordBatch();
+          BufferAllocator finalVectorsAllocator = allocator.newChildAllocator("new vector", 0, Long.MAX_VALUE);
+          VectorSchemaRoot schemaRoot2 = VectorSchemaRoot.create(schema, finalVectorsAllocator);
+      ) {
+
+        VectorLoader vectorLoader = new VectorLoader(schemaRoot2);
+        vectorLoader.load(recordBatch);
+
+        ViewVarCharVector vector2 = (ViewVarCharVector) schemaRoot2.getVector(fieldName);
+        /*
+         * lastSet would have internally been set by VectorLoader.load() when it invokes
+         * loadFieldBuffers.
+         */
+        assertEquals(14, vector2.getLastSet());
+        vector2.setValueCount(25);
+        assertEquals(24, vector2.getLastSet());
+
+        /* Check the vector output */
+        assertArrayEquals(STR1, vector2.get(0));
+        assertArrayEquals(STR2, vector2.get(1));
+        assertArrayEquals(STR3, vector2.get(2));
+        assertArrayEquals(STR4, vector2.get(3));
+        assertArrayEquals(STR5, vector2.get(4));
+        assertArrayEquals(STR6, vector2.get(5));
+      }
+    }
+  }
+
+  @Test
+  public void testVectorLoadUnload2() {
+
+    try (final VarCharVector vector1 = new VarCharVector("myvector", allocator)) {
+
+      setVector(vector1, STR1, STR2, STR3, STR4, STR5, STR6);
+
+      assertEquals(5, vector1.getLastSet());
+      vector1.setValueCount(15);
+      assertEquals(14, vector1.getLastSet());
+
+      /* Check the vector output */
+      assertArrayEquals(STR1, vector1.get(0));
+      assertArrayEquals(STR2, vector1.get(1));
+      assertArrayEquals(STR3, vector1.get(2));
+      assertArrayEquals(STR4, vector1.get(3));
+      assertArrayEquals(STR5, vector1.get(4));
+      assertArrayEquals(STR6, vector1.get(5));
+
+      Field field = vector1.getField();
+      String fieldName = field.getName();
+
+      List<Field> fields = new ArrayList<>();
+      List<FieldVector> fieldVectors = new ArrayList<>();
+
+      fields.add(field);
+      fieldVectors.add(vector1);
+
+      Schema schema = new Schema(fields);
+
+      VectorSchemaRoot schemaRoot1 = new VectorSchemaRoot(schema, fieldVectors, vector1.getValueCount());
+      VectorUnloader vectorUnloader = new VectorUnloader(schemaRoot1);
+
+      try (
+          ArrowRecordBatch recordBatch = vectorUnloader.getRecordBatch();
+          BufferAllocator finalVectorsAllocator = allocator.newChildAllocator("new vector", 0, Long.MAX_VALUE);
+          VectorSchemaRoot schemaRoot2 = VectorSchemaRoot.create(schema, finalVectorsAllocator);
+      ) {
+
+        VectorLoader vectorLoader = new VectorLoader(schemaRoot2);
+        vectorLoader.load(recordBatch);
+
+        VarCharVector vector2 = (VarCharVector) schemaRoot2.getVector(fieldName);
+        /*
+         * lastSet would have internally been set by VectorLoader.load() when it invokes
+         * loadFieldBuffers.
+         */
+        assertEquals(14, vector2.getLastSet());
+        vector2.setValueCount(25);
+        assertEquals(24, vector2.getLastSet());
+
+        /* Check the vector output */
+        assertArrayEquals(STR1, vector2.get(0));
+        assertArrayEquals(STR2, vector2.get(1));
+        assertArrayEquals(STR3, vector2.get(2));
+        assertArrayEquals(STR4, vector2.get(3));
+        assertArrayEquals(STR5, vector2.get(4));
+        assertArrayEquals(STR6, vector2.get(5));
+      }
+    }
+  }
+
+  @Test
+  public void testUnloadLoadAddPadding() throws IOException {
+    int count = 10000;
+    Schema schema;
+    try (
+        BufferAllocator originalVectorsAllocator =
+            allocator.newChildAllocator("original vectors", 0, Integer.MAX_VALUE);
+        NonNullableStructVector parent = NonNullableStructVector.empty("parent", originalVectorsAllocator)) {
+
+      // write some data
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
+      ListWriter list = rootWriter.list("list");
+      IntWriter intWriter = list.integer();
+      for (int i = 0; i < count; i++) {
+        list.setPosition(i);
+        list.startList();
+        for (int j = 0; j < i % 4 + 1; j++) {
+          intWriter.writeInt(i);
+        }
+        list.endList();
+      }
+      writer.setValueCount(count);
+
+      // unload it
+      FieldVector root = parent.getChild("root");
+      schema = new Schema(root.getField().getChildren());
+      VectorUnloader vectorUnloader = newVectorUnloader(root);
+      try (
+          ArrowRecordBatch recordBatch = vectorUnloader.getRecordBatch();
+          BufferAllocator finalVectorsAllocator = allocator.newChildAllocator("final vectors", 0, Integer.MAX_VALUE);
+          VectorSchemaRoot newRoot = VectorSchemaRoot.create(schema, finalVectorsAllocator);
+      ) {
+        List<ArrowBuf> oldBuffers = recordBatch.getBuffers();
+        List<ArrowBuf> newBuffers = new ArrayList<>();
+        for (ArrowBuf oldBuffer : oldBuffers) {
+          long l = oldBuffer.readableBytes();
+          if (l % 64 != 0) {
+            // pad
+            l = l + 64 - l % 64;
+          }
+          ArrowBuf newBuffer = allocator.buffer(l);
+          for (long i = oldBuffer.readerIndex(); i < oldBuffer.writerIndex(); i++) {
+            newBuffer.setByte(i - oldBuffer.readerIndex(), oldBuffer.getByte(i));
+          }
+          newBuffer.readerIndex(0);
+          newBuffer.writerIndex(l);
+          newBuffers.add(newBuffer);
+        }
+
+        try (ArrowRecordBatch newBatch =
+            new ArrowRecordBatch(recordBatch.getLength(), recordBatch.getNodes(), newBuffers);) {
+          // load it
+          VectorLoader vectorLoader = new VectorLoader(newRoot);
+
+          vectorLoader.load(newBatch);
+
+          FieldReader reader = newRoot.getVector("list").getReader();
+          for (int i = 0; i < count; i++) {
+            reader.setPosition(i);
+            List<Integer> expected = new ArrayList<>();
+            for (int j = 0; j < i % 4 + 1; j++) {
+              expected.add(i);
+            }
+            assertEquals(expected, reader.readObject());
+          }
+        }
+
+        for (ArrowBuf newBuf : newBuffers) {
+          newBuf.getReferenceManager().release();
+        }
+      }
+    }
+  }
+
+  public static VectorUnloader newVectorUnloader(FieldVector root) {
+    Schema schema = new Schema(root.getField().getChildren());
+    int valueCount = root.getValueCount();
+    List<FieldVector> fields = root.getChildrenFromFields();
+    VectorSchemaRoot vsr = new VectorSchemaRoot(schema.getFields(), fields, valueCount);
+    return new VectorUnloader(vsr);
   }
 }


### PR DESCRIPTION
### Rationale for this change

This PR adds the `variadicBufferCounts` attribute to `ArrowRecordBatch` in Java module. Furthermore, it also updates the `TypeLayout` functions `getTypeBufferCount` and `getTypeLayout` functions along with the corresponding test cases. Previously these changes were listed as issues https://github.com/apache/arrow/issues/40934, https://github.com/apache/arrow/issues/40935 and https://github.com/apache/arrow/issues/40931. These two tickets will also be closed by this PR. 

### What changes are included in this PR?

The introduced two functions to `TypeLayout` is deprecating the old API and adds a new API. In this PR we are updating a few modules to use the new API.  Corresponding tests for the changed functions have also been added. 

This also updates the usage of `ArrowRecordBatch` across other modules and `TypeLayout` usage across a few modules. Some modules were excluded as mentioned in the issues non-goals section to be completed in a follow up effort as the scope and required tasks remain at large.  These modules will still use the deprecated API for TypeLayouts, but documented in the code for updating to the new API in a follow up effort. 

### Closing Subtasks 

- [X] https://github.com/apache/arrow/issues/40934
- [X] https://github.com/apache/arrow/issues/40935
- [X] https://github.com/apache/arrow/issues/40931

### Are these changes tested?

The changes are tested using existing tests and new tests

### Are there any user-facing changes?

Yes

**This PR includes breaking changes to public APIs.**
* GitHub Issue: apache/arrow#41730
* GitHub Issue: #41730