### PR TITLE
GH-40749: [Python][Packaging] Strip unnecessary symbols when building wheels

### DIFF
--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -185,7 +185,7 @@ wheel_name=$(ls pyarrow-*.whl)
 # Unzip and remove old wheel
 unzip $wheel_name
 rm $wheel_name
-for filename in $(ls pyarrow/*.so pyarrow/*.so.*); do
+for filename in $(ls pyarrow/*.dylib pyarrow/*.so); do
     echo "Stripping debug symbols from: $filename";
     strip -S $filename
 done

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -187,7 +187,7 @@ unzip $wheel_name
 rm $wheel_name
 for filename in $(ls pyarrow/*.so pyarrow/*.so.*); do
     echo "Stripping debug symbols from: $filename";
-    strip --strip-debug $filename
+    strip -S $filename
 done
 # Zip wheel again after stripping symbols
 zip -r $wheel_name .

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -176,6 +176,24 @@ pushd ${source_dir}/python
 python setup.py bdist_wheel
 popd
 
+echo "=== Strip symbols from wheel ==="
+mkdir ${source_dir}/python/dist/temp-fix-wheel
+mv ${source_dir}/python/dist/pyarrow-*.whl ${source_dir}/python/dist/temp-fix-wheel
+
+pushd ${source_dir}/python/dist/temp-fix-wheel
+wheel_name=$(ls pyarrow-*.whl)
+# Unzip and remove old wheel
+unzip $wheel_name
+rm $wheel_name
+for filename in $(ls pyarrow/*.so pyarrow/*.so.*); do
+    echo "Stripping debug symbols from: $filename";
+    strip --strip-debug $filename
+done
+# Zip wheel again after stripping symbols
+zip -r $wheel_name .
+mv $wheel_name ..
+popd
+
 echo "=== (${PYTHON_VERSION}) Show dynamic libraries the wheel depend on ==="
 deps=$(delocate-listdeps ${source_dir}/python/dist/*.whl)
 

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -176,24 +176,6 @@ pushd ${source_dir}/python
 python setup.py bdist_wheel
 popd
 
-echo "=== Strip symbols from wheel ==="
-mkdir ${source_dir}/python/dist/temp-fix-wheel
-mv ${source_dir}/python/dist/pyarrow-*.whl ${source_dir}/python/dist/temp-fix-wheel
-
-pushd ${source_dir}/python/dist/temp-fix-wheel
-wheel_name=$(ls pyarrow-*.whl)
-# Unzip and remove old wheel
-unzip $wheel_name
-rm $wheel_name
-for filename in $(ls pyarrow/*.dylib pyarrow/*.so); do
-    echo "Stripping debug symbols from: $filename";
-    strip -S $filename
-done
-# Zip wheel again after stripping symbols
-zip -r $wheel_name .
-mv $wheel_name ..
-popd
-
 echo "=== (${PYTHON_VERSION}) Show dynamic libraries the wheel depend on ==="
 deps=$(delocate-listdeps ${source_dir}/python/dist/*.whl)
 

--- a/ci/scripts/python_wheel_manylinux_build.sh
+++ b/ci/scripts/python_wheel_manylinux_build.sh
@@ -160,6 +160,26 @@ export CMAKE_PREFIX_PATH=/tmp/arrow-dist
 pushd /arrow/python
 python setup.py bdist_wheel
 
+echo "=== Strip symbols from wheel ==="
+mkdir dist/temp-fix-wheel
+mv dist/pyarrow-*.whl dist/temp-fix-wheel
+
+pushd dist/temp-fix-wheel
+wheel_name=$(ls pyarrow-*.whl)
+# Unzip and remove old wheel
+unzip $wheel_name
+rm $wheel_name
+for filename in $(ls pyarrow/*.so pyarrow/*.so.*); do
+    echo "Stripping debug symbols from: $filename";
+    strip --strip-debug $filename
+done
+# Zip wheel again after stripping symbols
+zip -r $wheel_name .
+mv $wheel_name ..
+popd
+
+rm -rf dist/temp-fix-wheel
+
 echo "=== (${PYTHON_VERSION}) Tag the wheel with manylinux${MANYLINUX_VERSION} ==="
-auditwheel repair --strip -L . dist/pyarrow-*.whl -w repaired_wheels
+auditwheel repair -L . dist/pyarrow-*.whl -w repaired_wheels
 popd

--- a/ci/scripts/python_wheel_manylinux_build.sh
+++ b/ci/scripts/python_wheel_manylinux_build.sh
@@ -161,5 +161,5 @@ pushd /arrow/python
 python setup.py bdist_wheel
 
 echo "=== (${PYTHON_VERSION}) Tag the wheel with manylinux${MANYLINUX_VERSION} ==="
-auditwheel repair -L . dist/pyarrow-*.whl -w repaired_wheels
+auditwheel repair --strip -L . dist/pyarrow-*.whl -w repaired_wheels
 popd

--- a/ci/scripts/python_wheel_manylinux_build.sh
+++ b/ci/scripts/python_wheel_manylinux_build.sh
@@ -161,7 +161,7 @@ pushd /arrow/python
 python setup.py bdist_wheel
 
 echo "=== Strip symbols from wheel ==="
-mkdir dist/temp-fix-wheel
+mkdir -p dist/temp-fix-wheel
 mv dist/pyarrow-*.whl dist/temp-fix-wheel
 
 pushd dist/temp-fix-wheel


### PR DESCRIPTION
### Rationale for this change

Removing unnecessary symbols for wheels will allow us to reduce the size of the wheels considerably.

### What changes are included in this PR?

Running `strip --strip-debug` on Linux wheels for all *.so files.

### Are these changes tested?

Yes, via Archery.

### Are there any user-facing changes?

No
* GitHub Issue: #40749