### PR TITLE
GH-41741: [C++] Check that extension metadata key is present before attempting to delete it

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1059,8 +1059,14 @@ struct SchemaImporter {
         ARROW_ASSIGN_OR_RAISE(
             type_, registered_ext_type->Deserialize(std::move(type_),
                                                     metadata_.extension_serialized));
-        RETURN_NOT_OK(metadata_.metadata->DeleteMany(
+        // If metadata is present, delete both metadata keys (otherwise, just remove
+        // the extension name key)
+        if (metadata_.extension_serialized_index >= 0) {
+          RETURN_NOT_OK(metadata_.metadata->DeleteMany(
             {metadata_.extension_name_index, metadata_.extension_serialized_index}));
+        } else {
+          RETURN_NOT_OK(metadata_.metadata->Delete(metadata_.extension_name_index));
+        }
       }
     }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1063,7 +1063,7 @@ struct SchemaImporter {
         // the extension name key)
         if (metadata_.extension_serialized_index >= 0) {
           RETURN_NOT_OK(metadata_.metadata->DeleteMany(
-            {metadata_.extension_name_index, metadata_.extension_serialized_index}));
+              {metadata_.extension_name_index, metadata_.extension_serialized_index}));
         } else {
           RETURN_NOT_OK(metadata_.metadata->Delete(metadata_.extension_name_index));
         }

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -4099,25 +4099,6 @@ TEST_F(TestArrayRoundtrip, RegisteredExtension) {
 }
 
 TEST_F(TestArrayRoundtrip, RegisteredExtensionNoMetadata) {
-  // A minimal extension type that does not error when passed blank extension information
-  class MetadataOptionalExtensionType : public ExtensionType {
-   public:
-    MetadataOptionalExtensionType() : ExtensionType(null()) {}
-    std::string extension_name() const override { return "metadata.optional"; }
-    std::string Serialize() const override { return ""; }
-    std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override {
-      return nullptr;
-    }
-    bool ExtensionEquals(const ExtensionType& other) const override {
-      return other.extension_name() == extension_name();
-    }
-    Result<std::shared_ptr<DataType>> Deserialize(
-        std::shared_ptr<DataType> storage_type,
-        const std::string& serialized_data) const override {
-      return std::make_shared<MetadataOptionalExtensionType>();
-    }
-  };
-
   auto ext_type = std::make_shared<MetadataOptionalExtensionType>();
   ExtensionTypeGuard guard(ext_type);
 
@@ -4131,7 +4112,7 @@ TEST_F(TestArrayRoundtrip, RegisteredExtensionNoMetadata) {
 
   ASSERT_OK_AND_ASSIGN(auto ext_type_roundtrip, ImportType(&c_schema));
   ASSERT_EQ(ext_type_roundtrip->id(), Type::EXTENSION);
-  ASSERT_TRUE(ext_type_roundtrip->Equals(ext_type));
+  AssertTypeEqual(ext_type_roundtrip, ext_type);
 }
 
 TEST_F(TestArrayRoundtrip, UnregisteredExtension) {

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -132,6 +132,25 @@ class ARROW_TESTING_EXPORT DictExtensionType : public ExtensionType {
   std::string Serialize() const override { return "dict-extension-serialized"; }
 };
 
+// A minimal extension type that does not error when passed blank extension information
+class ARROW_TESTING_EXPORT MetadataOptionalExtensionType : public ExtensionType {
+ public:
+  MetadataOptionalExtensionType() : ExtensionType(null()) {}
+  std::string extension_name() const override { return "metadata.optional"; }
+  std::string Serialize() const override { return ""; }
+  std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override {
+    return nullptr;
+  }
+  bool ExtensionEquals(const ExtensionType& other) const override {
+    return other.extension_name() == extension_name();
+  }
+  Result<std::shared_ptr<DataType>> Deserialize(
+      std::shared_ptr<DataType> storage_type,
+      const std::string& serialized_data) const override {
+    return std::make_shared<MetadataOptionalExtensionType>();
+  }
+};
+
 class ARROW_TESTING_EXPORT Complex128Array : public ExtensionArray {
  public:
   using ExtensionArray::ExtensionArray;


### PR DESCRIPTION
### Rationale for this change

Neither Schema.fbs nor the Arrow C Data interface nor the columnar specification indicates that the ARROW:extension:metadata key must be present; however, the `ImportType()` implementation assumes that both `ARROW:extension:name` and `ARROW:extension:metadata` are both present and throws an exception if `ARROW:extension:metadata` is missing. This causes pyarrow to crash (see issue for reproducer).

### What changes are included in this PR?

This PR checks that the extension metadata is present before attempting to delete it.

### Are these changes tested?

Yes (test added).

### Are there any user-facing changes?

No.
* GitHub Issue: #41741