### PR TITLE
MINOR: [Python] try harder to set up s3_server fixture

### DIFF
--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -192,7 +192,7 @@ def retry(attempts=3, delay=1.0, max_delay=None, backoff=1):
 
 @pytest.fixture(scope='session')
 def s3_server(s3_connection, tmpdir_factory):
-    @retry(attempts=5, delay=0.1, backoff=2)
+    @retry(attempts=5, delay=1, backoff=2)
     def minio_server_health_check(address):
         resp = urllib.request.urlopen(f"http://{address}/minio/health/cluster")
         assert resp.getcode() == 200


### PR DESCRIPTION
In conda-forge, when running the aarch tests in emulation, we regularly run into the [issue](https://github.com/conda-forge/pyarrow-feedstock/issues/117) that the fixture setup fails. Extending the timeouts fixes this. Since it only happens once per session, it doesn't hurt to take a little bit more time.

