### PR TITLE
GH-41397: [C#] Downgrade macOS test runner to avoid infrastructure bug

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -94,8 +94,8 @@ jobs:
         run: ci/scripts/csharp_test.sh $(pwd)
 
   macos:
-    name: ARM64 macOS 14 C# ${{ matrix.dotnet }}
-    runs-on: macos-latest
+    name: AMD64 macOS 13 C# ${{ matrix.dotnet }}
+    runs-on: macos-13 # Pending https://github.com/pythonnet/pythonnet/issues/2396
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
### What changes are included in this PR?

Downgrades the macOS test image for C# to use an older operating system. This works around https://github.com/pythonnet/pythonnet/issues/2396.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41397