### PR TITLE
GH-41841: [R][CI] Remove more defunct rhub containers

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -370,11 +370,12 @@ jobs:
             MAKEFLAGS = paste0("-j", parallel::detectCores()),
             ARROW_R_DEV = TRUE,
             "_R_CHECK_FORCE_SUGGESTS_" = FALSE,
-            "_R_CHECK_STOP_ON_INVALID_NUMERIC_VERSION_INPUTS_" = TRUE
+            "_R_CHECK_STOP_ON_INVALID_NUMERIC_VERSION_INPUTS_" = TRUE,
+            "_R_CHECK_DONTTEST_EXAMPLES_" = TRUE
           )
           rcmdcheck::rcmdcheck(".",
             build_args = '--no-build-vignettes',
-            args = c('--no-manual', '--as-cran', '--ignore-vignettes', '--run-donttest'),
+            args = c('--no-manual', '--as-cran', '--ignore-vignettes'),
             error_on = 'warning',
             check_dir = 'check',
             timeout = 3600

--- a/ci/scripts/r_install_system_dependencies.sh
+++ b/ci/scripts/r_install_system_dependencies.sh
@@ -21,29 +21,30 @@ set -ex
 
 : ${ARROW_SOURCE_HOME:=/arrow}
 
+# Figure out what package manager we have
+if [ "`which dnf`" ]; then
+  PACKAGE_MANAGER=dnf
+elif [ "`which yum`" ]; then
+  PACKAGE_MANAGER=yum
+elif [ "`which zypper`" ]; then
+  PACKAGE_MANAGER=zypper
+else
+  PACKAGE_MANAGER=apt-get
+  apt-get update
+fi
+
+# Install curl and OpenSSL (technically, only needed for S3/GCS support, but
+# installing the R curl package fails without it)
+case "$PACKAGE_MANAGER" in
+  apt-get)
+    apt-get install -y libcurl4-openssl-dev libssl-dev
+    ;;
+  *)
+    $PACKAGE_MANAGER install -y libcurl-devel openssl-devel
+    ;;
+esac
+
 if [ "$ARROW_S3" == "ON" ] || [ "$ARROW_GCS" == "ON" ] || [ "$ARROW_R_DEV" == "TRUE" ]; then
-  # Figure out what package manager we have
-  if [ "`which dnf`" ]; then
-    PACKAGE_MANAGER=dnf
-  elif [ "`which yum`" ]; then
-    PACKAGE_MANAGER=yum
-  elif [ "`which zypper`" ]; then
-    PACKAGE_MANAGER=zypper
-  else
-    PACKAGE_MANAGER=apt-get
-    apt-get update
-  fi
-
-  # Install curl and OpenSSL for S3/GCS support
-  case "$PACKAGE_MANAGER" in
-    apt-get)
-      apt-get install -y libcurl4-openssl-dev libssl-dev
-      ;;
-    *)
-      $PACKAGE_MANAGER install -y libcurl-devel openssl-devel
-      ;;
-  esac
-
   # The Dockerfile should have put this file here
   if [ "$ARROW_S3" == "ON" ] && [ -f "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" ] && [ "`which wget`" ]; then
     "${ARROW_SOURCE_HOME}/ci/scripts/install_minio.sh" latest /usr/local

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -93,7 +93,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     env <- c('_R_CHECK_CRAN_INCOMING_REMOTE_'='TRUE')
 
     # Attempt to install pandoc, this will only work on systems with apt
-    system(c('apt', 'install', '-y', 'pandoc')
+    system(c('apt', 'install', '-y', 'pandoc'))
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -90,10 +90,11 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   if (as_cran) {
     args <- '--as-cran'
     build_args <- character()
-    Sys.setenv('_R_CHECK_CRAN_INCOMING_REMOTE_'=TRUE)
+    env <- c('_R_CHECK_CRAN_INCOMING_REMOTE_'='TRUE')
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'
+    env <- c()
   }
 
   if (requireNamespace('reticulate', quietly = TRUE) && reticulate::py_module_available('pyarrow')) {
@@ -121,7 +122,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     args <- c(args, paste0('--install-args=\"', install_args, '\"'))
   }
 
-  rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600)"
+  rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600, env = env)"
 echo "$SCRIPT" | ${R_BIN} --no-save
 
 AFTER=$(ls -alh ~/)

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -90,14 +90,9 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   if (as_cran) {
     args <- '--as-cran'
     build_args <- character()
-    env <- c('_R_CHECK_CRAN_INCOMING_REMOTE_'='TRUE')
-
-    # Attempt to install pandoc, this will only work on systems with apt
-    system(c('apt install -y pandoc'))
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'
-    env <- c()
   }
 
   if (requireNamespace('reticulate', quietly = TRUE) && reticulate::py_module_available('pyarrow')) {
@@ -115,11 +110,6 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
       on.exit(tools::pskill(pid_flight), add = TRUE)
   }
 
-  run_donttest <- identical(tolower(Sys.getenv('_R_CHECK_DONTTEST_EXAMPLES_', 'true')), 'true')
-  if (run_donttest) {
-    args <- c(args, '--run-donttest')
-  }
-
   install_args <- Sys.getenv('INSTALL_ARGS')
   if (nzchar(install_args)) {
     args <- c(args, paste0('--install-args=\"', install_args, '\"'))
@@ -128,9 +118,8 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   message('Running rcmdcheck with:\n')
   print(build_args)
   print(args)
-  print(env)
 
-  rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600, env = env)"
+  rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600)"
 echo "$SCRIPT" | ${R_BIN} --no-save
 
 AFTER=$(ls -alh ~/)

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -93,7 +93,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     env <- c('_R_CHECK_CRAN_INCOMING_REMOTE_'='TRUE')
 
     # Attempt to install pandoc, this will only work on systems with apt
