### PR TITLE
GH-41668: [C++] Support cast kernel from nested types to string

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -490,6 +490,15 @@ void AddBinaryToBinaryCast(CastFunction* func) {
   AddBinaryToBinaryCast<OutType, FixedSizeBinaryType>(func);
 }
 
+template <typename OutType>
+void AddListLikeToBinaryCast(CastFunction* func) {
+  auto out_ty = TypeTraits<OutType>::type_singleton();
+  for (const auto& in_ty : {Type::LIST, Type::LARGE_LIST}) {
+    DCHECK_OK(func->AddKernel(in_ty, {InputType(in_ty)}, out_ty,
+                            ZeroCopyCastExec, NullHandling::COMPUTED_NO_PREALLOCATE));
+  }
+}
+
 template <typename InType>
 void AddBinaryToFixedSizeBinaryCast(CastFunction* func) {
   auto resolver_fsb = [](KernelContext* ctx, const std::vector<TypeHolder>&) {
@@ -528,6 +537,7 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   AddDecimalToStringCasts<StringType>(cast_string.get());
   AddTemporalToStringCasts<StringType>(cast_string.get());
   AddBinaryToBinaryCast<StringType>(cast_string.get());
+  AddListLikeToBinaryCast<StringType>(cast_string.get());
 
   auto cast_large_string =
       std::make_shared<CastFunction>("cast_large_string", Type::LARGE_STRING);

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1292,11 +1292,9 @@ class TestListLikeScalar : public ::testing::Test {
     auto invalid_cast_type = fixed_size_list(value_->type(), 5);
     CheckListCastError(scalar, invalid_cast_type);
 
-    // Cast() function doesn't support casting list-like to string, use Scalar::CastTo()
-    // instead.
-    ASSERT_OK_AND_ASSIGN(auto casted_str, scalar.CastTo(utf8()));
-    ASSERT_EQ(casted_str->type->id(), utf8()->id());
-    ASSERT_EQ(casted_str->ToString(), scalar.ToString());
+    ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, utf8()));
+    ASSERT_EQ(casted_str.scalar()->type->id(), utf8()->id());
+    ASSERT_EQ(casted_str.scalar()->ToString(), scalar.ToString());
   }
 
  protected:
@@ -1337,11 +1335,9 @@ TEST(TestFixedSizeListScalar, Cast) {
   auto invalid_cast_type = fixed_size_list(int16(), 4);
   CheckListCastError(scalar, invalid_cast_type);
 
-  // Cast() function doesn't support casting list-like to string, use Scalar::CastTo()
-  // instead.
-  ASSERT_OK_AND_ASSIGN(auto casted_str, scalar.CastTo(utf8()));
-  ASSERT_EQ(casted_str->type->id(), utf8()->id());
-  ASSERT_EQ(casted_str->ToString(), scalar.ToString());
+  ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, utf8()));
+  ASSERT_EQ(casted_str.scalar()->type->id(), utf8()->id());
+  ASSERT_EQ(casted_str.scalar()->ToString(), scalar.ToString());
 }
 
 TEST(TestMapScalar, Basics) {
@@ -1374,11 +1370,10 @@ TEST(TestMapScalar, Cast) {
   auto invalid_cast_type = fixed_size_list(key_value_type, 5);
   CheckListCastError(scalar, invalid_cast_type);
 
-  // Cast() function doesn't support casting map to string, use Scalar::CastTo() instead.
-  ASSERT_OK_AND_ASSIGN(auto casted_str, scalar.CastTo(utf8()));
-  ASSERT_TRUE(casted_str->Equals(StringScalar(
+  ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, utf8()));
+  ASSERT_TRUE(casted_str.scalar()->Equals(StringScalar(
       R"(map<string, int8>[{key:string = a, value:int8 = 1}, {key:string = b, value:int8 = 2}])")))
-      << casted_str->ToString();
+      << casted_str.scalar()->ToString();
 }
 
 TEST(TestStructScalar, FieldAccess) {
@@ -1475,10 +1470,9 @@ TEST(TestStructScalar, Cast) {
   auto ty = struct_({field("i", int32()), field("s", utf8())});
   StructScalar scalar({MakeScalar(42), MakeScalar("xxx")}, ty);
 
-  // Cast() function doesn't support casting map to string, use Scalar::CastTo() instead.
-  ASSERT_OK_AND_ASSIGN(auto casted_str, scalar.CastTo(utf8()));
-  ASSERT_TRUE(casted_str->Equals(StringScalar(R"({i:int32 = 42, s:string = xxx})")))
-      << casted_str->ToString();
+  ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, utf8()));
+  ASSERT_TRUE(casted_str.scalar()->Equals(StringScalar(R"({i:int32 = 42, s:string = xxx})")))
+      << casted_str.scalar()->ToString();
 }
 
 TEST(TestDictionaryScalar, Basics) {
@@ -1855,11 +1849,9 @@ class TestUnionScalar : public ::testing::Test {
   }
 
   void TestCast() {
-    // Cast() function doesn't support casting union to string, use Scalar::CastTo()
-    // instead.
-    ASSERT_OK_AND_ASSIGN(auto casted, union_alpha_->CastTo(utf8()));
-    ASSERT_TRUE(casted->Equals(StringScalar(R"(union{string: string = alpha})")))
-        << casted->ToString();
+    ASSERT_OK_AND_ASSIGN(auto casted, Cast(union_alpha_, utf8()));
+    ASSERT_TRUE(casted.scalar()->Equals(StringScalar(R"(union{string: string = alpha})")))
+        << casted.scalar()->ToString();
   }
 
  protected:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41668