### PR TITLE
GH-41770: [CI][GLib] Remove temporary files explicitly

### DIFF
--- a/c_glib/test/parquet/test-arrow-file-reader.rb
+++ b/c_glib/test/parquet/test-arrow-file-reader.rb
@@ -31,7 +31,11 @@ class TestParquetArrowFileReader < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       @reader = Parquet::ArrowFileReader.new(@file.path)
-      yield
+      begin
+        yield
+      ensure
+        @reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-arrow-file-reader.rb
+++ b/c_glib/test/parquet/test-arrow-file-reader.rb
@@ -20,16 +20,19 @@ class TestParquetArrowFileReader < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @a_array = build_string_array(["foo", "bar"])
-    @b_array = build_int32_array([123, 456])
-    @table = build_table("a" => @a_array,
-                         "b" => @b_array)
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1
-    writer.write_table(@table, chunk_size)
-    writer.close
-    @reader = Parquet::ArrowFileReader.new(@file.path)
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @a_array = build_string_array(["foo", "bar"])
+      @b_array = build_int32_array([123, 456])
+      @table = build_table("a" => @a_array,
+                           "b" => @b_array)
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1
+      writer.write_table(@table, chunk_size)
+      writer.close
+      @reader = Parquet::ArrowFileReader.new(@file.path)
+      yield
+    end
   end
 
   def test_schema

--- a/c_glib/test/parquet/test-arrow-file-writer.rb
+++ b/c_glib/test/parquet/test-arrow-file-writer.rb
@@ -36,14 +36,18 @@ class TestParquetArrowFileWriter < Test::Unit::TestCase
     writer.close
 
     reader = Parquet::ArrowFileReader.new(@file.path)
-    reader.use_threads = true
-    assert_equal([
-                   enabled_values.length / chunk_size,
-                   true,
-                 ],
-                 [
-                   reader.n_row_groups,
-                   table.equal_metadata(reader.read_table, false),
-                 ])
+    begin
+      reader.use_threads = true
+      assert_equal([
+                     enabled_values.length / chunk_size,
+                     true,
+                   ],
+                   [
+                     reader.n_row_groups,
+                     table.equal_metadata(reader.read_table, false),
+                   ])
+    ensure
+      reader.unref
+    end
   end
 end

--- a/c_glib/test/parquet/test-arrow-file-writer.rb
+++ b/c_glib/test/parquet/test-arrow-file-writer.rb
@@ -20,7 +20,10 @@ class TestParquetArrowFileWriter < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      yield
+    end
   end
 
   def test_write

--- a/c_glib/test/parquet/test-boolean-statistics.rb
+++ b/c_glib/test/parquet/test-boolean-statistics.rb
@@ -20,14 +20,17 @@ class TestParquetBooleanStatistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @table = build_table("boolean" => build_boolean_array([nil, false, true]))
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @table = build_table("boolean" => build_boolean_array([nil, false, true]))
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#min") do

--- a/c_glib/test/parquet/test-boolean-statistics.rb
+++ b/c_glib/test/parquet/test-boolean-statistics.rb
@@ -28,8 +28,13 @@ class TestParquetBooleanStatistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-byte-array-statistics.rb
+++ b/c_glib/test/parquet/test-byte-array-statistics.rb
@@ -28,8 +28,13 @@ class TestParquetByteArrayStatistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-byte-array-statistics.rb
+++ b/c_glib/test/parquet/test-byte-array-statistics.rb
@@ -20,14 +20,17 @@ class TestParquetByteArrayStatistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @table = build_table("string" => build_string_array([nil, "abc", "xyz"]))
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @table = build_table("string" => build_string_array([nil, "abc", "xyz"]))
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#min") do

--- a/c_glib/test/parquet/test-column-chunk-metadata.rb
+++ b/c_glib/test/parquet/test-column-chunk-metadata.rb
@@ -42,8 +42,12 @@ class TestParquetColumnChunkMetadata < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
-      yield
+      begin
+        @metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-column-chunk-metadata.rb
+++ b/c_glib/test/parquet/test-column-chunk-metadata.rb
@@ -20,28 +20,31 @@ class TestParquetColumnChunkMetadata < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @string_array = build_string_array([nil, "hello"])
-    fields = [
-      Arrow::Field.new("int8", Arrow::Int8DataType.new),
-      Arrow::Field.new("boolean", Arrow::BooleanDataType.new),
-    ]
-    structs = [
-      {
-        "int8" => -29,
-        "boolean" => true,
-      },
-      nil,
-    ]
-    @struct_array = build_struct_array(fields, structs)
-    @table = build_table("string" => @string_array,
-                         "struct" => @struct_array)
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @string_array = build_string_array([nil, "hello"])
+      fields = [
+        Arrow::Field.new("int8", Arrow::Int8DataType.new),
+        Arrow::Field.new("boolean", Arrow::BooleanDataType.new),
+      ]
+      structs = [
+        {
+          "int8" => -29,
+          "boolean" => true,
+        },
+        nil,
+      ]
+      @struct_array = build_struct_array(fields, structs)
+      @table = build_table("string" => @string_array,
+                           "struct" => @struct_array)
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
+      yield
+    end
   end
 
   test("#==") do

