### PR TITLE
GH-42030: [Java] Update Unit Tests for Adapter Module

### DIFF
--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroLogicalTypesTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroLogicalTypesTest.java
@@ -32,7 +32,7 @@ import org.apache.arrow.vector.util.DateUtility;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericFixed;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AvroLogicalTypesTest extends AvroTestBase {
 

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroSkipFieldTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroSkipFieldTest.java
@@ -31,7 +31,7 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AvroSkipFieldTest extends AvroTestBase {
 

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroSkipFieldTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroSkipFieldTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.arrow.adapter.avro;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
@@ -84,7 +84,7 @@ public class AvroTestBase {
     File dataFile = new File(TMP, "test.avro");
 
     try (FileOutputStream fos = new FileOutputStream(dataFile);
-         FileInputStream fis = new FileInputStream(dataFile)) {
+        FileInputStream fis = new FileInputStream(dataFile)) {
 
       BinaryEncoder encoder = new EncoderFactory().directBinaryEncoder(fos, null);
       DatumWriter<Object> writer = new GenericDatumWriter<>(schema);

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
@@ -43,17 +44,17 @@ import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 public class AvroTestBase {
 
-  @ClassRule public static final TemporaryFolder TMP = new TemporaryFolder();
+  @TempDir
+  protected Path tempDir;
 
   protected AvroToArrowConfig config;
 
-  @Before
+  @BeforeEach
   public void init() {
     BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     config = new AvroToArrowConfigBuilder(allocator).build();
@@ -82,7 +83,7 @@ public class AvroTestBase {
   }
 
   protected VectorSchemaRoot writeAndRead(Schema schema, List data) throws Exception {
-    File dataFile = TMP.newFile();
+    File dataFile = tempDir.resolve("test.avro").toFile();
 
     BinaryEncoder encoder =
         new EncoderFactory().directBinaryEncoder(new FileOutputStream(dataFile), null);

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
@@ -16,9 +16,9 @@
  */
 package org.apache.arrow.adapter.avro;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
@@ -48,8 +48,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class AvroTestBase {
 
-  @TempDir
-  public File TMP;
+  @TempDir public File TMP;
 
   protected AvroToArrowConfig config;
 

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroTestBase.java
@@ -26,7 +26,6 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
@@ -50,7 +49,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class AvroTestBase {
 
   @TempDir
-  protected Path tempDir;
+  public File TMP;
 
   protected AvroToArrowConfig config;
 
@@ -83,7 +82,7 @@ public class AvroTestBase {
   }
 
   protected VectorSchemaRoot writeAndRead(Schema schema, List data) throws Exception {
-    File dataFile = tempDir.resolve("test.avro").toFile();
+    File dataFile = new File(TMP, "test.avro");
 
     BinaryEncoder encoder =
         new EncoderFactory().directBinaryEncoder(new FileOutputStream(dataFile), null);

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
@@ -55,9 +55,17 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
     this.config = new AvroToArrowConfigBuilder(allocator).setTargetBatchSize(3).build();
   }
 
-  private AvroToArrowVectorIterator convert(Schema schema, List data) throws Exception {
-    File dataFile = new File(TMP, "test.avro");
+  private AvroToArrowVectorIterator convert(Schema schema, FileInputStream fis) throws Exception {
+    BinaryDecoder decoder = DecoderFactory.get().directBinaryDecoder(fis, null);
+    return AvroToArrow.avroToArrowIterator(schema, decoder, config);
+  }
 
+  @Test
+  public void testStringType() throws Exception {
+    Schema schema = getSchema("test_primitive_string.avsc");
+    List<String> data = Arrays.asList("v1", "v2", "v3", "v4", "v5");
+
+    File dataFile = new File(TMP, "test.avro");
     try (FileOutputStream fos = new FileOutputStream(dataFile)) {
       BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
       DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
@@ -68,20 +76,10 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
       encoder.flush();
     }
 
-    FileInputStream fis = new FileInputStream(dataFile);
-    BinaryDecoder decoder = DecoderFactory.get().directBinaryDecoder(fis, null);
-
-    return AvroToArrow.avroToArrowIterator(schema, decoder, config);
-  }
-
-  @Test
-  public void testStringType() throws Exception {
-    Schema schema = getSchema("test_primitive_string.avsc");
-    List<String> data = Arrays.asList("v1", "v2", "v3", "v4", "v5");
-
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<FieldVector> vectors = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = convert(schema, data)) {
+    try (FileInputStream fis = new FileInputStream(dataFile);
+        AvroToArrowVectorIterator iterator = convert(schema, fis)) {
       while (iterator.hasNext()) {
         VectorSchemaRoot root = iterator.next();
         FieldVector vector = root.getFieldVectors().get(0);
@@ -107,9 +105,21 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
       data.add(record);
     }
 
+    File dataFile = new File(TMP, "test.avro");
+    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
+      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
+      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+
+      for (Object value : data) {
+        writer.write(value, encoder);
+      }
+      encoder.flush();
+    }
+
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<FieldVector> vectors = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = convert(schema, data); ) {
+    try (FileInputStream fis = new FileInputStream(dataFile);
+        AvroToArrowVectorIterator iterator = convert(schema, fis)) {
       while (iterator.hasNext()) {
         VectorSchemaRoot root = iterator.next();
         FieldVector vector = root.getFieldVectors().get(0);
@@ -133,8 +143,20 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
       data.add(record);
     }
 
+    File dataFile = new File(TMP, "test.avro");
+    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
+      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
+      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+
+      for (Object value : data) {
+        writer.write(value, encoder);
+      }
+      encoder.flush();
+    }
+
     List<VectorSchemaRoot> roots = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = convert(schema, data)) {
+    try (FileInputStream fis = new FileInputStream(dataFile);
+        AvroToArrowVectorIterator iterator = convert(schema, fis)) {
       while (iterator.hasNext()) {
         roots.add(iterator.next());
       }
@@ -154,9 +176,21 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
             Arrays.asList("1vvv", "2bbb"),
             Arrays.asList("1fff", "2"));
 
+    File dataFile = new File(TMP, "test.avro");
+    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
+      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
+      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+
+      for (Object value : data) {
+        writer.write(value, encoder);
+      }
+      encoder.flush();
+    }
+
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<ListVector> vectors = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = convert(schema, data)) {
+    try (FileInputStream fis = new FileInputStream(dataFile);
+        AvroToArrowVectorIterator iterator = convert(schema, fis)) {
       while (iterator.hasNext()) {
         VectorSchemaRoot root = iterator.next();
         roots.add(root);

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.arrow.adapter.avro;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.EOFException;
 import java.io.File;

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
@@ -55,6 +55,18 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
     this.config = new AvroToArrowConfigBuilder(allocator).setTargetBatchSize(3).build();
   }
 
+  private void writeDataToFile(Schema schema, List<?> data, File dataFile) throws Exception {
+    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
+      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
+      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+
+      for (Object value : data) {
+        writer.write(value, encoder);
+      }
+      encoder.flush();
+    }
+  }
+
   private AvroToArrowVectorIterator convert(Schema schema, FileInputStream fis) throws Exception {
     BinaryDecoder decoder = DecoderFactory.get().directBinaryDecoder(fis, null);
     return AvroToArrow.avroToArrowIterator(schema, decoder, config);
@@ -66,15 +78,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
     List<String> data = Arrays.asList("v1", "v2", "v3", "v4", "v5");
 
     File dataFile = new File(TMP, "test.avro");
-    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
-      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
-      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
-
-      for (Object value : data) {
-        writer.write(value, encoder);
-      }
-      encoder.flush();
-    }
+    writeDataToFile(schema, data, dataFile);
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<FieldVector> vectors = new ArrayList<>();
@@ -106,15 +110,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
     }
 
     File dataFile = new File(TMP, "test.avro");
-    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
-      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
-      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
-
-      for (Object value : data) {
-        writer.write(value, encoder);
-      }
-      encoder.flush();
-    }
+    writeDataToFile(schema, data, dataFile);
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<FieldVector> vectors = new ArrayList<>();
@@ -144,15 +140,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
     }
 
     File dataFile = new File(TMP, "test.avro");
-    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
-      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
-      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
-
-      for (Object value : data) {
-        writer.write(value, encoder);
-      }
-      encoder.flush();
-    }
+    writeDataToFile(schema, data, dataFile);
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
     try (FileInputStream fis = new FileInputStream(dataFile);
@@ -177,15 +165,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
             Arrays.asList("1fff", "2"));
 
     File dataFile = new File(TMP, "test.avro");
-    try (FileOutputStream fos = new FileOutputStream(dataFile)) {
-      BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(fos, null);
-      DatumWriter<Object> writer = new GenericDatumWriter<>(schema);
-
-      for (Object value : data) {
-        writer.write(value, encoder);
-      }
-      encoder.flush();
-    }
+    writeDataToFile(schema, data, dataFile);
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<ListVector> vectors = new ArrayList<>();

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
@@ -56,7 +56,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
   }
 
   private AvroToArrowVectorIterator convert(Schema schema, List data) throws Exception {
-    File dataFile = tempDir.resolve("test.avro").toFile();
+    File dataFile = new File(TMP, "test.avro");
 
     BinaryEncoder encoder =
         new EncoderFactory().directBinaryEncoder(new FileOutputStream(dataFile), null);

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowIteratorTest.java
@@ -44,18 +44,19 @@ import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.util.Utf8;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AvroToArrowIteratorTest extends AvroTestBase {
 
-  @Override
+  @BeforeEach
   public void init() {
     final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
     this.config = new AvroToArrowConfigBuilder(allocator).setTargetBatchSize(3).build();
   }
 
   private AvroToArrowVectorIterator convert(Schema schema, List data) throws Exception {
-    File dataFile = TMP.newFile();
+    File dataFile = tempDir.resolve("test.avro").toFile();
 
     BinaryEncoder encoder =
         new EncoderFactory().directBinaryEncoder(new FileOutputStream(dataFile), null);

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowTest.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AvroToArrowTest extends AvroTestBase {
 

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/AvroToArrowTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.arrow.adapter.avro;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
@@ -19,6 +19,7 @@ package org.apache.arrow.adapter.avro;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.Schema;
@@ -30,18 +31,21 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestWriteReadAvroRecord {
 
-  @ClassRule public static final TemporaryFolder TMP = new TemporaryFolder();
+  private static File dataFile;
+
+  @BeforeAll
+  public static void setup(@TempDir Path tempDir) {
+    dataFile = tempDir.resolve("test.avro").toFile();
+  }
 
   @Test
   public void testWriteAndRead() throws Exception {
-
-    File dataFile = TMP.newFile();
     Schema schema = AvroTestBase.getSchema("test.avsc");
 
     // write data to disk

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
@@ -37,11 +37,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class TestWriteReadAvroRecord {
 
-  private static File dataFile;
+  public static File dataFile;
 
   @BeforeAll
   public static void setup(@TempDir Path tempDir) {
-    dataFile = tempDir.resolve("test.avro").toFile();
+    dataFile = new File(tempDir.toFile(), "test.avro");
   }
 
   @Test

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
@@ -53,20 +53,22 @@ public class TestWriteReadAvroRecord {
     user2.put("favorite_color", "red");
 
     DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<GenericRecord>(schema);
-    DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<GenericRecord>(datumWriter);
-    dataFileWriter.create(schema, dataFile);
-    dataFileWriter.append(user1);
-    dataFileWriter.append(user2);
-    dataFileWriter.close();
+    try (DataFileWriter<GenericRecord> dataFileWriter =
+        new DataFileWriter<GenericRecord>(datumWriter)) {
+      dataFileWriter.create(schema, dataFile);
+      dataFileWriter.append(user1);
+      dataFileWriter.append(user2);
+    }
 
     // read data from disk
     DatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>(schema);
-    DataFileReader<GenericRecord> dataFileReader =
-        new DataFileReader<GenericRecord>(dataFile, datumReader);
     List<GenericRecord> result = new ArrayList<>();
-    while (dataFileReader.hasNext()) {
-      GenericRecord user = dataFileReader.next();
-      result.add(user);
+    try (DataFileReader<GenericRecord> dataFileReader =
+        new DataFileReader<GenericRecord>(dataFile, datumReader)) {
+      while (dataFileReader.hasNext()) {
+        GenericRecord user = dataFileReader.next();
+        result.add(user);
+      }
     }
 
     assertEquals(2, result.size());

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
@@ -16,7 +16,7 @@
  */
 package org.apache.arrow.adapter.avro;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/adapter/avro/TestWriteReadAvroRecord.java
@@ -19,7 +19,6 @@ package org.apache.arrow.adapter.avro;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.Schema;
@@ -31,21 +30,16 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestWriteReadAvroRecord {
 
-  public static File dataFile;
-
-  @BeforeAll
-  public static void setup(@TempDir Path tempDir) {
-    dataFile = new File(tempDir.toFile(), "test.avro");
-  }
+  @TempDir public static File TMP;
 
   @Test
   public void testWriteAndRead() throws Exception {
+    File dataFile = new File(TMP, "test.avro");
     Schema schema = AvroTestBase.getSchema("test.avsc");
 
     // write data to disk

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
@@ -37,9 +37,9 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.util.ValueVectorUtility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Class to abstract out some common test functionality for testing JDBC to Arrow. */
 public abstract class AbstractJdbcToArrowTest {
@@ -94,7 +94,7 @@ public abstract class AbstractJdbcToArrowTest {
    * @throws SQLException on error
    * @throws ClassNotFoundException on error
    */
-  @Before
+  @BeforeEach
   public void setUp() throws SQLException, ClassNotFoundException {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     String url = "jdbc:h2:mem:JdbcToArrowTest";
@@ -114,7 +114,7 @@ public abstract class AbstractJdbcToArrowTest {
    *
    * @throws SQLException on error
    */
-  @After
+  @AfterEach
   public void destroy() throws SQLException {
     if (conn != null) {
       conn.close();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
@@ -92,7 +92,9 @@ public abstract class AbstractJdbcToArrowTest {
    * @throws SQLException on error
    * @throws ClassNotFoundException on error
    */
-  public void setUp() throws SQLException, ClassNotFoundException {
+  protected void initializeDatabase(Table table) throws SQLException, ClassNotFoundException {
+    this.table = table;
+
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     String url = "jdbc:h2:mem:JdbcToArrowTest";
     String driver = "org.h2.Driver";

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
@@ -149,7 +149,8 @@ public abstract class AbstractJdbcToArrowTest {
    * @throws SQLException on error
    * @throws IOException on error
    */
-  public abstract void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException;
+  public abstract void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException;
 
   /**
    * Abstract method to implement logic to assert test various datatype values.

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
@@ -38,8 +38,6 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.util.ValueVectorUtility;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 /** Class to abstract out some common test functionality for testing JDBC to Arrow. */
 public abstract class AbstractJdbcToArrowTest {
@@ -94,7 +92,6 @@ public abstract class AbstractJdbcToArrowTest {
    * @throws SQLException on error
    * @throws ClassNotFoundException on error
    */
-  @BeforeEach
   public void setUp() throws SQLException, ClassNotFoundException {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     String url = "jdbc:h2:mem:JdbcToArrowTest";
@@ -146,11 +143,11 @@ public abstract class AbstractJdbcToArrowTest {
   /**
    * Abstract method to implement test Functionality to test JdbcToArrow methods.
    *
+   * @param table Table object
    * @throws SQLException on error
    * @throws IOException on error
    */
-  @Test
-  public abstract void testJdbcToArrowValues() throws SQLException, IOException;
+  public abstract void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException;
 
   /**
    * Abstract method to implement logic to assert test various datatype values.

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcFieldInfoTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcFieldInfoTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.arrow.adapter.jdbc;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Types;
 import org.junit.Test;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcFieldInfoTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcFieldInfoTest.java
@@ -19,7 +19,8 @@ package org.apache.arrow.adapter.jdbc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Types;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class JdbcFieldInfoTest {
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcFieldInfoTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcFieldInfoTest.java
@@ -19,7 +19,6 @@ package org.apache.arrow.adapter.jdbc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Types;
-
 import org.junit.jupiter.api.Test;
 
 public class JdbcFieldInfoTest {

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowCommentMetadataTest.java
@@ -37,9 +37,9 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JdbcToArrowCommentMetadataTest {
 
@@ -53,7 +53,7 @@ public class JdbcToArrowCommentMetadataTest {
    * @throws SQLException on error
    * @throws ClassNotFoundException on error
    */
-  @Before
+  @BeforeEach
   public void setUp() throws SQLException, ClassNotFoundException {
     String url =
         "jdbc:h2:mem:JdbcToArrowTest?characterEncoding=UTF-8;INIT=runscript from 'classpath:/h2/comment.sql'";
@@ -62,7 +62,7 @@ public class JdbcToArrowCommentMetadataTest {
     conn = DriverManager.getConnection(url);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws SQLException {
     if (conn != null) {
       conn.close();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.arrow.adapter.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Types;
 import java.util.Calendar;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -40,16 +40,20 @@ public class JdbcToArrowConfigTest {
 
   @Test
   public void testConfigNullArguments() {
-    assertThrows(NullPointerException.class, () -> {
-      new JdbcToArrowConfig(null, null);
-    });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new JdbcToArrowConfig(null, null);
+        });
   }
 
   @Test
   public void testBuilderNullArguments() {
-    assertThrows(NullPointerException.class, () -> {
-      new JdbcToArrowConfigBuilder(null, null);
-    });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new JdbcToArrowConfigBuilder(null, null);
+        });
   }
 
   @Test
@@ -67,24 +71,30 @@ public class JdbcToArrowConfigTest {
 
   @Test
   public void testConfigNullAllocator() {
-    assertThrows(NullPointerException.class, () -> {
-      new JdbcToArrowConfig(null, calendar);
-    });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new JdbcToArrowConfig(null, calendar);
+        });
   }
 
   @Test
   public void testBuilderNullAllocator() {
-    assertThrows(NullPointerException.class, () -> {
-      new JdbcToArrowConfigBuilder(null, calendar);
-    });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new JdbcToArrowConfigBuilder(null, calendar);
+        });
   }
 
   @Test
   public void testSetNullAllocator() {
-    assertThrows(NullPointerException.class, () -> {
-      JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(allocator, calendar);
-      builder.setAllocator(null);
-    });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(allocator, calendar);
+          builder.setAllocator(null);
+        });
   }
 
   @Test

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Types;
@@ -29,7 +30,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JdbcToArrowConfigTest {
 
@@ -37,14 +38,18 @@ public class JdbcToArrowConfigTest {
   private static final Calendar calendar =
       Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testConfigNullArguments() {
-    new JdbcToArrowConfig(null, null);
+    assertThrows(NullPointerException.class, () -> {
+      new JdbcToArrowConfig(null, null);
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testBuilderNullArguments() {
-    new JdbcToArrowConfigBuilder(null, null);
+    assertThrows(NullPointerException.class, () -> {
+      new JdbcToArrowConfigBuilder(null, null);
+    });
   }
 
   @Test
@@ -60,20 +65,26 @@ public class JdbcToArrowConfigTest {
     assertNull(config.getCalendar());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testConfigNullAllocator() {
-    new JdbcToArrowConfig(null, calendar);
+    assertThrows(NullPointerException.class, () -> {
+      new JdbcToArrowConfig(null, calendar);
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testBuilderNullAllocator() {
-    new JdbcToArrowConfigBuilder(null, calendar);
+    assertThrows(NullPointerException.class, () -> {
+      new JdbcToArrowConfigBuilder(null, calendar);
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testSetNullAllocator() {
-    JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(allocator, calendar);
-    builder.setAllocator(null);
+    assertThrows(NullPointerException.class, () -> {
+      JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(allocator, calendar);
+      builder.setAllocator(null);
+    });
   }
 
   @Test

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
@@ -16,10 +16,10 @@
  */
 package org.apache.arrow.adapter.jdbc;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.arrow.adapter.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -44,14 +44,11 @@ public class ResultSetUtilityTest {
                 .build();
 
         ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, config);
-        assertTrue("Iterator on zero row ResultSet should haveNext() before use", iter.hasNext());
+        assertTrue(iter.hasNext(), "Iterator on zero row ResultSet should haveNext() before use");
         VectorSchemaRoot root = iter.next();
-        assertNotNull("VectorSchemaRoot from first next() result should never be null", root);
-        assertEquals(
-            "VectorSchemaRoot from empty ResultSet should have zero rows", 0, root.getRowCount());
-        assertFalse(
-            "hasNext() should return false on empty ResultSets after initial next() call",
-            iter.hasNext());
+        assertNotNull(root, "Iterator on zero row ResultSet should haveNext() before use");
+        assertEquals(0, root.getRowCount(), "VectorSchemaRoot from empty ResultSet should have zero rows");
+        assertFalse(iter.hasNext(), "hasNext() should return false on empty ResultSets after initial next() call");
       }
     }
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
@@ -28,7 +28,7 @@ import java.sql.Types;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests of the ResultSetUtility. */
 public class ResultSetUtilityTest {

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
@@ -47,8 +47,11 @@ public class ResultSetUtilityTest {
         assertTrue(iter.hasNext(), "Iterator on zero row ResultSet should haveNext() before use");
         VectorSchemaRoot root = iter.next();
         assertNotNull(root, "VectorSchemaRoot from first next() result should never be null");
-        assertEquals(0, root.getRowCount(), "VectorSchemaRoot from empty ResultSet should have zero rows");
-        assertFalse(iter.hasNext(), "hasNext() should return false on empty ResultSets after initial next() call");
+        assertEquals(
+            0, root.getRowCount(), "VectorSchemaRoot from empty ResultSet should have zero rows");
+        assertFalse(
+            iter.hasNext(),
+            "hasNext() should return false on empty ResultSets after initial next() call");
       }
     }
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/ResultSetUtilityTest.java
@@ -46,7 +46,7 @@ public class ResultSetUtilityTest {
         ArrowVectorIterator iter = JdbcToArrow.sqlToArrowVectorIterator(rs, config);
         assertTrue(iter.hasNext(), "Iterator on zero row ResultSet should haveNext() before use");
         VectorSchemaRoot root = iter.next();
-        assertNotNull(root, "Iterator on zero row ResultSet should haveNext() before use");
+        assertNotNull(root, "VectorSchemaRoot from first next() result should never be null");
         assertEquals(0, root.getRowCount(), "VectorSchemaRoot from empty ResultSet should have zero rows");
         assertFalse(iter.hasNext(), "hasNext() should return false on empty ResultSets after initial next() call");
       }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
@@ -40,9 +40,9 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -56,12 +56,12 @@ public class UnreliableMetaDataTest {
     this.reuseVectorSchemaRoot = reuseVectorSchemaRoot;
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     allocator = new RootAllocator();
   }
 
-  @After
+  @AfterEach
   public void afterEach() {
     allocator.close();
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.arrow.adapter.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -75,15 +75,15 @@ public class UnreliableMetaDataTest {
   public void testUnreliableMetaDataPrecisionAndScale() throws Exception {
     ResultSet rs = buildIncorrectPrecisionAndScaleMetaDataResultSet();
     ResultSetMetaData rsmd = rs.getMetaData();
-    assertEquals("Column type should be Types.DECIMAL", Types.DECIMAL, rsmd.getColumnType(1));
-    assertEquals("Column scale should be zero", 0, rsmd.getScale(1));
-    assertEquals("Column precision should be zero", 0, rsmd.getPrecision(1));
+    assertEquals(Types.DECIMAL, rsmd.getColumnType(1), "Column type should be Types.DECIMAL");
+    assertEquals(0, rsmd.getScale(1), "Column scale should be zero");
+    assertEquals(0, rsmd.getPrecision(1), "Column precision should be zero");
     rs.next();
     BigDecimal bd1 = rs.getBigDecimal(1);
-    assertEquals("Value should be 1000000000000000.01", new BigDecimal("1000000000000000.01"), bd1);
-    assertEquals("Value scale should be 2", 2, bd1.scale());
-    assertEquals("Value precision should be 18", 18, bd1.precision());
-    assertFalse("No more rows!", rs.next());
+    assertEquals(new BigDecimal("1000000000000000.01"), bd1, "Value should be 1000000000000000.01");
+    assertEquals(2, bd1.scale(), "Value scale should be 2");
+    assertEquals(18, bd1.precision(), "Value precision should be 18");
+    assertFalse(rs.next(), "No more rows!");
 
     // reset the ResultSet:
     rs.beforeFirst();
@@ -122,20 +122,19 @@ public class UnreliableMetaDataTest {
   public void testInconsistentPrecisionAndScale() throws Exception {
     ResultSet rs = buildVaryingPrecisionAndScaleResultSet();
     ResultSetMetaData rsmd = rs.getMetaData();
-    assertEquals("Column type should be Types.DECIMAL", Types.DECIMAL, rsmd.getColumnType(1));
-    assertEquals("Column scale should be zero", 0, rsmd.getScale(1));
-    assertEquals("Column precision should be zero", 0, rsmd.getPrecision(1));
+    assertEquals(Types.DECIMAL, rsmd.getColumnType(1), "Column type should be Types.DECIMAL");
+    assertEquals(0, rsmd.getScale(1), "Column scale should be zero");
+    assertEquals(0, rsmd.getPrecision(1), "Column precision should be zero");
     rs.next();
     BigDecimal bd1 = rs.getBigDecimal(1);
-    assertEquals("Value should be 1000000000000000.01", new BigDecimal("1000000000000000.01"), bd1);
-    assertEquals("Value scale should be 2", 2, bd1.scale());
-    assertEquals("Value precision should be 18", 18, bd1.precision());
+    assertEquals(new BigDecimal("1000000000000000.01"), bd1, "Value should be 1000000000000000.01");
+    assertEquals(2, bd1.scale(), "Value scale should be 2");
+    assertEquals(18, bd1.precision(), "Value precision should be 18");
     rs.next();
     BigDecimal bd2 = rs.getBigDecimal(1);
-    assertEquals(
-        "Value should be 1000000000300.0000001", new BigDecimal("1000000000300.0000001"), bd2);
-    assertEquals("Value scale should be 7", 7, bd2.scale());
-    assertEquals("Value precision should be 20", 20, bd2.precision());
+    assertEquals(new BigDecimal("1000000000300.0000001"), bd2, "Value should be 1000000000300.0000001");
+    assertEquals(7, bd2.scale(), "Value scale should be 7");
+    assertEquals(20, bd2.precision(), "Value precision should be 20");
     rs.beforeFirst();
     JdbcFieldInfo explicitMappingField = new JdbcFieldInfo(Types.DECIMAL, 20, 7);
     Map<Integer, JdbcFieldInfo> explicitMapping = new HashMap<>();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/UnreliableMetaDataTest.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -62,12 +61,13 @@ public class UnreliableMetaDataTest {
   }
 
   public static Stream<Arguments> getTestData() {
-    return Arrays.stream(new Object[][] { {false}, {true} }).map(Arguments::of);
+    return Arrays.stream(new Object[][] {{false}, {true}}).map(Arguments::of);
   }
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testUnreliableMetaDataPrecisionAndScale(boolean reuseVectorSchemaRoot) throws Exception {
+  public void testUnreliableMetaDataPrecisionAndScale(boolean reuseVectorSchemaRoot)
+      throws Exception {
     ResultSet rs = buildIncorrectPrecisionAndScaleMetaDataResultSet();
     ResultSetMetaData rsmd = rs.getMetaData();
     assertEquals(Types.DECIMAL, rsmd.getColumnType(1), "Column type should be Types.DECIMAL");
@@ -128,7 +128,8 @@ public class UnreliableMetaDataTest {
     assertEquals(18, bd1.precision(), "Value precision should be 18");
     rs.next();
     BigDecimal bd2 = rs.getBigDecimal(1);
-    assertEquals(new BigDecimal("1000000000300.0000001"), bd2, "Value should be 1000000000300.0000001");
+    assertEquals(
+        new BigDecimal("1000000000300.0000001"), bd2, "Value should be 1000000000300.0000001");
     assertEquals(7, bd2.scale(), "Value scale should be 7");
     assertEquals(20, bd2.precision(), "Value precision should be 20");
     rs.beforeFirst();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/AbstractConsumerTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/AbstractConsumerTest.java
@@ -18,19 +18,19 @@ package org.apache.arrow.adapter.jdbc.consumer;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractConsumerTest {
 
   protected BufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     allocator = new RootAllocator(Long.MAX_VALUE);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     allocator.close();
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumerTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumerTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.arrow.adapter.jdbc.consumer;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumerTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumerTest.java
@@ -24,7 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BinaryConsumerTest extends AbstractConsumerTest {
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcAliasToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcAliasToArrowTest.java
@@ -17,7 +17,7 @@
 package org.apache.arrow.adapter.jdbc.h2;
 
 import static org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest.sqlToArrow;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcAliasToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcAliasToArrowTest.java
@@ -31,9 +31,9 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JdbcAliasToArrowTest {
   private Connection conn = null;
@@ -46,7 +46,7 @@ public class JdbcAliasToArrowTest {
   private static final String COLUMN_A = "A";
   private static final String COLUMN_B = "B";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     String url = "jdbc:h2:mem:JdbcAliasToArrowTest";
     String driver = "org.h2.Driver";
@@ -110,7 +110,7 @@ public class JdbcAliasToArrowTest {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws SQLException {
     try (Statement stmt = conn.createStatement()) {
       stmt.executeUpdate(DROP_STATEMENT);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowArrayTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowArrayTest.java
@@ -17,9 +17,9 @@
 package org.apache.arrow.adapter.jdbc.h2;
 
 import static org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest.sqlToArrow;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Array;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowArrayTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowArrayTest.java
@@ -44,9 +44,9 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JdbcToArrowArrayTest {
   private Connection conn = null;
@@ -66,7 +66,7 @@ public class JdbcToArrowArrayTest {
   private static final String FLOAT_ARRAY_FIELD_NAME = "FLOAT_ARRAY";
   private static final String STRING_ARRAY_FIELD_NAME = "STRING_ARRAY";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     String url = "jdbc:h2:mem:JdbcToArrowTest";
     String driver = "org.h2.Driver";
@@ -294,7 +294,7 @@ public class JdbcToArrowArrayTest {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws SQLException {
     try (Statement stmt = conn.createStatement()) {
       stmt.executeUpdate(DROP_STATEMENT);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
@@ -28,7 +28,6 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.stream.Stream;
-
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -63,7 +62,7 @@ public class JdbcToArrowCharSetTest extends AbstractJdbcToArrowTest {
     String driver = "org.h2.Driver";
     Class.forName(driver);
     conn = DriverManager.getConnection(url);
-    try (Statement stmt = conn.createStatement();) {
+    try (Statement stmt = conn.createStatement(); ) {
       stmt.executeUpdate(table.getCreate());
       for (String insert : table.getData()) {
         stmt.executeUpdate(insert);
@@ -79,8 +78,10 @@ public class JdbcToArrowCharSetTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowCharSetTest.class)).map(Arguments::of);
+  public static Stream<Arguments> getTestData()
+      throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowCharSetTest.class))
+        .map(Arguments::of);
   }
 
   /**
@@ -89,11 +90,14 @@ public class JdbcToArrowCharSetTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance()), false);
+    testDataSets(
+        sqlToArrow(
+            conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance()),
+        false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
     testDataSets(
         sqlToArrow(
@@ -132,7 +136,8 @@ public class JdbcToArrowCharSetTest extends AbstractJdbcToArrowTest {
   public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true).build();
+    JdbcToArrowConfig config =
+        new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true).build();
     ResultSetMetaData rsmd = conn.createStatement().executeQuery(table.getQuery()).getMetaData();
     Schema schema = JdbcToArrowUtils.jdbcToArrowSchema(rsmd, config);
     JdbcToArrowTestHelper.assertFieldMetadataMatchesResultSetMetadata(rsmd, schema);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
@@ -55,6 +55,7 @@ public class JdbcToArrowCharSetTest extends AbstractJdbcToArrowTest {
     "h2/test1_charset_kr_h2.yml"
   };
 
+  @Override
   public void initializeDatabase(Table table) throws SQLException, ClassNotFoundException {
     this.table = table;
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
@@ -38,8 +38,8 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -73,7 +73,7 @@ public class JdbcToArrowCharSetTest extends AbstractJdbcToArrowTest {
    * @throws SQLException on error
    * @throws ClassNotFoundException on error
    */
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws SQLException, ClassNotFoundException {
     String url = "jdbc:h2:mem:JdbcToArrowTest?characterEncoding=UTF-8";

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
@@ -64,7 +64,6 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -134,7 +133,9 @@ public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
         Calendar.getInstance()), false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
@@ -172,12 +173,14 @@ public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
         false);
   }
 
-  @Test
-  public void testJdbcSchemaMetadata() throws SQLException {
-    JdbcToArrowConfig config =
-        new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
-            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
-            .build();
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
+    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
+        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
+        .build();
     ResultSetMetaData rsmd = conn.createStatement().executeQuery(table.getQuery()).getMetaData();
     Schema schema = JdbcToArrowUtils.jdbcToArrowSchema(rsmd, config);
     JdbcToArrowTestHelper.assertFieldMetadataMatchesResultSetMetadata(rsmd, schema);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
@@ -63,7 +63,7 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
@@ -39,7 +39,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.stream.Stream;
-
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -124,20 +123,23 @@ public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowMapDataTypeTest.class)).map(Arguments::of);
+  public static Stream<Arguments> getTestData()
+      throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowMapDataTypeTest.class))
+        .map(Arguments::of);
   }
 
-  /**
-   * Test Method to test JdbcToArrow Functionality for various H2 DB based datatypes.
-   */
+  /** Test Method to test JdbcToArrow Functionality for various H2 DB based datatypes. */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance()), false);
+    testDataSets(
+        sqlToArrow(
+            conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance()),
+        false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
     testDataSets(
         sqlToArrow(
@@ -178,9 +180,10 @@ public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
   public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
-        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
-        .build();
+    JdbcToArrowConfig config =
+        new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
+            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
+            .build();
     ResultSetMetaData rsmd = conn.createStatement().executeQuery(table.getQuery()).getMetaData();
     Schema schema = JdbcToArrowUtils.jdbcToArrowSchema(rsmd, config);
     JdbcToArrowTestHelper.assertFieldMetadataMatchesResultSetMetadata(rsmd, schema);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
@@ -38,7 +38,8 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
+import java.util.stream.Stream;
+
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -64,15 +65,14 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * JUnit Test Class which contains methods to test JDBC to Arrow data conversion functionality with
  * various data types for H2 database using multiple test data files.
  */
-@RunWith(Parameterized.class)
 public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
 
   private static final String BIGINT = "big_int";
@@ -118,15 +118,6 @@ public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
   };
 
   /**
-   * Constructor which populates the table object for each test iteration.
-   *
-   * @param table Table object
-   */
-  public JdbcToArrowDataTypesTest(Table table) {
-    this.table = table;
-  }
-
-  /**
    * Get the test data as a collection of Table objects for each test iteration.
    *
    * @return Collection of Table objects
@@ -134,20 +125,18 @@ public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  @Parameters
-  public static Collection<Object[]> getTestData()
-      throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.asList(prepareTestData(testFiles, JdbcToArrowDataTypesTest.class));
+  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowMapDataTypeTest.class)).map(Arguments::of);
   }
 
-  /** Test Method to test JdbcToArrow Functionality for various H2 DB based datatypes. */
-  @Test
-  @Override
-  public void testJdbcToArrowValues() throws SQLException, IOException {
-    testDataSets(
-        sqlToArrow(
-            conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance()),
-        false);
+  /**
+   * Test Method to test JdbcToArrow Functionality for various H2 DB based datatypes.
+   */
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
+        Calendar.getInstance()), false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
     testDataSets(
         sqlToArrow(

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
@@ -23,24 +23,32 @@ import java.io.IOException;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Calendar;
+import java.util.stream.Stream;
+
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
+import org.apache.arrow.adapter.jdbc.Table;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.MapVector;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /** Test MapConsumer with OTHER jdbc type. */
 public class JdbcToArrowMapDataTypeTest extends AbstractJdbcToArrowTest {
 
-  public JdbcToArrowMapDataTypeTest() throws IOException {
-    this.table = getTable("h2/test1_map_h2.yml", JdbcToArrowMapDataTypeTest.class);
+  public static Stream<Arguments> getTestData() throws IOException {
+    return Stream.of(Arguments.of(getTable("h2/test1_map_h2.yml", JdbcToArrowMapDataTypeTest.class)));
   }
 
-  /** Test Method to test JdbcToArrow Functionality for Map form Types.OTHER column */
-  @Test
-  @Override
-  public void testJdbcToArrowValues() throws SQLException, IOException {
+  /**
+   * Test Method to test JdbcToArrow Functionality for Map form Types.OTHER column
+   */
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+    this.table = getTable("h2/test1_map_h2.yml", JdbcToArrowMapDataTypeTest.class);
     Calendar calendar = Calendar.getInstance();
     ResultSetMetaData rsmd = getQueryMetaData(table.getQuery());
     testDataSets(

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
@@ -50,7 +50,6 @@ public class JdbcToArrowMapDataTypeTest extends AbstractJdbcToArrowTest {
   public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    this.table = getTable("h2/test1_map_h2.yml", JdbcToArrowMapDataTypeTest.class);
     Calendar calendar = Calendar.getInstance();
     ResultSetMetaData rsmd = getQueryMetaData(table.getQuery());
     testDataSets(

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
@@ -24,7 +24,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.stream.Stream;
-
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
 import org.apache.arrow.adapter.jdbc.Table;
@@ -39,15 +38,15 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class JdbcToArrowMapDataTypeTest extends AbstractJdbcToArrowTest {
 
   public static Stream<Arguments> getTestData() throws IOException {
-    return Stream.of(Arguments.of(getTable("h2/test1_map_h2.yml", JdbcToArrowMapDataTypeTest.class)));
+    return Stream.of(
+        Arguments.of(getTable("h2/test1_map_h2.yml", JdbcToArrowMapDataTypeTest.class)));
   }
 
-  /**
-   * Test Method to test JdbcToArrow Functionality for Map form Types.OTHER column
-   */
+  /** Test Method to test JdbcToArrow Functionality for Map form Types.OTHER column */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
     Calendar calendar = Calendar.getInstance();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
@@ -28,7 +28,7 @@ import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.MapVector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Test MapConsumer with OTHER jdbc type. */
 public class JdbcToArrowMapDataTypeTest extends AbstractJdbcToArrowTest {

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowMapDataTypeTest.java
@@ -47,7 +47,9 @@ public class JdbcToArrowMapDataTypeTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     this.table = getTable("h2/test1_map_h2.yml", JdbcToArrowMapDataTypeTest.class);
     Calendar calendar = Calendar.getInstance();
     ResultSetMetaData rsmd = getQueryMetaData(table.getQuery());

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
@@ -75,7 +75,6 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -114,7 +113,9 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
         Calendar.getInstance()), false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
@@ -156,12 +157,14 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
         true);
   }
 
-  @Test
-  public void testJdbcSchemaMetadata() throws SQLException {
-    JdbcToArrowConfig config =
-        new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
-            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
-            .build();
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
+    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
+        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
+        .build();
     ResultSetMetaData rsmd = conn.createStatement().executeQuery(table.getQuery()).getMetaData();
     Schema schema = JdbcToArrowUtils.jdbcToArrowSchema(rsmd, config);
     JdbcToArrowTestHelper.assertFieldMetadataMatchesResultSetMetadata(rsmd, schema);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
@@ -49,7 +49,8 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
+import java.util.stream.Stream;
+
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -75,15 +76,14 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * JUnit Test Class which contains methods to test JDBC to Arrow data conversion functionality with
  * null values for H2 database.
  */
-@RunWith(Parameterized.class)
 public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
 
   private static final String NULL = "null";
@@ -97,15 +97,6 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
   };
 
   /**
-   * Constructor which populates the table object for each test iteration.
-   *
-   * @param table Table object
-   */
-  public JdbcToArrowNullTest(Table table) {
-    this.table = table;
-  }
-
-  /**
    * Get the test data as a collection of Table objects for each test iteration.
    *
    * @return Collection of Table objects
@@ -113,23 +104,19 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  @Parameters
-  public static Collection<Object[]> getTestData()
-      throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.asList(prepareTestData(testFiles, JdbcToArrowNullTest.class));
+  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowNullTest.class)).map(Arguments::of);
   }
 
   /**
    * Test Method to test JdbcToArrow Functionality for various H2 DB based datatypes with null
    * values.
    */
-  @Test
-  @Override
-  public void testJdbcToArrowValues() throws SQLException, IOException {
-    testDataSets(
-        sqlToArrow(
-            conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance()),
-        false);
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
+        Calendar.getInstance()), false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
     testDataSets(
         sqlToArrow(

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
@@ -50,7 +50,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.stream.Stream;
-
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -103,7 +102,8 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
+  public static Stream<Arguments> getTestData()
+      throws SQLException, ClassNotFoundException, IOException {
     return Arrays.stream(prepareTestData(testFiles, JdbcToArrowNullTest.class)).map(Arguments::of);
   }
 
@@ -113,11 +113,14 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance()), false);
+    testDataSets(
+        sqlToArrow(
+            conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance()),
+        false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
     testDataSets(
         sqlToArrow(
@@ -162,9 +165,10 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
   public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
-        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
-        .build();
+    JdbcToArrowConfig config =
+        new JdbcToArrowConfigBuilder(new RootAllocator(0), Calendar.getInstance(), true)
+            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
+            .build();
     ResultSetMetaData rsmd = conn.createStatement().executeQuery(table.getQuery()).getMetaData();
     Schema schema = JdbcToArrowUtils.jdbcToArrowSchema(rsmd, config);
     JdbcToArrowTestHelper.assertFieldMetadataMatchesResultSetMetadata(rsmd, schema);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
@@ -74,7 +74,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
@@ -17,7 +17,7 @@
 package org.apache.arrow.adapter.jdbc.h2;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.sql.SQLException;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
@@ -58,7 +58,9 @@ public class JdbcToArrowOptionalColumnsTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
   }
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
@@ -22,32 +22,23 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
+
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper;
 import org.apache.arrow.adapter.jdbc.Table;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * JUnit Test Class which contains methods to test JDBC to Arrow data conversion functionality for
  * (non-)optional columns, in particular with regard to the ensuing VectorSchemaRoot's schema.
  */
-@RunWith(Parameterized.class)
 public class JdbcToArrowOptionalColumnsTest extends AbstractJdbcToArrowTest {
   private static final String[] testFiles = {"h2/test1_null_and_notnull.yml"};
-
-  /**
-   * Constructor which populates the table object for each test iteration.
-   *
-   * @param table Table object
-   */
-  public JdbcToArrowOptionalColumnsTest(Table table) {
-    this.table = table;
-  }
 
   /**
    * Get the test data as a collection of Table objects for each test iteration.
@@ -57,19 +48,17 @@ public class JdbcToArrowOptionalColumnsTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  @Parameterized.Parameters
-  public static Collection<Object[]> getTestData()
-      throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.asList(prepareTestData(testFiles, JdbcToArrowOptionalColumnsTest.class));
+  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowOptionalColumnsTest.class)).map(Arguments::of);
   }
 
   /**
    * Test Method to test JdbcToArrow Functionality for dealing with nullable and non-nullable
    * columns.
    */
-  @Test
-  @Override
-  public void testJdbcToArrowValues() throws SQLException, IOException {
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
   }
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.stream.Stream;
-
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper;
 import org.apache.arrow.adapter.jdbc.Table;
@@ -48,8 +47,10 @@ public class JdbcToArrowOptionalColumnsTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowOptionalColumnsTest.class)).map(Arguments::of);
+  public static Stream<Arguments> getTestData()
+      throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowOptionalColumnsTest.class))
+        .map(Arguments::of);
   }
 
   /**
@@ -58,7 +59,8 @@ public class JdbcToArrowOptionalColumnsTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowOptionalColumnsTest.java
@@ -28,7 +28,7 @@ import org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper;
 import org.apache.arrow.adapter.jdbc.Table;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -131,7 +131,8 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
+  public void testJdbcSchemaMetadata(Table table, boolean reuseVectorSchemaRoot)
+      throws SQLException, ClassNotFoundException {
     this.initializeDatabase(table);
 
     Calendar calendar = Calendar.getInstance();
@@ -254,7 +255,8 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void runLargeNumberOfRows(Table table) throws IOException, SQLException, ClassNotFoundException {
+  public void runLargeNumberOfRows(Table table, boolean reuseVectorSchemaRoot)
+      throws IOException, SQLException, ClassNotFoundException {
     this.initializeDatabase(table);
 
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -17,7 +17,7 @@
 package org.apache.arrow.adapter.jdbc.h2;
 
 import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.sql.ResultSet;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -55,7 +55,6 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -67,17 +66,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
   private static final String[] testFiles = {"h2/test1_all_datatypes_h2.yml"};
-
-  /**
-   * Constructor which populates the table object for each test iteration.
-   *
-   * @param table Table object
-   * @param reuseVectorSchemaRoot A flag indicating if we should reuse vector schema roots.
-   */
-  public JdbcToArrowTest(Table table, boolean reuseVectorSchemaRoot) {
-    this.table = table;
-    this.reuseVectorSchemaRoot = reuseVectorSchemaRoot;
-  }
 
   /**
    * Get the test data as a collection of Table objects for each test iteration.
@@ -98,7 +86,9 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
         Calendar.getInstance()), false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
@@ -139,8 +129,11 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
         true);
   }
 
-  @Test
-  public void testJdbcSchemaMetadata() throws SQLException {
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     Calendar calendar = Calendar.getInstance();
     ResultSetMetaData rsmd = getQueryMetaData(table.getQuery());
     JdbcToArrowConfig config =
@@ -259,8 +252,11 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
     }
   }
 
-  @Test
-  public void runLargeNumberOfRows() throws IOException, SQLException {
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void runLargeNumberOfRows(Table table) throws IOException, SQLException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
     int x = 0;
     final int targetRows = 600000;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -75,7 +75,8 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
+  public static Stream<Arguments> getTestData()
+      throws SQLException, ClassNotFoundException, IOException {
     return Arrays.stream(prepareTestData(testFiles, JdbcToArrowTest.class))
         .flatMap(row -> Stream.of(Arguments.of(row[0], true), Arguments.of(row[0], false)));
   }
@@ -86,11 +87,14 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance()), false);
+    testDataSets(
+        sqlToArrow(
+            conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance()),
+        false);
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE)), false);
     testDataSets(
         sqlToArrow(

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -57,7 +57,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
@@ -39,7 +39,7 @@ import org.apache.arrow.vector.TimeMilliVector;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
@@ -40,7 +40,6 @@ import org.apache.arrow.vector.TimeMilliVector;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -91,8 +90,9 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
-    this.table = table;
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
         Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))), false);
     testDataSets(sqlToArrow(conn.createStatement().executeQuery(table.getQuery()),
@@ -132,8 +132,11 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
         false);
   }
 
-  @Test
-  public void testJdbcSchemaMetadata() throws SQLException {
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcSchemaMetadata(Table table) throws SQLException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()));
     JdbcToArrowConfig config =
         new JdbcToArrowConfigBuilder(new RootAllocator(0), calendar, true).build();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
@@ -123,25 +123,6 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
         false);
     testDataSets(
         sqlToArrow(
-            conn.createStatement().executeQuery(table.getQuery()),
-            new RootAllocator(Integer.MAX_VALUE),
-            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))),
-        false);
-    testDataSets(
-        sqlToArrow(
-            conn.createStatement().executeQuery(table.getQuery()),
-            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))),
-        false);
-    testDataSets(
-        sqlToArrow(
-            conn.createStatement().executeQuery(table.getQuery()),
-            new JdbcToArrowConfigBuilder(
-                    new RootAllocator(Integer.MAX_VALUE),
-                    Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone())))
-                .build()),
-        false);
-    testDataSets(
-        sqlToArrow(
             conn,
             table.getQuery(),
             new JdbcToArrowConfigBuilder(

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
@@ -25,8 +25,9 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.TimeZone;
+import java.util.stream.Stream;
+
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -40,15 +41,14 @@ import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * JUnit Test Class which contains methods to test JDBC to Arrow data conversion functionality with
  * TimeZone based Date, Time and Timestamp datatypes for H2 database.
  */
-@RunWith(Parameterized.class)
 public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
 
   private static final String EST_DATE = "est_date";
@@ -74,15 +74,6 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
   };
 
   /**
-   * Constructor which populates the table object for each test iteration.
-   *
-   * @param table Table object
-   */
-  public JdbcToArrowTimeZoneTest(Table table) {
-    this.table = table;
-  }
-
-  /**
    * Get the test data as a collection of Table objects for each test iteration.
    *
    * @return Collection of Table objects
@@ -90,26 +81,27 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  @Parameters
-  public static Collection<Object[]> getTestData()
-      throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.asList(prepareTestData(testFiles, JdbcToArrowTimeZoneTest.class));
+  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowTimeZoneTest.class)).map(Arguments::of);
   }
 
   /**
    * Test Method to test JdbcToArrow Functionality for various H2 DB based datatypes with TimeZone
    * based Date, Time and Timestamp datatype.
    */
-  @Test
-  @Override
-  public void testJdbcToArrowValues() throws SQLException, IOException {
-    testDataSets(
-        sqlToArrow(
-            conn,
-            table.getQuery(),
-            new RootAllocator(Integer.MAX_VALUE),
-            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))),
-        false);
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException {
+    this.table = table;
+    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
+        Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))), false);
+    testDataSets(sqlToArrow(conn.createStatement().executeQuery(table.getQuery()),
+        new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))), false);
+    testDataSets(sqlToArrow(conn.createStatement().executeQuery(table.getQuery()),
+        Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))), false);
+    testDataSets(sqlToArrow(conn.createStatement().executeQuery(table.getQuery()),
+        new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
+            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))).build()), false);
     testDataSets(
         sqlToArrow(
             conn.createStatement().executeQuery(table.getQuery()),

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.stream.Stream;
-
 import org.apache.arrow.adapter.jdbc.AbstractJdbcToArrowTest;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
@@ -80,8 +79,10 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
    * @throws ClassNotFoundException on error
    * @throws IOException on error
    */
-  public static Stream<Arguments> getTestData() throws SQLException, ClassNotFoundException, IOException {
-    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowTimeZoneTest.class)).map(Arguments::of);
+  public static Stream<Arguments> getTestData()
+      throws SQLException, ClassNotFoundException, IOException {
+    return Arrays.stream(prepareTestData(testFiles, JdbcToArrowTimeZoneTest.class))
+        .map(Arguments::of);
   }
 
   /**
@@ -90,18 +91,36 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
    */
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    testDataSets(sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))), false);
-    testDataSets(sqlToArrow(conn.createStatement().executeQuery(table.getQuery()),
-        new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))), false);
-    testDataSets(sqlToArrow(conn.createStatement().executeQuery(table.getQuery()),
-        Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))), false);
-    testDataSets(sqlToArrow(conn.createStatement().executeQuery(table.getQuery()),
-        new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
-            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))).build()), false);
+    testDataSets(
+        sqlToArrow(
+            conn,
+            table.getQuery(),
+            new RootAllocator(Integer.MAX_VALUE),
+            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))),
+        false);
+    testDataSets(
+        sqlToArrow(
+            conn.createStatement().executeQuery(table.getQuery()),
+            new RootAllocator(Integer.MAX_VALUE),
+            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))),
+        false);
+    testDataSets(
+        sqlToArrow(
+            conn.createStatement().executeQuery(table.getQuery()),
+            Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone()))),
+        false);
+    testDataSets(
+        sqlToArrow(
+            conn.createStatement().executeQuery(table.getQuery()),
+            new JdbcToArrowConfigBuilder(
+                    new RootAllocator(Integer.MAX_VALUE),
+                    Calendar.getInstance(TimeZone.getTimeZone(table.getTimezone())))
+                .build()),
+        false);
     testDataSets(
         sqlToArrow(
             conn.createStatement().executeQuery(table.getQuery()),

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -69,30 +69,21 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
-  /**
-   * Constructor which populates the table object for each test iteration.
-   *
-   * @param table Table object
-   * @param reuseVectorSchemaRoot A flag indicating if we should reuse vector schema roots.
-   */
-  public JdbcToArrowVectorIteratorTest(Table table, boolean reuseVectorSchemaRoot) {
-    super(table, reuseVectorSchemaRoot);
-  }
-
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues() throws SQLException, IOException {
-    JdbcToArrowConfig config =
-        new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance())
-            .setTargetBatchSize(3)
-            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
-            .build();
+  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
+    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
+        Calendar.getInstance())
+        .setTargetBatchSize(3)
+        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
+        .build();
 
     ArrowVectorIterator iterator =
         JdbcToArrow.sqlToArrowVectorIterator(
@@ -101,8 +92,11 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
     validate(iterator);
   }
 
-  @Test
-  public void testVectorSchemaRootReuse() throws SQLException, IOException {
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testVectorSchemaRootReuse(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     Integer[][] intValues = {
       {101, 102, 103},
       {104, null, null},
@@ -174,8 +168,10 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
     assertTrue(batchCount > 1);
   }
 
-  @Test
-  public void testJdbcToArrowValuesNoLimit() throws SQLException, IOException {
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcToArrowValuesNoLimit(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
 
     JdbcToArrowConfig config =
         new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance())
@@ -190,8 +186,11 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
     validate(iterator);
   }
 
-  @Test
-  public void testTimeStampConsumer() throws SQLException, IOException {
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testTimeStampConsumer(Table table) throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
     final String sql = "select timestamp_field11 from table1";
 
     // first experiment, with calendar and time zone.
@@ -534,13 +533,16 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
     return result;
   }
 
-  @Test
-  public void testJdbcToArrowCustomTypeConversion() throws SQLException, IOException {
-    JdbcToArrowConfigBuilder builder =
-        new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance())
-            .setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE)
-            .setReuseVectorSchemaRoot(reuseVectorSchemaRoot)
-            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP);
+  @ParameterizedTest
+  @MethodSource("getTestData")
+  public void testJdbcToArrowCustomTypeConversion(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
+    this.initializeDatabase(table);
+
+    JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
+        Calendar.getInstance()).setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE)
+        .setReuseVectorSchemaRoot(reuseVectorSchemaRoot)
+        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP);
 
     // first experiment, using default type converter
     JdbcToArrowConfig config = builder.build();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -25,11 +25,11 @@ import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getFloatValues
 import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getIntValues;
 import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getListValues;
 import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getLongValues;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -76,14 +76,15 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValues(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValues(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance())
-        .setTargetBatchSize(3)
-        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
-        .build();
+    JdbcToArrowConfig config =
+        new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance())
+            .setTargetBatchSize(3)
+            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP)
+            .build();
 
     ArrowVectorIterator iterator =
         JdbcToArrow.sqlToArrowVectorIterator(
@@ -171,7 +172,8 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowValuesNoLimit(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testJdbcToArrowValuesNoLimit(Table table)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
     JdbcToArrowConfig config =
@@ -541,10 +543,11 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
       throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
-    JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
-        Calendar.getInstance()).setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE)
-        .setReuseVectorSchemaRoot(reuseVectorSchemaRoot)
-        .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP);
+    JdbcToArrowConfigBuilder builder =
+        new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance())
+            .setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE)
+            .setReuseVectorSchemaRoot(reuseVectorSchemaRoot)
+            .setArraySubTypeByColumnNameMap(ARRAY_SUB_TYPE_BY_COLUMN_NAME_MAP);
 
     // first experiment, using default type converter
     JdbcToArrowConfig config = builder.build();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -70,10 +70,9 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
   /**
@@ -86,8 +85,8 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
     super(table, reuseVectorSchemaRoot);
   }
 
-  @Test
-  @Override
+  @ParameterizedTest
+  @MethodSource("getTestData")
   public void testJdbcToArrowValues() throws SQLException, IOException {
     JdbcToArrowConfig config =
         new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE), Calendar.getInstance())

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -94,7 +94,8 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testVectorSchemaRootReuse(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testVectorSchemaRootReuse(Table table, boolean reuseVectorSchemaRoot)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
     Integer[][] intValues = {
@@ -188,7 +189,8 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testTimeStampConsumer(Table table) throws SQLException, IOException, ClassNotFoundException {
+  public void testTimeStampConsumer(Table table, boolean reuseVectorSchemaRoot)
+      throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 
     final String sql = "select timestamp_field11 from table1";
@@ -535,7 +537,7 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
   @ParameterizedTest
   @MethodSource("getTestData")
-  public void testJdbcToArrowCustomTypeConversion(Table table)
+  public void testJdbcToArrowCustomTypeConversion(Table table, boolean reuseVectorSchemaRoot)
       throws SQLException, IOException, ClassNotFoundException {
     this.initializeDatabase(table);
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -69,7 +69,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
+++ b/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
@@ -44,8 +43,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class OrcReaderTest {
 
-  @TempDir
-  public File testFolder;
+  @TempDir public File testFolder;
 
   private static final int MAX_ALLOCATION = 8 * 1024;
   private static RootAllocator allocator;

--- a/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
+++ b/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class OrcReaderTest {
 
   @TempDir
-  File testFolder;
+  public File testFolder;
 
   private static final int MAX_ALLOCATION = 8 * 1024;
   private static RootAllocator allocator;

--- a/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
+++ b/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
@@ -37,19 +38,19 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class OrcReaderTest {
 
-  @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+  @TempDir
+  File testFolder;
 
   private static final int MAX_ALLOCATION = 8 * 1024;
   private static RootAllocator allocator;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     allocator = new RootAllocator(MAX_ALLOCATION);
   }
@@ -57,7 +58,7 @@ public class OrcReaderTest {
   @Test
   public void testOrcJniReader() throws Exception {
     TypeDescription schema = TypeDescription.fromString("struct<x:int,y:string>");
-    File testFile = new File(testFolder.getRoot(), "test-orc");
+    File testFile = new File(testFolder, "test-orc");
 
     Writer writer =
         OrcFile.createWriter(

--- a/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
+++ b/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.arrow.adapter.orc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Update package from JUnit 4(`org.junit`) to JUnit 5(`org.junit.jupiter`).

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- `avro` and `jdbc` module
  - [x] Replacing `org.junit` with `org.junit.jupiter.api`.
  - [x] Updating `Assertions.assertXXX` to `assertXXX` using static imports.
  - [x] Updating annotations such as `@Before`, `@After`.
    - `@Before` -> `@BeforeEach`
    - `@After` -> `@AfterEach`
    - `@Test` -> `@Test` with `org.junit.jupiter`
    - `@ClassRule` -> `@TempDir` and `@BeforeAll`
  - [x] Updating `Parameterized` test
  - [x] Doing self review for avro
  - [x] Dealing with `java.io.IOException: Failed to delete temp directory` on Windows with JDK 11
  - [x] Exploring a more effective structure for `ParameterizedTest` in JDBC tests.
  - [x] Doing self review for jdbc
- `orc` module
  - [x] Reviewing the build method
  - [x] Updating annotations such as `@BeforeAll`, `@Rule`, `@TemporaryFolder`
  - [x] Doing self review

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, existing tests have passed.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #42030