-    system(c('apt', 'install', '-y', 'pandoc'))
+    system(c('apt install -y pandoc'))
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'
@@ -126,11 +126,8 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   }
 
   message('Running rcmdcheck with:\n')
-  message('build_args:\n')
   print(build_args)
-  message('args:\n')
   print(args)
-  message('env:\n')
   print(env)
 
   rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600, env = env)"

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -93,7 +93,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     env <- c('_R_CHECK_CRAN_INCOMING_REMOTE_'='TRUE')
 
     # Attempt to install pandoc
-    system('apt', 'install', '-y', 'pandoc)
+    system('apt', 'install', '-y', 'pandoc')
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -91,6 +91,9 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     args <- '--as-cran'
     build_args <- character()
     env <- c('_R_CHECK_CRAN_INCOMING_REMOTE_'='TRUE')
+
+    # Attempt to install pandoc
+    system('apt', 'install', '-y', 'pandoc)
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'
@@ -122,12 +125,13 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     args <- c(args, paste0('--install-args=\"', install_args, '\"'))
   }
 
-  message(
-    'Running rcmdcheck with:\n',
-    'build_args: ', build_args,
-    'args: ', args,
-    'env: ', env
-  )
+  message('Running rcmdcheck with:\n')
+  message('build_args:\n')
+  print(build_args)
+  message('args:\n')
+  print(args)
+  message('env:\n')
+  print(env)
 
   rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600, env = env)"
 echo "$SCRIPT" | ${R_BIN} --no-save

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -92,8 +92,8 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     build_args <- character()
     env <- c('_R_CHECK_CRAN_INCOMING_REMOTE_'='TRUE')
 
-    # Attempt to install pandoc
-    system('apt', 'install', '-y', 'pandoc')
+    # Attempt to install pandoc, this will only work on systems with apt
+    system(c('apt', 'install', '-y', 'pandoc')
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -122,7 +122,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     args <- c(args, paste0('--install-args=\"', install_args, '\"'))
   }
 
-  massage(
+  message(
     'Running rcmdcheck with:\n',
     'build_args: ', build_args,
     'args: ', args,

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -90,6 +90,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   if (as_cran) {
     args <- '--as-cran'
     build_args <- character()
+    Sys.setenv('_R_CHECK_CRAN_INCOMING_REMOTE_'=TRUE)
   } else {
     args <- c('--no-manual', '--ignore-vignettes')
     build_args <- '--no-build-vignettes'

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -122,6 +122,13 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     args <- c(args, paste0('--install-args=\"', install_args, '\"'))
   }
 
+  massage(
+    'Running rcmdcheck with:\n',
+    'build_args: ', build_args,
+    'args: ', args,
+    'env: ', env
+  )
+
   rcmdcheck::rcmdcheck(build_args = build_args, args = args, error_on = 'warning', check_dir = 'check', timeout = 3600, env = env)"
 echo "$SCRIPT" | ${R_BIN} --no-save
 

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -28,11 +28,10 @@ jobs:
       matrix:
         # See https://hub.docker.com/r/rhub
         r_image:
-          - debian-gcc-devel
-          - debian-gcc-patched
-          - debian-gcc-release
-          - fedora-gcc-devel
-          - fedora-clang-devel
+          - ubuntu-gcc12    # ~ r-devel-linux-x86_64-debian-gcc
+          - ubuntu-clang    # ~ r-devel-linux-x86_64-debian-clang
+          - ubuntu-next     # ~ r-patched-linux-x86_64
+          - ubuntu-release  # ~ r-release-linux-x86_64
     env:
       R_ORG: "rhub"
       R_IMAGE: {{ MATRIX }}

--- a/r/Makefile
+++ b/r/Makefile
@@ -52,11 +52,11 @@ build: doc sync-cpp
 	R CMD build ${args} .
 
 check: build
-	-export _R_CHECK_CRAN_INCOMING_REMOTE_=FALSE && export ARROW_R_DEV=$(ARROW_R_DEV) && export _R_CHECK_TESTS_NLINES_=0 && R CMD check --as-cran --run-donttest arrow_$(VERSION).tar.gz
+	-export _R_CHECK_CRAN_INCOMING_REMOTE_=FALSE && export ARROW_R_DEV=$(ARROW_R_DEV) && export _R_CHECK_TESTS_NLINES_=0 && R CMD check --as-cran arrow_$(VERSION).tar.gz
 	rm -rf arrow.Rcheck/
 
 release: build
-	-export _R_CHECK_TESTS_NLINES_=0 && R CMD check --as-cran --run-donttest arrow_$(VERSION).tar.gz
+	-export _R_CHECK_TESTS_NLINES_=0 && R CMD check --as-cran arrow_$(VERSION).tar.gz
 	rm -rf arrow.Rcheck/
 
 clean:


### PR DESCRIPTION
Testing CI to see if we can replicate the incoming NOTEs:

```
Found the following (possibly) invalid file URIs:
  URI: articles/read_write.html
    From: README.md
  URI: articles/data_wrangling.html
    From: README.md
  URI: reference/acero.html
    From: README.md
  URI: articles/install.html
    From: README.md
  URI: articles/install_nightly.html
    From: README.md
```

I wasn't able to replicate them in CI (even with `_R_CHECK_CRAN_INCOMING_REMOTE_` set to true, and installing pandoc so that the docs could be munged.)

But in the process realized we were running old rhub images that aren't updated anymore (thanks, @thisisnic). Also did a bit of cleanup of `--run-donttest` which is now no longer needed (was removed in favor of the env var in 4.0)
* GitHub Issue: #41841