### PR TITLE
GH-41810: [C++] Support cast kernel from (dense or sparse) union to (large) string

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -541,7 +541,7 @@ struct UnionToStringCastFunctor {
       RETURN_NOT_OK(child_span.ToArray()->GetScalar(child_index).Value(&child_scalar));
 
       std::string str = "union{" + field->name() + ": " + field->type()->ToString() +
-                           " = " + child_scalar->ToString() + "}";
+                        " = " + child_scalar->ToString() + "}";
       RETURN_NOT_OK(builder.Append(str));
     }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -540,11 +540,9 @@ struct UnionToStringCastFunctor {
       auto child_index = union_type.mode() == UnionMode::DENSE ? offsets[i] : i;
       RETURN_NOT_OK(child_span.ToArray()->GetScalar(child_index).Value(&child_scalar));
 
-      std::stringstream ss;
-      ss << "union{" << field->name() << ": " << field->type()->ToString() << " = "
-         << child_scalar->ToString() << "}";
-
-      RETURN_NOT_OK(builder.Append(ss.str()));
+      std::string str = "union{" + field->name() + ": " + field->type()->ToString() +
+                           " = " + child_scalar->ToString() + "}";
+      RETURN_NOT_OK(builder.Append(str));
     }
 
     std::shared_ptr<Array> output_array;

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1921,11 +1921,13 @@ TEST_F(TestSparseUnionScalar, GetScalar) {
   CheckGetNullUnionScalar(*arr, 4);
 }
 
