### PR TITLE
GH-40828: [Java] Format arrow-maven-plugins modules

### DIFF
--- a/java/maven/module-info-compiler-maven-plugin/src/main/java/org/apache/arrow/maven/plugins/BaseModuleInfoCompilerPlugin.java
+++ b/java/maven/module-info-compiler-maven-plugin/src/main/java/org/apache/arrow/maven/plugins/BaseModuleInfoCompilerPlugin.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.maven.plugins;
 
 import java.io.File;
@@ -28,14 +27,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.glavo.mic.ModuleInfoCompiler;
 
-/**
- * Compiles the first module-info.java file in the project purely syntactically.
- */
+/** Compiles the first module-info.java file in the project purely syntactically. */
 public abstract class BaseModuleInfoCompilerPlugin extends AbstractMojo {
   protected abstract List<String> getSourceRoots();
 
@@ -60,9 +56,10 @@ public abstract class BaseModuleInfoCompilerPlugin extends AbstractMojo {
 
       // Invoke the compiler,
       ModuleInfoCompiler compiler = new ModuleInfoCompiler();
-      try (Reader reader = new InputStreamReader(Files.newInputStream(moduleInfoFile.get().toPath()),
-          StandardCharsets.UTF_8);
-           OutputStream output = Files.newOutputStream(targetPath)) {
+      try (Reader reader =
+              new InputStreamReader(
+                  Files.newInputStream(moduleInfoFile.get().toPath()), StandardCharsets.UTF_8);
+          OutputStream output = Files.newOutputStream(targetPath)) {
         compiler.compile(reader, output);
         getLog().info("Successfully wrote module-info.class file.");
       } catch (IOException ex) {
@@ -73,18 +70,17 @@ public abstract class BaseModuleInfoCompilerPlugin extends AbstractMojo {
     }
   }
 
-  /**
-   * Finds the first module-info.java file in the set of source directories.
-   */
+  /** Finds the first module-info.java file in the set of source directories. */
   private Optional<File> findFirstModuleInfo(List<String> sourceDirectories) {
     if (sourceDirectories == null) {
       return Optional.empty();
     }
 
-    return sourceDirectories.stream().map(Paths::get)
-        .map(sourcePath ->
-            sourcePath.toFile().listFiles(file ->
-                file.getName().equals("module-info.java")))
+    return sourceDirectories.stream()
+        .map(Paths::get)
+        .map(
+            sourcePath ->
+                sourcePath.toFile().listFiles(file -> file.getName().equals("module-info.java")))
         .filter(matchingFiles -> matchingFiles != null && matchingFiles.length != 0)
         .map(matchingFiles -> matchingFiles[0])
         .findAny();

--- a/java/maven/module-info-compiler-maven-plugin/src/main/java/org/apache/arrow/maven/plugins/ModuleInfoCompilerPlugin.java
+++ b/java/maven/module-info-compiler-maven-plugin/src/main/java/org/apache/arrow/maven/plugins/ModuleInfoCompilerPlugin.java
@@ -14,24 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.maven.plugins;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * A maven plugin for compiler module-info files in main code with JDK8.
- */
+/** A maven plugin for compiler module-info files in main code with JDK8. */
 @Mojo(name = "compile", defaultPhase = LifecyclePhase.COMPILE)
 public class ModuleInfoCompilerPlugin extends BaseModuleInfoCompilerPlugin {
 
-  @Parameter(defaultValue = "${project.compileSourceRoots}", property = "compileSourceRoots",
+  @Parameter(
+      defaultValue = "${project.compileSourceRoots}",
+      property = "compileSourceRoots",
       required = true)
   private final List<String> compileSourceRoots = new ArrayList<>();
 

--- a/java/maven/module-info-compiler-maven-plugin/src/main/java/org/apache/arrow/maven/plugins/ModuleInfoTestCompilerPlugin.java
+++ b/java/maven/module-info-compiler-maven-plugin/src/main/java/org/apache/arrow/maven/plugins/ModuleInfoTestCompilerPlugin.java
@@ -14,19 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.maven.plugins;
 
 import java.util.List;
-
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-/**
- * A maven plugin for compiler module-info files in unit tests with JDK8.
- */
+/** A maven plugin for compiler module-info files in unit tests with JDK8. */
 @Mojo(name = "testCompile", defaultPhase = LifecyclePhase.TEST_COMPILE)
 public class ModuleInfoTestCompilerPlugin extends BaseModuleInfoCompilerPlugin {
 

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -236,7 +236,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <configLocation>../dev/checkstyle/checkstyle.xml</configLocation>
+          <configLocation>../dev/checkstyle/checkstyle-spotless.xml</configLocation>
           <headerLocation>../dev/license/asf-java.license</headerLocation>
           <suppressionsLocation>../dev/checkstyle/suppressions.xml</suppressionsLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -298,6 +298,16 @@
           <pom>
             <sortPom></sortPom>
           </pom>
+          <java>
+            <googleJavaFormat>
+              <version>1.7</version>
+              <style>GOOGLE</style>
+            </googleJavaFormat>
+            <licenseHeader>
+              <file>${maven.multiModuleProjectDirectory}/dev/license/asf-java.license</file>
+              <delimiter>package</delimiter>
+            </licenseHeader>
+          </java>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
### Rationale for this change
    
Adding code style and formatting options for `apache-maven-plugin` module and submodules
    
### What changes are included in this PR?
    
Java code formatting spotless plugin has been added.
    
### Are these changes tested?
    
Yes, but doesn't involve test cases, the plugin itself corrects.
    
### Are there any user-facing changes?

No


* GitHub Issue: #40828