### PR TITLE
GH-40930: [Java] Implement a function to retrieve reference buffers in StringView

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -715,14 +715,14 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
     if (getBufferSize() == 0) {
       buffers = new ArrowBuf[0];
     } else {
-      final int dataBufferCount = dataBuffers.size();
+      final int dataBufferSize = dataBuffers.size();
       // validity and view buffers
-      final int numFixedBuffers = 2;
-      buffers = new ArrowBuf[numFixedBuffers + dataBufferCount];
+      final int fixedBufferSize = 2;
+      buffers = new ArrowBuf[fixedBufferSize + dataBufferSize];
       buffers[0] = validityBuffer;
       buffers[1] = viewBuffer;
-      for (int i = numFixedBuffers; i < numFixedBuffers + dataBufferCount; i++) {
-        buffers[i] = dataBuffers.get(i - numFixedBuffers);
+      for (int i = fixedBufferSize; i < fixedBufferSize + dataBufferSize; i++) {
+        buffers[i] = dataBuffers.get(i - fixedBufferSize);
       }
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -703,13 +703,6 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
    * impact the reference counts for this buffer, so it only should be used for in-context
    * access. Also note that this buffer changes regularly, thus
    * external classes shouldn't hold a reference to it (unless they change it).
-   * <p>
-   * Note: This method only returns validityBuffer and valueBuffer.
-   * But it doesn't return the data buffers.
-   * <p>
-   * TODO: Implement a strategy to retrieve the data buffers.
-   * <a href="https://github.com/apache/arrow/issues/40930">data buffer retrieval.</a>
-   *
    * @param clear Whether to clear vector before returning, the buffers will still be refcounted
    *              but the returned array will be the only reference to them
    * @return The underlying {@link ArrowBuf buffers} that is used by this
@@ -722,9 +715,15 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
     if (getBufferSize() == 0) {
       buffers = new ArrowBuf[0];
     } else {
-      buffers = new ArrowBuf[2];
+      final int dataBufferCount = dataBuffers.size();
+      // validity and view buffers
+      final int numFixedBuffers = 2;
+      buffers = new ArrowBuf[numFixedBuffers + dataBufferCount];
       buffers[0] = validityBuffer;
       buffers[1] = viewBuffer;
+      for (int i = numFixedBuffers; i < numFixedBuffers + dataBufferCount; i++) {
+        buffers[i] = dataBuffers.get(i - numFixedBuffers);
+      }
     }
     if (clear) {
       for (final ArrowBuf buffer : buffers) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
@@ -94,6 +94,18 @@ public class TestVectorReset {
   }
 
   @Test
+  public void testVariableViewTypeReset() {
+    try (final ViewVarCharVector vector = new ViewVarCharVector("ViewVarChar", allocator)) {
+      vector.allocateNewSafe();
+      vector.set(0, "a".getBytes(StandardCharsets.UTF_8));
+      vector.setLastSet(0);
+      vector.setValueCount(1);
+      resetVectorAndVerify(vector, vector.getBuffers(false));
+      assertEquals(-1, vector.getLastSet());
+    }
+  }
+
+  @Test
   public void testLargeVariableTypeReset() {
     try (final LargeVarCharVector vector = new LargeVarCharVector("LargeVarChar", allocator)) {
       vector.allocateNewSafe();


### PR DESCRIPTION
### Rationale for this change

This PR includes a minor changes to the `getBuffers` method in `BaseVariableWidthViewVector`. 

### What changes are included in this PR?

Previously the fixed buffers were the only ones returned from this method because of lack of clarity in the initial implementation stage. In this PR, it includes the variadic buffers to the result. A test case has also being added. 

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #40930