### PR TITLE
GH-41902: [Java] Variadic Buffer Counts Incorrect

### DIFF
--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Collections2;
+import org.apache.arrow.vector.BaseVariableWidthViewVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TypeLayout;
 import org.apache.arrow.vector.complex.StructVector;
@@ -54,7 +55,12 @@ public class StructVectorLoader {
 
   /**
    * Construct with a schema.
-   *
+   * <p>
+   * The schema referred to here can be obtained from the struct vector.
+   * Consider a {@link StructVector} structVector, the schema can be obtained as follows:
+   * <code>
+   * Schema schema = new Schema(structVector.getField().getChildren());
+   * </code>
    * @param schema buffers are added based on schema.
    */
   public StructVectorLoader(Schema schema) {
@@ -111,7 +117,7 @@ public class StructVectorLoader {
     ArrowFieldNode fieldNode = nodes.next();
     // variadicBufferLayoutCount will be 0 for vectors of type except BaseVariableWidthViewVector
     long variadicBufferLayoutCount = 0;
-    if (variadicBufferCounts.hasNext()) {
+    if (vector instanceof BaseVariableWidthViewVector && variadicBufferCounts.hasNext()) {
       variadicBufferLayoutCount = variadicBufferCounts.next();
     }
     int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType()));

--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
@@ -57,7 +57,9 @@ public class StructVectorLoader {
    * Construct with a schema.
    * <p>
    * The schema referred to here can be obtained from the struct vector.
-   * Consider a {@link StructVector} structVector, the schema can be obtained as follows:
+   * The schema here should be the children of a struct vector, not a schema
+   * containing the struct field itself.
+   * For example:
    * <code>
    * Schema schema = new Schema(structVector.getField().getChildren());
    * </code>

--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorLoader.java
@@ -90,7 +90,7 @@ public class StructVectorLoader {
         .fromCompressionType(recordBatch.getBodyCompression().getCodec());
     decompressionNeeded = codecType != CompressionUtil.CodecType.NO_COMPRESSION;
     CompressionCodec codec = decompressionNeeded ? factory.createCodec(codecType) : NoCompressionCodec.INSTANCE;
-    Iterator<Long> variadicBufferCounts = null;
+    Iterator<Long> variadicBufferCounts = Collections.emptyIterator();
     if (recordBatch.getVariadicBufferCounts() != null && !recordBatch.getVariadicBufferCounts().isEmpty()) {
       variadicBufferCounts = recordBatch.getVariadicBufferCounts().iterator();
     }
@@ -111,7 +111,7 @@ public class StructVectorLoader {
     ArrowFieldNode fieldNode = nodes.next();
     // variadicBufferLayoutCount will be 0 for vectors of type except BaseVariableWidthViewVector
     long variadicBufferLayoutCount = 0;
-    if (variadicBufferCounts != null) {
+    if (variadicBufferCounts.hasNext()) {
       variadicBufferLayoutCount = variadicBufferCounts.next();
     }
     int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType()));

--- a/java/c/src/main/java/org/apache/arrow/c/StructVectorUnloader.java
+++ b/java/c/src/main/java/org/apache/arrow/c/StructVectorUnloader.java
@@ -109,7 +109,10 @@ public class StructVectorUnloader {
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
     long variadicBufferCount = getVariadicBufferCount(vector);
     int expectedBufferCount = (int) (TypeLayout.getTypeBufferCount(vector.getField().getType()) + variadicBufferCount);
-    variadicBufferCounts.add(variadicBufferCount);
+    // only update variadicBufferCounts for vectors that have variadic buffers
+    if (variadicBufferCount > 0) {
+      variadicBufferCounts.add(variadicBufferCount);
+    }
     if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format("wrong number of buffers for field %s in vector %s. found: %s",
           vector.getField(), vector.getClass().getSimpleName(), fieldBuffers));

--- a/java/c/src/test/java/org/apache/arrow/c/DictionaryTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/DictionaryTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.c;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -29,6 +31,7 @@ import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.CDataDictionaryProvider;
 import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
@@ -36,13 +39,19 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ViewVarCharVector;
 import org.apache.arrow.vector.compare.VectorEqualsVisitor;
+import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -214,6 +223,57 @@ public class DictionaryTest {
 
     ByteArrayInputStream in = new ByteArrayInputStream(os.toByteArray());
     return new ArrowStreamReader(in, allocator);
+  }
+
+  private void createStructVector(StructVector vector) {
+    final ViewVarCharVector child1 = vector.addOrGet("f0",
+        FieldType.nullable(MinorType.VIEWVARCHAR.getType()), ViewVarCharVector.class);
+    final IntVector child2 = vector.addOrGet("f1",
+        FieldType.nullable(MinorType.INT.getType()), IntVector.class);
+
+    // Write the values to child 1
+    child1.allocateNew();
+    child1.set(0, "01234567890".getBytes());
+    child1.set(1, "012345678901234567".getBytes());
+    vector.setIndexDefined(0);
+
+    // Write the values to child 2
+    child2.allocateNew();
+    child2.set(0, 10);
+    child2.set(1, 11);
+    vector.setIndexDefined(1);
+
+    vector.setValueCount(2);
+  }
+
+  @Test
+  public void testVectorLoadUnloadOnStructVector() {
+    try (final StructVector structVector1 = StructVector.empty("struct", allocator)) {
+      createStructVector(structVector1);
+      Field field1 = structVector1.getField();
+      Schema schema = new Schema(field1.getChildren());
+      StructVectorUnloader vectorUnloader = new StructVectorUnloader(structVector1);
+
+      try (
+          ArrowRecordBatch recordBatch = vectorUnloader.getRecordBatch();
+          BufferAllocator finalVectorsAllocator = allocator.newChildAllocator("struct", 0, Long.MAX_VALUE);
+      ) {
+        // validating recordBatch contains an output for variadicBufferCounts
+        assertFalse(recordBatch.getVariadicBufferCounts().isEmpty());
+        assertEquals(1, recordBatch.getVariadicBufferCounts().size());
+        assertEquals(1, recordBatch.getVariadicBufferCounts().get(0));
+
+        StructVectorLoader vectorLoader = new StructVectorLoader(schema);
+        try (StructVector structVector2 = vectorLoader.load(finalVectorsAllocator, recordBatch)) {
+          // Improve this after fixing https://github.com/apache/arrow/issues/41933
+          // assertTrue(VectorEqualsVisitor.vectorEquals(structVector1, structVector2), "vectors are not equivalent");
+          assertTrue(VectorEqualsVisitor.vectorEquals(structVector1.getChild("f0"), structVector2.getChild("f0")),
+              "vectors are not equivalent");
+          assertTrue(VectorEqualsVisitor.vectorEquals(structVector1.getChild("f1"), structVector2.getChild("f1")),
+              "vectors are not equivalent");
+        }
+      }
+    }
   }
 
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.util.Preconditions.checkArgument;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -80,7 +81,7 @@ public class VectorLoader {
         CompressionUtil.CodecType.fromCompressionType(recordBatch.getBodyCompression().getCodec());
     decompressionNeeded = codecType != CompressionUtil.CodecType.NO_COMPRESSION;
     CompressionCodec codec = decompressionNeeded ? factory.createCodec(codecType) : NoCompressionCodec.INSTANCE;
-    Iterator<Long> variadicBufferCounts = null;
+    Iterator<Long> variadicBufferCounts = Collections.emptyIterator();;
     if (recordBatch.getVariadicBufferCounts() != null && !recordBatch.getVariadicBufferCounts().isEmpty()) {
       variadicBufferCounts = recordBatch.getVariadicBufferCounts().iterator();
     }
@@ -106,7 +107,7 @@ public class VectorLoader {
     ArrowFieldNode fieldNode = nodes.next();
     // variadicBufferLayoutCount will be 0 for vectors of type except BaseVariableWidthViewVector
     long variadicBufferLayoutCount = 0;
-    if (variadicBufferCounts != null) {
+    if (variadicBufferCounts.hasNext()) {
       variadicBufferLayoutCount = variadicBufferCounts.next();
     }
     int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType()));

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -107,7 +107,7 @@ public class VectorLoader {
     ArrowFieldNode fieldNode = nodes.next();
     // variadicBufferLayoutCount will be 0 for vectors of type except BaseVariableWidthViewVector
     long variadicBufferLayoutCount = 0;
-    if (variadicBufferCounts.hasNext()) {
+    if (vector instanceof BaseVariableWidthViewVector && variadicBufferCounts.hasNext()) {
       variadicBufferLayoutCount = variadicBufferCounts.next();
     }
     int bufferLayoutCount = (int) (variadicBufferLayoutCount + TypeLayout.getTypeBufferCount(field.getType()));

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -103,7 +103,10 @@ public class VectorUnloader {
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
     long variadicBufferCount = getVariadicBufferCount(vector);
     int expectedBufferCount = (int) (TypeLayout.getTypeBufferCount(vector.getField().getType()) + variadicBufferCount);
-    variadicBufferCounts.add(variadicBufferCount);
+    // only update variadicBufferCounts for vectors that have variadic buffers
+    if (variadicBufferCount > 0) {
+      variadicBufferCounts.add(variadicBufferCount);
+    }
     if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format(
           "wrong number of buffers for field %s in vector %s. found: %s",


### PR DESCRIPTION
### Rationale for this change

In the initial PR for `variadicBufferCounts` addition to Java spec, the non variadic buffer-ed vectors were assigned with 0 valued non-empty `variadicBufferCounts`. And this caused CIs to fail in Arrow Rust. 

### What changes are included in this PR?

This PR changes such that non variadic buffer-ed vectors would contain an empty `variadicBufferCounts` attribute in `ArrowRecordBatch` interface in Java. Also this includes upgrade to JUNIT5. 


### Are these changes tested?

Yes, from existing tests and a new test added. 

### Are there any user-facing changes?

No
* GitHub Issue: apache/arrow#41902
* GitHub Issue: #41902