### PR TITLE
GH-25118: [Python] Make NumPy an optional runtime dependency  

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,6 +59,7 @@ jobs:
           - conda-python-3.9-nopandas
           - conda-python-3.8-pandas-1.0
           - conda-python-3.10-pandas-latest
+          - conda-python-3.10-no-numpy
         include:
           - name: conda-python-docs
             cache: conda-python-3.9
@@ -83,6 +84,11 @@ jobs:
             title: AMD64 Conda Python 3.10 Pandas latest
             python: "3.10"
             pandas: latest
+          - name: conda-python-3.10-no-numpy
+            cache: conda-python-3.10
+            image: conda-python-no-numpy
+            title: AMD64 Conda Python 3.10 Testing without numpy latest
+            python: "3.10"
     env:
       PYTHON: ${{ matrix.python || 3.8 }}
       UBUNTU: ${{ matrix.ubuntu || 20.04 }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,7 +87,7 @@ jobs:
           - name: conda-python-3.10-no-numpy
             cache: conda-python-3.10
             image: conda-python-no-numpy
-            title: AMD64 Conda Python 3.10 Testing without numpy latest
+            title: AMD64 Conda Python 3.10 Testing without numpy
             python: "3.10"
     env:
       PYTHON: ${{ matrix.python || 3.8 }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -87,7 +87,7 @@ jobs:
           - name: conda-python-3.10-no-numpy
             cache: conda-python-3.10
             image: conda-python-no-numpy
-            title: AMD64 Conda Python 3.10 Testing without numpy
+            title: AMD64 Conda Python 3.10 without NumPy
             python: "3.10"
     env:
       PYTHON: ${{ matrix.python || 3.8 }}

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -69,4 +69,8 @@ export PYARROW_TEST_PARQUET_ENCRYPTION
 export PYARROW_TEST_S3
 
 # Testing PyArrow
-pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
+if [ -z "${TEST_COMMAND}" ]; then
+  pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
+else
+  ${TEST_COMMAND}
+fi

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -69,4 +69,4 @@ export PYARROW_TEST_PARQUET_ENCRYPTION
 export PYARROW_TEST_S3
 
 # Testing PyArrow
-pytest -r s ${PYTEST_ARGS} --pyargs ${PYTEST_PYARGS:-'pyarrow'}
+pytest -r s ${PYTEST_ARGS} --pyargs pyarrow

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -69,8 +69,4 @@ export PYARROW_TEST_PARQUET_ENCRYPTION
 export PYARROW_TEST_S3
 
 # Testing PyArrow
-if [ -z "${TEST_COMMAND}" ]; then
-  pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
-else
-  ${TEST_COMMAND}
-fi
+pytest -r s ${PYTEST_ARGS} --pyargs ${PYTEST_PYARGS:-'pyarrow'}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1276,16 +1276,10 @@ services:
         repo: ${REPO}
         arch: ${ARCH}
         python: ${PYTHON}
-        numpy: ${NUMPY}
-        pandas: ${PANDAS}
     shm_size: *shm-size
     environment:
       <<: [*common, *ccache, *sccache]
       PARQUET_REQUIRE_ENCRYPTION:  # inherit
-      # The without numpy mark is only used to select tests to be run
-      # when numpy is not installed but those tests will also run
-      # if numpy is present.
-      PYTEST_ARGS: "-k without_numpy"
       # Some tests fail to be collected due to numpy fixtures.
       # That is why we just collect tests from the following modules.
       PYTEST_PYARGS: "pyarrow.tests.test_array

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1282,9 +1282,13 @@ services:
     environment:
       <<: [*common, *ccache, *sccache]
       PARQUET_REQUIRE_ENCRYPTION:  # inherit
+      # The without numpy mark is only used to select tests to be run
+      # when numpy is not installed but those tests will also run
+      # if numpy is present.
+      PYTEST_ARGS: "-k without_numpy"
       # In the future we are supposed to run all tests.
-      # This is only temporary.
-      PYTEST_PYARGS:  "pyarrow.tests.test_array pyarrow.tests.test_without_numpy"
+      # Some tests fail to be collected so we just collect tests from some modules.
+      PYTEST_PYARGS: "pyarrow.tests.test_array pyarrow.tests.test_compute pyarrow.tests.test_without_numpy"
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1269,9 +1269,9 @@ services:
     image: ${REPO}:${ARCH}-conda-python-${PYTHON}-no-numpy
     build:
       context: .
-      dockerfile: ci/docker/conda-python-pandas.dockerfile
+      dockerfile: ci/docker/conda-python.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-conda-python-${PYTHON}-pandas-${PANDAS}
+        - ${REPO}:${ARCH}-conda-python-${PYTHON}
       args:
         repo: ${REPO}
         arch: ${ARCH}
@@ -1287,7 +1287,7 @@ services:
       ["
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
-        pip uninstall numpy -y &&
+        mamba uninstall -y numpy &&
         /arrow/ci/scripts/python_test.sh /arrow"]
 
   conda-python-docs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1284,7 +1284,7 @@ services:
       PARQUET_REQUIRE_ENCRYPTION:  # inherit
       # In the future we are supposed to run all tests.
       # This is only temporary.
-      TEST_COMMAND:  "pytest -r s --pyargs pyarrow.tests.test_array"
+      PYTEST_PYARGS:  "pyarrow.tests.test_array"
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,7 @@ x-hierarchy:
         - conda-python-hdfs
         - conda-python-java-integration
         - conda-python-jpype
+        - conda-python-no-numpy
         - conda-python-spark
         - conda-python-substrait
   - conda-verify-rc
@@ -1257,6 +1258,40 @@ services:
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes
     command: *python-conda-command
+
+  conda-python-no-numpy:
+    # Usage:
+    #   docker-compose build conda
+    #   docker-compose build conda-cpp
+    #   docker-compose build conda-python
+    #   docker-compose build conda-python-no-numpy
+    #   docker-compose run --rm conda-python-no-numpy
+    image: ${REPO}:${ARCH}-conda-python-${PYTHON}-no-numpy
+    build:
+      context: .
+      dockerfile: ci/docker/conda-python-pandas.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-conda-python-${PYTHON}-pandas-${PANDAS}
+      args:
+        repo: ${REPO}
+        arch: ${ARCH}
+        python: ${PYTHON}
+        numpy: ${NUMPY}
+        pandas: ${PANDAS}
+    shm_size: *shm-size
+    environment:
+      <<: [*common, *ccache, *sccache]
+      PARQUET_REQUIRE_ENCRYPTION:  # inherit
+      PYTEST_ARGS:  # inherit
+      HYPOTHESIS_PROFILE:  # inherit
+      PYARROW_TEST_HYPOTHESIS:  # inherit
+    volumes: *conda-volumes
+    command:
+      ["
+        /arrow/ci/scripts/cpp_build.sh /arrow /build &&
+        /arrow/ci/scripts/python_build.sh /arrow /build &&
+        pip uninstall numpy -y &&
+        python -c 'import pyarrow as pa; arr = pa.array([1,2,3]); assert len(arr.buffers()) == 2'"]
 
   conda-python-docs:
     # Usage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1284,7 +1284,7 @@ services:
       PARQUET_REQUIRE_ENCRYPTION:  # inherit
       # In the future we are supposed to run all tests.
       # This is only temporary.
-      PYTEST_PYARGS:  "pyarrow.tests.test_array"
+      PYTEST_PYARGS:  "pyarrow.tests.test_array pyarrow.tests.test_without_numpy"
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1286,9 +1286,13 @@ services:
       # when numpy is not installed but those tests will also run
       # if numpy is present.
       PYTEST_ARGS: "-k without_numpy"
-      # In the future we are supposed to run all tests.
-      # Some tests fail to be collected so we just collect tests from some modules.
-      PYTEST_PYARGS: "pyarrow.tests.test_array pyarrow.tests.test_compute pyarrow.tests.test_without_numpy"
+      # Some tests fail to be collected due to numpy fixtures.
+      # That is why we just collect tests from the following modules.
+      PYTEST_PYARGS: "pyarrow.tests.test_array
+                      pyarrow.tests.test_compute
+                      pyarrow.tests.test_dataset
+                      pyarrow.tests.test_flight
+                      pyarrow.tests.test_without_numpy"
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1280,13 +1280,6 @@ services:
     environment:
       <<: [*common, *ccache, *sccache]
       PARQUET_REQUIRE_ENCRYPTION:  # inherit
-      # Some tests fail to be collected due to numpy fixtures.
-      # That is why we just collect tests from the following modules.
-      PYTEST_PYARGS: "pyarrow.tests.test_array
-                      pyarrow.tests.test_compute
-                      pyarrow.tests.test_dataset
-                      pyarrow.tests.test_flight
-                      pyarrow.tests.test_without_numpy"
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1282,7 +1282,9 @@ services:
     environment:
       <<: [*common, *ccache, *sccache]
       PARQUET_REQUIRE_ENCRYPTION:  # inherit
-      PYTEST_ARGS:  # inherit
+      # In the future we are supposed to run all tests.
+      # This is only temporary.
+      TEST_COMMAND:  "pytest -r s --pyargs pyarrow.tests.test_array"
       HYPOTHESIS_PROFILE:  # inherit
       PYARROW_TEST_HYPOTHESIS:  # inherit
     volumes: *conda-volumes
@@ -1291,7 +1293,7 @@ services:
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         pip uninstall numpy -y &&
-        python -c 'import pyarrow as pa; arr = pa.array([1,2,3]); assert len(arr.buffers()) == 2'"]
+        /arrow/ci/scripts/python_test.sh /arrow"]
 
   conda-python-docs:
     # Usage:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -339,17 +339,17 @@ set(PYARROW_CPP_SRCS
     ${PYARROW_CPP_SOURCE_DIR}/gdb.cc
     ${PYARROW_CPP_SOURCE_DIR}/helpers.cc
     ${PYARROW_CPP_SOURCE_DIR}/inference.cc
-    ${PYARROW_CPP_SOURCE_DIR}/init.cc
     ${PYARROW_CPP_SOURCE_DIR}/io.cc
     ${PYARROW_CPP_SOURCE_DIR}/ipc.cc
     ${PYARROW_CPP_SOURCE_DIR}/numpy_convert.cc
+    ${PYARROW_CPP_SOURCE_DIR}/numpy_init.cc
     ${PYARROW_CPP_SOURCE_DIR}/numpy_to_arrow.cc
     ${PYARROW_CPP_SOURCE_DIR}/python_test.cc
     ${PYARROW_CPP_SOURCE_DIR}/python_to_arrow.cc
     ${PYARROW_CPP_SOURCE_DIR}/pyarrow.cc
     ${PYARROW_CPP_SOURCE_DIR}/serialize.cc
     ${PYARROW_CPP_SOURCE_DIR}/udf.cc)
-set_source_files_properties(${PYARROW_CPP_SOURCE_DIR}/init.cc
+set_source_files_properties(${PYARROW_CPP_SOURCE_DIR}/numpy_init.cc
                             PROPERTIES SKIP_PRECOMPILE_HEADERS ON
                                        SKIP_UNITY_BUILD_INCLUSION ON)
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -73,10 +73,6 @@ from pyarrow.lib import (BuildInfo, RuntimeInfo, set_timezone_db_path,
                          io_thread_count, set_io_thread_count)
 
 
-# Expose whether NUMPY is available or not
-from pyarrow.lib import HAS_NUMPY
-
-
 def show_versions():
     """
     Print various version information, to help with error reporting.

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -73,6 +73,10 @@ from pyarrow.lib import (BuildInfo, RuntimeInfo, set_timezone_db_path,
                          io_thread_count, set_io_thread_count)
 
 
+# Expose whether NUMPY is available or not
+from pyarrow.lib import HAS_NUMPY
+
+
 def show_versions():
     """
     Print various version information, to help with error reporting.

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -476,7 +476,7 @@ cdef class MetaFunction(Function):
 
 cdef _pack_compute_args(object values, vector[CDatum]* out):
     for val in values:
-        if np is not None and isinstance(val, (list, np.ndarray)):
+        if isinstance(val, list) or (np is not None and isinstance(val, np.ndarray)):
             val = lib.asarray(val)
 
         if isinstance(val, Array):
@@ -2192,7 +2192,7 @@ class QuantileOptions(_QuantileOptions):
 
     def __init__(self, q=0.5, *, interpolation="linear", skip_nulls=True,
                  min_count=0):
-        if not isinstance(q, (list, tuple, np.ndarray)):
+        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, np.ndarray)):
             q = [q]
         self._set_options(q, interpolation, skip_nulls, min_count)
 
@@ -2225,7 +2225,7 @@ class TDigestOptions(_TDigestOptions):
 
     def __init__(self, q=0.5, *, delta=100, buffer_size=500, skip_nulls=True,
                  min_count=0):
-        if not isinstance(q, (list, tuple, np.ndarray)):
+        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, np.ndarray)):
             q = [q]
         self._set_options(q, delta, buffer_size, skip_nulls, min_count)
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -24,7 +24,7 @@ from cython.operator cimport dereference as deref
 
 from collections import namedtuple
 
-from pyarrow.lib import frombytes, tobytes, ArrowInvalid
+from pyarrow.lib import frombytes, tobytes, ArrowInvalid, HAS_NUMPY
 from pyarrow.lib cimport *
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
@@ -476,7 +476,7 @@ cdef class MetaFunction(Function):
 
 cdef _pack_compute_args(object values, vector[CDatum]* out):
     for val in values:
-        if "numpy" in sys.modules and isinstance(val, (list, np.ndarray)):
+        if HAS_NUMPY and isinstance(val, (list, np.ndarray)):
             val = lib.asarray(val)
 
         if isinstance(val, Array):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -46,6 +46,11 @@ _substrait_msg = (
 )
 
 
+SUPPORTED_INPUT_ARR_TYPES = (list, tuple)
+if np is not None:
+    SUPPORTED_INPUT_ARR_TYPES += (np.ndarray, )
+
+
 def _pas():
     global __pas
     if __pas is None:
@@ -476,7 +481,7 @@ cdef class MetaFunction(Function):
 
 cdef _pack_compute_args(object values, vector[CDatum]* out):
     for val in values:
-        if isinstance(val, list) or (np is not None and isinstance(val, np.ndarray)):
+        if isinstance(val, SUPPORTED_INPUT_ARR_TYPES):
             val = lib.asarray(val)
 
         if isinstance(val, Array):
@@ -2192,7 +2197,7 @@ class QuantileOptions(_QuantileOptions):
 
     def __init__(self, q=0.5, *, interpolation="linear", skip_nulls=True,
                  min_count=0):
-        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, (list, tuple, np.ndarray))):
+        if not isinstance(q, SUPPORTED_INPUT_ARR_TYPES):
             q = [q]
         self._set_options(q, interpolation, skip_nulls, min_count)
 
@@ -2225,7 +2230,7 @@ class TDigestOptions(_TDigestOptions):
 
     def __init__(self, q=0.5, *, delta=100, buffer_size=500, skip_nulls=True,
                  min_count=0):
-        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, (list, tuple, np.ndarray))):
+        if not isinstance(q, SUPPORTED_INPUT_ARR_TYPES):
             q = [q]
         self._set_options(q, delta, buffer_size, skip_nulls, min_count)
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -24,7 +24,7 @@ from cython.operator cimport dereference as deref
 
 from collections import namedtuple
 
-from pyarrow.lib import frombytes, tobytes, ArrowInvalid, HAS_NUMPY
+from pyarrow.lib import frombytes, tobytes, ArrowInvalid
 from pyarrow.lib cimport *
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
@@ -36,7 +36,7 @@ import inspect
 try:
     import numpy as np
 except ImportError:
-    pass
+    np = None
 import warnings
 
 
@@ -476,7 +476,7 @@ cdef class MetaFunction(Function):
 
 cdef _pack_compute_args(object values, vector[CDatum]* out):
     for val in values:
-        if HAS_NUMPY and isinstance(val, (list, np.ndarray)):
+        if np is not None and isinstance(val, (list, np.ndarray)):
             val = lib.asarray(val)
 
         if isinstance(val, Array):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -33,7 +33,10 @@ from pyarrow.util import _DEPR_MSG
 from libcpp cimport bool as c_bool
 
 import inspect
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 import warnings
 
 
@@ -473,7 +476,7 @@ cdef class MetaFunction(Function):
 
 cdef _pack_compute_args(object values, vector[CDatum]* out):
     for val in values:
-        if isinstance(val, (list, np.ndarray)):
+        if "numpy" in sys.modules and isinstance(val, (list, np.ndarray)):
             val = lib.asarray(val)
 
         if isinstance(val, Array):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2192,7 +2192,7 @@ class QuantileOptions(_QuantileOptions):
 
     def __init__(self, q=0.5, *, interpolation="linear", skip_nulls=True,
                  min_count=0):
-        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, np.ndarray)):
+        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, (list, tuple, np.ndarray))):
             q = [q]
         self._set_options(q, interpolation, skip_nulls, min_count)
 
@@ -2225,7 +2225,7 @@ class TDigestOptions(_TDigestOptions):
 
     def __init__(self, q=0.5, *, delta=100, buffer_size=500, skip_nulls=True,
                  min_count=0):
-        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, np.ndarray)):
+        if not isinstance(q, (list, tuple)) or (np is not None and not isinstance(q, (list, tuple, np.ndarray))):
             q = [q]
         self._set_options(q, delta, buffer_size, skip_nulls, min_count)
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1612,7 +1612,7 @@ cdef class Array(_PandasConvertible):
 
         if np is None:
             raise ImportError(
-                "Cannot return a numpy.ndarray if Numpy is not present")
+                "Cannot return a numpy.ndarray if NumPy is not present")
         cdef:
             PyObject* out
             PandasOptions c_options

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1610,7 +1610,7 @@ cdef class Array(_PandasConvertible):
         """
         self._assert_cpu()
 
-        if not HAS_NUMPY:
+        if "numpy" not in sys.modules:
             raise ValueError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1610,6 +1610,9 @@ cdef class Array(_PandasConvertible):
         """
         self._assert_cpu()
 
