### PR TITLE
GH-37728: [Java] Add methods to get an Iterable for a ValueVector

### DIFF
--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -161,6 +161,11 @@ under the License.
       <version>2.15.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/java/dataset/src/test/java/org/apache/arrow/dataset/substrait/TestAceroSubstraitConsumer.java
+++ b/java/dataset/src/test/java/org/apache/arrow/dataset/substrait/TestAceroSubstraitConsumer.java
@@ -16,10 +16,10 @@
  */
 package org.apache.arrow.dataset.substrait;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -299,8 +299,10 @@ public class TestAceroSubstraitConsumer extends TestDataset {
         assertThat(idVector.getValueIterable(), IsIterableContainingInOrder.contains(19, 1, 11));
         final ValueIterableVector<Text> nameVector =
             (ValueIterableVector<Text>) reader.getVectorSchemaRoot().getVector("name");
-        assertThat(nameVector.getValueIterable(), IsIterableContainingInOrder.contains(
-            new Text("value_19"), new Text("value_1"), new Text("value_11")));
+        assertThat(
+            nameVector.getValueIterable(),
+            IsIterableContainingInOrder.contains(
+                new Text("value_19"), new Text("value_1"), new Text("value_11")));
       }
       assertEquals(3, rowcount);
     }
@@ -448,14 +450,20 @@ public class TestAceroSubstraitConsumer extends TestDataset {
       int rowcount = 0;
       while (reader.loadNextBatch()) {
         final ValueIterableVector<Integer> sumVector =
-            (ValueIterableVector<Integer>) reader.getVectorSchemaRoot().getVector("add_two_to_column_a");
-        assertThat(sumVector.getValueIterable(), IsIterableContainingInOrder.contains(21, 3, 13, 23, 47));
+            (ValueIterableVector<Integer>)
+                reader.getVectorSchemaRoot().getVector("add_two_to_column_a");
+        assertThat(
+            sumVector.getValueIterable(), IsIterableContainingInOrder.contains(21, 3, 13, 23, 47));
         final ValueIterableVector<Text> nameVector =
-            (ValueIterableVector<Text>) reader.getVectorSchemaRoot().getVector("concat_column_a_and_b");
-        assertThat(nameVector.getValueIterable(),
+            (ValueIterableVector<Text>)
+                reader.getVectorSchemaRoot().getVector("concat_column_a_and_b");
+        assertThat(
+            nameVector.getValueIterable(),
             IsIterableContainingInOrder.contains(
-                new Text("value_19 - value_19"), new Text("value_1 - value_1"),
-                new Text("value_11 - value_11"), new Text("value_21 - value_21"),
+                new Text("value_19 - value_19"),
+                new Text("value_1 - value_1"),
+                new Text("value_11 - value_11"),
+                new Text("value_21 - value_21"),
                 new Text("value_45 - value_45")));
         rowcount += reader.getVectorSchemaRoot().getRowCount();
       }

--- a/java/dataset/src/test/java/org/apache/arrow/dataset/substrait/TestAceroSubstraitConsumer.java
+++ b/java/dataset/src/test/java/org/apache/arrow/dataset/substrait/TestAceroSubstraitConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.dataset.substrait;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -39,11 +40,14 @@ import org.apache.arrow.dataset.scanner.ScanOptions;
 import org.apache.arrow.dataset.scanner.Scanner;
 import org.apache.arrow.dataset.source.Dataset;
 import org.apache.arrow.dataset.source.DatasetFactory;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.Text;
+import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -290,13 +294,13 @@ public class TestAceroSubstraitConsumer extends TestDataset {
       int rowcount = 0;
       while (reader.loadNextBatch()) {
         rowcount += reader.getVectorSchemaRoot().getRowCount();
-        assertTrue(reader.getVectorSchemaRoot().getVector("id").toString().equals("[19, 1, 11]"));
-        assertTrue(
-            reader
-                .getVectorSchemaRoot()
-                .getVector("name")
-                .toString()
-                .equals("[value_19, value_1, value_11]"));
+        final ValueIterableVector<Integer> idVector =
+            (ValueIterableVector<Integer>) reader.getVectorSchemaRoot().getVector("id");
+        assertThat(idVector.getValueIterable(), IsIterableContainingInOrder.contains(19, 1, 11));
+        final ValueIterableVector<Text> nameVector =
+            (ValueIterableVector<Text>) reader.getVectorSchemaRoot().getVector("name");
+        assertThat(nameVector.getValueIterable(), IsIterableContainingInOrder.contains(
+            new Text("value_19"), new Text("value_1"), new Text("value_11")));
       }
       assertEquals(3, rowcount);
     }
@@ -443,20 +447,16 @@ public class TestAceroSubstraitConsumer extends TestDataset {
       assertEquals(schema.getFields(), reader.getVectorSchemaRoot().getSchema().getFields());
       int rowcount = 0;
       while (reader.loadNextBatch()) {
-        assertTrue(
-            reader
-                .getVectorSchemaRoot()
-                .getVector("add_two_to_column_a")
-                .toString()
-                .equals("[21, 3, 13, 23, 47]"));
-        assertTrue(
-            reader
-                .getVectorSchemaRoot()
-                .getVector("concat_column_a_and_b")
-                .toString()
-                .equals(
-                    "[value_19 - value_19, value_1 - value_1, value_11 - value_11, "
-                        + "value_21 - value_21, value_45 - value_45]"));
+        final ValueIterableVector<Integer> sumVector =
+            (ValueIterableVector<Integer>) reader.getVectorSchemaRoot().getVector("add_two_to_column_a");
+        assertThat(sumVector.getValueIterable(), IsIterableContainingInOrder.contains(21, 3, 13, 23, 47));
+        final ValueIterableVector<Text> nameVector =
+            (ValueIterableVector<Text>) reader.getVectorSchemaRoot().getVector("concat_column_a_and_b");
+        assertThat(nameVector.getValueIterable(),
+            IsIterableContainingInOrder.contains(
+                new Text("value_19 - value_19"), new Text("value_1 - value_1"),
+                new Text("value_11 - value_11"), new Text("value_21 - value_21"),
+                new Text("value_45 - value_45")));
         rowcount += reader.getVectorSchemaRoot().getRowCount();
       }
       assertEquals(5, rowcount);
@@ -507,12 +507,10 @@ public class TestAceroSubstraitConsumer extends TestDataset {
       assertEquals(schema.getFields(), reader.getVectorSchemaRoot().getSchema().getFields());
       int rowcount = 0;
       while (reader.loadNextBatch()) {
-        assertTrue(
-            reader
-                .getVectorSchemaRoot()
-                .getVector("filter_id_lower_than_20")
-                .toString()
-                .equals("[true, true, true, false, false]"));
+        final ValueIterableVector<Boolean> booleanVector =
+            (ValueIterableVector<Boolean>) reader.getVectorSchemaRoot().getVector("filter_id_lower_than_20");
+        assertThat(booleanVector.getValueIterable(),
+            IsIterableContainingInOrder.contains(true, true, true, false, false));
         rowcount += reader.getVectorSchemaRoot().getRowCount();
       }
       assertEquals(5, rowcount);
@@ -618,18 +616,15 @@ public class TestAceroSubstraitConsumer extends TestDataset {
       assertEquals(schema.getFields(), reader.getVectorSchemaRoot().getSchema().getFields());
       int rowcount = 0;
       while (reader.loadNextBatch()) {
-        assertTrue(
-            reader
-                .getVectorSchemaRoot()
-                .getVector("add_two_to_column_a")
-                .toString()
-                .equals("[21, 3, 13]"));
-        assertTrue(
-            reader
-                .getVectorSchemaRoot()
-                .getVector("concat_column_a_and_b")
-                .toString()
-                .equals("[value_19 - value_19, value_1 - value_1, value_11 - value_11]"));
+        final ValueIterableVector<Integer> sumVector =
+            (ValueIterableVector<Integer>) reader.getVectorSchemaRoot().getVector("add_two_to_column_a");
+        assertThat(sumVector.getValueIterable(), IsIterableContainingInOrder.contains(21, 3, 13));
+        final ValueIterableVector<Text> nameVector =
+            (ValueIterableVector<Text>) reader.getVectorSchemaRoot().getVector("conccat_column_a_and_b");
+        assertThat(nameVector.getValueIterable(),
+            IsIterableContainingInOrder.contains(
+                new Text("value_19 - value_19"), new Text("value_1 - value_1"),
+                new Text("value_11 - value_11")));
         rowcount += reader.getVectorSchemaRoot().getRowCount();
       }
       assertEquals(3, rowcount);

--- a/java/dataset/src/test/java/org/apache/arrow/dataset/substrait/TestAceroSubstraitConsumer.java
+++ b/java/dataset/src/test/java/org/apache/arrow/dataset/substrait/TestAceroSubstraitConsumer.java
@@ -516,8 +516,10 @@ public class TestAceroSubstraitConsumer extends TestDataset {
       int rowcount = 0;
       while (reader.loadNextBatch()) {
         final ValueIterableVector<Boolean> booleanVector =
-            (ValueIterableVector<Boolean>) reader.getVectorSchemaRoot().getVector("filter_id_lower_than_20");
-        assertThat(booleanVector.getValueIterable(),
+            (ValueIterableVector<Boolean>)
+                reader.getVectorSchemaRoot().getVector("filter_id_lower_than_20");
+        assertThat(
+            booleanVector.getValueIterable(),
             IsIterableContainingInOrder.contains(true, true, true, false, false));
         rowcount += reader.getVectorSchemaRoot().getRowCount();
       }
@@ -625,13 +627,17 @@ public class TestAceroSubstraitConsumer extends TestDataset {
       int rowcount = 0;
       while (reader.loadNextBatch()) {
         final ValueIterableVector<Integer> sumVector =
-            (ValueIterableVector<Integer>) reader.getVectorSchemaRoot().getVector("add_two_to_column_a");
+            (ValueIterableVector<Integer>)
+                reader.getVectorSchemaRoot().getVector("add_two_to_column_a");
         assertThat(sumVector.getValueIterable(), IsIterableContainingInOrder.contains(21, 3, 13));
         final ValueIterableVector<Text> nameVector =
-            (ValueIterableVector<Text>) reader.getVectorSchemaRoot().getVector("conccat_column_a_and_b");
-        assertThat(nameVector.getValueIterable(),
+            (ValueIterableVector<Text>)
+                reader.getVectorSchemaRoot().getVector("conccat_column_a_and_b");
+        assertThat(
+            nameVector.getValueIterable(),
             IsIterableContainingInOrder.contains(
-                new Text("value_19 - value_19"), new Text("value_1 - value_1"),
+                new Text("value_19 - value_19"),
+                new Text("value_1 - value_1"),
                 new Text("value_11 - value_11")));
         rowcount += reader.getVectorSchemaRoot().getRowCount();
       }

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -86,6 +86,11 @@ under the License.
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -23,6 +23,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.AbstractStructVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -62,6 +63,7 @@ import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.BaseValueVector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.util.OversizedAllocationException;
 import org.apache.arrow.util.Preconditions;
 
@@ -84,7 +86,7 @@ import static org.apache.arrow.vector.types.UnionMode.Dense;
  * each time the vector is accessed.
  * Source code generated using FreeMarker template ${.template_name}
  */
-public class DenseUnionVector extends AbstractContainerVector implements FieldVector {
+public class DenseUnionVector extends AbstractContainerVector implements FieldVector, ValueIterableVector<Object> {
   int valueCount;
 
   NonNullableStructVector internalStruct;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * BigIntVector implements a fixed width vector (8 bytes) of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class BigIntVector extends BaseFixedWidthVector implements BaseIntVector {
+public final class BigIntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Long> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * BigIntVector implements a fixed width vector (8 bytes) of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class BigIntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Long> {
+public final class BigIntVector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Long> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * BitVector implements a fixed width (1 bit) vector of boolean values which could be null. Each
  * value in the vector corresponds to a single bit in the underlying data stream backing the vector.
  */
-public final class BitVector extends BaseFixedWidthVector {
+public final class BitVector extends BaseFixedWidthVector implements ValueIterableVector<Boolean> {
 
   private static final int HASH_CODE_FOR_ZERO = 17;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * DateDayVector implements a fixed width (4 bytes) vector of date values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class DateDayVector extends BaseFixedWidthVector implements ValueIterableVector<Integer> {
+public final class DateDayVector extends BaseFixedWidthVector
+    implements ValueIterableVector<Integer> {
 
   public static final byte TYPE_WIDTH = 4;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * DateDayVector implements a fixed width (4 bytes) vector of date values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class DateDayVector extends BaseFixedWidthVector {
+public final class DateDayVector extends BaseFixedWidthVector implements ValueIterableVector<Integer> {
 
   public static final byte TYPE_WIDTH = 4;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * DateMilliVector implements a fixed width vector (8 bytes) of date values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class DateMilliVector extends BaseFixedWidthVector implements ValueIterableVector<LocalDateTime> {
+public final class DateMilliVector extends BaseFixedWidthVector
+    implements ValueIterableVector<LocalDateTime> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * DateMilliVector implements a fixed width vector (8 bytes) of date values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class DateMilliVector extends BaseFixedWidthVector {
+public final class DateMilliVector extends BaseFixedWidthVector implements ValueIterableVector<LocalDateTime> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
@@ -40,7 +40,7 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * null. A validity buffer (bit vector) is maintained to track which elements in the vector are
  * null.
  */
-public final class Decimal256Vector extends BaseFixedWidthVector {
+public final class Decimal256Vector extends BaseFixedWidthVector implements ValueIterableVector<BigDecimal> {
   public static final int MAX_PRECISION = 76;
   public static final byte TYPE_WIDTH = 32;
   private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;

--- a/java/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
@@ -40,7 +40,8 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * null. A validity buffer (bit vector) is maintained to track which elements in the vector are
  * null.
  */
-public final class Decimal256Vector extends BaseFixedWidthVector implements ValueIterableVector<BigDecimal> {
+public final class Decimal256Vector extends BaseFixedWidthVector
+    implements ValueIterableVector<BigDecimal> {
   public static final int MAX_PRECISION = 76;
   public static final byte TYPE_WIDTH = 32;
   private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;

--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -39,7 +39,8 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * DecimalVector implements a fixed width vector (16 bytes) of decimal values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class DecimalVector extends BaseFixedWidthVector implements ValueIterableVector<BigDecimal> {
+public final class DecimalVector extends BaseFixedWidthVector
+    implements ValueIterableVector<BigDecimal> {
   public static final int MAX_PRECISION = 38;
   public static final byte TYPE_WIDTH = 16;
   private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;

--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -39,7 +39,7 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * DecimalVector implements a fixed width vector (16 bytes) of decimal values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class DecimalVector extends BaseFixedWidthVector {
+public final class DecimalVector extends BaseFixedWidthVector implements ValueIterableVector<BigDecimal> {
   public static final int MAX_PRECISION = 38;
   public static final byte TYPE_WIDTH = 16;
   private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -38,7 +38,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * duration values which could be null. A validity buffer (bit vector) is maintained to track which
  * elements in the vector are null.
  */
-public final class DurationVector extends BaseFixedWidthVector implements ValueIterableVector<Duration> {
+public final class DurationVector extends BaseFixedWidthVector
+    implements ValueIterableVector<Duration> {
   public static final byte TYPE_WIDTH = 8;
 
   private final TimeUnit unit;

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * duration values which could be null. A validity buffer (bit vector) is maintained to track which
  * elements in the vector are null.
  */
-public final class DurationVector extends BaseFixedWidthVector {
+public final class DurationVector extends BaseFixedWidthVector implements ValueIterableVector<Duration> {
   public static final byte TYPE_WIDTH = 8;
 
   private final TimeUnit unit;

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -37,7 +37,7 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * FixedSizeBinaryVector implements a fixed width vector of binary values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public class FixedSizeBinaryVector extends BaseFixedWidthVector {
+public class FixedSizeBinaryVector extends BaseFixedWidthVector implements ValueIterableVector<byte[]> {
   private final int byteWidth;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -37,7 +37,8 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * FixedSizeBinaryVector implements a fixed width vector of binary values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public class FixedSizeBinaryVector extends BaseFixedWidthVector implements ValueIterableVector<byte[]> {
+public class FixedSizeBinaryVector extends BaseFixedWidthVector
+    implements ValueIterableVector<byte[]> {
   private final int byteWidth;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float2Vector.java
@@ -34,8 +34,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * Float2Vector implements a fixed width (2 bytes) vector of short values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class Float2Vector extends BaseFixedWidthVector implements FloatingPointVector,
-    ValueIterableVector<Short> {
+public final class Float2Vector extends BaseFixedWidthVector
+    implements FloatingPointVector, ValueIterableVector<Short> {
   public static final byte TYPE_WIDTH = 2;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float2Vector.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * Float2Vector implements a fixed width (2 bytes) vector of short values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class Float2Vector extends BaseFixedWidthVector implements FloatingPointVector {
+public final class Float2Vector extends BaseFixedWidthVector implements FloatingPointVector,
+    ValueIterableVector<Short> {
   public static final byte TYPE_WIDTH = 2;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
@@ -33,8 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * Float4Vector implements a fixed width vector (4 bytes) of float values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class Float4Vector extends BaseFixedWidthVector implements FloatingPointVector,
-    ValueIterableVector<Float> {
+public final class Float4Vector extends BaseFixedWidthVector
+    implements FloatingPointVector, ValueIterableVector<Float> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * Float4Vector implements a fixed width vector (4 bytes) of float values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class Float4Vector extends BaseFixedWidthVector implements FloatingPointVector {
+public final class Float4Vector extends BaseFixedWidthVector implements FloatingPointVector,
+    ValueIterableVector<Float> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * Float8Vector implements a fixed width vector (8 bytes) of double values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class Float8Vector extends BaseFixedWidthVector implements FloatingPointVector {
+public final class Float8Vector extends BaseFixedWidthVector implements FloatingPointVector,
+    ValueIterableVector<Double> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
@@ -33,8 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * Float8Vector implements a fixed width vector (8 bytes) of double values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class Float8Vector extends BaseFixedWidthVector implements FloatingPointVector,
-    ValueIterableVector<Double> {
+public final class Float8Vector extends BaseFixedWidthVector
+    implements FloatingPointVector, ValueIterableVector<Double> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * IntVector implements a fixed width (4 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class IntVector extends BaseFixedWidthVector implements BaseIntVector {
+public final class IntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Integer> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * IntVector implements a fixed width (4 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class IntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Integer> {
+public final class IntVector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Integer> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class IntervalDayVector extends BaseFixedWidthVector implements ValueIterableVector<Duration> {
+public final class IntervalDayVector extends BaseFixedWidthVector
+    implements ValueIterableVector<Duration> {
   public static final byte TYPE_WIDTH = 8;
   private static final byte MILLISECOND_OFFSET = 4;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class IntervalDayVector extends BaseFixedWidthVector {
+public final class IntervalDayVector extends BaseFixedWidthVector implements ValueIterableVector<Duration> {
   public static final byte TYPE_WIDTH = 8;
   private static final byte MILLISECOND_OFFSET = 4;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalMonthDayNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalMonthDayNanoVector.java
@@ -39,7 +39,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * <p>Month, day and nanoseconds are independent from one another and there is no specific limits
  * imposed on their values.
  */
-public final class IntervalMonthDayNanoVector extends BaseFixedWidthVector {
+public final class IntervalMonthDayNanoVector extends BaseFixedWidthVector
+    implements ValueIterableVector<PeriodDuration> {
   public static final byte TYPE_WIDTH = 16;
   private static final byte DAY_OFFSET = 4;
   private static final byte NANOSECOND_OFFSET = 8;

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class IntervalYearVector extends BaseFixedWidthVector {
+public final class IntervalYearVector extends BaseFixedWidthVector implements ValueIterableVector<Period> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class IntervalYearVector extends BaseFixedWidthVector implements ValueIterableVector<Period> {
+public final class IntervalYearVector extends BaseFixedWidthVector
+    implements ValueIterableVector<Period> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
@@ -32,7 +32,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * NULL. A validity buffer (bit vector) is maintained to track which elements in the vector are
  * null. The size of the underlying buffer can be over 2GB.
  */
-public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector {
+public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector implements ValueIterableVector<byte[]> {
 
   /**
    * Instantiate a LargeVarBinaryVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
@@ -32,7 +32,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * NULL. A validity buffer (bit vector) is maintained to track which elements in the vector are
  * null. The size of the underlying buffer can be over 2GB.
  */
-public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector implements ValueIterableVector<byte[]> {
+public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector
+    implements ValueIterableVector<byte[]> {
 
   /**
    * Instantiate a LargeVarBinaryVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
@@ -37,7 +37,8 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  *
  * <p>The offset width of this vector is 8, so the underlying buffer can be larger than 2GB.
  */
-public final class LargeVarCharVector extends BaseLargeVariableWidthVector implements ValueIterableVector<Text> {
+public final class LargeVarCharVector extends BaseLargeVariableWidthVector
+    implements ValueIterableVector<Text> {
 
   /**
    * Instantiate a LargeVarCharVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/LargeVarCharVector.java
@@ -37,7 +37,7 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  *
  * <p>The offset width of this vector is 8, so the underlying buffer can be larger than 2GB.
  */
-public final class LargeVarCharVector extends BaseLargeVariableWidthVector {
+public final class LargeVarCharVector extends BaseLargeVariableWidthVector implements ValueIterableVector<Text> {
 
   /**
    * Instantiate a LargeVarCharVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.TransferPair;
 
 /** A null type vector. */
-public class NullVector implements FieldVector {
+public class NullVector implements FieldVector, ValueIterableVector<Object> {
 
   private int valueCount;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * SmallIntVector implements a fixed width (2 bytes) vector of short values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector {
+public final class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Short> {
   public static final byte TYPE_WIDTH = 2;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * SmallIntVector implements a fixed width (2 bytes) vector of short values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Short> {
+public final class SmallIntVector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Short> {
   public static final byte TYPE_WIDTH = 2;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * which could be null. A validity buffer (bit vector) is maintained to track which elements in the
  * vector are null.
  */
-public final class TimeMicroVector extends BaseFixedWidthVector implements ValueIterableVector<Long> {
+public final class TimeMicroVector extends BaseFixedWidthVector
+    implements ValueIterableVector<Long> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * which could be null. A validity buffer (bit vector) is maintained to track which elements in the
  * vector are null.
  */
-public final class TimeMicroVector extends BaseFixedWidthVector {
+public final class TimeMicroVector extends BaseFixedWidthVector implements ValueIterableVector<Long> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * which could be null. A validity buffer (bit vector) is maintained to track which elements in the
  * vector are null.
  */
-public final class TimeMilliVector extends BaseFixedWidthVector {
+public final class TimeMilliVector extends BaseFixedWidthVector implements ValueIterableVector<LocalDateTime> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
@@ -36,7 +36,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * which could be null. A validity buffer (bit vector) is maintained to track which elements in the
  * vector are null.
  */
-public final class TimeMilliVector extends BaseFixedWidthVector implements ValueIterableVector<LocalDateTime> {
+public final class TimeMilliVector extends BaseFixedWidthVector
+    implements ValueIterableVector<LocalDateTime> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * which could be null. A validity buffer (bit vector) is maintained to track which elements in the
  * vector are null.
  */
-public final class TimeNanoVector extends BaseFixedWidthVector {
+public final class TimeNanoVector extends BaseFixedWidthVector implements ValueIterableVector<Long> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * which could be null. A validity buffer (bit vector) is maintained to track which elements in the
  * vector are null.
  */
-public final class TimeNanoVector extends BaseFixedWidthVector implements ValueIterableVector<Long> {
+public final class TimeNanoVector extends BaseFixedWidthVector
+    implements ValueIterableVector<Long> {
   public static final byte TYPE_WIDTH = 8;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * could be null. A validity buffer (bit vector) is maintained to track which elements in the vector
  * are null.
  */
-public final class TimeSecVector extends BaseFixedWidthVector {
+public final class TimeSecVector extends BaseFixedWidthVector implements ValueIterableVector<Integer> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * could be null. A validity buffer (bit vector) is maintained to track which elements in the vector
  * are null.
  */
-public final class TimeSecVector extends BaseFixedWidthVector implements ValueIterableVector<Integer> {
+public final class TimeSecVector extends BaseFixedWidthVector
+    implements ValueIterableVector<Integer> {
   public static final byte TYPE_WIDTH = 4;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMicroTZVector extends TimeStampVector {
+public final class TimeStampMicroTZVector extends TimeStampVector implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMicroTZVector extends TimeStampVector implements ValueIterableVector<Long> {
+public final class TimeStampMicroTZVector extends TimeStampVector
+    implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMicroVector extends TimeStampVector {
+public final class TimeStampMicroVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampMicroVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMicroVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
+public final class TimeStampMicroVector extends TimeStampVector
+    implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampMicroVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMilliTZVector extends TimeStampVector {
+public final class TimeStampMilliTZVector extends TimeStampVector implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMilliTZVector extends TimeStampVector implements ValueIterableVector<Long> {
+public final class TimeStampMilliTZVector extends TimeStampVector
+    implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMilliVector extends TimeStampVector {
+public final class TimeStampMilliVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampMilliVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampMilliVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
+public final class TimeStampMilliVector extends TimeStampVector
+    implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampMilliVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampNanoTZVector extends TimeStampVector {
+public final class TimeStampNanoTZVector extends TimeStampVector implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampNanoTZVector extends TimeStampVector implements ValueIterableVector<Long> {
+public final class TimeStampNanoTZVector extends TimeStampVector
+    implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampNanoVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
+public final class TimeStampNanoVector extends TimeStampVector
+    implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampNanoVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * resolution) values which could be null. A validity buffer (bit vector) is maintained to track
  * which elements in the vector are null.
  */
-public final class TimeStampNanoVector extends TimeStampVector {
+public final class TimeStampNanoVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampNanoVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class TimeStampSecTZVector extends TimeStampVector {
+public final class TimeStampSecTZVector extends TimeStampVector implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class TimeStampSecTZVector extends TimeStampVector implements ValueIterableVector<Long> {
+public final class TimeStampSecTZVector extends TimeStampVector
+    implements ValueIterableVector<Long> {
   private final String timeZone;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class TimeStampSecVector extends TimeStampVector {
+public final class TimeStampSecVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampSecVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * values which could be null. A validity buffer (bit vector) is maintained to track which elements
  * in the vector are null.
  */
-public final class TimeStampSecVector extends TimeStampVector implements ValueIterableVector<LocalDateTime> {
+public final class TimeStampSecVector extends TimeStampVector
+    implements ValueIterableVector<LocalDateTime> {
 
   /**
    * Instantiate a TimeStampSecVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * TinyIntVector implements a fixed width (1 bytes) vector of byte values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector {
+public final class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Byte> {
   public static final byte TYPE_WIDTH = 1;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * TinyIntVector implements a fixed width (1 bytes) vector of byte values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Byte> {
+public final class TinyIntVector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Byte> {
   public static final byte TYPE_WIDTH = 1;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt1Vector implements a fixed width (1 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
+public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Byte> {
   /** The mask to use when promoting the unsigned byte value to an integer. */
   public static final int PROMOTION_MASK = 0xFF;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt1Vector implements a fixed width (1 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Byte> {
+public final class UInt1Vector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Byte> {
   /** The mask to use when promoting the unsigned byte value to an integer. */
   public static final int PROMOTION_MASK = 0xFF;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt2Vector implements a fixed width (2 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Character> {
+public final class UInt2Vector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Character> {
 
   /** The maximum 16-bit unsigned integer. */
   public static final char MAX_UINT2 = (char) 0XFFFF;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt2Vector implements a fixed width (2 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
+public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Character> {
 
   /** The maximum 16-bit unsigned integer. */
   public static final char MAX_UINT2 = (char) 0XFFFF;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -34,7 +34,8 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt4Vector implements a fixed width (4 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Integer> {
+public final class UInt4Vector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Integer> {
 
   /** The mask to use when promoting the unsigned int value to a long int. */
   public static final long PROMOTION_MASK = 0x00000000FFFFFFFFL;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt4Vector implements a fixed width (4 bytes) vector of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
+public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Integer> {
 
   /** The mask to use when promoting the unsigned int value to a long int. */
   public static final long PROMOTION_MASK = 0x00000000FFFFFFFFL;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt8Vector implements a fixed width vector (8 bytes) of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Long> {
+public final class UInt8Vector extends BaseFixedWidthVector
+    implements BaseIntVector, ValueIterableVector<Long> {
 
   /** The maximum 64-bit unsigned long integer. */
   public static final long MAX_UINT8 = 0XFFFFFFFFFFFFFFFFL;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.util.ValueVectorUtility;
  * UInt8Vector implements a fixed width vector (8 bytes) of integer values which could be null. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector {
+public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector, ValueIterableVector<Long> {
 
   /** The maximum 64-bit unsigned long integer. */
   public static final long MAX_UINT8 = 0XFFFFFFFFFFFFFFFFL;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueIterableVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueIterableVector.java
@@ -14,15 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.vector;
 
 import java.util.Iterator;
 
 public interface ValueIterableVector<T> extends ValueVector {
   /**
-   * Get an Iterable that can be used to iterate over the values in the
-   * vector.
+   * Get an Iterable that can be used to iterate over the values in the vector.
    *
    * @return an Iterable for the vector's values
    */
@@ -30,11 +28,13 @@ public interface ValueIterableVector<T> extends ValueVector {
     return new Iterator<T>() {
       private int index = 0;
 
-      @Override public boolean hasNext() {
+      @Override
+      public boolean hasNext() {
         return index < ValueIterableVector.this.getValueCount();
       }
 
-      @Override public T next() {
+      @Override
+      public T next() {
         return (T) ValueIterableVector.this.getObject(index++);
       }
     };

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueIterableVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueIterableVector.java
@@ -19,22 +19,7 @@ package org.apache.arrow.vector;
 
 import java.util.Iterator;
 
-public interface ValueIterableVector<T> {
-  /**
-   * Gets the number of values.
-   *
-   * @return number of values in the vector
-   */
-  int getValueCount();
-
-  /**
-   * Get friendly type object from the vector.
-   *
-   * @param index index of object to get
-   * @return friendly type object
-   */
-  Object getObject(int index);
-
+public interface ValueIterableVector<T> extends ValueVector {
   /**
    * Get an Iterable that can be used to iterate over the values in the
    * vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueIterableVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueIterableVector.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+import java.util.Iterator;
+
+public interface ValueIterableVector<T> {
+  /**
+   * Gets the number of values.
+   *
+   * @return number of values in the vector
+   */
+  int getValueCount();
+
+  /**
+   * Get friendly type object from the vector.
+   *
+   * @param index index of object to get
+   * @return friendly type object
+   */
+  Object getObject(int index);
+
+  /**
+   * Get an Iterable that can be used to iterate over the values in the
+   * vector.
+   *
+   * @return an Iterable for the vector's values
+   */
+  default Iterator<T> getValueIterator() {
+    return new Iterator<T>() {
+      private int index = 0;
+
+      @Override public boolean hasNext() {
+        return index < ValueIterableVector.this.getValueCount();
+      }
+
+      @Override public T next() {
+        return (T) ValueIterableVector.this.getObject(index++);
+      }
+    };
+  }
+
+  /**
+   * Get an Iterator for the values in the vector.
+   *
+   * @return an Iterator for the values in the vector
+   */
+  default Iterable<T> getValueIterable() {
+    return this::getValueIterator;
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * VarBinaryVector implements a variable width vector of binary values which could be NULL. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class VarBinaryVector extends BaseVariableWidthVector {
+public final class VarBinaryVector extends BaseVariableWidthVector implements ValueIterableVector<byte[]> {
 
   /**
    * Instantiate a VarBinaryVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * VarBinaryVector implements a variable width vector of binary values which could be NULL. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class VarBinaryVector extends BaseVariableWidthVector implements ValueIterableVector<byte[]> {
+public final class VarBinaryVector extends BaseVariableWidthVector
+    implements ValueIterableVector<byte[]> {
 
   /**
    * Instantiate a VarBinaryVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -35,7 +35,8 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * VarCharVector implements a variable width vector of VARCHAR values which could be NULL. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class VarCharVector extends BaseVariableWidthVector implements ValueIterableVector<Text> {
+public final class VarCharVector extends BaseVariableWidthVector
+    implements ValueIterableVector<Text> {
 
   /**
    * Instantiate a VarCharVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * VarCharVector implements a variable width vector of VARCHAR values which could be NULL. A
  * validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class VarCharVector extends BaseVariableWidthVector {
+public final class VarCharVector extends BaseVariableWidthVector implements ValueIterableVector<Text> {
 
   /**
    * Instantiate a VarCharVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * ViewVarBinaryVector implements a variable width view vector of binary values which could be NULL.
  * A validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class ViewVarBinaryVector extends BaseVariableWidthViewVector {
+public final class ViewVarBinaryVector extends BaseVariableWidthViewVector implements ValueIterableVector<byte[]> {
 
   /**
    * Instantiate a ViewVarBinaryVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
@@ -33,7 +33,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * ViewVarBinaryVector implements a variable width view vector of binary values which could be NULL.
  * A validity buffer (bit vector) is maintained to track which elements in the vector are null.
  */
-public final class ViewVarBinaryVector extends BaseVariableWidthViewVector implements ValueIterableVector<byte[]> {
+public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
+    implements ValueIterableVector<byte[]> {
 
   /**
    * Instantiate a ViewVarBinaryVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -37,7 +37,7 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * null. A viewBuffer keeps track of all values in the vector, and an external data buffer is kept
  * to keep longer strings (>12).
  */
-public final class ViewVarCharVector extends BaseVariableWidthViewVector {
+public final class ViewVarCharVector extends BaseVariableWidthViewVector implements ValueIterableVector<Text> {
 
   /**
    * Instantiate a ViewVarCharVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -37,7 +37,8 @@ import org.apache.arrow.vector.validate.ValidateUtil;
  * null. A viewBuffer keeps track of all values in the vector, and an external data buffer is kept
  * to keep longer strings (>12).
  */
-public final class ViewVarCharVector extends BaseVariableWidthViewVector implements ValueIterableVector<Text> {
+public final class ViewVarCharVector extends BaseVariableWidthViewVector
+    implements ValueIterableVector<Text> {
 
   /**
    * Instantiate a ViewVarCharVector. This doesn't allocate any memory for the data in vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -41,6 +41,7 @@ import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
@@ -60,7 +61,7 @@ import org.apache.arrow.vector.util.TransferPair;
 
 /** A ListVector where every list value is of the same size. */
 public class FixedSizeListVector extends BaseValueVector
-    implements BaseListVector, PromotableVector {
+    implements BaseListVector, PromotableVector, ValueIterableVector<List<?>> {
 
   public static FixedSizeListVector empty(String name, int size, BufferAllocator allocator) {
     FieldType fieldType = FieldType.nullable(new ArrowType.FixedSizeList(size));

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -43,6 +43,7 @@ import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
@@ -79,7 +80,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * aren't needed.
  */
 public class LargeListVector extends BaseValueVector
-    implements RepeatedValueVector, FieldVector, PromotableVector {
+    implements RepeatedValueVector, FieldVector, PromotableVector, ValueIterableVector<List<?>> {
 
   public static LargeListVector empty(String name, BufferAllocator allocator) {
     return new LargeListVector(

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -67,7 +67,8 @@ import org.apache.arrow.vector.util.TransferPair;
  *
  * The latter two are managed by its superclass.
  */
-public class ListVector extends BaseRepeatedValueVector implements PromotableVector, ValueIterableVector<List<?>> {
+public class ListVector extends BaseRepeatedValueVector
+    implements PromotableVector, ValueIterableVector<List<?>> {
 
   public static ListVector empty(String name, BufferAllocator allocator) {
     return new ListVector(name, allocator, FieldType.nullable(ArrowType.List.INSTANCE), null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -37,6 +37,7 @@ import org.apache.arrow.vector.AddOrGetResult;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
@@ -66,7 +67,7 @@ import org.apache.arrow.vector.util.TransferPair;
  *
  * The latter two are managed by its superclass.
  */
-public class ListVector extends BaseRepeatedValueVector implements PromotableVector {
+public class ListVector extends BaseRepeatedValueVector implements PromotableVector, ValueIterableVector<List<?>> {
 
   public static ListVector empty(String name, BufferAllocator allocator) {
     return new ListVector(name, allocator, FieldType.nullable(ArrowType.List.INSTANCE), null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
@@ -36,6 +36,7 @@ import org.apache.arrow.vector.AddOrGetResult;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
@@ -68,7 +69,8 @@ import org.apache.arrow.vector.util.TransferPair;
 /*
  * TODO: consider merging the functionality in `BaseRepeatedValueVector` into this class.
  */
-public class ListViewVector extends BaseRepeatedValueViewVector implements PromotableVector {
+public class ListViewVector extends BaseRepeatedValueViewVector
+    implements PromotableVector, ValueIterableVector<List<?>> {
 
   protected ArrowBuf validityBuffer;
   protected UnionListReader reader;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -46,7 +46,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * A struct vector that has no null values (and no validity buffer). Child Vectors are handled in
  * {@link AbstractStructVector}.
  */
-public class NonNullableStructVector extends AbstractStructVector implements ValueIterableVector<Map<String, ?>> {
+public class NonNullableStructVector extends AbstractStructVector
+    implements ValueIterableVector<Map<String, ?>> {
 
   /**
    * Construct a new empty instance which replaces an existing field with the new one in case of

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -28,6 +28,7 @@ import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.SingleStructReaderImpl;
@@ -45,7 +46,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * A struct vector that has no null values (and no validity buffer). Child Vectors are handled in
  * {@link AbstractStructVector}.
  */
-public class NonNullableStructVector extends AbstractStructVector {
+public class NonNullableStructVector extends AbstractStructVector implements ValueIterableVector<Map<String, ?>> {
 
   /**
    * Construct a new empty instance which replaces an existing field with the new one in case of

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -33,6 +33,7 @@ import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.impl.NullableStructReaderImpl;
 import org.apache.arrow.vector.complex.impl.NullableStructWriter;
@@ -50,7 +51,7 @@ import org.apache.arrow.vector.util.TransferPair;
  * A Struct vector consists of nullability/validity buffer and children vectors that make up the
  * struct's fields. The children vectors are handled by the parent class.
  */
-public class StructVector extends NonNullableStructVector implements FieldVector {
+public class StructVector extends NonNullableStructVector implements FieldVector, ValueIterableVector<Map<String, ?>> {
 
   /**
    * Construct a new empty instance which replaces an existing field with the new one in case of

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -51,7 +51,8 @@ import org.apache.arrow.vector.util.TransferPair;
  * A Struct vector consists of nullability/validity buffer and children vectors that make up the
  * struct's fields. The children vectors are handled by the parent class.
  */
-public class StructVector extends NonNullableStructVector implements FieldVector, ValueIterableVector<Map<String, ?>> {
+public class StructVector extends NonNullableStructVector
+    implements FieldVector, ValueIterableVector<Map<String, ?>> {
 
   /**
    * Construct a new empty instance which replaces an existing field with the new one in case of

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVectorIterable.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVectorIterable.java
@@ -1,0 +1,909 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.ListViewVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.impl.NullableStructWriter;
+import org.apache.arrow.vector.complex.impl.UnionLargeListWriter;
+import org.apache.arrow.vector.complex.impl.UnionListViewWriter;
+import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.util.Text;
+import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestValueVectorIterable {
+  private BufferAllocator allocator;
+
+  @BeforeEach
+  public void init() {
+    allocator = new DirtyRootAllocator(Long.MAX_VALUE, (byte) 100);
+  }
+
+  @AfterEach
+  public void terminate() throws Exception {
+    allocator.close();
+  }
+
+  @Test
+  public void testBigIntVectorIterable() {
+    try (final BigIntVector bigIntVector = new BigIntVector("bigInt", allocator)) {
+      bigIntVector.allocateNew(3);
+      bigIntVector.setSafe(0, 6);
+      bigIntVector.setSafe(1, 2);
+      bigIntVector.setSafe(2, 19);
+      bigIntVector.setValueCount(3);
+
+      assertThat(
+          bigIntVector.getValueIterable(), IsIterableContainingInOrder.contains(6L, 2L, 19L));
+    }
+  }
+
+  @Test
+  public void testBitVectorIterable() {
+    try (final BitVector bitVector = new BitVector("bit", allocator)) {
+      bitVector.allocateNew(3);
+      bitVector.setSafe(0, 0);
+      bitVector.setNull(1);
+      bitVector.setSafe(2, 1);
+      bitVector.setValueCount(3);
+
+      assertThat(
+          bitVector.getValueIterable(), IsIterableContainingInOrder.contains(false, null, true));
+    }
+  }
+
+  @Test
+  public void testDateDayVectorIterable() {
+    try (final DateDayVector dateDayVector = new DateDayVector("dateDay", allocator)) {
+      dateDayVector.allocateNew(3);
+      dateDayVector.setSafe(0, 30000);
+      dateDayVector.setNull(1);
+      dateDayVector.setSafe(2, 555);
+      dateDayVector.setValueCount(3);
+
+      assertThat(
+          dateDayVector.getValueIterable(), IsIterableContainingInOrder.contains(30000, null, 555));
+    }
+  }
+
+  @Test
+  public void testDateMilliVectorIterable() {
+    try (final DateMilliVector dateMilliVector = new DateMilliVector("dateMilli", allocator)) {
+      dateMilliVector.allocateNew(3);
+      dateMilliVector.setSafe(0, 30000L);
+      dateMilliVector.setNull(1);
+      dateMilliVector.setSafe(2, 555L);
+      dateMilliVector.setValueCount(3);
+
+      final LocalDateTime value1 = LocalDateTime.ofEpochSecond(30L, 0, ZoneOffset.ofHours(0));
+      final LocalDateTime value3 =
+          LocalDateTime.ofEpochSecond(0L, 555000000, ZoneOffset.ofHours(0));
+      assertThat(
+          dateMilliVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testDecimal256VectorIterable() {
+    try (final Decimal256Vector decimal256Vector =
+        new Decimal256Vector("decimal256", allocator, 8, 2)) {
+      decimal256Vector.allocateNew(3);
+      decimal256Vector.setSafe(0, 30000L);
+      decimal256Vector.setNull(1);
+      decimal256Vector.setSafe(2, 555L);
+      decimal256Vector.setValueCount(3);
+
+      final BigDecimal value1 = new BigDecimal(300L).setScale(2, RoundingMode.HALF_UP);
+      final BigDecimal value3 =
+          new BigDecimal(555L).scaleByPowerOfTen(-2).setScale(2, RoundingMode.HALF_UP);
+      assertThat(
+          decimal256Vector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testDecimalVectorIterable() {
+    try (final DecimalVector decimalVector = new DecimalVector("decimalDay", allocator, 8, 2)) {
+      decimalVector.allocateNew(3);
+      decimalVector.setSafe(0, 30000);
+      decimalVector.setNull(1);
+      decimalVector.setSafe(2, 555);
+      decimalVector.setValueCount(3);
+
+      final BigDecimal value1 = new BigDecimal(300L).setScale(2, RoundingMode.HALF_UP);
+      final BigDecimal value3 =
+          new BigDecimal(555L).scaleByPowerOfTen(-2).setScale(2, RoundingMode.HALF_UP);
+      assertThat(
+          decimalVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testDurationVectorIterable() {
+    try (final DurationVector durationVector =
+        new DurationVector(
+            Field.nullablePrimitive("duration", new ArrowType.Duration(TimeUnit.MILLISECOND)),
+            allocator)) {
+      durationVector.allocateNew(3);
+      durationVector.setSafe(0, 30000);
+      durationVector.setNull(1);
+      durationVector.setSafe(2, 555);
+      durationVector.setValueCount(3);
+
+      final Duration value1 = Duration.ofMillis(30000);
+      final Duration value3 = Duration.ofMillis(555);
+      assertThat(
+          durationVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testFixedSizeBinaryVectorIterable() {
+    try (final FixedSizeBinaryVector fixedSizeBinaryVector =
+        new FixedSizeBinaryVector("binary", allocator, 4)) {
+      final byte[] value1 = new byte[] {0, 0, 0, 1};
+      final byte[] value3 = new byte[] {1, 0, 0, 0};
+
+      fixedSizeBinaryVector.allocateNew(3);
+      fixedSizeBinaryVector.setSafe(0, value1);
+      fixedSizeBinaryVector.setNull(1);
+      fixedSizeBinaryVector.setSafe(2, value3);
+      fixedSizeBinaryVector.setValueCount(3);
+
+      assertThat(
+          fixedSizeBinaryVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testFloat2VectorIterable() {
+    try (final Float2Vector float2Vector = new Float2Vector("float2", allocator)) {
+      float2Vector.allocateNew(3);
+      float2Vector.setSafe(0, (short) 7777);
+      float2Vector.setNull(1);
+      float2Vector.setSafe(2, (short) 5);
+      float2Vector.setValueCount(3);
+
+      assertThat(
+          float2Vector.getValueIterable(),
+          IsIterableContainingInOrder.contains((short) 7777, null, (short) 5));
+    }
+  }
+
+  @Test
+  public void testFloat4VectorIterable() {
+    try (final Float4Vector float4Vector = new Float4Vector("float4", allocator)) {
+      float4Vector.allocateNew(3);
+      float4Vector.setSafe(0, 16.32f);
+      float4Vector.setNull(1);
+      float4Vector.setSafe(2, -10.75f);
+      float4Vector.setValueCount(3);
+
+      assertThat(
+          float4Vector.getValueIterable(),
+          IsIterableContainingInOrder.contains(16.32f, null, -10.75f));
+    }
+  }
+
+  @Test
+  public void testFloat8VectorIterable() {
+    try (final Float8Vector float8Vector = new Float8Vector("float8", allocator)) {
+      float8Vector.allocateNew(3);
+      float8Vector.setSafe(0, 16.32);
+      float8Vector.setNull(1);
+      float8Vector.setSafe(2, -10.75);
+      float8Vector.setValueCount(3);
+
+      assertThat(
+          float8Vector.getValueIterable(),
+          IsIterableContainingInOrder.contains(16.32, null, -10.75));
+    }
+  }
+
+  @Test
+  public void testIntVectorIterable() {
+    try (final IntVector intVector = new IntVector("int", allocator)) {
+      intVector.allocateNew(3);
+      intVector.setSafe(0, 78);
+      intVector.setNull(1);
+      intVector.setSafe(2, -93);
+      intVector.setValueCount(3);
+
+      assertThat(intVector.getValueIterable(), IsIterableContainingInOrder.contains(78, null, -93));
+    }
+  }
+
+  @Test
+  public void testIntervalDayVectorIterable() {
+    try (final IntervalDayVector intervalDayVector =
+        new IntervalDayVector("intervalDay", allocator)) {
+      intervalDayVector.allocateNew(3);
+      intervalDayVector.setSafe(0, 63, 0);
+      intervalDayVector.setNull(1);
+      intervalDayVector.setSafe(2, 555, 0);
+      intervalDayVector.setValueCount(3);
+
+      final Duration value1 = Duration.ofDays(63);
+      final Duration value3 = Duration.ofDays(555);
+      assertThat(
+          intervalDayVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testIntervalMonthDayNanoVectorIterable() {
+    try (final IntervalMonthDayNanoVector intervalMonthDayNanoVector =
+        new IntervalMonthDayNanoVector("intervalMonthDayNano", allocator)) {
+      intervalMonthDayNanoVector.allocateNew(3);
+      intervalMonthDayNanoVector.setSafe(0, 3, 4, 0);
+      intervalMonthDayNanoVector.setNull(1);
+      intervalMonthDayNanoVector.setSafe(2, 7, 18, 0);
+      intervalMonthDayNanoVector.setValueCount(3);
+
+      final PeriodDuration value1 = new PeriodDuration(Period.of(0, 3, 4), Duration.ofSeconds(0));
+      final PeriodDuration value3 = new PeriodDuration(Period.of(0, 7, 18), Duration.ofSeconds(0));
+      assertThat(
+          intervalMonthDayNanoVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testIntervalYearVectorIterable() {
+    try (final IntervalYearVector intervalYearVector =
+        new IntervalYearVector("intervalYear", allocator)) {
+      intervalYearVector.allocateNew(3);
+      intervalYearVector.setSafe(0, 3);
+      intervalYearVector.setNull(1);
+      intervalYearVector.setSafe(2, 17);
+      intervalYearVector.setValueCount(3);
+
+      final Period value1 = Period.ofMonths(3);
+      final Period value3 = Period.ofMonths(17);
+      assertThat(
+          intervalYearVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testLargeVarBinaryVectorIterable() {
+    try (final LargeVarBinaryVector largeVarBinaryVector =
+        new LargeVarBinaryVector("largeVarBinary", allocator)) {
+      final byte[] value1 = new byte[] {0, 0, 0, 1};
+      final byte[] value3 = new byte[] {1, 0, 0};
+
+      largeVarBinaryVector.allocateNew(3);
+      largeVarBinaryVector.setSafe(0, value1);
+      largeVarBinaryVector.setNull(1);
+      largeVarBinaryVector.setSafe(2, value3);
+      largeVarBinaryVector.setValueCount(3);
+
+      assertThat(
+          largeVarBinaryVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testLargeVarCharVectorIterable() {
+    try (final LargeVarCharVector largeVarCharVector =
+        new LargeVarCharVector("largeVarChar", allocator)) {
+      final Text value1 = new Text("hello");
+      final Text value3 = new Text("worlds");
+
+      largeVarCharVector.allocateNew(3);
+      largeVarCharVector.setSafe(0, value1);
+      largeVarCharVector.setNull(1);
+      largeVarCharVector.setSafe(2, value3);
+      largeVarCharVector.setValueCount(3);
+
+      assertThat(
+          largeVarCharVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testNullVectorIterable() {
+    try (final NullVector nullVector = new NullVector("null", 3)) {
+      assertThat(
+          nullVector.getValueIterable(), IsIterableContainingInOrder.contains(null, null, null));
+    }
+  }
+
+  @Test
+  public void testSmallIntVectorIterable() {
+    try (final SmallIntVector smallIntVector = new SmallIntVector("smallInt", allocator)) {
+      smallIntVector.allocateNew(3);
+      smallIntVector.setSafe(0, 78);
+      smallIntVector.setNull(1);
+      smallIntVector.setSafe(2, -93);
+      smallIntVector.setValueCount(3);
+
+      assertThat(
+          smallIntVector.getValueIterable(),
+          IsIterableContainingInOrder.contains((short) 78, null, (short) -93));
+    }
+  }
+
+  @Test
+  public void testTimeMicroVectorIterable() {
+    try (final TimeMicroVector timeMicroVector = new TimeMicroVector("timeMicro", allocator)) {
+      timeMicroVector.allocateNew(3);
+      timeMicroVector.setSafe(0, 70000);
+      timeMicroVector.setNull(1);
+      timeMicroVector.setSafe(2, 555);
+      timeMicroVector.setValueCount(3);
+
+      assertThat(
+          timeMicroVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(70000L, null, 555L));
+    }
+  }
+
+  @Test
+  public void testTimeMilliVectorIterable() {
+    try (final TimeMilliVector timeMilliVector = new TimeMilliVector("timeMilli", allocator)) {
+      timeMilliVector.allocateNew(3);
+      timeMilliVector.setSafe(0, 70000);
+      timeMilliVector.setNull(1);
+      timeMilliVector.setSafe(2, 555);
+      timeMilliVector.setValueCount(3);
+
+      final LocalDateTime value1 = LocalDateTime.ofEpochSecond(70L, 0, ZoneOffset.ofHours(0));
+      final LocalDateTime value3 =
+          LocalDateTime.ofEpochSecond(0L, 555000000, ZoneOffset.ofHours(0));
+      assertThat(
+          timeMilliVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testTimeNanoVectorIterable() {
+    try (final TimeNanoVector timeNanoVector = new TimeNanoVector("timeNano", allocator)) {
+      timeNanoVector.allocateNew(3);
+      timeNanoVector.setSafe(0, 70000);
+      timeNanoVector.setNull(1);
+      timeNanoVector.setSafe(2, 555);
+      timeNanoVector.setValueCount(3);
+
+      assertThat(
+          timeNanoVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(70000L, null, 555L));
+    }
+  }
+
+  @Test
+  public void testTimeSecVectorIterable() {
+    try (final TimeSecVector timeSecVector = new TimeSecVector("timeSec", allocator)) {
+      timeSecVector.allocateNew(3);
+      timeSecVector.setSafe(0, 70000);
+      timeSecVector.setNull(1);
+      timeSecVector.setSafe(2, 555);
+      timeSecVector.setValueCount(3);
+
+      assertThat(
+          timeSecVector.getValueIterable(), IsIterableContainingInOrder.contains(70000, null, 555));
+    }
+  }
+
+  @Test
+  public void testTimeStampMicroTZVectorIterable() {
+    try (final TimeStampMicroTZVector timeStampMicroTzVector =
+        new TimeStampMicroTZVector("timeStampMicroTZ", allocator, "UTC")) {
+      timeStampMicroTzVector.allocateNew(3);
+      timeStampMicroTzVector.setSafe(0, 70000);
+      timeStampMicroTzVector.setNull(1);
+      timeStampMicroTzVector.setSafe(2, 555);
+      timeStampMicroTzVector.setValueCount(3);
+
+      assertThat(
+          timeStampMicroTzVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(70000L, null, 555L));
+    }
+  }
+
+  @Test
+  public void testTimeStampMicroVectorIterable() {
+    try (final TimeStampMicroVector timeStampMicroVector =
+        new TimeStampMicroVector("timeStampMicro", allocator)) {
+      timeStampMicroVector.allocateNew(3);
+      timeStampMicroVector.setSafe(0, 70000);
+      timeStampMicroVector.setNull(1);
+      timeStampMicroVector.setSafe(2, 555);
+      timeStampMicroVector.setValueCount(3);
+
+      final LocalDateTime value1 = LocalDateTime.ofEpochSecond(0L, 70000000, ZoneOffset.ofHours(0));
+      final LocalDateTime value3 = LocalDateTime.ofEpochSecond(0L, 555000, ZoneOffset.ofHours(0));
+      assertThat(
+          timeStampMicroVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testTimeStampMilliTZVectorIterable() {
+    try (final TimeStampMilliTZVector timeStampMilliTzVector =
+        new TimeStampMilliTZVector("timeStampMilliTZ", allocator, "UTC")) {
+      timeStampMilliTzVector.allocateNew(3);
+      timeStampMilliTzVector.setSafe(0, 70000);
+      timeStampMilliTzVector.setNull(1);
+      timeStampMilliTzVector.setSafe(2, 555);
+      timeStampMilliTzVector.setValueCount(3);
+
+      assertThat(
+          timeStampMilliTzVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(70000L, null, 555L));
+    }
+  }
+
+  @Test
+  public void testTimeStampMilliVectorIterable() {
+    try (final TimeStampMilliVector timeStampMilliVector =
+        new TimeStampMilliVector("timeStampMilli", allocator)) {
+      timeStampMilliVector.allocateNew(3);
+      timeStampMilliVector.setSafe(0, 70000);
+      timeStampMilliVector.setNull(1);
+      timeStampMilliVector.setSafe(2, 555);
+      timeStampMilliVector.setValueCount(3);
+
+      final LocalDateTime value1 = LocalDateTime.ofEpochSecond(70L, 0, ZoneOffset.ofHours(0));
+      final LocalDateTime value3 =
+          LocalDateTime.ofEpochSecond(0L, 555000000, ZoneOffset.ofHours(0));
+      assertThat(
+          timeStampMilliVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testTimeStampNanoTZVectorIterable() {
+    try (final TimeStampNanoTZVector timeStampNanoTzVector =
+        new TimeStampNanoTZVector("timeStampNanoTZ", allocator, "UTC")) {
+      timeStampNanoTzVector.allocateNew(3);
+      timeStampNanoTzVector.setSafe(0, 70000);
+      timeStampNanoTzVector.setNull(1);
+      timeStampNanoTzVector.setSafe(2, 555);
+      timeStampNanoTzVector.setValueCount(3);
+
+      assertThat(
+          timeStampNanoTzVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(70000L, null, 555L));
+    }
+  }
+
+  @Test
+  public void testTimeStampNanoVectorIterable() {
+    try (final TimeStampNanoVector timeStampNanoVector =
+        new TimeStampNanoVector("timeStampNano", allocator)) {
+      timeStampNanoVector.allocateNew(3);
+      timeStampNanoVector.setSafe(0, 70000);
+      timeStampNanoVector.setNull(1);
+      timeStampNanoVector.setSafe(2, 555);
+      timeStampNanoVector.setValueCount(3);
+
+      final LocalDateTime value1 = LocalDateTime.ofEpochSecond(0L, 70000, ZoneOffset.ofHours(0));
+      final LocalDateTime value3 = LocalDateTime.ofEpochSecond(0L, 555, ZoneOffset.ofHours(0));
+      assertThat(
+          timeStampNanoVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testTimeStampSecTZVectorIterable() {
+    try (final TimeStampSecTZVector timeStampSecTzVector =
+        new TimeStampSecTZVector("timeStampSecTZ", allocator, "UTC")) {
+      timeStampSecTzVector.allocateNew(3);
+      timeStampSecTzVector.setSafe(0, 70000);
+      timeStampSecTzVector.setNull(1);
+      timeStampSecTzVector.setSafe(2, 555);
+      timeStampSecTzVector.setValueCount(3);
+
+      assertThat(
+          timeStampSecTzVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(70000L, null, 555L));
+    }
+  }
+
+  @Test
+  public void testTimeStampSecVectorIterable() {
+    try (final TimeStampSecVector timeStampSecVector =
+        new TimeStampSecVector("timeStampSec", allocator)) {
+      timeStampSecVector.allocateNew(3);
+      timeStampSecVector.setSafe(0, 70000);
+      timeStampSecVector.setNull(1);
+      timeStampSecVector.setSafe(2, 555);
+      timeStampSecVector.setValueCount(3);
+
+      final LocalDateTime value1 = LocalDateTime.ofEpochSecond(70000L, 0, ZoneOffset.ofHours(0));
+      final LocalDateTime value3 = LocalDateTime.ofEpochSecond(555L, 0, ZoneOffset.ofHours(0));
+      assertThat(
+          timeStampSecVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testTinyIntVectorIterable() {
+    try (final TinyIntVector tinyIntVector = new TinyIntVector("tinyInt", allocator)) {
+      tinyIntVector.allocateNew(3);
+      tinyIntVector.setSafe(0, 8);
+      tinyIntVector.setNull(1);
+      tinyIntVector.setSafe(2, -17);
+      tinyIntVector.setValueCount(3);
+
+      assertThat(
+          tinyIntVector.getValueIterable(),
+          IsIterableContainingInOrder.contains((byte) 8, null, (byte) -17));
+    }
+  }
+
+  @Test
+  public void testUInt1VectorIterable() {
+    try (final UInt1Vector uint1Vector = new UInt1Vector("uint1", allocator)) {
+      uint1Vector.allocateNew(3);
+      uint1Vector.setSafe(0, 8);
+      uint1Vector.setNull(1);
+      uint1Vector.setSafe(2, 101);
+      uint1Vector.setValueCount(3);
+
+      assertThat(
+          uint1Vector.getValueIterable(),
+          IsIterableContainingInOrder.contains((byte) 8, null, (byte) 101));
+    }
+  }
+
+  @Test
+  public void testUInt2VectorIterable() {
+    try (final UInt2Vector uint2Vector = new UInt2Vector("uint2", allocator)) {
+      uint2Vector.allocateNew(3);
+      uint2Vector.setSafe(0, 78);
+      uint2Vector.setNull(1);
+      uint2Vector.setSafe(2, 3456);
+      uint2Vector.setValueCount(3);
+
+      assertThat(
+          uint2Vector.getValueIterable(),
+          IsIterableContainingInOrder.contains((char) 78, null, (char) 3456));
+    }
+  }
+
+  @Test
+  public void testUInt4VectorIterable() {
+    try (final UInt4Vector uint4Vector = new UInt4Vector("uint4", allocator)) {
+      uint4Vector.allocateNew(3);
+      uint4Vector.setSafe(0, 78);
+      uint4Vector.setNull(1);
+      uint4Vector.setSafe(2, 3456);
+      uint4Vector.setValueCount(3);
+
+      assertThat(
+          uint4Vector.getValueIterable(), IsIterableContainingInOrder.contains(78, null, 3456));
+    }
+  }
+
+  @Test
+  public void testUInt8VectorIterable() {
+    try (final UInt8Vector uint8Vector = new UInt8Vector("uint8", allocator)) {
+      uint8Vector.allocateNew(3);
+      uint8Vector.setSafe(0, 6);
+      uint8Vector.setSafe(1, 2);
+      uint8Vector.setSafe(2, 19);
+      uint8Vector.setValueCount(3);
+
+      assertThat(uint8Vector.getValueIterable(), IsIterableContainingInOrder.contains(6L, 2L, 19L));
+    }
+  }
+
+  @Test
+  public void testVarBinaryVectorIterable() {
+    try (final VarBinaryVector varBinaryVector = new VarBinaryVector("varBinary", allocator)) {
+      final byte[] value1 = new byte[] {0, 0, 0, 1};
+      final byte[] value3 = new byte[] {1, 0, 0};
+
+      varBinaryVector.allocateNew(3);
+      varBinaryVector.setSafe(0, value1);
+      varBinaryVector.setNull(1);
+      varBinaryVector.setSafe(2, value3);
+      varBinaryVector.setValueCount(3);
+
+      assertThat(
+          varBinaryVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testVarCharVectorIterable() {
+    try (final VarCharVector varCharVector = new VarCharVector("varChar", allocator)) {
+      final Text value1 = new Text("hello");
+      final Text value3 = new Text("worlds");
+
+      varCharVector.allocateNew(3);
+      varCharVector.setSafe(0, value1);
+      varCharVector.setNull(1);
+      varCharVector.setSafe(2, value3);
+      varCharVector.setValueCount(3);
+
+      assertThat(
+          varCharVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testViewVarBinaryVectorIterable() {
+    try (final ViewVarBinaryVector viewVarBinaryVector =
+        new ViewVarBinaryVector("viewVarBinary", allocator)) {
+      final byte[] value1 = new byte[] {0, 0, 0, 1};
+      final byte[] value3 = new byte[] {1, 0, 0};
+
+      viewVarBinaryVector.allocateNew(3);
+      viewVarBinaryVector.setSafe(0, value1);
+      viewVarBinaryVector.setNull(1);
+      viewVarBinaryVector.setSafe(2, value3);
+      viewVarBinaryVector.setValueCount(3);
+
+      assertThat(
+          viewVarBinaryVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testViewVarCharVectorIterable() {
+    try (final ViewVarCharVector viewVarCharVector =
+        new ViewVarCharVector("viewVarChar", allocator)) {
+      final Text value1 = new Text("hello");
+      final Text value3 = new Text("worlds");
+
+      viewVarCharVector.allocateNew(3);
+      viewVarCharVector.setSafe(0, value1);
+      viewVarCharVector.setNull(1);
+      viewVarCharVector.setSafe(2, value3);
+      viewVarCharVector.setValueCount(3);
+
+      assertThat(
+          viewVarCharVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+
+  @Test
+  public void testFIxedSizeListVectorIterable() {
+    try (final FixedSizeListVector fixedSizeListVector =
+        new FixedSizeListVector(
+            "fixedSizeList", allocator, FieldType.nullable(new ArrowType.FixedSizeList(3)), null)) {
+      final IntVector listVector =
+          (IntVector)
+              fixedSizeListVector
+                  .addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()))
+                  .getVector();
+      listVector.setSafe(0, 1);
+      listVector.setSafe(1, 2);
+      listVector.setSafe(2, 3);
+      listVector.setSafe(3, 4);
+      listVector.setSafe(4, 5);
+      listVector.setSafe(5, 6);
+      listVector.setValueCount(6);
+      fixedSizeListVector.setValueCount(2);
+      fixedSizeListVector.setNotNull(0);
+      fixedSizeListVector.setNotNull(1);
+
+      final List<Integer> list1 = new ArrayList<>();
+      list1.add(1);
+      list1.add(2);
+      list1.add(3);
+      final List<Integer> list2 = new ArrayList<>();
+      list2.add(4);
+      list2.add(5);
+      list2.add(6);
+
+      assertThat(
+          fixedSizeListVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(list1, list2));
+    }
+  }
+
+  @Test
+  public void testLargeListVectorIterable() {
+    try (final LargeListVector largeListVector = LargeListVector.empty("largeList", allocator)) {
+      UnionLargeListWriter writer = largeListVector.getWriter();
+      writer.allocate();
+
+      writer.startList();
+      writer.integer().writeInt(1);
+      writer.integer().writeInt(2);
+      writer.integer().writeInt(3);
+      writer.endList();
+      writer.startList();
+      writer.integer().writeInt(4);
+      writer.integer().writeInt(5);
+      writer.endList();
+
+      largeListVector.setValueCount(2);
+
+      final List<Integer> list1 = new ArrayList<>();
+      list1.add(1);
+      list1.add(2);
+      list1.add(3);
+      final List<Integer> list2 = new ArrayList<>();
+      list2.add(4);
+      list2.add(5);
+
+      assertThat(
+          largeListVector.getValueIterable(), IsIterableContainingInOrder.contains(list1, list2));
+    }
+  }
+
+  @Test
+  public void testListVectorIterable() {
+    try (final ListVector listVector = ListVector.empty("largeList", allocator)) {
+      UnionListWriter writer = listVector.getWriter();
+      writer.allocate();
+
+      writer.startList();
+      writer.integer().writeInt(1);
+      writer.integer().writeInt(2);
+      writer.integer().writeInt(3);
+      writer.endList();
+      writer.startList();
+      writer.integer().writeInt(4);
+      writer.integer().writeInt(5);
+      writer.endList();
+
+      listVector.setValueCount(2);
+
+      final List<Integer> list1 = new ArrayList<>();
+      list1.add(1);
+      list1.add(2);
+      list1.add(3);
+      final List<Integer> list2 = new ArrayList<>();
+      list2.add(4);
+      list2.add(5);
+
+      assertThat(listVector.getValueIterable(), IsIterableContainingInOrder.contains(list1, list2));
+    }
+  }
+
+  @Test
+  public void testListViewVectorIterable() {
+    try (final ListViewVector listViewVector = ListViewVector.empty("largeList", allocator)) {
+      UnionListViewWriter writer = listViewVector.getWriter();
+      writer.allocate();
+
+      writer.startList();
+      writer.integer().writeInt(1);
+      writer.integer().writeInt(2);
+      writer.integer().writeInt(3);
+      writer.endList();
+      writer.startList();
+      writer.integer().writeInt(4);
+      writer.integer().writeInt(5);
+      writer.endList();
+
+      listViewVector.setValueCount(2);
+
+      final List<Integer> list1 = new ArrayList<>();
+      list1.add(1);
+      list1.add(2);
+      list1.add(3);
+      final List<Integer> list2 = new ArrayList<>();
+      list2.add(4);
+      list2.add(5);
+
+      assertThat(
+          listViewVector.getValueIterable(), IsIterableContainingInOrder.contains(list1, list2));
+    }
+  }
+
+  @Test
+  public void testNonNullableStructVectorIterable() {
+    try (final NonNullableStructVector nonNullableStructVector =
+        NonNullableStructVector.empty("nonNullableStruct", allocator)) {
+      nonNullableStructVector.setValueCount(2);
+
+      IntVector key1Vector =
+          nonNullableStructVector.addOrGet(
+              "key1", FieldType.notNullable(new ArrowType.Int(32, true)), IntVector.class);
+      IntVector key2Vector =
+          nonNullableStructVector.addOrGet(
+              "key2", FieldType.notNullable(new ArrowType.Int(32, true)), IntVector.class);
+      key1Vector.setSafe(0, 1);
+      key1Vector.setSafe(1, 3);
+      key2Vector.setSafe(0, 2);
+      key2Vector.setSafe(1, 4);
+      key1Vector.setValueCount(2);
+      key2Vector.setValueCount(2);
+
+      final Map<String, Integer> value1 = new HashMap<>();
+      value1.put("key1", 1);
+      value1.put("key2", 2);
+      final Map<String, Integer> value2 = new HashMap<>();
+      value2.put("key1", 3);
+      value2.put("key2", 4);
+
+      assertThat(
+          nonNullableStructVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, value2));
+    }
+  }
+
+  @Test
+  public void testStructVectorIterable() {
+    try (final StructVector structVector = StructVector.empty("struct", allocator)) {
+      structVector.addOrGetList("struct");
+      NullableStructWriter structWriter = structVector.getWriter();
+      structWriter.setPosition(0);
+      structWriter.start();
+      structWriter.integer("key1").writeInt(1);
+      structWriter.integer("key2").writeInt(2);
+      structWriter.end();
+      structWriter.setPosition(2);
+      structWriter.start();
+      structWriter.integer("key1").writeInt(3);
+      structWriter.integer("key2").writeInt(4);
+      structWriter.end();
+      structWriter.setValueCount(3);
+
+      final Map<String, Integer> value1 = new HashMap<>();
+      value1.put("key1", 1);
+      value1.put("key2", 2);
+      final Map<String, Integer> value3 = new HashMap<>();
+      value3.put("key1", 3);
+      value3.put("key2", 4);
+
+      assertThat(
+          structVector.getValueIterable(),
+          IsIterableContainingInOrder.contains(value1, null, value3));
+    }
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -332,7 +332,8 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector> implements ValueIterableVector<UUID> {
+  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector>
+      implements ValueIterableVector<UUID> {
 
     public UuidVector(
         String name, BufferAllocator allocator, FixedSizeBinaryVector underlyingVector) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -41,6 +41,7 @@ import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.ValueIterableVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
@@ -331,7 +332,7 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector> {
+  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector> implements ValueIterableVector<UUID> {
 
     public UuidVector(
         String name, BufferAllocator allocator, FixedSizeBinaryVector underlyingVector) {
@@ -399,7 +400,8 @@ public class TestExtensionType {
     }
   }
 
-  public static class LocationVector extends ExtensionTypeVector<StructVector> {
+  public static class LocationVector extends ExtensionTypeVector<StructVector>
+      implements ValueIterableVector<java.util.Map<String, ?>> {
 
     private static StructVector buildUnderlyingVector(String name, BufferAllocator allocator) {
       final StructVector underlyingVector =


### PR DESCRIPTION
### Rationale for this change

Simplify validating the values in a `ValueVector` in unit tests.

### What changes are included in this PR?

Methods for creating an `Iterable` and `Iterator` for a `ValueVector`. Also updated some unit tests to use the new methods.

### Are these changes tested?

Some unit tests were updated.

### Are there any user-facing changes?

The new methods are publicly available in the `ValueVectorUtility` class.
* GitHub Issue: #37728