### PR TITLE
MINOR: [Java] Fix develocity cache directory name in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,4 @@ __debug_bin
 .envrc
 
 # Develocity
-.mvn/.develocity.xml
+.mvn/.develocity/


### PR DESCRIPTION
### Rationale for this change

`.gitignore` is not referencing correctly the develocity cache directory

### What changes are included in this PR?

Changing from `.mvn/.develocity.xml` to `.mvn/.develocity/`

### Are these changes tested?

No (Checking local git output)

### Are there any user-facing changes?

No