### PR TITLE
MINOR: [Python] Increase timeout in TestThreadedCSVTableRead::test_cancellation

### DIFF
--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -1470,7 +1470,7 @@ class BaseCSVTableRead(BaseTestCSV):
             pytest.fail("Failed to get an interruption during CSV reading")
 
         # Interruption should have arrived timely
-        assert last_duration <= 1.0
+        assert last_duration <= 2.0
         e = exc_info.__context__
         assert isinstance(e, pa.ArrowCancelled)
         assert e.signum == signum


### PR DESCRIPTION
We hit this in conda-forge on some runners:
```
=================================== FAILURES ===================================
__________________ TestThreadedCSVTableRead.test_cancellation __________________
[...]
        # Interruption should have arrived timely
>       assert last_duration <= 1.0
E       assert 1.2137842178344727 <= 1.0

pyarrow/tests/test_csv.py:1473: AssertionError
----------------------------- Captured stdout call -----------------------------
workload size: 100000
workload size: 300000
workload size: 900000
workload size: 2700000
workload size: 8100000
```

Give a little bit more time for the expected duration so conda-forge's test suite doesn't fail spuriously (and then have to be restarted manually).