### PR TITLE
GH-41604: [C++] Make CompressedInputStream buffer adaptative

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -58,6 +58,9 @@ namespace Storage = Azure::Storage;
 
 using HNSSupport = internal::HierarchicalNamespaceSupport;
 
+// Instruct callers to avoid reads < 4 MiB if possible.
+static constexpr int64_t kPreferredReadSize = 4 * 1024 * 1024;
+
 // -----------------------------------------------------------------------
 // AzureOptions Implementation
 
@@ -769,6 +772,10 @@ class ObjectInputFile final : public io::RandomAccessFile {
   }
 
   // RandomAccessFile APIs
+
+  int64_t preferred_read_size(std::optional<int64_t> nbytes) const override {
+    return kPreferredReadSize;
+  }
 
   Result<std::shared_ptr<const KeyValueMetadata>> ReadMetadata() override {
     return metadata_;

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -115,6 +115,13 @@ Result<std::string_view> InputStream::Peek(int64_t ARROW_ARG_UNUSED(nbytes)) {
 
 bool InputStream::supports_zero_copy() const { return false; }
 
+int64_t InputStream::preferred_read_size(std::optional<int64_t> nbytes) const {
+  if (nbytes.has_value()) {
+    return nbytes.value();
+  }
+  return 16 << 10;  // 16 kiB, arbitrary value
+}
+
 Result<std::shared_ptr<const KeyValueMetadata>> InputStream::ReadMetadata() {
   return std::shared_ptr<const KeyValueMetadata>{};
 }

--- a/cpp/src/arrow/io/test_common.cc
+++ b/cpp/src/arrow/io/test_common.cc
@@ -130,6 +130,9 @@ class TrackedRandomAccessFileImpl : public TrackedRandomAccessFile {
     return delegate_->Read(nbytes);
   }
   bool supports_zero_copy() const override { return delegate_->supports_zero_copy(); }
+  int64_t preferred_read_size(std::optional<int64_t> nbytes) const override {
+    return delegate_->preferred_read_size(nbytes);
+  }
   Result<int64_t> GetSize() override { return delegate_->GetSize(); }
   Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override {
     SaveReadRange(position, nbytes);


### PR DESCRIPTION
### Rationale for this change

`CompressedInputStream` currently uses a fixed-size 64 kiB buffer for compressed input read from the underlying stream. This makes the reads issued to the underlying stream too small for efficient operation on filesystems such as S3.

### What changes are included in this PR?

The changes introduced in this PR are two-fold:
1. Introduce a `InputStream` API to query the preferred read chunk size.
2. Use it in `CompressedInputStream` to choose an adequate size for the input buffer.

### Are these changes tested?

Only as far as existing tests (for now?).

### Are there any user-facing changes?

No.
* GitHub Issue: #41604