### PR TITLE
GH-41974: [C++][Compute] Support more precise pre-allocation and more pre-allocated types for ScalarExecutor and VectorExecutor

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -1031,30 +1031,7 @@ class VectorExecutor : public KernelExecutorImpl<VectorKernel> {
       if (arg.is_chunked_array()) have_chunked_arrays = true;
     }
 
-    output_num_buffers_ = static_cast<int>(output_type_.type->layout().buffers.size());
-
-    // Decide if we need to preallocate memory for this kernel
-    validity_preallocated_ = false;
-    if (output_type_.type->id() != Type::NA) {
-      if (kernel_->null_handling == NullHandling::COMPUTED_PREALLOCATE) {
-        // Override the flag if kernel asks for pre-allocation
-        validity_preallocated_ = true;
-      } else if (kernel_->null_handling == NullHandling::INTERSECTION) {
-        bool elide_validity_bitmap = true;
-        for (const auto& arg : batch.values) {
-          auto null_gen = NullGeneralization::Get(arg) == NullGeneralization::ALL_VALID;
-
-          // If not all valid, this becomes false
-          elide_validity_bitmap = elide_validity_bitmap && null_gen;
-        }
-        validity_preallocated_ = !elide_validity_bitmap;
-      }
-    }
-
-    if (kernel_->mem_allocation == MemAllocation::PREALLOCATE) {
-      data_preallocated_.clear();
-      ComputeDataPreallocate(*output_type_.type, &data_preallocated_);
-    }
+    RETURN_NOT_OK(SetupPreallocation(batch.values));
 
     if (kernel_->can_execute_chunkwise) {
       RETURN_NOT_OK(span_iterator_.Init(batch, exec_context()->exec_chunksize()));
@@ -1135,6 +1112,36 @@ class VectorExecutor : public KernelExecutorImpl<VectorKernel> {
       DCHECK(out.is_chunked_array());
       return EmitResult(out.chunked_array(), listener);
     }
+  }
+
+  Status SetupPreallocation(const std::vector<Datum>& args) {
+    output_num_buffers_ = static_cast<int>(output_type_.type->layout().buffers.size());
+    const auto& out_type_id = output_type_.type->id();
+
+    // Decide if we need to preallocate memory for this kernel
+    validity_preallocated_ = false;
+    if (out_type_id != Type::NA) {
+      if (kernel_->null_handling == NullHandling::COMPUTED_PREALLOCATE) {
+        // Override the flag if kernel asks for pre-allocation
+        validity_preallocated_ = true;
+      } else if (kernel_->null_handling == NullHandling::INTERSECTION) {
+        bool elide_validity_bitmap = true;
+        for (const auto& arg : args) {
+          auto null_gen = NullGeneralization::Get(arg) == NullGeneralization::ALL_VALID;
+
+          // If not all valid, this becomes false
+          elide_validity_bitmap = elide_validity_bitmap && null_gen;
+        }
+        validity_preallocated_ = !elide_validity_bitmap;
+      }
+    }
+
+    if (kernel_->mem_allocation == MemAllocation::PREALLOCATE) {
+      data_preallocated_.clear();
+      ComputeDataPreallocate(*output_type_.type, &data_preallocated_);
+    }
+
+    return Status::OK();
   }
 
   ExecSpanIterator span_iterator_;

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -132,9 +132,6 @@ class ARROW_EXPORT KernelExecutor {
   /// for all scanned batches in a dataset filter.
   virtual Status Init(KernelContext*, KernelInitArgs) = 0;
 
-  // TODO(wesm): per ARROW-16819, adding ExecBatch variant so that a batch
-  // length can be passed in for scalar functions; will have to return and
-  // clean a bunch of things up
   virtual Status Execute(const ExecBatch& batch, ExecListener* listener) = 0;
 
   virtual Datum WrapResults(const std::vector<Datum>& args,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Mainly for below improvement and codes simplification:

1. `NullGeneralization` not support chunked-array's null status check which may prevent some optimization for preallocation.
2. `ComputeDataPreallocate` not support [Large]ListView's preallocate.
3. Some DCHECK and branch check for preallocate the validity-bitmaps are unnecessary.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Described as above.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes, covered by exists.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41974