--- a/c_glib/test/parquet/test-column-chunk-metadata.rb
+++ b/c_glib/test/parquet/test-column-chunk-metadata.rb
@@ -53,9 +53,13 @@ class TestParquetColumnChunkMetadata < Test::Unit::TestCase
 
   test("#==") do
     reader = Parquet::ArrowFileReader.new(@file.path)
-    other_metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
-    assert do
-      @metadata == other_metadata
+    begin
+      other_metadata = reader.metadata.get_row_group(0).get_column_chunk(0)
+      assert do
+        @metadata == other_metadata
+      end
+    ensure
+      reader.unref
     end
   end
 

--- a/c_glib/test/parquet/test-double-statistics.rb
+++ b/c_glib/test/parquet/test-double-statistics.rb
@@ -20,14 +20,17 @@ class TestParquetDoubleStatistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @table = build_table("double" => build_double_array([nil, -2.9, 2.9]))
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @table = build_table("double" => build_double_array([nil, -2.9, 2.9]))
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#min") do

--- a/c_glib/test/parquet/test-double-statistics.rb
+++ b/c_glib/test/parquet/test-double-statistics.rb
@@ -28,8 +28,13 @@ class TestParquetDoubleStatistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-file-metadata.rb
+++ b/c_glib/test/parquet/test-file-metadata.rb
@@ -42,16 +42,24 @@ class TestParquetFileMetadata < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @metadata = reader.metadata
-      yield
+      begin
+        @metadata = reader.metadata
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 
   test("#==") do
     reader = Parquet::ArrowFileReader.new(@file.path)
-    other_metadata = reader.metadata
-    assert do
-      @metadata == other_metadata
+    begin
+      other_metadata = reader.metadata
+      assert do
+        @metadata == other_metadata
+      end
+    ensure
+      reader.unref
     end
   end
 

--- a/c_glib/test/parquet/test-file-metadata.rb
+++ b/c_glib/test/parquet/test-file-metadata.rb
@@ -20,28 +20,31 @@ class TestParquetFileMetadata < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @string_array = build_string_array([nil, "hello"])
-    fields = [
-      Arrow::Field.new("int8", Arrow::Int8DataType.new),
-      Arrow::Field.new("boolean", Arrow::BooleanDataType.new),
-    ]
-    structs = [
-      {
-        "int8" => -29,
-        "boolean" => true,
-      },
-      nil,
-    ]
-    @struct_array = build_struct_array(fields, structs)
-    @table = build_table("string" => @string_array,
-                         "struct" => @struct_array)
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @metadata = reader.metadata
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @string_array = build_string_array([nil, "hello"])
+      fields = [
+        Arrow::Field.new("int8", Arrow::Int8DataType.new),
+        Arrow::Field.new("boolean", Arrow::BooleanDataType.new),
+      ]
+      structs = [
+        {
+          "int8" => -29,
+          "boolean" => true,
+        },
+        nil,
+      ]
+      @struct_array = build_struct_array(fields, structs)
+      @table = build_table("string" => @string_array,
+                           "struct" => @struct_array)
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @metadata = reader.metadata
+      yield
+    end
   end
 
   test("#==") do

--- a/c_glib/test/parquet/test-fixed-length-byte-array-statistics.rb
+++ b/c_glib/test/parquet/test-fixed-length-byte-array-statistics.rb
@@ -20,16 +20,19 @@ class TestParquetFixedLengthByteArrayStatistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    data_type = Arrow::FixedSizeBinaryDataType.new(3)
-    array = build_fixed_size_binary_array(data_type, [nil, "abc", "xyz"])
-    @table = build_table("binary" => array)
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      data_type = Arrow::FixedSizeBinaryDataType.new(3)
+      array = build_fixed_size_binary_array(data_type, [nil, "abc", "xyz"])
+      @table = build_table("binary" => array)
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#min") do

--- a/c_glib/test/parquet/test-fixed-length-byte-array-statistics.rb
+++ b/c_glib/test/parquet/test-fixed-length-byte-array-statistics.rb
@@ -30,8 +30,13 @@ class TestParquetFixedLengthByteArrayStatistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-float-statistics.rb
+++ b/c_glib/test/parquet/test-float-statistics.rb
@@ -28,8 +28,13 @@ class TestParquetFloatStatistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-float-statistics.rb
+++ b/c_glib/test/parquet/test-float-statistics.rb
@@ -20,14 +20,17 @@ class TestParquetFloatStatistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @table = build_table("float" => build_float_array([nil, -2.9, 2.9]))
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @table = build_table("float" => build_float_array([nil, -2.9, 2.9]))
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#min") do

