### PR TITLE
GH-41780: [C++][Flight][Benchmark] Ensure waiting server ready

### DIFF
--- a/cpp/src/arrow/flight/flight_benchmark.cc
+++ b/cpp/src/arrow/flight/flight_benchmark.cc
@@ -131,7 +131,8 @@ struct PerformanceStats {
 Status WaitForReady(FlightClient* client, const FlightCallOptions& call_options) {
   Action action{"ping", nullptr};
   for (int attempt = 0; attempt < 10; attempt++) {
-    if (client->DoAction(call_options, action).ok()) {
+    auto result_stream_result = client->DoAction(call_options, action);
+    if (result_stream_result.ok() && (*result_stream_result)->Drain().ok()) {
       return Status::OK();
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));


### PR DESCRIPTION
### Rationale for this change

We should read from result stream to get an error of this RPC. If we don't read from result stream, we can't detect an error of this RPC.

### What changes are included in this PR?

Call `Drain()` to detect an error.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41780