### PR TITLE
GH-41920: [CI][JS] Add missing build directory argument

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -106,10 +106,10 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Build
         shell: bash
-        run: ci/scripts/js_build.sh $(pwd)
+        run: ci/scripts/js_build.sh $(pwd) build
       - name: Test
         shell: bash
-        run: ci/scripts/js_test.sh $(pwd)
+        run: ci/scripts/js_test.sh $(pwd) build
 
   windows:
     name: AMD64 Windows NodeJS ${{ matrix.node }}
@@ -136,7 +136,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Build
         shell: bash
-        run: ci/scripts/js_build.sh $(pwd)
+        run: ci/scripts/js_build.sh $(pwd) build
       - name: Test
         shell: bash
-        run: ci/scripts/js_test.sh $(pwd)
+        run: ci/scripts/js_test.sh $(pwd) build


### PR DESCRIPTION
### Rationale for this change

This is a follow-up of GH-41455.

### What changes are included in this PR?

Add missing build directory argument.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41920