### PR TITLE
MINOR: [CI] Only try to read vcpkg version from .env if it isn't specified

### DIFF
--- a/ci/scripts/install_vcpkg.sh
+++ b/ci/scripts/install_vcpkg.sh
@@ -25,12 +25,15 @@ if [ "$#" -lt 1 ]; then
 fi
 
 arrow_dir=$(cd -- "$(dirname -- "$0")/../.." && pwd -P)
-default_vcpkg_version=$(source "${arrow_dir}/.env" && echo "$VCPKG" || echo "")
 default_vcpkg_ports_patch="${arrow_dir}/ci/vcpkg/ports.patch"
 
 vcpkg_destination=$1
-vcpkg_version=${2:-$default_vcpkg_version}
+vcpkg_version=${2:-}
 vcpkg_ports_patch=${3:-$default_vcpkg_ports_patch}
+
+if [ -z "${vcpkg_version}" ]; then
+  vcpkg_version=$(source "${arrow_dir}/.env" && echo "$VCPKG")
+fi
 
 # reduce the fetched data using a shallow clone
 git clone --shallow-since=2021-04-01 https://github.com/microsoft/vcpkg ${vcpkg_destination}


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/pull/41599#discussion_r1612517256

This is a small tidy up of `install_vcpkg.sh` based on code review in #41599 after it was merged. Some uses of `install_vcpkg.sh` are in Docker containers where the `.env` file hasn't been copied. Rather than try to read it and ignore any errors, only read the `.env` file if the vcpkg version wasn't specified as an argument to the script. This way if there is an error reading the `.env` file and we do need the default version, the error should be more helpful.

### What changes are included in this PR?

Update `install_vcpkg.sh` to only try to read the vcpkg version from `.env` if it isn't specified as an argument and don't ignore any errors.

### Are these changes tested?

Yes, this script already runs as part of CI.

### Are there any user-facing changes?

No