### PR TITLE
GH-41994 [C++]: kernel.cc: Remove defaults on switch so that compiler can check full enum coverage for us

### DIFF
--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -361,7 +361,8 @@ size_t InputType::Hash() const {
     case InputType::EXACT_TYPE:
       hash_combine(result, type_->Hash());
       break;
-    default:
+    case InputType::ANY_TYPE:
+    case InputType::USE_TYPE_MATCHER:
       break;
   }
   return result;
@@ -378,10 +379,8 @@ std::string InputType::ToString() const {
       break;
     case InputType::USE_TYPE_MATCHER: {
       ss << type_matcher_->ToString();
-    } break;
-    default:
-      DCHECK(false);
       break;
+    }
   }
   return ss.str();
 }
@@ -400,9 +399,8 @@ bool InputType::Equals(const InputType& other) const {
       return type_->Equals(*other.type_);
     case InputType::USE_TYPE_MATCHER:
       return type_matcher_->Equals(*other.type_matcher_);
-    default:
-      return false;
   }
+  return false;
 }
 
 bool InputType::Matches(const DataType& type) const {
@@ -411,21 +409,23 @@ bool InputType::Matches(const DataType& type) const {
       return type_->Equals(type);
     case InputType::USE_TYPE_MATCHER:
       return type_matcher_->Matches(type);
-    default:
-      // ANY_TYPE
-      return true;
+    case InputType::ANY_TYPE:
+      break;
   }
+  return true;
 }
 
 bool InputType::Matches(const Datum& value) const {
   switch (value.kind()) {
+    case Datum::NONE:
+    case Datum::RECORD_BATCH:
+    case Datum::TABLE:
+      DCHECK(false) << "Matches expects ARRAY, CHUNKED_ARRAY or SCALAR";
+      return false;
     case Datum::ARRAY:
     case Datum::CHUNKED_ARRAY:
     case Datum::SCALAR:
       break;
-    default:
-      DCHECK(false);
-      return false;
   }
   return Matches(*value.type());
 }
@@ -445,11 +445,13 @@ const TypeMatcher& InputType::type_matcher() const {
 
 Result<TypeHolder> OutputType::Resolve(KernelContext* ctx,
                                        const std::vector<TypeHolder>& types) const {
-  if (kind_ == OutputType::FIXED) {
-    return type_.get();
-  } else {
-    return resolver_(ctx, types);
+  switch (kind_) {
+    case OutputType::FIXED:
+      return type_;
+    case OutputType::COMPUTED:
+      break;
   }
+  return resolver_(ctx, types);
 }
 
 const std::shared_ptr<DataType>& OutputType::type() const {
@@ -463,11 +465,13 @@ const OutputType::Resolver& OutputType::resolver() const {
 }
 
 std::string OutputType::ToString() const {
-  if (kind_ == OutputType::FIXED) {
-    return type_->ToString();
-  } else {
-    return "computed";
+  switch (kind_) {
+    case OutputType::FIXED:
+      return type_->ToString();
+    case OutputType::COMPUTED:
+      break;
   }
+  return "computed";
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -410,9 +410,9 @@ bool InputType::Matches(const DataType& type) const {
     case InputType::USE_TYPE_MATCHER:
       return type_matcher_->Matches(type);
     case InputType::ANY_TYPE:
-      break;
+      return true;
   }
-  return true;
+  return false;
 }
 
 bool InputType::Matches(const Datum& value) const {


### PR DESCRIPTION
### Rationale for this change

To let the compiler warn us about missing cases and make the non-handled cases more obvious.

### What changes are included in this PR?

Removal of `default` in the switches and improving some dchecks with a message.

### Are these changes tested?

By existing tests.
* GitHub Issue: #41994