### PR TITLE
GH-41758: [Python] Disallow direct pa.RecordBatchReader() construction to avoid segfaults

### DIFF
--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -659,6 +659,11 @@ cdef class RecordBatchReader(_Weakrefable):
 
     # cdef block is in lib.pxd
 
+    def __init__(self):
+        raise TypeError("Do not call {}'s constructor directly, "
+                        "use one of the RecordBatchReader.from_* functions instead."
+                        .format(self.__class__.__name__))
+
     def __iter__(self):
         return self
 

--- a/python/pyarrow/tests/test_misc.py
+++ b/python/pyarrow/tests/test_misc.py
@@ -237,6 +237,7 @@ def test_set_timezone_db_path_non_windows():
     pa.StructScalar,
     pa.DictionaryScalar,
     pa.RunEndEncodedScalar,
+    pa.RecordBatchReader,
     pa.ipc.Message,
     pa.ipc.MessageReader,
     pa.MemoryPool,


### PR DESCRIPTION
### Rationale for this change

A user should never do this, but if you do you easily get segfaults. We should raise an error with an informative message like we do for other classes.

### Are these changes tested?
Yes

* GitHub Issue: #41758