### PR TITLE
MINOR: [C++] always generate compile_commands.json

### DIFF
--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -22,6 +22,7 @@ CMakeUserPresets.json
 CTestTestfile.cmake
 Makefile
 cmake_install.cmake
+compile_commands.json
 build/
 *-build/
 Testing/

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -182,14 +182,7 @@ endif()
 
 find_package(ClangTools)
 find_package(InferTools)
-if("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1"
-   OR CLANG_TIDY_FOUND
-   OR INFER_FOUND)
-  # Generate a Clang compile_commands.json "compilation database" file for use
-  # with various development tools, such as Vim's YouCompleteMe plugin.
-  # See http://clang.llvm.org/docs/JSONCompilationDatabase.html
-  set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-endif()
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 # Needed for linting targets, etc.
 # Use the first Python installation on PATH, not the newest one


### PR DESCRIPTION
This generates the [JSON compilation database](http://clang.llvm.org/docs/JSONCompilationDatabase.html) so that clangd can find includes properly

### Rationale for this change

This makes clangd always correct wtr to compiler flags/preprocessor flags which provides much better developer experience in all editors that support it. One doesn't have to have clang-format installed for this to work.

### What changes are included in this PR?

Instruct cmake to generate compile_commands.json by default.

### Are these changes tested?

Manually on vscode running the clangd extension.

### Are there any user-facing changes?

n/a
