### PR TITLE
GH-40933: [Java] Enhance the copyFrom* functionality in StringView

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -1335,24 +1335,21 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
   /**
    * Copy a cell value from a particular index in source vector to a particular position in this
    * vector.
-   * TODO: Improve functionality to support copying views.
-   * <a href="https://github.com/apache/arrow/issues/40933">Enhance CopyFrom</a>
-   *
    * @param fromIndex position to copy from in source vector
    * @param thisIndex position to copy to in this vector
    * @param from source vector
    */
   @Override
   public void copyFrom(int fromIndex, int thisIndex, ValueVector from) {
-    Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
+    Preconditions.checkArgument(getMinorType() == from.getMinorType());
     if (from.isNull(fromIndex)) {
-      BitVectorHelper.unsetBit(this.validityBuffer, thisIndex);
+      BitVectorHelper.unsetBit(validityBuffer, thisIndex);
     } else {
       final int viewLength = from.getDataBuffer().getInt((long) fromIndex * ELEMENT_SIZE);
-      BitVectorHelper.setBit(this.validityBuffer, thisIndex);
+      BitVectorHelper.setBit(validityBuffer, thisIndex);
       final int start = thisIndex * ELEMENT_SIZE;
       final int copyStart = fromIndex * ELEMENT_SIZE;
-      from.getDataBuffer().getBytes(start, this.viewBuffer, copyStart, ELEMENT_SIZE);
+      from.getDataBuffer().getBytes(start, viewBuffer, copyStart, ELEMENT_SIZE);
       if (viewLength > INLINE_SIZE) {
         final int bufIndex = from.getDataBuffer().getInt(((long) fromIndex * ELEMENT_SIZE) +
             LENGTH_WIDTH + PREFIX_WIDTH);
@@ -1370,25 +1367,23 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
   /**
    * Same as {@link #copyFrom(int, int, ValueVector)} except that it handles the case when the
    * capacity of the vector needs to be expanded before copy.
-   * TODO: Improve functionality to support copying views.
-   * <a href="https://github.com/apache/arrow/issues/40933">Enhance CopyFrom</a>
    * @param fromIndex position to copy from in source vector
    * @param thisIndex position to copy to in this vector
    * @param from source vector
    */
   @Override
   public void copyFromSafe(int fromIndex, int thisIndex, ValueVector from) {
-    Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
+    Preconditions.checkArgument(getMinorType() == from.getMinorType());
     if (from.isNull(fromIndex)) {
       handleSafe(thisIndex, 0);
-      BitVectorHelper.unsetBit(this.validityBuffer, thisIndex);
+      BitVectorHelper.unsetBit(validityBuffer, thisIndex);
     } else {
       final int viewLength = from.getDataBuffer().getInt((long) fromIndex * ELEMENT_SIZE);
       handleSafe(thisIndex, viewLength);
-      BitVectorHelper.setBit(this.validityBuffer, thisIndex);
+      BitVectorHelper.setBit(validityBuffer, thisIndex);
       final int start = thisIndex * ELEMENT_SIZE;
       final int copyStart = fromIndex * ELEMENT_SIZE;
-      from.getDataBuffer().getBytes(start, this.viewBuffer, copyStart, ELEMENT_SIZE);
+      from.getDataBuffer().getBytes(start, viewBuffer, copyStart, ELEMENT_SIZE);
       if (viewLength > INLINE_SIZE) {
         final int bufIndex = from.getDataBuffer().getInt(((long) fromIndex * ELEMENT_SIZE) +
             LENGTH_WIDTH + PREFIX_WIDTH);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -568,7 +568,7 @@ public class Types {
         return new VarBinaryWriterImpl((VarBinaryVector) vector);
       }
     },
-    VIEWVARBINARY(Binary.INSTANCE) {
+    VIEWVARBINARY(BinaryView.INSTANCE) {
       @Override
       public FieldVector getNewVector(
               Field field,

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
@@ -47,10 +47,8 @@ import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
 import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.util.ReusableByteArray;
 import org.apache.arrow.vector.util.Text;
 import org.junit.jupiter.api.AfterEach;
@@ -1462,34 +1460,6 @@ public class TestVarCharViewVector {
     }
   }
 
-  static Stream<Arguments> vectorCreatorProvider() {
-    return Stream.of(
-        Arguments.of((Function<BufferAllocator, BaseVariableWidthViewVector>)
-            (allocator -> newVector(ViewVarBinaryVector.class, EMPTY_SCHEMA_PATH,
-                Types.MinorType.VIEWVARBINARY, allocator))),
-        Arguments.of((Function<BufferAllocator, BaseVariableWidthViewVector>)
-            (allocator -> newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH,
-                Types.MinorType.VIEWVARCHAR, allocator)))
-    );
-  }
-
-  BiFunction<BufferAllocator, MinorType, BaseVariableWidthViewVector> vectorCreator = (allocator, type) -> {
-    if (type == Types.MinorType.VIEWVARBINARY) {
-      return newVector(ViewVarBinaryVector.class, EMPTY_SCHEMA_PATH, Types.MinorType.VIEWVARBINARY, allocator);
-    } else if (type == Types.MinorType.VIEWVARCHAR) {
-      return newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH, Types.MinorType.VIEWVARCHAR, allocator);
-    } else {
-      throw new UnsupportedOperationException("Not supported type : " + type);
-    }
-  };
-  }
-
-  static Stream<Arguments> vectorTypeAndClassProvider() {
-    return Stream.of(
-        Arguments.of(Types.MinorType.VIEWVARBINARY),
-        Arguments.of(Types.MinorType.VIEWVARCHAR)
-    );
-  }
   @Test
   public void testVectorLoadUnload() {
 
@@ -1552,12 +1522,16 @@ public class TestVarCharViewVector {
     }
   }
 
-  @Test
-  public void testCopyFromWithNulls() {
-    try (final ViewVarCharVector vector = newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH,
-        MinorType.VIEWVARCHAR, allocator);
-        final ViewVarCharVector vector2 =
-            newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VIEWVARCHAR, allocator)) {
+  static Stream<Arguments> vectorCreatorProvider() {
+    return Stream.of(
+        Arguments.of((Function<BufferAllocator, BaseVariableWidthViewVector>)
+            (allocator -> newVector(ViewVarBinaryVector.class, EMPTY_SCHEMA_PATH,
+                Types.MinorType.VIEWVARBINARY, allocator))),
+        Arguments.of((Function<BufferAllocator, BaseVariableWidthViewVector>)
+            (allocator -> newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH,
+                Types.MinorType.VIEWVARCHAR, allocator)))
+    );
+  }
 
   @ParameterizedTest
   @MethodSource({"vectorCreatorProvider"})

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
@@ -1460,10 +1460,30 @@ public class TestVarCharViewVector {
     }
   }
 
+  private ViewVarCharVector createViewVarCharVector(BufferAllocator allocator) {
+    return newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH,
+        Types.MinorType.VIEWVARCHAR, allocator);
+  }
+
+  private ViewVarBinaryVector createViewVarBinaryVector(BufferAllocator allocator) {
+    return newVector(ViewVarBinaryVector.class, EMPTY_SCHEMA_PATH,
+        Types.MinorType.VIEWVARBINARY, allocator);
+  }
+
+  private BaseVariableWidthViewVector createVector(Types.MinorType type, BufferAllocator allocator) {
+    if (type == Types.MinorType.VIEWVARBINARY) {
+      return createViewVarBinaryVector(allocator);
+    } else if (type == Types.MinorType.VIEWVARCHAR) {
+      return createViewVarCharVector(allocator);
+    } else {
+      throw new UnsupportedOperationException("Not supported type : " + type);
+    }
+  }
+
   static Stream<Arguments> vectorTypeAndClassProvider() {
     return Stream.of(
-        Arguments.of(Types.MinorType.VIEWVARBINARY, ViewVarBinaryVector.class),
-        Arguments.of(Types.MinorType.VIEWVARCHAR, ViewVarCharVector.class)
+        Arguments.of(Types.MinorType.VIEWVARBINARY),
+        Arguments.of(Types.MinorType.VIEWVARCHAR)
     );
   }
   @Test
@@ -1537,12 +1557,9 @@ public class TestVarCharViewVector {
 
   @ParameterizedTest
   @MethodSource({"vectorTypeAndClassProvider"})
-  public void testCopyFromWithNulls(Types.MinorType type,
-      Class<? extends BaseVariableWidthViewVector> vectorClass) {
-    try (final BaseVariableWidthViewVector vector = newVector(vectorClass, EMPTY_SCHEMA_PATH,
-        type, allocator);
-        final BaseVariableWidthViewVector vector2 = newVector(vectorClass, EMPTY_SCHEMA_PATH,
-            type, allocator)) {
+  public void testCopyFromWithNulls(Types.MinorType type) {
+    try (final BaseVariableWidthViewVector vector = createVector(type, allocator);
+        final BaseVariableWidthViewVector vector2 = createVector(type, allocator)) {
       final int initialCapacity = 1024;
       vector.setInitialCapacity(initialCapacity);
       vector.allocateNew();
@@ -1630,12 +1647,9 @@ public class TestVarCharViewVector {
 
   @ParameterizedTest
   @MethodSource("vectorTypeAndClassProvider")
-  public void testCopyFromSafeWithNulls(Types.MinorType type,
-      Class<? extends BaseVariableWidthViewVector> vectorClass) {
-    try (final BaseVariableWidthViewVector vector = newVector(vectorClass, EMPTY_SCHEMA_PATH,
-        type, allocator);
-        final BaseVariableWidthViewVector vector2 = newVector(vectorClass, EMPTY_SCHEMA_PATH,
-            type, allocator)) {
+  public void testCopyFromSafeWithNulls(Types.MinorType type) {
+    try (final BaseVariableWidthViewVector vector = createVector(type, allocator);
+        final BaseVariableWidthViewVector vector2 = createVector(type, allocator)) {
 
       final int initialCapacity = 4096;
       vector.setInitialCapacity(initialCapacity);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -56,6 +55,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 
@@ -1460,10 +1460,10 @@ public class TestVarCharViewVector {
     }
   }
 
-  static Stream<Class<? extends BaseVariableWidthViewVector>> vectorProvider() {
+  static Stream<Arguments> vectorTypeAndClassProvider() {
     return Stream.of(
-        ViewVarCharVector.class,
-        ViewVarBinaryVector.class
+        Arguments.of(Types.MinorType.VIEWVARBINARY, ViewVarBinaryVector.class),
+        Arguments.of(Types.MinorType.VIEWVARCHAR, ViewVarCharVector.class)
     );
   }
   @Test
@@ -1536,13 +1536,13 @@ public class TestVarCharViewVector {
             newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VIEWVARCHAR, allocator)) {
 
   @ParameterizedTest
-  @MethodSource("vectorProvider")
-  public void testCopyFromWithNulls(Class<? extends BaseVariableWidthViewVector> vectorClass)
-      throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-    try (final BaseVariableWidthViewVector vector = vectorClass.getConstructor(String.class, BufferAllocator.class)
-        .newInstance(EMPTY_SCHEMA_PATH, allocator);
-        final BaseVariableWidthViewVector vector2 = vectorClass.getConstructor(String.class, BufferAllocator.class)
-            .newInstance(EMPTY_SCHEMA_PATH, allocator)) {
+  @MethodSource({"vectorTypeAndClassProvider"})
+  public void testCopyFromWithNulls(Types.MinorType type,
+      Class<? extends BaseVariableWidthViewVector> vectorClass) {
+    try (final BaseVariableWidthViewVector vector = newVector(vectorClass, EMPTY_SCHEMA_PATH,
+        type, allocator);
+        final BaseVariableWidthViewVector vector2 = newVector(vectorClass, EMPTY_SCHEMA_PATH,
+            type, allocator)) {
       final int initialCapacity = 1024;
       vector.setInitialCapacity(initialCapacity);
       vector.allocateNew();
@@ -1629,13 +1629,13 @@ public class TestVarCharViewVector {
   }
 
   @ParameterizedTest
-  @MethodSource("vectorProvider")
-  public void testCopyFromSafeWithNulls(Class<? extends BaseVariableWidthViewVector> vectorClass)
-      throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
-    try (final BaseVariableWidthViewVector vector = vectorClass.getConstructor(String.class, BufferAllocator.class)
-        .newInstance(EMPTY_SCHEMA_PATH, allocator);
-        final BaseVariableWidthViewVector vector2 = vectorClass.getConstructor(String.class, BufferAllocator.class)
-            .newInstance(EMPTY_SCHEMA_PATH, allocator)) {
+  @MethodSource("vectorTypeAndClassProvider")
+  public void testCopyFromSafeWithNulls(Types.MinorType type,
+      Class<? extends BaseVariableWidthViewVector> vectorClass) {
+    try (final BaseVariableWidthViewVector vector = newVector(vectorClass, EMPTY_SCHEMA_PATH,
+        type, allocator);
+        final BaseVariableWidthViewVector vector2 = newVector(vectorClass, EMPTY_SCHEMA_PATH,
+            type, allocator)) {
 
       final int initialCapacity = 4096;
       vector.setInitialCapacity(initialCapacity);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.arrow.memory.ArrowBuf;
@@ -1462,10 +1462,14 @@ public class TestVarCharViewVector {
     }
   }
 
-  static Stream<Arguments> vectorTypeProvider() {
+  static Stream<Arguments> vectorCreatorProvider() {
     return Stream.of(
-        Arguments.of(Types.MinorType.VIEWVARBINARY),
-        Arguments.of(Types.MinorType.VIEWVARCHAR)
+        Arguments.of((Function<BufferAllocator, BaseVariableWidthViewVector>)
+            (allocator -> newVector(ViewVarBinaryVector.class, EMPTY_SCHEMA_PATH,
+                Types.MinorType.VIEWVARBINARY, allocator))),
+        Arguments.of((Function<BufferAllocator, BaseVariableWidthViewVector>)
+            (allocator -> newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH,
+                Types.MinorType.VIEWVARCHAR, allocator)))
     );
   }
 
@@ -1556,10 +1560,10 @@ public class TestVarCharViewVector {
             newVector(ViewVarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VIEWVARCHAR, allocator)) {
 
   @ParameterizedTest
-  @MethodSource({"vectorTypeProvider"})
-  public void testCopyFromWithNulls(Types.MinorType type) {
-    try (final BaseVariableWidthViewVector vector = vectorCreator.apply(allocator, type);
-        final BaseVariableWidthViewVector vector2 = vectorCreator.apply(allocator, type)) {
+  @MethodSource({"vectorCreatorProvider"})
+  public void testCopyFromWithNulls(Function<BufferAllocator, BaseVariableWidthViewVector> vectorCreator) {
+    try (final BaseVariableWidthViewVector vector = vectorCreator.apply(allocator);
+        final BaseVariableWidthViewVector vector2 = vectorCreator.apply(allocator)) {
       final int initialCapacity = 1024;
       vector.setInitialCapacity(initialCapacity);
       vector.allocateNew();
@@ -1646,10 +1650,10 @@ public class TestVarCharViewVector {
   }
 
   @ParameterizedTest
-  @MethodSource("vectorTypeProvider")
-  public void testCopyFromSafeWithNulls(Types.MinorType type) {
-    try (final BaseVariableWidthViewVector vector = vectorCreator.apply(allocator, type);
-        final BaseVariableWidthViewVector vector2 = vectorCreator.apply(allocator, type)) {
+  @MethodSource("vectorCreatorProvider")
+  public void testCopyFromSafeWithNulls(Function<BufferAllocator, BaseVariableWidthViewVector> vectorCreator) {
+    try (final BaseVariableWidthViewVector vector = vectorCreator.apply(allocator);
+        final BaseVariableWidthViewVector vector2 = vectorCreator.apply(allocator)) {
 
       final int initialCapacity = 4096;
       vector.setInitialCapacity(initialCapacity);


### PR DESCRIPTION
### Rationale for this change

Initial implementation of StringView doesn't contain `copy` functionality. This PR adds that feature. 

### What changes are included in this PR?

This PR adds `copyFrom` and `copyFromSafe` functions to `BaseVariableWidthViewVector`. 

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #40933