### PR TITLE
GH-41668: [C++] Support cast kernel from list-like to (large) string

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -517,7 +517,8 @@ template <typename O, typename I>
 struct ListLikeToStringCastFunctor {
   using BuilderType = typename TypeTraits<O>::BuilderType;
 
-  static Status AppendValue(const ArraySpan& values, std::stringstream& ss, int64_t j, int64_t start) {
+  static Status AppendValue(const ArraySpan& values, std::stringstream& ss, int64_t j,
+                            int64_t start) {
     if (j != start) {
       ss << ", ";
     }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -633,6 +633,7 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   AddDecimalToStringCasts<LargeStringType>(cast_large_string.get());
   AddTemporalToStringCasts<LargeStringType>(cast_large_string.get());
   AddBinaryToBinaryCast<LargeStringType>(cast_large_string.get());
+  AddListLikeToStringCasts<LargeStringType>(cast_large_string.get());
 
   auto cast_fsb =
       std::make_shared<CastFunction>("cast_fixed_size_binary", Type::FIXED_SIZE_BINARY);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2592,22 +2592,22 @@ TEST_F(TestMapScalar, RenameMap) {
   CheckCast(src, dst);
 }
 
-TEST_F(TestMapScalar, CastMap) {
+TEST_F(TestMapScalar, CastToMap) {
   // Can map keys and values
   CheckMapCast(map(large_utf8(), field("y", int32())));
 }
 
-TEST_F(TestMapScalar, CastList) {
+TEST_F(TestMapScalar, CastToList) {
   // Can cast a map to a list<struct<keys=.., values=..>>
   CheckMapCast(list(struct_({field("a", utf8()), field("b", int64())})));
 }
 
-TEST_F(TestMapScalar, CastLargeList) {
+TEST_F(TestMapScalar, CastToLargeList) {
   // Can cast a map to a large_list<struct<keys=.., values=..>>
   CheckMapCast(large_list(struct_({field("a", utf8()), field("b", int64())})));
 }
 
-TEST_F(TestMapScalar, CastListWithInvalidFields) {
+TEST_F(TestMapScalar, CastToListWithInvalidFields) {
   std::shared_ptr<DataType> src_type = map(utf8(), field("x", list(field("a", int64()))));
   std::shared_ptr<Array> src =
       ArrayFromJSON(src_type, R"([[["1", [1,2,3]]], [["2", [4,5,6]]]])");
@@ -2620,7 +2620,7 @@ TEST_F(TestMapScalar, CastListWithInvalidFields) {
       Cast(src, dst_type));
 }
 
-TEST_F(TestMapScalar, MapToString) {
+TEST_F(TestMapScalar, CastToString) {
   const std::string expected_str = {
       "[\n  \"map<string, int64>[{key:string = x, value:int64 = 1}, "
       "{key:string = y, value:int64 = 8}, {key:string = z, value:int64 = 9}]\","

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2509,27 +2509,50 @@ TEST(Cast, ListToFSL) {
 }
 
 TEST_F(TestCastToString, ListToString) {
-  // Example with int32 list
-  std::shared_ptr<DataType> list_type = list(int32());
-  const std::string list_json = R"([[1, 2, 3], [4, 5], [6], []])";
-  const std::string expected_str = R"([
-  "list<item: int32>[1, 2, 3]",
-  "list<item: int32>[4, 5]",
-  "list<item: int32>[6]",
+  // Example with int32 list, large list, list view and large list view
+  const std::vector<std::pair<std::shared_ptr<DataType>, std::string>> list_types = {
+      {list(int32()), R"([
+  "list<item: int32>[1, 2]",
+  "list<item: int32>[3]",
   "list<item: int32>[]"
-])";
-  CheckCastToString(list_type, list_json, expected_str);
+])"},
+      {large_list(int32()), R"([
+  "large_list<item: int32>[1, 2]",
+  "large_list<item: int32>[3]",
+  "large_list<item: int32>[]"
+])"},
+      {list_view(int32()), R"([
+  "list_view<item: int32>[1, 2]",
+  "list_view<item: int32>[3]",
+  "list_view<item: int32>[]"
+])"},
+      {large_list_view(int32()), R"([
+  "large_list_view<item: int32>[1, 2]",
+  "large_list_view<item: int32>[3]",
+  "large_list_view<item: int32>[]"
+])"}};
 
-  // Example with nested list of int32
-  list_type = list(list(int32()));
-  const std::string nested_list_json = R"([[[1, 2], [3, 4]], [[5], [6, 7]], [[]], []])";
-  const std::string expected_nested_str = R"([
-  "list<item: list<item: int32>>[list<item: int32>[1, 2], list<item: int32>[3, 4]]",
-  "list<item: list<item: int32>>[list<item: int32>[5], list<item: int32>[6, 7]]",
+  const std::string list_json = R"([[1, 2], [3], []])";
+
+  for (const auto& [list_type, expected_str] : list_types) {
+    CheckCastToString(list_type, list_json, expected_str);
+  }
+
+  // Example with nested list of int32.  To avoid further code duplication, the code for
+  // large_list, list_view, and large_list_view is omitted.
+  const std::vector<std::pair<std::shared_ptr<DataType>, std::string>> nested_list_types =
+      {{list(list(int32())), R"([
+  "list<item: list<item: int32>>[list<item: int32>[1, 2], list<item: int32>[3]]",
+  "list<item: list<item: int32>>[list<item: int32>[4]]",
   "list<item: list<item: int32>>[list<item: int32>[]]",
   "list<item: list<item: int32>>[]"
-])";
-  CheckCastToString(list_type, nested_list_json, expected_nested_str);
+])"}};
+
+  const std::string nested_list_json = R"([[[1, 2], [3]], [[4]], [[]], []])";
+
+  for (const auto& [nested_list_type, expected_nested_str] : nested_list_types) {
+    CheckCastToString(nested_list_type, nested_list_json, expected_nested_str);
+  }
 }
 
 class TestMapScalar : public TestCastToString {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2576,9 +2576,9 @@ TEST(Cast, CastMap) {
   std::shared_ptr<DataType> dst_type = map(utf8(), field("y", list(field("b", int64()))));
 
   std::shared_ptr<Array> src =
-      ArrayFromJSON(src_type, R"([[["1", [1,2,3]]], [["2", [4,5,6]]]])");
+      ArrayFromJSON(src_type, "[[[\"1\", [1,2,3]]], [[\"2\", [4,5,6]]]]");
   std::shared_ptr<Array> dst =
-      ArrayFromJSON(dst_type, R"([[["1", [1,2,3]]], [["2", [4,5,6]]]])");
+      ArrayFromJSON(dst_type, "[[[\"1\", [1,2,3]]], [[\"2\", [4,5,6]]]]");
 
   CheckCast(src, dst);
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2430,10 +2430,12 @@ TEST(Cast, FSLToString) {
                                  const std::string& fsl_json,
                                  const std::string& expected_str) {
     std::shared_ptr<Array> src = ArrayFromJSON(fsl_type, fsl_json);
-    ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(*src, utf8()));
+    for (const auto& out_ty : {utf8(), large_utf8()}) {
+      ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(*src, out_ty));
 
-    std::shared_ptr<Array> expected_array = ArrayFromJSON(utf8(), expected_str);
-    ASSERT_TRUE(casted_str->Equals(expected_array)) << casted_str->ToString();
+      std::shared_ptr<Array> expected_array = ArrayFromJSON(out_ty, expected_str);
+      ASSERT_TRUE(casted_str->Equals(expected_array)) << casted_str->ToString();
+    }
   };
 
   // Example with int32 list
@@ -2511,10 +2513,11 @@ TEST(Cast, ListToString) {
                                   const std::string& list_json,
                                   const std::string& expected_str) {
     std::shared_ptr<Array> src = ArrayFromJSON(list_type, list_json);
-    ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(*src, utf8()));
-
-    std::shared_ptr<Array> expected_array = ArrayFromJSON(utf8(), expected_str);
-    ASSERT_TRUE(casted_str->Equals(expected_array)) << casted_str->ToString();
+    for (const auto& out_ty : {utf8(), large_utf8()}) {
+      ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(*src, out_ty));
+      std::shared_ptr<Array> expected_array = ArrayFromJSON(out_ty, expected_str);
+      ASSERT_TRUE(casted_str->Equals(expected_array)) << casted_str->ToString();
+    }
   };
 
   // Example with int32 list
@@ -2598,9 +2601,11 @@ void CheckMapToStringCast(const std::string& map_json,
     std::shared_ptr<Array> src = ArrayFromJSON(src_type, json);
     for (int64_t i = 0; i < src->length(); ++i) {
       ASSERT_OK_AND_ASSIGN(auto scalar, src->GetScalar(i));
-      ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, utf8()));
-      ASSERT_EQ(casted_str.scalar()->type->id(), utf8()->id());
-      ASSERT_EQ(casted_str.scalar()->ToString(), expected[i]);
+      for (const auto& out_ty : {utf8(), large_utf8()}) {
+        ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, out_ty));
+        ASSERT_EQ(casted_str.scalar()->type->id(), out_ty->id());
+        ASSERT_EQ(casted_str.scalar()->ToString(), expected[i]);
+      }
     }
   };
 

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1292,11 +1292,9 @@ class TestListLikeScalar : public ::testing::Test {
     auto invalid_cast_type = fixed_size_list(value_->type(), 5);
     CheckListCastError(scalar, invalid_cast_type);
 
-    // Cast() function doesn't support casting list-like to string, use Scalar::CastTo()
-    // instead.
-    ASSERT_OK_AND_ASSIGN(auto casted_str, scalar.CastTo(utf8()));
-    ASSERT_EQ(casted_str->type->id(), utf8()->id());
-    ASSERT_EQ(casted_str->ToString(), scalar.ToString());
+    ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, utf8()));
+    ASSERT_EQ(casted_str.scalar()->type->id(), utf8()->id());
+    ASSERT_EQ(casted_str.scalar()->ToString(), scalar.ToString());
   }
 
  protected:
