### PR TITLE
GH-41679: [Release][Packaging][deb] Update package name in 01-preparesh too

### DIFF
--- a/dev/release/01-prepare.sh
+++ b/dev/release/01-prepare.sh
@@ -39,6 +39,7 @@ release_candidate_branch="release-${version}-rc${rc_number}"
 
 : ${PREPARE_DEFAULT:=1}
 : ${PREPARE_CHANGELOG:=${PREPARE_DEFAULT}}
+: ${PREPARE_DEB_PACKAGE_NAMES:=${PREPARE_DEFAULT}}
 : ${PREPARE_LINUX_PACKAGES:=${PREPARE_DEFAULT}}
 : ${PREPARE_VERSION_PRE_TAG:=${PREPARE_DEFAULT}}
 : ${PREPARE_BRANCH:=${PREPARE_DEFAULT}}
@@ -78,16 +79,12 @@ if [ ${PREPARE_CHANGELOG} -gt 0 ]; then
   git commit -m "MINOR: [Release] Update CHANGELOG.md for $version"
 fi
 
+if [ ${PREPARE_DEB_PACKAGE_NAMES} -gt 0 ]; then
+  update_deb_package_names "$(current_version)" "${version}"
+fi
+
 if [ ${PREPARE_LINUX_PACKAGES} -gt 0 ]; then
-  echo "Updating .deb/.rpm changelogs for $version"
-  cd $SOURCE_DIR/../tasks/linux-packages
-  rake \
-    version:update \
-    ARROW_RELEASE_TIME="$(date +%Y-%m-%dT%H:%M:%S%z)" \
-    ARROW_VERSION=${version}
-  git add */debian*/changelog */yum/*.spec.in
-  git commit -m "MINOR: [Release] Update .deb/.rpm changelogs for $version"
-  cd -
+  update_linux_packages "${version}" "$(date +%Y-%m-%dT%H:%M:%S%z)"
 fi
 
 if [ ${PREPARE_VERSION_PRE_TAG} -gt 0 ]; then

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -74,7 +74,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
     end
   end
 
-  data(:release_type, [:major, :minor, :patch])
+  data(:next_release_type, [:major, :minor, :patch])
   def test_version_post_tag
     omit_on_release_branch
 
@@ -136,7 +136,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         ],
       },
     ]
-    unless release_type == :patch
+    unless next_release_type == :patch
       expected_changes += [
         {
           path: "docs/source/_static/versions.json",
@@ -202,7 +202,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         ],
       },
     ]
-    if release_type == :major
+    if next_release_type == :major
       expected_changes += [
         {
           path: "c_glib/tool/generate-version-header.py",
@@ -276,7 +276,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
 
       import_path = "github.com/apache/arrow/go/v#{@snapshot_major_version}"
       hunks = []
-      if release_type == :major
+      if next_release_type == :major
         lines = File.readlines(path, chomp: true)
         target_lines = lines.each_with_index.select do |line, i|
           line.include?(import_path)


### PR DESCRIPTION
### Rationale for this change

It's needed when we publish minor release. For example:

```console
$ dev/release/01-prepare.sh 16.0.0 17.0.0 # Release 16.0.0
...
$ dev/release/post-11-bump-versions.sh 16.0.0 17.0.0 # Released 16.0.0
...
$ dev/release/01-prepare.sh 16.1.0 17.0.0 # Release 16.1.0: This is effected
...
$ dev/release/post-11-bump-versions.sh 16.1.0 17.0.0 # Released 16.1.0
```

We can't detect minor release in `post-11-bump-versions.sh`.

### What changes are included in this PR?

Share update codes via `utils-prepare.sh` and use the same logic in `01-prepare.sh` too.

Linux packages related update code are also shared but it's not related to this change. Sorry.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #41679