### PR TITLE
GH-41983: [Dev] Run issue labeling bot only when opening an issue (not editing)

### DIFF
--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -21,7 +21,6 @@ on:
   issues:
     types:
       - opened
-      - edited
 
 permissions:
   contents: read


### PR DESCRIPTION
### Rationale for this change

Currently the bot will remove manually added Component labels, because at that point you are editing the issue and the workflow is run again, reinstating the labels in the "Components" section in the top post created by the issue form.

Therefore, restrict this bot to only run when the issue is "opened"

* GitHub Issue: #41983