### PR TITLE
GH-41719: [C++][Parquet] Cannot read encrypted parquet datasets via _metadata file

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -35,6 +35,8 @@
 #include "arrow/util/future.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging_internal.h"
+#include "arrow/util/key_value_metadata.h"
+#include "arrow/util/logging.h"
 #include "arrow/util/range.h"
 #include "arrow/util/tracing_internal.h"
 #include "parquet/arrow/reader.h"
@@ -42,6 +44,7 @@
 #include "parquet/arrow/writer.h"
 #include "parquet/encryption/crypto_factory.h"
 #include "parquet/encryption/encryption.h"
+#include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/encryption/kms_client.h"
 #include "parquet/file_reader.h"
 #include "parquet/properties.h"
@@ -1091,7 +1094,17 @@ Result<std::shared_ptr<DatasetFactory>> ParquetDatasetFactory::Make(
   std::vector<std::pair<std::string, std::vector<int>>> paths_with_row_group_ids;
   std::unordered_map<std::string, int> paths_to_index;
 
+  // Check if file is a metadata only file and if so extract the AADs for each RowGroup
+  auto kvmd = metadata->key_value_metadata();
+  auto encrypted_metadata_only_file =
+      metadata_source.path() == "_metadata" && kvmd && kvmd->Contains("row_group_aad_0");
+
   for (int i = 0; i < metadata->num_row_groups(); i++) {
+    if (encrypted_metadata_only_file) {
+      PARQUET_ASSIGN_OR_THROW(auto aad, metadata->key_value_metadata()->Get(
+                                            "row_group_aad_" + std::to_string(i)));
+      metadata->set_file_decryptor_aad(aad);
+    }
     auto row_group = metadata->RowGroup(i);
     ARROW_ASSIGN_OR_RAISE(auto path,
                           FileFromRowGroup(filesystem.get(), base_path, *row_group,

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -589,6 +589,14 @@ Status WriteMetaDataFile(const FileMetaData& file_metadata,
   return Status::OK();
 }
 
+Status WriteEncryptedMetadataFile(
+    const FileMetaData& file_metadata, std::shared_ptr<::arrow::io::OutputStream> sink,
+    std::shared_ptr<FileEncryptionProperties> file_encryption_properties) {
+  PARQUET_CATCH_NOT_OK(::parquet::WriteEncryptedMetadataFile(file_metadata, sink,
+                                                             file_encryption_properties));
+  return Status::OK();
+}
+
 Status WriteTable(const ::arrow::Table& table, ::arrow::MemoryPool* pool,
                   std::shared_ptr<::arrow::io::OutputStream> sink, int64_t chunk_size,
                   std::shared_ptr<WriterProperties> properties,

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -153,6 +153,12 @@ PARQUET_EXPORT
 ::arrow::Status WriteMetaDataFile(const FileMetaData& file_metadata,
                                   ::arrow::io::OutputStream* sink);
 
+/// \brief Write encrypted metadata-only Parquet file to indicated Arrow OutputStream
+PARQUET_EXPORT
+::arrow::Status WriteEncryptedMetadataFile(
+    const FileMetaData& file_metadata, std::shared_ptr<::arrow::io::OutputStream> sink,
+    std::shared_ptr<FileEncryptionProperties> file_encryption_properties);
+
 /// \brief Write a Table to Parquet.
 ///
 /// This writes one table in a single shot. To write a Parquet file with

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -583,6 +583,44 @@ void WriteEncryptedFileMetadata(const FileMetaData& file_metadata,
   }
 }
 
+void WriteEncryptedMetadataFile(
+    const FileMetaData& metadata, std::shared_ptr<::arrow::io::OutputStream> sink,
+    std::shared_ptr<FileEncryptionProperties> file_encryption_properties) {
+  auto file_encryptor = std::make_unique<InternalFileEncryptor>(
+      file_encryption_properties.get(), ::arrow::default_memory_pool());
+
+  if (file_encryption_properties->encrypted_footer()) {
+    PARQUET_THROW_NOT_OK(sink->Write(kParquetEMagic, 4));
+
+    PARQUET_ASSIGN_OR_THROW(int64_t position, sink->Tell());
+    auto metadata_start = static_cast<uint64_t>(position);
+
+    auto writer_props = parquet::WriterProperties::Builder()
+                            .encryption(file_encryption_properties)
+                            ->build();
+    auto builder = FileMetaDataBuilder::Make(metadata.schema(), writer_props);
+
+    auto footer_metadata = builder->Finish(metadata.key_value_metadata());
+    auto crypto_metadata = builder->GetCryptoMetaData();
+
+    WriteFileCryptoMetaData(*crypto_metadata, sink.get());
+
+    auto footer_encryptor = file_encryptor->GetFooterEncryptor();
+    WriteEncryptedFileMetadata(metadata, sink.get(), footer_encryptor, true);
+
+    PARQUET_ASSIGN_OR_THROW(position, sink->Tell());
+    auto footer_and_crypto_len = static_cast<uint32_t>(position - metadata_start);
+    PARQUET_THROW_NOT_OK(
+        sink->Write(reinterpret_cast<uint8_t*>(&footer_and_crypto_len), 4));
+    PARQUET_THROW_NOT_OK(sink->Write(kParquetEMagic, 4));
+  } else {
+    // Encrypted file with plaintext footer mode.
+    PARQUET_THROW_NOT_OK(sink->Write(kParquetMagic, 4));
+    auto footer_signing_encryptor = file_encryptor->GetFooterSigningEncryptor();
+    WriteEncryptedFileMetadata(metadata, sink.get(), footer_signing_encryptor, false);
+  }
+}
+
 void WriteFileCryptoMetaData(const FileCryptoMetaData& crypto_metadata,
                              ArrowOutputStream* sink) {
   crypto_metadata.WriteTo(sink);

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -118,6 +118,11 @@ void WriteMetaDataFile(const FileMetaData& file_metadata,
                        ::arrow::io::OutputStream* sink);
 
 PARQUET_EXPORT
+void WriteEncryptedMetadataFile(
+    const FileMetaData& file_metadata, std::shared_ptr<::arrow::io::OutputStream> sink,
+    std::shared_ptr<FileEncryptionProperties> file_encryption_properties);
+
+PARQUET_EXPORT
 void WriteEncryptedFileMetadata(const FileMetaData& file_metadata,
                                 ArrowOutputStream* sink,
                                 const std::shared_ptr<Encryptor>& encryptor,
@@ -125,9 +130,10 @@ void WriteEncryptedFileMetadata(const FileMetaData& file_metadata,
 
 PARQUET_EXPORT
 void WriteEncryptedFileMetadata(const FileMetaData& file_metadata,
-                                ::arrow::io::OutputStream* sink,
+                                std::shared_ptr<::arrow::io::OutputStream> sink,
                                 const std::shared_ptr<Encryptor>& encryptor = NULLPTR,
                                 bool encrypt_footer = false);
+
 PARQUET_EXPORT
 void WriteFileCryptoMetaData(const FileCryptoMetaData& crypto_metadata,
                              ::arrow::io::OutputStream* sink);

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -905,6 +905,13 @@ class FileMetaData::FileMetaDataImpl {
     out->impl_->key_value_metadata_ = key_value_metadata_;
     out->impl_->file_decryptor_ = file_decryptor_;
 
+    if (key_value_metadata_ && key_value_metadata_->Contains("row_group_aad_0")) {
+      PARQUET_ASSIGN_OR_THROW(
+          auto aad,
+          key_value_metadata_->Get("row_group_aad_" + std::to_string(row_groups[0])));
+      out->set_file_decryptor_aad(aad);
+    }
+
     return out;
   }
 
@@ -1029,6 +1036,10 @@ EncryptionAlgorithm FileMetaData::encryption_algorithm() const {
   return impl_->encryption_algorithm();
 }
 
+const std::string& FileMetaData::file_aad() const {
+  return impl_->file_decryptor()->file_aad();
+}
+
 const std::string& FileMetaData::footer_signing_key_metadata() const {
   return impl_->footer_signing_key_metadata();
 }
@@ -1036,6 +1047,13 @@ const std::string& FileMetaData::footer_signing_key_metadata() const {
 void FileMetaData::set_file_decryptor(
     std::shared_ptr<InternalFileDecryptor> file_decryptor) {
   impl_->set_file_decryptor(std::move(file_decryptor));
+}
+
+void FileMetaData::set_file_decryptor_aad(const std::string& aad) {
+  auto fd = impl_->file_decryptor();
+  auto file_decryptor = std::make_shared<parquet::InternalFileDecryptor>(
+      fd->properties(), aad, fd->algorithm(), fd->footer_key_metadata(), fd->pool());
+  set_file_decryptor(file_decryptor);
 }
 
 const std::shared_ptr<InternalFileDecryptor>& FileMetaData::file_decryptor() const {
@@ -1087,6 +1105,36 @@ std::string FileMetaData::SerializeUnencrypted(bool scrub, bool debug) const {
 void FileMetaData::WriteTo(::arrow::io::OutputStream* dst,
                            const std::shared_ptr<Encryptor>& encryptor) const {
   return impl_->WriteTo(dst, encryptor);
+}
+
+::arrow::Result<std::shared_ptr<parquet::FileMetaData>> FileMetaData::CoalesceMetadata(
+    std::vector<std::shared_ptr<parquet::FileMetaData>>& metadata_list,
+    std::shared_ptr<parquet::WriterProperties>& writer_props) {
+  if (metadata_list.empty()) {
+    return ::arrow::Status::Invalid("No metadata to coalesce");
+  }
+
+  std::vector<std::string> values, keys;
+
+  // Read metadata from all dataset files and store AADs.
+  for (size_t i = 0; i < metadata_list.size(); i++) {
+    const auto& file_metadata = metadata_list[i];
+    keys.push_back("row_group_aad_" + std::to_string(i));
+    values.push_back(file_metadata->file_aad());
+    if (i > 0) {
+      metadata_list[0]->AppendRowGroups(*file_metadata);
+    }
+  }
+
+  // Create a new FileMetadata object with the created AADs as key_value_metadata.
+  auto fmd_builder =
+      parquet::FileMetaDataBuilder::Make(metadata_list[0]->schema(), writer_props);
+  const std::shared_ptr<const KeyValueMetadata> file_aad_metadata =
+      ::arrow::key_value_metadata(keys, values);
+  auto metadata = fmd_builder->Finish(file_aad_metadata);
+  metadata->AppendRowGroups(*metadata_list[0]);
+
+  return metadata;
 }
 
 class FileCryptoMetaData::FileCryptoMetaDataImpl {

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -328,6 +328,8 @@ class PARQUET_EXPORT FileMetaData {
   EncryptionAlgorithm encryption_algorithm() const;
   const std::string& footer_signing_key_metadata() const;
 
+  const std::string& file_aad() const;
+
   /// \brief Verify signature of FileMetaData when file is encrypted but footer
   /// is not encrypted (plaintext footer).
   bool VerifySignature(const void* signature);
@@ -376,6 +378,23 @@ class PARQUET_EXPORT FileMetaData {
   /// \param[in] debug whether to serialize the metadata as Thrift (if false) or
   /// debug text (if true).
   std::string SerializeUnencrypted(bool scrub, bool debug) const;
+
+  /// \brief Coalesce metadata from multiple files into a single metadata file by
+  /// appending row groups.
+  ///
+  /// \param[in] metadata_list list of FileMetaData objects to coalesce.
+  /// \param[in] writer_props WriterProperties to use to create coalesced FileMetaData
+  /// object.
+  /// \return a new FileMetaData object containing all row groups from the input
+  /// FileMetaData objects.
+  static ::arrow::Result<std::shared_ptr<FileMetaData>> CoalesceMetadata(
+      std::vector<std::shared_ptr<FileMetaData>>& metadata_list,
+      std::shared_ptr<WriterProperties>& writer_props);
+
+  /// \brief Set the AAD of decryptor of the file.
+  ///
+  /// \param[in] aad AAD to set on the decryptor.
+  void set_file_decryptor_aad(const std::string& aad);
 
  private:
   friend FileMetaDataBuilder;


### PR DESCRIPTION
### Rationale for this change

Metadata written into _metadata file appears to not be encrypted.

### What changes are included in this PR?

This adds a code path to encrypt _metadata file and a test.

### Are these changes tested?

Yes

### Are there any user-facing changes?

This adds user facing `encryption_properties` parameter  to `pyarrow.parquet.write_metadata`.
* GitHub Issue: #41719