### PR TITLE
GH-41684: [C++][Python] Add optional null_bitmap to MapArray::FromArrays

### DIFF
--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -1368,6 +1368,23 @@ TEST_F(TestMapArray, FromArrays) {
   ASSERT_EQ(keys_with_null->length(), tmp_items->length());
   ASSERT_RAISES(Invalid,
                 MapArray::FromArrays(offsets1, keys_with_null, tmp_items, pool_));
+
+  // With null_bitmap
+  ASSERT_OK_AND_ASSIGN(auto map7, MapArray::FromArrays(offsets1, keys, items, pool_,
+                                                       offsets3->data()->buffers[0]));
+  ASSERT_OK(map7->Validate());
+  MapArray expected7(map_type, length, offsets1->data()->buffers[1], keys, items,
+                     offsets3->data()->buffers[0], 1);
+  AssertArraysEqual(expected7, *map7);
+
+  // Null bitmap and offset with null
+  ASSERT_RAISES(Invalid, MapArray::FromArrays(offsets3, keys, items, pool_,
+                                              offsets3->data()->buffers[0]));
+
+  // Null bitmap and offset with offset
+  ASSERT_RAISES(NotImplemented,
+                MapArray::FromArrays(offsets3->Slice(2), keys, items, pool_,
+                                     offsets3->data()->buffers[0]));
 }
 
 TEST_F(TestMapArray, FromArraysEquality) {

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -532,15 +532,18 @@ class ARROW_EXPORT MapArray : public ListArray {
   /// \param[in] keys Array containing key values
   /// \param[in] items Array containing item values
   /// \param[in] pool MemoryPool in case new offsets array needs to be
+  /// \param[in] null_bitmap Optional validity bitmap
   /// allocated because of null values
   static Result<std::shared_ptr<Array>> FromArrays(
       const std::shared_ptr<Array>& offsets, const std::shared_ptr<Array>& keys,
-      const std::shared_ptr<Array>& items, MemoryPool* pool = default_memory_pool());
+      const std::shared_ptr<Array>& items, MemoryPool* pool = default_memory_pool(),
+      const std::shared_ptr<Buffer>& null_bitmap = NULLPTR);
 
   static Result<std::shared_ptr<Array>> FromArrays(
       std::shared_ptr<DataType> type, const std::shared_ptr<Array>& offsets,
       const std::shared_ptr<Array>& keys, const std::shared_ptr<Array>& items,
-      MemoryPool* pool = default_memory_pool());
+      MemoryPool* pool = default_memory_pool(),
+      const std::shared_ptr<Buffer>& null_bitmap = NULLPTR);
 
   const MapType* map_type() const { return map_type_; }
 
@@ -560,7 +563,7 @@ class ARROW_EXPORT MapArray : public ListArray {
   static Result<std::shared_ptr<Array>> FromArraysInternal(
       std::shared_ptr<DataType> type, const std::shared_ptr<Array>& offsets,
       const std::shared_ptr<Array>& keys, const std::shared_ptr<Array>& items,
-      MemoryPool* pool);
+      MemoryPool* pool, const std::shared_ptr<Buffer>& null_bitmap = NULLPTR);
 
  private:
   const MapType* map_type_;

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3060,7 +3060,7 @@ cdef class MapArray(ListArray):
     """
 
     @staticmethod
-    def from_arrays(offsets, keys, items, DataType type=None, MemoryPool pool=None):
+    def from_arrays(offsets, keys, items, DataType type=None, MemoryPool pool=None, mask=None):
         """
         Construct MapArray from arrays of int32 offsets and key, item arrays.
 
@@ -3072,6 +3072,8 @@ cdef class MapArray(ListArray):
         type : DataType, optional
             If not specified, a default MapArray with the keys' and items' type is used.
         pool : MemoryPool
+        mask : Array (boolean type), optional
+            Indicate which values are null (True) or not null (False).
 
         Returns
         -------
@@ -3153,24 +3155,27 @@ cdef class MapArray(ListArray):
         cdef:
             Array _offsets, _keys, _items
             shared_ptr[CArray] out
+            shared_ptr[CBuffer] c_mask
         cdef CMemoryPool* cpool = maybe_unbox_memory_pool(pool)
 
         _offsets = asarray(offsets, type='int32')
         _keys = asarray(keys)
         _items = asarray(items)
 
+        c_mask = c_mask_inverted_from_obj(mask, pool)
+
         if type is not None:
             with nogil:
                 out = GetResultValue(
                     CMapArray.FromArraysAndType(
                         type.sp_type, _offsets.sp_array,
-                        _keys.sp_array, _items.sp_array, cpool))
+                        _keys.sp_array, _items.sp_array, cpool, c_mask))
         else:
             with nogil:
                 out = GetResultValue(
                     CMapArray.FromArrays(_offsets.sp_array,
                                          _keys.sp_array,
-                                         _items.sp_array, cpool))
+                                         _items.sp_array, cpool, c_mask))
         cdef Array result = pyarrow_wrap_array(out)
         result.validate()
         return result

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -788,7 +788,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
             const shared_ptr[CArray]& offsets,
             const shared_ptr[CArray]& keys,
             const shared_ptr[CArray]& items,
