### PR TITLE
GH-41735: [CI][Archery] Update archery to be compatible with pygit2 1.15 API change

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -427,13 +427,13 @@ class Repo:
         return branch
 
     def create_tag(self, tag_name, commit_id, message=''):
-        commit_object = (
+        git_object_commit = (
             pygit2.GIT_OBJECT_COMMIT
             if getattr(pygit2, 'GIT_OBJECT_COMMIT')
             else pygit2.GIT_OBJ_COMMIT
         )
         tag_id = self.repo.create_tag(tag_name, commit_id,
-                                      commit_object,
+                                      git_object_commit,
                                       self.signature,
                                       message)
 

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -427,8 +427,14 @@ class Repo:
         return branch
 
     def create_tag(self, tag_name, commit_id, message=''):
+        commit_object = (
+            pygit2.GIT_OBJECT_COMMIT
+            if getattr(pygit2, 'GIT_OBJECT_COMMIT')
+            else pygit2.GIT_OBJ_COMMIT
+        )
         tag_id = self.repo.create_tag(tag_name, commit_id,
-                                      pygit2.GIT_OBJ_COMMIT, self.signature,
+                                      commit_object,
+                                      self.signature,
                                       message)
 
         # append to the pushable references


### PR DESCRIPTION
### Rationale for this change

pygit2 updated how they expose some of the `GIT_OBJ` variables to use `GIT_OBJECT` prefix here: https://github.com/libgit2/pygit2/commit/8b3861b9092d1e3517b11f6ab06434ea866dd051

### What changes are included in this PR?

Update code to make it compatible with both possible APIs.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #41735