--- a/c_glib/test/parquet/test-int32-statistics.rb
+++ b/c_glib/test/parquet/test-int32-statistics.rb
@@ -28,8 +28,13 @@ class TestParquetInt32Statistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-int32-statistics.rb
+++ b/c_glib/test/parquet/test-int32-statistics.rb
@@ -20,14 +20,17 @@ class TestParquetInt32Statistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @table = build_table("int32" => build_int32_array([nil, -2, 9]))
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @table = build_table("int32" => build_int32_array([nil, -2, 9]))
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#min") do

--- a/c_glib/test/parquet/test-int64-statistics.rb
+++ b/c_glib/test/parquet/test-int64-statistics.rb
@@ -20,15 +20,18 @@ class TestParquetInt64Statistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    array = build_int64_array([nil, -(2 ** 32), 2 ** 32])
-    @table = build_table("int64" => array)
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      array = build_int64_array([nil, -(2 ** 32), 2 ** 32])
+      @table = build_table("int64" => array)
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#min") do

--- a/c_glib/test/parquet/test-int64-statistics.rb
+++ b/c_glib/test/parquet/test-int64-statistics.rb
@@ -29,8 +29,13 @@ class TestParquetInt64Statistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 

--- a/c_glib/test/parquet/test-row-group-metadata.rb
+++ b/c_glib/test/parquet/test-row-group-metadata.rb
@@ -20,28 +20,31 @@ class TestParquetRowGroupMetadata < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @string_array = build_string_array([nil, "hello"])
-    fields = [
-      Arrow::Field.new("int8", Arrow::Int8DataType.new),
-      Arrow::Field.new("boolean", Arrow::BooleanDataType.new),
-    ]
-    structs = [
-      {
-        "int8" => -29,
-        "boolean" => true,
-      },
-      nil,
-    ]
-    @struct_array = build_struct_array(fields, structs)
-    @table = build_table("string" => @string_array,
-                         "struct" => @struct_array)
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @metadata = reader.metadata.get_row_group(0)
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @string_array = build_string_array([nil, "hello"])
+      fields = [
+        Arrow::Field.new("int8", Arrow::Int8DataType.new),
+        Arrow::Field.new("boolean", Arrow::BooleanDataType.new),
+      ]
+      structs = [
+        {
+          "int8" => -29,
+          "boolean" => true,
+        },
+        nil,
+      ]
+      @struct_array = build_struct_array(fields, structs)
+      @table = build_table("string" => @string_array,
+                           "struct" => @struct_array)
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @metadata = reader.metadata.get_row_group(0)
+      yield
+    end
   end
 
   test("#==") do

--- a/c_glib/test/parquet/test-row-group-metadata.rb
+++ b/c_glib/test/parquet/test-row-group-metadata.rb
@@ -42,16 +42,24 @@ class TestParquetRowGroupMetadata < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @metadata = reader.metadata.get_row_group(0)
-      yield
+      begin
+        @metadata = reader.metadata.get_row_group(0)
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 
   test("#==") do
     reader = Parquet::ArrowFileReader.new(@file.path)
-    other_metadata = reader.metadata.get_row_group(0)
-    assert do
-      @metadata == other_metadata
+    begin
+      other_metadata = reader.metadata.get_row_group(0)
+      assert do
+        @metadata == other_metadata
+      end
+    ensure
+      reader.unref
     end
   end
 

--- a/c_glib/test/parquet/test-statistics.rb
+++ b/c_glib/test/parquet/test-statistics.rb
@@ -20,14 +20,17 @@ class TestParquetStatistics < Test::Unit::TestCase
 
   def setup
     omit("Parquet is required") unless defined?(::Parquet)
-    @file = Tempfile.open(["data", ".parquet"])
-    @table = build_table("int32" => build_int32_array([nil, 2, 2, 9]))
-    writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
-    chunk_size = 1024
-    writer.write_table(@table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(@file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      @table = build_table("int32" => build_int32_array([nil, 2, 2, 9]))
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      yield
+    end
   end
 
   test("#==") do

--- a/c_glib/test/parquet/test-statistics.rb
+++ b/c_glib/test/parquet/test-statistics.rb
@@ -28,17 +28,26 @@ class TestParquetStatistics < Test::Unit::TestCase
       writer.write_table(@table, chunk_size)
       writer.close
       reader = Parquet::ArrowFileReader.new(@file.path)
-      @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-      yield
+      begin
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
     end
   end
 
   test("#==") do
     reader = Parquet::ArrowFileReader.new(@file.path)
-    other_statistics =
-      reader.metadata.get_row_group(0).get_column_chunk(0).statistics
-    assert do
-      @statistics == other_statistics
+    begin
+      other_statistics =
+        reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+      assert do
+        @statistics == other_statistics
+      end
+    ensure
+      reader.unref
     end
   end
 


### PR DESCRIPTION
### Rationale for this change

If we remove temporary files by GC, "`unlink': Permission denied" warnings are happen on Windows.

### What changes are included in this PR?

Use `Tempfile.create {...}` to remove temporary files explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41770