+        if not HAS_NUMPY:
+            raise ValueError(
+                "Cannot return a numpy.ndarray if Numpy is not present")
         cdef:
             PyObject* out
             PandasOptions c_options

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -50,7 +50,7 @@ cdef _sequence_to_array(object sequence, object mask, object size,
 
 
 cdef inline _is_array_like(obj):
-    if "numpy" not in sys.modules:
+    if np is None:
         return False
     if isinstance(obj, np.ndarray):
         return True
@@ -1610,8 +1610,8 @@ cdef class Array(_PandasConvertible):
         """
         self._assert_cpu()
 
-        if "numpy" not in sys.modules:
-            raise ValueError(
+        if np is None:
+            raise ImportError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef:
             PyObject* out

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -50,6 +50,8 @@ cdef _sequence_to_array(object sequence, object mask, object size,
 
 
 cdef inline _is_array_like(obj):
+    if "numpy" not in sys.modules:
+        return False
     if isinstance(obj, np.ndarray):
         return True
     return pandas_api._have_pandas_internal() and pandas_api.is_array_like(obj)

--- a/python/pyarrow/builder.pxi
+++ b/python/pyarrow/builder.pxi
@@ -42,7 +42,7 @@ cdef class StringBuilder(_Weakrefable):
         value : string/bytes or np.nan/None
             The value to append to the string array builder.
         """
-        if value is None or value is np.nan:
+        if value is None or ('numpy' in sys.modules and value is np.nan):
             self.builder.get().AppendNull()
         elif isinstance(value, (bytes, str)):
             self.builder.get().Append(tobytes(value))
@@ -108,7 +108,7 @@ cdef class StringViewBuilder(_Weakrefable):
         value : string/bytes or np.nan/None
             The value to append to the string array builder.
         """
-        if value is None or value is np.nan:
+        if value is None or ('numpy' in sys.modules and value is np.nan):
             self.builder.get().AppendNull()
         elif isinstance(value, (bytes, str)):
             self.builder.get().Append(tobytes(value))

--- a/python/pyarrow/builder.pxi
+++ b/python/pyarrow/builder.pxi
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import math
+
 
 cdef class StringBuilder(_Weakrefable):
     """
@@ -42,10 +44,10 @@ cdef class StringBuilder(_Weakrefable):
         value : string/bytes or np.nan/None
             The value to append to the string array builder.
         """
-        if value is None or ('numpy' in sys.modules and value is np.nan):
-            self.builder.get().AppendNull()
-        elif isinstance(value, (bytes, str)):
+        if isinstance(value, (bytes, str)):
             self.builder.get().Append(tobytes(value))
+        elif value is None or math.isnan(value):
+            self.builder.get().AppendNull()
         else:
             raise TypeError('StringBuilder only accepts string objects')
 
@@ -108,10 +110,10 @@ cdef class StringViewBuilder(_Weakrefable):
         value : string/bytes or np.nan/None
             The value to append to the string array builder.
         """
-        if value is None or ('numpy' in sys.modules and value is np.nan):
-            self.builder.get().AppendNull()
-        elif isinstance(value, (bytes, str)):
+        if isinstance(value, (bytes, str)):
             self.builder.get().Append(tobytes(value))
+        elif value is None or math.isnan(value):
+            self.builder.get().AppendNull()
         else:
             raise TypeError('StringViewBuilder only accepts string objects')
 

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -25,7 +25,10 @@ from pyarrow.lib import is_threading_enabled
 from pyarrow.tests.util import windows_has_tzdata
 import sys
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 groups = [
     'acero',
@@ -46,6 +49,7 @@ groups = [
     'lz4',
     'memory_leak',
     'nopandas',
+    'numpy',
     'orc',
     'pandas',
     'parquet',
@@ -81,6 +85,7 @@ defaults = {
     'lz4': Codec.is_available('lz4'),
     'memory_leak': False,
     'nopandas': False,
+    'numpy': False,
     'orc': False,
     'pandas': False,
     'parquet': False,
@@ -157,6 +162,12 @@ try:
     defaults['pandas'] = True
 except ImportError:
     defaults['nopandas'] = True
+
+try:
+    import numpy  # noqa
+    defaults['numpy'] = True
+except ImportError:
+    pass
 
 try:
     import pyarrow.parquet  # noqa

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -45,6 +45,7 @@ groups = [
     'lz4',
     'memory_leak',
     'nopandas',
+    'nonumpy',
     'numpy',
     'orc',
     'pandas',
@@ -81,6 +82,7 @@ defaults = {
     'lz4': Codec.is_available('lz4'),
     'memory_leak': False,
     'nopandas': False,
+    'nonumpy': False,
     'numpy': False,
     'orc': False,
     'pandas': False,
@@ -163,7 +165,7 @@ try:
     import numpy  # noqa
     defaults['numpy'] = True
 except ImportError:
-    pass
+    defaults['nonumpy'] = True
 
 try:
     import pyarrow.parquet  # noqa

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -25,10 +25,6 @@ from pyarrow.lib import is_threading_enabled
 from pyarrow.tests.util import windows_has_tzdata
 import sys
 
-try:
-    import numpy as np
-except ImportError:
-    pass
 
 groups = [
     'acero',
@@ -338,6 +334,7 @@ def unary_agg_func_fixture():
     Register a unary aggregate function (mean)
     """
     from pyarrow import compute as pc
+    import numpy as np
 
     def func(ctx, x):
         return pa.scalar(np.nanmean(x))
@@ -363,6 +360,7 @@ def varargs_agg_func_fixture():
     Register a unary aggregate function
     """
     from pyarrow import compute as pc
+    import numpy as np
 
     def func(ctx, *args):
         sum = 0.0

--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -249,7 +249,7 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py::internal" nogil:
 
 
 cdef extern from "arrow/python/init.h":
-    int arrow_init_numpy() except -1
+    int arrow_init_numpy(c_bool import_numpy) except -1
 
 
 cdef extern from "arrow/python/pyarrow.h" namespace "arrow::py":

--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -248,8 +248,8 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py::internal" nogil:
     CResult[PyObject*] StringToTzinfo(c_string)
 
 
-cdef extern from "arrow/python/init.h":
-    int arrow_init_numpy(c_bool import_numpy) except -1
+cdef extern from "arrow/python/numpy_init.h" namespace "arrow::py":
+    int arrow_init_numpy() except -1
 
 
 cdef extern from "arrow/python/pyarrow.h" namespace "arrow::py":

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -36,9 +36,12 @@ cimport pyarrow.includes.libarrow_python as libarrow_python
 cimport cpython as cp
 
 # Initialize NumPy C API only if numpy was able to be imported
+
+
 def initialize_numpy():
     if "numpy" in sys.modules:
         arrow_init_numpy()
+
 
 initialize_numpy()
 # Initialize PyArrow C++ API

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -35,9 +35,8 @@ from pyarrow.includes.common cimport PyObject_to_object
 cimport pyarrow.includes.libarrow_python as libarrow_python
 cimport cpython as cp
 
+
 # Initialize NumPy C API only if numpy was able to be imported
-
-
 if np is not None:
     arrow_init_numpy()
 

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -21,8 +21,10 @@
 
 import datetime
 import decimal as _pydecimal
+HAS_NUMPY=False
 try:
     import numpy as np
+    HAS_NUMPY=True
 except ImportError:
     np = None
 import os

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -21,10 +21,8 @@
 
 import datetime
 import decimal as _pydecimal
-HAS_NUMPY=False
 try:
     import numpy as np
-    HAS_NUMPY=True
 except ImportError:
     np = None
 import os

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -24,7 +24,7 @@ import decimal as _pydecimal
 try:
     import numpy as np
 except ImportError:
-    pass
+    np = None
 import os
 import sys
 
@@ -38,14 +38,9 @@ cimport cpython as cp
 # Initialize NumPy C API only if numpy was able to be imported
 
 
-def initialize_numpy():
-    if "numpy" in sys.modules:
-        arrow_init_numpy(True)
-    else:
-        arrow_init_numpy(False)
+if np is not None:
+    arrow_init_numpy()
 
-
-initialize_numpy()
 # Initialize PyArrow C++ API
 # (used from some of our C++ code, see e.g. ARROW-5260)
 import_pyarrow()

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -40,7 +40,9 @@ cimport cpython as cp
 
 def initialize_numpy():
     if "numpy" in sys.modules:
-        arrow_init_numpy()
+        arrow_init_numpy(True)
+    else:
+        arrow_init_numpy(False)
 
 
 initialize_numpy()

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -21,7 +21,10 @@
 
 import datetime
 import decimal as _pydecimal
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 import os
 import sys
 
@@ -32,8 +35,12 @@ from pyarrow.includes.common cimport PyObject_to_object
 cimport pyarrow.includes.libarrow_python as libarrow_python
 cimport cpython as cp
 
-# Initialize NumPy C API
-arrow_init_numpy()
+# Initialize NumPy C API only if numpy was able to be imported
+def initialize_numpy():
+    if "numpy" in sys.modules:
+        arrow_init_numpy()
+
+initialize_numpy()
 # Initialize PyArrow C++ API
 # (used from some of our C++ code, see e.g. ARROW-5260)
 import_pyarrow()

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -30,13 +30,17 @@ import operator
 import re
 import warnings
 
-import numpy as np
-
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pyarrow as pa
 from pyarrow.lib import _pandas_api, frombytes, is_threading_enabled  # noqa
 
 
 _logical_type_map = {}
+_numpy_logical_type_map = {}
+_pandas_logical_type_map = {}
 
 
 def get_logical_type_map():
@@ -85,27 +89,32 @@ def get_logical_type(arrow_type):
         return 'object'
 
 
-_numpy_logical_type_map = {
-    np.bool_: 'bool',
-    np.int8: 'int8',
-    np.int16: 'int16',
-    np.int32: 'int32',
-    np.int64: 'int64',
-    np.uint8: 'uint8',
-    np.uint16: 'uint16',
-    np.uint32: 'uint32',
-    np.uint64: 'uint64',
-    np.float32: 'float32',
-    np.float64: 'float64',
-    'datetime64[D]': 'date',
-    np.str_: 'string',
-    np.bytes_: 'bytes',
-}
+def get_numpy_logical_type_map():
+    global _numpy_logical_type_map
+    if not _numpy_logical_type_map:
+        _numpy_logical_type_map.update({
+            np.bool_: 'bool',
+            np.int8: 'int8',
+            np.int16: 'int16',
+            np.int32: 'int32',
+            np.int64: 'int64',
+            np.uint8: 'uint8',
+            np.uint16: 'uint16',
+            np.uint32: 'uint32',
+            np.uint64: 'uint64',
+            np.float32: 'float32',
+            np.float64: 'float64',
+            'datetime64[D]': 'date',
+            np.str_: 'string',
+            np.bytes_: 'bytes',
+        })
+    return _numpy_logical_type_map
 
 
 def get_logical_type_from_numpy(pandas_collection):
+    numpy_logical_type_map = get_numpy_logical_type_map()
     try:
-        return _numpy_logical_type_map[pandas_collection.dtype.type]
+        return numpy_logical_type_map[pandas_collection.dtype.type]
     except KeyError:
         if hasattr(pandas_collection.dtype, 'tz'):
             return 'datetimetz'
@@ -1022,19 +1031,23 @@ def _is_generated_index_name(name):
     pattern = r'^__index_level_\d+__$'
     return re.match(pattern, name) is not None
 
+def get_pandas_logical_type_map():
+    global _pandas_logical_type_map
 
-_pandas_logical_type_map = {
-    'date': 'datetime64[D]',
-    'datetime': 'datetime64[ns]',
-    'datetimetz': 'datetime64[ns]',
-    'unicode': np.str_,
-    'bytes': np.bytes_,
-    'string': np.str_,
-    'integer': np.int64,
-    'floating': np.float64,
-    'decimal': np.object_,
-    'empty': np.object_,
-}
+    if not _pandas_logical_type_map:
+        _pandas_logical_type_map.update({
+            'date': 'datetime64[D]',
+            'datetime': 'datetime64[ns]',
+            'datetimetz': 'datetime64[ns]',
+            'unicode': np.str_,
+            'bytes': np.bytes_,
+            'string': np.str_,
+            'integer': np.int64,
+            'floating': np.float64,
+            'decimal': np.object_,
+            'empty': np.object_,
+        })
+    return _pandas_logical_type_map
 
 
 def _pandas_type_to_numpy_type(pandas_type):
@@ -1050,8 +1063,9 @@ def _pandas_type_to_numpy_type(pandas_type):
     dtype : np.dtype
         The dtype that corresponds to `pandas_type`.
     """
+    pandas_logical_type_map = get_pandas_logical_type_map()
     try:
-        return _pandas_logical_type_map[pandas_type]
+        return pandas_logical_type_map[pandas_type]
     except KeyError:
         if 'mixed' in pandas_type:
             # catching 'mixed', 'mixed-integer' and 'mixed-integer-float'

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -1031,6 +1031,7 @@ def _is_generated_index_name(name):
     pattern = r'^__index_level_\d+__$'
     return re.match(pattern, name) is not None
 
+
 def get_pandas_logical_type_map():
     global _pandas_logical_type_map
 

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -395,11 +395,11 @@ class TypeInferrer {
       *keep_going = make_unions_;
     } else if (arrow::py::is_scalar(obj)) {
       RETURN_NOT_OK(VisitArrowScalar(obj, keep_going));
-    } else if (get_numpy_imported() && PyArray_CheckAnyScalarExact(obj)) {
+    } else if (has_numpy() && PyArray_CheckAnyScalarExact(obj)) {
       RETURN_NOT_OK(VisitDType(PyArray_DescrFromScalar(obj), keep_going));
     } else if (PySet_Check(obj) || (Py_TYPE(obj) == &PyDictValues_Type)) {
       RETURN_NOT_OK(VisitSet(obj, keep_going));
-    } else if (get_numpy_imported() && PyArray_Check(obj)) {
+    } else if (has_numpy() && PyArray_Check(obj)) {
       RETURN_NOT_OK(VisitNdarray(obj, keep_going));
     } else if (PyDict_Check(obj)) {
       RETURN_NOT_OK(VisitDict(obj));

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -395,11 +395,11 @@ class TypeInferrer {
       *keep_going = make_unions_;
     } else if (arrow::py::is_scalar(obj)) {
       RETURN_NOT_OK(VisitArrowScalar(obj, keep_going));
-    } else if (PyArray_CheckAnyScalarExact(obj)) {
+    } else if (get_numpy_imported() && PyArray_CheckAnyScalarExact(obj)) {
       RETURN_NOT_OK(VisitDType(PyArray_DescrFromScalar(obj), keep_going));
     } else if (PySet_Check(obj) || (Py_TYPE(obj) == &PyDictValues_Type)) {
       RETURN_NOT_OK(VisitSet(obj, keep_going));
-    } else if (PyArray_Check(obj)) {
+    } else if (get_numpy_imported() && PyArray_Check(obj)) {
       RETURN_NOT_OK(VisitNdarray(obj, keep_going));
     } else if (PyDict_Check(obj)) {
       RETURN_NOT_OK(VisitDict(obj));

--- a/python/pyarrow/src/arrow/python/init.cc
+++ b/python/pyarrow/src/arrow/python/init.cc
@@ -21,4 +21,17 @@
 #include "arrow/python/init.h"
 #include "arrow/python/numpy_interop.h"
 
-int arrow_init_numpy() { return arrow::py::import_numpy(); }
+bool numpy_imported = false;
+
+int arrow_init_numpy(bool import_numpy) {
+    if (import_numpy) {
+        numpy_imported = true;
+        return arrow::py::import_numpy();
+    } else {
+        return 0;
+    }
+}
+
+bool get_numpy_imported() {
+    return numpy_imported;
+}

--- a/python/pyarrow/src/arrow/python/init.cc
+++ b/python/pyarrow/src/arrow/python/init.cc
@@ -24,14 +24,12 @@
 bool numpy_imported = false;
 
 int arrow_init_numpy(bool import_numpy) {
-    if (import_numpy) {
-        numpy_imported = true;
-        return arrow::py::import_numpy();
-    } else {
-        return 0;
-    }
+  if (import_numpy) {
+    numpy_imported = true;
+    return arrow::py::import_numpy();
+  } else {
+    return 0;
+  }
 }
 
-bool get_numpy_imported() {
-    return numpy_imported;
-}
+bool get_numpy_imported() { return numpy_imported; }

--- a/python/pyarrow/src/arrow/python/init.h
+++ b/python/pyarrow/src/arrow/python/init.h
@@ -22,5 +22,6 @@
 
 extern "C" {
 ARROW_PYTHON_EXPORT
-int arrow_init_numpy();
+int arrow_init_numpy(bool import_numpy);
+bool get_numpy_imported();
 }

--- a/python/pyarrow/src/arrow/python/iterators.h
+++ b/python/pyarrow/src/arrow/python/iterators.h
@@ -21,6 +21,7 @@
 
 #include "arrow/array/array_primitive.h"
 
+#include "arrow/python/init.h"
 #include "arrow/python/common.h"
 #include "arrow/python/numpy_internal.h"
 
@@ -44,8 +45,7 @@ inline Status VisitSequenceGeneric(PyObject* obj, int64_t offset, VisitorFunc&& 
   // VisitorFunc may set to false to terminate iteration
   bool keep_going = true;
 
-#ifdef NUMPY_IMPORT_ARRAY
-  if (PyArray_Check(obj)) {
+  if (get_numpy_imported() && PyArray_Check(obj)) {
     PyArrayObject* arr_obj = reinterpret_cast<PyArrayObject*>(obj);
     if (PyArray_NDIM(arr_obj) != 1) {
       return Status::Invalid("Only 1D arrays accepted");
@@ -65,7 +65,6 @@ inline Status VisitSequenceGeneric(PyObject* obj, int64_t offset, VisitorFunc&& 
     // This code path is inefficient: callers should implement dedicated
     // logic for non-object arrays.
   }
-#endif
 
   if (PySequence_Check(obj)) {
     if (PyList_Check(obj) || PyTuple_Check(obj)) {
@@ -104,7 +103,7 @@ inline Status VisitSequence(PyObject* obj, int64_t offset, VisitorFunc&& func) {
 template <class VisitorFunc>
 inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, int64_t offset,
                                   VisitorFunc&& func) {
-  if (PyArray_Check(mo)) {
+  if (get_numpy_imported() && PyArray_Check(mo)) {
     PyArrayObject* mask = reinterpret_cast<PyArrayObject*>(mo);
     if (PyArray_NDIM(mask) != 1) {
       return Status::Invalid("Mask must be 1D array");

--- a/python/pyarrow/src/arrow/python/iterators.h
+++ b/python/pyarrow/src/arrow/python/iterators.h
@@ -44,6 +44,7 @@ inline Status VisitSequenceGeneric(PyObject* obj, int64_t offset, VisitorFunc&& 
   // VisitorFunc may set to false to terminate iteration
   bool keep_going = true;
 
+#ifdef NUMPY_IMPORT_ARRAY
   if (PyArray_Check(obj)) {
     PyArrayObject* arr_obj = reinterpret_cast<PyArrayObject*>(obj);
     if (PyArray_NDIM(arr_obj) != 1) {
@@ -64,6 +65,8 @@ inline Status VisitSequenceGeneric(PyObject* obj, int64_t offset, VisitorFunc&& 
     // This code path is inefficient: callers should implement dedicated
     // logic for non-object arrays.
   }
+#endif
+
   if (PySequence_Check(obj)) {
     if (PyList_Check(obj) || PyTuple_Check(obj)) {
       // Use fast item access

--- a/python/pyarrow/src/arrow/python/iterators.h
+++ b/python/pyarrow/src/arrow/python/iterators.h
@@ -22,7 +22,7 @@
 #include "arrow/array/array_primitive.h"
 
 #include "arrow/python/common.h"
-#include "arrow/python/init.h"
+#include "arrow/python/numpy_init.h"
 #include "arrow/python/numpy_internal.h"
 
 namespace arrow {
@@ -45,7 +45,7 @@ inline Status VisitSequenceGeneric(PyObject* obj, int64_t offset, VisitorFunc&& 
   // VisitorFunc may set to false to terminate iteration
   bool keep_going = true;
 
-  if (get_numpy_imported() && PyArray_Check(obj)) {
+  if (has_numpy() && PyArray_Check(obj)) {
     PyArrayObject* arr_obj = reinterpret_cast<PyArrayObject*>(obj);
     if (PyArray_NDIM(arr_obj) != 1) {
       return Status::Invalid("Only 1D arrays accepted");
@@ -103,7 +103,7 @@ inline Status VisitSequence(PyObject* obj, int64_t offset, VisitorFunc&& func) {
 template <class VisitorFunc>
 inline Status VisitSequenceMasked(PyObject* obj, PyObject* mo, int64_t offset,
                                   VisitorFunc&& func) {
-  if (get_numpy_imported() && PyArray_Check(mo)) {
+  if (has_numpy() && PyArray_Check(mo)) {
     PyArrayObject* mask = reinterpret_cast<PyArrayObject*>(mo);
     if (PyArray_NDIM(mask) != 1) {
       return Status::Invalid("Mask must be 1D array");

--- a/python/pyarrow/src/arrow/python/iterators.h
+++ b/python/pyarrow/src/arrow/python/iterators.h
@@ -21,8 +21,8 @@
 
 #include "arrow/array/array_primitive.h"
 
-#include "arrow/python/init.h"
 #include "arrow/python/common.h"
+#include "arrow/python/init.h"
 #include "arrow/python/numpy_internal.h"
 
 namespace arrow {

--- a/python/pyarrow/src/arrow/python/numpy_init.cc
+++ b/python/pyarrow/src/arrow/python/numpy_init.cc
@@ -30,4 +30,4 @@ int arrow_init_numpy() {
 }
 
 bool has_numpy() { return numpy_imported; }
-} // namespace arrow::py
+}  // namespace arrow::py

--- a/python/pyarrow/src/arrow/python/numpy_init.cc
+++ b/python/pyarrow/src/arrow/python/numpy_init.cc
@@ -18,18 +18,16 @@
 // Trigger the array import (inversion of NO_IMPORT_ARRAY)
 #define NUMPY_IMPORT_ARRAY
 
-#include "arrow/python/init.h"
+#include "arrow/python/numpy_init.h"
 #include "arrow/python/numpy_interop.h"
 
+namespace arrow::py {
 bool numpy_imported = false;
 
-int arrow_init_numpy(bool import_numpy) {
-  if (import_numpy) {
-    numpy_imported = true;
-    return arrow::py::import_numpy();
-  } else {
-    return 0;
-  }
+int arrow_init_numpy() {
+  numpy_imported = true;
+  return arrow::py::import_numpy();
 }
 
-bool get_numpy_imported() { return numpy_imported; }
+bool has_numpy() { return numpy_imported; }
+} // namespace arrow::py

--- a/python/pyarrow/src/arrow/python/numpy_init.h
+++ b/python/pyarrow/src/arrow/python/numpy_init.h
@@ -24,4 +24,4 @@ namespace arrow::py {
 ARROW_PYTHON_EXPORT
 int arrow_init_numpy();
 bool has_numpy();
-} // namespace arrow::py
+}  // namespace arrow::py

--- a/python/pyarrow/src/arrow/python/numpy_init.h
+++ b/python/pyarrow/src/arrow/python/numpy_init.h
@@ -20,8 +20,8 @@
 #include "arrow/python/platform.h"
 #include "arrow/python/visibility.h"
 
-extern "C" {
+namespace arrow::py {
 ARROW_PYTHON_EXPORT
-int arrow_init_numpy(bool import_numpy);
-bool get_numpy_imported();
-}
+int arrow_init_numpy();
+bool has_numpy();
+} // namespace arrow::py

--- a/python/pyarrow/src/arrow/python/numpy_internal.h
+++ b/python/pyarrow/src/arrow/python/numpy_internal.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "arrow/python/init.h"
 #include "arrow/python/numpy_interop.h"
 
 #include "arrow/status.h"
@@ -155,15 +156,27 @@ inline Status VisitNumpyArrayInline(PyArrayObject* arr, VISITOR* visitor) {
 namespace internal {
 
 inline bool PyFloatScalar_Check(PyObject* obj) {
-  return PyFloat_Check(obj) || PyArray_IsScalar(obj, Floating);
+  if(get_numpy_imported()) {
+    return PyFloat_Check(obj) || PyArray_IsScalar(obj, Floating);
+  } else {
+    return PyFloat_Check(obj);
+  }
 }
 
 inline bool PyIntScalar_Check(PyObject* obj) {
-  return PyLong_Check(obj) || PyArray_IsScalar(obj, Integer);
+  if(get_numpy_imported()) {
+    return PyLong_Check(obj) || PyArray_IsScalar(obj, Integer);
+  } else {
+    return PyLong_Check(obj);
+  }
 }
 
 inline bool PyBoolScalar_Check(PyObject* obj) {
-  return PyBool_Check(obj) || PyArray_IsScalar(obj, Bool);
+  if(get_numpy_imported()) {
+    return PyBool_Check(obj) || PyArray_IsScalar(obj, Bool);
+  } else {
+    return PyBool_Check(obj);
+  }
 }
 
 static inline PyArray_Descr* GetSafeNumPyDtype(int type) {

--- a/python/pyarrow/src/arrow/python/numpy_internal.h
+++ b/python/pyarrow/src/arrow/python/numpy_internal.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "arrow/python/init.h"
+#include "arrow/python/numpy_init.h"
 #include "arrow/python/numpy_interop.h"
 
 #include "arrow/status.h"
@@ -156,7 +156,7 @@ inline Status VisitNumpyArrayInline(PyArrayObject* arr, VISITOR* visitor) {
 namespace internal {
 
 inline bool PyFloatScalar_Check(PyObject* obj) {
-  if (get_numpy_imported()) {
+  if (has_numpy()) {
     return PyFloat_Check(obj) || PyArray_IsScalar(obj, Floating);
   } else {
     return PyFloat_Check(obj);
@@ -164,7 +164,7 @@ inline bool PyFloatScalar_Check(PyObject* obj) {
 }
 
 inline bool PyIntScalar_Check(PyObject* obj) {
-  if (get_numpy_imported()) {
+  if (has_numpy()) {
     return PyLong_Check(obj) || PyArray_IsScalar(obj, Integer);
   } else {
     return PyLong_Check(obj);
@@ -172,7 +172,7 @@ inline bool PyIntScalar_Check(PyObject* obj) {
 }
 
 inline bool PyBoolScalar_Check(PyObject* obj) {
-  if (get_numpy_imported()) {
+  if (has_numpy()) {
     return PyBool_Check(obj) || PyArray_IsScalar(obj, Bool);
   } else {
     return PyBool_Check(obj);

--- a/python/pyarrow/src/arrow/python/numpy_internal.h
+++ b/python/pyarrow/src/arrow/python/numpy_internal.h
@@ -156,7 +156,7 @@ inline Status VisitNumpyArrayInline(PyArrayObject* arr, VISITOR* visitor) {
 namespace internal {
 
 inline bool PyFloatScalar_Check(PyObject* obj) {
-  if(get_numpy_imported()) {
+  if (get_numpy_imported()) {
     return PyFloat_Check(obj) || PyArray_IsScalar(obj, Floating);
   } else {
     return PyFloat_Check(obj);
@@ -164,7 +164,7 @@ inline bool PyFloatScalar_Check(PyObject* obj) {
 }
 
 inline bool PyIntScalar_Check(PyObject* obj) {
-  if(get_numpy_imported()) {
+  if (get_numpy_imported()) {
     return PyLong_Check(obj) || PyArray_IsScalar(obj, Integer);
   } else {
     return PyLong_Check(obj);
@@ -172,7 +172,7 @@ inline bool PyIntScalar_Check(PyObject* obj) {
 }
 
 inline bool PyBoolScalar_Check(PyObject* obj) {
-  if(get_numpy_imported()) {
+  if (get_numpy_imported()) {
     return PyBool_Check(obj) || PyArray_IsScalar(obj, Bool);
   } else {
     return PyBool_Check(obj);

--- a/python/pyarrow/src/arrow/python/python_test.cc
+++ b/python/pyarrow/src/arrow/python/python_test.cc
@@ -870,7 +870,7 @@ std::vector<TestCase> GetCppTestCases() {
        TestInferAllLeadingZerosExponentialNotationPositive},
       {"test_infer_all_leading_zeros_exponential_notation_negative",
        TestInferAllLeadingZerosExponentialNotationNegative},
-      {"test_object_block_write_fails", TestObjectBlockWriteFails},
+      {"test_object_block_write_fails_pandas_convert", TestObjectBlockWriteFails},
       {"test_mixed_type_fails", TestMixedTypeFails},
       {"test_from_python_decimal_rescale_not_truncateable",
        TestFromPythonDecimalRescaleNotTruncateable},

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -202,7 +202,7 @@ class PyValue {
       return true;
     } else if (obj == Py_False) {
       return false;
-    } else if (get_numpy_imported() && PyArray_IsScalar(obj, Bool)) {
+    } else if (has_numpy() && PyArray_IsScalar(obj, Bool)) {
       return reinterpret_cast<PyBoolScalarObject*>(obj)->obval == NPY_TRUE;
     } else {
       return internal::InvalidValue(obj, "tried to convert to boolean");
@@ -385,7 +385,7 @@ class PyValue {
         default:
           return Status::UnknownError("Invalid time unit");
       }
-    } else if (get_numpy_imported() && PyArray_CheckAnyScalarExact(obj)) {
+    } else if (has_numpy() && PyArray_CheckAnyScalarExact(obj)) {
       // validate that the numpy scalar has np.datetime64 dtype
       ARROW_ASSIGN_OR_RAISE(auto numpy_type, NumPyScalarToArrowDataType(obj));
       if (!numpy_type->Equals(*type)) {
@@ -664,7 +664,7 @@ class PyPrimitiveConverter<
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));
       // Numpy NaT sentinels can be checked after the conversion
-      if (get_numpy_imported() && PyArray_CheckAnyScalarExact(value) &&
+      if (has_numpy() && PyArray_CheckAnyScalarExact(value) &&
           PyValue::IsNaT(this->primitive_type_, converted)) {
         this->primitive_builder_->UnsafeAppendNull();
       } else {
@@ -804,7 +804,7 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
     if (PyValue::IsNull(this->options_, value)) {
       return this->list_builder_->AppendNull();
     }
-    if (get_numpy_imported() && PyArray_Check(value)) {
+    if (has_numpy() && PyArray_Check(value)) {
       RETURN_NOT_OK(AppendNdarray(value));
     } else if (PySequence_Check(value)) {
       RETURN_NOT_OK(AppendSequence(value));

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -385,7 +385,7 @@ class PyValue {
         default:
           return Status::UnknownError("Invalid time unit");
       }
-    } else if (PyArray_CheckAnyScalarExact(obj)) {
+    } else if (get_numpy_imported() && PyArray_CheckAnyScalarExact(obj)) {
       // validate that the numpy scalar has np.datetime64 dtype
       ARROW_ASSIGN_OR_RAISE(auto numpy_type, NumPyScalarToArrowDataType(obj));
       if (!numpy_type->Equals(*type)) {

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -464,7 +464,7 @@ class PyValue {
         default:
           return Status::UnknownError("Invalid time unit");
       }
-    } else if (PyArray_CheckAnyScalarExact(obj)) {
+    } else if (has_numpy() && PyArray_CheckAnyScalarExact(obj)) {
       // validate that the numpy scalar has np.datetime64 dtype
       ARROW_ASSIGN_OR_RAISE(auto numpy_type, NumPyScalarToArrowDataType(obj));
       if (!numpy_type->Equals(*type)) {

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -495,7 +495,7 @@ cdef class ChunkedArray(_PandasConvertible):
         >>> n_legs.to_numpy()
         array([  2,   2,   4,   4,   5, 100])
         """
-        if not HAS_NUMPY:
+        if "numpy" not in sys.modules:
             raise ValueError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         if zero_copy_only:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -495,8 +495,8 @@ cdef class ChunkedArray(_PandasConvertible):
         >>> n_legs.to_numpy()
         array([  2,   2,   4,   4,   5, 100])
         """
-        if "numpy" not in sys.modules:
-            raise ValueError(
+        if np is None:
+            raise ImportError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         if zero_copy_only:
             raise ValueError(

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -497,7 +497,7 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         if np is None:
             raise ImportError(
-                "Cannot return a numpy.ndarray if Numpy is not present")
+                "Cannot return a numpy.ndarray if NumPy is not present")
         if zero_copy_only:
             raise ValueError(
                 "zero_copy_only must be False for pyarrow.ChunkedArray.to_numpy"

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -495,6 +495,9 @@ cdef class ChunkedArray(_PandasConvertible):
         >>> n_legs.to_numpy()
         array([  2,   2,   4,   4,   5, 100])
         """
+        if not HAS_NUMPY:
+            raise ValueError(
+                "Cannot return a numpy.ndarray if Numpy is not present")
         if zero_copy_only:
             raise ValueError(
                 "zero_copy_only must be False for pyarrow.ChunkedArray.to_numpy"

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -107,6 +107,9 @@ strides: {0.strides}""".format(self)
         array([[  2,   2,   4],
                [  4,   5, 100]], dtype=int32)
         """
+        if not HAS_NUMPY:
+            raise ValueError(
+                "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out
 
         check_status(TensorToNdarray(self.sp_tensor, self, &out))
@@ -478,6 +481,9 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCOOTensor to numpy.ndarrays with zero copy.
         """
+        if not HAS_NUMPY:
+            raise ValueError(
+                "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_coords
 
@@ -743,6 +749,9 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSRMatrix to numpy.ndarrays with zero copy.
         """
+        if not HAS_NUMPY:
+            raise ValueError(
+                "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
         cdef PyObject* out_indices
@@ -981,6 +990,9 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSCMatrix to numpy.ndarrays with zero copy
         """
+        if not HAS_NUMPY:
+            raise ValueError(
+                "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
         cdef PyObject* out_indices
@@ -1216,6 +1228,9 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSFTensor to numpy.ndarrays with zero copy
         """
+        if not HAS_NUMPY:
+            raise ValueError(
+                "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
         cdef PyObject* out_indices

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -109,7 +109,7 @@ strides: {0.strides}""".format(self)
         """
         if np is None:
             raise ImportError(
-                "Cannot return a numpy.ndarray if Numpy is not present")
+                "Cannot return a numpy.ndarray if NumPy is not present")
         cdef PyObject* out
 
         check_status(TensorToNdarray(self.sp_tensor, self, &out))
@@ -483,7 +483,7 @@ shape: {0.shape}""".format(self)
         """
         if np is None:
             raise ImportError(
-                "Cannot return a numpy.ndarray if Numpy is not present")
+                "Cannot return a numpy.ndarray if NumPy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_coords
 
@@ -751,7 +751,7 @@ shape: {0.shape}""".format(self)
         """
         if np is None:
             raise ImportError(
-                "Cannot return a numpy.ndarray if Numpy is not present")
+                "Cannot return a numpy.ndarray if NumPy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
         cdef PyObject* out_indices
@@ -992,7 +992,7 @@ shape: {0.shape}""".format(self)
         """
         if np is None:
             raise ImportError(
-                "Cannot return a numpy.ndarray if Numpy is not present")
+                "Cannot return a numpy.ndarray if NumPy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
         cdef PyObject* out_indices
@@ -1230,7 +1230,7 @@ shape: {0.shape}""".format(self)
         """
         if np is None:
             raise ImportError(
-                "Cannot return a numpy.ndarray if Numpy is not present")
+                "Cannot return a numpy.ndarray if NumPy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
         cdef PyObject* out_indices

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -107,7 +107,7 @@ strides: {0.strides}""".format(self)
         array([[  2,   2,   4],
                [  4,   5, 100]], dtype=int32)
         """
-        if not HAS_NUMPY:
+        if "numpy" not in sys.modules:
             raise ValueError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out
@@ -481,7 +481,7 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCOOTensor to numpy.ndarrays with zero copy.
         """
-        if not HAS_NUMPY:
+        if "numpy" not in sys.modules:
             raise ValueError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
@@ -749,7 +749,7 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSRMatrix to numpy.ndarrays with zero copy.
         """
-        if not HAS_NUMPY:
+        if "numpy" not in sys.modules:
             raise ValueError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
@@ -990,7 +990,7 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSCMatrix to numpy.ndarrays with zero copy
         """
-        if not HAS_NUMPY:
+        if "numpy" not in sys.modules:
             raise ValueError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
@@ -1228,7 +1228,7 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSFTensor to numpy.ndarrays with zero copy
         """
-        if not HAS_NUMPY:
+        if "numpy" not in sys.modules:
             raise ValueError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -107,8 +107,8 @@ strides: {0.strides}""".format(self)
         array([[  2,   2,   4],
                [  4,   5, 100]], dtype=int32)
         """
-        if "numpy" not in sys.modules:
-            raise ValueError(
+        if np is None:
+            raise ImportError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out
 
@@ -481,8 +481,8 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCOOTensor to numpy.ndarrays with zero copy.
         """
-        if "numpy" not in sys.modules:
-            raise ValueError(
+        if np is None:
+            raise ImportError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_coords
@@ -749,8 +749,8 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSRMatrix to numpy.ndarrays with zero copy.
         """
-        if "numpy" not in sys.modules:
-            raise ValueError(
+        if np is None:
+            raise ImportError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
@@ -990,8 +990,8 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSCMatrix to numpy.ndarrays with zero copy
         """
-        if "numpy" not in sys.modules:
-            raise ValueError(
+        if np is None:
+            raise ImportError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr
@@ -1228,8 +1228,8 @@ shape: {0.shape}""".format(self)
         """
         Convert arrow::SparseCSFTensor to numpy.ndarrays with zero copy
         """
-        if "numpy" not in sys.modules:
-            raise ValueError(
+        if np is None:
+            raise ImportError(
                 "Cannot return a numpy.ndarray if Numpy is not present")
         cdef PyObject* out_data
         cdef PyObject* out_indptr

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -117,6 +117,15 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
+    # Apply numpy mark if the test name already contains
+    # numpy or pandas on the name.
+    numpy_test_names = [
+        'ndarray',
+        'numpy',
+        'pandas',
+    ]
+    if any(name in item.name for name in numpy_test_names):
+        item.add_marker(pytest.mark.numpy)
     # Apply test markers to skip tests selectively
     for mark in item.iter_markers():
         item.config.pyarrow.apply_mark(mark)

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -25,8 +25,14 @@ import urllib.request
 
 import pytest
 import hypothesis as h
+try:
+    import numpy as np
+except ImportError:
+    pass
+
 from ..conftest import groups, defaults
 
+import pyarrow as pa
 from pyarrow import set_timezone_db_path
 from pyarrow.util import find_free_port
 
@@ -114,6 +120,30 @@ def pytest_runtest_setup(item):
     # Apply test markers to skip tests selectively
     for mark in item.iter_markers():
         item.config.pyarrow.apply_mark(mark)
+
+
+@pytest.fixture
+def all_array_types():
+    return [
+        ('bool', [True, False, False, True, True]),
+        ('uint8', np.arange(5)),
+        ('int8', np.arange(5)),
+        ('uint16', np.arange(5)),
+        ('int16', np.arange(5)),
+        ('uint32', np.arange(5)),
+        ('int32', np.arange(5)),
+        ('uint64', np.arange(5, 10)),
+        ('int64', np.arange(5, 10)),
+        ('float', np.arange(0, 0.5, 0.1)),
+        ('double', np.arange(0, 0.5, 0.1)),
+        ('string', ['a', 'b', None, 'ddd', 'ee']),
+        ('binary', [b'a', b'b', b'c', b'ddd', b'ee']),
+        (pa.binary(3), [b'abc', b'bcd', b'cde', b'def', b'efg']),
+        (pa.list_(pa.int8()), [[1, 2], [3, 4], [5, 6], None, [9, 16]]),
+        (pa.large_list(pa.int16()), [[1], [2, 3, 4], [5, 6], None, [9, 16]]),
+        (pa.struct([('a', pa.int8()), ('b', pa.int8())]), [
+            {'a': 1, 'b': 2}, None, {'a': 3, 'b': 4}, None, {'a': 5, 'b': 6}]),
+    ]
 
 
 @pytest.fixture

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -28,7 +28,6 @@ import hypothesis as h
 
 from ..conftest import groups, defaults
 
-import pyarrow as pa
 from pyarrow import set_timezone_db_path
 from pyarrow.util import find_free_port
 

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -25,10 +25,6 @@ import urllib.request
 
 import pytest
 import hypothesis as h
-try:
-    import numpy as np
-except ImportError:
-    pass
 
 from ..conftest import groups, defaults
 
@@ -120,30 +116,6 @@ def pytest_runtest_setup(item):
     # Apply test markers to skip tests selectively
     for mark in item.iter_markers():
         item.config.pyarrow.apply_mark(mark)
-
-
-@pytest.fixture
-def all_array_types():
-    return [
-        ('bool', [True, False, False, True, True]),
-        ('uint8', np.arange(5)),
-        ('int8', np.arange(5)),
-        ('uint16', np.arange(5)),
-        ('int16', np.arange(5)),
-        ('uint32', np.arange(5)),
-        ('int32', np.arange(5)),
-        ('uint64', np.arange(5, 10)),
-        ('int64', np.arange(5, 10)),
-        ('float', np.arange(0, 0.5, 0.1)),
-        ('double', np.arange(0, 0.5, 0.1)),
-        ('string', ['a', 'b', None, 'ddd', 'ee']),
-        ('binary', [b'a', b'b', b'c', b'ddd', b'ee']),
-        (pa.binary(3), [b'abc', b'bcd', b'cde', b'def', b'efg']),
-        (pa.list_(pa.int8()), [[1, 2], [3, 4], [5, 6], None, [9, 16]]),
-        (pa.large_list(pa.int16()), [[1], [2, 3, 4], [5, 6], None, [9, 16]]),
-        (pa.struct([('a', pa.int8()), ('b', pa.int8())]), [
-            {'a': 1, 'b': 2}, None, {'a': 3, 'b': 4}, None, {'a': 5, 'b': 6}]),
-    ]
 
 
 @pytest.fixture

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -26,11 +26,6 @@ import urllib.request
 import pytest
 import hypothesis as h
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
-
 from ..conftest import groups, defaults
 
 from pyarrow import set_timezone_db_path

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -122,16 +122,6 @@ def pytest_runtest_setup(item):
         item.config.pyarrow.apply_mark(mark)
 
 
-def pytest_collection_modifyitems(items):
-    # Apply numpy and pandas markers to injected C++ tests
-    for item in items:
-        if np is None and 'test_cpp_internals' in item.nodeid:
-            if 'numpy' in item.name:
-                item.add_marker('numpy')
-            elif 'pandas' in item.name:
-                item.add_marker('pandas')
-
-
 @pytest.fixture
 def tempdir(tmpdir):
     # convert pytest's LocalPath to pathlib.Path

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -117,15 +117,6 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    # Apply numpy mark if the test name already contains
-    # numpy or pandas on the name.
-    numpy_test_names = [
-        'ndarray',
-        'numpy',
-        'pandas',
-    ]
-    if any(name in item.name for name in numpy_test_names):
-        item.add_marker(pytest.mark.numpy)
     # Apply test markers to skip tests selectively
     for mark in item.iter_markers():
         item.config.pyarrow.apply_mark(mark)

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -26,6 +26,11 @@ import urllib.request
 import pytest
 import hypothesis as h
 
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
 from ..conftest import groups, defaults
 
 from pyarrow import set_timezone_db_path
@@ -115,6 +120,16 @@ def pytest_runtest_setup(item):
     # Apply test markers to skip tests selectively
     for mark in item.iter_markers():
         item.config.pyarrow.apply_mark(mark)
+
+
+def pytest_collection_modifyitems(items):
+    # Apply numpy and pandas markers to injected C++ tests
+    for item in items:
+        if np is None and 'test_cpp_internals' in item.nodeid:
+            if 'numpy' in item.name:
+                item.add_marker('numpy')
+            elif 'pandas' in item.name:
+                item.add_marker('pandas')
 
 
 @pytest.fixture

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -23,7 +23,8 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
+                allow_module_level=True)
 
 import pyarrow.interchange as pi
 from pyarrow.interchange.column import (

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -23,8 +23,7 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
-                allow_module_level=True)
+    np = None
 
 import pyarrow.interchange as pi
 from pyarrow.interchange.column import (
@@ -112,13 +111,13 @@ def test_offset_of_sliced_array():
     "int", [pa.int8(), pa.int16(), pa.int32(), pa.int64()]
 )
 @pytest.mark.parametrize(
-    "float, np_float", [
+    "float, np_float_str", [
         # (pa.float16(), np.float16),   #not supported by pandas
-        (pa.float32(), np.float32),
-        (pa.float64(), np.float64)
+        (pa.float32(), "float32"),
+        (pa.float64(), "float64")
     ]
 )
-def test_pandas_roundtrip(uint, int, float, np_float):
+def test_pandas_roundtrip(uint, int, float, np_float_str):
     if Version(pd.__version__) < Version("1.5.0"):
         pytest.skip("__dataframe__ added to pandas in 1.5.0")
 
@@ -127,7 +126,7 @@ def test_pandas_roundtrip(uint, int, float, np_float):
         {
             "a": pa.array(arr, type=uint),
             "b": pa.array(arr, type=int),
-            "c": pa.array(np.array(arr, dtype=np_float), type=float),
+            "c": pa.array(np.array(arr, dtype=np.dtype(np_float_str)), type=float),
             "d": [True, False, True],
         }
     )
@@ -331,13 +330,13 @@ def test_pandas_roundtrip_datetime(unit):
 
 @pytest.mark.pandas
 @pytest.mark.parametrize(
-    "np_float", [np.float32, np.float64]
+    "np_float_str", ["float32", "float64"]
 )
-def test_pandas_to_pyarrow_with_missing(np_float):
+def test_pandas_to_pyarrow_with_missing(np_float_str):
     if Version(pd.__version__) < Version("1.5.0"):
         pytest.skip("__dataframe__ added to pandas in 1.5.0")
 
-    np_array = np.array([0, np.nan, 2], dtype=np_float)
+    np_array = np.array([0, np.nan, 2], dtype=np.dtype(np_float_str))
     datetime_array = [None, dt(2007, 7, 14), dt(2007, 7, 15)]
     df = pd.DataFrame({
         # float, ColumnNullType.USE_NAN
@@ -369,6 +368,7 @@ def test_pandas_to_pyarrow_float16_with_missing():
         pi.from_dataframe(df)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(
     "uint", [pa.uint8(), pa.uint16(), pa.uint32()]
 )
@@ -376,16 +376,16 @@ def test_pandas_to_pyarrow_float16_with_missing():
     "int", [pa.int8(), pa.int16(), pa.int32(), pa.int64()]
 )
 @pytest.mark.parametrize(
-    "float, np_float", [
-        (pa.float16(), np.float16),
-        (pa.float32(), np.float32),
-        (pa.float64(), np.float64)
+    "float, np_float_str", [
+        (pa.float16(), "float16"),
+        (pa.float32(), "float32"),
+        (pa.float64(), "float64")
     ]
 )
 @pytest.mark.parametrize("unit", ['s', 'ms', 'us', 'ns'])
 @pytest.mark.parametrize("tz", ['America/New_York', '+07:30', '-04:30'])
 @pytest.mark.parametrize("offset, length", [(0, 3), (0, 2), (1, 2), (2, 1)])
-def test_pyarrow_roundtrip(uint, int, float, np_float,
+def test_pyarrow_roundtrip(uint, int, float, np_float_str,
                            unit, tz, offset, length):
 
     from datetime import datetime as dt
@@ -396,7 +396,7 @@ def test_pyarrow_roundtrip(uint, int, float, np_float,
         {
             "a": pa.array(arr, type=uint),
             "b": pa.array(arr, type=int),
-            "c": pa.array(np.array(arr, dtype=np_float),
+            "c": pa.array(np.array(arr, dtype=np.dtype(np_float_str)),
                           type=float, from_pandas=True),
             "d": [True, False, True],
             "e": [True, False, None],

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -16,10 +16,14 @@
 # under the License.
 
 from datetime import datetime as dt
-import numpy as np
 import pyarrow as pa
 from pyarrow.vendored.version import Version
 import pytest
+
+try:
+    import numpy as np
+except ImportError:
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
 
 import pyarrow.interchange as pi
 from pyarrow.interchange.column import (

--- a/python/pyarrow/tests/interchange/test_interchange_spec.py
+++ b/python/pyarrow/tests/interchange/test_interchange_spec.py
@@ -43,6 +43,7 @@ all_types = st.deferred(
 
 # datetime is tested in test_extra.py
 # dictionary is tested in test_categorical()
+@pytest.mark.numpy
 @h.given(past.arrays(all_types, size=3))
 def test_dtypes(arr):
     table = pa.table([arr], names=["a"])

--- a/python/pyarrow/tests/interchange/test_interchange_spec.py
+++ b/python/pyarrow/tests/interchange/test_interchange_spec.py
@@ -23,8 +23,7 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
-                allow_module_level=True)
+    np = None
 import pyarrow as pa
 import pyarrow.tests.strategies as past
 
@@ -56,6 +55,7 @@ def test_dtypes(arr):
     assert df.get_column(0).offset == 0
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(
     "uint, uint_bw",
     [
@@ -73,17 +73,17 @@ def test_dtypes(arr):
     ]
 )
 @pytest.mark.parametrize(
-    "float, float_bw, np_float", [
-        (pa.float16(), 16, np.float16),
-        (pa.float32(), 32, np.float32),
-        (pa.float64(), 64, np.float64)
+    "float, float_bw, np_float_str", [
+        (pa.float16(), 16, "float16"),
+        (pa.float32(), 32, "float32"),
+        (pa.float64(), 64, "float64")
     ]
 )
 @pytest.mark.parametrize("unit", ['s', 'ms', 'us', 'ns'])
 @pytest.mark.parametrize("tz", ['', 'America/New_York', '+07:30', '-04:30'])
 @pytest.mark.parametrize("use_batch", [False, True])
 def test_mixed_dtypes(uint, uint_bw, int, int_bw,
-                      float, float_bw, np_float, unit, tz,
+                      float, float_bw, np_float_str, unit, tz,
                       use_batch):
     from datetime import datetime as dt
     arr = [1, 2, 3]
@@ -92,7 +92,7 @@ def test_mixed_dtypes(uint, uint_bw, int, int_bw,
         {
             "a": pa.array(arr, type=uint),
             "b": pa.array(arr, type=int),
-            "c": pa.array(np.array(arr, dtype=np_float), type=float),
+            "c": pa.array(np.array(arr, dtype=np.dtype(np_float_str)), type=float),
             "d": [True, False, True],
             "e": ["a", "", "c"],
             "f": pa.array(dt_arr, type=pa.timestamp(unit, tz=tz))
@@ -205,16 +205,16 @@ def test_column_get_chunks(use_batch, size, n_chunks):
     "int", [pa.int8(), pa.int16(), pa.int32(), pa.int64()]
 )
 @pytest.mark.parametrize(
-    "float, np_float", [
-        (pa.float16(), np.float16),
-        (pa.float32(), np.float32),
-        (pa.float64(), np.float64)
+    "float, np_float_str", [
+        (pa.float16(), "float16"),
+        (pa.float32(), "float32"),
+        (pa.float64(), "float64")
     ]
 )
 @pytest.mark.parametrize("use_batch", [False, True])
-def test_get_columns(uint, int, float, np_float, use_batch):
+def test_get_columns(uint, int, float, np_float_str, use_batch):
     arr = [[1, 2, 3], [4, 5]]
-    arr_float = np.array([1, 2, 3, 4, 5], dtype=np_float)
+    arr_float = np.array([1, 2, 3, 4, 5], dtype=np.dtype(np_float_str))
     table = pa.table(
         {
             "a": pa.chunked_array(arr, type=uint),

--- a/python/pyarrow/tests/interchange/test_interchange_spec.py
+++ b/python/pyarrow/tests/interchange/test_interchange_spec.py
@@ -23,7 +23,8 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
+                allow_module_level=True)
 import pyarrow as pa
 import pyarrow.tests.strategies as past
 

--- a/python/pyarrow/tests/interchange/test_interchange_spec.py
+++ b/python/pyarrow/tests/interchange/test_interchange_spec.py
@@ -19,10 +19,13 @@ import ctypes
 import hypothesis as h
 import hypothesis.strategies as st
 
-import numpy as np
+import pytest
+try:
+    import numpy as np
+except ImportError:
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
 import pyarrow as pa
 import pyarrow.tests.strategies as past
-import pytest
 
 
 all_types = st.deferred(

--- a/python/pyarrow/tests/parquet/common.py
+++ b/python/pyarrow/tests/parquet/common.py
@@ -17,7 +17,10 @@
 
 import io
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 import pyarrow as pa
 from pyarrow.tests import util

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -22,10 +22,6 @@ import warnings
 from shutil import copytree
 from decimal import Decimal
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
 import pytest
 
 import pyarrow as pa
@@ -50,6 +46,10 @@ try:
 except ImportError:
     pd = tm = None
 
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not parquet'

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -22,7 +22,10 @@ import warnings
 from shutil import copytree
 from decimal import Decimal
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 
 import pyarrow as pa

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -18,7 +18,10 @@
 import decimal
 import io
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 
 import pyarrow as pa
@@ -173,6 +176,7 @@ def test_direct_read_dictionary_subfield():
     assert result[0].num_chunks == 1
 
 
+@pytest.mark.numpy
 def test_dictionary_array_automatically_read():
     # ARROW-3246
 
@@ -331,6 +335,7 @@ def test_column_of_lists(tempdir):
     tm.assert_frame_equal(df, df_read)
 
 
+@pytest.mark.numpy
 def test_large_list_records():
     # This was fixed in PARQUET-1100
 

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -17,6 +17,7 @@
 
 import decimal
 import io
+import random
 
 try:
     import numpy as np
@@ -335,14 +336,13 @@ def test_column_of_lists(tempdir):
     tm.assert_frame_equal(df, df_read)
 
 
-@pytest.mark.numpy
 def test_large_list_records():
     # This was fixed in PARQUET-1100
 
-    list_lengths = np.random.randint(0, 500, size=50)
-    list_lengths[::10] = 0
+    list_lengths = [random.randint(0, 500) for _ in range(50)]
+    list_lengths[::10] = [0, 0, 0, 0, 0]
 
-    list_values = [list(map(int, np.random.randint(0, 100, size=x)))
+    list_values = [list(map(int, [random.randint(0, 100) for _ in range(x)]))
                    if i % 8 else None
                    for i, x in enumerate(list_lengths)]
 

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -20,7 +20,10 @@ import inspect
 import os
 import pathlib
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 import unittest.mock as mock
 
@@ -1153,6 +1156,7 @@ def test_partitioned_dataset(tempdir):
     pq.write_table(table, path / "output.parquet")
 
 
+@pytest.mark.numpy
 def test_dataset_read_dictionary(tempdir):
     path = tempdir / "ARROW-3325-dataset"
     t1 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1156,7 +1156,6 @@ def test_partitioned_dataset(tempdir):
     pq.write_table(table, path / "output.parquet")
 
 
-@pytest.mark.numpy
 def test_dataset_read_dictionary(tempdir):
     path = tempdir / "ARROW-3325-dataset"
     t1 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])

--- a/python/pyarrow/tests/parquet/test_datetime.py
+++ b/python/pyarrow/tests/parquet/test_datetime.py
@@ -19,7 +19,10 @@ import datetime
 import io
 import warnings
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 
 import pyarrow as pa

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -20,7 +20,10 @@ import decimal
 from collections import OrderedDict
 import io
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 
 import pyarrow as pa
@@ -579,6 +582,7 @@ def test_write_metadata(tempdir):
         )
 
 
+@pytest.mark.numpy
 def test_table_large_metadata():
     # ARROW-8694
     my_schema = pa.schema([pa.field('f0', 'double')],

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -582,13 +582,12 @@ def test_write_metadata(tempdir):
         )
 
 
-@pytest.mark.numpy
 def test_table_large_metadata():
     # ARROW-8694
     my_schema = pa.schema([pa.field('f0', 'double')],
                           metadata={'large': 'x' * 10000000})
 
-    table = pa.table([np.arange(10)], schema=my_schema)
+    table = pa.table([range(10)], schema=my_schema)
     _check_roundtrip(table)
 
 

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -18,7 +18,10 @@
 import io
 import json
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 
 import pyarrow as pa

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -21,7 +21,10 @@ import sys
 import pytest
 import hypothesis as h
 import hypothesis.strategies as st
-import hypothesis.extra.numpy as npst
+try:
+    import hypothesis.extra.numpy as npst
+except ImportError:
+    pass
 try:
     import hypothesis.extra.pytz as tzst
 except ImportError:
@@ -35,7 +38,10 @@ if sys.platform == 'win32':
         import tzdata  # noqa:F401
     except ImportError:
         zoneinfo = None
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 import pyarrow as pa
 

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import datetime
+import math
 import sys
 
 import pytest
@@ -38,10 +39,6 @@ if sys.platform == 'win32':
         import tzdata  # noqa:F401
     except ImportError:
         zoneinfo = None
-try:
-    import numpy as np
-except ImportError:
-    pass
 
 import pyarrow as pa
 
@@ -282,7 +279,7 @@ def arrays(draw, type, size=None, nullable=True):
         values = draw(npst.arrays(ty.to_pandas_dtype(), shape=(size,)))
         # Workaround ARROW-4952: no easy way to assert array equality
         # in a NaN-tolerant way.
-        values[np.isnan(values)] = -42.0
+        values[math.isnan(values)] = -42.0
         return pa.array(values, type=ty)
     elif pa.types.is_decimal(ty):
         # TODO(kszucs): properly limit the precision

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -25,7 +25,7 @@ import hypothesis.strategies as st
 try:
     import hypothesis.extra.numpy as npst
 except ImportError:
-    pass
+    npst = None
 try:
     import hypothesis.extra.pytz as tzst
 except ImportError:

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -16,7 +16,6 @@
 # under the License.
 
 import datetime
-import math
 import sys
 
 import pytest
@@ -39,6 +38,10 @@ if sys.platform == 'win32':
         import tzdata  # noqa:F401
     except ImportError:
         zoneinfo = None
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 import pyarrow as pa
 
@@ -279,7 +282,7 @@ def arrays(draw, type, size=None, nullable=True):
         values = draw(npst.arrays(ty.to_pandas_dtype(), shape=(size,)))
         # Workaround ARROW-4952: no easy way to assert array equality
         # in a NaN-tolerant way.
-        values[math.isnan(values)] = -42.0
+        values[np.isnan(values)] = -42.0
         return pa.array(values, type=ty)
     elif pa.types.is_decimal(ty):
         # TODO(kszucs): properly limit the precision

--- a/python/pyarrow/tests/test_adhoc_memory_leak.py
+++ b/python/pyarrow/tests/test_adhoc_memory_leak.py
@@ -17,7 +17,10 @@
 
 import pytest
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pyarrow as pa
 
 import pyarrow.tests.util as test_util

--- a/python/pyarrow/tests/test_adhoc_memory_leak.py
+++ b/python/pyarrow/tests/test_adhoc_memory_leak.py
@@ -17,7 +17,10 @@
 
 import pytest
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 import pyarrow as pa
 
 import pyarrow.tests.util as test_util
@@ -28,6 +31,7 @@ except ImportError:
     pass
 
 
+@pytest.mark.numpy
 @pytest.mark.memory_leak
 @pytest.mark.pandas
 def test_deserialize_pandas_arrow_7956():

--- a/python/pyarrow/tests/test_adhoc_memory_leak.py
+++ b/python/pyarrow/tests/test_adhoc_memory_leak.py
@@ -31,7 +31,6 @@ except ImportError:
     pass
 
 
-@pytest.mark.numpy
 @pytest.mark.memory_leak
 @pytest.mark.pandas
 def test_deserialize_pandas_arrow_7956():

--- a/python/pyarrow/tests/test_adhoc_memory_leak.py
+++ b/python/pyarrow/tests/test_adhoc_memory_leak.py
@@ -17,10 +17,7 @@
 
 import pytest
 
-try:
-    import numpy as np
-except ImportError:
-    pass
+import numpy as np
 import pyarrow as pa
 
 import pyarrow.tests.util as test_util

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -30,7 +30,7 @@ import weakref
 try:
     import numpy as np
 except ImportError:
-    pass
+    np = None
 
 import pyarrow as pa
 import pyarrow.tests.strategies as past
@@ -74,6 +74,7 @@ def test_constructor_raises():
         pa.Array([1, 2])
 
 
+@pytest.mark.without_numpy
 def test_list_format():
     arr = pa.array([[1], None, [2, 3, None]])
     result = arr.to_string()
@@ -134,6 +135,7 @@ def test_top_level_indented_string_format():
     assert result == expected
 
 
+@pytest.mark.without_numpy
 def test_binary_format():
     arr = pa.array([b'\x00', b'', None, b'\x01foo', b'\x80\xff'])
     result = arr.to_string()
@@ -331,6 +333,7 @@ def test_asarray():
     assert np_arr.tolist() == ['a', 'b', 'c', 'a', 'b']
 
 
+@pytest.mark.without_numpy
 @pytest.mark.parametrize('ty', [
     None,
     pa.null(),
@@ -350,6 +353,7 @@ def test_nulls(ty):
         assert arr.type == ty
 
 
+@pytest.mark.without_numpy
 def test_array_from_scalar():
     pytz = pytest.importorskip("pytz")
 
@@ -440,6 +444,7 @@ def test_array_getitem_numpy_scalars():
         assert arr[np.int32(idx)].as_py() == lst[idx]
 
 
+@pytest.mark.without_numpy
 def test_array_slice():
     arr = pa.array(range(10))
 
@@ -481,7 +486,6 @@ def test_array_slice():
                 assert res.to_numpy().tolist() == expected
 
 
-@pytest.mark.numpy
 def test_array_slice_negative_step():
     # ARROW-2714
     np_arr = np.arange(20)
@@ -552,7 +556,6 @@ def test_struct_array_slice():
                                    {'a': 5, 'b': 6.5}]
 
 
-@pytest.mark.numpy
 def test_array_factory_invalid_type():
 
     class MyObject:
@@ -587,7 +590,6 @@ def test_array_eq():
     assert (arr1 == None) is False  # noqa: E711
 
 
-@pytest.mark.numpy
 def test_array_from_buffers():
     values_buf = pa.py_buffer(np.int16([4, 5, 6, 7]))
     nulls_buf = pa.py_buffer(np.uint8([0b00001101]))
@@ -877,7 +879,6 @@ def test_dictionary_to_numpy():
     )
 
 
-@pytest.mark.numpy
 def test_dictionary_from_boxed_arrays():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)
@@ -923,7 +924,6 @@ def test_dictionary_indices():
     arr.indices.validate(full=True)
 
 
-@pytest.mark.numpy
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),
                          [(pa.ListArray, pa.list_),
                           (pa.LargeListArray, pa.large_list)])
@@ -1066,7 +1066,6 @@ def test_map_from_dict():
     assert tup_arr.equals(dict_arr)
 
 
-@pytest.mark.numpy
 def test_map_from_arrays():
     offsets_arr = np.array([0, 2, 5, 8], dtype='i4')
     offsets = pa.array(offsets_arr, type='int32')
@@ -1487,7 +1486,6 @@ def _check_cast_case(case, *, safe=True, check_array_construction=True):
         assert in_arr.equals(expected)
 
 
-@pytest.mark.numpy
 def test_cast_integers_safe():
     safe_cases = [
         (np.array([0, 1, 2, 3], dtype='i1'), 'int8',
@@ -1574,7 +1572,6 @@ def test_chunked_array_data_warns():
     assert isinstance(res, pa.ChunkedArray)
 
 
-@pytest.mark.numpy
 def test_cast_integers_unsafe():
     # We let NumPy do the unsafe casting.
     # Note that NEP50 in the NumPy spec no longer allows
@@ -1595,7 +1592,6 @@ def test_cast_integers_unsafe():
         _check_cast_case(case, safe=False)
 
 
-@pytest.mark.numpy
 def test_floating_point_truncate_safe():
     safe_cases = [
         (np.array([1.0, 2.0, 3.0], dtype='float32'), 'float32',
@@ -1609,7 +1605,6 @@ def test_floating_point_truncate_safe():
         _check_cast_case(case, safe=True)
 
 
-@pytest.mark.numpy
 def test_floating_point_truncate_unsafe():
     unsafe_cases = [
         (np.array([1.1, 2.2, 3.3], dtype='float32'), 'float32',
@@ -1654,7 +1649,6 @@ def test_decimal_to_int_safe():
         _check_cast_case(case, safe=True)
 
 
-@pytest.mark.numpy
 def test_decimal_to_int_value_out_of_bounds():
     out_of_bounds_cases = [
         (
@@ -1755,7 +1749,6 @@ def test_decimal_to_decimal():
         result = arr.cast(pa.decimal128(5, 2))
 
 
-@pytest.mark.numpy
 def test_safe_cast_nan_to_int_raises():
     arr = pa.array([np.nan, 1.])
 
@@ -1763,7 +1756,6 @@ def test_safe_cast_nan_to_int_raises():
         arr.cast(pa.int64(), safe=True)
 
 
-@pytest.mark.numpy
 def test_cast_signed_to_unsigned():
     safe_cases = [
         (np.array([0, 1, 2, 3], dtype='i1'), pa.uint8(),
@@ -2014,7 +2006,6 @@ def test_dictionary_decode():
         assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_cast_time32_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int32'),
                    type=pa.time32('s'))
@@ -2024,7 +2015,6 @@ def test_cast_time32_to_int():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_cast_time64_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.time64('us'))
@@ -2034,7 +2024,6 @@ def test_cast_time64_to_int():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_cast_timestamp_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.timestamp('us'))
@@ -2060,7 +2049,6 @@ def test_cast_date32_to_int():
     assert result2.equals(arr)
 
 
-@pytest.mark.numpy
 def test_cast_duration_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.duration('us'))
@@ -2070,7 +2058,6 @@ def test_cast_duration_to_int():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_cast_binary_to_utf8():
     binary_arr = pa.array([b'foo', b'bar', b'baz'], type=pa.binary())
     utf8_arr = binary_arr.cast(pa.utf8())
@@ -2091,7 +2078,6 @@ def test_cast_binary_to_utf8():
     assert casted.null_count == 1
 
 
-@pytest.mark.numpy
 def test_cast_date64_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.date64())
@@ -2227,14 +2213,12 @@ def test_to_numpy_roundtrip():
         np.testing.assert_array_equal(narr[2:6], arr[2:6].to_numpy())
 
 
-@pytest.mark.numpy
 def test_array_uint64_from_py_over_range():
     arr = pa.array([2 ** 63], type=pa.uint64())
     expected = pa.array(np.array([2 ** 63], dtype='u8'))
     assert arr.equals(expected)
 
 
-@pytest.mark.numpy
 def test_array_conversions_no_sentinel_values():
     arr = np.array([1, 2, 3, 4], dtype='int8')
     refcount = sys.getrefcount(arr)
@@ -2383,7 +2367,6 @@ def test_array_from_different_numpy_datetime_units_raises():
         pa.array(data)
 
 
-@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['ns', 'us', 'ms', 's'])
 def test_array_from_list_of_timestamps(unit):
     n = np.datetime64('NaT', unit)
@@ -2398,7 +2381,6 @@ def test_array_from_list_of_timestamps(unit):
     assert a1[0] == a2[0]
 
 
-@pytest.mark.numpy
 def test_array_from_timestamp_with_generic_unit():
     n = np.datetime64('NaT')
     x = np.datetime64('2017-01-01 01:01:01.111111111')
@@ -2628,14 +2610,12 @@ def test_array_from_numpy_unicode():
     assert arrow_arr.equals(expected)
 
 
-@pytest.mark.numpy
 def test_array_string_from_non_string():
     # ARROW-5682 - when converting to string raise on non string-like dtype
     with pytest.raises(TypeError):
         pa.array(np.array([1, 2, 3]), type=pa.string())
 
 
-@pytest.mark.numpy
 def test_array_string_from_all_null():
     # ARROW-5682
     vals = np.array([None, None], dtype=object)
@@ -2650,7 +2630,6 @@ def test_array_string_from_all_null():
     assert arr.null_count == 2
 
 
-@pytest.mark.numpy
 def test_array_from_masked():
     ma = np.ma.array([1, 2, 3, 4], dtype='int64',
                      mask=[False, False, True, False])
@@ -2662,7 +2641,6 @@ def test_array_from_masked():
         pa.array(ma, mask=np.array([True, False, False, False]))
 
 
-@pytest.mark.numpy
 def test_array_from_shrunken_masked():
     ma = np.ma.array([0], dtype='int64')
     result = pa.array(ma)
@@ -2670,7 +2648,6 @@ def test_array_from_shrunken_masked():
     assert expected.equals(result)
 
 
-@pytest.mark.numpy
 def test_array_from_invalid_dim_raises():
     msg = "only handle 1-dimensional arrays"
     arr2d = np.array([[1, 2, 3], [4, 5, 6]])
@@ -2682,7 +2659,6 @@ def test_array_from_invalid_dim_raises():
         pa.array(arr0d)
 
 
-@pytest.mark.numpy
 def test_array_from_strided_bool():
     # ARROW-6325
     arr = np.ones((3, 2), dtype=bool)
@@ -2694,7 +2670,6 @@ def test_array_from_strided_bool():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_array_from_strided():
     pydata = [
         ([b"ab", b"cd", b"ef"], (pa.binary(), pa.binary(2))),
@@ -2719,7 +2694,6 @@ def test_boolean_true_count_false_count():
     assert arr.false_count == 1000
 
 
-@pytest.mark.numpy
 def test_buffers_primitive():
     a = pa.array([1, 2, None, 4], type=pa.int16())
     buffers = a.buffers()
@@ -2792,7 +2766,6 @@ def test_buffers_nested():
     assert struct.unpack('4xh', values) == (43,)
 
 
-@pytest.mark.numpy
 def test_total_buffer_size():
     a = pa.array(np.array([4, 5, 6], dtype='int64'))
     assert a.nbytes == 8 * 3
@@ -3217,7 +3190,6 @@ def test_array_from_numpy_str_utf8():
         pa.array(vec, pa.string(), mask=np.array([False]))
 
 
-@pytest.mark.numpy
 @pytest.mark.slow
 @pytest.mark.large_memory
 def test_numpy_binary_overflow_to_chunked():
@@ -3276,7 +3248,6 @@ def test_list_child_overflow_to_chunked():
     assert len(arr.chunk(1)) == 1
 
 
-@pytest.mark.numpy
 def test_infer_type_masked():
     # ARROW-5208
     ty = pa.infer_type(['foo', 'bar', None, 2],
@@ -3292,7 +3263,6 @@ def test_infer_type_masked():
     assert pa.infer_type([], mask=[]) == pa.null()
 
 
-@pytest.mark.numpy
 def test_array_masked():
     # ARROW-5208
     arr = pa.array([4, None, 4, 3.],
@@ -3305,7 +3275,6 @@ def test_array_masked():
     assert arr.type == pa.int64()
 
 
-@pytest.mark.numpy
 def test_array_supported_masks():
     # ARROW-13883
     arr = pa.array([4, None, 4, 3.],
@@ -3364,7 +3333,6 @@ def test_array_supported_pandas_masks():
     assert arr.to_pylist() == [None, 1]
 
 
-@pytest.mark.numpy
 def test_binary_array_masked():
     # ARROW-12431
     masked_basic = pa.array([b'\x05'], type=pa.binary(1),
@@ -3397,7 +3365,6 @@ def test_binary_array_masked():
     assert ([b'aaa', b'bbb', b'ccc']*10) == arrow_array.to_pylist()
 
 
-@pytest.mark.numpy
 def test_binary_array_strided():
     # Masked
     nparray = np.array([b"ab", b"cd", b"ef"])
@@ -3411,7 +3378,6 @@ def test_binary_array_strided():
     assert [b"ab", b"ef"] == arrow_array.to_pylist()
 
 
-@pytest.mark.numpy
 def test_array_invalid_mask_raises():
     # ARROW-10742
     cases = [
@@ -3491,7 +3457,6 @@ def test_numpy_array_protocol():
     assert result.dtype == "float64"
 
 
-@pytest.mark.numpy
 def test_array_protocol():
 
     class MyArray:
@@ -3815,7 +3780,6 @@ def test_run_end_encoded_from_buffers():
                                            1, offset, children)
 
 
-@pytest.mark.numpy
 def test_run_end_encoded_from_array_with_type():
     run_ends = [1, 3, 6]
     values = [1, 2, 3]
@@ -4070,7 +4034,6 @@ def test_list_view_slice(list_view_type):
     assert sliced_array[0].as_py() == sliced_array.values[i:j].to_pylist() == [4]
 
 
-@pytest.mark.numpy
 @pytest.mark.parametrize('numpy_native_dtype', ['u2', 'i4', 'f8'])
 def test_swapped_byte_order_fails(numpy_native_dtype):
     # ARROW-39129

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -27,7 +27,10 @@ import subprocess
 import sys
 import weakref
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 import pyarrow as pa
 import pyarrow.tests.strategies as past
@@ -157,6 +160,7 @@ def test_binary_total_values_length():
     assert large_arr.slice(1, 3).total_values_length == 11
 
 
+@pytest.mark.numpy
 def test_to_numpy_zero_copy():
     arr = pa.array(range(10))
 
@@ -176,6 +180,7 @@ def test_to_numpy_zero_copy():
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 def test_chunked_array_to_numpy_zero_copy():
     elements = [[2, 2, 4], [4, 5, 100]]
 
@@ -191,6 +196,7 @@ def test_chunked_array_to_numpy_zero_copy():
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 def test_to_numpy_unsupported_types():
     # ARROW-2871: Some primitive types are not yet supported in to_numpy
     bool_arr = pa.array([True, False, True])
@@ -217,7 +223,9 @@ def test_to_numpy_unsupported_types():
         arr.to_numpy()
 
 
+@pytest.mark.numpy
 def test_to_numpy_writable():
+    # TODO: Validate this is not segfaulting
     arr = pa.array(range(10))
     np_arr = arr.to_numpy()
 
@@ -234,6 +242,7 @@ def test_to_numpy_writable():
         arr.to_numpy(zero_copy_only=True, writable=True)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
 @pytest.mark.parametrize('tz', [None, "UTC"])
 def test_to_numpy_datetime64(unit, tz):
@@ -243,6 +252,7 @@ def test_to_numpy_datetime64(unit, tz):
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
 def test_to_numpy_timedelta64(unit):
     arr = pa.array([1, 2, 3], pa.duration(unit))
@@ -251,6 +261,7 @@ def test_to_numpy_timedelta64(unit):
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 def test_to_numpy_dictionary():
     # ARROW-7591
     arr = pa.array(["a", "b", "a"]).dictionary_encode()
@@ -259,6 +270,7 @@ def test_to_numpy_dictionary():
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 @pytest.mark.pandas
 def test_to_pandas_zero_copy():
     import gc
@@ -287,6 +299,7 @@ def test_to_pandas_zero_copy():
         series.sum()
 
 
+@pytest.mark.numpy
 @pytest.mark.nopandas
 @pytest.mark.pandas
 def test_asarray():
@@ -414,6 +427,7 @@ def test_array_from_dictionary_scalar():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_getitem():
     arr = pa.array(range(10, 15))
     lst = arr.to_pylist()
@@ -469,9 +483,11 @@ def test_array_slice():
             res.validate()
             expected = arr.to_pylist()[start:stop]
             assert res.to_pylist() == expected
-            assert res.to_numpy().tolist() == expected
+            if "numpy" in sys.modules:
+                assert res.to_numpy().tolist() == expected
 
 
+@pytest.mark.numpy
 def test_array_slice_negative_step():
     # ARROW-2714
     np_arr = np.arange(20)
@@ -542,6 +558,7 @@ def test_struct_array_slice():
                                    {'a': 5, 'b': 6.5}]
 
 
+@pytest.mark.numpy
 def test_array_factory_invalid_type():
 
     class MyObject:
@@ -552,6 +569,7 @@ def test_array_factory_invalid_type():
         pa.array(arr)
 
 
+@pytest.mark.numpy
 def test_array_ref_to_ndarray_base():
     arr = np.array([1, 2, 3])
 
@@ -576,6 +594,7 @@ def test_array_eq():
     assert (arr1 == None) is False  # noqa: E711
 
 
+@pytest.mark.numpy
 def test_array_from_buffers():
     values_buf = pa.py_buffer(np.int16([4, 5, 6, 7]))
     nulls_buf = pa.py_buffer(np.uint8([0b00001101]))
@@ -773,6 +792,7 @@ def test_dictionary_from_buffers(offset):
     assert a[offset:] == b
 
 
+@pytest.mark.numpy
 def test_dictionary_from_numpy():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)
@@ -795,6 +815,7 @@ def test_dictionary_from_numpy():
             assert d2[i].as_py() == dictionary[indices[i]]
 
 
+@pytest.mark.numpy
 def test_dictionary_to_numpy():
     expected = pa.array(
         ["foo", "bar", None, "foo"]
@@ -865,6 +886,7 @@ def test_dictionary_to_numpy():
     )
 
 
+@pytest.mark.numpy
 def test_dictionary_from_boxed_arrays():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)
@@ -910,6 +932,7 @@ def test_dictionary_indices():
     arr.indices.validate(full=True)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),
                          [(pa.ListArray, pa.list_),
                           (pa.LargeListArray, pa.large_list)])
@@ -1052,6 +1075,7 @@ def test_map_from_dict():
     assert tup_arr.equals(dict_arr)
 
 
+@pytest.mark.numpy
 def test_map_from_arrays():
     offsets_arr = np.array([0, 2, 5, 8], dtype='i4')
     offsets = pa.array(offsets_arr, type='int32')
@@ -1472,6 +1496,7 @@ def _check_cast_case(case, *, safe=True, check_array_construction=True):
         assert in_arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_integers_safe():
     safe_cases = [
         (np.array([0, 1, 2, 3], dtype='i1'), 'int8',
@@ -1558,6 +1583,7 @@ def test_chunked_array_data_warns():
     assert isinstance(res, pa.ChunkedArray)
 
 
+@pytest.mark.numpy
 def test_cast_integers_unsafe():
     # We let NumPy do the unsafe casting.
     # Note that NEP50 in the NumPy spec no longer allows
@@ -1578,6 +1604,7 @@ def test_cast_integers_unsafe():
         _check_cast_case(case, safe=False)
 
 
+@pytest.mark.numpy
 def test_floating_point_truncate_safe():
     safe_cases = [
         (np.array([1.0, 2.0, 3.0], dtype='float32'), 'float32',
@@ -1591,6 +1618,7 @@ def test_floating_point_truncate_safe():
         _check_cast_case(case, safe=True)
 
 
+@pytest.mark.numpy
 def test_floating_point_truncate_unsafe():
     unsafe_cases = [
         (np.array([1.1, 2.2, 3.3], dtype='float32'), 'float32',
@@ -1635,6 +1663,7 @@ def test_decimal_to_int_safe():
         _check_cast_case(case, safe=True)
 
 
+@pytest.mark.numpy
 def test_decimal_to_int_value_out_of_bounds():
     out_of_bounds_cases = [
         (
@@ -1735,6 +1764,7 @@ def test_decimal_to_decimal():
         result = arr.cast(pa.decimal128(5, 2))
 
 
+@pytest.mark.numpy
 def test_safe_cast_nan_to_int_raises():
     arr = pa.array([np.nan, 1.])
 
@@ -1742,6 +1772,7 @@ def test_safe_cast_nan_to_int_raises():
         arr.cast(pa.int64(), safe=True)
 
 
+@pytest.mark.numpy
 def test_cast_signed_to_unsigned():
     safe_cases = [
         (np.array([0, 1, 2, 3], dtype='i1'), pa.uint8(),
@@ -1992,6 +2023,7 @@ def test_dictionary_decode():
         assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_time32_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int32'),
                    type=pa.time32('s'))
@@ -2001,6 +2033,7 @@ def test_cast_time32_to_int():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_time64_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.time64('us'))
@@ -2010,6 +2043,7 @@ def test_cast_time64_to_int():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_timestamp_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.timestamp('us'))
@@ -2035,6 +2069,7 @@ def test_cast_date32_to_int():
     assert result2.equals(arr)
 
 
+@pytest.mark.numpy
 def test_cast_duration_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.duration('us'))
@@ -2044,6 +2079,7 @@ def test_cast_duration_to_int():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_binary_to_utf8():
     binary_arr = pa.array([b'foo', b'bar', b'baz'], type=pa.binary())
     utf8_arr = binary_arr.cast(pa.utf8())
@@ -2064,6 +2100,7 @@ def test_cast_binary_to_utf8():
     assert casted.null_count == 1
 
 
+@pytest.mark.numpy
 def test_cast_date64_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.date64())
@@ -2177,9 +2214,9 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
         assert result_addresses == addresses
 
 
-@pytest.mark.parametrize(
-    'narr',
-    [
+@pytest.mark.numpy
+def test_to_numpy_roundtrip():
+    for narr in [
         np.arange(10, dtype=np.int64),
         np.arange(10, dtype=np.int32),
         np.arange(10, dtype=np.int16),
@@ -2191,23 +2228,23 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
         np.arange(10, dtype=np.float64),
         np.arange(10, dtype=np.float32),
         np.arange(10, dtype=np.float16),
-    ]
-)
-def test_to_numpy_roundtrip(narr):
-    arr = pa.array(narr)
-    assert narr.dtype == arr.to_numpy().dtype
-    np.testing.assert_array_equal(narr, arr.to_numpy())
-    np.testing.assert_array_equal(narr[:6], arr[:6].to_numpy())
-    np.testing.assert_array_equal(narr[2:], arr[2:].to_numpy())
-    np.testing.assert_array_equal(narr[2:6], arr[2:6].to_numpy())
+    ]:
+        arr = pa.array(narr)
+        assert narr.dtype == arr.to_numpy().dtype
+        np.testing.assert_array_equal(narr, arr.to_numpy())
+        np.testing.assert_array_equal(narr[:6], arr[:6].to_numpy())
+        np.testing.assert_array_equal(narr[2:], arr[2:].to_numpy())
+        np.testing.assert_array_equal(narr[2:6], arr[2:6].to_numpy())
 
 
+@pytest.mark.numpy
 def test_array_uint64_from_py_over_range():
     arr = pa.array([2 ** 63], type=pa.uint64())
     expected = pa.array(np.array([2 ** 63], dtype='u8'))
     assert arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_conversions_no_sentinel_values():
     arr = np.array([1, 2, 3, 4], dtype='int8')
     refcount = sys.getrefcount(arr)
@@ -2249,6 +2286,7 @@ def test_time32_time64_from_integer():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_binary_string_pandas_null_sentinels():
     # ARROW-6227
     def _check_case(ty):
@@ -2259,6 +2297,7 @@ def test_binary_string_pandas_null_sentinels():
     _check_case('utf8')
 
 
+@pytest.mark.numpy
 def test_pandas_null_sentinels_raise_error():
     # ARROW-6227
     cases = [
@@ -2299,6 +2338,7 @@ def test_pandas_null_sentinels_index():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_roundtrip_from_numpy_datetimeD():
     arr = np.array([None, datetime.date(2017, 4, 4)], dtype='datetime64[D]')
 
@@ -2319,6 +2359,7 @@ def test_array_from_naive_datetimes():
     assert arr.type == pa.timestamp('us', tz=None)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('dtype', 'type'), [
     ('datetime64[s]', pa.timestamp('s')),
     ('datetime64[ms]', pa.timestamp('ms')),
@@ -2342,6 +2383,7 @@ def test_array_from_numpy_datetime(dtype, type):
     assert arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_from_different_numpy_datetime_units_raises():
     data = [
         None,
@@ -2356,6 +2398,7 @@ def test_array_from_different_numpy_datetime_units_raises():
         pa.array(data)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['ns', 'us', 'ms', 's'])
 def test_array_from_list_of_timestamps(unit):
     n = np.datetime64('NaT', unit)
@@ -2370,6 +2413,7 @@ def test_array_from_list_of_timestamps(unit):
     assert a1[0] == a2[0]
 
 
+@pytest.mark.numpy
 def test_array_from_timestamp_with_generic_unit():
     n = np.datetime64('NaT')
     x = np.datetime64('2017-01-01 01:01:01.111111111')
@@ -2380,6 +2424,7 @@ def test_array_from_timestamp_with_generic_unit():
         pa.array([n, x, y])
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('dtype', 'type'), [
     ('timedelta64[s]', pa.duration('s')),
     ('timedelta64[ms]', pa.duration('ms')),
@@ -2408,6 +2453,7 @@ def test_array_from_numpy_timedelta(dtype, type):
     assert arr.to_pylist() == data
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_timedelta_incorrect_unit():
     # generic (no unit)
     td = np.timedelta64(1)
@@ -2423,6 +2469,7 @@ def test_array_from_numpy_timedelta_incorrect_unit():
             pa.array(data)
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_ascii():
     arr = np.array(['abcde', 'abc', ''], dtype='|S5')
 
@@ -2567,6 +2614,7 @@ def test_interval_array_from_dateoffset():
     assert list(actual_list[0]) == expected_from_pandas
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_unicode():
     dtypes = ['<U5', '>U5']
 
@@ -2599,12 +2647,14 @@ def test_array_from_numpy_unicode():
     assert arrow_arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_string_from_non_string():
     # ARROW-5682 - when converting to string raise on non string-like dtype
     with pytest.raises(TypeError):
         pa.array(np.array([1, 2, 3]), type=pa.string())
 
 
+@pytest.mark.numpy
 def test_array_string_from_all_null():
     # ARROW-5682
     vals = np.array([None, None], dtype=object)
@@ -2619,6 +2669,7 @@ def test_array_string_from_all_null():
     assert arr.null_count == 2
 
 
+@pytest.mark.numpy
 def test_array_from_masked():
     ma = np.ma.array([1, 2, 3, 4], dtype='int64',
                      mask=[False, False, True, False])
@@ -2630,6 +2681,7 @@ def test_array_from_masked():
         pa.array(ma, mask=np.array([True, False, False, False]))
 
 
+@pytest.mark.numpy
 def test_array_from_shrunken_masked():
     ma = np.ma.array([0], dtype='int64')
     result = pa.array(ma)
@@ -2637,6 +2689,7 @@ def test_array_from_shrunken_masked():
     assert expected.equals(result)
 
 
+@pytest.mark.numpy
 def test_array_from_invalid_dim_raises():
     msg = "only handle 1-dimensional arrays"
     arr2d = np.array([[1, 2, 3], [4, 5, 6]])
@@ -2648,6 +2701,7 @@ def test_array_from_invalid_dim_raises():
         pa.array(arr0d)
 
 
+@pytest.mark.numpy
 def test_array_from_strided_bool():
     # ARROW-6325
     arr = np.ones((3, 2), dtype=bool)
@@ -2659,6 +2713,7 @@ def test_array_from_strided_bool():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_from_strided():
     pydata = [
         ([b"ab", b"cd", b"ef"], (pa.binary(), pa.binary(2))),
@@ -2683,6 +2738,7 @@ def test_boolean_true_count_false_count():
     assert arr.false_count == 1000
 
 
+@pytest.mark.numpy
 def test_buffers_primitive():
     a = pa.array([1, 2, None, 4], type=pa.int16())
     buffers = a.buffers()
@@ -2755,6 +2811,7 @@ def test_buffers_nested():
     assert struct.unpack('4xh', values) == (43,)
 
 
+@pytest.mark.numpy
 def test_total_buffer_size():
     a = pa.array(np.array([4, 5, 6], dtype='int64'))
     assert a.nbytes == 8 * 3
@@ -3153,6 +3210,7 @@ def test_nested_dictionary_array():
     assert dict_arr2.to_pylist() == ['a', 'b', 'a', 'b', 'a']
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_str_utf8():
     # ARROW-3890 -- in Python 3, NPY_UNICODE arrays are produced, but in Python
     # 2 they are NPY_STRING (binary), so we must do UTF-8 validation
@@ -3179,6 +3237,7 @@ def test_array_from_numpy_str_utf8():
         pa.array(vec, pa.string(), mask=np.array([False]))
 
 
+@pytest.mark.numpy
 @pytest.mark.slow
 @pytest.mark.large_memory
 def test_numpy_binary_overflow_to_chunked():
@@ -3237,6 +3296,7 @@ def test_list_child_overflow_to_chunked():
     assert len(arr.chunk(1)) == 1
 
 
+@pytest.mark.numpy
 def test_infer_type_masked():
     # ARROW-5208
     ty = pa.infer_type(['foo', 'bar', None, 2],
@@ -3252,6 +3312,7 @@ def test_infer_type_masked():
     assert pa.infer_type([], mask=[]) == pa.null()
 
 
+@pytest.mark.numpy
 def test_array_masked():
     # ARROW-5208
     arr = pa.array([4, None, 4, 3.],
@@ -3264,6 +3325,7 @@ def test_array_masked():
     assert arr.type == pa.int64()
 
 
+@pytest.mark.numpy
 def test_array_supported_masks():
     # ARROW-13883
     arr = pa.array([4, None, 4, 3.],
@@ -3322,6 +3384,7 @@ def test_array_supported_pandas_masks():
     assert arr.to_pylist() == [None, 1]
 
 
+@pytest.mark.numpy
 def test_binary_array_masked():
     # ARROW-12431
     masked_basic = pa.array([b'\x05'], type=pa.binary(1),
@@ -3354,6 +3417,7 @@ def test_binary_array_masked():
     assert ([b'aaa', b'bbb', b'ccc']*10) == arrow_array.to_pylist()
 
 
+@pytest.mark.numpy
 def test_binary_array_strided():
     # Masked
     nparray = np.array([b"ab", b"cd", b"ef"])
@@ -3367,6 +3431,7 @@ def test_binary_array_strided():
     assert [b"ab", b"ef"] == arrow_array.to_pylist()
 
 
+@pytest.mark.numpy
 def test_array_invalid_mask_raises():
     # ARROW-10742
     cases = [
@@ -3400,6 +3465,7 @@ def test_array_from_large_pyints():
         pa.array([int(2 ** 63)])
 
 
+@pytest.mark.numpy
 def test_numpy_array_protocol():
     # test the __array__ method on pyarrow.Array
     arr = pa.array([1, 2, 3])
@@ -3446,6 +3512,7 @@ def test_numpy_array_protocol():
     assert result.dtype == "float64"
 
 
+@pytest.mark.numpy
 def test_array_protocol():
 
     class MyArray:
@@ -3769,6 +3836,7 @@ def test_run_end_encoded_from_buffers():
                                            1, offset, children)
 
 
+@pytest.mark.numpy
 def test_run_end_encoded_from_array_with_type():
     run_ends = [1, 3, 6]
     values = [1, 2, 3]
@@ -3808,6 +3876,7 @@ def test_run_end_encoded_from_array_with_type():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_run_end_encoded_to_numpy():
     arr = [1, 2, 2, 3, 3, 3]
     ree_array = pa.array(arr, pa.run_end_encoded(pa.int32(), pa.int64()))
@@ -4023,6 +4092,7 @@ def test_list_view_slice(list_view_type):
     assert sliced_array[0].as_py() == sliced_array.values[i:j].to_pylist() == [4]
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('numpy_native_dtype', ['u2', 'i4', 'f8'])
 def test_swapped_byte_order_fails(numpy_native_dtype):
     # ARROW-39129

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2184,6 +2184,7 @@ def test_array_pickle_dictionary(pickle_module):
         assert array.equals(result)
 
 
+@pytest.mark.numpy
 @h.settings(suppress_health_check=(h.HealthCheck.too_slow,))
 @h.given(
     past.arrays(

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -160,7 +160,6 @@ def test_binary_total_values_length():
     assert large_arr.slice(1, 3).total_values_length == 11
 
 
-@pytest.mark.numpy
 def test_to_numpy_zero_copy():
     arr = pa.array(range(10))
 
@@ -180,7 +179,6 @@ def test_to_numpy_zero_copy():
     np.testing.assert_array_equal(np_arr, expected)
 
 
-@pytest.mark.numpy
 def test_chunked_array_to_numpy_zero_copy():
     elements = [[2, 2, 4], [4, 5, 100]]
 
@@ -196,7 +194,6 @@ def test_chunked_array_to_numpy_zero_copy():
     np.testing.assert_array_equal(np_arr, expected)
 
 
-@pytest.mark.numpy
 def test_to_numpy_unsupported_types():
     # ARROW-2871: Some primitive types are not yet supported in to_numpy
     bool_arr = pa.array([True, False, True])
@@ -223,7 +220,6 @@ def test_to_numpy_unsupported_types():
         arr.to_numpy()
 
 
-@pytest.mark.numpy
 def test_to_numpy_writable():
     # TODO: Validate this is not segfaulting
     arr = pa.array(range(10))
@@ -242,7 +238,6 @@ def test_to_numpy_writable():
         arr.to_numpy(zero_copy_only=True, writable=True)
 
 
-@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
 @pytest.mark.parametrize('tz', [None, "UTC"])
 def test_to_numpy_datetime64(unit, tz):
@@ -252,7 +247,6 @@ def test_to_numpy_datetime64(unit, tz):
     np.testing.assert_array_equal(np_arr, expected)
 
 
-@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
 def test_to_numpy_timedelta64(unit):
     arr = pa.array([1, 2, 3], pa.duration(unit))
@@ -261,7 +255,6 @@ def test_to_numpy_timedelta64(unit):
     np.testing.assert_array_equal(np_arr, expected)
 
 
-@pytest.mark.numpy
 def test_to_numpy_dictionary():
     # ARROW-7591
     arr = pa.array(["a", "b", "a"]).dictionary_encode()
@@ -270,7 +263,6 @@ def test_to_numpy_dictionary():
     np.testing.assert_array_equal(np_arr, expected)
 
 
-@pytest.mark.numpy
 @pytest.mark.pandas
 def test_to_pandas_zero_copy():
     import gc
@@ -299,7 +291,6 @@ def test_to_pandas_zero_copy():
         series.sum()
 
 
-@pytest.mark.numpy
 @pytest.mark.nopandas
 @pytest.mark.pandas
 def test_asarray():
@@ -441,7 +432,6 @@ def test_array_getitem():
             arr[idx]
 
 
-@pytest.mark.numpy
 def test_array_getitem_numpy_scalars():
     arr = pa.array(range(10, 15))
     lst = arr.to_pylist()
@@ -573,7 +563,6 @@ def test_array_factory_invalid_type():
         pa.array(arr)
 
 
-@pytest.mark.numpy
 def test_array_ref_to_ndarray_base():
     arr = np.array([1, 2, 3])
 
@@ -796,7 +785,6 @@ def test_dictionary_from_buffers(offset):
     assert a[offset:] == b
 
 
-@pytest.mark.numpy
 def test_dictionary_from_numpy():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)
@@ -819,7 +807,6 @@ def test_dictionary_from_numpy():
             assert d2[i].as_py() == dictionary[indices[i]]
 
 
-@pytest.mark.numpy
 def test_dictionary_to_numpy():
     expected = pa.array(
         ["foo", "bar", None, "foo"]
@@ -2218,7 +2205,6 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
         assert result_addresses == addresses
 
 
-@pytest.mark.numpy
 def test_to_numpy_roundtrip():
     for narr in [
         np.arange(10, dtype=np.int64),
@@ -2290,7 +2276,6 @@ def test_time32_time64_from_integer():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_binary_string_pandas_null_sentinels():
     # ARROW-6227
     def _check_case(ty):
@@ -2301,7 +2286,6 @@ def test_binary_string_pandas_null_sentinels():
     _check_case('utf8')
 
 
-@pytest.mark.numpy
 def test_pandas_null_sentinels_raise_error():
     # ARROW-6227
     cases = [
@@ -2342,7 +2326,6 @@ def test_pandas_null_sentinels_index():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_array_roundtrip_from_numpy_datetimeD():
     arr = np.array([None, datetime.date(2017, 4, 4)], dtype='datetime64[D]')
 
@@ -2363,7 +2346,6 @@ def test_array_from_naive_datetimes():
     assert arr.type == pa.timestamp('us', tz=None)
 
 
-@pytest.mark.numpy
 @pytest.mark.parametrize(('dtype', 'type'), [
     ('datetime64[s]', pa.timestamp('s')),
     ('datetime64[ms]', pa.timestamp('ms')),
@@ -2387,7 +2369,6 @@ def test_array_from_numpy_datetime(dtype, type):
     assert arr.equals(expected)
 
 
-@pytest.mark.numpy
 def test_array_from_different_numpy_datetime_units_raises():
     data = [
         None,
@@ -2428,7 +2409,6 @@ def test_array_from_timestamp_with_generic_unit():
         pa.array([n, x, y])
 
 
-@pytest.mark.numpy
 @pytest.mark.parametrize(('dtype', 'type'), [
     ('timedelta64[s]', pa.duration('s')),
     ('timedelta64[ms]', pa.duration('ms')),
@@ -2457,7 +2437,6 @@ def test_array_from_numpy_timedelta(dtype, type):
     assert arr.to_pylist() == data
 
 
-@pytest.mark.numpy
 def test_array_from_numpy_timedelta_incorrect_unit():
     # generic (no unit)
     td = np.timedelta64(1)
@@ -2473,7 +2452,6 @@ def test_array_from_numpy_timedelta_incorrect_unit():
             pa.array(data)
 
 
-@pytest.mark.numpy
 def test_array_from_numpy_ascii():
     arr = np.array(['abcde', 'abc', ''], dtype='|S5')
 
@@ -2618,7 +2596,6 @@ def test_interval_array_from_dateoffset():
     assert list(actual_list[0]) == expected_from_pandas
 
 
-@pytest.mark.numpy
 def test_array_from_numpy_unicode():
     dtypes = ['<U5', '>U5']
 
@@ -3214,7 +3191,6 @@ def test_nested_dictionary_array():
     assert dict_arr2.to_pylist() == ['a', 'b', 'a', 'b', 'a']
 
 
-@pytest.mark.numpy
 def test_array_from_numpy_str_utf8():
     # ARROW-3890 -- in Python 3, NPY_UNICODE arrays are produced, but in Python
     # 2 they are NPY_STRING (binary), so we must do UTF-8 validation
@@ -3469,7 +3445,6 @@ def test_array_from_large_pyints():
         pa.array([int(2 ** 63)])
 
 
-@pytest.mark.numpy
 def test_numpy_array_protocol():
     # test the __array__ method on pyarrow.Array
     arr = pa.array([1, 2, 3])
@@ -3880,7 +3855,6 @@ def test_run_end_encoded_from_array_with_type():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_run_end_encoded_to_numpy():
     arr = [1, 2, 2, 3, 3, 3]
     ree_array = pa.array(arr, pa.run_end_encoded(pa.int32(), pa.int64()))

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -427,7 +427,6 @@ def test_array_from_dictionary_scalar():
     assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_array_getitem():
     arr = pa.array(range(10, 15))
     lst = arr.to_pylist()
@@ -441,6 +440,11 @@ def test_array_getitem():
         with pytest.raises(IndexError):
             arr[idx]
 
+
+@pytest.mark.numpy
+def test_array_getitem_numpy_scalars():
+    arr = pa.array(range(10, 15))
+    lst = arr.to_pylist()
     # check that numpy scalars are supported
     for idx in range(-len(arr), len(arr)):
         assert arr[np.int32(idx)].as_py() == lst[idx]

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -74,7 +74,6 @@ def test_constructor_raises():
         pa.Array([1, 2])
 
 
-@pytest.mark.without_numpy
 def test_list_format():
     arr = pa.array([[1], None, [2, 3, None]])
     result = arr.to_string()
@@ -135,7 +134,6 @@ def test_top_level_indented_string_format():
     assert result == expected
 
 
-@pytest.mark.without_numpy
 def test_binary_format():
     arr = pa.array([b'\x00', b'', None, b'\x01foo', b'\x80\xff'])
     result = arr.to_string()
@@ -162,6 +160,7 @@ def test_binary_total_values_length():
     assert large_arr.slice(1, 3).total_values_length == 11
 
 
+@pytest.mark.numpy
 def test_to_numpy_zero_copy():
     arr = pa.array(range(10))
 
@@ -181,6 +180,7 @@ def test_to_numpy_zero_copy():
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 def test_chunked_array_to_numpy_zero_copy():
     elements = [[2, 2, 4], [4, 5, 100]]
 
@@ -196,6 +196,7 @@ def test_chunked_array_to_numpy_zero_copy():
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 def test_to_numpy_unsupported_types():
     # ARROW-2871: Some primitive types are not yet supported in to_numpy
     bool_arr = pa.array([True, False, True])
@@ -222,6 +223,7 @@ def test_to_numpy_unsupported_types():
         arr.to_numpy()
 
 
+@pytest.mark.numpy
 def test_to_numpy_writable():
     arr = pa.array(range(10))
     np_arr = arr.to_numpy()
@@ -239,6 +241,7 @@ def test_to_numpy_writable():
         arr.to_numpy(zero_copy_only=True, writable=True)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
 @pytest.mark.parametrize('tz', [None, "UTC"])
 def test_to_numpy_datetime64(unit, tz):
@@ -248,6 +251,7 @@ def test_to_numpy_datetime64(unit, tz):
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
 def test_to_numpy_timedelta64(unit):
     arr = pa.array([1, 2, 3], pa.duration(unit))
@@ -256,6 +260,7 @@ def test_to_numpy_timedelta64(unit):
     np.testing.assert_array_equal(np_arr, expected)
 
 
+@pytest.mark.numpy
 def test_to_numpy_dictionary():
     # ARROW-7591
     arr = pa.array(["a", "b", "a"]).dictionary_encode()
@@ -332,7 +337,6 @@ def test_asarray():
     assert np_arr.tolist() == ['a', 'b', 'c', 'a', 'b']
 
 
-@pytest.mark.without_numpy
 @pytest.mark.parametrize('ty', [
     None,
     pa.null(),
@@ -352,7 +356,6 @@ def test_nulls(ty):
         assert arr.type == ty
 
 
-@pytest.mark.without_numpy
 def test_array_from_scalar():
     pytz = pytest.importorskip("pytz")
 
@@ -435,6 +438,7 @@ def test_array_getitem():
             arr[idx]
 
 
+@pytest.mark.numpy
 def test_array_getitem_numpy_scalars():
     arr = pa.array(range(10, 15))
     lst = arr.to_pylist()
@@ -443,7 +447,6 @@ def test_array_getitem_numpy_scalars():
         assert arr[np.int32(idx)].as_py() == lst[idx]
 
 
-@pytest.mark.without_numpy
 def test_array_slice():
     arr = pa.array(range(10))
 
@@ -485,6 +488,7 @@ def test_array_slice():
                 assert res.to_numpy().tolist() == expected
 
 
+@pytest.mark.numpy
 def test_array_slice_negative_step():
     # ARROW-2714
     np_arr = np.arange(20)
@@ -555,6 +559,7 @@ def test_struct_array_slice():
                                    {'a': 5, 'b': 6.5}]
 
 
+@pytest.mark.numpy
 def test_array_factory_invalid_type():
 
     class MyObject:
@@ -565,6 +570,7 @@ def test_array_factory_invalid_type():
         pa.array(arr)
 
 
+@pytest.mark.numpy
 def test_array_ref_to_ndarray_base():
     arr = np.array([1, 2, 3])
 
@@ -589,6 +595,7 @@ def test_array_eq():
     assert (arr1 == None) is False  # noqa: E711
 
 
+@pytest.mark.numpy
 def test_array_from_buffers():
     values_buf = pa.py_buffer(np.int16([4, 5, 6, 7]))
     nulls_buf = pa.py_buffer(np.uint8([0b00001101]))
@@ -786,6 +793,7 @@ def test_dictionary_from_buffers(offset):
     assert a[offset:] == b
 
 
+@pytest.mark.numpy
 def test_dictionary_from_numpy():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)
@@ -808,6 +816,7 @@ def test_dictionary_from_numpy():
             assert d2[i].as_py() == dictionary[indices[i]]
 
 
+@pytest.mark.numpy
 def test_dictionary_to_numpy():
     expected = pa.array(
         ["foo", "bar", None, "foo"]
@@ -878,6 +887,7 @@ def test_dictionary_to_numpy():
     )
 
 
+@pytest.mark.numpy
 def test_dictionary_from_boxed_arrays():
     indices = np.repeat([0, 1, 2], 2)
     dictionary = np.array(['foo', 'bar', 'baz'], dtype=object)
@@ -923,6 +933,7 @@ def test_dictionary_indices():
     arr.indices.validate(full=True)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('list_array_type', 'list_type_factory'),
                          [(pa.ListArray, pa.list_),
                           (pa.LargeListArray, pa.large_list)])
@@ -1065,6 +1076,7 @@ def test_map_from_dict():
     assert tup_arr.equals(dict_arr)
 
 
+@pytest.mark.numpy
 def test_map_from_arrays():
     offsets_arr = np.array([0, 2, 5, 8], dtype='i4')
     offsets = pa.array(offsets_arr, type='int32')
@@ -1485,6 +1497,7 @@ def _check_cast_case(case, *, safe=True, check_array_construction=True):
         assert in_arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_integers_safe():
     safe_cases = [
         (np.array([0, 1, 2, 3], dtype='i1'), 'int8',
@@ -1571,6 +1584,7 @@ def test_chunked_array_data_warns():
     assert isinstance(res, pa.ChunkedArray)
 
 
+@pytest.mark.numpy
 def test_cast_integers_unsafe():
     # We let NumPy do the unsafe casting.
     # Note that NEP50 in the NumPy spec no longer allows
@@ -1591,6 +1605,7 @@ def test_cast_integers_unsafe():
         _check_cast_case(case, safe=False)
 
 
+@pytest.mark.numpy
 def test_floating_point_truncate_safe():
     safe_cases = [
         (np.array([1.0, 2.0, 3.0], dtype='float32'), 'float32',
@@ -1604,6 +1619,7 @@ def test_floating_point_truncate_safe():
         _check_cast_case(case, safe=True)
 
 
+@pytest.mark.numpy
 def test_floating_point_truncate_unsafe():
     unsafe_cases = [
         (np.array([1.1, 2.2, 3.3], dtype='float32'), 'float32',
@@ -1648,6 +1664,7 @@ def test_decimal_to_int_safe():
         _check_cast_case(case, safe=True)
 
 
+@pytest.mark.numpy
 def test_decimal_to_int_value_out_of_bounds():
     out_of_bounds_cases = [
         (
@@ -1748,6 +1765,7 @@ def test_decimal_to_decimal():
         result = arr.cast(pa.decimal128(5, 2))
 
 
+@pytest.mark.numpy
 def test_safe_cast_nan_to_int_raises():
     arr = pa.array([np.nan, 1.])
 
@@ -1755,6 +1773,7 @@ def test_safe_cast_nan_to_int_raises():
         arr.cast(pa.int64(), safe=True)
 
 
+@pytest.mark.numpy
 def test_cast_signed_to_unsigned():
     safe_cases = [
         (np.array([0, 1, 2, 3], dtype='i1'), pa.uint8(),
@@ -2005,6 +2024,7 @@ def test_dictionary_decode():
         assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_time32_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int32'),
                    type=pa.time32('s'))
@@ -2014,6 +2034,7 @@ def test_cast_time32_to_int():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_time64_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.time64('us'))
@@ -2023,6 +2044,7 @@ def test_cast_time64_to_int():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_timestamp_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.timestamp('us'))
@@ -2048,6 +2070,7 @@ def test_cast_date32_to_int():
     assert result2.equals(arr)
 
 
+@pytest.mark.numpy
 def test_cast_duration_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.duration('us'))
@@ -2057,6 +2080,7 @@ def test_cast_duration_to_int():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_cast_binary_to_utf8():
     binary_arr = pa.array([b'foo', b'bar', b'baz'], type=pa.binary())
     utf8_arr = binary_arr.cast(pa.utf8())
@@ -2077,6 +2101,7 @@ def test_cast_binary_to_utf8():
     assert casted.null_count == 1
 
 
+@pytest.mark.numpy
 def test_cast_date64_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int64'),
                    type=pa.date64())
@@ -2190,6 +2215,7 @@ def test_array_pickle_protocol5(data, typ, pickle_module):
         assert result_addresses == addresses
 
 
+@pytest.mark.numpy
 def test_to_numpy_roundtrip():
     for narr in [
         np.arange(10, dtype=np.int64),
@@ -2212,12 +2238,14 @@ def test_to_numpy_roundtrip():
         np.testing.assert_array_equal(narr[2:6], arr[2:6].to_numpy())
 
 
+@pytest.mark.numpy
 def test_array_uint64_from_py_over_range():
     arr = pa.array([2 ** 63], type=pa.uint64())
     expected = pa.array(np.array([2 ** 63], dtype='u8'))
     assert arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_conversions_no_sentinel_values():
     arr = np.array([1, 2, 3, 4], dtype='int8')
     refcount = sys.getrefcount(arr)
@@ -2259,6 +2287,7 @@ def test_time32_time64_from_integer():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_binary_string_pandas_null_sentinels():
     # ARROW-6227
     def _check_case(ty):
@@ -2269,6 +2298,7 @@ def test_binary_string_pandas_null_sentinels():
     _check_case('utf8')
 
 
+@pytest.mark.numpy
 def test_pandas_null_sentinels_raise_error():
     # ARROW-6227
     cases = [
@@ -2309,6 +2339,7 @@ def test_pandas_null_sentinels_index():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_roundtrip_from_numpy_datetimeD():
     arr = np.array([None, datetime.date(2017, 4, 4)], dtype='datetime64[D]')
 
@@ -2329,6 +2360,7 @@ def test_array_from_naive_datetimes():
     assert arr.type == pa.timestamp('us', tz=None)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('dtype', 'type'), [
     ('datetime64[s]', pa.timestamp('s')),
     ('datetime64[ms]', pa.timestamp('ms')),
@@ -2352,6 +2384,7 @@ def test_array_from_numpy_datetime(dtype, type):
     assert arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_from_different_numpy_datetime_units_raises():
     data = [
         None,
@@ -2366,6 +2399,7 @@ def test_array_from_different_numpy_datetime_units_raises():
         pa.array(data)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('unit', ['ns', 'us', 'ms', 's'])
 def test_array_from_list_of_timestamps(unit):
     n = np.datetime64('NaT', unit)
@@ -2380,6 +2414,7 @@ def test_array_from_list_of_timestamps(unit):
     assert a1[0] == a2[0]
 
 
+@pytest.mark.numpy
 def test_array_from_timestamp_with_generic_unit():
     n = np.datetime64('NaT')
     x = np.datetime64('2017-01-01 01:01:01.111111111')
@@ -2390,6 +2425,7 @@ def test_array_from_timestamp_with_generic_unit():
         pa.array([n, x, y])
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('dtype', 'type'), [
     ('timedelta64[s]', pa.duration('s')),
     ('timedelta64[ms]', pa.duration('ms')),
@@ -2418,6 +2454,7 @@ def test_array_from_numpy_timedelta(dtype, type):
     assert arr.to_pylist() == data
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_timedelta_incorrect_unit():
     # generic (no unit)
     td = np.timedelta64(1)
@@ -2433,6 +2470,7 @@ def test_array_from_numpy_timedelta_incorrect_unit():
             pa.array(data)
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_ascii():
     arr = np.array(['abcde', 'abc', ''], dtype='|S5')
 
@@ -2577,6 +2615,7 @@ def test_interval_array_from_dateoffset():
     assert list(actual_list[0]) == expected_from_pandas
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_unicode():
     dtypes = ['<U5', '>U5']
 
@@ -2609,12 +2648,14 @@ def test_array_from_numpy_unicode():
     assert arrow_arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_string_from_non_string():
     # ARROW-5682 - when converting to string raise on non string-like dtype
     with pytest.raises(TypeError):
         pa.array(np.array([1, 2, 3]), type=pa.string())
 
 
+@pytest.mark.numpy
 def test_array_string_from_all_null():
     # ARROW-5682
     vals = np.array([None, None], dtype=object)
@@ -2629,6 +2670,7 @@ def test_array_string_from_all_null():
     assert arr.null_count == 2
 
 
+@pytest.mark.numpy
 def test_array_from_masked():
     ma = np.ma.array([1, 2, 3, 4], dtype='int64',
                      mask=[False, False, True, False])
@@ -2640,6 +2682,7 @@ def test_array_from_masked():
         pa.array(ma, mask=np.array([True, False, False, False]))
 
 
+@pytest.mark.numpy
 def test_array_from_shrunken_masked():
     ma = np.ma.array([0], dtype='int64')
     result = pa.array(ma)
@@ -2647,6 +2690,7 @@ def test_array_from_shrunken_masked():
     assert expected.equals(result)
 
 
+@pytest.mark.numpy
 def test_array_from_invalid_dim_raises():
     msg = "only handle 1-dimensional arrays"
     arr2d = np.array([[1, 2, 3], [4, 5, 6]])
@@ -2658,6 +2702,7 @@ def test_array_from_invalid_dim_raises():
         pa.array(arr0d)
 
 
+@pytest.mark.numpy
 def test_array_from_strided_bool():
     # ARROW-6325
     arr = np.ones((3, 2), dtype=bool)
@@ -2669,6 +2714,7 @@ def test_array_from_strided_bool():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_array_from_strided():
     pydata = [
         ([b"ab", b"cd", b"ef"], (pa.binary(), pa.binary(2))),
@@ -2693,6 +2739,7 @@ def test_boolean_true_count_false_count():
     assert arr.false_count == 1000
 
 
+@pytest.mark.numpy
 def test_buffers_primitive():
     a = pa.array([1, 2, None, 4], type=pa.int16())
     buffers = a.buffers()
@@ -2765,6 +2812,7 @@ def test_buffers_nested():
     assert struct.unpack('4xh', values) == (43,)
 
 
+@pytest.mark.numpy
 def test_total_buffer_size():
     a = pa.array(np.array([4, 5, 6], dtype='int64'))
     assert a.nbytes == 8 * 3
@@ -3163,6 +3211,7 @@ def test_nested_dictionary_array():
     assert dict_arr2.to_pylist() == ['a', 'b', 'a', 'b', 'a']
 
 
+@pytest.mark.numpy
 def test_array_from_numpy_str_utf8():
     # ARROW-3890 -- in Python 3, NPY_UNICODE arrays are produced, but in Python
     # 2 they are NPY_STRING (binary), so we must do UTF-8 validation
@@ -3189,6 +3238,7 @@ def test_array_from_numpy_str_utf8():
         pa.array(vec, pa.string(), mask=np.array([False]))
 
 
+@pytest.mark.numpy
 @pytest.mark.slow
 @pytest.mark.large_memory
 def test_numpy_binary_overflow_to_chunked():
@@ -3247,6 +3297,7 @@ def test_list_child_overflow_to_chunked():
     assert len(arr.chunk(1)) == 1
 
 
+@pytest.mark.numpy
 def test_infer_type_masked():
     # ARROW-5208
     ty = pa.infer_type(['foo', 'bar', None, 2],
@@ -3262,6 +3313,7 @@ def test_infer_type_masked():
     assert pa.infer_type([], mask=[]) == pa.null()
 
 
+@pytest.mark.numpy
 def test_array_masked():
     # ARROW-5208
     arr = pa.array([4, None, 4, 3.],
@@ -3274,6 +3326,7 @@ def test_array_masked():
     assert arr.type == pa.int64()
 
 
+@pytest.mark.numpy
 def test_array_supported_masks():
     # ARROW-13883
     arr = pa.array([4, None, 4, 3.],
@@ -3332,6 +3385,7 @@ def test_array_supported_pandas_masks():
     assert arr.to_pylist() == [None, 1]
 
 
+@pytest.mark.numpy
 def test_binary_array_masked():
     # ARROW-12431
     masked_basic = pa.array([b'\x05'], type=pa.binary(1),
@@ -3364,6 +3418,7 @@ def test_binary_array_masked():
     assert ([b'aaa', b'bbb', b'ccc']*10) == arrow_array.to_pylist()
 
 
+@pytest.mark.numpy
 def test_binary_array_strided():
     # Masked
     nparray = np.array([b"ab", b"cd", b"ef"])
@@ -3377,6 +3432,7 @@ def test_binary_array_strided():
     assert [b"ab", b"ef"] == arrow_array.to_pylist()
 
 
+@pytest.mark.numpy
 def test_array_invalid_mask_raises():
     # ARROW-10742
     cases = [
@@ -3410,6 +3466,7 @@ def test_array_from_large_pyints():
         pa.array([int(2 ** 63)])
 
 
+@pytest.mark.numpy
 def test_numpy_array_protocol():
     # test the __array__ method on pyarrow.Array
     arr = pa.array([1, 2, 3])
@@ -3456,6 +3513,7 @@ def test_numpy_array_protocol():
     assert result.dtype == "float64"
 
 
+@pytest.mark.numpy
 def test_array_protocol():
 
     class MyArray:
@@ -3779,6 +3837,7 @@ def test_run_end_encoded_from_buffers():
                                            1, offset, children)
 
 
+@pytest.mark.numpy
 def test_run_end_encoded_from_array_with_type():
     run_ends = [1, 3, 6]
     values = [1, 2, 3]
@@ -3818,6 +3877,7 @@ def test_run_end_encoded_from_array_with_type():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_run_end_encoded_to_numpy():
     arr = [1, 2, 2, 3, 3, 3]
     ree_array = pa.array(arr, pa.run_end_encoded(pa.int32(), pa.int64()))
@@ -4033,6 +4093,7 @@ def test_list_view_slice(list_view_type):
     assert sliced_array[0].as_py() == sliced_array.values[i:j].to_pylist() == [4]
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('numpy_native_dtype', ['u2', 'i4', 'f8'])
 def test_swapped_byte_order_fails(numpy_native_dtype):
     # ARROW-39129

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -487,7 +487,7 @@ def test_array_slice():
             res.validate()
             expected = arr.to_pylist()[start:stop]
             assert res.to_pylist() == expected
-            if "numpy" in sys.modules:
+            if pa.HAS_NUMPY:
                 assert res.to_numpy().tolist() == expected
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -223,7 +223,6 @@ def test_to_numpy_unsupported_types():
 
 
 def test_to_numpy_writable():
-    # TODO: Validate this is not segfaulting
     arr = pa.array(range(10))
     np_arr = arr.to_numpy()
 
@@ -482,7 +481,7 @@ def test_array_slice():
             res.validate()
             expected = arr.to_pylist()[start:stop]
             assert res.to_pylist() == expected
-            if pa.HAS_NUMPY:
+            if np is not None:
                 assert res.to_numpy().tolist() == expected
 
 

--- a/python/pyarrow/tests/test_builder.py
+++ b/python/pyarrow/tests/test_builder.py
@@ -15,12 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import math
 import weakref
-
-try:
-    import numpy as np
-except ImportError:
-    np = None
 
 import pyarrow as pa
 from pyarrow.lib import StringBuilder, StringViewBuilder
@@ -38,7 +34,7 @@ def test_string_builder_append():
     sbuilder = StringBuilder()
     sbuilder.append(b"a byte string")
     sbuilder.append("a string")
-    sbuilder.append(np.nan)
+    sbuilder.append(math.nan)
     sbuilder.append(None)
     assert len(sbuilder) == 4
     assert sbuilder.null_count == 2
@@ -53,7 +49,7 @@ def test_string_builder_append():
 
 def test_string_builder_append_values():
     sbuilder = StringBuilder()
-    sbuilder.append_values([np.nan, None, "text", None, "other text"])
+    sbuilder.append_values([math.nan, None, "text", None, "other text"])
     assert sbuilder.null_count == 3
     arr = sbuilder.finish()
     assert arr.null_count == 3
@@ -63,7 +59,7 @@ def test_string_builder_append_values():
 
 def test_string_builder_append_after_finish():
     sbuilder = StringBuilder()
-    sbuilder.append_values([np.nan, None, "text", None, "other text"])
+    sbuilder.append_values([math.nan, None, "text", None, "other text"])
     arr = sbuilder.finish()
     sbuilder.append("No effect")
     expected = [None, None, "text", None, "other text"]
@@ -75,7 +71,7 @@ def test_string_view_builder():
     builder.append(b"a byte string")
     builder.append("a string")
     builder.append("a longer not-inlined string")
-    builder.append(np.nan)
+    builder.append(math.nan)
     builder.append_values([None, "text"])
     assert len(builder) == 6
     assert builder.null_count == 2

--- a/python/pyarrow/tests/test_builder.py
+++ b/python/pyarrow/tests/test_builder.py
@@ -17,12 +17,10 @@
 
 import weakref
 
-import pytest
-
 try:
     import numpy as np
 except ImportError:
-    pass
+    np = None
 
 import pyarrow as pa
 from pyarrow.lib import StringBuilder, StringViewBuilder
@@ -36,8 +34,7 @@ def test_weakref():
     assert wr() is None
 
 
-@pytest.mark.numpy
-def test_string_builder_append_with_nan():
+def test_string_builder_append():
     sbuilder = StringBuilder()
     sbuilder.append(b"a byte string")
     sbuilder.append("a string")
@@ -54,24 +51,7 @@ def test_string_builder_append_with_nan():
     assert arr.to_pylist() == expected
 
 
-def test_string_builder_append():
-    sbuilder = StringBuilder()
-    sbuilder.append(b"a byte string")
-    sbuilder.append("a string")
-    sbuilder.append(None)
-    assert len(sbuilder) == 3
-    assert sbuilder.null_count == 1
-    arr = sbuilder.finish()
-    assert len(sbuilder) == 0
-    assert isinstance(arr, pa.Array)
-    assert arr.null_count == 1
-    assert arr.type == 'str'
-    expected = ["a byte string", "a string", None]
-    assert arr.to_pylist() == expected
-
-
-@pytest.mark.numpy
-def test_string_builder_append_values_with_nan():
+def test_string_builder_append_values():
     sbuilder = StringBuilder()
     sbuilder.append_values([np.nan, None, "text", None, "other text"])
     assert sbuilder.null_count == 3
@@ -81,18 +61,7 @@ def test_string_builder_append_values_with_nan():
     assert arr.to_pylist() == expected
 
 
-def test_string_builder_append_values():
-    sbuilder = StringBuilder()
-    sbuilder.append_values([None, "text", None, "other text"])
-    assert sbuilder.null_count == 2
-    arr = sbuilder.finish()
-    assert arr.null_count == 2
-    expected = [None, "text", None, "other text"]
-    assert arr.to_pylist() == expected
-
-
-@pytest.mark.numpy
-def test_string_builder_append_after_finish_with_nan():
+def test_string_builder_append_after_finish():
     sbuilder = StringBuilder()
     sbuilder.append_values([np.nan, None, "text", None, "other text"])
     arr = sbuilder.finish()
@@ -101,17 +70,7 @@ def test_string_builder_append_after_finish_with_nan():
     assert arr.to_pylist() == expected
 
 
-def test_string_builder_append_after_finish():
-    sbuilder = StringBuilder()
-    sbuilder.append_values([None, "text", None, "other text"])
-    arr = sbuilder.finish()
-    sbuilder.append("No effect")
-    expected = [None, "text", None, "other text"]
-    assert arr.to_pylist() == expected
-
-
-@pytest.mark.numpy
-def test_string_view_builder_with_nan():
+def test_string_view_builder():
     builder = StringViewBuilder()
     builder.append(b"a byte string")
     builder.append("a string")
@@ -126,23 +85,5 @@ def test_string_view_builder_with_nan():
     assert arr.type == 'string_view'
     expected = [
         "a byte string", "a string", "a longer not-inlined string", None, None, "text"
-    ]
-    assert arr.to_pylist() == expected
-
-
-def test_string_view_builder():
-    builder = StringViewBuilder()
-    builder.append(b"a byte string")
-    builder.append("a string")
-    builder.append("a longer not-inlined string")
-    builder.append_values([None, "text"])
-    assert len(builder) == 5
-    assert builder.null_count == 1
-    arr = builder.finish()
-    assert isinstance(arr, pa.Array)
-    assert arr.null_count == 1
-    assert arr.type == 'string_view'
-    expected = [
-        "a byte string", "a string", "a longer not-inlined string", None, "text"
     ]
     assert arr.to_pylist() == expected

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -31,7 +31,7 @@ import textwrap
 try:
     import numpy as np
 except ImportError:
-    pass
+    np = None
 
 try:
     import pandas as pd
@@ -212,6 +212,7 @@ def test_option_class_equality(request):
         "ArraySortOptions(order=Ascending, null_placement=AtEnd)"
 
 
+@pytest.mark.without_numpy
 def test_list_functions():
     assert len(pc.list_functions()) > 10
     assert "add" in pc.list_functions()
@@ -308,6 +309,7 @@ def test_input_type_conversion():
                     "foo").to_pylist() == [True, False, None]
 
 
+@pytest.mark.without_numpy
 @pytest.mark.parametrize('arrow_type', numerical_arrow_types)
 def test_sum_array(arrow_type):
     arr = pa.array([1, 2, 3, 4], type=arrow_type)
@@ -443,6 +445,7 @@ def test_count_substring_regex():
         assert expected.equals(result)
 
 
+@pytest.mark.without_numpy
 def test_find_substring():
     for ty in [pa.string(), pa.binary(), pa.large_string(), pa.large_binary()]:
         arr = pa.array(["ab", "cab", "ba", None], type=ty)
@@ -475,6 +478,7 @@ def test_match_like():
     assert expected.equals(result)
 
 
+@pytest.mark.without_numpy
 def test_match_substring():
     arr = pa.array(["ab", "abc", "ba", None])
     result = pc.match_substring(arr, "ab")
@@ -566,6 +570,7 @@ def test_binary_slice_compatibility():
             assert actual.as_py() == expected
 
 
+@pytest.mark.without_numpy
 def test_split_pattern():
     arr = pa.array(["-foo---bar--", "---foo---b"])
     result = pc.split_pattern(arr, pattern="---")
@@ -627,6 +632,7 @@ def test_split_pattern_regex():
             arr, pattern="---", max_splits=1, reverse=True)
 
 
+@pytest.mark.without_numpy
 def test_min_max():
     # An example generated function wrapper with possible options
     data = [4, 5, 6, None, 1]
@@ -1092,7 +1098,6 @@ def test_binary_join_element_wise():
         'a', 'b', null, options=replace).as_py() is None
 
 
-@pytest.mark.numpy
 def test_take(all_array_types):
     for ty, values in all_array_types:
         arr = pa.array(values, type=ty)
@@ -1199,7 +1204,7 @@ def test_take_null_type():
     assert len(table.take(indices).column(0)) == 4
 
 
-@pytest.mark.numpy
+
 def test_drop_null(all_array_types):
     for ty, values in all_array_types:
         arr = pa.array(values, type=ty)
@@ -1276,7 +1281,6 @@ def test_drop_null_null_type():
     assert len(table.drop_null().column(0)) == 0
 
 
-@pytest.mark.numpy
 def test_filter(all_array_types):
     for ty, values in all_array_types:
         arr = pa.array(values, type=ty)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -236,7 +236,6 @@ def test_option_class_equality(request):
         "ArraySortOptions(order=Ascending, null_placement=AtEnd)"
 
 
-@pytest.mark.without_numpy
 def test_list_functions():
     assert len(pc.list_functions()) > 10
     assert "add" in pc.list_functions()
@@ -270,6 +269,7 @@ def test_get_function_hash_aggregate():
                         pc.HashAggregateKernel, 1)
 
 
+@pytest.mark.numpy
 def test_call_function_with_memory_pool():
     arr = pa.array(["foo", "bar", "baz"])
     indices = np.array([2, 2, 1])
@@ -333,7 +333,6 @@ def test_input_type_conversion():
                     "foo").to_pylist() == [True, False, None]
 
 
-@pytest.mark.without_numpy
 @pytest.mark.parametrize('arrow_type', numerical_arrow_types)
 def test_sum_array(arrow_type):
     arr = pa.array([1, 2, 3, 4], type=arrow_type)
@@ -469,7 +468,6 @@ def test_count_substring_regex():
         assert expected.equals(result)
 
 
-@pytest.mark.without_numpy
 def test_find_substring():
     for ty in [pa.string(), pa.binary(), pa.large_string(), pa.large_binary()]:
         arr = pa.array(["ab", "cab", "ba", None], type=ty)
@@ -502,7 +500,6 @@ def test_match_like():
     assert expected.equals(result)
 
 
-@pytest.mark.without_numpy
 def test_match_substring():
     arr = pa.array(["ab", "abc", "ba", None])
     result = pc.match_substring(arr, "ab")
@@ -594,7 +591,6 @@ def test_binary_slice_compatibility():
             assert actual.as_py() == expected
 
 
-@pytest.mark.without_numpy
 def test_split_pattern():
     arr = pa.array(["-foo---bar--", "---foo---b"])
     result = pc.split_pattern(arr, pattern="---")
@@ -690,7 +686,6 @@ def test_min_max():
         s = pc.min_max()
 
 
-@pytest.mark.without_numpy
 def test_any():
     # ARROW-1846
 
@@ -710,7 +705,6 @@ def test_any():
     assert pc.any(a, options=options).as_py() is None
 
 
-@pytest.mark.without_numpy
 def test_all():
     # ARROW-10301
 
@@ -1123,6 +1117,7 @@ def test_binary_join_element_wise():
         'a', 'b', null, options=replace).as_py() is None
 
 
+@pytest.mark.numpy
 def test_take(all_array_types):
     for ty, values in all_array_types:
         arr = pa.array(values, type=ty)
@@ -1166,6 +1161,7 @@ def test_take_indices_types():
             arr.take(indices)
 
 
+@pytest.mark.numpy
 def test_take_on_chunked_array():
     # ARROW-9504
     arr = pa.chunked_array([
@@ -1229,6 +1225,7 @@ def test_take_null_type():
     assert len(table.take(indices).column(0)) == 4
 
 
+@pytest.mark.numpy
 def test_drop_null(all_array_types):
     for ty, values in all_array_types:
         arr = pa.array(values, type=ty)
@@ -1305,6 +1302,7 @@ def test_drop_null_null_type():
     assert len(table.drop_null().column(0)) == 0
 
 
+@pytest.mark.numpy
 def test_filter(all_array_types):
     for ty, values in all_array_types:
         arr = pa.array(values, type=ty)
@@ -1574,6 +1572,7 @@ def test_arithmetic_multiply():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize("ty", ["round", "round_to_multiple"])
 def test_round_to_integer(ty):
     if ty == "round":
@@ -1602,6 +1601,7 @@ def test_round_to_integer(ty):
         np.testing.assert_array_equal(result, pa.array(expected))
 
 
+@pytest.mark.numpy
 def test_round():
     values = [320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045, None]
     ndigits_and_expected = {
@@ -1620,6 +1620,7 @@ def test_round():
         assert pc.round(values, ndigits, "half_towards_infinity") == result
 
 
+@pytest.mark.numpy
 def test_round_to_multiple():
     values = [320, 3.5, 3.075, 4.5, -3.212, -35.1234, -3.045, None]
     multiple_and_expected = {
@@ -1664,6 +1665,7 @@ def test_round_binary():
         5.0, scale, round_mode="half_towards_infinity") == expect_inf
 
 
+@pytest.mark.numpy
 def test_is_null():
     arr = pa.array([1, 2, 3, None])
     result = arr.is_null()
@@ -1693,6 +1695,7 @@ def test_is_null():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_is_nan():
     arr = pa.array([1, 2, 3, None, np.nan])
     result = arr.is_nan()
@@ -1999,6 +2002,7 @@ def check_cast_float_to_decimal(float_ty, float_val, decimal_ty, decimal_ctx,
 
 
 # Cannot test float32 as case generators above assume float64
+@pytest.mark.numpy
 @pytest.mark.parametrize('float_ty', [pa.float64()], ids=str)
 @pytest.mark.parametrize('decimal_ty', decimal_type_traits,
                          ids=lambda v: v.name)
@@ -2016,6 +2020,7 @@ def test_cast_float_to_decimal(float_ty, decimal_ty, case_generator):
                 ctx, decimal_ty.max_precision)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('float_ty', [pa.float32(), pa.float64()], ids=str)
 @pytest.mark.parametrize('decimal_traits', decimal_type_traits,
                          ids=lambda v: v.name)
@@ -2921,6 +2926,7 @@ def test_min_max_element_wise():
     assert result == pa.array([1, 2, None])
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('start', (1.25, 10.5, -10.5))
 @pytest.mark.parametrize('skip_nulls', (True, False))
 def test_cumulative_sum(start, skip_nulls):
@@ -2975,6 +2981,7 @@ def test_cumulative_sum(start, skip_nulls):
             pc.cumulative_sum([1, 2, 3], start=strt)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('start', (1.25, 10.5, -10.5))
 @pytest.mark.parametrize('skip_nulls', (True, False))
 def test_cumulative_prod(start, skip_nulls):
@@ -3028,7 +3035,7 @@ def test_cumulative_prod(start, skip_nulls):
         with pytest.raises(pa.ArrowInvalid):
             pc.cumulative_prod([1, 2, 3], start=strt)
 
-
+@pytest.mark.numpy
 @pytest.mark.parametrize('start', (0.5, 3.5, 6.5))
 @pytest.mark.parametrize('skip_nulls', (True, False))
 def test_cumulative_max(start, skip_nulls):
@@ -3086,6 +3093,7 @@ def test_cumulative_max(start, skip_nulls):
             pc.cumulative_max([1, 2, 3], start=strt)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('start', (0.5, 3.5, 6.5))
 @pytest.mark.parametrize('skip_nulls', (True, False))
 def test_cumulative_min(start, skip_nulls):
@@ -3420,6 +3428,7 @@ def create_sample_expressions():
 # Tests the Arrow-specific serialization mechanism
 
 
+@pytest.mark.numpy
 def test_expression_serialization_arrow(pickle_module):
     for expr in create_sample_expressions()["all"]:
         assert isinstance(expr, pc.Expression)
@@ -3427,6 +3436,7 @@ def test_expression_serialization_arrow(pickle_module):
         assert expr.equals(restored)
 
 
+@pytest.mark.numpy
 @pytest.mark.substrait
 def test_expression_serialization_substrait():
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -69,6 +69,30 @@ numerical_arrow_types = [
 ]
 
 
+@pytest.fixture
+def all_array_types():
+    return [
+        ('bool', [True, False, False, True, True]),
+        ('uint8', np.arange(5)),
+        ('int8', np.arange(5)),
+        ('uint16', np.arange(5)),
+        ('int16', np.arange(5)),
+        ('uint32', np.arange(5)),
+        ('int32', np.arange(5)),
+        ('uint64', np.arange(5, 10)),
+        ('int64', np.arange(5, 10)),
+        ('float', np.arange(0, 0.5, 0.1)),
+        ('double', np.arange(0, 0.5, 0.1)),
+        ('string', ['a', 'b', None, 'ddd', 'ee']),
+        ('binary', [b'a', b'b', b'c', b'ddd', b'ee']),
+        (pa.binary(3), [b'abc', b'bcd', b'cde', b'def', b'efg']),
+        (pa.list_(pa.int8()), [[1, 2], [3, 4], [5, 6], None, [9, 16]]),
+        (pa.large_list(pa.int16()), [[1], [2, 3, 4], [5, 6], None, [9, 16]]),
+        (pa.struct([('a', pa.int8()), ('b', pa.int8())]), [
+            {'a': 1, 'b': 2}, None, {'a': 3, 'b': 4}, None, {'a': 5, 'b': 6}]),
+    ]
+
+
 def test_exported_functions():
     # Check that all exported concrete functions can be called with
     # the right number of arguments.

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -632,7 +632,6 @@ def test_split_pattern_regex():
             arr, pattern="---", max_splits=1, reverse=True)
 
 
-@pytest.mark.without_numpy
 def test_min_max():
     # An example generated function wrapper with possible options
     data = [4, 5, 6, None, 1]
@@ -667,6 +666,7 @@ def test_min_max():
         s = pc.min_max()
 
 
+@pytest.mark.without_numpy
 def test_any():
     # ARROW-1846
 
@@ -686,6 +686,7 @@ def test_any():
     assert pc.any(a, options=options).as_py() is None
 
 
+@pytest.mark.without_numpy
 def test_all():
     # ARROW-10301
 
@@ -1202,7 +1203,6 @@ def test_take_null_type():
     assert len(chunked_arr.take(indices)) == 4
     assert len(batch.take(indices).column(0)) == 4
     assert len(table.take(indices).column(0)) == 4
-
 
 
 def test_drop_null(all_array_types):

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1314,10 +1314,10 @@ def test_filter(ty, values):
     with pytest.raises(NotImplementedError):
         arr.filter(mask)
 
-        # wrong length
-        mask = pa.array([True, False, True])
-        with pytest.raises(ValueError, match="must all be the same length"):
-            arr.filter(mask)
+    # wrong length
+    mask = pa.array([True, False, True])
+    with pytest.raises(ValueError, match="must all be the same length"):
+        arr.filter(mask)
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1276,7 +1276,7 @@ def test_drop_null_null_type():
     assert len(table.drop_null().column(0)) == 0
 
 
-@pytest.mark.nump
+@pytest.mark.numpy
 def test_filter(all_array_types):
     for ty, values in all_array_types:
         arr = pa.array(values, type=ty)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3035,6 +3035,7 @@ def test_cumulative_prod(start, skip_nulls):
         with pytest.raises(pa.ArrowInvalid):
             pc.cumulative_prod([1, 2, 3], start=strt)
 
+
 @pytest.mark.numpy
 @pytest.mark.parametrize('start', (0.5, 3.5, 6.5))
 @pytest.mark.parametrize('skip_nulls', (True, False))

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -23,8 +23,11 @@ import math
 import re
 
 import hypothesis as h
-import numpy as np
 import pytest
+try:
+    import numpy as np
+except ImportError:
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
 
 from pyarrow.pandas_compat import _pandas_api  # noqa
 import pyarrow as pa

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -285,11 +285,14 @@ def test_list_with_non_list(seq):
 
 
 @parametrize_with_sequence_types
+@pytest.mark.parametrize(
+    "inner_seq", SEQUENCE_TYPES
+)
 @pytest.mark.parametrize("factory", [
     pa.list_, pa.large_list, pa.list_view, pa.large_list_view])
-def test_nested_arrays(seq, factory):
-    arr = pa.array(seq([pa.array([], type=pa.int64()),
-                        pa.array([1, 2], type=pa.int64()), None]),
+def test_nested_arrays(seq, inner_seq, factory):
+    arr = pa.array(seq([inner_seq([]),
+                        inner_seq([1, 2]), None]),
                    type=factory(pa.int64()))
     assert len(arr) == 3
     assert arr.null_count == 1

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -27,7 +27,8 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
+                allow_module_level=True)
 
 from pyarrow.pandas_compat import _pandas_api  # noqa
 import pyarrow as pa

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -27,8 +27,7 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
-                allow_module_level=True)
+    np = None
 
 from pyarrow.pandas_compat import _pandas_api  # noqa
 import pyarrow as pa
@@ -36,17 +35,17 @@ import pyarrow.tests.strategies as past
 
 
 int_type_pairs = [
-    (np.int8, pa.int8()),
-    (np.int16, pa.int16()),
-    (np.int32, pa.int32()),
-    (np.int64, pa.int64()),
-    (np.uint8, pa.uint8()),
-    (np.uint16, pa.uint16()),
-    (np.uint32, pa.uint32()),
-    (np.uint64, pa.uint64())]
+    ("int8", pa.int8()),
+    ("int16", pa.int16()),
+    ("int32", pa.int32()),
+    ("int64", pa.int64()),
+    ("uint8", pa.uint8()),
+    ("uint16", pa.uint16()),
+    ("uint32", pa.uint32()),
+    ("uint64", pa.uint64())]
 
 
-np_int_types, pa_int_types = zip(*int_type_pairs)
+np_str_int_types, pa_int_types = zip(*int_type_pairs)
 
 
 class StrangeIterable:
@@ -178,7 +177,9 @@ def _as_set(xs):
     return set(xs)
 
 
-SEQUENCE_TYPES = [_as_list, _as_tuple, _as_numpy_array]
+SEQUENCE_TYPES = [_as_list, _as_tuple]
+if np is not None:
+    SEQUENCE_TYPES.append(_as_numpy_array)
 ITERABLE_TYPES = [_as_set, _as_dict_values] + SEQUENCE_TYPES
 COLLECTIONS_TYPES = [_as_deque] + ITERABLE_TYPES
 
@@ -221,6 +222,7 @@ def test_sequence_boolean(seq):
     assert arr.to_pylist() == expected
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
 def test_sequence_numpy_boolean(seq):
     expected = [np.bool_(True), None, np.bool_(False), None]
@@ -229,6 +231,7 @@ def test_sequence_numpy_boolean(seq):
     assert arr.to_pylist() == [True, None, False, None]
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
 def test_sequence_mixed_numpy_python_bools(seq):
     values = np.array([True, False])
@@ -285,8 +288,8 @@ def test_list_with_non_list(seq):
 @pytest.mark.parametrize("factory", [
     pa.list_, pa.large_list, pa.list_view, pa.large_list_view])
 def test_nested_arrays(seq, factory):
-    arr = pa.array(seq([np.array([], dtype=np.int64),
-                        np.array([1, 2], dtype=np.int64), None]),
+    arr = pa.array(seq([pa.array([], type=pa.int64()),
+                        pa.array([1, 2], type=pa.int64()), None]),
                    type=factory(pa.int64()))
     assert len(arr) == 3
     assert arr.null_count == 1
@@ -294,6 +297,7 @@ def test_nested_arrays(seq, factory):
     assert arr.to_pylist() == [[], [1, 2], None]
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
 def test_nested_fixed_size_list(seq):
     # sequence of lists
@@ -338,10 +342,12 @@ def test_sequence_all_none(seq):
     assert arr.to_pylist() == [None, None]
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
 @pytest.mark.parametrize("np_scalar_pa_type", int_type_pairs)
 def test_sequence_integer(seq, np_scalar_pa_type):
-    np_scalar, pa_type = np_scalar_pa_type
+    np_str_scalar, pa_type = np_scalar_pa_type
+    np_scalar = getattr(np, np_str_scalar)
     expected = [1, None, 3, None,
                 np.iinfo(np_scalar).min, np.iinfo(np_scalar).max]
     arr = pa.array(seq(expected), type=pa_type)
@@ -351,12 +357,12 @@ def test_sequence_integer(seq, np_scalar_pa_type):
     assert arr.to_pylist() == expected
 
 
+@pytest.mark.numpy
 @parametrize_with_collections_types
-@pytest.mark.parametrize("np_scalar_pa_type", int_type_pairs)
-def test_sequence_integer_np_nan(seq, np_scalar_pa_type):
+@pytest.mark.parametrize("pa_type", pa_int_types)
+def test_sequence_integer_np_nan(seq, pa_type):
     # ARROW-2806: numpy.nan is a double value and thus should produce
     # a double array.
-    _, pa_type = np_scalar_pa_type
     with pytest.raises(ValueError):
         pa.array(seq([np.nan]), type=pa_type, from_pandas=False)
 
@@ -368,12 +374,12 @@ def test_sequence_integer_np_nan(seq, np_scalar_pa_type):
     assert arr.to_pylist() == expected
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
-@pytest.mark.parametrize("np_scalar_pa_type", int_type_pairs)
-def test_sequence_integer_nested_np_nan(seq, np_scalar_pa_type):
+@pytest.mark.parametrize("pa_type", pa_int_types)
+def test_sequence_integer_nested_np_nan(seq, pa_type):
     # ARROW-2806: numpy.nan is a double value and thus should produce
     # a double array.
-    _, pa_type = np_scalar_pa_type
     with pytest.raises(ValueError):
         pa.array(seq([[np.nan]]), type=pa.list_(pa_type), from_pandas=False)
 
@@ -395,10 +401,12 @@ def test_sequence_integer_inferred(seq):
     assert arr.to_pylist() == expected
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
 @pytest.mark.parametrize("np_scalar_pa_type", int_type_pairs)
 def test_sequence_numpy_integer(seq, np_scalar_pa_type):
-    np_scalar, pa_type = np_scalar_pa_type
+    np_str_scalar, pa_type = np_scalar_pa_type
+    np_scalar = getattr(np, np_str_scalar)
     expected = [np_scalar(1), None, np_scalar(3), None,
                 np_scalar(np.iinfo(np_scalar).min),
                 np_scalar(np.iinfo(np_scalar).max)]
@@ -409,10 +417,12 @@ def test_sequence_numpy_integer(seq, np_scalar_pa_type):
     assert arr.to_pylist() == expected
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
 @pytest.mark.parametrize("np_scalar_pa_type", int_type_pairs)
 def test_sequence_numpy_integer_inferred(seq, np_scalar_pa_type):
-    np_scalar, pa_type = np_scalar_pa_type
+    np_str_scalar, pa_type = np_scalar_pa_type
+    np_scalar = getattr(np, np_str_scalar)
     expected = [np_scalar(1), None, np_scalar(3), None]
     expected += [np_scalar(np.iinfo(np_scalar).min),
                  np_scalar(np.iinfo(np_scalar).max)]
@@ -438,6 +448,7 @@ def test_broken_integers(seq):
         pa.array(seq(data), type=pa.int64())
 
 
+@pytest.mark.numpy
 def test_numpy_scalars_mixed_type():
     # ARROW-4324
     data = [np.int32(10), np.float32(0.5)]
@@ -452,6 +463,7 @@ def test_numpy_scalars_mixed_type():
     assert arr.equals(expected)
 
 
+@pytest.mark.numpy
 @pytest.mark.xfail(reason="Type inference for uint64 not implemented",
                    raises=OverflowError)
 def test_uint64_max_convert():
@@ -495,7 +507,7 @@ def test_integer_from_string_error(seq, typ):
 
 def test_convert_with_mask():
     data = [1, 2, 3, 4, 5]
-    mask = np.array([False, True, False, False, True])
+    mask = [False, True, False, False, True]
 
     result = pa.array(data, mask=mask)
     expected = pa.array([1, None, 3, 4, None])
@@ -563,6 +575,7 @@ def test_double_integer_coerce_representable_range():
         pa.array(invalid_values2)
 
 
+@pytest.mark.numpy
 def test_float32_integer_coerce_representable_range():
     f32 = np.float32
     valid_values = [f32(1.5), 1 << 24, -(1 << 24)]
@@ -591,14 +604,16 @@ def test_mixed_sequence_errors():
         pa.array([1.5, 'foo'])
 
 
+@pytest.mark.numpy
 @parametrize_with_sequence_types
-@pytest.mark.parametrize("np_scalar,pa_type", [
-    (np.float16, pa.float16()),
-    (np.float32, pa.float32()),
-    (np.float64, pa.float64())
+@pytest.mark.parametrize("np_str_scalar,pa_type", [
+    ("float16", pa.float16()),
+    ("float32", pa.float32()),
+    ("float64", pa.float64())
 ])
 @pytest.mark.parametrize("from_pandas", [True, False])
-def test_sequence_numpy_double(seq, np_scalar, pa_type, from_pandas):
+def test_sequence_numpy_double(seq, np_str_scalar, pa_type, from_pandas):
+    np_scalar = getattr(np, np_str_scalar)
     data = [np_scalar(1.5), np_scalar(1), None, np_scalar(2.5), None, np.nan]
     arr = pa.array(seq(data), from_pandas=from_pandas)
     assert len(arr) == 6
@@ -620,27 +635,29 @@ def test_sequence_numpy_double(seq, np_scalar, pa_type, from_pandas):
         assert np.isnan(arr.to_pylist()[5])
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize("from_pandas", [True, False])
-@pytest.mark.parametrize("inner_seq", [np.array, list])
-def test_ndarray_nested_numpy_double(from_pandas, inner_seq):
+def test_ndarray_nested_numpy_double(from_pandas):
     # ARROW-2806
-    data = np.array([
-        inner_seq([1., 2.]),
-        inner_seq([1., 2., 3.]),
-        inner_seq([np.nan]),
-        None
-    ], dtype=object)
-    arr = pa.array(data, from_pandas=from_pandas)
-    assert len(arr) == 4
-    assert arr.null_count == 1
-    assert arr.type == pa.list_(pa.float64())
-    if from_pandas:
-        assert arr.to_pylist() == [[1.0, 2.0], [1.0, 2.0, 3.0], [None], None]
-    else:
-        np.testing.assert_equal(arr.to_pylist(),
-                                [[1., 2.], [1., 2., 3.], [np.nan], None])
+    for inner_seq in (np.array, list):
+        data = np.array([
+            inner_seq([1., 2.]),
+            inner_seq([1., 2., 3.]),
+            inner_seq([np.nan]),
+            None
+        ], dtype=object)
+        arr = pa.array(data, from_pandas=from_pandas)
+        assert len(arr) == 4
+        assert arr.null_count == 1
+        assert arr.type == pa.list_(pa.float64())
+        if from_pandas:
+            assert arr.to_pylist() == [[1.0, 2.0], [1.0, 2.0, 3.0], [None], None]
+        else:
+            np.testing.assert_equal(arr.to_pylist(),
+                                    [[1., 2.], [1., 2., 3.], [np.nan], None])
 
 
+@pytest.mark.numpy
 def test_nested_ndarray_in_object_array():
     # ARROW-4350
     arr = np.empty(2, dtype=object)
@@ -668,6 +685,7 @@ def test_nested_ndarray_in_object_array():
     assert result.to_pylist() == [[[1], [2]], [[1], [2]]]
 
 
+@pytest.mark.numpy
 @pytest.mark.xfail(reason=("Type inference for multidimensional ndarray "
                            "not yet implemented"),
                    raises=AssertionError)
@@ -686,6 +704,7 @@ def test_multidimensional_ndarray_as_nested_list():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('data', 'value_type'), [
     ([True, False], pa.bool_()),
     ([None, None], pa.null()),
@@ -715,6 +734,7 @@ def test_list_array_from_object_ndarray(data, value_type):
     assert arr.to_pylist() == [data]
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize(('data', 'value_type'), [
     ([[1, 2], [3]], pa.list_(pa.int64())),
     ([[1, 2], [3, 4]], pa.list_(pa.int64(), 2)),
@@ -734,13 +754,14 @@ def test_array_ignore_nan_from_pandas():
     # See ARROW-4324, this reverts logic that was introduced in
     # ARROW-2240
     with pytest.raises(ValueError):
-        pa.array([np.nan, 'str'])
+        pa.array([float("nan"), 'str'])
 
-    arr = pa.array([np.nan, 'str'], from_pandas=True)
+    arr = pa.array([float("nan"), 'str'], from_pandas=True)
     expected = pa.array([None, 'str'])
     assert arr.equals(expected)
 
 
+@pytest.mark.numpy
 def test_nested_ndarray_different_dtypes():
     data = [
         np.array([1, 2, 3], dtype='int64'),
@@ -1242,6 +1263,7 @@ def test_sequence_timestamp_out_of_bounds_nanosecond():
     assert arr.to_pylist()[0] == datetime.datetime(2262, 4, 12)
 
 
+@pytest.mark.numpy
 def test_sequence_numpy_timestamp():
     data = [
         np.datetime64(datetime.datetime(2007, 7, 13, 1, 23, 34, 123456)),
@@ -1411,14 +1433,25 @@ def test_sequence_timestamp_from_int_with_unit():
             pa.array([1, CustomClass()], type=ty)
 
 
-@pytest.mark.parametrize('np_scalar', [True, False])
-def test_sequence_duration(np_scalar):
+def test_sequence_duration():
     td1 = datetime.timedelta(2, 3601, 1)
     td2 = datetime.timedelta(1, 100, 1000)
-    if np_scalar:
-        data = [np.timedelta64(td1), None, np.timedelta64(td2)]
-    else:
-        data = [td1, None, td2]
+    data = [td1, None, td2]
+
+    arr = pa.array(data)
+    assert len(arr) == 3
+    assert arr.type == pa.duration('us')
+    assert arr.null_count == 1
+    assert arr[0].as_py() == td1
+    assert arr[1].as_py() is None
+    assert arr[2].as_py() == td2
+
+
+@pytest.mark.numpy
+def test_sequence_duration_np_scalar():
+    td1 = datetime.timedelta(2, 3601, 1)
+    td2 = datetime.timedelta(1, 100, 1000)
+    data = [np.timedelta64(td1), None, np.timedelta64(td2)]
 
     arr = pa.array(data)
     assert len(arr) == 3
@@ -1484,6 +1517,7 @@ def test_sequence_duration_nested_lists_with_explicit_type(factory):
     assert arr.to_pylist() == data
 
 
+@pytest.mark.numpy
 def test_sequence_duration_nested_lists_numpy():
     td1 = datetime.timedelta(1, 1, 1000)
     td2 = datetime.timedelta(1, 100)
@@ -1773,6 +1807,7 @@ def test_struct_from_dicts_bytes_keys():
     ]
 
 
+@pytest.mark.numpy
 def test_struct_from_tuples():
     ty = pa.struct([pa.field('a', pa.int32()),
                     pa.field('b', pa.string()),
@@ -1919,6 +1954,7 @@ def test_struct_from_mixed_sequence():
         pa.array(data, type=ty)
 
 
+@pytest.mark.numpy
 def test_struct_from_dicts_inference():
     expected_type = pa.struct([pa.field('a', pa.int64()),
                                pa.field('b', pa.string()),
@@ -1996,7 +2032,7 @@ def test_structarray_from_arrays_coerce():
 
 
 def test_decimal_array_with_none_and_nan():
-    values = [decimal.Decimal('1.234'), None, np.nan, decimal.Decimal('nan')]
+    values = [decimal.Decimal('1.234'), None, float("nan"), decimal.Decimal('nan')]
 
     with pytest.raises(TypeError):
         # ARROW-6227: Without from_pandas=True, NaN is considered a float
@@ -2502,6 +2538,7 @@ def test_array_accepts_pyarrow_scalar(seq, data, scalar_data, value_type):
     assert expect.equals(result)
 
 
+@pytest.mark.numpy
 @parametrize_with_collections_types
 def test_array_accepts_pyarrow_scalar_errors(seq):
     sequence = seq([pa.scalar(1), pa.scalar("a"), pa.scalar(3.0)])

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2255,6 +2255,7 @@ def test_roundtrip_nanosecond_resolution_pandas_temporal_objects():
     ]
 
 
+@pytest.mark.numpy
 @h.given(past.all_arrays)
 def test_array_to_pylist_roundtrip(arr):
     seq = arr.to_pylist()

--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -34,6 +34,7 @@ def inject_cpp_tests(ns):
         if np is None and ('numpy' in case.name or 'pandas' in case.name):
             # Skip C++ tests that require pandas or numpy if numpy not present
             continue
+
         def wrapper(case=case):
             case()
         wrapper.__name__ = wrapper.__qualname__ = case.name

--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -18,10 +18,6 @@
 import os.path
 from os.path import join as pjoin
 
-try:
-    import numpy as np
-except ImportError:
-    np = None
 
 from pyarrow._pyarrow_cpp_tests import get_cpp_tests
 
@@ -31,9 +27,6 @@ def inject_cpp_tests(ns):
     Inject C++ tests as Python functions into namespace `ns` (a dict).
     """
     for case in get_cpp_tests():
-        if np is None and ('numpy' in case.name or 'pandas' in case.name):
-            # Skip C++ tests that require pandas or numpy if numpy not present
-            continue
 
         def wrapper(case=case):
             case()

--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -18,6 +18,7 @@
 import os.path
 from os.path import join as pjoin
 
+import pytest
 
 from pyarrow._pyarrow_cpp_tests import get_cpp_tests
 
@@ -32,6 +33,11 @@ def inject_cpp_tests(ns):
             case()
         wrapper.__name__ = wrapper.__qualname__ = case.name
         wrapper.__module__ = ns['__name__']
+        # Add numpy or pandas marks if the test requires it
+        if 'numpy' in case.name:
+            wrapper = pytest.mark.numpy(wrapper)
+        elif 'pandas' in case.name:
+            wrapper = pytest.mark.pandas(wrapper)
         ns[case.name] = wrapper
 
 

--- a/python/pyarrow/tests/test_cpp_internals.py
+++ b/python/pyarrow/tests/test_cpp_internals.py
@@ -18,6 +18,11 @@
 import os.path
 from os.path import join as pjoin
 
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
 from pyarrow._pyarrow_cpp_tests import get_cpp_tests
 
 
@@ -26,6 +31,9 @@ def inject_cpp_tests(ns):
     Inject C++ tests as Python functions into namespace `ns` (a dict).
     """
     for case in get_cpp_tests():
+        if np is None and ('numpy' in case.name or 'pandas' in case.name):
+            # Skip C++ tests that require pandas or numpy if numpy not present
+            continue
         def wrapper(case=case):
             case()
         wrapper.__name__ = wrapper.__qualname__ = case.name

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -36,7 +36,10 @@ import weakref
 
 import pytest
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 import pyarrow as pa
 from pyarrow.csv import (
@@ -415,6 +418,7 @@ class BaseTestCSV(abc.ABC):
             "kl": [],
         }
 
+    @pytest.mark.numpy
     def test_skip_rows_after_names(self):
         rows = b"ab,cd\nef,gh\nij,kl\nmn,op\n"
 
@@ -520,6 +524,7 @@ class BaseTestCSV(abc.ABC):
             assert (values[opts.skip_rows + opts.skip_rows_after_names:] ==
                     table_dict[name])
 
+    @pytest.mark.numpy
     def test_row_number_offset_in_errors(self):
         # Row numbers are only correctly counted in serial reads
         def format_msg(msg_format, row, *args):
@@ -1361,6 +1366,7 @@ class BaseCSVTableRead(BaseTestCSV):
             'b,c': ['eh'],
         }
 
+    @pytest.mark.numpy
     def test_small_random_csv(self):
         csv, expected = make_random_csv(num_cols=2, num_rows=10)
         table = self.read_bytes(csv)
@@ -1368,6 +1374,7 @@ class BaseCSVTableRead(BaseTestCSV):
         assert table.equals(expected)
         assert table.to_pydict() == expected.to_pydict()
 
+    @pytest.mark.numpy
     def test_stress_block_sizes(self):
         # Test a number of small block sizes to stress block stitching
         csv_base, expected = make_random_csv(num_cols=2, num_rows=500)
@@ -1735,6 +1742,7 @@ class BaseStreamingCSVRead(BaseTestCSV):
                           [{'a': ["un"],
                             'b': ["éléphant"]}])
 
+    @pytest.mark.numpy
     def test_small_random_csv(self):
         csv, expected = make_random_csv(num_cols=2, num_rows=10)
         reader = self.open_bytes(csv)
@@ -1743,6 +1751,7 @@ class BaseStreamingCSVRead(BaseTestCSV):
         assert table.equals(expected)
         assert table.to_pydict() == expected.to_pydict()
 
+    @pytest.mark.numpy
     def test_stress_block_sizes(self):
         # Test a number of small block sizes to stress block stitching
         csv_base, expected = make_random_csv(num_cols=2, num_rows=500)
@@ -1802,6 +1811,7 @@ class BaseStreamingCSVRead(BaseTestCSV):
         with pytest.raises(StopIteration):
             assert reader.read_next_batch()
 
+    @pytest.mark.numpy
     def test_skip_rows_after_names(self):
         super().test_skip_rows_after_names()
 
@@ -1848,6 +1858,7 @@ class BaseTestCompressedCSVRead:
         except pa.ArrowNotImplementedError as e:
             pytest.skip(str(e))
 
+    @pytest.mark.numpy
     def test_random_csv(self):
         csv, expected = make_random_csv(num_cols=2, num_rows=100)
         csv_path = os.path.join(self.tmpdir, self.csv_filename)

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -55,8 +55,8 @@ def generate_col_names():
 
 def split_rows(arr, num_cols, num_rows):
     # Split a num_cols x num_rows array into rows
-    for i in range(0, num_rows*num_cols, num_cols):
-        yield list(itertools.islice(arr, i, i + num_cols))
+    for i in range(0, num_rows * num_cols, num_cols):
+        yield arr[i:i + num_cols]
 
 
 def split_columns(arr, num_cols, num_rows):

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -142,7 +142,7 @@ class InvalidRowHandler:
 def test_split_rows_and_columns_utility():
     num_cols = 5
     num_rows = 2
-    arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    arr = [x for x in range(1, 11)]
     rows = list(split_rows(arr, num_cols, num_rows))
     assert rows == [
         [1, 2, 3, 4, 5],

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -62,7 +62,7 @@ def split_rows(arr, num_cols, num_rows):
 def split_columns(arr, num_cols, num_rows):
     # Split a num_cols x num_rows array into columns
     for i in range(0, num_cols):
-        yield list(itertools.islice(arr, i, num_cols * num_rows, num_cols))
+        yield arr[i::num_cols]
 
 
 def make_random_csv(num_cols=2, num_rows=10, linesep='\r\n', write_names=True):

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -66,7 +66,8 @@ def split_columns(arr, num_cols, num_rows):
 
 
 def make_random_csv(num_cols=2, num_rows=10, linesep='\r\n', write_names=True):
-    arr = [random.randint(0, 1000) for _ in range(num_cols * num_rows)]
+    rnd = random.Random(42)
+    arr = [rnd.randint(0, 1000) for _ in range(num_cols * num_rows)]
     csv = io.StringIO()
     col_names = list(itertools.islice(generate_col_names(), num_cols))
     if write_names:

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -26,7 +26,10 @@ import sysconfig
 import pytest
 
 import pyarrow as pa
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pytestmark = pytest.mark.numpy
 
 
 cuda = pytest.importorskip("pyarrow.cuda")

--- a/python/pyarrow/tests/test_cuda_numba_interop.py
+++ b/python/pyarrow/tests/test_cuda_numba_interop.py
@@ -17,7 +17,10 @@
 
 import pytest
 import pyarrow as pa
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pytestmark = pytest.mark.numpy
 
 dtypes = ['uint8', 'int16', 'float32']
 cuda = pytest.importorskip("pyarrow.cuda")

--- a/python/pyarrow/tests/test_cython.py
+++ b/python/pyarrow/tests/test_cython.py
@@ -80,6 +80,8 @@ def check_cython_example_module(mod):
         mod.cast_scalar(scal, pa.list_(pa.int64()))
 
 
+# NumPy is still a required build dependency. It is present in our
+# headers and is required to build for the cython tests.
 @pytest.mark.numpy
 @pytest.mark.cython
 def test_cython_api(tmpdir):

--- a/python/pyarrow/tests/test_cython.py
+++ b/python/pyarrow/tests/test_cython.py
@@ -80,6 +80,7 @@ def check_cython_example_module(mod):
         mod.cast_scalar(scal, pa.list_(pa.int64()))
 
 
+@pytest.mark.numpy
 @pytest.mark.cython
 def test_cython_api(tmpdir):
     """
@@ -162,6 +163,7 @@ def test_cython_api(tmpdir):
                               env=subprocess_env)
 
 
+@pytest.mark.numpy
 @pytest.mark.cython
 def test_visit_strings(tmpdir):
     with tmpdir.as_cwd():

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -20,6 +20,7 @@ import datetime
 import os
 import pathlib
 import posixpath
+import random
 import sys
 import tempfile
 import textwrap
@@ -583,7 +584,6 @@ def test_abstract_classes():
             klass()
 
 
-@pytest.mark.numpy
 def test_partitioning():
     schema = pa.schema([
         pa.field('i64', pa.int64()),
@@ -688,8 +688,8 @@ def test_partitioning():
 
     # test partitioning roundtrip
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))],
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a'] * 10 + ['b'] * 10)],
         names=["f1", "f2", "part"]
     )
     partitioning_schema = pa.schema([("part", pa.string())])
@@ -2498,12 +2498,11 @@ def _create_partitioned_dataset(basedir):
         pq.write_table(table.slice(3*i, 3), part / "test.parquet")
 
     full_table = table.append_column(
-        "part", pa.array(np.repeat([0, 1, 2], 3), type=pa.int32()))
+        "part", pa.array([0] * 3 + [1] * 3 + [2] * 3, type=pa.int32()))
 
     return full_table, path
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 def test_open_dataset_partitioned_directory(tempdir, dataset_reader, pickle_module):
     full_table, path = _create_partitioned_dataset(tempdir)
@@ -2537,7 +2536,7 @@ def test_open_dataset_partitioned_directory(tempdir, dataset_reader, pickle_modu
 
     result = dataset.to_table()
     expected = table.append_column(
-        "part", pa.array(np.repeat([0, 1, 2], 3), type=pa.int8()))
+        "part", pa.array([0] * 3 + [1] * 3 + [2] * 3, type=pa.int8()))
     assert result.equals(expected)
 
 
@@ -3572,7 +3571,7 @@ def _create_parquet_dataset_simple(root_path):
     metadata_collector = []
 
     for i in range(4):
-        table = pa.table({'f1': [i] * 10, 'f2': np.random.randn(10)})
+        table = pa.table({'f1': [i] * 10, 'f2': [random.random() for _ in range(10)]})
         pq.write_to_dataset(
             table, str(root_path), metadata_collector=metadata_collector
         )
@@ -4260,7 +4259,7 @@ def test_write_dataset_existing_data(tempdir):
 
 
 def _generate_random_int_array(size=4, min=1, max=10):
-    return np.random.randint(min, max, size)
+    return [random.randint(min, max) for _ in range(size)]
 
 
 def _generate_data_and_columns(num_of_columns, num_of_records):
@@ -4279,7 +4278,6 @@ def _get_num_of_files_generated(base_directory, file_format):
     return len(list(pathlib.Path(base_directory).glob(f'**/*.{file_format}')))
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_max_rows_per_file(tempdir):
     directory = tempdir / 'ds'
@@ -4317,7 +4315,6 @@ def test_write_dataset_max_rows_per_file(tempdir):
                for file_rowcount in result_row_combination)
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_min_rows_per_group(tempdir):
     directory = tempdir / 'ds'
@@ -4354,7 +4351,6 @@ def test_write_dataset_min_rows_per_group(tempdir):
                 assert rows_per_batch <= max_rows_per_group
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_max_rows_per_group(tempdir):
     directory = tempdir / 'ds'
@@ -4519,11 +4515,10 @@ def test_write_dataset_use_threads(tempdir):
     assert result1.to_table().equals(result2.to_table())
 
 
-@pytest.mark.numpy
 def test_write_table(tempdir):
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a'] * 10 + ['b'] * 10)
     ], names=["f1", "f2", "part"])
 
     base_dir = tempdir / 'single'
@@ -4567,11 +4562,10 @@ def test_write_table(tempdir):
         assert pathlib.Path(visited_path) in expected_paths
 
 
-@pytest.mark.numpy
 def test_write_table_multiple_fragments(tempdir):
     table = pa.table([
-        pa.array(range(10)), pa.array(np.random.randn(10)),
-        pa.array(np.repeat(['a', 'b'], 5))
+        pa.array(range(10)), pa.array(random.random() for _ in range(10)),
+        pa.array(['a'] * 5 + ['b'] * 5)
     ], names=["f1", "f2", "part"])
     table = pa.concat_tables([table]*2)
 
@@ -4604,11 +4598,10 @@ def test_write_table_multiple_fragments(tempdir):
     )
 
 
-@pytest.mark.numpy
 def test_write_iterable(tempdir):
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a'] * 10 + ['b'] * 10)
     ], names=["f1", "f2", "part"])
 
     base_dir = tempdir / 'inmemory_iterable'
@@ -4627,11 +4620,10 @@ def test_write_iterable(tempdir):
     assert result.equals(table)
 
 
-@pytest.mark.numpy
 def test_write_scanner(tempdir, dataset_reader):
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a'] * 10 + ['b'] * 10)
     ], names=["f1", "f2", "part"])
     dataset = ds.dataset(table)
 
@@ -4654,13 +4646,12 @@ def test_write_scanner(tempdir, dataset_reader):
                          schema=table.schema, format="feather")
 
 
-@pytest.mark.numpy
 def test_write_table_partitioned_dict(tempdir):
     # ensure writing table partitioned on a dictionary column works without
     # specifying the dictionary values explicitly
     table = pa.table([
         pa.array(range(20)),
-        pa.array(np.repeat(['a', 'b'], 10)).dictionary_encode(),
+        pa.array(['a'] * 10 + ['b'] * 10).dictionary_encode(),
     ], names=['col', 'part'])
 
     partitioning = ds.partitioning(table.select(["part"]).schema)
@@ -4724,11 +4715,10 @@ def test_write_dataset_parquet(tempdir):
         assert result.equals(expected)
 
 
-@pytest.mark.numpy
 def test_write_dataset_csv(tempdir):
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a'] * 10 + ['b'] * 10)
     ], names=["f1", "f2", "chr1"])
 
     base_dir = tempdir / 'csv_dataset'
@@ -4751,12 +4741,11 @@ def test_write_dataset_csv(tempdir):
     assert result.equals(table)
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_parquet_file_visitor(tempdir):
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a'] * 10 + ['b'] * 10)
     ], names=["f1", "f2", "part"])
 
     visitor_called = False
@@ -4774,13 +4763,12 @@ def test_write_dataset_parquet_file_visitor(tempdir):
     assert visitor_called
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 def test_partition_dataset_parquet_file_visitor(tempdir):
     f1_vals = [item for chunk in range(4) for item in [chunk] * 10]
     f2_vals = [item*10 for chunk in range(4) for item in [chunk] * 10]
     table = pa.table({'f1': f1_vals, 'f2': f2_vals,
-                      'part': np.repeat(['a', 'b'], 20)})
+                      'part': ['a'] * 20 + ['b'] * 20})
 
     root_path = tempdir / 'partitioned'
     partitioning = ds.partitioning(
@@ -4847,7 +4835,6 @@ def test_write_dataset_schema_metadata_parquet(tempdir):
     assert schema.metadata == {b'key': b'value'}
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_write_dataset_s3(s3_example_simple):
@@ -4859,8 +4846,8 @@ def test_write_dataset_s3(s3_example_simple):
     )
 
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))],
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a'] * 10 + ['b'] * 10)],
         names=["f1", "f2", "part"]
     )
     part = ds.partitioning(pa.schema([("part", pa.string())]), flavor="hive")
@@ -4915,7 +4902,6 @@ _minio_put_only_policy = """{
 }"""
 
 
-@pytest.mark.numpy
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_write_dataset_s3_put_only(s3_server):
@@ -4937,8 +4923,8 @@ def test_write_dataset_s3_put_only(s3_server):
     _configure_s3_limited_user(s3_server, _minio_put_only_policy)
 
     table = pa.table([
-        pa.array(range(20)), pa.array(np.random.randn(20)),
-        pa.array(np.repeat(['a', 'b'], 10))],
+        pa.array(range(20)), pa.array(random.random() for _ in range(20)),
+        pa.array(['a']*10 + ['b'] * 10)],
         names=["f1", "f2", "part"]
     )
     part = ds.partitioning(pa.schema([("part", pa.string())]), flavor="hive")
@@ -5344,7 +5330,6 @@ def test_union_dataset_filter(tempdir, dstype):
         ds.dataset((filtered_ds1, filtered_ds2))
 
 
-@pytest.mark.numpy
 def test_parquet_dataset_filter(tempdir):
     root_path = tempdir / "test_parquet_dataset_filter"
     metadata_path, _ = _create_parquet_dataset_simple(root_path)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -583,6 +583,7 @@ def test_abstract_classes():
             klass()
 
 
+@pytest.mark.numpy
 def test_partitioning():
     schema = pa.schema([
         pa.field('i64', pa.int64()),
@@ -2502,6 +2503,7 @@ def _create_partitioned_dataset(basedir):
     return full_table, path
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 def test_open_dataset_partitioned_directory(tempdir, dataset_reader, pickle_module):
     full_table, path = _create_partitioned_dataset(tempdir)
@@ -2963,7 +2965,6 @@ def test_dataset_union(multisourcefs):
     assert isinstance(factory.finish(), ds.Dataset)
 
 
-@pytest.mark.without_numpy
 def test_union_dataset_from_other_datasets(tempdir, multisourcefs):
     child1 = ds.dataset('/plain', filesystem=multisourcefs, format='parquet')
     child2 = ds.dataset('/schema', filesystem=multisourcefs, format='parquet',
@@ -3068,7 +3069,6 @@ def test_union_dataset_filesystem_datasets(multisourcefs):
     assert dataset.schema.equals(expected_schema)
 
 
-@pytest.mark.without_numpy
 @pytest.mark.parquet
 def test_specified_schema(tempdir, dataset_reader):
     table = pa.table({'a': [1, 2, 3], 'b': [.1, .2, .3]})
@@ -3167,7 +3167,6 @@ def test_ipc_format(tempdir, dataset_reader):
         assert result.equals(table)
 
 
-@pytest.mark.without_numpy
 @pytest.mark.orc
 def test_orc_format(tempdir, dataset_reader):
     from pyarrow import orc
@@ -3305,7 +3304,6 @@ def test_csv_format_compressed(tempdir, compression, dataset_reader):
     assert result.equals(table)
 
 
-@pytest.mark.without_numpy
 def test_csv_format_options(tempdir, dataset_reader):
     path = str(tempdir / 'test.csv')
     with open(path, 'w') as sink:
@@ -3481,7 +3479,6 @@ def test_column_names_encoding(tempdir, dataset_reader):
     assert dataset_transcoded.to_table().equals(expected_table)
 
 
-@pytest.mark.without_numpy
 def test_feather_format(tempdir, dataset_reader):
     from pyarrow.feather import write_feather
 
@@ -4282,6 +4279,7 @@ def _get_num_of_files_generated(base_directory, file_format):
     return len(list(pathlib.Path(base_directory).glob(f'**/*.{file_format}')))
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_max_rows_per_file(tempdir):
     directory = tempdir / 'ds'
@@ -4319,6 +4317,7 @@ def test_write_dataset_max_rows_per_file(tempdir):
                for file_rowcount in result_row_combination)
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_min_rows_per_group(tempdir):
     directory = tempdir / 'ds'
@@ -4355,6 +4354,7 @@ def test_write_dataset_min_rows_per_group(tempdir):
                 assert rows_per_batch <= max_rows_per_group
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_max_rows_per_group(tempdir):
     directory = tempdir / 'ds'
@@ -4519,6 +4519,7 @@ def test_write_dataset_use_threads(tempdir):
     assert result1.to_table().equals(result2.to_table())
 
 
+@pytest.mark.numpy
 def test_write_table(tempdir):
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),
@@ -4566,6 +4567,7 @@ def test_write_table(tempdir):
         assert pathlib.Path(visited_path) in expected_paths
 
 
+@pytest.mark.numpy
 def test_write_table_multiple_fragments(tempdir):
     table = pa.table([
         pa.array(range(10)), pa.array(np.random.randn(10)),
@@ -4602,6 +4604,7 @@ def test_write_table_multiple_fragments(tempdir):
     )
 
 
+@pytest.mark.numpy
 def test_write_iterable(tempdir):
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),
@@ -4624,6 +4627,7 @@ def test_write_iterable(tempdir):
     assert result.equals(table)
 
 
+@pytest.mark.numpy
 def test_write_scanner(tempdir, dataset_reader):
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),
@@ -4650,6 +4654,7 @@ def test_write_scanner(tempdir, dataset_reader):
                          schema=table.schema, format="feather")
 
 
+@pytest.mark.numpy
 def test_write_table_partitioned_dict(tempdir):
     # ensure writing table partitioned on a dictionary column works without
     # specifying the dictionary values explicitly
@@ -4674,6 +4679,7 @@ def test_write_table_partitioned_dict(tempdir):
     assert result.equals(table)
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_parquet(tempdir):
     table = pa.table([
@@ -4718,6 +4724,7 @@ def test_write_dataset_parquet(tempdir):
         assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_write_dataset_csv(tempdir):
     table = pa.table([
         pa.array(range(20)), pa.array(np.random.randn(20)),
@@ -4744,6 +4751,7 @@ def test_write_dataset_csv(tempdir):
     assert result.equals(table)
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 def test_write_dataset_parquet_file_visitor(tempdir):
     table = pa.table([
@@ -4766,6 +4774,7 @@ def test_write_dataset_parquet_file_visitor(tempdir):
     assert visitor_called
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 def test_partition_dataset_parquet_file_visitor(tempdir):
     f1_vals = [item for chunk in range(4) for item in [chunk] * 10]
@@ -4838,6 +4847,7 @@ def test_write_dataset_schema_metadata_parquet(tempdir):
     assert schema.metadata == {b'key': b'value'}
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_write_dataset_s3(s3_example_simple):
@@ -4905,6 +4915,7 @@ _minio_put_only_policy = """{
 }"""
 
 
+@pytest.mark.numpy
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_write_dataset_s3_put_only(s3_server):
@@ -5333,6 +5344,7 @@ def test_union_dataset_filter(tempdir, dstype):
         ds.dataset((filtered_ds1, filtered_ds2))
 
 
+@pytest.mark.numpy
 def test_parquet_dataset_filter(tempdir):
     root_path = tempdir / "test_parquet_dataset_filter"
     metadata_path, _ = _create_parquet_dataset_simple(root_path)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -28,7 +28,10 @@ import time
 from shutil import copytree
 from urllib.parse import quote
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 
 import pyarrow as pa
@@ -2960,6 +2963,7 @@ def test_dataset_union(multisourcefs):
     assert isinstance(factory.finish(), ds.Dataset)
 
 
+@pytest.mark.without_numpy
 def test_union_dataset_from_other_datasets(tempdir, multisourcefs):
     child1 = ds.dataset('/plain', filesystem=multisourcefs, format='parquet')
     child2 = ds.dataset('/schema', filesystem=multisourcefs, format='parquet',
@@ -3064,6 +3068,7 @@ def test_union_dataset_filesystem_datasets(multisourcefs):
     assert dataset.schema.equals(expected_schema)
 
 
+@pytest.mark.without_numpy
 @pytest.mark.parquet
 def test_specified_schema(tempdir, dataset_reader):
     table = pa.table({'a': [1, 2, 3], 'b': [.1, .2, .3]})
@@ -3162,6 +3167,7 @@ def test_ipc_format(tempdir, dataset_reader):
         assert result.equals(table)
 
 
+@pytest.mark.without_numpy
 @pytest.mark.orc
 def test_orc_format(tempdir, dataset_reader):
     from pyarrow import orc
@@ -3299,6 +3305,7 @@ def test_csv_format_compressed(tempdir, compression, dataset_reader):
     assert result.equals(table)
 
 
+@pytest.mark.without_numpy
 def test_csv_format_options(tempdir, dataset_reader):
     path = str(tempdir / 'test.csv')
     with open(path, 'w') as sink:
@@ -3474,6 +3481,7 @@ def test_column_names_encoding(tempdir, dataset_reader):
     assert dataset_transcoded.to_table().equals(expected_table)
 
 
+@pytest.mark.without_numpy
 def test_feather_format(tempdir, dataset_reader):
     from pyarrow.feather import write_feather
 

--- a/python/pyarrow/tests/test_dataset_encryption.py
+++ b/python/pyarrow/tests/test_dataset_encryption.py
@@ -17,10 +17,7 @@
 
 import base64
 from datetime import timedelta
-try:
-    import numpy as np
-except ImportError:
-    np = None
+import random
 import pyarrow.fs as fs
 import pyarrow as pa
 
@@ -173,7 +170,6 @@ def test_write_dataset_parquet_without_encryption():
         _ = pformat.make_write_options(encryption_config="some value")
 
 
-@pytest.mark.numpy
 @pytest.mark.skipif(
     encryption_unavailable, reason="Parquet Encryption is not currently enabled"
 )
@@ -191,7 +187,10 @@ def test_large_row_encryption_decryption():
 
     row_count = 2**15 + 1
     table = pa.Table.from_arrays(
-        [pa.array(np.random.rand(row_count), type=pa.float32())], names=["foo"]
+        [pa.array(
+            [random.random() for _ in range(row_count)],
+            type=pa.float32()
+        )], names=["foo"]
     )
 
     kms_config = pe.KmsConnectionConfig()

--- a/python/pyarrow/tests/test_dataset_encryption.py
+++ b/python/pyarrow/tests/test_dataset_encryption.py
@@ -20,7 +20,7 @@ from datetime import timedelta
 try:
     import numpy as np
 except ImportError:
-    np=None
+    np = None
 import pyarrow.fs as fs
 import pyarrow as pa
 

--- a/python/pyarrow/tests/test_dataset_encryption.py
+++ b/python/pyarrow/tests/test_dataset_encryption.py
@@ -17,7 +17,10 @@
 
 import base64
 from datetime import timedelta
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np=None
 import pyarrow.fs as fs
 import pyarrow as pa
 
@@ -170,6 +173,7 @@ def test_write_dataset_parquet_without_encryption():
         _ = pformat.make_write_options(encryption_config="some value")
 
 
+@pytest.mark.numpy
 @pytest.mark.skipif(
     encryption_unavailable, reason="Parquet Encryption is not currently enabled"
 )

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -22,11 +22,15 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
-                allow_module_level=True)
+    np = None
 
 import pyarrow as pa
 from pyarrow.vendored.version import Version
+
+
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not numpy'
+pytestmark = pytest.mark.numpy
 
 
 def PyCapsule_IsValid(capsule, name):
@@ -56,45 +60,45 @@ def check_bytes_allocated(f):
 
 @check_bytes_allocated
 @pytest.mark.parametrize(
-    ('value_type', 'np_type'),
+    ('value_type', 'np_type_str'),
     [
-        (pa.uint8(), np.uint8),
-        (pa.uint16(), np.uint16),
-        (pa.uint32(), np.uint32),
-        (pa.uint64(), np.uint64),
-        (pa.int8(), np.int8),
-        (pa.int16(), np.int16),
-        (pa.int32(), np.int32),
-        (pa.int64(), np.int64),
-        (pa.float16(), np.float16),
-        (pa.float32(), np.float32),
-        (pa.float64(), np.float64),
+        (pa.uint8(), "uint8"),
+        (pa.uint16(), "uint16"),
+        (pa.uint32(), "uint32"),
+        (pa.uint64(), "uint64"),
+        (pa.int8(), "int8"),
+        (pa.int16(), "int16"),
+        (pa.int32(), "int32"),
+        (pa.int64(), "int64"),
+        (pa.float16(), "float16"),
+        (pa.float32(), "float32"),
+        (pa.float64(), "float64"),
     ]
 )
-def test_dlpack(value_type, np_type):
+def test_dlpack(value_type, np_type_str):
     if Version(np.__version__) < Version("1.24.0"):
         pytest.skip("No dlpack support in numpy versions older than 1.22.0, "
                     "strict keyword in assert_array_equal added in numpy version "
                     "1.24.0")
 
-    expected = np.array([1, 2, 3], dtype=np_type)
+    expected = np.array([1, 2, 3], dtype=np.dtype(np_type_str))
     arr = pa.array(expected, type=value_type)
     check_dlpack_export(arr, expected)
 
     arr_sliced = arr.slice(1, 1)
-    expected = np.array([2], dtype=np_type)
+    expected = np.array([2], dtype=np.dtype(np_type_str))
     check_dlpack_export(arr_sliced, expected)
 
     arr_sliced = arr.slice(0, 1)
-    expected = np.array([1], dtype=np_type)
+    expected = np.array([1], dtype=np.dtype(np_type_str))
     check_dlpack_export(arr_sliced, expected)
 
     arr_sliced = arr.slice(1)
-    expected = np.array([2, 3], dtype=np_type)
+    expected = np.array([2, 3], dtype=np.dtype(np_type_str))
     check_dlpack_export(arr_sliced, expected)
 
     arr_zero = pa.array([], type=value_type)
-    expected = np.array([], dtype=np_type)
+    expected = np.array([], dtype=np.dtype(np_type_str))
     check_dlpack_export(arr_zero, expected)
 
 

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -19,7 +19,10 @@ import ctypes
 from functools import wraps
 import pytest
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
 
 import pyarrow as pa
 from pyarrow.vendored.version import Version

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -22,7 +22,8 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
+                allow_module_level=True)
 
 import pyarrow as pa
 from pyarrow.vendored.version import Version

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1826,6 +1826,7 @@ def test_bool8_to_bool_conversion():
     assert bool_arr.cast(pa.bool8()) == canonical_bool8_arr
 
 
+@pytest.mark.numpy
 def test_bool8_to_numpy_conversion():
     arr = pa.ExtensionArray.from_storage(
         pa.bool8(),
@@ -1866,6 +1867,7 @@ def test_bool8_to_numpy_conversion():
     assert arr_to_np_writable.ctypes.data != arr_no_nulls.buffers()[1].address
 
 
+@pytest.mark.numpy
 def test_bool8_from_numpy_conversion():
     np_arr_no_nulls = np.array([True, False, True, True], dtype=np.bool_)
     canonical_bool8_arr_no_nulls = pa.ExtensionArray.from_storage(

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1292,7 +1292,7 @@ def test_empty_take():
 ))
 @pytest.mark.parametrize(
     "into", [
-        pytest.param("numpy", marks=pytest.mark.pandas),
+        pytest.param("to_numpy", marks=pytest.mark.numpy),
         pytest.param("to_pandas", marks=pytest.mark.pandas)
     ]
 )

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -23,11 +23,14 @@ import weakref
 from uuid import uuid4, UUID
 import sys
 
-import numpy as np
+import pytest
+try:
+    import numpy as np
+except ImportError:
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+
 import pyarrow as pa
 from pyarrow.vendored.version import Version
-
-import pytest
 
 
 @contextlib.contextmanager

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -27,8 +27,7 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
-                allow_module_level=True)
+    np = None
 
 import pyarrow as pa
 from pyarrow.vendored.version import Version
@@ -566,6 +565,7 @@ def test_ext_array_pickling(pickle_module):
         assert arr.storage.to_pylist() == [b"foo", b"bar"]
 
 
+@pytest.mark.numpy
 def test_ext_array_conversion_to_numpy():
     storage1 = pa.array([1, 2, 3], type=pa.int64())
     storage2 = pa.array([b"123", b"456", b"789"], type=pa.binary(3))
@@ -623,6 +623,7 @@ def struct_w_ext_data():
     return [sarr1, sarr2]
 
 
+@pytest.mark.numpy
 def test_struct_w_ext_array_to_numpy(struct_w_ext_data):
     # ARROW-15291
     # Check that we don't segfault when trying to build
@@ -1237,6 +1238,7 @@ def test_parquet_extension_nested_in_extension(tmpdir):
             assert table == orig_table
 
 
+@pytest.mark.numpy
 def test_to_numpy():
     period_type = PeriodType('D')
     storage = pa.array([1, 2, 3, 4], pa.int64())
@@ -1289,7 +1291,11 @@ def test_empty_take():
     (["cat", "dog", "horse"], LabelType)
 ))
 @pytest.mark.parametrize(
-    "into", ["to_numpy", pytest.param("to_pandas", marks=pytest.mark.pandas)])
+    "into", [
+        pytest.param("numpy", marks=pytest.mark.pandas),
+        pytest.param("to_pandas", marks=pytest.mark.pandas)
+    ]
+)
 def test_extension_array_to_numpy_pandas(data, ty, into):
     storage = pa.array(data)
     ext_arr = pa.ExtensionArray.from_storage(ty(), storage)
@@ -1305,6 +1311,7 @@ def test_extension_array_to_numpy_pandas(data, ty, into):
         assert np.array_equal(result, expected)
 
 
+@pytest.mark.numpy
 def test_array_constructor():
     ext_type = IntegerType()
     storage = pa.array([1, 2, 3], type=pa.int64())
@@ -1337,6 +1344,7 @@ def test_array_constructor_from_pandas():
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 @pytest.mark.cython
 def test_cpp_extension_in_python(tmpdir):
     from .test_cython import (
@@ -1434,38 +1442,45 @@ def test_tensor_type():
     assert tensor_type.permutation is None
 
 
-@pytest.mark.parametrize("value_type", (np.int8(), np.int64(), np.float32()))
-def test_tensor_class_methods(value_type):
+@pytest.mark.numpy
+@pytest.mark.parametrize("np_type_str", ("int8", "int64", "float32"))
+def test_tensor_class_methods(np_type_str):
     from numpy.lib.stride_tricks import as_strided
-    arrow_type = pa.from_numpy_dtype(value_type)
+    arrow_type = pa.from_numpy_dtype(np.dtype(np_type_str))
 
     tensor_type = pa.fixed_shape_tensor(arrow_type, [2, 3])
     storage = pa.array([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
                        pa.list_(arrow_type, 6))
     arr = pa.ExtensionArray.from_storage(tensor_type, storage)
     expected = np.array(
-        [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], dtype=value_type)
+        [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+        dtype=np.dtype(np_type_str)
+    )
     np.testing.assert_array_equal(arr.to_tensor(), expected)
     np.testing.assert_array_equal(arr.to_numpy_ndarray(), expected)
 
-    expected = np.array([[[7, 8, 9], [10, 11, 12]]], dtype=value_type)
+    expected = np.array([[[7, 8, 9], [10, 11, 12]]], dtype=np.dtype(np_type_str))
     result = arr[1:].to_numpy_ndarray()
     np.testing.assert_array_equal(result, expected)
 
     values = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]]
-    flat_arr = np.array(values[0], dtype=value_type)
-    bw = value_type.itemsize
+    flat_arr = np.array(values[0], dtype=np.dtype(np_type_str))
+    bw = np.dtype(np_type_str).itemsize
     storage = pa.array(values, pa.list_(arrow_type, 12))
 
     tensor_type = pa.fixed_shape_tensor(arrow_type, [2, 2, 3], permutation=[0, 1, 2])
     result = pa.ExtensionArray.from_storage(tensor_type, storage)
     expected = np.array(
-        [[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]], dtype=value_type)
+        [[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]],
+        dtype=np.dtype(np_type_str)
+    )
     np.testing.assert_array_equal(result.to_numpy_ndarray(), expected)
 
     result = flat_arr.reshape(1, 2, 3, 2)
     expected = np.array(
-        [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]], dtype=value_type)
+        [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]],
+        dtype=np.dtype(np_type_str)
+    )
     np.testing.assert_array_equal(result, expected)
 
     tensor_type = pa.fixed_shape_tensor(arrow_type, [2, 2, 3], permutation=[0, 2, 1])
@@ -1486,25 +1501,27 @@ def test_tensor_class_methods(value_type):
     assert result.to_tensor().strides == (12 * bw, 1 * bw, 6 * bw, 2 * bw)
 
 
-@pytest.mark.parametrize("value_type", (np.int8(), np.int64(), np.float32()))
-def test_tensor_array_from_numpy(value_type):
+@pytest.mark.numpy
+@pytest.mark.parametrize("np_type_str", ("int8", "int64", "float32"))
+def test_tensor_array_from_numpy(np_type_str):
     from numpy.lib.stride_tricks import as_strided
-    arrow_type = pa.from_numpy_dtype(value_type)
+    arrow_type = pa.from_numpy_dtype(np.dtype(np_type_str))
 
     arr = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
-                   dtype=value_type, order="C")
+                   dtype=np.dtype(np_type_str), order="C")
     tensor_array_from_numpy = pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
     assert isinstance(tensor_array_from_numpy.type, pa.FixedShapeTensorType)
     assert tensor_array_from_numpy.type.value_type == arrow_type
     assert tensor_array_from_numpy.type.shape == [2, 3]
 
     arr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]],
-                   dtype=value_type, order="F")
+                   dtype=np.dtype(np_type_str), order="F")
     with pytest.raises(ValueError, match="First stride needs to be largest"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
 
-    flat_arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dtype=value_type)
-    bw = value_type.itemsize
+    flat_arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                        dtype=np.dtype(np_type_str))
+    bw = np.dtype(np_type_str).itemsize
 
     arr = flat_arr.reshape(1, 3, 4)
     tensor_array_from_numpy = pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
@@ -1522,23 +1539,26 @@ def test_tensor_array_from_numpy(value_type):
     arr = flat_arr.reshape(1, 2, 3, 2)
     result = pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
     expected = np.array(
-        [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]], dtype=value_type)
+        [[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]],
+        dtype=np.dtype(np_type_str)
+    )
     np.testing.assert_array_equal(result.to_numpy_ndarray(), expected)
 
-    arr = np.array([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]], dtype=value_type)
+    arr = np.array([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]],
+                   dtype=np.dtype(np_type_str))
     expected = arr[1:]
     result = pa.FixedShapeTensorArray.from_numpy_ndarray(arr)[1:].to_numpy_ndarray()
     np.testing.assert_array_equal(result, expected)
 
-    arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dtype=value_type)
+    arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dtype=np.dtype(np_type_str))
     with pytest.raises(ValueError, match="Cannot convert 1D array or scalar to fixed"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
 
-    arr = np.array(1, dtype=value_type)
+    arr = np.array(1, dtype=np.dtype(np_type_str))
     with pytest.raises(ValueError, match="Cannot convert 1D array or scalar to fixed"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
 
-    arr = np.array([], dtype=value_type)
+    arr = np.array([], dtype=np.dtype(np_type_str))
 
     with pytest.raises(ValueError, match="Cannot convert 1D array or scalar to fixed"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr.reshape((0)))
@@ -1550,6 +1570,7 @@ def test_tensor_array_from_numpy(value_type):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr.reshape((3, 0, 2)))
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize("tensor_type", (
     pa.fixed_shape_tensor(pa.int8(), [2, 2, 3]),
     pa.fixed_shape_tensor(pa.int8(), [2, 2, 3], permutation=[0, 2, 1]),

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -27,7 +27,8 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
+                allow_module_level=True)
 
 import pyarrow as pa
 from pyarrow.vendored.version import Version

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -23,7 +23,10 @@ import pytest
 import hypothesis as h
 import hypothesis.strategies as st
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 import pyarrow as pa
 import pyarrow.tests.strategies as past
@@ -135,6 +138,7 @@ def _assert_error_on_write(df, exc, path=None, version=2):
     pytest.raises(exc, f)
 
 
+@pytest.mark.numpy
 def test_dataset(version):
     num_values = (100, 100)
     num_files = 5
@@ -354,6 +358,7 @@ def test_buffer_bounds_error(version):
         _check_arrow_roundtrip(table)
 
 
+@pytest.mark.numpy
 def test_boolean_object_nulls(version):
     repeats = 100
     table = pa.Table.from_arrays(
@@ -540,6 +545,7 @@ def test_read_columns(version):
                             columns=['boo', 'woo'])
 
 
+@pytest.mark.numpy
 def test_overwritten_file(version):
     path = random_path()
     TEST_FILES.append(path)
@@ -675,6 +681,7 @@ def test_v2_compression_options():
         write_feather(df, buf, compression='snappy')
 
 
+@pytest.mark.numpy
 def test_v2_lz4_default_compression():
     # ARROW-8750: Make sure that the compression=None option selects lz4 if
     # it's available

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -814,6 +814,7 @@ def test_nested_types(compression):
     _check_arrow_roundtrip(table, compression=compression)
 
 
+@pytest.mark.numpy
 @h.given(past.all_tables, st.sampled_from(["uncompressed", "lz4", "zstd"]))
 def test_roundtrip(table, compression):
     _check_arrow_roundtrip(table, compression=compression)

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -28,7 +28,10 @@ import time
 import traceback
 import json
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 import pyarrow as pa
 
@@ -54,6 +57,8 @@ except ImportError:
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not flight'
 pytestmark = pytest.mark.flight
+# All tests on this module can be run when numpy is or is not available
+pytestmark = pytest.mark.without_numpy
 
 
 def test_import():
@@ -1588,6 +1593,7 @@ def test_flight_do_put_metadata():
                 assert idx == server_idx
 
 
+@pytest.mark.numpy
 def test_flight_do_put_limit():
     """Try a simple do_put call with a size limit."""
     large_batch = pa.RecordBatch.from_arrays([

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -57,8 +57,6 @@ except ImportError:
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not flight'
 pytestmark = pytest.mark.flight
-# All tests on this module can be run when numpy is or is not available
-pytestmark = pytest.mark.without_numpy
 
 
 def test_import():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -25,6 +25,7 @@ import math
 import os
 import pathlib
 import pytest
+import random
 import sys
 import tempfile
 import weakref
@@ -1071,8 +1072,8 @@ def test_mock_output_stream():
 @pytest.fixture
 def sample_disk_data(request, tmpdir):
     SIZE = 4096
-    arr = np.random.randint(0, 256, size=SIZE).astype('u1')
-    data = arr.tobytes()[:SIZE]
+    arr = [random.randint(0, 255) for _ in range(SIZE)]
+    data = bytes(arr[:SIZE])
 
     path = os.path.join(str(tmpdir), guid())
 
@@ -1119,13 +1120,11 @@ def _check_native_file_reader(FACTORY, sample_data,
     assert f.tell() == ex_length
 
 
-@pytest.mark.numpy
 def test_memory_map_reader(sample_disk_data):
     _check_native_file_reader(pa.memory_map, sample_disk_data,
                               allow_read_out_of_bounds=False)
 
 
-@pytest.mark.numpy
 def test_memory_map_retain_buffer_reference(sample_disk_data):
     path, data = sample_disk_data
 
@@ -1142,7 +1141,6 @@ def test_memory_map_retain_buffer_reference(sample_disk_data):
         assert buf.to_pybytes() == expected
 
 
-@pytest.mark.numpy
 def test_os_file_reader(sample_disk_data):
     _check_native_file_reader(pa.OSFile, sample_disk_data)
 
@@ -1158,13 +1156,12 @@ def _try_delete(path):
         pass
 
 
-@pytest.mark.numpy
 def test_memory_map_writer(tmpdir):
     if sys.platform == "emscripten":
         pytest.xfail("Multiple memory maps to same file don't work on emscripten")
     SIZE = 4096
-    arr = np.random.randint(0, 256, size=SIZE).astype('u1')
-    data = arr.tobytes()[:SIZE]
+    arr = [random.randint(0, 255) for _ in range(SIZE)]
+    data = bytes(arr[:SIZE])
 
     path = os.path.join(str(tmpdir), guid())
     with open(path, 'wb') as f:
@@ -1202,12 +1199,11 @@ def test_memory_map_writer(tmpdir):
     assert f.read(3) == b'foo'
 
 
-@pytest.mark.numpy
 def test_memory_map_resize(tmpdir):
     SIZE = 4096
-    arr = np.random.randint(0, 256, size=SIZE).astype(np.uint8)
-    data1 = arr.tobytes()[:(SIZE // 2)]
-    data2 = arr.tobytes()[(SIZE // 2):]
+    arr = [random.randint(0, 255) for _ in range(SIZE)]
+    data1 = bytes(arr[:(SIZE // 2)])
+    data2 = bytes(arr[(SIZE // 2):])
 
     path = os.path.join(str(tmpdir), guid())
 
@@ -1220,7 +1216,7 @@ def test_memory_map_resize(tmpdir):
     mmap.close()
 
     with open(path, 'rb') as f:
-        assert f.read() == arr.tobytes()
+        assert f.read() == bytes(arr[:SIZE])
 
 
 def test_memory_zero_length(tmpdir):
@@ -1257,11 +1253,10 @@ def test_memory_map_deref_remove(tmpdir):
     os.remove(path)  # Shouldn't fail
 
 
-@pytest.mark.numpy
 def test_os_file_writer(tmpdir):
     SIZE = 4096
-    arr = np.random.randint(0, 256, size=SIZE).astype('u1')
-    data = arr.tobytes()[:SIZE]
+    arr = [random.randint(0, 255) for _ in range(SIZE)]
+    data = bytes(arr[:SIZE])
 
     path = os.path.join(str(tmpdir), guid())
     with open(path, 'wb') as f:

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -24,7 +24,10 @@ import socket
 import threading
 import weakref
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 import pyarrow as pa
 from pyarrow.tests.util import changed_environ, invoke_script
@@ -161,14 +164,17 @@ def test_empty_file():
         pa.ipc.open_file(pa.BufferReader(buf))
 
 
+@pytest.mark.numpy
 def test_file_simple_roundtrip(file_fixture):
     file_fixture._check_roundtrip(as_table=False)
 
 
+@pytest.mark.numpy
 def test_file_write_table(file_fixture):
     file_fixture._check_roundtrip(as_table=True)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize("sink_factory", [
     lambda: io.BytesIO(),
     lambda: pa.BufferOutputStream()
@@ -186,6 +192,7 @@ def test_file_read_all(sink_factory):
     assert result.equals(expected)
 
 
+@pytest.mark.numpy
 def test_open_file_from_buffer(file_fixture):
     # ARROW-2859; APIs accept the buffer protocol
     file_fixture.write_batches()
@@ -221,6 +228,7 @@ def test_file_read_pandas(file_fixture):
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.numpy
 def test_file_pathlib(file_fixture, tmpdir):
     file_fixture.write_batches()
     source = file_fixture.get_source()
@@ -278,6 +286,7 @@ def test_stream_categorical_roundtrip(stream_fixture):
     assert_frame_equal(table.to_pandas(), df)
 
 
+@pytest.mark.numpy
 def test_open_stream_from_buffer(stream_fixture):
     # ARROW-2859
     stream_fixture.write_batches()
@@ -303,6 +312,7 @@ def test_open_stream_from_buffer(stream_fixture):
     assert tuple(st1) == tuple(stream_fixture.write_stats)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('options', [
     pa.ipc.IpcReadOptions(),
     pa.ipc.IpcReadOptions(use_threads=False),
@@ -321,6 +331,7 @@ def test_open_stream_options(stream_fixture, options):
     assert tuple(st) == tuple(stream_fixture.write_stats)
 
 
+@pytest.mark.numpy
 def test_open_stream_with_wrong_options(stream_fixture):
     stream_fixture.write_batches()
     source = stream_fixture.get_source()
@@ -329,6 +340,7 @@ def test_open_stream_with_wrong_options(stream_fixture):
         pa.ipc.open_stream(source, options=True)
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('options', [
     pa.ipc.IpcReadOptions(),
     pa.ipc.IpcReadOptions(use_threads=False),
@@ -346,6 +358,7 @@ def test_open_file_options(file_fixture, options):
     assert st.num_record_batches == 5
 
 
+@pytest.mark.numpy
 def test_open_file_with_wrong_options(file_fixture):
     file_fixture.write_batches()
     source = file_fixture.get_source()
@@ -399,6 +412,7 @@ def test_stream_write_table_batches(stream_fixture):
                                  ignore_index=True))
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('use_legacy_ipc_format', [False, True])
 def test_stream_simple_roundtrip(stream_fixture, use_legacy_ipc_format):
     stream_fixture.use_legacy_ipc_format = use_legacy_ipc_format
@@ -419,6 +433,7 @@ def test_stream_simple_roundtrip(stream_fixture, use_legacy_ipc_format):
         reader.read_next_batch()
 
 
+@pytest.mark.numpy
 @pytest.mark.zstd
 def test_compression_roundtrip():
     sink = io.BytesIO()
@@ -508,6 +523,7 @@ def test_write_options_legacy_exclusive(stream_fixture):
         stream_fixture.write_batches()
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('options', [
     pa.ipc.IpcWriteOptions(),
     pa.ipc.IpcWriteOptions(allow_64bit=True),
@@ -703,6 +719,7 @@ def test_envvar_set_legacy_ipc_format():
             assert writer._metadata_version == pa.ipc.MetadataVersion.V4
 
 
+@pytest.mark.numpy
 def test_stream_read_all(stream_fixture):
     batches = stream_fixture.write_batches()
     file_contents = pa.BufferReader(stream_fixture.get_source())
@@ -741,6 +758,7 @@ def test_message_ctors_no_segfault():
         repr(pa.MessageReader())
 
 
+@pytest.mark.numpy
 def test_message_reader(example_messages):
     _, messages = example_messages
 
@@ -757,6 +775,7 @@ def test_message_reader(example_messages):
         assert msg.metadata_version == pa.MetadataVersion.V5
 
 
+@pytest.mark.numpy
 def test_message_serialize_read_message(example_messages):
     _, messages = example_messages
 
@@ -781,6 +800,7 @@ def test_message_serialize_read_message(example_messages):
         pa.ipc.read_message(reader)
 
 
+@pytest.mark.numpy
 @pytest.mark.gzip
 def test_message_read_from_compressed(example_messages):
     # Part of ARROW-5910
@@ -797,12 +817,14 @@ def test_message_read_from_compressed(example_messages):
         assert result.equals(message)
 
 
+@pytest.mark.numpy
 def test_message_read_schema(example_messages):
     batches, messages = example_messages
     schema = pa.ipc.read_schema(messages[0])
     assert schema.equals(batches[1].schema)
 
 
+@pytest.mark.numpy
 def test_message_read_record_batch(example_messages):
     batches, messages = example_messages
 
@@ -897,6 +919,7 @@ def socket_fixture():
 
 
 @pytest.mark.sockets
+@pytest.mark.numpy
 def test_socket_simple_roundtrip(socket_fixture):
     socket_fixture.start_server(do_read_all=False)
     writer_batches = socket_fixture.write_batches()
@@ -909,6 +932,7 @@ def test_socket_simple_roundtrip(socket_fixture):
 
 
 @pytest.mark.sockets
+@pytest.mark.numpy
 def test_socket_read_all(socket_fixture):
     socket_fixture.start_server(do_read_all=True)
     writer_batches = socket_fixture.write_batches()

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -26,7 +26,7 @@ import unittest
 try:
     import numpy as np
 except ImportError:
-    np=None
+    np = None
 import pytest
 
 import pyarrow as pa

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -23,7 +23,10 @@ import json
 import string
 import unittest
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np=None
 import pytest
 
 import pyarrow as pa
@@ -297,6 +300,7 @@ class BaseTestJSONRead:
                            match="JSON parse error: unexpected field"):
             self.read_bytes(rows, parse_options=opts)
 
+    @pytest.mark.numpy
     def test_small_random_json(self):
         data, expected = make_random_json(num_cols=2, num_rows=10)
         table = self.read_bytes(data)
@@ -304,6 +308,7 @@ class BaseTestJSONRead:
         assert table.equals(expected)
         assert table.to_pydict() == expected.to_pydict()
 
+    @pytest.mark.numpy
     def test_load_large_json(self):
         data, expected = make_random_json(num_cols=2, num_rows=100100)
         # set block size is 10MB
@@ -312,6 +317,7 @@ class BaseTestJSONRead:
         assert table.num_rows == 100100
         assert expected.num_rows == 100100
 
+    @pytest.mark.numpy
     def test_stress_block_sizes(self):
         # Test a number of small block sizes to stress block stitching
         data_base, expected = make_random_json(num_cols=2, num_rows=100)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2938,10 +2938,10 @@ class TestConvertMisc:
         ("float64", pa.float64()),
         # XXX unsupported
         # (np.dtype([('a', 'i2')]), pa.struct([pa.field('a', pa.int16())])),
-        ("object_", pa.string()),
-        ("object_", pa.binary()),
-        ("object_", pa.binary(10)),
-        ("object_", pa.list_(pa.int64())),
+        ("object", pa.string()),
+        ("object", pa.binary()),
+        ("object", pa.binary(10)),
+        ("object", pa.list_(pa.int64())),
     ]
 
     def test_all_none_objects(self):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1206,6 +1206,8 @@ class TestConvertDateTimeLikeTypes:
         [True, False, False, True, False, False],
     ])
     def test_pandas_datetime_to_date64(self, mask):
+        if mask:
+            mask = np.array(mask)
         s = pd.to_datetime([
             '2018-05-10T00:00:00',
             '2018-05-11T00:00:00',

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -31,9 +31,14 @@ import pytest
 try:
     import numpy as np
     import numpy.testing as npt
+    try:
+        _np_VisibleDeprecationWarning = np.VisibleDeprecationWarning
+    except AttributeError:
+        from numpy.exceptions import (
+            VisibleDeprecationWarning as _np_VisibleDeprecationWarning
+        )
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
-                allow_module_level=True)
+    np = None
 
 from pyarrow.pandas_compat import get_logical_type, _pandas_api
 from pyarrow.tests.util import invoke_script, random_ascii, rands
@@ -53,14 +58,6 @@ try:
     from .pandas_examples import dataframe_with_arrays, dataframe_with_lists
 except ImportError:
     pass
-
-
-try:
-    _np_VisibleDeprecationWarning = np.VisibleDeprecationWarning
-except AttributeError:
-    from numpy.exceptions import (
-        VisibleDeprecationWarning as _np_VisibleDeprecationWarning
-    )
 
 
 # Marks all of the tests in this module
@@ -1206,7 +1203,7 @@ class TestConvertDateTimeLikeTypes:
 
     @pytest.mark.parametrize('mask', [
         None,
-        np.array([True, False, False, True, False, False]),
+        [True, False, False, True, False, False],
     ])
     def test_pandas_datetime_to_date64(self, mask):
         s = pd.to_datetime([
@@ -1612,7 +1609,8 @@ class TestConvertDateTimeLikeTypes:
         assert pa.Array.from_pandas(expected).equals(result)
 
     @pytest.mark.skipif(
-        Version('1.16.0') <= Version(np.__version__) < Version('1.16.1'),
+        np is not None and Version('1.16.0') <= Version(
+            np.__version__) < Version('1.16.1'),
         reason='Until numpy/numpy#12745 is resolved')
     def test_fixed_offset_timezone(self):
         df = pd.DataFrame({
@@ -2925,23 +2923,23 @@ class TestConvertMisc:
     """
 
     type_pairs = [
-        (np.int8, pa.int8()),
-        (np.int16, pa.int16()),
-        (np.int32, pa.int32()),
-        (np.int64, pa.int64()),
-        (np.uint8, pa.uint8()),
-        (np.uint16, pa.uint16()),
-        (np.uint32, pa.uint32()),
-        (np.uint64, pa.uint64()),
-        (np.float16, pa.float16()),
-        (np.float32, pa.float32()),
-        (np.float64, pa.float64()),
+        ("int8", pa.int8()),
+        ("int16", pa.int16()),
+        ("int32", pa.int32()),
+        ("int64", pa.int64()),
+        ("uint8", pa.uint8()),
+        ("uint16", pa.uint16()),
+        ("uint32", pa.uint32()),
+        ("uint64", pa.uint64()),
+        ("float16", pa.float16()),
+        ("float32", pa.float32()),
+        ("float64", pa.float64()),
         # XXX unsupported
         # (np.dtype([('a', 'i2')]), pa.struct([pa.field('a', pa.int16())])),
-        (np.object_, pa.string()),
-        (np.object_, pa.binary()),
-        (np.object_, pa.binary(10)),
-        (np.object_, pa.list_(pa.int64())),
+        ("object_", pa.string()),
+        ("object_", pa.binary()),
+        ("object_", pa.binary(10)),
+        ("object_", pa.list_(pa.int64())),
     ]
 
     def test_all_none_objects(self):
@@ -2954,8 +2952,8 @@ class TestConvertMisc:
         _check_pandas_roundtrip(df)
 
     def test_empty_arrays(self):
-        for dtype, pa_type in self.type_pairs:
-            arr = np.array([], dtype=dtype)
+        for dtype_str, pa_type in self.type_pairs:
+            arr = np.array([], dtype=np.dtype(dtype_str))
             _check_array_roundtrip(arr, type=pa_type)
 
     def test_non_threaded_conversion(self):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -27,9 +27,12 @@ from datetime import date, datetime, time, timedelta, timezone
 
 import hypothesis as h
 import hypothesis.strategies as st
-import numpy as np
-import numpy.testing as npt
 import pytest
+try:
+    import numpy as np
+    import numpy.testing as npt
+except ImportError:
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
 
 from pyarrow.pandas_compat import get_logical_type, _pandas_api
 from pyarrow.tests.util import invoke_script, random_ascii, rands

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -32,7 +32,8 @@ try:
     import numpy as np
     import numpy.testing as npt
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
+                allow_module_level=True)
 
 from pyarrow.pandas_compat import get_logical_type, _pandas_api
 from pyarrow.tests.util import invoke_script, random_ascii, rands

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -20,7 +20,10 @@ import decimal
 import pytest
 import weakref
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
 
 import pyarrow as pa
 import pyarrow.compute as pc

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -23,7 +23,8 @@ import weakref
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled", allow_module_level=True)
+    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
+                allow_module_level=True)
 
 import pyarrow as pa
 import pyarrow.compute as pc

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -23,8 +23,7 @@ import weakref
 try:
     import numpy as np
 except ImportError:
-    pytest.skip(reason="Failures on test collection due to numpy NOT enabled",
-                allow_module_level=True)
+    np = None
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -44,7 +43,6 @@ import pyarrow.compute as pc
     (1, pa.int64(), pa.Int64Scalar),
     (1, pa.uint64(), pa.UInt64Scalar),
     (1.0, None, pa.DoubleScalar),
-    (np.float16(1.0), pa.float16(), pa.HalfFloatScalar),
     (1.0, pa.float32(), pa.FloatScalar),
     (decimal.Decimal("1.123"), None, pa.Decimal128Scalar),
     (decimal.Decimal("1.1234567890123456789012345678901234567890"),
@@ -74,6 +72,37 @@ import pyarrow.compute as pc
     ([('a', 1), ('b', 2)], pa.map_(pa.string(), pa.int8()), pa.MapScalar),
 ])
 def test_basics(value, ty, klass, pickle_module):
+    s = pa.scalar(value, type=ty)
+    s.validate()
+    s.validate(full=True)
+    assert isinstance(s, klass)
+    assert s.as_py() == value
+    assert s == pa.scalar(value, type=ty)
+    assert s != value
+    assert s != "else"
+    assert hash(s) == hash(s)
+    assert s.is_valid is True
+    assert s != None  # noqa: E711
+
+    s = pa.scalar(None, type=s.type)
+    assert s.is_valid is False
+    assert s.as_py() is None
+    assert s != pa.scalar(value, type=ty)
+
+    # test pickle roundtrip
+    restored = pickle_module.loads(pickle_module.dumps(s))
+    assert s.equals(restored)
+
+    # test that scalars are weak-referenceable
+    wr = weakref.ref(s)
+    assert wr() is not None
+    del s
+    assert wr() is None
+
+
+@pytest.mark.numpy
+def test_basics_np_required(pickle_module):
+    value, ty, klass = (np.float16(1.0), pa.float16(), pa.HalfFloatScalar),
     s = pa.scalar(value, type=ty)
     s.validate()
     s.validate(full=True)
@@ -206,14 +235,15 @@ def test_numerics():
     assert str(s) == "1.5"
     assert s.as_py() == 1.5
 
-    # float16
-    s = pa.scalar(np.float16(0.5), type='float16')
-    assert isinstance(s, pa.HalfFloatScalar)
-    # on numpy2 repr(np.float16(0.5)) == "np.float16(0.5)"
-    # on numpy1 repr(np.float16(0.5)) == "0.5"
-    assert repr(s) == f"<pyarrow.HalfFloatScalar: {np.float16(0.5)!r}>"
-    assert str(s) == "0.5"
-    assert s.as_py() == 0.5
+    if np is not None:
+        # float16
+        s = pa.scalar(np.float16(0.5), type='float16')
+        assert isinstance(s, pa.HalfFloatScalar)
+        # on numpy2 repr(np.float16(0.5)) == "np.float16(0.5)"
+        # on numpy1 repr(np.float16(0.5)) == "0.5"
+        assert repr(s) == f"<pyarrow.HalfFloatScalar: {np.float16(0.5)!r}>"
+        assert str(s) == "0.5"
+        assert s.as_py() == 0.5
 
 
 def test_decimal128():
@@ -438,6 +468,7 @@ def test_timestamp_fixed_offset_print():
     assert str(arr[0]) == "1970-01-01 02:00:00+02:00"
 
 
+@pytest.mark.numpy
 def test_duration():
     arr = np.array([0, 3600000000000], dtype='timedelta64[ns]')
 
@@ -563,6 +594,7 @@ def test_list(ty, klass):
         s[2]
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize('ty', [
     pa.list_(pa.int64()),
     pa.large_list(pa.int64()),

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -102,7 +102,7 @@ def test_basics(value, ty, klass, pickle_module):
 
 @pytest.mark.numpy
 def test_basics_np_required(pickle_module):
-    value, ty, klass = (np.float16(1.0), pa.float16(), pa.HalfFloatScalar),
+    value, ty, klass = np.float16(1.0), pa.float16(), pa.HalfFloatScalar
     s = pa.scalar(value, type=ty)
     s.validate()
     s.validate(full=True)

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -100,6 +100,9 @@ def test_basics(value, ty, klass, pickle_module):
     assert wr() is None
 
 
+# This test is a copy of test_basics but only for float16 (HalfFloatScalar)
+# which currently requires a numpy scalar to create it. The test collection
+# fails if numpy is used on the parametrization when not present.
 @pytest.mark.numpy
 def test_basics_np_required(pickle_module):
     value, ty, klass = np.float16(1.0), pa.float16(), pa.HalfFloatScalar

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -20,7 +20,10 @@ import sys
 import weakref
 
 import pytest
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pyarrow as pa
 
 import pyarrow.tests.util as test_util
@@ -185,6 +188,7 @@ def test_time_types():
         pa.time64('s')
 
 
+@pytest.mark.numpy
 def test_from_numpy_dtype():
     cases = [
         (np.dtype('bool'), pa.bool_()),

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -19,7 +19,10 @@ import pytest
 import sys
 import weakref
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pytestmark = pytest.mark.numpy
 import pyarrow as pa
 
 try:

--- a/python/pyarrow/tests/test_strategies.py
+++ b/python/pyarrow/tests/test_strategies.py
@@ -17,6 +17,8 @@
 
 import hypothesis as h
 
+import pytest
+
 import pyarrow as pa
 import pyarrow.tests.strategies as past
 
@@ -36,11 +38,13 @@ def test_schemas(schema):
     assert isinstance(schema, pa.lib.Schema)
 
 
+@pytest.mark.numpy
 @h.given(past.all_arrays)
 def test_arrays(array):
     assert isinstance(array, pa.lib.Array)
 
 
+@pytest.mark.numpy
 @h.given(past.arrays(past.primitive_types, nullable=False))
 def test_array_nullability(array):
     assert array.null_count == 0
@@ -56,6 +60,7 @@ def test_record_batches(record_bath):
     assert isinstance(record_bath, pa.lib.RecordBatch)
 
 
+@pytest.mark.numpy
 @h.given(past.all_tables)
 def test_tables(table):
     assert isinstance(table, pa.lib.Table)

--- a/python/pyarrow/tests/test_substrait.py
+++ b/python/pyarrow/tests/test_substrait.py
@@ -608,6 +608,7 @@ def test_output_field_names(use_threads):
     assert res_tb == expected
 
 
+@pytest.mark.numpy
 def test_scalar_aggregate_udf_basic(varargs_agg_func_fixture):
 
     test_table = pa.Table.from_pydict(
@@ -756,6 +757,7 @@ def test_scalar_aggregate_udf_basic(varargs_agg_func_fixture):
     assert res_tb == expected_tb
 
 
+@pytest.mark.numpy
 def test_hash_aggregate_udf_basic(varargs_agg_func_fixture):
 
     test_table = pa.Table.from_pydict(

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -978,7 +978,7 @@ def check_tensors(tensor, expected_tensor, type, size):
 
 
 @pytest.mark.numpy
-def test_recordbatch_to_tensor_uniform_type(typ):
+def test_recordbatch_to_tensor_uniform_type():
     for typ in [
         np.uint8, np.uint16, np.uint32, np.uint64,
         np.int8, np.int16, np.int32, np.int64,

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -978,63 +978,64 @@ def check_tensors(tensor, expected_tensor, type, size):
 
 
 @pytest.mark.numpy
-def test_recordbatch_to_tensor_uniform_type():
-    for typ in [
-        np.uint8, np.uint16, np.uint32, np.uint64,
-        np.int8, np.int16, np.int32, np.int64,
-        np.float32, np.float64,
-    ]:
-        arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        arr2 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
-        arr3 = [100, 100, 100, 100, 100, 100, 100, 100, 100]
-        batch = pa.RecordBatch.from_arrays(
-            [
-                pa.array(arr1, type=pa.from_numpy_dtype(typ)),
-                pa.array(arr2, type=pa.from_numpy_dtype(typ)),
-                pa.array(arr3, type=pa.from_numpy_dtype(typ)),
-            ], ["a", "b", "c"]
-        )
+@pytest.mark.parametrize('typ_str', [
+    "uint8", "uint16", "uint32", "uint64",
+    "int8", "int16", "int32", "int64",
+    "float32", "float64",
+])
+def test_recordbatch_to_tensor_uniform_type(typ_str):
+    typ = np.dtype(typ_str)
+    arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    arr2 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
+    arr3 = [100, 100, 100, 100, 100, 100, 100, 100, 100]
+    batch = pa.RecordBatch.from_arrays(
+        [
+            pa.array(arr1, type=pa.from_numpy_dtype(typ)),
+            pa.array(arr2, type=pa.from_numpy_dtype(typ)),
+            pa.array(arr3, type=pa.from_numpy_dtype(typ)),
+        ], ["a", "b", "c"]
+    )
 
-        result = batch.to_tensor(row_major=False)
-        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
-        expected = pa.Tensor.from_numpy(x)
-        check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
+    result = batch.to_tensor(row_major=False)
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
+    expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
-        result = batch.to_tensor()
-        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
-        expected = pa.Tensor.from_numpy(x)
-        check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
+    result = batch.to_tensor()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
+    expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
-        # Test offset
-        batch1 = batch.slice(1)
-        arr1 = [2, 3, 4, 5, 6, 7, 8, 9]
-        arr2 = [20, 30, 40, 50, 60, 70, 80, 90]
-        arr3 = [100, 100, 100, 100, 100, 100, 100, 100]
+    # Test offset
+    batch1 = batch.slice(1)
+    arr1 = [2, 3, 4, 5, 6, 7, 8, 9]
+    arr2 = [20, 30, 40, 50, 60, 70, 80, 90]
+    arr3 = [100, 100, 100, 100, 100, 100, 100, 100]
 
-        result = batch1.to_tensor(row_major=False)
-        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
-        expected = pa.Tensor.from_numpy(x)
-        check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
+    result = batch1.to_tensor(row_major=False)
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
+    expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
-        result = batch1.to_tensor()
-        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
-        expected = pa.Tensor.from_numpy(x)
-        check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
+    result = batch1.to_tensor()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
+    expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
-        batch2 = batch.slice(1, 5)
-        arr1 = [2, 3, 4, 5, 6]
-        arr2 = [20, 30, 40, 50, 60]
-        arr3 = [100, 100, 100, 100, 100]
+    batch2 = batch.slice(1, 5)
+    arr1 = [2, 3, 4, 5, 6]
+    arr2 = [20, 30, 40, 50, 60]
+    arr3 = [100, 100, 100, 100, 100]
 
-        result = batch2.to_tensor(row_major=False)
-        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
-        expected = pa.Tensor.from_numpy(x)
-        check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
+    result = batch2.to_tensor(row_major=False)
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
+    expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
-        result = batch2.to_tensor()
-        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
-        expected = pa.Tensor.from_numpy(x)
-        check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
+    result = batch2.to_tensor()
+    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
+    expected = pa.Tensor.from_numpy(x)
+    check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
 
 @pytest.mark.numpy

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -20,7 +20,10 @@ from collections.abc import Iterable
 import sys
 import weakref
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pytest
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -125,6 +128,7 @@ def test_chunked_array_can_combine_chunks_with_no_chunks():
     ).combine_chunks() == pa.array([], type=pa.bool_())
 
 
+@pytest.mark.numpy
 def test_chunked_array_to_numpy():
     data = pa.chunked_array([
         [1, 2, 3],
@@ -173,6 +177,7 @@ def test_chunked_array_str():
 ]"""
 
 
+@pytest.mark.numpy
 def test_chunked_array_getitem():
     data = [
         pa.array([1, 2, 3]),
@@ -972,65 +977,67 @@ def check_tensors(tensor, expected_tensor, type, size):
     assert tensor.strides == expected_tensor.strides
 
 
-@pytest.mark.parametrize('typ', [
-    np.uint8, np.uint16, np.uint32, np.uint64,
-    np.int8, np.int16, np.int32, np.int64,
-    np.float32, np.float64,
-])
+@pytest.mark.numpy
 def test_recordbatch_to_tensor_uniform_type(typ):
-    arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    arr2 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
-    arr3 = [100, 100, 100, 100, 100, 100, 100, 100, 100]
-    batch = pa.RecordBatch.from_arrays(
-        [
-            pa.array(arr1, type=pa.from_numpy_dtype(typ)),
-            pa.array(arr2, type=pa.from_numpy_dtype(typ)),
-            pa.array(arr3, type=pa.from_numpy_dtype(typ)),
-        ], ["a", "b", "c"]
-    )
+    for typ in [
+        np.uint8, np.uint16, np.uint32, np.uint64,
+        np.int8, np.int16, np.int32, np.int64,
+        np.float32, np.float64,
+    ]:
+        arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        arr2 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
+        arr3 = [100, 100, 100, 100, 100, 100, 100, 100, 100]
+        batch = pa.RecordBatch.from_arrays(
+            [
+                pa.array(arr1, type=pa.from_numpy_dtype(typ)),
+                pa.array(arr2, type=pa.from_numpy_dtype(typ)),
+                pa.array(arr3, type=pa.from_numpy_dtype(typ)),
+            ], ["a", "b", "c"]
+        )
 
-    result = batch.to_tensor(row_major=False)
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
-    expected = pa.Tensor.from_numpy(x)
-    check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
+        result = batch.to_tensor(row_major=False)
+        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
+        expected = pa.Tensor.from_numpy(x)
+        check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
-    result = batch.to_tensor()
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
-    expected = pa.Tensor.from_numpy(x)
-    check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
+        result = batch.to_tensor()
+        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
+        expected = pa.Tensor.from_numpy(x)
+        check_tensors(result, expected, pa.from_numpy_dtype(typ), 27)
 
-    # Test offset
-    batch1 = batch.slice(1)
-    arr1 = [2, 3, 4, 5, 6, 7, 8, 9]
-    arr2 = [20, 30, 40, 50, 60, 70, 80, 90]
-    arr3 = [100, 100, 100, 100, 100, 100, 100, 100]
+        # Test offset
+        batch1 = batch.slice(1)
+        arr1 = [2, 3, 4, 5, 6, 7, 8, 9]
+        arr2 = [20, 30, 40, 50, 60, 70, 80, 90]
+        arr3 = [100, 100, 100, 100, 100, 100, 100, 100]
 
-    result = batch1.to_tensor(row_major=False)
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
-    expected = pa.Tensor.from_numpy(x)
-    check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
+        result = batch1.to_tensor(row_major=False)
+        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
+        expected = pa.Tensor.from_numpy(x)
+        check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
-    result = batch1.to_tensor()
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
-    expected = pa.Tensor.from_numpy(x)
-    check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
+        result = batch1.to_tensor()
+        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
+        expected = pa.Tensor.from_numpy(x)
+        check_tensors(result, expected, pa.from_numpy_dtype(typ), 24)
 
-    batch2 = batch.slice(1, 5)
-    arr1 = [2, 3, 4, 5, 6]
-    arr2 = [20, 30, 40, 50, 60]
-    arr3 = [100, 100, 100, 100, 100]
+        batch2 = batch.slice(1, 5)
+        arr1 = [2, 3, 4, 5, 6]
+        arr2 = [20, 30, 40, 50, 60]
+        arr3 = [100, 100, 100, 100, 100]
 
-    result = batch2.to_tensor(row_major=False)
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
-    expected = pa.Tensor.from_numpy(x)
-    check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
+        result = batch2.to_tensor(row_major=False)
+        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="F")
+        expected = pa.Tensor.from_numpy(x)
+        check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
-    result = batch2.to_tensor()
-    x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
-    expected = pa.Tensor.from_numpy(x)
-    check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
+        result = batch2.to_tensor()
+        x = np.column_stack([arr1, arr2, arr3]).astype(typ, order="C")
+        expected = pa.Tensor.from_numpy(x)
+        check_tensors(result, expected, pa.from_numpy_dtype(typ), 15)
 
 
+@pytest.mark.numpy
 def test_recordbatch_to_tensor_uniform_float_16():
     arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
     arr2 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
@@ -1054,6 +1061,7 @@ def test_recordbatch_to_tensor_uniform_float_16():
     check_tensors(result, expected, pa.float16(), 27)
 
 
+@pytest.mark.numpy
 def test_recordbatch_to_tensor_mixed_type():
     # uint16 + int16 = int32
     arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -1105,6 +1113,7 @@ def test_recordbatch_to_tensor_mixed_type():
     assert result.strides == expected.strides
 
 
+@pytest.mark.numpy
 def test_recordbatch_to_tensor_unsupported_mixed_type_with_float16():
     arr1 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
     arr2 = [10, 20, 30, 40, 50, 60, 70, 80, 90]
@@ -1124,6 +1133,7 @@ def test_recordbatch_to_tensor_unsupported_mixed_type_with_float16():
         batch.to_tensor()
 
 
+@pytest.mark.numpy
 def test_recordbatch_to_tensor_nan():
     arr1 = [1, 2, 3, 4, np.nan, 6, 7, 8, 9]
     arr2 = [10, 20, 30, 40, 50, 60, 70, np.nan, 90]
@@ -1144,6 +1154,7 @@ def test_recordbatch_to_tensor_nan():
     assert result.strides == expected.strides
 
 
+@pytest.mark.numpy
 def test_recordbatch_to_tensor_null():
     arr1 = [1, 2, 3, 4, None, 6, 7, 8, 9]
     arr2 = [10, 20, 30, 40, 50, 60, 70, None, 90]
@@ -1204,6 +1215,7 @@ def test_recordbatch_to_tensor_null():
     assert result.strides == expected.strides
 
 
+@pytest.mark.numpy
 def test_recordbatch_to_tensor_empty():
     batch = pa.RecordBatch.from_arrays(
         [
@@ -1295,6 +1307,7 @@ def test_slice_zero_length_table():
     table.to_pandas()
 
 
+@pytest.mark.numpy
 def test_recordbatchlist_schema_equals():
     a1 = np.array([1], dtype='uint32')
     a2 = np.array([4.0, 5.0], dtype='float64')
@@ -2130,6 +2143,7 @@ def test_table_unsafe_casting(cls):
     assert casted_table.equals(expected_table)
 
 
+@pytest.mark.numpy
 def test_invalid_table_construct():
     array = np.array([0, 1], dtype=np.uint8)
     u8 = pa.uint8()
@@ -3287,6 +3301,7 @@ def test_table_sort_by(cls):
     assert sorted_tab_dict["b"] == ["foo", "car", "bar", "foobar"]
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize("constructor", [pa.table, pa.record_batch])
 def test_numpy_asarray(constructor):
     table = constructor([[1, 2, 3], [4.0, 5.0, 6.0]], names=["a", "b"])
@@ -3319,6 +3334,7 @@ def test_numpy_asarray(constructor):
     assert result.dtype == "int32"
 
 
+@pytest.mark.numpy
 @pytest.mark.parametrize("constructor", [pa.table, pa.record_batch])
 def test_numpy_array_protocol(constructor):
     table = constructor([[1, 2, 3], [4.0, 5.0, 6.0]], names=["a", "b"])

--- a/python/pyarrow/tests/test_tensor.py
+++ b/python/pyarrow/tests/test_tensor.py
@@ -21,7 +21,10 @@ import pytest
 import warnings
 import weakref
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pytestmark = pytest.mark.numpy
 import pyarrow as pa
 
 

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -30,7 +30,10 @@ except ImportError:
     tzst = None
 import weakref
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 import pyarrow as pa
 import pyarrow.types as types
 import pyarrow.tests.strategies as past
@@ -1263,12 +1266,14 @@ def test_field_modified_copies():
     assert f0.equals(f0_)
 
 
+@pytest.mark.numpy
 def test_is_integer_value():
     assert pa.types.is_integer_value(1)
     assert pa.types.is_integer_value(np.int64(1))
     assert not pa.types.is_integer_value('1')
 
 
+@pytest.mark.numpy
 def test_is_float_value():
     assert not pa.types.is_float_value(1)
     assert pa.types.is_float_value(1.)
@@ -1276,6 +1281,7 @@ def test_is_float_value():
     assert not pa.types.is_float_value('1.0')
 
 
+@pytest.mark.numpy
 def test_is_boolean_value():
     assert not pa.types.is_boolean_value(1)
     assert pa.types.is_boolean_value(True)

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -1273,21 +1273,21 @@ def test_is_integer_value():
     assert not pa.types.is_integer_value('1')
 
 
-@pytest.mark.numpy
 def test_is_float_value():
     assert not pa.types.is_float_value(1)
     assert pa.types.is_float_value(1.)
-    assert pa.types.is_float_value(np.float64(1))
+    if np is not None:
+        assert pa.types.is_float_value(np.float64(1))
     assert not pa.types.is_float_value('1.0')
 
 
-@pytest.mark.numpy
 def test_is_boolean_value():
     assert not pa.types.is_boolean_value(1)
     assert pa.types.is_boolean_value(True)
     assert pa.types.is_boolean_value(False)
-    assert pa.types.is_boolean_value(np.bool_(True))
-    assert pa.types.is_boolean_value(np.bool_(False))
+    if np is not None:
+        assert pa.types.is_boolean_value(np.bool_(True))
+        assert pa.types.is_boolean_value(np.bool_(False))
 
 
 @h.settings(suppress_health_check=(h.HealthCheck.too_slow,))

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -1266,10 +1266,10 @@ def test_field_modified_copies():
     assert f0.equals(f0_)
 
 
-@pytest.mark.numpy
 def test_is_integer_value():
     assert pa.types.is_integer_value(1)
-    assert pa.types.is_integer_value(np.int64(1))
+    if np is not None:
+        assert pa.types.is_integer_value(np.int64(1))
     assert not pa.types.is_integer_value('1')
 
 

--- a/python/pyarrow/tests/test_udf.py
+++ b/python/pyarrow/tests/test_udf.py
@@ -18,7 +18,10 @@
 
 import pytest
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 import pyarrow as pa
 from pyarrow import compute as pc
@@ -749,6 +752,7 @@ def test_udt_datasource1_exception():
         _test_datasource1_udt(datasource1_exception)
 
 
+@pytest.mark.numpy
 def test_scalar_agg_basic(unary_agg_func_fixture):
     arr = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
     result = pc.call_function("mean_udf", [arr])
@@ -756,6 +760,7 @@ def test_scalar_agg_basic(unary_agg_func_fixture):
     assert result == expected
 
 
+@pytest.mark.numpy
 def test_scalar_agg_empty(unary_agg_func_fixture):
     empty = pa.array([], pa.float64())
 
@@ -775,6 +780,7 @@ def test_scalar_agg_wrong_output_type(wrong_output_type_agg_func_fixture):
         pc.call_function("y=wrong_output_type(x)", [arr])
 
 
+@pytest.mark.numpy
 def test_scalar_agg_varargs(varargs_agg_func_fixture):
     arr1 = pa.array([10, 20, 30, 40, 50], pa.int64())
     arr2 = pa.array([1.0, 2.0, 3.0, 4.0, 5.0], pa.float64())
@@ -786,6 +792,7 @@ def test_scalar_agg_varargs(varargs_agg_func_fixture):
     assert result == expected
 
 
+@pytest.mark.numpy
 def test_scalar_agg_exception(exception_agg_func_fixture):
     arr = pa.array([10, 20, 30, 40, 50, 60], pa.int64())
 
@@ -793,6 +800,7 @@ def test_scalar_agg_exception(exception_agg_func_fixture):
         pc.call_function("y=exception_len(x)", [arr])
 
 
+@pytest.mark.numpy
 def test_hash_agg_basic(unary_agg_func_fixture):
     arr1 = pa.array([10.0, 20.0, 30.0, 40.0, 50.0], pa.float64())
     arr2 = pa.array([4, 2, 1, 2, 1], pa.int32())
@@ -811,6 +819,7 @@ def test_hash_agg_basic(unary_agg_func_fixture):
     assert result.sort_by('id') == expected.sort_by('id')
 
 
+@pytest.mark.numpy
 def test_hash_agg_empty(unary_agg_func_fixture):
     arr1 = pa.array([], pa.float64())
     arr2 = pa.array([], pa.int32())
@@ -841,6 +850,7 @@ def test_hash_agg_wrong_output_type(wrong_output_type_agg_func_fixture):
         table.group_by("id").aggregate([("value", "y=wrong_output_type(x)")])
 
 
+@pytest.mark.numpy
 def test_hash_agg_exception(exception_agg_func_fixture):
     arr1 = pa.array([10, 20, 30, 40, 50], pa.int64())
     arr2 = pa.array([4, 2, 1, 2, 1], pa.int32())
@@ -850,6 +860,7 @@ def test_hash_agg_exception(exception_agg_func_fixture):
         table.group_by("id").aggregate([("value", "y=exception_len(x)")])
 
 
+@pytest.mark.numpy
 def test_hash_agg_random(sum_agg_func_fixture):
     """Test hash aggregate udf with randomly sampled data"""
 

--- a/python/pyarrow/tests/test_without_numpy.py
+++ b/python/pyarrow/tests/test_without_numpy.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.nonumpy
 def test_array_to_np():
     arr = pa.array(range(10))
 
-    msg = "Cannot return a numpy.ndarray if Numpy is not present"
+    msg = "Cannot return a numpy.ndarray if NumPy is not present"
 
     with pytest.raises(ImportError, match=msg):
         arr.to_numpy()
@@ -39,7 +39,7 @@ def test_chunked_array_to_np():
         [4, 5, 6],
         []
     ])
-    msg = "Cannot return a numpy.ndarray if Numpy is not present"
+    msg = "Cannot return a numpy.ndarray if NumPy is not present"
 
     with pytest.raises(ImportError, match=msg):
         data.to_numpy()
@@ -52,7 +52,7 @@ def test_tensor_to_np():
     tensor_array = pa.ExtensionArray.from_storage(tensor_type, storage)
 
     tensor = tensor_array.to_tensor()
-    msg = "Cannot return a numpy.ndarray if Numpy is not present"
+    msg = "Cannot return a numpy.ndarray if NumPy is not present"
 
     with pytest.raises(ImportError, match=msg):
         tensor.to_numpy()

--- a/python/pyarrow/tests/test_without_numpy.py
+++ b/python/pyarrow/tests/test_without_numpy.py
@@ -1,0 +1,30 @@
+import pytest
+
+import pyarrow as pa
+
+# Marks all of the tests in this module
+# Ignore these with pytest ... -m 'not nonumpy'
+pytestmark = pytest.mark.nonumpy
+
+
+def test_array_to_np():
+    arr = pa.array(range(10))
+
+    msg = "Cannot return a numpy.ndarray if Numpy is not present"
+
+    with pytest.raises(ValueError, match=msg):
+        arr.to_numpy()
+
+
+def test_chunked_array_to_np():
+    data = pa.chunked_array([
+        [1, 2, 3],
+        [4, 5, 6],
+        []
+    ])
+    msg = "Cannot return a numpy.ndarray if Numpy is not present"
+
+    with pytest.raises(ValueError, match=msg):
+        data.to_numpy()
+
+

--- a/python/pyarrow/tests/test_without_numpy.py
+++ b/python/pyarrow/tests/test_without_numpy.py
@@ -28,3 +28,14 @@ def test_chunked_array_to_np():
         data.to_numpy()
 
 
+def test_tensor_to_np():
+    tensor_type = pa.fixed_shape_tensor(pa.int32(), [2, 2])
+    arr = [[1, 2, 3, 4], [10, 20, 30, 40], [100, 200, 300, 400]]
+    storage = pa.array(arr, pa.list_(pa.int32(), 4))
+    tensor_array = pa.ExtensionArray.from_storage(tensor_type, storage)
+
+    tensor = tensor_array.to_tensor()
+    msg = "Cannot return a numpy.ndarray if Numpy is not present"
+
+    with pytest.raises(ValueError, match=msg):
+        tensor.to_numpy()

--- a/python/pyarrow/tests/test_without_numpy.py
+++ b/python/pyarrow/tests/test_without_numpy.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import pytest
 
 import pyarrow as pa

--- a/python/pyarrow/tests/test_without_numpy.py
+++ b/python/pyarrow/tests/test_without_numpy.py
@@ -29,7 +29,7 @@ def test_array_to_np():
 
     msg = "Cannot return a numpy.ndarray if Numpy is not present"
 
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ImportError, match=msg):
         arr.to_numpy()
 
 
@@ -41,7 +41,7 @@ def test_chunked_array_to_np():
     ])
     msg = "Cannot return a numpy.ndarray if Numpy is not present"
 
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ImportError, match=msg):
         data.to_numpy()
 
 
@@ -54,5 +54,5 @@ def test_tensor_to_np():
     tensor = tensor_array.to_tensor()
     msg = "Cannot return a numpy.ndarray if Numpy is not present"
 
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(ImportError, match=msg):
         tensor.to_numpy()

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -22,7 +22,10 @@ Utility functions for testing
 import contextlib
 import decimal
 import gc
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    pass
 import os
 import random
 import re

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -117,10 +117,8 @@ def rands(nchars):
     """
     Generate one random string.
     """
-    import numpy as np
-    RANDS_CHARS = np.array(
-        list(string.ascii_letters + string.digits), dtype=(np.str_, 1))
-    return "".join(np.random.choice(RANDS_CHARS, nchars))
+    RANDS_CHARS = list(string.ascii_letters + string.digits)
+    return "".join(random.choice(RANDS_CHARS) for i in range(nchars))
 
 
 def memory_leak_check(f, metric='rss', threshold=1 << 17, iterations=10,

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -22,10 +22,6 @@ Utility functions for testing
 import contextlib
 import decimal
 import gc
-try:
-    import numpy as np
-except ImportError:
-    pass
 import os
 import random
 import re
@@ -113,6 +109,7 @@ def randdecimal(precision, scale):
 
 
 def random_ascii(length):
+    import numpy as np
     return bytes(np.random.randint(65, 123, size=length, dtype='i1'))
 
 
@@ -120,20 +117,10 @@ def rands(nchars):
     """
     Generate one random string.
     """
+    import numpy as np
     RANDS_CHARS = np.array(
         list(string.ascii_letters + string.digits), dtype=(np.str_, 1))
     return "".join(np.random.choice(RANDS_CHARS, nchars))
-
-
-def make_dataframe():
-    import pandas as pd
-
-    N = 30
-    df = pd.DataFrame(
-        {col: np.random.randn(N) for col in string.ascii_uppercase[:4]},
-        index=pd.Index([rands(10) for _ in range(N)])
-    )
-    return df
 
 
 def memory_leak_check(f, metric='rss', threshold=1 << 17, iterations=10,

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -109,8 +109,7 @@ def randdecimal(precision, scale):
 
 
 def random_ascii(length):
-    import numpy as np
-    return bytes(np.random.randint(65, 123, size=length, dtype='i1'))
+    return bytes([random.randint(65, 122) for i in range(length)])
 
 
 def rands(nchars):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -33,6 +33,8 @@ from cython import sizeof
 
 # These are imprecise because the type (in pandas 0.x) depends on the presence
 # of nulls
+
+
 def _get_pandas_type_map():
     cdef dict _pandas_type_map = {
         _Type_NA: np.object_,  # NaNs
@@ -71,6 +73,7 @@ def _get_pandas_type_map():
         _Type_DECIMAL128: np.object_,
     }
     return _pandas_type_map
+
 
 cdef dict _pep3118_type_map = {
     _Type_INT8: b'b',

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -33,42 +33,44 @@ from cython import sizeof
 
 # These are imprecise because the type (in pandas 0.x) depends on the presence
 # of nulls
-cdef dict _pandas_type_map = {
-    _Type_NA: np.object_,  # NaNs
-    _Type_BOOL: np.bool_,
-    _Type_INT8: np.int8,
-    _Type_INT16: np.int16,
-    _Type_INT32: np.int32,
-    _Type_INT64: np.int64,
-    _Type_UINT8: np.uint8,
-    _Type_UINT16: np.uint16,
-    _Type_UINT32: np.uint32,
-    _Type_UINT64: np.uint64,
-    _Type_HALF_FLOAT: np.float16,
-    _Type_FLOAT: np.float32,
-    _Type_DOUBLE: np.float64,
-    # Pandas does not support [D]ay, so default to [ms] for date32
-    _Type_DATE32: np.dtype('datetime64[ms]'),
-    _Type_DATE64: np.dtype('datetime64[ms]'),
-    _Type_TIMESTAMP: {
-        's': np.dtype('datetime64[s]'),
-        'ms': np.dtype('datetime64[ms]'),
-        'us': np.dtype('datetime64[us]'),
-        'ns': np.dtype('datetime64[ns]'),
-    },
-    _Type_DURATION: {
-        's': np.dtype('timedelta64[s]'),
-        'ms': np.dtype('timedelta64[ms]'),
-        'us': np.dtype('timedelta64[us]'),
-        'ns': np.dtype('timedelta64[ns]'),
-    },
-    _Type_BINARY: np.object_,
-    _Type_FIXED_SIZE_BINARY: np.object_,
-    _Type_STRING: np.object_,
-    _Type_LIST: np.object_,
-    _Type_MAP: np.object_,
-    _Type_DECIMAL128: np.object_,
-}
+def _get_pandas_type_map():
+    cdef dict _pandas_type_map = {
+        _Type_NA: np.object_,  # NaNs
+        _Type_BOOL: np.bool_,
+        _Type_INT8: np.int8,
+        _Type_INT16: np.int16,
+        _Type_INT32: np.int32,
+        _Type_INT64: np.int64,
+        _Type_UINT8: np.uint8,
+        _Type_UINT16: np.uint16,
+        _Type_UINT32: np.uint32,
+        _Type_UINT64: np.uint64,
+        _Type_HALF_FLOAT: np.float16,
+        _Type_FLOAT: np.float32,
+        _Type_DOUBLE: np.float64,
+        # Pandas does not support [D]ay, so default to [ms] for date32
+        _Type_DATE32: np.dtype('datetime64[ms]'),
+        _Type_DATE64: np.dtype('datetime64[ms]'),
+        _Type_TIMESTAMP: {
+            's': np.dtype('datetime64[s]'),
+            'ms': np.dtype('datetime64[ms]'),
+            'us': np.dtype('datetime64[us]'),
+            'ns': np.dtype('datetime64[ns]'),
+        },
+        _Type_DURATION: {
+            's': np.dtype('timedelta64[s]'),
+            'ms': np.dtype('timedelta64[ms]'),
+            'us': np.dtype('timedelta64[us]'),
+            'ns': np.dtype('timedelta64[ns]'),
+        },
+        _Type_BINARY: np.object_,
+        _Type_FIXED_SIZE_BINARY: np.object_,
+        _Type_STRING: np.object_,
+        _Type_LIST: np.object_,
+        _Type_MAP: np.object_,
+        _Type_DECIMAL128: np.object_,
+    }
+    return _pandas_type_map
 
 cdef dict _pep3118_type_map = {
     _Type_INT8: b'b',
@@ -149,14 +151,14 @@ def _is_primitive(Type type):
 
 def _get_pandas_type(arrow_type, coerce_to_ns=False):
     cdef Type type_id = arrow_type.id
-    if type_id not in _pandas_type_map:
+    if type_id not in _get_pandas_type_map:
         return None
     if coerce_to_ns:
         # ARROW-3789: Coerce date/timestamp types to datetime64[ns]
         if type_id == _Type_DURATION:
             return np.dtype('timedelta64[ns]')
         return np.dtype('datetime64[ns]')
-    pandas_type = _pandas_type_map[type_id]
+    pandas_type = _get_pandas_type_map[type_id]
     if isinstance(pandas_type, dict):
         unit = getattr(arrow_type, 'unit', None)
         pandas_type = pandas_type.get(unit, None)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -33,45 +33,48 @@ from cython import sizeof
 
 # These are imprecise because the type (in pandas 0.x) depends on the presence
 # of nulls
+cdef dict _pandas_type_map = {}
 
 
 def _get_pandas_type_map():
-    cdef dict _pandas_type_map = {
-        _Type_NA: np.object_,  # NaNs
-        _Type_BOOL: np.bool_,
-        _Type_INT8: np.int8,
-        _Type_INT16: np.int16,
-        _Type_INT32: np.int32,
-        _Type_INT64: np.int64,
-        _Type_UINT8: np.uint8,
-        _Type_UINT16: np.uint16,
-        _Type_UINT32: np.uint32,
-        _Type_UINT64: np.uint64,
-        _Type_HALF_FLOAT: np.float16,
-        _Type_FLOAT: np.float32,
-        _Type_DOUBLE: np.float64,
-        # Pandas does not support [D]ay, so default to [ms] for date32
-        _Type_DATE32: np.dtype('datetime64[ms]'),
-        _Type_DATE64: np.dtype('datetime64[ms]'),
-        _Type_TIMESTAMP: {
-            's': np.dtype('datetime64[s]'),
-            'ms': np.dtype('datetime64[ms]'),
-            'us': np.dtype('datetime64[us]'),
-            'ns': np.dtype('datetime64[ns]'),
-        },
-        _Type_DURATION: {
-            's': np.dtype('timedelta64[s]'),
-            'ms': np.dtype('timedelta64[ms]'),
-            'us': np.dtype('timedelta64[us]'),
-            'ns': np.dtype('timedelta64[ns]'),
-        },
-        _Type_BINARY: np.object_,
-        _Type_FIXED_SIZE_BINARY: np.object_,
-        _Type_STRING: np.object_,
-        _Type_LIST: np.object_,
-        _Type_MAP: np.object_,
-        _Type_DECIMAL128: np.object_,
-    }
+    global _pandas_type_map
+    if not _pandas_type_map:
+        _pandas_type_map.update({
+            _Type_NA: np.object_,  # NaNs
+            _Type_BOOL: np.bool_,
+            _Type_INT8: np.int8,
+            _Type_INT16: np.int16,
+            _Type_INT32: np.int32,
+            _Type_INT64: np.int64,
+            _Type_UINT8: np.uint8,
+            _Type_UINT16: np.uint16,
+            _Type_UINT32: np.uint32,
+            _Type_UINT64: np.uint64,
+            _Type_HALF_FLOAT: np.float16,
+            _Type_FLOAT: np.float32,
+            _Type_DOUBLE: np.float64,
+            # Pandas does not support [D]ay, so default to [ms] for date32
+            _Type_DATE32: np.dtype('datetime64[ms]'),
+            _Type_DATE64: np.dtype('datetime64[ms]'),
+            _Type_TIMESTAMP: {
+                's': np.dtype('datetime64[s]'),
+                'ms': np.dtype('datetime64[ms]'),
+                'us': np.dtype('datetime64[us]'),
+                'ns': np.dtype('datetime64[ns]'),
+            },
+            _Type_DURATION: {
+                's': np.dtype('timedelta64[s]'),
+                'ms': np.dtype('timedelta64[ms]'),
+                'us': np.dtype('timedelta64[us]'),
+                'ns': np.dtype('timedelta64[ns]'),
+            },
+            _Type_BINARY: np.object_,
+            _Type_FIXED_SIZE_BINARY: np.object_,
+            _Type_STRING: np.object_,
+            _Type_LIST: np.object_,
+            _Type_MAP: np.object_,
+            _Type_DECIMAL128: np.object_,
+        })
     return _pandas_type_map
 
 
@@ -154,14 +157,15 @@ def _is_primitive(Type type):
 
 def _get_pandas_type(arrow_type, coerce_to_ns=False):
     cdef Type type_id = arrow_type.id
-    if type_id not in _get_pandas_type_map():
+    cdef dict pandas_type_map = _get_pandas_type_map()
+    if type_id not in pandas_type_map:
         return None
     if coerce_to_ns:
         # ARROW-3789: Coerce date/timestamp types to datetime64[ns]
         if type_id == _Type_DURATION:
             return np.dtype('timedelta64[ns]')
         return np.dtype('datetime64[ns]')
-    pandas_type = _get_pandas_type_map()[type_id]
+    pandas_type = pandas_type_map[type_id]
     if isinstance(pandas_type, dict):
         unit = getattr(arrow_type, 'unit', None)
         pandas_type = pandas_type.get(unit, None)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -154,14 +154,14 @@ def _is_primitive(Type type):
 
 def _get_pandas_type(arrow_type, coerce_to_ns=False):
     cdef Type type_id = arrow_type.id
-    if type_id not in _get_pandas_type_map:
+    if type_id not in _get_pandas_type_map():
         return None
     if coerce_to_ns:
         # ARROW-3789: Coerce date/timestamp types to datetime64[ns]
         if type_id == _Type_DURATION:
             return np.dtype('timedelta64[ns]')
         return np.dtype('datetime64[ns]')
-    pandas_type = _get_pandas_type_map[type_id]
+    pandas_type = _get_pandas_type_map()[type_id]
     if isinstance(pandas_type, dict):
         unit = getattr(arrow_type, 'unit', None)
         pandas_type = pandas_type.get(unit, None)


### PR DESCRIPTION
### Rationale for this change

Being able to run pyarrow without requiring numpy.

### What changes are included in this PR?

If numpy is not present we are able to import pyarrow and run functionality.
A new CI job has been created to run some basic tests without numpy.

### Are these changes tested?

Yes via CI.

### Are there any user-facing changes?

Yes, NumPy can be removed from the user installation and pyarrow functionality still works

<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #25118