### PR TITLE
GH-41903: [CI][GLib] Use the latest Ruby to use OpenSSL 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -197,9 +197,7 @@ jobs:
         mingw-n-bits:
           - 64
         ruby-version:
-          # TODO: Use the latest Ruby again when we fix GH-39130.
-          # - ruby
-          - "3.1"
+          - ruby
     env:
       ARROW_BUILD_STATIC: OFF
       ARROW_BUILD_TESTS: OFF


### PR DESCRIPTION
### Rationale for this change

Old Ruby ships OpenSSL 1 but googld-cloud-cpp requires OpenSSL 3. We need to use Ruby that ships OpenSSL 3.

### What changes are included in this PR?

Use the latest Ruby.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #41903