### PR TITLE
GH-41662: [Python] Ensure Buffer methods don't crash with non-CPU data

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1435,7 +1435,7 @@ cdef class Buffer(_Weakrefable):
                 "Device on which the data resides differs between buffers: "
                 f"{self.device.type_name} and {other.device.type_name}."
             )
-        if not self.is_cpu and not other.is_cpu:
+        if not self.is_cpu:
             if self.address != other.address:
                 raise NotImplementedError(
                     "Implemented only for data on CPU device or data with equal "

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1431,6 +1431,9 @@ cdef class Buffer(_Weakrefable):
         are_equal : bool
             True if buffer contents and size are equal
         """
+        self._assert_cpu()
+        other._assert_cpu()
+
         cdef c_bool result = False
         with nogil:
             result = self.buffer.get().Equals(deref(other.buffer.get()))

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1375,8 +1375,6 @@ cdef class Buffer(_Weakrefable):
             return pyarrow_wrap_buffer(parent_buf)
 
     def __getitem__(self, key):
-        self._assert_cpu()
-
         if isinstance(key, slice):
             if (key.step or 1) != 1:
                 raise IndexError('only slices with step 1 supported')
@@ -1385,6 +1383,7 @@ cdef class Buffer(_Weakrefable):
         return self.getitem(_normalize_index(key, self.size))
 
     cdef getitem(self, int64_t i):
+        self._assert_cpu()
         return self.buffer.get().data()[i]
 
     def slice(self, offset=0, length=None):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1470,6 +1470,8 @@ cdef class Buffer(_Weakrefable):
             self.buffer.get().size())
 
     def __getbuffer__(self, cp.Py_buffer* buffer, int flags):
+        self._assert_cpu()
+
         if self.buffer.get().is_mutable():
             buffer.readonly = 0
         else:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1286,6 +1286,10 @@ cdef class Buffer(_Weakrefable):
                 f"is_cpu={self.is_cpu} "
                 f"is_mutable={self.is_mutable}>")
 
+    def _assert_cpu(self):
+        if not self.is_cpu:
+            raise NotImplementedError("Implemented only for data on CPU device")
+
     @property
     def size(self):
         """
@@ -1311,10 +1315,8 @@ cdef class Buffer(_Weakrefable):
         -------
         : bytes
         """
-        if self.is_cpu:
-            return self.buffer.get().ToHexString()
-        else:
-            raise NotImplementedError("Implemented only for data on CPU device")
+        self._assert_cpu()
+        return self.buffer.get().ToHexString()
 
     @property
     def is_mutable(self):
@@ -1373,8 +1375,7 @@ cdef class Buffer(_Weakrefable):
             return pyarrow_wrap_buffer(parent_buf)
 
     def __getitem__(self, key):
-        if not self.is_cpu:
-            raise NotImplementedError("Implemented only for data on CPU device")
+        self._assert_cpu()
 
         if isinstance(key, slice):
             if (key.step or 1) != 1:
@@ -1442,8 +1443,8 @@ cdef class Buffer(_Weakrefable):
             return self.equals(py_buffer(other))
 
     def __reduce_ex__(self, protocol):
-        if not self.is_cpu:
-            raise NotImplementedError("Implemented only for data on CPU device")
+        self._assert_cpu()
+
         if protocol >= 5:
             bufobj = pickle.PickleBuffer(self)
         elif self.buffer.get().is_mutable():

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1430,11 +1430,17 @@ cdef class Buffer(_Weakrefable):
         are_equal : bool
             True if buffer contents and size are equal
         """
+        if self.device != other.device:
+            raise ValueError(
+                "Device on which the data resides differs between buffers: "
+                f"{self.device.type_name} and {other.device.type_name}."
+            )
         if not self.is_cpu and not other.is_cpu:
             if self.address != other.address:
                 raise NotImplementedError(
-                    "Implemented only for data on CPU device or data with equal addresses"
-                    )
+                    "Implemented only for data on CPU device or data with equal "
+                    "addresses"
+                )
 
         cdef c_bool result = False
         with nogil:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1442,6 +1442,8 @@ cdef class Buffer(_Weakrefable):
             return self.equals(py_buffer(other))
 
     def __reduce_ex__(self, protocol):
+        if not self.is_cpu:
+            raise NotImplementedError("Implemented only for data on CPU device")
         if protocol >= 5:
             bufobj = pickle.PickleBuffer(self)
         elif self.buffer.get().is_mutable():

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1461,6 +1461,8 @@ cdef class Buffer(_Weakrefable):
         """
         Return this buffer as a Python bytes object. Memory is copied.
         """
