### PR TITLE
GH-41755: [C++][ORC] Ensure setting detected ORC version

### DIFF
--- a/cpp/cmake_modules/FindorcAlt.cmake
+++ b/cpp/cmake_modules/FindorcAlt.cmake
@@ -71,4 +71,5 @@ if(orcAlt_FOUND)
                           PROPERTIES IMPORTED_LOCATION "${ORC_STATIC_LIB}"
                                      INTERFACE_INCLUDE_DIRECTORIES "${ORC_INCLUDE_DIR}")
   endif()
+  set(orcAlt_VERSION ${ORC_VERSION})
 endif()


### PR DESCRIPTION
`FindorcAlt.cmake` doesn't set `orcAlt_VERSION` when it finds ORC by `find_library()`/`find_path()`. If `orcAlt_VERSION` isn't set, ORC version detection by caller is failed.

`cpp/src/arrow/adapters/orc/adapter.cc` uses detected ORC version. If detected ORC version isn't correct, needless time zone database check is used.

Deployed in conda-forge through https://github.com/conda-forge/arrow-cpp-feedstock/pull/1424 and confirmed as working in https://github.com/conda-forge/pyarrow-feedstock/pull/122
* GitHub Issue: #41755