### PR TITLE
GH-41766: [C++][Parquet] Copy key value metadata when store_schema is false

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -892,14 +892,13 @@ TYPED_TEST(TestParquetIO, ZeroChunksTable) {
 }
 
 TYPED_TEST(TestParquetIO, TableWithMetadata) {
-  auto values =
-      std::make_shared<ChunkedArray>(::arrow::ArrayVector{}, ::arrow::int32());
-  auto table = MakeSimpleTable(
-      values, false, ::arrow::KeyValueMetadata::Make({"foo"}, {"bar"}));
+  auto values = std::make_shared<ChunkedArray>(::arrow::ArrayVector{}, ::arrow::int32());
+  auto table =
+      MakeSimpleTable(values, false, ::arrow::KeyValueMetadata::Make({"foo"}, {"bar"}));
 
   this->ResetSink();
-  ASSERT_OK_NO_THROW(WriteTable(*table, ::arrow::default_memory_pool(),
-                                this->sink_, SMALL_SIZE));
+  ASSERT_OK_NO_THROW(
+      WriteTable(*table, ::arrow::default_memory_pool(), this->sink_, SMALL_SIZE));
 
   std::shared_ptr<Table> out;
   std::unique_ptr<FileReader> reader;
@@ -4055,8 +4054,7 @@ TEST(TestArrowReaderAdHoc, OldDataPageV2) {
     GTEST_SKIP() << "ARROW_TEST_DATA not set.";
   }
   std::stringstream ss;
-  ss << c_root << "/"
-     << "parquet/ARROW-17100.parquet";
+  ss << c_root << "/" << "parquet/ARROW-17100.parquet";
   std::string path = ss.str();
   TryReadDataFile(path);
 }

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4054,7 +4054,8 @@ TEST(TestArrowReaderAdHoc, OldDataPageV2) {
     GTEST_SKIP() << "ARROW_TEST_DATA not set.";
   }
   std::stringstream ss;
-  ss << c_root << "/" << "parquet/ARROW-17100.parquet";
+  ss << c_root << "/"
+     << "parquet/ARROW-17100.parquet";
   std::string path = ss.str();
   TryReadDataFile(path);
 }

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -649,22 +649,24 @@ class ParquetIOTestBase : public ::testing::Test {
     AssertArraysEqual(values, *out);
   }
 