@@ -1337,11 +1335,9 @@ TEST(TestFixedSizeListScalar, Cast) {
   auto invalid_cast_type = fixed_size_list(int16(), 4);
   CheckListCastError(scalar, invalid_cast_type);
 
-  // Cast() function doesn't support casting list-like to string, use Scalar::CastTo()
-  // instead.
-  ASSERT_OK_AND_ASSIGN(auto casted_str, scalar.CastTo(utf8()));
-  ASSERT_EQ(casted_str->type->id(), utf8()->id());
-  ASSERT_EQ(casted_str->ToString(), scalar.ToString());
+  ASSERT_OK_AND_ASSIGN(auto casted_str, Cast(scalar, utf8()));
+  ASSERT_EQ(casted_str.scalar()->type->id(), utf8()->id());
+  ASSERT_EQ(casted_str.scalar()->ToString(), scalar.ToString());
 }
 
 TEST(TestMapScalar, Basics) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Support `cast` kernel from list-like (such as `list`, `large list`, `list view`, `large list view`, `fixed size list`, and `map`) to (large) string

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Support `cast` kernel
  - from `list` to (large) `string`
  - from `large list` to (large) `string`
  - from `list view` to (large) `string`
  - from `large list view` to (large) `string`
  - from `fixed size list` to (large) `string`
  - from `map` to (large) `string`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. It is passed by existing test cases.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41668