### PR TITLE
GH-42017: [CI][Python][C++] Fix utf8proc detection for wheel on Windows

### DIFF
--- a/cpp/cmake_modules/Findutf8proc.cmake
+++ b/cpp/cmake_modules/Findutf8proc.cmake
@@ -19,7 +19,7 @@ if(utf8proc_FOUND)
   return()
 endif()
 
-if(ARROW_PACKAGE_KIND STREQUAL "vcpkg")
+if(ARROW_PACKAGE_KIND STREQUAL "vcpkg" OR VCPKG_TOOLCHAIN)
   set(find_package_args "")
   if(utf8proc_FIND_VERSION)
     list(APPEND find_package_args ${utf8proc_FIND_VERSION})

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2819,11 +2819,13 @@ macro(build_utf8proc)
 endmacro()
 
 if(ARROW_WITH_UTF8PROC)
-  resolve_dependency(utf8proc
-                     PC_PACKAGE_NAMES
-                     libutf8proc
-                     REQUIRED_VERSION
-                     "2.2.0")
+  set(utf8proc_resolve_dependency_args utf8proc PC_PACKAGE_NAMES libutf8proc)
+  if(NOT VCPKG_TOOLCHAIN)
+    # utf8proc in vcpkg doesn't provide version information:
+    # https://github.com/microsoft/vcpkg/issues/39176
+    list(APPEND utf8proc_resolve_dependency_args REQUIRED_VERSION "2.2.0")
+  endif()
+  resolve_dependency(${utf8proc_resolve_dependency_args})
 endif()
 
 macro(build_cares)

--- a/cpp/cmake_modules/Usevcpkg.cmake
+++ b/cpp/cmake_modules/Usevcpkg.cmake
@@ -237,9 +237,6 @@ set(LZ4_ROOT
     CACHE STRING "")
 
 if(CMAKE_HOST_WIN32)
-  set(utf8proc_MSVC_STATIC_LIB_SUFFIX
-      ""
-      CACHE STRING "")
   set(LZ4_MSVC_LIB_PREFIX
       ""
       CACHE STRING "")


### PR DESCRIPTION
### Rationale for this change

utf8proc in vcpkg provides CMake package. If we use it, we don't need to care about static library name (`utf8proc.lib` or `utf8proc_static.lib`).

### What changes are included in this PR?

Use `unofficial-utf8proc` CMake package with vcpkg.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #42017