-  void ReadTableFromFile(std::unique_ptr<FileReader> reader, bool expect_metadata,
+  void ReadTableFromFile(std::unique_ptr<FileReader> reader, bool expect_schema,
                          std::shared_ptr<Table>* out) {
     ASSERT_OK_NO_THROW(reader->ReadTable(out));
     auto key_value_metadata =
         reader->parquet_reader()->metadata()->key_value_metadata().get();
-    if (!expect_metadata) {
-      ASSERT_EQ(nullptr, key_value_metadata);
+    if (!expect_schema) {
+      ASSERT_TRUE(key_value_metadata == nullptr ||
+                  !key_value_metadata->Contains("ARROW:schema"));
     } else {
       ASSERT_NE(nullptr, key_value_metadata);
+      ASSERT_TRUE(key_value_metadata->Contains("ARROW:schema"));
     }
     ASSERT_NE(nullptr, out->get());
   }
 
   void ReadTableFromFile(std::unique_ptr<FileReader> reader,
                          std::shared_ptr<Table>* out) {
-    ReadTableFromFile(std::move(reader), /*expect_metadata=*/false, out);
+    ReadTableFromFile(std::move(reader), /*expect_schema=*/false, out);
   }
 
   void RoundTripSingleColumn(
@@ -680,9 +682,9 @@ class ParquetIOTestBase : public ::testing::Test {
     std::shared_ptr<Table> out;
     std::unique_ptr<FileReader> reader;
     ASSERT_NO_FATAL_FAILURE(this->ReaderFromSink(&reader));
-    const bool expect_metadata = arrow_properties->store_schema();
+    const bool expect_schema = arrow_properties->store_schema();
     ASSERT_NO_FATAL_FAILURE(
-        this->ReadTableFromFile(std::move(reader), expect_metadata, &out));
+        this->ReadTableFromFile(std::move(reader), expect_schema, &out));
     ASSERT_EQ(1, out->num_columns());
     ASSERT_EQ(table->num_rows(), out->num_rows());
 
@@ -887,6 +889,25 @@ TYPED_TEST(TestParquetIO, ZeroChunksTable) {
   ASSERT_EQ(0, out->column(0)->length());
   // odd: even though zero chunks were written, a single empty chunk is read
   ASSERT_EQ(1, out->column(0)->num_chunks());
+}
+
+TYPED_TEST(TestParquetIO, TableWithMetadata) {
+  auto values =
+      std::make_shared<ChunkedArray>(::arrow::ArrayVector{}, ::arrow::int32());
+  auto table = MakeSimpleTable(
+      values, false, ::arrow::KeyValueMetadata::Make({"foo"}, {"bar"}));
+
+  this->ResetSink();
+  ASSERT_OK_NO_THROW(WriteTable(*table, ::arrow::default_memory_pool(),
+                                this->sink_, SMALL_SIZE));
+
+  std::shared_ptr<Table> out;
+  std::unique_ptr<FileReader> reader;
+  ASSERT_NO_FATAL_FAILURE(this->ReaderFromSink(&reader));
+  ASSERT_NO_FATAL_FAILURE(this->ReadTableFromFile(std::move(reader), &out));
+  ASSERT_NE(nullptr, out->schema()->metadata());
+  ASSERT_TRUE(out->schema()->metadata()->Contains("foo"));
+  ASSERT_EQ("bar", out->schema()->metadata()->Get("foo"));
 }
 
 TYPED_TEST(TestParquetIO, SingleColumnTableRequiredWrite) {

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -479,15 +479,18 @@ Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
 }
 
 std::shared_ptr<::arrow::Table> MakeSimpleTable(
-    const std::shared_ptr<ChunkedArray>& values, bool nullable) {
-  auto schema = ::arrow::schema({::arrow::field("col", values->type(), nullable)});
+    const std::shared_ptr<ChunkedArray>& values, bool nullable,
+    std::shared_ptr<::arrow::KeyValueMetadata> metadata = nullptr) {
+  auto schema = ::arrow::schema(
+      {::arrow::field("col", values->type(), nullable)}, std::move(metadata));
   return ::arrow::Table::Make(schema, {values});
 }
 
-std::shared_ptr<::arrow::Table> MakeSimpleTable(const std::shared_ptr<Array>& values,
-                                                bool nullable) {
+std::shared_ptr<::arrow::Table> MakeSimpleTable(
+    const std::shared_ptr<Array>& values, bool nullable,
+    std::shared_ptr<::arrow::KeyValueMetadata> metadata = nullptr) {
   auto carr = std::make_shared<::arrow::ChunkedArray>(values);
-  return MakeSimpleTable(carr, nullable);
+  return MakeSimpleTable(carr, nullable, std::move(metadata));
 }
 
 template <typename T>

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -481,8 +481,8 @@ Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
 std::shared_ptr<::arrow::Table> MakeSimpleTable(
     const std::shared_ptr<ChunkedArray>& values, bool nullable,
     std::shared_ptr<::arrow::KeyValueMetadata> metadata = nullptr) {
-  auto schema = ::arrow::schema(
-      {::arrow::field("col", values->type(), nullable)}, std::move(metadata));
+  auto schema = ::arrow::schema({::arrow::field("col", values->type(), nullable)},
+                                std::move(metadata));
   return ::arrow::Table::Make(schema, {values});
 }
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -529,7 +529,12 @@ Status GetSchemaMetadata(const ::arrow::Schema& schema, ::arrow::MemoryPool* poo
                          const ArrowWriterProperties& properties,
                          std::shared_ptr<const KeyValueMetadata>* out) {
   if (!properties.store_schema()) {
-    *out = nullptr;
+    if (schema.metadata()) {
+      *out = schema.metadata()->Copy();
+    } else {
+      // No metadata to propagate
+      *out = nullptr;
+    }
     return Status::OK();
   }
 


### PR DESCRIPTION
### What changes are included in this PR?

This modifies `parquet::arrow::FileWriter` to always copy the arrow Table's schema-level metadata into the produced parquet file. Currently `FileWriter` only does this if `ArrowWriterProperties::store_schema` is true.

### Are these changes tested?

Yes

### Are there any user-facing changes?

This slightly changes the behavior of `parquet::arrow::FileWriter`, I'm not sure if this would be considered a user-facing change or not.
* GitHub Issue: #41766