### PR TITLE
GH-41919: [C++][FlightRPC] Avoid using raw pointers for auth handlers

### DIFF
--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -520,8 +520,7 @@ class GrpcResultStream : public ResultStream {
   }
 
   Status Init(pb::FlightService::Stub* stub,
-              std::shared_ptr<ClientAuthHandler> auth_handler,
-              const Action& action) {
+              std::shared_ptr<ClientAuthHandler> auth_handler, const Action& action) {
     pb::Action pb_action;
     RETURN_NOT_OK(internal::ToProto(action, &pb_action));
     RETURN_NOT_OK(rpc_.SetToken(std::move(auth_handler)));
@@ -901,8 +900,8 @@ class GrpcClientImpl : public internal::ClientTransport {
 
   Status DoAction(const FlightCallOptions& options, const Action& action,
                   std::unique_ptr<ResultStream>* results) override {
-    ARROW_ASSIGN_OR_RAISE(*results, GrpcResultStream::Make(options, stub_.get(),
-                                                           auth_handler_, action));
+    ARROW_ASSIGN_OR_RAISE(
+        *results, GrpcResultStream::Make(options, stub_.get(), auth_handler_, action));
     return Status::OK();
   }
 


### PR DESCRIPTION
### Rationale for this change

Avoid pointer access after deletion bug explained in #41919

### What changes are included in this PR?

Change SetToken argument from a raw pointer to an `std::shared_ptr`.

### Are these changes tested?

This PR leans on existing CI tests and compile-time type checking, no additional/specific testing was performed.

### Are there any user-facing changes?

No
* GitHub Issue: #41919