### PR TITLE
GH-42006: [CI][Python] Use pip install -e instead of setup.py build_ext --inplace for installing pyarrow on verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -756,7 +756,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv "cython>=0.29.31" numpy "setuptools_scm<8.0.0" setuptools
+  maybe_setup_virtualenv "cython>=0.29.31" numpy "setuptools_scm>=8.0.0" "setuptools>=64"
   maybe_setup_conda --file ci/conda_env_python.txt
 
   if [ "${USE_CONDA}" -gt 0 ]; then

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -788,7 +788,7 @@ test_python() {
   pushd python
 
   # Build pyarrow
-  python -m pip install .
+  python -m pip install -e .
 
   # Check mandatory and optional imports
   python -c "

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -756,7 +756,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv "cython>=0.29.31" numpy "setuptools_scm>=8.0.0" "setuptools>=64"
+  maybe_setup_virtualenv
   maybe_setup_conda --file ci/conda_env_python.txt
 
   if [ "${USE_CONDA}" -gt 0 ]; then
@@ -788,7 +788,7 @@ test_python() {
   pushd python
 
   # Build pyarrow
-  python setup.py build_ext --inplace
+  python -m pip install .
 
   # Check mandatory and optional imports
   python -c "


### PR DESCRIPTION
### Rationale for this change

Due to https://github.com/apache/arrow/issues/37929 we require a higher version of setuptools and setuptools_scm to be installed otherwise the job fails with setuptools_scm failing with ` TypeError: Configuration.__init__() got an unexpected keyword argument 'version_file'`

### What changes are included in this PR?

Remove the dependencies for the environment and let installation handle those using pip install -e instead of setup.py build_ext --inplace for installing pyarrow on verification script

### Are these changes tested?

Via Archery

### Are there any user-facing changes?

No
* GitHub Issue: #42006