### PR TITLE
GH-42046: [C++] Reduce the binary size of DictionaryArray::Compact() by 31.6Ki

### DIFF
--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -261,17 +261,35 @@ Result<int64_t> PopulateBitmapOfUsedIndices(const ArrayData& data,
   return dict_used_count;
 }
 
-/// \pre data->length > 0
-/// \pre data->dictionary->length > 0
+Result<std::shared_ptr<Array>> TransposeAndMakeArrayNoInline(
+    const std::shared_ptr<ArrayData>& data,
+    const std::shared_ptr<Array>& compact_dictionary,
+    std::unique_ptr<Buffer> transpose_map, MemoryPool* pool) {
+  ARROW_ASSIGN_OR_RAISE(
+      auto transposed,
+      TransposeDictIndices(data, data->type, data->type, compact_dictionary->data(),
+                           transpose_map->data_as<int32_t>(), pool));
+  return MakeArray(std::move(transposed));
+}
+
 template <typename IndexArrowType>
-Status CompactTransposeMap(const std::shared_ptr<ArrayData>& data,
-                           arrow::MemoryPool* pool,
-                           std::unique_ptr<Buffer>* out_transpose_map,
-                           std::shared_ptr<Array>* out_compact_dictionary) {
+Result<std::shared_ptr<Array>> CompactTransposeMap(const std::shared_ptr<ArrayData>& data,
+                                                   arrow::MemoryPool* pool) {
   const int64_t index_length = data->length;
   const int64_t dict_length = data->dictionary->length;
-  DCHECK_GT(index_length, 0);
-  DCHECK_GT(dict_length, 0);
+
+  if (dict_length == 0) {
+    // If the dictionary is empty, we can return the original
+    // array because it can't get any more compact.
+    return std::make_shared<DictionaryArray>(data);
+  }
+  if (index_length == 0) {
+    ARROW_ASSIGN_OR_RAISE(auto compact_dictionary,
+                          MakeEmptyArray(data->dictionary->type, pool));
+    ARROW_ASSIGN_OR_RAISE(auto transpose_map, AllocateBuffer(0, pool))
+    return TransposeAndMakeArrayNoInline(data, compact_dictionary,
+                                         std::move(transpose_map), pool);
+  }
 
   ARROW_ASSIGN_OR_RAISE(auto dict_used_bitmap_buffer,
                         AllocateEmptyBitmap(dict_length, pool));
@@ -281,9 +299,7 @@ Status CompactTransposeMap(const std::shared_ptr<ArrayData>& data,
                         PopulateBitmapOfUsedIndices<CType>(*data, dict_used));
   if (dict_used_count == dict_length) {
     // The dictionary is already compact, so just return here
-    *out_transpose_map = nullptr;
-    *out_compact_dictionary = nullptr;
-    return Status::OK();
+    return std::make_shared<DictionaryArray>(data);
   }
 
   using IndicesArrayType = typename TypeTraits<IndexArrowType>::ArrayType;
@@ -291,9 +307,9 @@ Status CompactTransposeMap(const std::shared_ptr<ArrayData>& data,
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> dict_indices_buffer,
                         AllocateBuffer(dict_used_count * sizeof(CType), pool));
   auto* compact_dict_indices = dict_indices_buffer->mutable_data_as<CType>();
-  ARROW_ASSIGN_OR_RAISE(*out_transpose_map,
+  ARROW_ASSIGN_OR_RAISE(auto transpose_map,
                         AllocateBuffer(dict_length * sizeof(int32_t), pool));
-  auto* output_map_raw = (*out_transpose_map)->mutable_data_as<int32_t>();
+  auto* output_map_raw = transpose_map->mutable_data_as<int32_t>();
   memset(output_map_raw, 0xff, dict_length * sizeof(int32_t));
   ::arrow::internal::SetBitRunReader reader(dict_used, 0, dict_length);
   int32_t current_index = 0;
@@ -316,8 +332,9 @@ Status CompactTransposeMap(const std::shared_ptr<ArrayData>& data,
       auto compacted_dict_res,
       arrow::compute::Take(Datum(data->dictionary), compacted_dict_indices_array,
                            arrow::compute::TakeOptions::NoBoundsCheck()));
-  *out_compact_dictionary = compacted_dict_res.make_array();
-  return Status::OK();
+  auto compact_dictionary = compacted_dict_res.make_array();
+  return TransposeAndMakeArrayNoInline(data, compact_dictionary, std::move(transpose_map),
+                                       pool);
 }
 
 }  // namespace
@@ -332,61 +349,25 @@ Result<std::shared_ptr<Array>> DictionaryArray::Transpose(
 }
 
 Result<std::shared_ptr<Array>> DictionaryArray::Compact(MemoryPool* pool) const {
-  if (data_->dictionary->length == 0) {
-    // If the dictionary is empty, we can return the original
-    // array because it can't get any more compact.
-    return std::make_shared<DictionaryArray>(this->data_);
-  }
-  std::shared_ptr<Array> compact_dictionary;
-  std::unique_ptr<Buffer> transpose_map;
-  if (data_->length == 0) {
-    ARROW_ASSIGN_OR_RAISE(compact_dictionary,
-                          MakeEmptyArray(data_->dictionary->type, pool));
-    ARROW_ASSIGN_OR_RAISE(transpose_map, AllocateBuffer(0, pool))
-  } else {
-    switch (dict_type_->index_type()->id()) {
-      case Type::UINT8:
-        RETURN_NOT_OK(CompactTransposeMap<UInt8Type>(data_, pool, &transpose_map,
-                                                     &compact_dictionary));
-        break;
-      case Type::INT8:
-        RETURN_NOT_OK(CompactTransposeMap<Int8Type>(data_, pool, &transpose_map,
-                                                    &compact_dictionary));
-        break;
-      case Type::UINT16:
-        RETURN_NOT_OK(CompactTransposeMap<UInt16Type>(data_, pool, &transpose_map,
-                                                      &compact_dictionary));
-        break;
-      case Type::INT16:
-        RETURN_NOT_OK(CompactTransposeMap<Int16Type>(data_, pool, &transpose_map,
-                                                     &compact_dictionary));
-        break;
-      case Type::UINT32:
-        RETURN_NOT_OK(CompactTransposeMap<UInt32Type>(data_, pool, &transpose_map,
-                                                      &compact_dictionary));
-        break;
-      case Type::INT32:
-        RETURN_NOT_OK(CompactTransposeMap<Int32Type>(data_, pool, &transpose_map,
-                                                     &compact_dictionary));
-        break;
-      case Type::UINT64:
-        RETURN_NOT_OK(CompactTransposeMap<UInt64Type>(data_, pool, &transpose_map,
-                                                      &compact_dictionary));
-        break;
-      case Type::INT64:
-        RETURN_NOT_OK(CompactTransposeMap<Int64Type>(data_, pool, &transpose_map,
-                                                     &compact_dictionary));
-        break;
-      default:
-        return Status::TypeError("Expected an Index Type of Int or UInt");
-    }
-  }
-
-  if (transpose_map == nullptr) {
-    return std::make_shared<DictionaryArray>(this->data_);
-  } else {
-    return this->Transpose(this->type(), compact_dictionary,
-                           transpose_map->data_as<int32_t>(), pool);
+  switch (dict_type_->index_type()->id()) {
+    case Type::UINT8:
+      return CompactTransposeMap<UInt8Type>(data_, pool);
+    case Type::INT8:
+      return CompactTransposeMap<Int8Type>(data_, pool);
+    case Type::UINT16:
+      return CompactTransposeMap<UInt16Type>(data_, pool);
+    case Type::INT16:
+      return CompactTransposeMap<Int16Type>(data_, pool);
+    case Type::UINT32:
+      return CompactTransposeMap<UInt32Type>(data_, pool);
+    case Type::INT32:
+      return CompactTransposeMap<Int32Type>(data_, pool);
+    case Type::UINT64:
+      return CompactTransposeMap<UInt64Type>(data_, pool);
+    case Type::INT64:
+      return CompactTransposeMap<Int64Type>(data_, pool);
+    default:
+      return Status::TypeError("Expected an Index Type of Int or UInt");
   }
 }
 

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -278,12 +278,12 @@ Result<std::shared_ptr<Array>> CompactTransposeMap(const std::shared_ptr<ArrayDa
   const int64_t index_length = data->length;
   const int64_t dict_length = data->dictionary->length;
 
-  if (dict_length == 0) {
+  if (ARROW_PREDICT_FALSE(dict_length == 0)) {
     // If the dictionary is empty, we can return the original
     // array because it can't get any more compact.
     return std::make_shared<DictionaryArray>(data);
   }
-  if (index_length == 0) {
+  if (ARROW_PREDICT_FALSE(index_length == 0)) {
     ARROW_ASSIGN_OR_RAISE(auto compact_dictionary,
                           MakeEmptyArray(data->dictionary->type, pool));
     ARROW_ASSIGN_OR_RAISE(auto transpose_map, AllocateBuffer(0, pool))
@@ -297,7 +297,7 @@ Result<std::shared_ptr<Array>> CompactTransposeMap(const std::shared_ptr<ArrayDa
   using CType = typename IndexArrowType::c_type;
   ARROW_ASSIGN_OR_RAISE(int64_t dict_used_count,
                         PopulateBitmapOfUsedIndices<CType>(*data, dict_used));
-  if (dict_used_count == dict_length) {
+  if (ARROW_PREDICT_FALSE(dict_used_count == dict_length)) {
     // The dictionary is already compact, so just return here
     return std::make_shared<DictionaryArray>(data);
   }

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -243,9 +243,9 @@ Result<int64_t> PopulateBitmapOfUsedIndices(const ArrayData& data,
 
     IndexCType current_index = indices_data[i];
     if (current_index < 0 || current_index > max_index) {
-      return Status::IndexError(
-          "Index out of bounds while compacting dictionary array: ", current_index,
-          " (dictionary is ", dict_length, " long) at position ", i);
+      return Status::IndexError("Index out of bounds while compacting dictionary array: ",
+                                internal::UpcastInt(current_index), " (dictionary is ",
+                                dict_length, " long) at position ", i);
     }
     if (bit_util::GetBit(out_dict_used_bitmap, current_index)) {
       continue;

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -213,13 +213,16 @@ Result<std::shared_ptr<ArrayData>> TransposeDictIndices(
 }
 
 struct CompactTransposeMapVisitor {
-  const std::shared_ptr<ArrayData>& data;
-  arrow::MemoryPool* pool;
-  std::unique_ptr<Buffer>* out_transpose_map;
-  std::shared_ptr<Array>* out_compact_dictionary;
+  const std::shared_ptr<ArrayData>& data_;
+  arrow::MemoryPool* pool_;
+  std::unique_ptr<Buffer>* out_transpose_map_;
+  std::shared_ptr<Array>* out_compact_dictionary_;
 
   template <typename IndexArrowType>
-  Status CompactTransposeMapImpl() {
+  static Status CompactTransposeMapImpl(const std::shared_ptr<ArrayData>& data,
+                                        arrow::MemoryPool* pool,
+                                        std::unique_ptr<Buffer>* out_transpose_map,
+                                        std::shared_ptr<Array>* out_compact_dictionary) {
     int64_t index_length = data->length;
     int64_t dict_length = data->dictionary->length;
     if (dict_length == 0) {
@@ -290,7 +293,8 @@ struct CompactTransposeMapVisitor {
 
   template <typename Type>
   enable_if_integer<Type, Status> Visit(const Type&) {
-    return CompactTransposeMapImpl<Type>();
+    return CompactTransposeMapImpl<Type>(data_, pool_, out_transpose_map_,
+                                         out_compact_dictionary_);
   }
 
   Status Visit(const DataType& type) {

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -241,7 +241,7 @@ Status CompactTransposeMap(const std::shared_ptr<ArrayData>& data,
     if (current_index < 0 || current_index >= dict_len) {
       return Status::IndexError(
           "Index out of bounds while compacting dictionary array: ", current_index,
-          "(dictionary is ", dict_length, " long) at position ", i);
+          " (dictionary is ", dict_length, " long) at position ", i);
     }
     if (bit_util::GetBit(dict_used, current_index)) {
       continue;

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -242,7 +242,7 @@ Result<int64_t> PopulateBitmapOfUsedIndices(const ArrayData& data,
     }
 
     IndexCType current_index = indices_data[i];
-    if (current_index < 0 || current_index > max_index) {
+    if (ARROW_PREDICT_FALSE(current_index < 0 || current_index > max_index)) {
       return Status::IndexError("Index out of bounds while compacting dictionary array: ",
                                 internal::UpcastInt(current_index), " (dictionary is ",
                                 dict_length, " long) at position ", i);

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -265,14 +265,13 @@ Status CompactTransposeMap(const std::shared_ptr<ArrayData>& data,
   ARROW_ASSIGN_OR_RAISE(*out_transpose_map,
                         AllocateBuffer(dict_length * sizeof(int32_t), pool));
   auto* output_map_raw = (*out_transpose_map)->mutable_data_as<int32_t>();
+  memset(output_map_raw, 0xff, dict_length * sizeof(int32_t));
   int32_t current_index = 0;
   for (CType i = 0; i < dict_len; i++) {
     if (bit_util::GetBit(dict_used, i)) {
       dict_indices_builder.UnsafeAppend(i);
       output_map_raw[i] = current_index;
       current_index++;
-    } else {
-      output_map_raw[i] = -1;
     }
   }
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> compacted_dict_indices,

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -219,7 +219,7 @@ struct CompactTransposeMapVisitor {
   std::shared_ptr<Array>* out_compact_dictionary;
 
   template <typename IndexArrowType>
-  Status CompactTransposeMapImpl() {
+  ARROW_NOINLINE Status CompactTransposeMapImpl() {
     int64_t index_length = data->length;
     int64_t dict_length = data->dictionary->length;
     if (dict_length == 0) {

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -219,7 +219,7 @@ struct CompactTransposeMapVisitor {
   std::shared_ptr<Array>* out_compact_dictionary;
 
   template <typename IndexArrowType>
-  ARROW_NOINLINE Status CompactTransposeMapImpl() {
+  Status CompactTransposeMapImpl() {
     int64_t index_length = data->length;
     int64_t dict_length = data->dictionary->length;
     if (dict_length == 0) {

--- a/cpp/src/arrow/util/int_util.h
+++ b/cpp/src/arrow/util/int_util.h
@@ -133,5 +133,19 @@ UpcastInt(Integer v) {
   return v;
 }
 
+/// \brief Trait to select integer type based on byte width and signedness
+template <int Bytes, bool Signed>
+struct int_type_from_byte_width;
+// clang-format off
+template <> struct int_type_from_byte_width<1, true>  { using type = int8_t; };
+template <> struct int_type_from_byte_width<1, false> { using type = uint8_t; };
+template <> struct int_type_from_byte_width<2, true>  { using type = int16_t; };
+template <> struct int_type_from_byte_width<2, false> { using type = uint16_t; };
+template <> struct int_type_from_byte_width<4, true>  { using type = int32_t; };
+template <> struct int_type_from_byte_width<4, false> { using type = uint32_t; };
+template <> struct int_type_from_byte_width<8, true>  { using type = int64_t; };
+template <> struct int_type_from_byte_width<8, false> { using type = uint64_t; };
+// clang-format on
+
 }  // namespace internal
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

Binary size reductions. See issue for details.

```
$ bloaty -d symbols -C full -n 0 ./release/libarrow.dylib -- MAIN-libarrow.dylib
    FILE SIZE        VM SIZE
 --------------  --------------
 ...
  -0.1% -30.9Ki  -0.1% -16.0Ki    TOTAL
```

Comparison of the file sizes show a reduction of 31.6 KB:

```
$ ls -l ./MAIN-libarrow.dylib ./release/libarrow.1700.0.0.dylib
-rwxr-xr-x@ 1 felipe  staff  29032280 Jun  9 22:06 ./MAIN-libarrow.dylib
-rwxr-xr-x@ 1 felipe  staff  29000648 Jun  9 22:07 ./release/libarrow.1700.0.0.dylib
```


### What changes are included in this PR?

 - Manual inlining of some functions
 - Replacing `VisitTypeInline` with custom dispatching logic on the integer types
 - Add new tests and fix an overflow bug
 - Drop the usage of array builders when a simple `Buffer` is enough
 - Use `ARROW_PREDICT_FALSE` to flag cold branches so the inliner is less aggressive (always measuring to check it's effective)\
 - Use a bitmap instead of std::vector<bool> and `SetBitRunReader`

### Are these changes tested?

Existing and a new test case.
* GitHub Issue: #42046