-            CMemoryPool* pool)
+            CMemoryPool* pool,
+            const shared_ptr[CBuffer] null_bitmap,
+        )
 
         @staticmethod
         CResult[shared_ptr[CArray]] FromArraysAndType" FromArrays"(
@@ -796,7 +798,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
             const shared_ptr[CArray]& offsets,
             const shared_ptr[CArray]& keys,
             const shared_ptr[CArray]& items,
-            CMemoryPool* pool)
+            CMemoryPool* pool,
+            const shared_ptr[CBuffer] null_bitmap,
+        )
 
         shared_ptr[CArray] keys()
         shared_ptr[CArray] items()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1088,21 +1088,23 @@ def test_map_from_arrays():
     assert result.equals(expected)
 
     # error if null bitmap and offsets with nulls passed
-    with pytest.raises(pa.ArrowInvalid, match='Ambiguous to specify both validity map and offsets with nulls'):
+    msg1 = 'Ambiguous to specify both validity map and offsets with nulls'
+    with pytest.raises(pa.ArrowInvalid, match=msg1):
         pa.MapArray.from_arrays(offsets, keys, items, pa.map_(
-        keys.type,
-        items.type),
-        mask=pa.array([False, True, False], type=pa.bool_())
-    )
+            keys.type,
+            items.type),
+            mask=pa.array([False, True, False], type=pa.bool_())
+        )
 
     # error if null bitmap passed to sliced offset
+    msg2 = 'Null bitmap with offsets slice not supported.'
     offsets = pa.array(offsets, pa.int32())
-    with pytest.raises(pa.ArrowNotImplementedError, match='Null bitmap with offsets slice not supported.'):
+    with pytest.raises(pa.ArrowNotImplementedError, match=msg2):
         pa.MapArray.from_arrays(offsets.slice(2), keys, items, pa.map_(
-        keys.type,
-        items.type),
-        mask=pa.array([False, True, False], type=pa.bool_())
-    )
+            keys.type,
+            items.type),
+            mask=pa.array([False, True, False], type=pa.bool_())
+        )
 
     # check invalid usage
     offsets = [0, 1, 3, 5]

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1079,10 +1079,16 @@ def test_map_from_arrays():
             pa.int64()
         ))
 
-    # pass in null bitmap
+    # pass in null bitmap with type
     result = pa.MapArray.from_arrays([0, 2, 2, 6], keys, items, pa.map_(
         keys.type,
         items.type),
+        mask=pa.array([False, True, False], type=pa.bool_())
+    )
+    assert result.equals(expected)
+
+    # pass in null bitmap without the type
+    result = pa.MapArray.from_arrays([0, 2, 2, 6], keys, items,
         mask=pa.array([False, True, False], type=pa.bool_())
     )
     assert result.equals(expected)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1089,8 +1089,9 @@ def test_map_from_arrays():
 
     # pass in null bitmap without the type
     result = pa.MapArray.from_arrays([0, 2, 2, 6], keys, items,
-        mask=pa.array([False, True, False], type=pa.bool_())
-    )
+                                     mask=pa.array([False, True, False],
+                                                   type=pa.bool_())
+                                     )
     assert result.equals(expected)
 
     # error if null bitmap and offsets with nulls passed

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1079,6 +1079,31 @@ def test_map_from_arrays():
             pa.int64()
         ))
 
+    # pass in null bitmap
+    result = pa.MapArray.from_arrays([0, 2, 2, 6], keys, items, pa.map_(
+        keys.type,
+        items.type),
+        mask=pa.array([False, True, False], type=pa.bool_())
+    )
+    assert result.equals(expected)
+
+    # error if null bitmap and offsets with nulls passed
+    with pytest.raises(pa.ArrowInvalid, match='Ambiguous to specify both validity map and offsets with nulls'):
+        pa.MapArray.from_arrays(offsets, keys, items, pa.map_(
+        keys.type,
+        items.type),
+        mask=pa.array([False, True, False], type=pa.bool_())
+    )
+
+    # error if null bitmap passed to sliced offset
+    offsets = pa.array(offsets, pa.int32())
+    with pytest.raises(pa.ArrowNotImplementedError, match='Null bitmap with offsets slice not supported.'):
+        pa.MapArray.from_arrays(offsets.slice(2), keys, items, pa.map_(
+        keys.type,
+        items.type),
+        mask=pa.array([False, True, False], type=pa.bool_())
+    )
+
     # check invalid usage
     offsets = [0, 1, 3, 5]
     keys = np.arange(5)


### PR DESCRIPTION
### Rationale for this change

When constructing a `MapArray` with `FromArrays` one can not supply a `null_bitmap`.

### What changes are included in this PR?

Optional `null_bitmap` argument is added to `MapArray::FromArrays`.

### Are these changes tested?

TODO (have them locally, need to clean them up and commit.

### Are there any user-facing changes?

No.
* GitHub Issue: #41684