### PR TITLE
GH-41723: [C++][Python][Acero] move group_id_array to 0 position in ha…

### DIFF
--- a/cpp/src/arrow/acero/aggregate_internal.cc
+++ b/cpp/src/arrow/acero/aggregate_internal.cc
@@ -58,8 +58,8 @@ namespace aggregate {
 std::vector<TypeHolder> ExtendWithGroupIdType(const std::vector<TypeHolder>& in_types) {
   std::vector<TypeHolder> aggr_in_types;
   aggr_in_types.reserve(in_types.size() + 1);
-  aggr_in_types = in_types;
   aggr_in_types.emplace_back(uint32());
+  aggr_in_types.insert(++aggr_in_types.begin(), in_types.begin(), in_types.end());
   return aggr_in_types;
 }
 

--- a/cpp/src/arrow/acero/groupby_aggregate_node.cc
+++ b/cpp/src/arrow/acero/groupby_aggregate_node.cc
@@ -240,10 +240,11 @@ Status GroupByNode::Consume(ExecSpan batch) {
     kernel_ctx.SetState(state->agg_states[i].get());
 
     std::vector<ExecValue> column_values;
+    column_values.reserve(agg_src_fieldsets_.size() + 1);
+    column_values.push_back(*id_batch.array());
     for (const int field : agg_src_fieldsets_[i]) {
       column_values.push_back(batch[field]);
     }
-    column_values.emplace_back(*id_batch.array());
     ExecSpan agg_batch(std::move(column_values), batch.length);
     RETURN_NOT_OK(agg_kernels_[i]->resize(&kernel_ctx, state->grouper->num_groups()));
     RETURN_NOT_OK(agg_kernels_[i]->consume(&kernel_ctx, agg_batch));


### PR DESCRIPTION
…sh aggregate function & kernel signature.

### Rationale for this change

Current implementation does not allow for resolution of hash aggregate kernel with signature containing var args example {int64...}.
The resolution fails because a uint32 (group_id_array) is appended to the argument list of the kernel signature {int64...} -> {int64...,uint32}.

This PR modify the ordering and moves the group_id_array to position 0, allowing for resolution of hash aggregate function with var args.

This simplify implementation of kernel of type:
sum(product(x,y))
sum(product(x,y,z))

into a single kernel

sum(product(x...))

### What changes are included in this PR?

### Are these changes tested?

Yes previous test covers existing hash aggregate kernels.

A test verifiying a valid Declaration can be produced with a var args hash aggregate is added.

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.** 

This should not break public APIs (to my knowledge), tough there is an api leak in python wrapper (python/pyarrow/src/arrow/python/udf.cc).
* GitHub Issue: #41723