### PR TITLE
GH-41964: [CI][C++] Clear cache for mamba on AppVeyor

### DIFF
--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -66,6 +66,9 @@ set CONDA_PACKAGES=%CONDA_PACKAGES% --file=ci\conda_env_cpp.txt
 @rem Force conda to use conda-forge
 conda config --add channels conda-forge
 conda config --remove channels defaults
+@rem Ensure using the latest information. If there are invalid caches,
+@rem mamba may use invalid download URL.
+mamba clean --all -y
 @rem Arrow conda environment
 mamba create -n arrow -y -c conda-forge ^
   --file=ci\conda_env_python.txt ^


### PR DESCRIPTION
### Rationale for this change

It seems that mamba may use invalid download URL when there are invalid caches.

### What changes are included in this PR?

Clear caches explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #41964