-TEST_F(TestSparseUnionScalar, Cast) {
+TEST_F(TestSparseUnionScalar, CastToString) {
   for (const auto& out_ty : {utf8(), large_utf8()}) {
-    auto expected = ArrayFromJSON(
-        out_ty,
-        R"(["union{string: string = alpha}", "union{number: uint64 = 2}", "union{string: string = beta}", null, null])");
+    auto expected = ArrayFromJSON(out_ty, R"(["union{string: string = alpha}",
+                                              "union{number: uint64 = 2}",
+                                              "union{string: string = beta}",
+                                              null,
+                                              null])");
     ASSERT_OK_AND_ASSIGN(auto casted, Cast(*arr, out_ty));
     ASSERT_TRUE(casted->Equals(*expected));
   }
@@ -1960,11 +1962,13 @@ TEST_F(TestDenseUnionScalar, GetScalar) {
   CheckGetValidUnionScalar(*arr, 4, *union_three_, *three_);
 }
 
-TEST_F(TestDenseUnionScalar, Cast) {
+TEST_F(TestDenseUnionScalar, CastToString) {
   for (const auto& out_ty : {utf8(), large_utf8()}) {
-    auto expected = ArrayFromJSON(
-        out_ty,
-        R"(["union{string: string = alpha}", "union{number: uint64 = 2}", "union{string: string = beta}", null, "union{number: uint64 = 3}"])");
+    auto expected = ArrayFromJSON(out_ty, R"(["union{string: string = alpha}",
+                                              "union{number: uint64 = 2}",
+                                              "union{string: string = beta}",
+                                              null,
+                                              "union{number: uint64 = 3}"])");
     ASSERT_OK_AND_ASSIGN(auto casted, Cast(*arr, out_ty));
     ASSERT_TRUE(casted->Equals(*expected));
   }

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1922,11 +1922,13 @@ TEST_F(TestSparseUnionScalar, GetScalar) {
 }
 
 TEST_F(TestSparseUnionScalar, Cast) {
-  auto expected = ArrayFromJSON(
-      utf8(),
-      R"(["union{string: string = alpha}", "union{number: uint64 = 2}", "union{string: string = beta}", null, null])");
-  ASSERT_OK_AND_ASSIGN(auto casted, Cast(*arr, utf8()));
-  ASSERT_TRUE(casted->Equals(*expected));
+  for (const auto& out_ty : {utf8(), large_utf8()}) {
+    auto expected = ArrayFromJSON(
+        out_ty,
+        R"(["union{string: string = alpha}", "union{number: uint64 = 2}", "union{string: string = beta}", null, null])");
+    ASSERT_OK_AND_ASSIGN(auto casted, Cast(*arr, out_ty));
+    ASSERT_TRUE(casted->Equals(*expected));
+  }
 }
 
 class TestDenseUnionScalar : public TestUnionScalar<DenseUnionType> {
@@ -1959,11 +1961,13 @@ TEST_F(TestDenseUnionScalar, GetScalar) {
 }
 
 TEST_F(TestDenseUnionScalar, Cast) {
-  auto expected = ArrayFromJSON(
-      utf8(),
-      R"(["union{string: string = alpha}", "union{number: uint64 = 2}", "union{string: string = beta}", null, "union{number: uint64 = 3}"])");
-  ASSERT_OK_AND_ASSIGN(auto casted, Cast(*arr, utf8()));
-  ASSERT_TRUE(casted->Equals(*expected));
+  for (const auto& out_ty : {utf8(), large_utf8()}) {
+    auto expected = ArrayFromJSON(
+        out_ty,
+        R"(["union{string: string = alpha}", "union{number: uint64 = 2}", "union{string: string = beta}", null, "union{number: uint64 = 3}"])");
+    ASSERT_OK_AND_ASSIGN(auto casted, Cast(*arr, out_ty));
+    ASSERT_TRUE(casted->Equals(*expected));
+  }
 }
 
 template <typename RunEndType>

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1855,11 +1855,21 @@ class TestUnionScalar : public ::testing::Test {
   }
 
   void TestCast() {
-    // Cast() function doesn't support casting union to string, use Scalar::CastTo()
-    // instead.
-    ASSERT_OK_AND_ASSIGN(auto casted, union_alpha_->CastTo(utf8()));
-    ASSERT_TRUE(casted->Equals(StringScalar(R"(union{string: string = alpha})")))
-        << casted->ToString();
+    std::vector<std::pair<std::shared_ptr<Scalar>, std::string>> test_cases = {
+        {union_alpha_, R"(union{string: string = alpha})"},
+        {union_beta_, R"(union{string: string = beta})"},
+        {union_two_, R"(union{number: uint64 = 2})"},
+        {union_three_, R"(union{number: uint64 = 3})"},
+        {union_other_two_, R"(union{other_number: uint64 = 2})"},
+        {union_string_null_, "null"},
+        {union_number_null_, "null"}
+    };
+
+    for (const auto& [scalar, expected] : test_cases) {
+      ASSERT_OK_AND_ASSIGN(auto casted, Cast(scalar, utf8()));
+      ASSERT_EQ(casted.scalar()->ToString(), expected)
+          << "Failed to cast " << scalar->ToString() << " to " << expected;
+    }
   }
 
  protected:

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1862,8 +1862,7 @@ class TestUnionScalar : public ::testing::Test {
         {union_three_, R"(union{number: uint64 = 3})"},
         {union_other_two_, R"(union{other_number: uint64 = 2})"},
         {union_string_null_, "null"},
-        {union_number_null_, "null"}
-    };
+        {union_number_null_, "null"}};
 
     for (const auto& [scalar, expected] : test_cases) {
       ASSERT_OK_AND_ASSIGN(auto casted, Cast(scalar, utf8()));

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1864,10 +1864,12 @@ class TestUnionScalar : public ::testing::Test {
         {union_string_null_, "null"},
         {union_number_null_, "null"}};
 
-    for (const auto& [scalar, expected] : test_cases) {
-      ASSERT_OK_AND_ASSIGN(auto casted, Cast(scalar, utf8()));
-      ASSERT_EQ(casted.scalar()->ToString(), expected)
-          << "Failed to cast " << scalar->ToString() << " to " << expected;
+    for (const auto& out_ty : {utf8(), large_utf8()}) {
+      for (const auto& [scalar, expected] : test_cases) {
+        ASSERT_OK_AND_ASSIGN(auto casted, Cast(scalar, out_ty));
+        ASSERT_EQ(casted.scalar()->ToString(), expected)
+            << "Failed to cast " << scalar->ToString() << " to " << expected;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Support `cast` kernel from (`dense` or `sparse`) union to (large) string

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Support `cast` kernel
  - from `dense union` to (large) `string`
  - from `sparse union` to (large) `string` 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. It is passed by existing test cases.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41810