### PR TITLE
GH-41799: [Java] Migrate to com.gradle:develocity-maven-extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,4 @@ __debug_bin
 .envrc
 
 # Develocity
-.mvn/.gradle-enterprise/
+.mvn/.develocity.xml

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -19,19 +19,19 @@
     under the License.
 
 -->
-<gradleEnterprise xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+<develocity xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
         <url>https://ge.apache.org</url>
         <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>
         <capture>
-            <goalInputFiles>true</goalInputFiles>
+            <fileFingerprints>true</fileFingerprints>
             <buildLogging>true</buildLogging>
             <testLogging>true</testLogging>
         </capture>
         <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
-        <publish>ALWAYS</publish>
+        <publishing><onlyIf>true</onlyIf></publishing>
         <publishIfAuthenticated>true</publishIfAuthenticated>
         <obfuscation>
             <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
@@ -42,4 +42,4 @@
             <enabled>false</enabled>
         </remote>
     </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -22,12 +22,12 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
     <extension>
         <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.20</version>
+        <artifactId>develocity-maven-extension</artifactId>
+        <version>1.21.4</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>1.12.5</version>
+        <version>2.0</version>
     </extension>
 </extensions>

--- a/java/maven/module-info-compiler-maven-plugin/pom.xml
+++ b/java/maven/module-info-compiler-maven-plugin/pom.xml
@@ -99,9 +99,9 @@
         </plugin>
         <plugin>
           <groupId>com.gradle</groupId>
-          <artifactId>gradle-enterprise-maven-extension</artifactId>
+          <artifactId>develocity-maven-extension</artifactId>
           <configuration>
-            <gradleEnterprise>
+            <develocity>
               <normalization>
                 <runtimeClassPath>
                   <ignoredFiles>
@@ -109,7 +109,7 @@
                   </ignoredFiles>
                 </runtimeClassPath>
               </normalization>
-            </gradleEnterprise>
+            </develocity>
           </configuration>
         </plugin>
       </plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -476,9 +476,9 @@
         </plugin>
         <plugin>
           <groupId>com.gradle</groupId>
-          <artifactId>gradle-enterprise-maven-extension</artifactId>
+          <artifactId>develocity-maven-extension</artifactId>
           <configuration>
-            <gradleEnterprise>
+            <develocity>
               <normalization>
                 <runtimeClassPath>
                   <ignoredFiles>
@@ -503,7 +503,7 @@
                   </inputs>
                 </plugin>
               </plugins>
-            </gradleEnterprise>
+            </develocity>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### Rationale for this change

`com.gradle:gradle-enterprise-maven-extension` has been relocated under a new name. Updating the dependency to pick up latest changes and bug fixes

### What changes are included in this PR?

Migrate `com.gradle:gradle-enterprise-maven-extension` artifact to `com.gradle:develociy-maven-extension`.

Apply steps described at https://docs.gradle.com/develocity/maven-extension/legacy/#develocity_migration to migrate associated files and configuration

### Are these changes tested?

No (not sure if someone can validate configuration changes directly with ge.apache.org)

### Are there any user-facing changes?

No
* GitHub Issue: #41799