### PR TITLE
MINOR: [C++] Slight improvement for ArrayData device_type

### DIFF
--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -233,28 +233,40 @@ DeviceAllocationType ArrayData::device_type() const {
   int type = 0;
   for (const auto& buf : buffers) {
     if (!buf) continue;
+#ifdef NDEBUG
+    return buf->device_type();
+#else
     if (type == 0) {
       type = static_cast<int>(buf->device_type());
     } else {
       DCHECK_EQ(type, static_cast<int>(buf->device_type()));
     }
+#endif
   }
 
   for (const auto& child : child_data) {
     if (!child) continue;
+#ifdef NDEBUG
+    return child->device_type();
+#else
     if (type == 0) {
       type = static_cast<int>(child->device_type());
     } else {
       DCHECK_EQ(type, static_cast<int>(child->device_type()));
     }
+#endif
   }
 
   if (dictionary) {
+#ifdef NDEBUG
+    return dictionary->device_type();
+#else
     if (type == 0) {
       type = static_cast<int>(dictionary->device_type());
     } else {
       DCHECK_EQ(type, static_cast<int>(dictionary->device_type()));
     }
+#endif
   }
 
   return type == 0 ? DeviceAllocationType::kCPU : static_cast<DeviceAllocationType>(type);

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -369,7 +369,7 @@ struct ARROW_EXPORT ArrayData {
   /// \see GetNullCount
   int64_t ComputeLogicalNullCount() const;
 
-  /// \brief Returns the device_type of the underlying buffers and children
+  /// \brief Return the device_type of the underlying buffers and children
   ///
   /// If there are no buffers in this ArrayData object, it just returns
   /// DeviceAllocationType::kCPU as a default. We also assume that all buffers


### PR DESCRIPTION
Responding to feedback on #40807:

              This condition implies that, conversely, in non-debug mode we could immediately return when we encounter a buffer? Instead of continue looping on all buffers and children...

_Originally posted in https://github.com/apache/arrow/pull/40807#discussion_r1611641179_

