### PR TITLE
GH-41791: [CI][Conda] Update azure.linux.yml task, replace CondaEnvironment@1 with Bash@3

### DIFF
--- a/dev/tasks/conda-recipes/azure.linux.yml
+++ b/dev/tasks/conda-recipes/azure.linux.yml
@@ -46,12 +46,6 @@ jobs:
 
   {{ macros.azure_checkout_arrow() }}
 
-  - task: CondaEnvironment@1
-    inputs:
-      packageSpecs: 'anaconda-client shyaml'
-      installOptions: '-c conda-forge'
-      updateConda: false
-
   - script: |
       mkdir build_artifacts
       CI=azure arrow/dev/tasks/conda-recipes/run_docker_build.sh $(pwd)/build_artifacts

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -224,6 +224,8 @@ env:
       conda create -y -n azure_upload_anaconda -c conda-forge anaconda-client
       source activate azure_upload_anaconda
       anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force {{ pattern }}
+    displayName: Upload packages to Anaconda
+
   {% endif %}
 {% endmacro %}
 

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -221,9 +221,9 @@ env:
 {%- macro azure_upload_anaconda(pattern) -%}
   {%- if arrow.is_default_branch() -%}
   - bash: |
-        conda create -y -n azure_upload_anaconda -c conda-forge anaconda-client
-        source activate azure_upload_anaconda
-        anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force {{ pattern }}
+      conda create -y -n azure_upload_anaconda -c conda-forge anaconda-client
+      source activate azure_upload_anaconda
+      anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force {{ pattern }}
   {% endif %}
 {% endmacro %}
 

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -220,12 +220,9 @@ env:
 
 {%- macro azure_upload_anaconda(pattern) -%}
   {%- if arrow.is_default_branch() -%}
-  - task: Bash@3
-    inputs:
-      targetType: inline
-      script: |
+  - bash: |
         conda create -y -n azure_upload_anaconda -c conda-forge anaconda-client
-        conda activate azure_upload_anaconda
+        source activate azure_upload_anaconda
         anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force {{ pattern }}
   {% endif %}
 {% endmacro %}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -220,15 +220,13 @@ env:
 
 {%- macro azure_upload_anaconda(pattern) -%}
   {%- if arrow.is_default_branch() -%}
-  - task: CondaEnvironment@1
+  - task: Bash@3
     inputs:
-      packageSpecs: 'anaconda-client'
-      installOptions: '-c conda-forge'
-      updateConda: no
-  - script: |
-      conda install -y anaconda-client
-      anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force {{ pattern }}
-    displayName: Upload packages to Anaconda
+      targetType: inline
+      script: |
+        conda create -y -n azure_upload_anaconda -c conda-forge anaconda-client
+        conda activate azure_upload_anaconda
+        anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force {{ pattern }}
   {% endif %}
 {% endmacro %}
 
@@ -407,4 +405,3 @@ env:
   {{ key }}: "{{ value }}"
   {% endfor %}
 {% endmacro %}
-


### PR DESCRIPTION
### What changes are included in this PR?


- Updated azure.linux.yml task to remove what looks like an unneeded step
- Updated macros.ninja to replace use of CondaEnvironment@1 with an equivalent Bash@3 task

### Are these changes tested?

Testing in CI.

### Are there any user-facing changes?

No
* GitHub Issue: #41791