+        self._assert_cpu()
+
         return cp.PyBytes_FromStringAndSize(
             <const char*>self.buffer.get().data(),
             self.buffer.get().size())

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1311,7 +1311,7 @@ cdef class Buffer(_Weakrefable):
         -------
         : bytes
         """
-        if (self.is_cpu):
+        if self.is_cpu:
             return self.buffer.get().ToHexString()
         else:
             raise NotImplementedError("Implemented only for data on CPU device")
@@ -1373,7 +1373,7 @@ cdef class Buffer(_Weakrefable):
             return pyarrow_wrap_buffer(parent_buf)
 
     def __getitem__(self, key):
-        if (not self.is_cpu):
+        if not self.is_cpu:
             raise NotImplementedError("Implemented only for data on CPU device")
 
         if isinstance(key, slice):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1430,8 +1430,11 @@ cdef class Buffer(_Weakrefable):
         are_equal : bool
             True if buffer contents and size are equal
         """
-        self._assert_cpu()
-        other._assert_cpu()
+        if not self.is_cpu and not other.is_cpu:
+            if self.address != other.address:
+                raise NotImplementedError(
+                    "Implemented only for data on CPU device or data with equal addresses"
+                    )
 
         cdef c_bool result = False
         with nogil:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1311,7 +1311,10 @@ cdef class Buffer(_Weakrefable):
         -------
         : bytes
         """
-        return self.buffer.get().ToHexString()
+        if (self.is_cpu):
+            return self.buffer.get().ToHexString()
+        else:
+            raise NotImplementedError("Implemented only for data on CPU device")
 
     @property
     def is_mutable(self):
@@ -1370,6 +1373,9 @@ cdef class Buffer(_Weakrefable):
             return pyarrow_wrap_buffer(parent_buf)
 
     def __getitem__(self, key):
+        if (not self.is_cpu):
+            raise NotImplementedError("Implemented only for data on CPU device")
+
         if isinstance(key, slice):
             if (key.step or 1) != 1:
                 raise IndexError('only slices with step 1 supported')

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -313,7 +313,8 @@ def test_CudaBuffer(size):
         assert cbuf[s].to_pybytes() == arr[s].tobytes()
 
     sbuf = cbuf.slice(size//4, size//2)
-    assert sbuf.parent == cbuf
+    cbuf_parent = cuda.CudaBuffer.from_buffer(sbuf.parent)
+    assert cbuf_parent.to_pybytes() == cbuf.to_pybytes()
 
     with pytest.raises(TypeError,
                        match="Do not call CudaBuffer's constructor directly"):

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -313,8 +313,7 @@ def test_CudaBuffer(size):
         assert cbuf[s].to_pybytes() == arr[s].tobytes()
 
     sbuf = cbuf.slice(size//4, size//2)
-    cbuf_parent = cuda.CudaBuffer.from_buffer(sbuf.parent)
-    assert cbuf_parent.to_pybytes() == cbuf.to_pybytes()
+    assert sbuf.parent == cbuf
 
     with pytest.raises(TypeError,
                        match="Do not call CudaBuffer's constructor directly"):

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -693,7 +693,22 @@ def test_non_cpu_buffer():
     with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu[1]
 
-    # TODO: test slice() and to_pybytes() on binary data
+    buf = pa.py_buffer(b'testing')
+    arr_offsets = pa.array([0, 7], type=pa.int32())
+    offsets_buf = arr_offsets.buffers()[1]
+    arr = pa.BinaryArray.from_buffers(pa.binary(), 1, [None, offsets_buf, buf])
+
+    buf_on_gpu = arr.buffers()[2]
+    buf_on_gpu_sliced = buf_on_gpu.slice(2)
+
+    buf = pa.py_buffer(b'sting')
+    arr_offsets = pa.array([0, 5], type=pa.int32())
+    offsets_buf = arr_offsets.buffers()[1]
+    arr = pa.BinaryArray.from_buffers(pa.binary(), 1, [None, offsets_buf, buf])
+
+    buf_on_gpu_expected = arr.buffers()[2]
+
+    assert buf_on_gpu_sliced.to_pybytes() == buf_on_gpu_expected.to_pybytes()
 
 
 def test_cache_options():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -684,6 +684,11 @@ def test_non_cpu_buffer():
     assert buf_on_gpu.address == cuda_buf.address
     assert buf_on_gpu.is_cpu == cuda_buf.is_cpu
 
+    repr1 = "<pyarrow.Buffer address="
+    repr2 = "size=16 is_cpu=False is_mutable=True>"
+    assert repr1 in repr(buf_on_gpu)
+    assert repr2 in repr(buf_on_gpu)
+
     msg = "Implemented only for data on CPU device"
     with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu.hex()
@@ -708,6 +713,8 @@ def test_non_cpu_buffer():
 
     buf_on_gpu_expected = arr.buffers()[2]
 
+    assert buf_on_gpu_sliced.equals(buf_on_gpu_expected)
+    assert buf.equals(buf_on_gpu_expected)
     assert buf_on_gpu_sliced.to_pybytes() == buf_on_gpu_expected.to_pybytes()
 
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -688,6 +688,8 @@ def test_non_cpu_buffer(pickle_module):
     assert repr1 in repr(buf_on_gpu)
     assert repr2 in repr(buf_on_gpu)
 
+    assert buf_on_gpu.equals(cuda_buf)
+
     msg = "Implemented only for data on CPU device"
     with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu.hex()
@@ -705,6 +707,9 @@ def test_non_cpu_buffer(pickle_module):
 
     with pytest.raises(NotImplementedError, match=msg):
         pickle_module.dumps(buf_on_gpu, protocol=4)
+
+    with pytest.raises(NotImplementedError, match=msg):
+        pickle_module.dumps(cuda_buf, protocol=4)
 
     buf = pa.py_buffer(b'testing')
     arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, buf])

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -692,7 +692,7 @@ def test_non_cpu_buffer(pickle_module):
     cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
     assert cuda_sliced.to_pybytes() == b'sting'
 
-    buf_on_gpu_sliced = buf_on_gpu[slice(2, 4, 1)]
+    buf_on_gpu_sliced = buf_on_gpu[2:4]
     cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
     assert cuda_sliced.to_pybytes() == b'st'
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -673,10 +673,9 @@ def test_non_cpu_buffer(pickle_module):
     cuda = pytest.importorskip("pyarrow.cuda")
     ctx = cuda.Context(0)
 
-    arr = np.arange(4, dtype=np.int32)
+    arr = np.array([b'testing'])
     cuda_buf = ctx.buffer_from_data(arr)
-
-    arr = pa.Array.from_buffers(pa.int32(), 4, [None, cuda_buf])
+    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, cuda_buf])
     buf_on_gpu = arr.buffers()[1]
 
     assert buf_on_gpu.size == cuda_buf.size
@@ -685,7 +684,7 @@ def test_non_cpu_buffer(pickle_module):
     assert buf_on_gpu.is_mutable
 
     repr1 = "<pyarrow.Buffer address="
-    repr2 = "size=16 is_cpu=False is_mutable=True>"
+    repr2 = "size=7 is_cpu=False is_mutable=True>"
     assert repr1 in repr(buf_on_gpu)
     assert repr2 in repr(buf_on_gpu)
 
@@ -713,11 +712,6 @@ def test_non_cpu_buffer(pickle_module):
 
     with pytest.raises(NotImplementedError, match=msg):
         pickle_module.dumps(cuda_buf, protocol=4)
-
-    arr = np.array([b'testing'])
-    cuda_buf = ctx.buffer_from_data(arr)
-    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, cuda_buf])
-    buf_on_gpu = arr.buffers()[1]
 
     buf_on_gpu_sliced = buf_on_gpu.slice(2)
     cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -673,8 +673,8 @@ def test_non_cpu_buffer(pickle_module):
     cuda = pytest.importorskip("pyarrow.cuda")
     ctx = cuda.Context(0)
 
-    arr = np.array([b'testing'])
-    cuda_buf = ctx.buffer_from_data(arr)
+    data = np.array([b'testing'])
+    cuda_buf = ctx.buffer_from_data(data)
     arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, cuda_buf])
     buf_on_gpu = arr.buffers()[1]
 
@@ -699,8 +699,12 @@ def test_non_cpu_buffer(pickle_module):
     # Sliced buffers with same address
     assert buf_on_gpu_sliced.equals(cuda_buf[2:4])
 
-    msg = "Implemented only for data on CPU device"
+    # Buffers on different devices
+    msg_device = "Device on which the data resides differs between buffers"
+    with pytest.raises(ValueError, match=msg_device):
+        buf_on_gpu.equals(pa.py_buffer(data))
 
+    msg = "Implemented only for data on CPU device"
     # Buffers with different addresses
     arr_short = np.array([b'sting'])
     cuda_buf_short = ctx.buffer_from_data(arr_short)

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -697,7 +697,7 @@ def test_non_cpu_buffer(pickle_module):
     assert cuda_sliced.to_pybytes() == b'st'
 
     # Sliced buffers with same address
-    assert buf_on_gpu.equals(cuda_buf)
+    assert buf_on_gpu_sliced.equals(cuda_buf[2:4])
 
     msg = "Implemented only for data on CPU device"
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -688,6 +688,14 @@ def test_non_cpu_buffer(pickle_module):
     assert repr1 in repr(buf_on_gpu)
     assert repr2 in repr(buf_on_gpu)
 
+    buf_on_gpu_sliced = buf_on_gpu.slice(2)
+    cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
+    assert cuda_sliced.to_pybytes() == b'sting'
+
+    buf_on_gpu_sliced = buf_on_gpu[slice(2, 4, 1)]
+    cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
+    assert cuda_sliced.to_pybytes() == b'st'
+
     msg = "Implemented only for data on CPU device"
     with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu.equals(cuda_buf)
@@ -713,13 +721,8 @@ def test_non_cpu_buffer(pickle_module):
     with pytest.raises(NotImplementedError, match=msg):
         pickle_module.dumps(cuda_buf, protocol=4)
 
-    buf_on_gpu_sliced = buf_on_gpu.slice(2)
-    cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
-    assert cuda_sliced.to_pybytes() == b'sting'
-
-    buf_on_gpu_sliced = buf_on_gpu[slice(2,4,1)]
-    cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
-    assert cuda_sliced.to_pybytes() == b'st'
+    with pytest.raises(NotImplementedError, match=msg):
+        memoryview(buf_on_gpu)
 
 
 def test_cache_options():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -707,7 +707,7 @@ def test_non_cpu_buffer(pickle_module):
     with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu_sliced.equals(cuda_buf_short)
     arr_short = pa.FixedSizeBinaryArray.from_buffers(
-        pa.binary(5), 1,[None, cuda_buf_short]
+        pa.binary(5), 1, [None, cuda_buf_short]
     )
     buf_on_gpu_short = arr_short.buffers()[1]
     with pytest.raises(NotImplementedError, match=msg):

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -700,20 +700,17 @@ def test_non_cpu_buffer():
     with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu[1]
 
-    buf = pa.py_buffer(b'testing')
-    arr_offsets = pa.array([0, 7], type=pa.int32())
-    offsets_buf = arr_offsets.buffers()[1]
-    arr = pa.BinaryArray.from_buffers(pa.binary(), 1, [None, offsets_buf, buf])
+    with pytest.raises(NotImplementedError, match=msg):
+        cuda_buf[1]
 
-    buf_on_gpu = arr.buffers()[2]
+    buf = pa.py_buffer(b'testing')
+    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, buf])
+    buf_on_gpu = arr.buffers()[1]
     buf_on_gpu_sliced = buf_on_gpu.slice(2)
 
     buf = pa.py_buffer(b'sting')
-    arr_offsets = pa.array([0, 5], type=pa.int32())
-    offsets_buf = arr_offsets.buffers()[1]
-    arr = pa.BinaryArray.from_buffers(pa.binary(), 1, [None, offsets_buf, buf])
-
-    buf_on_gpu_expected = arr.buffers()[2]
+    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(5), 1, [None, buf])
+    buf_on_gpu_expected = arr.buffers()[1]
 
     assert buf_on_gpu_sliced.equals(buf_on_gpu_expected)
     assert buf.equals(buf_on_gpu_expected)

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -673,7 +673,6 @@ def test_non_cpu_buffer():
     cuda = pytest.importorskip("pyarrow.cuda")
     ctx = cuda.Context(0)
 
-    import numpy as np
     arr = np.arange(4, dtype=np.int32)
     cuda_buf = ctx.buffer_from_data(arr)
 
@@ -692,6 +691,9 @@ def test_non_cpu_buffer():
     msg = "Implemented only for data on CPU device"
     with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu.hex()
+
+    with pytest.raises(NotImplementedError, match=msg):
+        cuda_buf.hex()
 
     assert buf_on_gpu.is_mutable
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -711,18 +711,20 @@ def test_non_cpu_buffer(pickle_module):
     with pytest.raises(NotImplementedError, match=msg):
         pickle_module.dumps(cuda_buf, protocol=4)
 
-    buf = pa.py_buffer(b'testing')
-    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, buf])
+    arr = np.array([b'testing'])
+    cuda_buf = ctx.buffer_from_data(arr)
+    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, cuda_buf])
     buf_on_gpu = arr.buffers()[1]
     buf_on_gpu_sliced = buf_on_gpu.slice(2)
 
-    buf = pa.py_buffer(b'sting')
-    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(5), 1, [None, buf])
+    arr = np.array([b'sting'])
+    cuda_buf = ctx.buffer_from_data(arr)
+    arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(5), 1, [None, cuda_buf])
     buf_on_gpu_expected = arr.buffers()[1]
 
-    assert buf_on_gpu_sliced.equals(buf_on_gpu_expected)
-    assert buf.equals(buf_on_gpu_expected)
-    assert buf_on_gpu_sliced.to_pybytes() == buf_on_gpu_expected.to_pybytes()
+    # assert buf_on_gpu_sliced.equals(buf_on_gpu_expected)
+    assert cuda_buf.equals(buf_on_gpu_expected)
+    # assert buf_on_gpu_sliced.to_pybytes() == b'sting'
 
 
 def test_cache_options():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -706,9 +706,6 @@ def test_non_cpu_buffer(pickle_module):
         buf_on_gpu[1]
 
     with pytest.raises(NotImplementedError, match=msg):
-        cuda_buf[1]
-
-    with pytest.raises(NotImplementedError, match=msg):
         buf_on_gpu.to_pybytes()
 
     with pytest.raises(NotImplementedError, match=msg):
@@ -725,6 +722,10 @@ def test_non_cpu_buffer(pickle_module):
     buf_on_gpu_sliced = buf_on_gpu.slice(2)
     cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
     assert cuda_sliced.to_pybytes() == b'sting'
+
+    buf_on_gpu_sliced = buf_on_gpu[slice(2,4,1)]
+    cuda_sliced = cuda.CudaBuffer.from_buffer(buf_on_gpu_sliced)
+    assert cuda_sliced.to_pybytes() == b'st'
 
 
 def test_cache_options():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -706,6 +706,9 @@ def test_non_cpu_buffer(pickle_module):
         cuda_buf[1]
 
     with pytest.raises(NotImplementedError, match=msg):
+        buf_on_gpu.to_pybytes()
+
+    with pytest.raises(NotImplementedError, match=msg):
         pickle_module.dumps(buf_on_gpu, protocol=4)
 
     with pytest.raises(NotImplementedError, match=msg):
@@ -717,14 +720,15 @@ def test_non_cpu_buffer(pickle_module):
     buf_on_gpu = arr.buffers()[1]
     buf_on_gpu_sliced = buf_on_gpu.slice(2)
 
+    assert cuda_buf.slice(2).to_pybytes() == b'sting'
+
     arr = np.array([b'sting'])
     cuda_buf = ctx.buffer_from_data(arr)
     arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(5), 1, [None, cuda_buf])
     buf_on_gpu_expected = arr.buffers()[1]
 
+    breakpoint()
     # assert buf_on_gpu_sliced.equals(buf_on_gpu_expected)
-    assert cuda_buf.equals(buf_on_gpu_expected)
-    # assert buf_on_gpu_sliced.to_pybytes() == b'sting'
 
 
 def test_cache_options():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -669,7 +669,7 @@ def test_allocate_buffer_resizable():
     assert buf.size == 200
 
 
-def test_non_cpu_buffer():
+def test_non_cpu_buffer(pickle_module):
     cuda = pytest.importorskip("pyarrow.cuda")
     ctx = cuda.Context(0)
 
@@ -702,6 +702,9 @@ def test_non_cpu_buffer():
 
     with pytest.raises(NotImplementedError, match=msg):
         cuda_buf[1]
+
+    with pytest.raises(NotImplementedError, match=msg):
+        pickle_module.dumps(buf_on_gpu, protocol=4)
 
     buf = pa.py_buffer(b'testing')
     arr = pa.FixedSizeBinaryArray.from_buffers(pa.binary(7), 1, [None, buf])


### PR DESCRIPTION
### Rationale for this change

`hex()` and `__getitem__` currently segfault if the data is not located on the CPU.

### What changes are included in this PR?

This PR adds a check and returns `NotImplementedError` if the data is not on CPU. 

### Are these changes tested?

Yes

### Are there any user-facing changes?

No.
* GitHub Issue: #41662