### PR TITLE
GH-41789: [Java] Clean up immutables and checkerframework dependencies

### DIFF
--- a/java/adapter/avro/pom.xml
+++ b/java/adapter/avro/pom.xml
@@ -47,7 +47,7 @@
 
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -48,7 +48,7 @@
 
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.orc</groupId>

--- a/java/algorithm/pom.xml
+++ b/java/algorithm/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
   </dependencies>
 

--- a/java/c/pom.xml
+++ b/java/c/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/compression/pom.xml
+++ b/java/compression/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -119,7 +119,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/memory/memory-core/pom.xml
+++ b/java/memory/memory-core/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.checkerframework</groupId>

--- a/java/memory/memory-core/src/main/java/module-info.java
+++ b/java/memory/memory-core/src/main/java/module-info.java
@@ -23,7 +23,5 @@ module org.apache.arrow.memory.core {
   exports org.apache.arrow.util;
   requires transitive jdk.unsupported;
   requires jsr305;
-  requires org.immutables.value;
   requires org.slf4j;
-  requires org.checkerframework.checker.qual;
 }

--- a/java/memory/memory-netty/pom.xml
+++ b/java/memory/memory-netty/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
   </dependencies>
 

--- a/java/memory/memory-unsafe/pom.xml
+++ b/java/memory/memory-unsafe/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
   </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,6 +115,7 @@
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>${checker.framework.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.google.flatbuffers</groupId>
@@ -149,8 +150,8 @@
       </dependency>
       <dependency>
         <groupId>org.immutables</groupId>
-        <artifactId>value</artifactId>
-        <version>2.10.0</version>
+        <artifactId>value-annotations</artifactId>
+        <version>2.10.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -309,7 +310,7 @@
               <path>
                 <groupId>org.immutables</groupId>
                 <artifactId>value</artifactId>
-                <version>2.10.0</version>
+                <version>2.10.1</version>
               </path>
             </annotationProcessorPaths>
           </configuration>
@@ -669,6 +670,9 @@
                     <exclude>org.mortbay.jetty:servlet-api</exclude>
                     <exclude>org.mortbay.jetty:servlet-api-2.5</exclude>
                     <exclude>log4j:log4j</exclude>
+                    <!-- Do not include annotation processors. Use the annotations-only artifacts -->
+                    <exclude>org.immutables:value</exclude>
+                    <exclude>org.checkerframework:checker</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>
@@ -777,7 +781,6 @@
                 <!-- source annotations (not kept in compiled code) -->
                 <ignoredDependency>javax.annotation:javax.annotation-api:*</ignoredDependency>
                 <ignoredDependency>org.apache.hadoop:hadoop-client-api</ignoredDependency>
-                <ignoredDependency>org.checkerframework:checker-qual</ignoredDependency>
               </ignoredDependencies>
             </configuration>
           </execution>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -32,7 +32,7 @@
     </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
-      <artifactId>value</artifactId>
+      <artifactId>value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### Rationale for this change

As annotation processing is directly configured in `maven-compiler-plugin`, project dependencies should not include annotation processors in their dependencies, and annotations should be limited to `provided` scope as much as possible.

### What changes are included in this PR?

Clean up immutables and checkerframework dependencies to address the issue above:
* switch from `org.immutables:value` to `org.immutables:value-annotations`
* update `org.immutables` dependencies from 2.10.0 to 2.10.1
* change `org.checkerframework:checker-qual` default scope from `compile` to `provided`
* add `org.immutables:value` and `org.checkerframework:checker` to the list of banned dependencies

### Are these changes tested?

CI only

### Are there any user-facing changes?

No
* GitHub Issue: #41789