### PR TITLE
GH-40932: [Java] Implement TransferPair functionality for StringView

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -820,7 +820,7 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
     target.viewBuffer = transferBuffer(viewBuffer, target.allocator);
     target.dataBuffers = new ArrayList<>(dataBuffers.size());
     for (int i = 0; i < dataBuffers.size(); i++) {
-      target.dataBuffers.set(i, transferBuffer(dataBuffers.get(i), target.allocator));
+      target.dataBuffers.add(transferBuffer(dataBuffers.get(i), target.allocator));
     }
 
     target.setLastSet(this.lastSet);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -924,7 +924,7 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
   private void splitAndTransferViewBuffer(int startIndex, int length,
       BaseVariableWidthViewVector target) {
     final int start = startIndex * ELEMENT_SIZE;
-    final int end = length * ELEMENT_SIZE;
+    final int end = start + length * ELEMENT_SIZE;
 
     if (length == 0) {
       return;
@@ -940,7 +940,7 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
 
   private void splitAndTransferDataBuffers(int startIndex, int length,
       BaseVariableWidthViewVector target) {
-    for (int i = startIndex; i < length; i++) {
+    for (int i = startIndex; i < startIndex + length; i++) {
       final int stringLength = getValueLength(i);
       if (stringLength > INLINE_SIZE) {
         final int bufIndex = viewBuffer.getInt(((long) i * ELEMENT_SIZE) +

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -951,10 +951,6 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
       // keeping track of reading index in the source view buffer
       int readPosition = i * ELEMENT_SIZE;
 
-      // to clear the memory segment of view being written to
-      // this is helpful in case of overwriting the value
-      target.viewBuffer.setZero(writePosition, ELEMENT_SIZE);
-
       // set length
       target.viewBuffer.setInt(writePosition, stringLength);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -923,8 +923,8 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
 
   private void splitAndTransferViewBuffer(int startIndex, int length,
       BaseVariableWidthViewVector target) {
-    final int start = startIndex * ELEMENT_SIZE;
-    final int end = start + length * ELEMENT_SIZE;
+    final int startingByte = startIndex * ELEMENT_SIZE;
+    final int lengthInBytes = length * ELEMENT_SIZE;
 
     if (length == 0) {
       return;
@@ -934,7 +934,7 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector implem
       target.viewBuffer.getReferenceManager().release();
     }
 
-    final ArrowBuf slicedViewBuffer = viewBuffer.slice(start, end);
+    final ArrowBuf slicedViewBuffer = viewBuffer.slice(startingByte, lengthInBytes);
     target.viewBuffer = transferBuffer(slicedViewBuffer, target.allocator);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -257,9 +257,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector {
    */
   @Override
   public TransferPair getTransferPair(String ref, BufferAllocator allocator) {
-    // TODO: https://github.com/apache/arrow/issues/40932
-    throw new UnsupportedOperationException(
-        "ViewVarCharVector does not support getTransferPair(String, BufferAllocator)");
+    return new TransferImpl(ref, allocator);
   }
 
   /**
@@ -271,21 +269,53 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector {
    */
   @Override
   public TransferPair getTransferPair(Field field, BufferAllocator allocator) {
-    // TODO: https://github.com/apache/arrow/issues/40932
-    throw new UnsupportedOperationException(
-        "ViewVarCharVector does not support getTransferPair(Field, BufferAllocator)");
+    return new TransferImpl(field, allocator);
   }
 
   /**
    * Construct a TransferPair with a desired target vector of the same type.
    *
-   * @param target the target for the transfer
+   * @param to the target for the transfer
    * @return {@link TransferPair} (UnsupportedOperationException)
    */
   @Override
-  public TransferPair makeTransferPair(ValueVector target) {
-    // TODO: https://github.com/apache/arrow/issues/40932
-    throw new UnsupportedOperationException(
-        "ViewVarCharVector does not support makeTransferPair(ValueVector)");
+  public TransferPair makeTransferPair(ValueVector to) {
+    return new TransferImpl((ViewVarCharVector) to);
+  }
+
+  private class TransferImpl implements TransferPair {
+    ViewVarCharVector to;
+
+    public TransferImpl(String ref, BufferAllocator allocator) {
+      to = new ViewVarCharVector(ref, field.getFieldType(), allocator);
+    }
+
+    public TransferImpl(Field field, BufferAllocator allocator) {
+      to = new ViewVarCharVector(field, allocator);
+    }
+
+    public TransferImpl(ViewVarCharVector to) {
+      this.to = to;
+    }
+
+    @Override
+    public ViewVarCharVector getTo() {
+      return to;
+    }
+
+    @Override
+    public void transfer() {
+      transferTo(to);
+    }
+
+    @Override
+    public void splitAndTransfer(int startIndex, int length) {
+      splitAndTransferTo(startIndex, length, to);
+    }
+
+    @Override
+    public void copyValueSafe(int fromIndex, int toIndex) {
+      to.copyFromSafe(fromIndex, toIndex, ViewVarCharVector.this);
+    }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
@@ -225,7 +225,7 @@ public class TestSplitAndTransfer {
     }
   }
 
-  @Test /* ViewVarCharVector */
+  @Test
   public void testView() throws Exception {
     try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
       viewVarCharVector.allocateNew(10000, 1000);
@@ -285,7 +285,15 @@ public class TestSplitAndTransfer {
   @Test
   public void testMemoryConstrainedTransferInViews() {
     try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
-      allocator.setLimit(32768); /* set limit of 32KB */
+      // Here we have the target vector being transferred with a long string
+      // hence, the data buffer will be allocated.
+      // The default data buffer allocation takes
+      // BaseVariableWidthViewVector.INITIAL_VIEW_VALUE_ALLOCATION * BaseVariableWidthViewVector.ELEMENT_SIZE
+      // set limit = BaseVariableWidthViewVector.INITIAL_VIEW_VALUE_ALLOCATION *
+      // BaseVariableWidthViewVector.ELEMENT_SIZE
+      final int setLimit = BaseVariableWidthViewVector.INITIAL_VIEW_VALUE_ALLOCATION *
+          BaseVariableWidthViewVector.ELEMENT_SIZE;
+      allocator.setLimit(setLimit);
 
       viewVarCharVector.allocateNew(16000, 1000);
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
@@ -17,10 +17,11 @@
 
 package org.apache.arrow.vector;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -38,20 +39,19 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestSplitAndTransfer {
   private BufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void init() {
     allocator = new RootAllocator(Long.MAX_VALUE);
   }
 
-  @After
+  @AfterEach
   public void terminate() throws Exception {
     allocator.close();
   }
@@ -283,7 +283,7 @@ public class TestSplitAndTransfer {
   }
 
   @Test
-  public void testMemoryConstrainedTransferViews() {
+  public void testMemoryConstrainedTransferInViews() {
     try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
       allocator.setLimit(32768); /* set limit of 32KB */
 
@@ -338,6 +338,37 @@ public class TestSplitAndTransfer {
   }
 
   @Test
+  public void testTransferInViews() {
+    try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
+      viewVarCharVector.allocateNew(16000, 1000);
+
+      final int valueCount = 500;
+      final String[] compareArray = new String[valueCount];
+      populateViewVarcharVector(viewVarCharVector, valueCount, compareArray);
+
+      final TransferPair tp = viewVarCharVector.getTransferPair(allocator);
+      final ViewVarCharVector newViewVarCharVector = (ViewVarCharVector) tp.getTo();
+      tp.transfer();
+
+      assertEquals(0, viewVarCharVector.valueCount);
+      assertEquals(valueCount, newViewVarCharVector.valueCount);
+
+      for (int i = 0; i < valueCount; i++) {
+        final boolean expectedSet = (i % 3) == 0;
+        if (expectedSet) {
+          final byte[] expectedValue = compareArray[i].getBytes(StandardCharsets.UTF_8);
+          assertFalse(newViewVarCharVector.isNull(i));
+          assertArrayEquals(expectedValue, newViewVarCharVector.get(i));
+        } else {
+          assertTrue(newViewVarCharVector.isNull(i));
+        }
+      }
+
+      newViewVarCharVector.clear();
+    }
+  }
+
+  @Test
   public void testCopyValueSafe() {
     try (final VarCharVector varCharVector = new VarCharVector("myvector", allocator);
          final VarCharVector newVarCharVector = new VarCharVector("newvector", allocator)) {
@@ -386,6 +417,24 @@ public class TestSplitAndTransfer {
   }
 
   @Test
+  public void testSplitAndTransferNonInViews() {
+    try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
+
+      viewVarCharVector.allocateNew(16000, 1000);
+      final int valueCount = 500;
+      populateViewVarcharVector(viewVarCharVector, valueCount, null);
+
+      final TransferPair tp = viewVarCharVector.getTransferPair(allocator);
+      ViewVarCharVector newViewVarCharVector = (ViewVarCharVector) tp.getTo();
+
+      tp.splitAndTransfer(0, 0);
+      assertEquals(0, newViewVarCharVector.getValueCount());
+
+      newViewVarCharVector.clear();
+    }
+  }
+
+  @Test
   public void testSplitAndTransferAll() {
     try (final VarCharVector varCharVector = new VarCharVector("myvector", allocator)) {
 
@@ -404,6 +453,24 @@ public class TestSplitAndTransfer {
   }
 
   @Test
+  public void testSplitAndTransferAllInViews() {
+    try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
+
+      viewVarCharVector.allocateNew(16000, 1000);
+      final int valueCount = 500;
+      populateViewVarcharVector(viewVarCharVector, valueCount, null);
+
+      final TransferPair tp = viewVarCharVector.getTransferPair(allocator);
+      ViewVarCharVector newViewVarCharVector = (ViewVarCharVector) tp.getTo();
+
+      tp.splitAndTransfer(0, valueCount);
+      assertEquals(valueCount, newViewVarCharVector.getValueCount());
+
+      newViewVarCharVector.clear();
+    }
+  }
+
+  @Test
   public void testInvalidStartIndex() {
     try (final VarCharVector varCharVector = new VarCharVector("myvector", allocator);
         final VarCharVector newVarCharVector = new VarCharVector("newvector", allocator)) {
@@ -414,13 +481,34 @@ public class TestSplitAndTransfer {
 
       final TransferPair tp = varCharVector.makeTransferPair(newVarCharVector);
 
-      IllegalArgumentException e = Assertions.assertThrows(
+      IllegalArgumentException e = assertThrows(
           IllegalArgumentException.class,
           () -> tp.splitAndTransfer(valueCount, 10));
 
       assertEquals("Invalid parameters startIndex: 500, length: 10 for valueCount: 500", e.getMessage());
 
       newVarCharVector.clear();
+    }
+  }
+
+  @Test
+  public void testInvalidStartIndexInViews() {
+    try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator);
+        final ViewVarCharVector newViewVarCharVector = new ViewVarCharVector("newvector", allocator)) {
+
+      viewVarCharVector.allocateNew(16000, 1000);
+      final int valueCount = 500;
+      populateViewVarcharVector(viewVarCharVector, valueCount, null);
+
+      final TransferPair tp = viewVarCharVector.makeTransferPair(newViewVarCharVector);
+
+      IllegalArgumentException e = assertThrows(
+          IllegalArgumentException.class,
+          () -> tp.splitAndTransfer(valueCount, 10));
+
+      assertEquals("Invalid parameters startIndex: 500, length: 10 for valueCount: 500", e.getMessage());
+
+      newViewVarCharVector.clear();
     }
   }
 
@@ -435,13 +523,34 @@ public class TestSplitAndTransfer {
 
       final TransferPair tp = varCharVector.makeTransferPair(newVarCharVector);
 
-      IllegalArgumentException e = Assertions.assertThrows(
+      IllegalArgumentException e = assertThrows(
           IllegalArgumentException.class,
           () -> tp.splitAndTransfer(0, valueCount * 2));
 
       assertEquals("Invalid parameters startIndex: 0, length: 1000 for valueCount: 500", e.getMessage());
 
       newVarCharVector.clear();
+    }
+  }
+
+  @Test
+  public void testInvalidLengthInViews() {
+    try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator);
+        final ViewVarCharVector newViewVarCharVector = new ViewVarCharVector("newvector", allocator)) {
+
+      viewVarCharVector.allocateNew(16000, 1000);
+      final int valueCount = 500;
+      populateViewVarcharVector(viewVarCharVector, valueCount, null);
+
+      final TransferPair tp = viewVarCharVector.makeTransferPair(newViewVarCharVector);
+
+      IllegalArgumentException e = assertThrows(
+          IllegalArgumentException.class,
+          () -> tp.splitAndTransfer(0, valueCount * 2));
+
+      assertEquals("Invalid parameters startIndex: 0, length: 1000 for valueCount: 500", e.getMessage());
+
+      newViewVarCharVector.clear();
     }
   }
 
@@ -464,6 +573,24 @@ public class TestSplitAndTransfer {
   }
 
   @Test
+  public void testZeroStartIndexAndLengthInViews() {
+    try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator);
+        final ViewVarCharVector newViewVarCharVector = new ViewVarCharVector("newvector", allocator)) {
+
+      viewVarCharVector.allocateNew(0, 0);
+      final int valueCount = 0;
+      populateViewVarcharVector(viewVarCharVector, valueCount, null);
+
+      final TransferPair tp = viewVarCharVector.makeTransferPair(newViewVarCharVector);
+
+      tp.splitAndTransfer(0, 0);
+      assertEquals(valueCount, newViewVarCharVector.getValueCount());
+
+      newViewVarCharVector.clear();
+    }
+  }
+
+  @Test
   public void testZeroLength() {
     try (final VarCharVector varCharVector = new VarCharVector("myvector", allocator);
          final VarCharVector newVarCharVector = new VarCharVector("newvector", allocator)) {
@@ -478,6 +605,24 @@ public class TestSplitAndTransfer {
       assertEquals(0, newVarCharVector.getValueCount());
 
       newVarCharVector.clear();
+    }
+  }
+
+  @Test
+  public void testZeroLengthInViews() {
+    try (final ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator);
+        final ViewVarCharVector newViewVarCharVector = new ViewVarCharVector("newvector", allocator)) {
+
+      viewVarCharVector.allocateNew(16000, 1000);
+      final int valueCount = 500;
+      populateViewVarcharVector(viewVarCharVector, valueCount, null);
+
+      final TransferPair tp = viewVarCharVector.makeTransferPair(newViewVarCharVector);
+
+      tp.splitAndTransfer(500, 0);
+      assertEquals(0, newViewVarCharVector.getValueCount());
+
+      newViewVarCharVector.clear();
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
@@ -1738,14 +1738,14 @@ public class TestVarCharViewVector {
         final int dataRefCnt = sourceVector.getDataBuffer().refCnt();
 
         sourceVector.splitAndTransferTo(0, 2, targetVector);
-        // split and transfer with slice starting at the beginning:
-        // this should not allocate anything new (all are inline strings)
-        assertEquals(allocatedMem, allocator.getAllocatedMemory());
+        // we allocate view and data buffers for the target vector
+        assertTrue(allocatedMem < allocator.getAllocatedMemory());
 
         // The validity buffer is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
         // Therefore, the refcnt of the validity buffer is increased once since the startIndex is 0.
         assertEquals(validityRefCnt + 1, sourceVector.getValidityBuffer().refCnt());
-        assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
+        // since the new view buffer is allocated, the refcnt is the same as the source vector.
+        assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
       }
       assertArrayEquals(STR4, targetVector.get(0));
       assertArrayEquals(STR5, targetVector.get(1));
@@ -1774,14 +1774,18 @@ public class TestVarCharViewVector {
         final int dataRefCnt = sourceVector.getDataBuffer().refCnt();
 
         sourceVector.splitAndTransferTo(0, 2, targetVector);
-        // split and transfer with slice starting at the beginning:
-        // this should allocate new (first is a long string)
+        // we allocate view and data buffers for the target vector
         assertTrue(allocatedMem < allocator.getAllocatedMemory());
 
         // The validity buffer is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
         // Therefore, the refcnt of the validity buffer is increased once since the startIndex is 0.
         assertEquals(validityRefCnt + 1, sourceVector.getValidityBuffer().refCnt());
-        assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
+        // since the new view buffer is allocated, the refcnt is the same as the source vector.
+        assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
+
+        assertArrayEquals(STR2, sourceVector.get(0));
+        assertArrayEquals(STR5, sourceVector.get(1));
+        assertArrayEquals(STR6, sourceVector.get(2));
       }
       assertArrayEquals(STR2, targetVector.get(0));
       assertArrayEquals(STR5, targetVector.get(1));
@@ -1809,13 +1813,17 @@ public class TestVarCharViewVector {
         final int validityRefCnt = sourceVector.getValidityBuffer().refCnt();
         final int dataRefCnt = sourceVector.getDataBuffer().refCnt();
 
-        // split and transfer with slice starting at the beginning: this should not allocate anything new
         sourceVector.splitAndTransferTo(0, 2, targetVector);
-        assertEquals(allocatedMem, allocator.getAllocatedMemory());
+        // we allocate view and data buffers for the target vector
+        assertTrue(allocatedMem < allocator.getAllocatedMemory());
         // The validity buffer is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
         // Therefore, the refcnt of the validity buffer is increased once since the startIndex is 0.
         assertEquals(validityRefCnt + 1, sourceVector.getValidityBuffer().refCnt());
-        assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
+        // since the new view buffer is allocated, the refcnt is the same as the source vector.
+        assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
+
+        assertArrayEquals(STR4, targetVector.get(0));
+        assertArrayEquals(STR5, targetVector.get(1));
       }
       assertArrayEquals(STR4, sourceVector.get(0));
       assertArrayEquals(STR5, sourceVector.get(1));
@@ -1845,13 +1853,16 @@ public class TestVarCharViewVector {
         final int dataRefCnt = sourceVector.getDataBuffer().refCnt();
 
         sourceVector.splitAndTransferTo(0, 2, targetVector);
-        // split and transfer with slice starting at the beginning:
-        // this should allocate new (first is a long string)
+        // we allocate view and data buffers for the target vector
         assertTrue(allocatedMem < allocator.getAllocatedMemory());
         // The validity buffer is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
         // Therefore, the refcnt of the validity buffer is increased once since the startIndex is 0.
         assertEquals(validityRefCnt + 1, sourceVector.getValidityBuffer().refCnt());
-        assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
+        // since the new view buffer is allocated, the refcnt is the same as the source vector.
+        assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
+
+        assertArrayEquals(STR2, targetVector.get(0));
+        assertArrayEquals(STR5, targetVector.get(1));
       }
       assertArrayEquals(STR2, sourceVector.get(0));
       assertArrayEquals(STR5, sourceVector.get(1));
@@ -1887,14 +1898,22 @@ public class TestVarCharViewVector {
       final long validitySize =
           DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY.getRoundedSize(
               BaseValueVector.getValidityBufferSizeFromCount(2));
-      assertEquals(allocatedMem + validitySize, allocator.getAllocatedMemory());
+      // we allocate view and data buffers for the target vector
+      assertTrue(allocatedMem + validitySize < allocator.getAllocatedMemory());
       // The validity is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
       // Since values up to the startIndex are empty/null validity refcnt should not change.
       assertEquals(validityRefCnt, sourceVector.getValidityBuffer().refCnt());
-      assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
+      // since the new view buffer is allocated, the refcnt is the same as the source vector.
+      assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
 
       assertArrayEquals(STR4, targetVector.get(0));
       assertArrayEquals(STR5, targetVector.get(1));
+
+      assertArrayEquals(new byte[0], sourceVector.get(0));
+      assertTrue(sourceVector.isNull(1));
+      assertArrayEquals(STR4, sourceVector.get(2));
+      assertArrayEquals(STR5, sourceVector.get(3));
+      assertArrayEquals(STR6, sourceVector.get(4));
     }
   }
 
@@ -1927,14 +1946,22 @@ public class TestVarCharViewVector {
       final long validitySize =
           DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY.getRoundedSize(
               BaseValueVector.getValidityBufferSizeFromCount(2));
+      // we allocate view and data buffers for the target vector
       assertTrue(allocatedMem + validitySize < allocator.getAllocatedMemory());
       // The validity is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
       // Since values up to the startIndex are empty/null validity refcnt should not change.
       assertEquals(validityRefCnt, sourceVector.getValidityBuffer().refCnt());
-      assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
+      // since the new view buffer is allocated, the refcnt is the same as the source vector.
+      assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
 
       assertArrayEquals(STR1, targetVector.get(0));
       assertArrayEquals(STR2, targetVector.get(1));
+
+      assertArrayEquals(new byte[0], sourceVector.get(0));
+      assertTrue(sourceVector.isNull(1));
+      assertArrayEquals(STR1, sourceVector.get(2));
+      assertArrayEquals(STR2, sourceVector.get(3));
+      assertArrayEquals(STR3, sourceVector.get(4));
     }
   }
 
@@ -1946,9 +1973,10 @@ public class TestVarCharViewVector {
    */
   @Test
   public void testSplitAndTransfer7() {
-    try (final BufferAllocator targetAllocator = allocator.newChildAllocator("target-alloc", 256, 256);
+    final int maxAllocation = 512;
+    try (final BufferAllocator targetAllocator = allocator.newChildAllocator("target-alloc", 256, maxAllocation);
         final ViewVarCharVector targetVector = newViewVarCharVector("split-target", targetAllocator)) {
-      try (final BufferAllocator sourceAllocator = allocator.newChildAllocator("source-alloc", 256, 256);
+      try (final BufferAllocator sourceAllocator = allocator.newChildAllocator("source-alloc", 256, maxAllocation);
           final ViewVarCharVector sourceVector = newViewVarCharVector(EMPTY_SCHEMA_PATH, sourceAllocator)) {
         sourceVector.allocateNew(50, 3);
 
@@ -1961,15 +1989,19 @@ public class TestVarCharViewVector {
         final int validityRefCnt = sourceVector.getValidityBuffer().refCnt();
         final int dataRefCnt = sourceVector.getDataBuffer().refCnt();
 
-        // split and transfer with slice starting at the beginning:
-        // this should not allocate anything new
         sourceVector.splitAndTransferTo(0, 2, targetVector);
+        // no extra allocation as strings are all inline
         assertEquals(allocatedMem, allocator.getAllocatedMemory());
-        // Unlike testSplitAndTransfer1 where the buffers originated from the same allocator,
+
         // the refcnts of each buffer for this test should be the same as what
         // the source allocator ended up with.
         assertEquals(validityRefCnt, sourceVector.getValidityBuffer().refCnt());
+        // since the new view buffer is allocated, the refcnt is the same as the source vector.
         assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
+
+        assertArrayEquals(STR4, sourceVector.get(0));
+        assertArrayEquals(STR5, sourceVector.get(1));
+        assertArrayEquals(STR6, sourceVector.get(2));
       }
       assertArrayEquals(STR4, targetVector.get(0));
       assertArrayEquals(STR5, targetVector.get(1));
@@ -1985,6 +2017,10 @@ public class TestVarCharViewVector {
   @Test
   public void testSplitAndTransfer8() {
     final int initialReservation = 1024;
+    // Here we have the target vector being transferred with a long string
+    // hence, the data buffer will be allocated.
+    // The default data buffer allocation takes
+    // BaseVariableWidthViewVector.INITIAL_VIEW_VALUE_ALLOCATION * BaseVariableWidthViewVector.ELEMENT_SIZE
     final int maxAllocation = initialReservation +
         BaseVariableWidthViewVector.INITIAL_VIEW_VALUE_ALLOCATION * BaseVariableWidthViewVector.ELEMENT_SIZE;
     try (final BufferAllocator targetAllocator = allocator.newChildAllocator("target-alloc",
@@ -2004,15 +2040,19 @@ public class TestVarCharViewVector {
         final int validityRefCnt = sourceVector.getValidityBuffer().refCnt();
         final int dataRefCnt = sourceVector.getDataBuffer().refCnt();
 
-        // split and transfer with slice starting at the beginning:
-        // this should not allocate anything new
         sourceVector.splitAndTransferTo(0, 2, targetVector);
+        // we allocate view and data buffers for the target vector
         assertTrue(allocatedMem < allocator.getAllocatedMemory());
-        // Unlike testSplitAndTransfer1 where the buffers originated from the same allocator,
+
         // the refcnts of each buffer for this test should be the same as what
         // the source allocator ended up with.
         assertEquals(validityRefCnt, sourceVector.getValidityBuffer().refCnt());
+        // since the new view buffer is allocated, the refcnt is the same as the source vector.
         assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
+
+        assertArrayEquals(STR1, sourceVector.get(0));
+        assertArrayEquals(STR2, sourceVector.get(1));
+        assertArrayEquals(STR3, sourceVector.get(2));
       }
       assertArrayEquals(STR1, targetVector.get(0));
       assertArrayEquals(STR2, targetVector.get(1));
@@ -2119,6 +2159,56 @@ public class TestVarCharViewVector {
       }
 
       toVector.close();
+    }
+  }
+
+  /**
+   * ARROW-7831:
+   * ensures that data is transferred from one allocator to another in case of 0-index
+   * start special cases.
+   * With long strings and multiple data buffers.
+   * Check multi-data buffer source copying
+   */
+  @Test
+  public void testSplitAndTransfer9() {
+    try (final ViewVarCharVector targetVector = new ViewVarCharVector("target", allocator)) {
+      String str4 = generateRandomString(35);
+      try (final ViewVarCharVector sourceVector = new ViewVarCharVector("source", allocator)) {
+        sourceVector.allocateNew(48, 4);
+
+        sourceVector.set(0, STR1);
+        sourceVector.set(1, STR2);
+        sourceVector.set(2, STR3);
+        sourceVector.set(3, str4.getBytes(StandardCharsets.UTF_8));
+        sourceVector.setValueCount(4);
+
+        // we should have multiple data buffers
+        assertTrue(sourceVector.getDataBuffers().size() > 1);
+
+        final long allocatedMem = allocator.getAllocatedMemory();
+        final int validityRefCnt = sourceVector.getValidityBuffer().refCnt();
+        final int dataRefCnt = sourceVector.getDataBuffer().refCnt();
+
+        // split and transfer with slice starting at the beginning:
+        // this should not allocate anything new
+        sourceVector.splitAndTransferTo(1, 3, targetVector);
+        // we allocate view and data buffers for the target vector
+        assertTrue(allocatedMem < allocator.getAllocatedMemory());
+
+        // the refcnts of each buffer for this test should be the same as what
+        // the source allocator ended up with.
+        assertEquals(validityRefCnt, sourceVector.getValidityBuffer().refCnt());
+        // since the new view buffer is allocated, the refcnt is the same as the source vector.
+        assertEquals(dataRefCnt, sourceVector.getDataBuffer().refCnt());
+
+        assertArrayEquals(STR1, sourceVector.get(0));
+        assertArrayEquals(STR2, sourceVector.get(1));
+        assertArrayEquals(STR3, sourceVector.get(2));
+        assertArrayEquals(str4.getBytes(StandardCharsets.UTF_8), sourceVector.get(3));
+      }
+      assertArrayEquals(STR2, targetVector.get(0));
+      assertArrayEquals(STR3, targetVector.get(1));
+      assertArrayEquals(str4.getBytes(StandardCharsets.UTF_8), targetVector.get(2));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
@@ -1720,6 +1720,7 @@ public class TestVarCharViewVector {
    * ARROW-7831:
    * this checks a slice taken off a buffer is still readable
    * after that buffer's allocator is closed.
+   * With short strings.
    */
   @Test
   public void testSplitAndTransfer1() {
@@ -1751,6 +1752,12 @@ public class TestVarCharViewVector {
     }
   }
 
+  /**
+   * ARROW-7831:
+   * this checks a slice taken off a buffer is still readable
+   * after that buffer's allocator is closed.
+   * With a long string included.
+   */
   @Test
   public void testSplitAndTransfer2() {
     try (final ViewVarCharVector targetVector = newViewVarCharVector("split-target", allocator)) {
@@ -1785,6 +1792,7 @@ public class TestVarCharViewVector {
    * ARROW-7831:
    * this checks a vector that got sliced
    * is still readable after the slice's allocator got closed.
+   * With short strings.
    */
   @Test
   public void testSplitAndTransfer3() {
@@ -1819,6 +1827,7 @@ public class TestVarCharViewVector {
    * ARROW-7831:
    * this checks a vector that got sliced
    * is still readable after the slice's allocator got closed.
+   * With a long string included.
    */
   @Test
   public void testSplitAndTransfer4() {
@@ -1854,7 +1863,7 @@ public class TestVarCharViewVector {
    * ARROW-7831:
    * this checks a validity splitting where the validity buffer is sliced from the same buffer.
    * In the case where all the values up to the start of the slice are null/empty.
-   * We check short strings here.
+   * With short strings.
    */
   @Test
   public void testSplitAndTransfer5() {
@@ -1880,6 +1889,7 @@ public class TestVarCharViewVector {
               BaseValueVector.getValidityBufferSizeFromCount(2));
       assertEquals(allocatedMem + validitySize, allocator.getAllocatedMemory());
       // The validity is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
+      // Since values up to the startIndex are empty/null validity refcnt should not change.
       assertEquals(validityRefCnt, sourceVector.getValidityBuffer().refCnt());
       assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
 
@@ -1892,7 +1902,7 @@ public class TestVarCharViewVector {
    * ARROW-7831:
    * this checks a validity splitting where the validity buffer is sliced from the same buffer.
    * In the case where all the values up to the start of the slice are null/empty.
-   * We check long strings here.
+   * With long strings.
    */
   @Test
   public void testSplitAndTransfer6() {
@@ -1919,6 +1929,7 @@ public class TestVarCharViewVector {
               BaseValueVector.getValidityBufferSizeFromCount(2));
       assertTrue(allocatedMem + validitySize < allocator.getAllocatedMemory());
       // The validity is sliced from the same buffer.See BaseFixedWidthViewVector#allocateBytes.
+      // Since values up to the startIndex are empty/null validity refcnt should not change.
       assertEquals(validityRefCnt, sourceVector.getValidityBuffer().refCnt());
       assertEquals(dataRefCnt + 1, sourceVector.getDataBuffer().refCnt());
 
@@ -1931,7 +1942,7 @@ public class TestVarCharViewVector {
    * ARROW-7831:
    * ensures that data is transferred from one allocator to another in case of 0-index
    * start special cases.
-   * We check short strings here.
+   * With short strings.
    */
   @Test
   public void testSplitAndTransfer7() {
@@ -1969,7 +1980,7 @@ public class TestVarCharViewVector {
    * ARROW-7831:
    * ensures that data is transferred from one allocator to another in case of 0-index
    * start special cases.
-   * We check long strings here.
+   * With long strings.
    */
   @Test
   public void testSplitAndTransfer8() {


### PR DESCRIPTION
### Rationale for this change

StringView implementation requires transferPair functionality which is required for C Data interface implementation as well. 

### What changes are included in this PR?

Adding transferPair functionality and corresponding test cases. 

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: apache/arrow#40932
* GitHub Issue: #40932