### PR TITLE
GH-41970: [C++] Misc changes making code around list-like types and list-view types behave the same way

### DIFF
--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -642,6 +642,8 @@ class ARROW_EXPORT MapBuilder : public ArrayBuilder {
 /// \brief Builder class for fixed-length list array value types
 class ARROW_EXPORT FixedSizeListBuilder : public ArrayBuilder {
  public:
+  using TypeClass = FixedSizeListType;
+
   /// Use this constructor to define the built array's type explicitly. If value_builder
   /// has indeterminate type, this builder will also.
   FixedSizeListBuilder(MemoryPool* pool,

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2281,7 +2281,7 @@ TEST(Cast, ListToPrimitive) {
       Cast(*ArrayFromJSON(list(binary()), R"([["1", "2"], ["3", "4"]])"), utf8()));
 }
 
-using make_list_t = std::shared_ptr<DataType>(const std::shared_ptr<DataType>&);
+using make_list_t = std::shared_ptr<DataType>(std::shared_ptr<DataType>);
 
 static const auto list_factories = std::vector<make_list_t*>{&list, &large_list};
 

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -698,13 +698,12 @@ void AddHashKernels(VectorFunction* func, VectorKernel base, OutputType out_ty) 
     DCHECK_OK(func->AddKernel(base));
   }
 
-  // Example parametric types that we want to match only on Type::type
-  auto parametric_types = {time32(TimeUnit::SECOND), time64(TimeUnit::MICRO),
-                           timestamp(TimeUnit::SECOND), duration(TimeUnit::SECOND),
-                           fixed_size_binary(0)};
-  for (const auto& ty : parametric_types) {
-    base.init = GetHashInit<Action>(ty->id());
-    base.signature = KernelSignature::Make({ty->id()}, out_ty);
+  // Parametric types that we want matching to be depededent only on type id
+  auto parametric_types = {Type::TIME32, Type::TIME64, Type::TIMESTAMP, Type::DURATION,
+                           Type::FIXED_SIZE_BINARY};
+  for (const auto& type_id : parametric_types) {
+    base.init = GetHashInit<Action>(type_id);
+    base.signature = KernelSignature::Make({type_id}, out_ty);
     DCHECK_OK(func->AddKernel(base));
   }
 

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -698,7 +698,7 @@ void AddHashKernels(VectorFunction* func, VectorKernel base, OutputType out_ty) 
     DCHECK_OK(func->AddKernel(base));
   }
 
-  // Parametric types that we want matching to be depededent only on type id
+  // Parametric types that we want matching to be dependent only on type id
   auto parametric_types = {Type::TIME32, Type::TIME64, Type::TIMESTAMP, Type::DURATION,
                            Type::FIXED_SIZE_BINARY};
   for (const auto& type_id : parametric_types) {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -3149,20 +3149,20 @@ std::shared_ptr<DataType> time64(TimeUnit::type unit) {
   return std::make_shared<Time64Type>(unit);
 }
 
-std::shared_ptr<DataType> list(const std::shared_ptr<DataType>& value_type) {
-  return std::make_shared<ListType>(value_type);
+std::shared_ptr<DataType> list(std::shared_ptr<DataType> value_type) {
+  return std::make_shared<ListType>(std::move(value_type));
 }
 
-std::shared_ptr<DataType> list(const std::shared_ptr<Field>& value_field) {
-  return std::make_shared<ListType>(value_field);
+std::shared_ptr<DataType> list(std::shared_ptr<Field> value_field) {
+  return std::make_shared<ListType>(std::move(value_field));
 }
 
-std::shared_ptr<DataType> large_list(const std::shared_ptr<DataType>& value_type) {
-  return std::make_shared<LargeListType>(value_type);
+std::shared_ptr<DataType> large_list(std::shared_ptr<DataType> value_type) {
+  return std::make_shared<LargeListType>(std::move(value_type));
 }
 
-std::shared_ptr<DataType> large_list(const std::shared_ptr<Field>& value_field) {
-  return std::make_shared<LargeListType>(value_field);
+std::shared_ptr<DataType> large_list(std::shared_ptr<Field> value_field) {
+  return std::make_shared<LargeListType>(std::move(value_field));
 }
 
 std::shared_ptr<DataType> map(std::shared_ptr<DataType> key_type,
@@ -3183,14 +3183,14 @@ std::shared_ptr<DataType> map(std::shared_ptr<Field> key_field,
                                    keys_sorted);
 }
 
-std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<DataType>& value_type,
+std::shared_ptr<DataType> fixed_size_list(std::shared_ptr<DataType> value_type,
                                           int32_t list_size) {
-  return std::make_shared<FixedSizeListType>(value_type, list_size);
+  return std::make_shared<FixedSizeListType>(std::move(value_type), list_size);
 }
 
-std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<Field>& value_field,
+std::shared_ptr<DataType> fixed_size_list(std::shared_ptr<Field> value_field,
                                           int32_t list_size) {
-  return std::make_shared<FixedSizeListType>(value_field, list_size);
+  return std::make_shared<FixedSizeListType>(std::move(value_field), list_size);
 }
 
 std::shared_ptr<DataType> list_view(std::shared_ptr<DataType> value_type) {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1122,11 +1122,11 @@ class ARROW_EXPORT ListType : public BaseListType {
   static constexpr const char* type_name() { return "list"; }
 
   // List can contain any other logical value type
-  explicit ListType(const std::shared_ptr<DataType>& value_type)
-      : ListType(std::make_shared<Field>("item", value_type)) {}
+  explicit ListType(std::shared_ptr<DataType> value_type)
+      : ListType(std::make_shared<Field>("item", std::move(value_type))) {}
 
-  explicit ListType(const std::shared_ptr<Field>& value_field) : BaseListType(type_id) {
-    children_ = {value_field};
+  explicit ListType(std::shared_ptr<Field> value_field) : BaseListType(type_id) {
+    children_ = {std::move(value_field)};
   }
 
   DataTypeLayout layout() const override {
@@ -1153,12 +1153,11 @@ class ARROW_EXPORT LargeListType : public BaseListType {
   static constexpr const char* type_name() { return "large_list"; }
 
   // List can contain any other logical value type
-  explicit LargeListType(const std::shared_ptr<DataType>& value_type)
-      : LargeListType(std::make_shared<Field>("item", value_type)) {}
+  explicit LargeListType(std::shared_ptr<DataType> value_type)
+      : LargeListType(std::make_shared<Field>("item", std::move(value_type))) {}
 
-  explicit LargeListType(const std::shared_ptr<Field>& value_field)
-      : BaseListType(type_id) {
-    children_ = {value_field};
+  explicit LargeListType(std::shared_ptr<Field> value_field) : BaseListType(type_id) {
+    children_ = {std::move(value_field)};
   }
 
   DataTypeLayout layout() const override {
@@ -1296,12 +1295,13 @@ class ARROW_EXPORT FixedSizeListType : public BaseListType {
   static constexpr const char* type_name() { return "fixed_size_list"; }
 
   // List can contain any other logical value type
-  FixedSizeListType(const std::shared_ptr<DataType>& value_type, int32_t list_size)
-      : FixedSizeListType(std::make_shared<Field>("item", value_type), list_size) {}
+  FixedSizeListType(std::shared_ptr<DataType> value_type, int32_t list_size)
+      : FixedSizeListType(std::make_shared<Field>("item", std::move(value_type)),
+                          list_size) {}
 
-  FixedSizeListType(const std::shared_ptr<Field>& value_field, int32_t list_size)
+  FixedSizeListType(std::shared_ptr<Field> value_field, int32_t list_size)
       : BaseListType(type_id), list_size_(list_size) {
-    children_ = {value_field};
+    children_ = {std::move(value_field)};
   }
 
   DataTypeLayout layout() const override {

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -525,19 +525,19 @@ std::shared_ptr<DataType> decimal256(int32_t precision, int32_t scale);
 
 /// \brief Create a ListType instance from its child Field type
 ARROW_EXPORT
-std::shared_ptr<DataType> list(const std::shared_ptr<Field>& value_type);
+std::shared_ptr<DataType> list(std::shared_ptr<Field> value_type);
 
 /// \brief Create a ListType instance from its child DataType
 ARROW_EXPORT
-std::shared_ptr<DataType> list(const std::shared_ptr<DataType>& value_type);
+std::shared_ptr<DataType> list(std::shared_ptr<DataType> value_type);
 
 /// \brief Create a LargeListType instance from its child Field type
 ARROW_EXPORT
-std::shared_ptr<DataType> large_list(const std::shared_ptr<Field>& value_type);
+std::shared_ptr<DataType> large_list(std::shared_ptr<Field> value_type);
 
 /// \brief Create a LargeListType instance from its child DataType
 ARROW_EXPORT
-std::shared_ptr<DataType> large_list(const std::shared_ptr<DataType>& value_type);
+std::shared_ptr<DataType> large_list(std::shared_ptr<DataType> value_type);
 
 /// \brief Create a ListViewType instance
 ARROW_EXPORT std::shared_ptr<DataType> list_view(std::shared_ptr<DataType> value_type);
@@ -568,12 +568,12 @@ std::shared_ptr<DataType> map(std::shared_ptr<DataType> key_type,
 
 /// \brief Create a FixedSizeListType instance from its child Field type
 ARROW_EXPORT
-std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<Field>& value_type,
+std::shared_ptr<DataType> fixed_size_list(std::shared_ptr<Field> value_type,
                                           int32_t list_size);
 
 /// \brief Create a FixedSizeListType instance from its child DataType
 ARROW_EXPORT
-std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<DataType>& value_type,
+std::shared_ptr<DataType> fixed_size_list(std::shared_ptr<DataType> value_type,
                                           int32_t list_size);
 /// \brief Return a Duration instance (naming use _type to avoid namespace conflict with
 /// built in time classes).

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1298,8 +1298,8 @@ Structural transforms
 +---------------------+------------+-------------+------------------+------------------------------+--------+
 
 * \(1) Each output element is the length of the corresponding input element
-  (null if input is null).  Output type is Int32 for List and FixedSizeList,
-  Int64 for LargeList.
+  (null if input is null).  Output type is Int32 for List, ListView, and
+  FixedSizeList, Int64 for LargeList and LargeListView.
 
 * \(2) The output struct's field types are the types of its arguments. The
   field names are specified using an instance of :struct:`MakeStructOptions`.

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1413,13 +1413,15 @@ null input value is converted into a null output value.
 +-----------------------------+------------------------------------+---------+
 | Struct                      | Struct                             | \(2)    |
 +-----------------------------+------------------------------------+---------+
-| List-like                   | List-like                          | \(3)    |
+| List-like                   | List-like or (Large)ListView       | \(3)    |
 +-----------------------------+------------------------------------+---------+
-| Map                         | Map or List of two-field struct    | \(4)    |
+| (Large)ListView             | List-like or (Large)ListView       | \(4)    |
++-----------------------------+------------------------------------+---------+
+| Map                         | Map or List of two-field struct    | \(5)    |
 +-----------------------------+------------------------------------+---------+
 | Null                        | Any                                |         |
 +-----------------------------+------------------------------------+---------+
-| Any                         | Extension                          | \(5)    |
+| Any                         | Extension                          | \(6)    |
 +-----------------------------+------------------------------------+---------+
 
 * \(1) The dictionary indices are unchanged, the dictionary values are
@@ -1433,14 +1435,20 @@ null input value is converted into a null output value.
 
 * \(3) The list offsets are unchanged, the list values are cast from the
   input value type to the output value type (if a conversion is
-  available).
+  available). If the output type is (Large)ListView, then sizes are
+  derived from the offsets.
 
-* \(4) Offsets are unchanged, the keys and values are cast from respective input
+* \(4) If output type is list-like, offsets might have to be rebuilt to be
+  sorted and spaced correctly. If output type is a list-view type, the offsets
+  and sizes are unchanged. In any case, the list values are cast from the input
+  value type to the output value type (if a conversion is available).
+
+* \(5) Offsets are unchanged, the keys and values are cast from respective input
   to output types (if a conversion is available). If output type is a list of
   struct, the key field is output as the first field and the value field the
   second field, regardless of field names chosen.
 
-* \(5) Any input type that can be cast to the resulting extension's storage type.
+* \(6) Any input type that can be cast to the resulting extension's storage type.
   This excludes extension types, unless being cast to the same extension type.
 
 Temporal component extraction

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1438,10 +1438,11 @@ null input value is converted into a null output value.
   available). If the output type is (Large)ListView, then sizes are
   derived from the offsets.
 
-* \(4) If output type is list-like, offsets might have to be rebuilt to be
-  sorted and spaced correctly. If output type is a list-view type, the offsets
-  and sizes are unchanged. In any case, the list values are cast from the input
-  value type to the output value type (if a conversion is available).
+* \(4) If output type is list-like, offsets (consequently, the values array)
+  might have to be rebuilt to be sorted and spaced adequately. If output type is
+  a list-view type, the offsets and sizes are unchanged. In any case, the list
+  values are cast from the input value type to the output value type (if a
+  conversion is available).
 
 * \(5) Offsets are unchanged, the keys and values are cast from respective input
   to output types (if a conversion is available). If output type is a list of

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1172,6 +1172,7 @@ of memory buffers for each layout.
    "Variable Binary",validity,offsets,data,
    "Variable Binary View",validity,views,,data
    "List",validity,offsets,,
+   "List View",validity,offsets,sizes,
    "Fixed-size List",validity,,,
    "Struct",validity,,,
    "Sparse Union",type ids,,,


### PR DESCRIPTION
### Rationale for this change

These changes facilitate the refactoring of compute kernels and tests to support not only the list-like types but also list-views.

### What changes are included in this PR?

 - Inclusion of `FixedSizeListBuilder::TypeClass` to make it in line with `VarLengthListLikeBuilder<TYPE>` classes
 - Small documentation updates related to list-view types
 - Change `list`/`large_list`/`fixed_size_list` factories to take `shared_ptr` by value instead of `const &`
 - Change `ListType`/`LargeListType`/`FixedSizeList` constructors take `shared_ptr` by value instead of `const &`

### Are these changes tested?

Yes. By existing tests.

### Are there any user-facing changes?

 - The `list`/`large_list`/`fixed_size_list` type factories now take the `shared_ptr` parameter value instead of `const &`.
 - The `ListType`/`LargeListType`/`FixedSizeList` constructors now take the `shared_ptr` parameter by value instead of `const &`

<!-- **This PR includes breaking changes to public APIs.** -->

* GitHub Issue: #41970