### PR TITLE
GH-41787: Update fmpp-maven-plugin output directory

### DIFF
--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -199,7 +199,7 @@
             <phase>generate-sources</phase>
             <configuration>
               <config>src/main/codegen/config.fmpp</config>
-              <output>${project.build.directory}/generated-sources</output>
+              <output>${project.build.directory}/generated-sources/fmpp</output>
               <templates>${project.build.directory}/codegen/templates</templates>
             </configuration>
           </execution>


### PR DESCRIPTION
### Rationale for this change

Per convention fmpp-maven-plugin should not directly generate files under target/generated-sources but into a subdirectory.

### What changes are included in this PR?

Changing config to output files under `target/generated-sources/fmpp`




<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### Are these changes tested?

CI

### Are there any user-facing changes?

No
* GitHub Issue: #41787