### PR TITLE
GH-40829: [Java] Adding Spotless to Memory modules

### DIFF
--- a/java/dev/checkstyle/checkstyle-spotless.xml
+++ b/java/dev/checkstyle/checkstyle-spotless.xml
@@ -60,10 +60,12 @@
       <property name="eachLine" value="true"/>
     </module>
 
+    <!--
     <module name="LineLength">
         <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
+    -->
 
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>

--- a/java/dev/checkstyle/checkstyle-spotless.xml
+++ b/java/dev/checkstyle/checkstyle-spotless.xml
@@ -60,6 +60,7 @@
       <property name="eachLine" value="true"/>
     </module>
 
+    <!-- Commenting to avoid conflict with spotless plugin -->
     <!--
     <module name="LineLength">
         <property name="max" value="120"/>

--- a/java/memory/memory-core/src/main/java/module-info.java
+++ b/java/memory/memory-core/src/main/java/module-info.java
@@ -21,6 +21,7 @@ module org.apache.arrow.memory.core {
   exports org.apache.arrow.memory.util;
   exports org.apache.arrow.memory.util.hash;
   exports org.apache.arrow.util;
+
   requires transitive jdk.unsupported;
   requires jsr305;
   requires org.slf4j;

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationListener.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationListener.java
@@ -14,14 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
  * An allocation listener being notified for allocation/deallocation
  *
- * <p>It might be called from multiple threads if the allocator hierarchy shares a listener, in which
- * case, the provider should take care of making the implementation thread-safe.
+ * <p>It might be called from multiple threads if the allocator hierarchy shares a listener, in
+ * which case, the provider should take care of making the implementation thread-safe.
  */
 public interface AllocationListener {
 
@@ -34,8 +33,7 @@ public interface AllocationListener {
    *
    * @param size the buffer size being allocated
    */
-  default void onPreAllocation(long size) {
-  }
+  default void onPreAllocation(long size) {}
 
   /**
    * Called each time a new buffer has been allocated.
@@ -44,26 +42,24 @@ public interface AllocationListener {
    *
    * @param size the buffer size being allocated
    */
-  default void onAllocation(long size) {
-  }
+  default void onAllocation(long size) {}
 
   /**
    * Informed each time a buffer is released from allocation.
    *
    * <p>An exception cannot be thrown by this method.
+   *
    * @param size The size of the buffer being released.
    */
-  default void onRelease(long size) {
-  }
-
+  default void onRelease(long size) {}
 
   /**
    * Called whenever an allocation failed, giving the caller a chance to create some space in the
    * allocator (either by freeing some resource, or by changing the limit), and, if successful,
    * allowing the allocator to retry the allocation.
    *
-   * @param size     the buffer size that was being allocated
-   * @param outcome  the outcome of the failed allocation. Carries information of what failed
+   * @param size the buffer size that was being allocated
+   * @param outcome the outcome of the failed allocation. Carries information of what failed
    * @return true, if the allocation can be retried; false if the allocation should fail
    */
   default boolean onFailedAllocation(long size, AllocationOutcome outcome) {
@@ -74,10 +70,9 @@ public interface AllocationListener {
    * Called immediately after a child allocator was added to the parent allocator.
    *
    * @param parentAllocator The parent allocator to which a child was added
-   * @param childAllocator  The child allocator that was just added
+   * @param childAllocator The child allocator that was just added
    */
-  default void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
-  }
+  default void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {}
 
   /**
    * Called immediately after a child allocator was removed from the parent allocator.
@@ -85,6 +80,5 @@ public interface AllocationListener {
    * @param parentAllocator The parent allocator from which a child was removed
    * @param childAllocator The child allocator that was just removed
    */
-  default void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
-  }
+  default void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {}
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import org.apache.arrow.util.Preconditions;
@@ -23,35 +22,47 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * An AllocationManager is the implementation of a physical memory allocation.
  *
- * <p>Manages the relationship between the allocators and a particular memory allocation. Ensures that
- * one allocator owns the memory that multiple allocators may be referencing. Manages a BufferLedger between
- * each of its associated allocators. It does not track the reference count; that is the role of {@link BufferLedger}
- * (aka {@link ReferenceManager}).
+ * <p>Manages the relationship between the allocators and a particular memory allocation. Ensures
+ * that one allocator owns the memory that multiple allocators may be referencing. Manages a
+ * BufferLedger between each of its associated allocators. It does not track the reference count;
+ * that is the role of {@link BufferLedger} (aka {@link ReferenceManager}).
  *
- * <p>This is a public interface implemented by concrete allocator implementations (e.g. Netty or Unsafe).
+ * <p>This is a public interface implemented by concrete allocator implementations (e.g. Netty or
+ * Unsafe).
  *
  * <p>Threading: AllocationManager manages thread-safety internally. Operations within the context
- * of a single BufferLedger are lockless in nature and can be leveraged by multiple threads. Operations that cross the
- * context of two ledgers will acquire a lock on the AllocationManager instance. Important note, there is one
- * AllocationManager per physical buffer allocation. As such, there will be thousands of these in a
- * typical query. The contention of acquiring a lock on AllocationManager should be very low.
+ * of a single BufferLedger are lockless in nature and can be leveraged by multiple threads.
+ * Operations that cross the context of two ledgers will acquire a lock on the AllocationManager
+ * instance. Important note, there is one AllocationManager per physical buffer allocation. As such,
+ * there will be thousands of these in a typical query. The contention of acquiring a lock on
+ * AllocationManager should be very low.
  */
 public abstract class AllocationManager {
-  // The RootAllocator we are associated with. An allocation can only ever be associated with a single RootAllocator.
+  // The RootAllocator we are associated with. An allocation can only ever be associated with a
+  // single RootAllocator.
   private final BufferAllocator root;
-  // An allocation can be tracked by multiple allocators. (This is because an allocator is more like a ledger.)
-  // All such allocators track reference counts individually, via BufferLedger instances. When an individual
-  // reference count reaches zero, the allocator will be dissociated from this allocation. If that was via the
-  // owningLedger, then no more allocators should be tracking this allocation, and the allocation will be freed.
+  // An allocation can be tracked by multiple allocators. (This is because an allocator is more like
+  // a ledger.)
+  // All such allocators track reference counts individually, via BufferLedger instances. When an
+  // individual
+  // reference count reaches zero, the allocator will be dissociated from this allocation. If that
+  // was via the
+  // owningLedger, then no more allocators should be tracking this allocation, and the allocation
+  // will be freed.
   // ARROW-1627: Trying to minimize memory overhead caused by previously used IdentityHashMap
-  private final LowCostIdentityHashMap<BufferAllocator, BufferLedger> map = new LowCostIdentityHashMap<>();
+  private final LowCostIdentityHashMap<BufferAllocator, BufferLedger> map =
+      new LowCostIdentityHashMap<>();
   // The primary BufferLedger (i.e. reference count) tracking this allocation.
-  // This is mostly a semantic constraint on the API user: if the reference count reaches 0 in the owningLedger, then
-  // there are not supposed to be any references through other allocators. In practice, this doesn't do anything
-  // as the implementation just forces ownership to be transferred to one of the other extant references.
+  // This is mostly a semantic constraint on the API user: if the reference count reaches 0 in the
+  // owningLedger, then
+  // there are not supposed to be any references through other allocators. In practice, this doesn't
+  // do anything
+  // as the implementation just forces ownership to be transferred to one of the other extant
+  // references.
   private volatile @Nullable BufferLedger owningLedger;
 
-  @SuppressWarnings("nullness:method.invocation") //call to associate(a, b) not allowed on the given receiver
+  @SuppressWarnings(
+      "nullness:method.invocation") // call to associate(a, b) not allowed on the given receiver
   protected AllocationManager(BufferAllocator accountingAllocator) {
     Preconditions.checkNotNull(accountingAllocator);
     accountingAllocator.assertOpen();
@@ -63,7 +74,8 @@ public abstract class AllocationManager {
     this.owningLedger = associate(accountingAllocator, false);
   }
 
-  @Nullable BufferLedger getOwningLedger() {
+  @Nullable
+  BufferLedger getOwningLedger() {
     return owningLedger;
   }
 
@@ -72,12 +84,12 @@ public abstract class AllocationManager {
   }
 
   /**
-   * Associate the existing underlying buffer with a new allocator. This will increase the
-   * reference count on the corresponding buffer ledger by 1.
+   * Associate the existing underlying buffer with a new allocator. This will increase the reference
+   * count on the corresponding buffer ledger by 1.
    *
    * @param allocator The target allocator to associate this buffer with.
-   * @return The reference manager (new or existing) that associates the underlying
-   *         buffer to this new ledger.
+   * @return The reference manager (new or existing) that associates the underlying buffer to this
+   *     new ledger.
    */
   BufferLedger associate(final BufferAllocator allocator) {
     return associate(allocator, true);
@@ -85,8 +97,9 @@ public abstract class AllocationManager {
 
   private BufferLedger associate(final BufferAllocator allocator, final boolean retain) {
     allocator.assertOpen();
-    Preconditions.checkState(root == allocator.getRoot(),
-          "A buffer can only be associated between two allocators that share the same root");
+    Preconditions.checkState(
+        root == allocator.getRoot(),
+        "A buffer can only be associated between two allocators that share the same root");
 
     synchronized (this) {
       BufferLedger ledger = map.get(allocator);
@@ -109,7 +122,8 @@ public abstract class AllocationManager {
 
       // store the mapping for <allocator, reference manager>
       BufferLedger oldLedger = map.put(ledger);
-      Preconditions.checkState(oldLedger == null,
+      Preconditions.checkState(
+          oldLedger == null,
           "Detected inconsistent state: A reference manager already exists for this allocator");
 
       if (allocator instanceof BaseAllocator) {
@@ -123,10 +137,9 @@ public abstract class AllocationManager {
 
   /**
    * The way that a particular ReferenceManager (BufferLedger) communicates back to the
-   * AllocationManager that it no longer needs to hold a reference to a particular
-   * piece of memory. Reference manager needs to hold a lock to invoke this method
-   * It is called when the shared refcount of all the ArrowBufs managed by the
-   * calling ReferenceManager drops to 0.
+   * AllocationManager that it no longer needs to hold a reference to a particular piece of memory.
+   * Reference manager needs to hold a lock to invoke this method It is called when the shared
+   * refcount of all the ArrowBufs managed by the calling ReferenceManager drops to 0.
    */
   void release(final BufferLedger ledger) {
     final BufferAllocator allocator = ledger.getAllocator();
@@ -134,10 +147,11 @@ public abstract class AllocationManager {
 
     // remove the <BaseAllocator, BufferLedger> mapping for the allocator
     // of calling BufferLedger
-    Preconditions.checkState(map.containsKey(allocator),
-            "Expecting a mapping for allocator and reference manager");
+    Preconditions.checkState(
+        map.containsKey(allocator), "Expecting a mapping for allocator and reference manager");
     final BufferLedger oldLedger = map.remove(allocator);
-    Preconditions.checkState(oldLedger != null, "Expecting a mapping for allocator and reference manager");
+    Preconditions.checkState(
+        oldLedger != null, "Expecting a mapping for allocator and reference manager");
     BufferAllocator oldAllocator = oldLedger.getAllocator();
     if (oldAllocator instanceof BaseAllocator) {
       // needed for debug only: tell the allocator that AllocationManager is removing a
@@ -169,8 +183,9 @@ public abstract class AllocationManager {
     } else {
       // the release call was made by a non-owning reference manager, so after remove there have
       // to be 1 or more <allocator, reference manager> mappings
-      Preconditions.checkState(map.size() > 0,
-              "The final removal of reference manager should be connected to owning reference manager");
+      Preconditions.checkState(
+          map.size() > 0,
+          "The final removal of reference manager should be connected to owning reference manager");
     }
   }
 
@@ -183,27 +198,23 @@ public abstract class AllocationManager {
    */
   public abstract long getSize();
 
-  /**
-   * Return the absolute memory address pointing to the fist byte of underlying memory chunk.
-   */
+  /** Return the absolute memory address pointing to the fist byte of underlying memory chunk. */
   protected abstract long memoryAddress();
 
-  /**
-   * Release the underlying memory chunk.
-   */
+  /** Release the underlying memory chunk. */
   protected abstract void release0();
 
   /**
-   * A factory interface for creating {@link AllocationManager}.
-   * One may extend this interface to use a user-defined AllocationManager implementation.
+   * A factory interface for creating {@link AllocationManager}. One may extend this interface to
+   * use a user-defined AllocationManager implementation.
    */
   public interface Factory {
 
     /**
      * Create an {@link AllocationManager}.
      *
-     * @param accountingAllocator The allocator that are expected to be associated with newly created AllocationManager.
-     *                            Currently it is always equivalent to "this"
+     * @param accountingAllocator The allocator that are expected to be associated with newly
+     *     created AllocationManager. Currently it is always equivalent to "this"
      * @param size Size (in bytes) of memory managed by the AllocationManager
      * @return The created AllocationManager used by this allocator
      */

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationOutcome.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationOutcome.java
@@ -14,17 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.util.Optional;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-
-/**
- * Describes the type of outcome that occurred when trying to account for allocation of memory.
- */
+/** Describes the type of outcome that occurred when trying to account for allocation of memory. */
 public class AllocationOutcome {
   private final Status status;
   private final @Nullable AllocationOutcomeDetails details;
@@ -41,6 +36,7 @@ public class AllocationOutcome {
 
   /**
    * Get the status of the allocation.
+   *
    * @return status code.
    */
   public Status getStatus() {
@@ -49,6 +45,7 @@ public class AllocationOutcome {
 
   /**
    * Get additional details of the allocation (like the status at each allocator in the hierarchy).
+   *
    * @return details of allocation
    */
   public Optional<AllocationOutcomeDetails> getDetails() {
@@ -57,34 +54,25 @@ public class AllocationOutcome {
 
   /**
    * Returns true if the allocation was a success.
+   *
    * @return true if allocation was successful, false otherwise.
    */
   public boolean isOk() {
     return status.isOk();
   }
 
-  /**
-   * Allocation status code.
-   */
+  /** Allocation status code. */
   public enum Status {
-    /**
-     * Allocation succeeded.
-     */
+    /** Allocation succeeded. */
     SUCCESS(true),
 
-    /**
-     * Allocation succeeded but only because the allocator was forced to move beyond a limit.
-     */
+    /** Allocation succeeded but only because the allocator was forced to move beyond a limit. */
     FORCED_SUCCESS(true),
 
-    /**
-     * Allocation failed because the local allocator's limits were exceeded.
-     */
+    /** Allocation failed because the local allocator's limits were exceeded. */
     FAILED_LOCAL(false),
 
-    /**
-     * Allocation failed because a parent allocator's limits were exceeded.
-     */
+    /** Allocation failed because a parent allocator's limits were exceeded. */
     FAILED_PARENT(false);
 
     private final boolean ok;

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
@@ -14,18 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-
-/**
- * Captures details of allocation for each accountant in the hierarchical chain.
- */
+/** Captures details of allocation for each accountant in the hierarchical chain. */
 public class AllocationOutcomeDetails {
   Deque<Entry> allocEntries;
 
@@ -33,8 +28,12 @@ public class AllocationOutcomeDetails {
     allocEntries = new ArrayDeque<>();
   }
 
-  void pushEntry(Accountant accountant, long totalUsedBeforeAllocation, long requestedSize,
-      long allocatedSize, boolean allocationFailed) {
+  void pushEntry(
+      Accountant accountant,
+      long totalUsedBeforeAllocation,
+      long requestedSize,
+      long allocatedSize,
+      boolean allocationFailed) {
 
     Entry top = allocEntries.peekLast();
     if (top != null && top.allocationFailed) {
@@ -42,12 +41,14 @@ public class AllocationOutcomeDetails {
       return;
     }
 
-    allocEntries.addLast(new Entry(accountant, totalUsedBeforeAllocation, requestedSize,
-        allocatedSize, allocationFailed));
+    allocEntries.addLast(
+        new Entry(
+            accountant, totalUsedBeforeAllocation, requestedSize, allocatedSize, allocationFailed));
   }
 
   /**
    * Get the allocator that caused the failure.
+   *
    * @return the allocator that caused failure, null if there was no failure.
    */
   public @Nullable BufferAllocator getFailedAllocator() {
@@ -67,9 +68,7 @@ public class AllocationOutcomeDetails {
     return sb.toString();
   }
 
-  /**
-   * Outcome of the allocation request at one accountant in the hierarchy.
-   */
+  /** Outcome of the allocation request at one accountant in the hierarchy. */
   public static class Entry {
     private final Accountant accountant;
 
@@ -82,8 +81,12 @@ public class AllocationOutcomeDetails {
     private final long allocatedSize;
     private final boolean allocationFailed;
 
-    Entry(Accountant accountant, long totalUsedBeforeAllocation, long requestedSize,
-        long allocatedSize, boolean allocationFailed) {
+    Entry(
+        Accountant accountant,
+        long totalUsedBeforeAllocation,
+        long requestedSize,
+        long allocatedSize,
+        boolean allocationFailed) {
       this.accountant = accountant;
       this.limit = accountant.getLimit();
       this.used = totalUsedBeforeAllocation;
@@ -119,15 +122,22 @@ public class AllocationOutcomeDetails {
 
     @Override
     public String toString() {
-      return "allocator[" + accountant.getName() + "]" +
-          " reservation: " + accountant.getInitReservation() +
-          " limit: " + limit +
-          " used: " + used +
-          " requestedSize: " + requestedSize +
-          " allocatedSize: " + allocatedSize +
-          " localAllocationStatus: " + (allocationFailed ? "fail" : "success") +
-          "\n";
+      return "allocator["
+          + accountant.getName()
+          + "]"
+          + " reservation: "
+          + accountant.getInitReservation()
+          + " limit: "
+          + limit
+          + " used: "
+          + used
+          + " requestedSize: "
+          + requestedSize
+          + " allocatedSize: "
+          + allocatedSize
+          + " localAllocationStatus: "
+          + (allocationFailed ? "fail" : "success")
+          + "\n";
     }
   }
-
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationReservation.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocationReservation.java
@@ -14,27 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
  * Supports cumulative allocation reservation. Clients may increase the size of the reservation
- * repeatedly until they
- * call for an allocation of the current total size. The reservation can only be used once, and
- * will throw an exception
- * if it is used more than once.
- * <p>
- * For the purposes of airtight memory accounting, the reservation must be close()d whether it is
- * used or not.
- * This is not threadsafe.
- * </p>
+ * repeatedly until they call for an allocation of the current total size. The reservation can only
+ * be used once, and will throw an exception if it is used more than once.
+ *
+ * <p>For the purposes of airtight memory accounting, the reservation must be close()d whether it is
+ * used or not. This is not threadsafe.
  */
 public interface AllocationReservation extends AutoCloseable {
 
   /**
    * Add to the current reservation.
    *
-   * <p>Adding may fail if the allocator is not allowed to consume any more space.</p>
+   * <p>Adding may fail if the allocator is not allowed to consume any more space.
    *
    * @param nBytes the number of bytes to add
    * @return true if the addition is possible, false otherwise
@@ -45,7 +40,7 @@ public interface AllocationReservation extends AutoCloseable {
   /**
    * Requests a reservation of additional space.
    *
-   * <p>The implementation of the allocator's inner class provides this.</p>
+   * <p>The implementation of the allocator's inner class provides this.
    *
    * @param nBytes the amount to reserve
    * @return true if the reservation can be satisfied, false otherwise
@@ -55,8 +50,8 @@ public interface AllocationReservation extends AutoCloseable {
   /**
    * Allocate a buffer whose size is the total of all the add()s made.
    *
-   * <p>The allocation request can still fail, even if the amount of space
-   * requested is available, if the allocation cannot be made contiguously.</p>
+   * <p>The allocation request can still fail, even if the amount of space requested is available,
+   * if the allocation cannot be made contiguously.
    *
    * @return the buffer, or null, if the request cannot be satisfied
    * @throws IllegalStateException if called more than once
@@ -84,5 +79,6 @@ public interface AllocationReservation extends AutoCloseable {
    */
   boolean isClosed();
 
-  @Override void close();
+  @Override
+  void close();
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocatorClosedException.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/AllocatorClosedException.java
@@ -14,13 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
-/**
- * Exception thrown when a closed BufferAllocator is used. Note
- * this is an unchecked exception.
- */
+/** Exception thrown when a closed BufferAllocator is used. Note this is an unchecked exception. */
 @SuppressWarnings("serial")
 public class AllocatorClosedException extends RuntimeException {
 

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.util.Collection;
@@ -23,7 +22,6 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.arrow.memory.rounding.DefaultRoundingPolicy;
 import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.arrow.memory.util.AssertionUtil;
@@ -39,17 +37,19 @@ import org.immutables.value.Value;
 /**
  * A base-class that implements all functionality of {@linkplain BufferAllocator}s.
  *
- * <p>The class is abstract to enforce usage of {@linkplain RootAllocator}/{@linkplain ChildAllocator}
- * facades.
+ * <p>The class is abstract to enforce usage of {@linkplain RootAllocator}/{@linkplain
+ * ChildAllocator} facades.
  */
 abstract class BaseAllocator extends Accountant implements BufferAllocator {
 
   public static final String DEBUG_ALLOCATOR = "arrow.memory.debug.allocator";
   public static final int DEBUG_LOG_LENGTH = 6;
   public static final boolean DEBUG;
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseAllocator.class);
+  private static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(BaseAllocator.class);
 
-  // Initialize this before DEFAULT_CONFIG as DEFAULT_CONFIG will eventually initialize the allocation manager,
+  // Initialize this before DEFAULT_CONFIG as DEFAULT_CONFIG will eventually initialize the
+  // allocation manager,
   // which in turn allocates an ArrowBuf, which requires DEBUG to have been properly initialized
   static {
     // the system property takes precedence.
@@ -59,8 +59,11 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     } else {
       DEBUG = false;
     }
-    logger.info("Debug mode " + (DEBUG ? "enabled."
-        : "disabled. Enable with the VM option -Darrow.memory.debug.allocator=true."));
+    logger.info(
+        "Debug mode "
+            + (DEBUG
+                ? "enabled."
+                : "disabled. Enable with the VM option -Darrow.memory.debug.allocator=true."));
   }
 
   public static final Config DEFAULT_CONFIG = ImmutableConfig.builder().build();
@@ -85,18 +88,16 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   /**
    * Initialize an allocator.
    *
-   * @param parentAllocator   parent allocator. null if defining a root allocator
-   * @param name              name of this allocator
-   * @param config            configuration including other options of this allocator
-   *
+   * @param parentAllocator parent allocator. null if defining a root allocator
+   * @param name name of this allocator
+   * @param config configuration including other options of this allocator
    * @see Config
    */
   @SuppressWarnings({"nullness:method.invocation", "nullness:cast.unsafe"})
-  //{"call to hist(,...) not allowed on the given receiver.", "cast cannot be statically verified"}
+  // {"call to hist(,...) not allowed on the given receiver.", "cast cannot be statically verified"}
   protected BaseAllocator(
-      final @Nullable BaseAllocator parentAllocator,
-      final String name,
-      final Config config) throws OutOfMemoryException {
+      final @Nullable BaseAllocator parentAllocator, final String name, final Config config)
+      throws OutOfMemoryException {
     super(parentAllocator, name, config.getInitReservation(), config.getMaxAllocation());
 
     this.listener = config.getListener();
@@ -109,8 +110,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
       this.root = (@Initialized RootAllocator) this;
       empty = createEmpty();
     } else {
-      throw new IllegalStateException("An parent allocator must either carry a root or be the " +
-        "root.");
+      throw new IllegalStateException(
+          "An parent allocator must either carry a root or be the " + "root.");
     }
 
     this.parentAllocator = parentAllocator;
@@ -148,15 +149,17 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     }
   }
 
-  private static String createErrorMsg(final BufferAllocator allocator, final long rounded, final long requested) {
+  private static String createErrorMsg(
+      final BufferAllocator allocator, final long rounded, final long requested) {
     if (rounded != requested) {
       return String.format(
-        "Unable to allocate buffer of size %d (rounded from %d) due to memory limit. Current " +
-          "allocation: %d", rounded, requested, allocator.getAllocatedMemory());
+          "Unable to allocate buffer of size %d (rounded from %d) due to memory limit. Current "
+              + "allocation: %d",
+          rounded, requested, allocator.getAllocatedMemory());
     } else {
       return String.format(
-        "Unable to allocate buffer of size %d due to memory limit. Current " +
-          "allocation: %d", rounded, allocator.getAllocatedMemory());
+          "Unable to allocate buffer of size %d due to memory limit. Current " + "allocation: %d",
+          rounded, allocator.getAllocatedMemory());
     }
   }
 
@@ -168,8 +171,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   public void assertOpen() {
     if (AssertionUtil.ASSERT_ENABLED) {
       if (isClosed) {
-        throw new IllegalStateException("Attempting operation on allocator when allocator is closed.\n" +
-          toVerboseString());
+        throw new IllegalStateException(
+            "Attempting operation on allocator when allocator is closed.\n" + toVerboseString());
       }
     }
   }
@@ -185,9 +188,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   }
 
   /**
-   * For debug/verification purposes only. Allows an AllocationManager to tell the allocator that
-   * we have a new ledger
-   * associated with this allocator.
+   * For debug/verification purposes only. Allows an AllocationManager to tell the allocator that we
+   * have a new ledger associated with this allocator.
    */
   void associateLedger(BufferLedger ledger) {
     assertOpen();
@@ -201,9 +203,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   }
 
   /**
-   * For debug/verification purposes only. Allows an AllocationManager to tell the allocator that
-   * we are removing a
-   * ledger associated with this allocator
+   * For debug/verification purposes only. Allows an AllocationManager to tell the allocator that we
+   * are removing a ledger associated with this allocator
    */
   void dissociateLedger(BufferLedger ledger) {
     assertOpen();
@@ -235,8 +236,12 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
           if (childAllocator.historicalLog != null) {
             childAllocator.historicalLog.logHistory(logger);
           }
-          throw new IllegalStateException("Child allocator[" + childAllocator.name +
-            "] not found in parent allocator[" + name + "]'s childAllocators");
+          throw new IllegalStateException(
+              "Child allocator["
+                  + childAllocator.name
+                  + "] not found in parent allocator["
+                  + name
+                  + "]'s childAllocators");
         }
       }
     } else {
@@ -257,15 +262,14 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
         outcome = this.allocateBytes(size);
       }
       if (!outcome.isOk()) {
-        throw new OutOfMemoryException(createErrorMsg(this, size,
-            size), outcome.getDetails());
+        throw new OutOfMemoryException(createErrorMsg(this, size, size), outcome.getDetails());
       }
     }
     try {
       final AllocationManager manager = new ForeignAllocationManager(this, allocation);
       final BufferLedger ledger = manager.associate(this);
       final ArrowBuf buf =
-          new ArrowBuf(ledger, /*bufferManager=*/null, size, allocation.memoryAddress());
+          new ArrowBuf(ledger, /*bufferManager=*/ null, size, allocation.memoryAddress());
       buf.writerIndex(size);
       listener.onAllocation(size);
       return buf;
@@ -291,7 +295,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     return buffer(initialRequestSize, null);
   }
 
-  @SuppressWarnings("nullness:dereference.of.nullable")//dereference of possibly-null reference allocationManagerFactory
+  @SuppressWarnings("nullness:dereference.of.nullable") // dereference of possibly-null reference
+  // allocationManagerFactory
   private ArrowBuf createEmpty() {
     return allocationManagerFactory.empty();
   }
@@ -318,8 +323,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
         outcome = this.allocateBytes(actualRequestSize);
       }
       if (!outcome.isOk()) {
-        throw new OutOfMemoryException(createErrorMsg(this, actualRequestSize,
-            initialRequestSize), outcome.getDetails());
+        throw new OutOfMemoryException(
+            createErrorMsg(this, actualRequestSize, initialRequestSize), outcome.getDetails());
       }
     }
 
@@ -339,12 +344,11 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   }
 
   /**
-   * Used by usual allocation as well as for allocating a pre-reserved buffer.
-   * Skips the typical accounting associated with creating a new buffer.
+   * Used by usual allocation as well as for allocating a pre-reserved buffer. Skips the typical
+   * accounting associated with creating a new buffer.
    */
-  private ArrowBuf bufferWithoutReservation(
-      final long size,
-      @Nullable BufferManager bufferManager) throws OutOfMemoryException {
+  private ArrowBuf bufferWithoutReservation(final long size, @Nullable BufferManager bufferManager)
+      throws OutOfMemoryException {
     assertOpen();
 
     final AllocationManager manager = newAllocationManager(size);
@@ -352,8 +356,11 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     final ArrowBuf buffer = ledger.newArrowBuf(size, bufferManager);
 
     // make sure that our allocation is equal to what we expected.
-    Preconditions.checkArgument(buffer.capacity() == size,
-        "Allocated capacity %d was not equal to requested capacity %d.", buffer.capacity(), size);
+    Preconditions.checkArgument(
+        buffer.capacity() == size,
+        "Allocated capacity %d was not equal to requested capacity %d.",
+        buffer.capacity(),
+        size);
 
     return buffer;
   }
@@ -361,7 +368,6 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   private AllocationManager newAllocationManager(long size) {
     return newAllocationManager(this, size);
   }
-
 
   private AllocationManager newAllocationManager(BaseAllocator accountingAllocator, long size) {
     return allocationManagerFactory.create(accountingAllocator, size);
@@ -374,9 +380,7 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
 
   @Override
   public BufferAllocator newChildAllocator(
-      final String name,
-      final long initReservation,
-      final long maxAllocation) {
+      final String name, final long initReservation, final long maxAllocation) {
     return newChildAllocator(name, this.listener, initReservation, maxAllocation);
   }
 
@@ -389,20 +393,23 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     assertOpen();
 
     final ChildAllocator childAllocator =
-        new ChildAllocator(this, name, configBuilder()
-            .listener(listener)
-            .initReservation(initReservation)
-            .maxAllocation(maxAllocation)
-            .roundingPolicy(roundingPolicy)
-            .allocationManagerFactory(allocationManagerFactory)
-            .build());
+        new ChildAllocator(
+            this,
+            name,
+            configBuilder()
+                .listener(listener)
+                .initReservation(initReservation)
+                .maxAllocation(maxAllocation)
+                .roundingPolicy(roundingPolicy)
+                .allocationManagerFactory(allocationManagerFactory)
+                .build());
 
     if (DEBUG) {
       synchronized (DEBUG_LOCK) {
         childAllocators.put(childAllocator, childAllocator);
         if (historicalLog != null) {
-          historicalLog.recordEvent("allocator[%s] created new child allocator[%s]", name,
-              childAllocator.getName());
+          historicalLog.recordEvent(
+              "allocator[%s] created new child allocator[%s]", name, childAllocator.getName());
         }
       }
     } else {
@@ -441,32 +448,33 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
         if (!childAllocators.isEmpty()) {
           for (final BaseAllocator childAllocator : childAllocators.keySet()) {
             if (childAllocator.isClosed) {
-              logger.warn(String.format(
-                  "Closed child allocator[%s] on parent allocator[%s]'s child list.\n%s",
-                  childAllocator.name, name, toString()));
+              logger.warn(
+                  String.format(
+                      "Closed child allocator[%s] on parent allocator[%s]'s child list.\n%s",
+                      childAllocator.name, name, toString()));
             }
           }
 
           throw new IllegalStateException(
-            String.format("Allocator[%s] closed with outstanding child allocators.\n%s", name,
-              toString()));
+              String.format(
+                  "Allocator[%s] closed with outstanding child allocators.\n%s", name, toString()));
         }
 
         // are there outstanding buffers?
         final int allocatedCount = childLedgers != null ? childLedgers.size() : 0;
         if (allocatedCount > 0) {
           throw new IllegalStateException(
-            String.format("Allocator[%s] closed with outstanding buffers allocated (%d).\n%s",
-              name, allocatedCount, toString()));
+              String.format(
+                  "Allocator[%s] closed with outstanding buffers allocated (%d).\n%s",
+                  name, allocatedCount, toString()));
         }
 
         if (reservations != null && reservations.size() != 0) {
           throw new IllegalStateException(
-            String.format("Allocator[%s] closed with outstanding reservations (%d).\n%s", name,
-              reservations.size(),
-              toString()));
+              String.format(
+                  "Allocator[%s] closed with outstanding reservations (%d).\n%s",
+                  name, reservations.size(), toString()));
         }
-
       }
     } else {
       if (!childAllocators.isEmpty()) {
@@ -485,8 +493,10 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
       if (parent != null && reservation > allocated) {
         parent.releaseBytes(reservation - allocated);
       }
-      String msg = String.format("Memory was leaked by query. Memory leaked: (%d)\n%s%s", allocated,
-          outstandingChildAllocators.toString(), toString());
+      String msg =
+          String.format(
+              "Memory was leaked by query. Memory leaked: (%d)\n%s%s",
+              allocated, outstandingChildAllocators.toString(), toString());
       logger.error(msg);
       throw new IllegalStateException(msg);
     }
@@ -505,14 +515,12 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
       }
       logger.debug(String.format("closed allocator[%s].", name));
     }
-
-
   }
 
   @Override
   public String toString() {
-    final Verbosity verbosity = logger.isTraceEnabled() ? Verbosity.LOG_WITH_STACKTRACE
-        : Verbosity.BASIC;
+    final Verbosity verbosity =
+        logger.isTraceEnabled() ? Verbosity.LOG_WITH_STACKTRACE : Verbosity.BASIC;
     final StringBuilder sb = new StringBuilder();
     print(sb, 0, verbosity);
     return sb.toString();
@@ -520,8 +528,7 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
 
   /**
    * Provide a verbose string of the current allocator state. Includes the state of all child
-   * allocators, along with
-   * historical logs of each object and including stacktraces.
+   * allocators, along with historical logs of each object and including stacktraces.
    *
    * @return A Verbose string of current allocator state.
    */
@@ -551,12 +558,12 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   }
 
   /**
-   * Verifies the accounting state of the allocator (Only works for DEBUG)
-   * This overload is used for recursive calls, allowing for checking
-   * that ArrowBufs are unique across all allocators that are checked.
+   * Verifies the accounting state of the allocator (Only works for DEBUG) This overload is used for
+   * recursive calls, allowing for checking that ArrowBufs are unique across all allocators that are
+   * checked.
    *
    * @param buffersSeen a map of buffers that have already been seen when walking a tree of
-   *                    allocators
+   *     allocators
    * @throws IllegalStateException when any problems are found
    */
   private void verifyAllocator(
@@ -598,15 +605,20 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
         }
         logger.debug("allocator[" + name + "] child event logs END");
         throw new IllegalStateException(
-          "Child allocators own more memory (" + childTotal + ") than their parent (name = " +
-            name + " ) has allocated (" + getAllocatedMemory() + ')');
+            "Child allocators own more memory ("
+                + childTotal
+                + ") than their parent (name = "
+                + name
+                + " ) has allocated ("
+                + getAllocatedMemory()
+                + ')');
       }
 
       // Furthermore, the amount I've allocated should be that plus buffers I've allocated.
       long bufferTotal = 0;
 
-      final Set<@KeyFor("this.childLedgers") BufferLedger> ledgerSet = childLedgers != null ?
-              childLedgers.keySet() : null;
+      final Set<@KeyFor("this.childLedgers") BufferLedger> ledgerSet =
+          childLedgers != null ? childLedgers.keySet() : null;
       if (ledgerSet != null) {
         for (final BufferLedger ledger : ledgerSet) {
           if (!ledger.isOwningLedger()) {
@@ -620,8 +632,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
            */
           final BaseAllocator otherOwner = buffersSeen.get(am);
           if (otherOwner != null) {
-            throw new IllegalStateException("This allocator's ArrowBuf already owned by another " +
-              "allocator");
+            throw new IllegalStateException(
+                "This allocator's ArrowBuf already owned by another " + "allocator");
           }
           buffersSeen.put(am, this);
 
@@ -630,8 +642,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
       }
 
       // Preallocated space has to be accounted for
-      final Set<@KeyFor("this.reservations") Reservation> reservationSet = reservations != null ?
-              reservations.keySet() : null;
+      final Set<@KeyFor("this.reservations") Reservation> reservationSet =
+          reservations != null ? reservations.keySet() : null;
       long reservedTotal = 0;
       if (reservationSet != null) {
         for (final Reservation reservation : reservationSet) {
@@ -689,14 +701,15 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
         final long allocated2 = getAllocatedMemory();
 
         if (allocated2 != allocated) {
-          throw new IllegalStateException(String.format(
-            "allocator[%s]: allocated t1 (%d) + allocated t2 (%d). Someone released memory while in verification.",
-            name, allocated, allocated2));
-
+          throw new IllegalStateException(
+              String.format(
+                  "allocator[%s]: allocated t1 (%d) + allocated t2 (%d). Someone released memory while in verification.",
+                  name, allocated, allocated2));
         }
-        throw new IllegalStateException(String.format(
-          "allocator[%s]: buffer space (%d) + prealloc space (%d) + child space (%d) != allocated (%d)",
-          name, bufferTotal, reservedTotal, childTotal, allocated));
+        throw new IllegalStateException(
+            String.format(
+                "allocator[%s]: buffer space (%d) + prealloc space (%d) + child space (%d) != allocated (%d)",
+                name, bufferTotal, reservedTotal, childTotal, allocated));
       }
     }
   }
@@ -718,23 +731,25 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
         .append('\n');
 
     if (DEBUG) {
-      CommonUtil.indent(sb, level + 1).append(String.format("child allocators: %d\n", childAllocators.size()));
+      CommonUtil.indent(sb, level + 1)
+          .append(String.format("child allocators: %d\n", childAllocators.size()));
       for (BaseAllocator child : childAllocators.keySet()) {
         child.print(sb, level + 2, verbosity);
       }
 
-      CommonUtil.indent(sb, level + 1).append(String.format("ledgers: %d\n", childLedgers != null ?
-              childLedgers.size() : 0));
+      CommonUtil.indent(sb, level + 1)
+          .append(String.format("ledgers: %d\n", childLedgers != null ? childLedgers.size() : 0));
       if (childLedgers != null) {
         for (BufferLedger ledger : childLedgers.keySet()) {
           ledger.print(sb, level + 2, verbosity);
         }
       }
 
-      final Set<@KeyFor("this.reservations") Reservation> reservations = this.reservations != null ?
-              this.reservations.keySet() : null;
-      CommonUtil.indent(sb, level + 1).append(String.format("reservations: %d\n",
-              reservations != null ? reservations.size() : 0));
+      final Set<@KeyFor("this.reservations") Reservation> reservations =
+          this.reservations != null ? this.reservations.keySet() : null;
+      CommonUtil.indent(sb, level + 1)
+          .append(
+              String.format("reservations: %d\n", reservations != null ? reservations.size() : 0));
       if (reservations != null) {
         for (final Reservation reservation : reservations) {
           if (verbosity.includeHistoricalLog) {
@@ -744,13 +759,12 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
           }
         }
       }
-
     }
-
   }
 
-  private void dumpBuffers(final StringBuilder sb,
-                           final @Nullable Set<@KeyFor("this.childLedgers") BufferLedger> ledgerSet) {
+  private void dumpBuffers(
+      final StringBuilder sb,
+      final @Nullable Set<@KeyFor("this.childLedgers") BufferLedger> ledgerSet) {
     if (ledgerSet != null) {
       for (final BufferLedger ledger : ledgerSet) {
         if (!ledger.isOwningLedger()) {
@@ -766,14 +780,12 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     }
   }
 
-  /**
-   * Enum for logging verbosity.
-   */
+  /** Enum for logging verbosity. */
   public enum Verbosity {
     BASIC(false, false), // only include basic information
     LOG(true, false), // include basic
     LOG_WITH_STACKTRACE(true, true) //
-    ;
+  ;
 
     public final boolean includeHistoricalLog;
     public final boolean includeStackTraces;
@@ -791,12 +803,9 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
    */
   public static Config defaultConfig() {
     return DEFAULT_CONFIG;
-
   }
 
-  /**
-   * Returns a builder class for configuring BaseAllocator's options.
-   */
+  /** Returns a builder class for configuring BaseAllocator's options. */
   public static ImmutableConfig.Builder configBuilder() {
     return ImmutableConfig.builder();
   }
@@ -806,47 +815,37 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     return roundingPolicy;
   }
 
-  /**
-   * Config class of {@link BaseAllocator}.
-   */
+  /** Config class of {@link BaseAllocator}. */
   @Value.Immutable
   abstract static class Config {
-    /**
-     * Factory for creating {@link AllocationManager} instances.
-     */
+    /** Factory for creating {@link AllocationManager} instances. */
     @Value.Default
     AllocationManager.Factory getAllocationManagerFactory() {
       return DefaultAllocationManagerOption.getDefaultAllocationManagerFactory();
     }
 
-    /**
-     * Listener callback. Must be non-null.
-     */
+    /** Listener callback. Must be non-null. */
     @Value.Default
     AllocationListener getListener() {
       return AllocationListener.NOOP;
     }
 
-    /**
-     * Initial reservation size (in bytes) for this allocator.
-     */
+    /** Initial reservation size (in bytes) for this allocator. */
     @Value.Default
     long getInitReservation() {
       return 0;
     }
 
     /**
-     * Max allocation size (in bytes) for this allocator, allocations past this limit fail.
-     * Can be modified after construction.
+     * Max allocation size (in bytes) for this allocator, allocations past this limit fail. Can be
+     * modified after construction.
      */
     @Value.Default
     long getMaxAllocation() {
       return Long.MAX_VALUE;
     }
 
-    /**
-     * The policy for rounding the buffer size.
-     */
+    /** The policy for rounding the buffer size. */
     @Value.Default
     RoundingPolicy getRoundingPolicy() {
       return DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY;
@@ -854,8 +853,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
   }
 
   /**
-   * Implementation of {@link AllocationReservation} that supports
-   * history tracking under {@linkplain #DEBUG} is true.
+   * Implementation of {@link AllocationReservation} that supports history tracking under
+   * {@linkplain #DEBUG} is true.
    */
   public class Reservation implements AllocationReservation {
 
@@ -867,14 +866,16 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     /**
      * Creates a new reservation.
      *
-     * <p>If {@linkplain #DEBUG} is true this will capture a historical
-     * log of events relevant to this Reservation.
+     * <p>If {@linkplain #DEBUG} is true this will capture a historical log of events relevant to
+     * this Reservation.
      */
-    @SuppressWarnings("nullness:argument")//to handle null assignment on third party dependency: System.identityHashCode
+    @SuppressWarnings("nullness:argument") // to handle null assignment on third party dependency:
+    // System.identityHashCode
     public Reservation() {
       if (DEBUG) {
-        historicalLog = new HistoricalLog("Reservation[allocator[%s], %d]", name, System
-          .identityHashCode(this));
+        historicalLog =
+            new HistoricalLog(
+                "Reservation[allocator[%s], %d]", name, System.identityHashCode(this));
         historicalLog.recordEvent("created");
         synchronized (DEBUG_LOCK) {
           if (reservations != null) {
@@ -891,8 +892,10 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
       assertOpen();
 
       Preconditions.checkArgument(nBytes >= 0, "nBytes(%d) < 0", nBytes);
-      Preconditions.checkState(!closed, "Attempt to increase reservation after reservation has been closed");
-      Preconditions.checkState(!used, "Attempt to increase reservation after reservation has been used");
+      Preconditions.checkState(
+          !closed, "Attempt to increase reservation after reservation has been closed");
+      Preconditions.checkState(
+          !used, "Attempt to increase reservation after reservation has been used");
 
       // we round up to next power of two since all reservations are done in powers of two. This
       // may overestimate the
@@ -956,8 +959,9 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
             final StringBuilder sb = new StringBuilder();
             print(sb, 0, Verbosity.LOG_WITH_STACKTRACE);
             logger.debug(sb.toString());
-            throw new IllegalStateException(String.format("Didn't find closing reservation[%d]",
-              System.identityHashCode(this)));
+            throw new IllegalStateException(
+                String.format(
+                    "Didn't find closing reservation[%d]", System.identityHashCode(this)));
           }
 
           if (historicalLog != null) {
@@ -1003,7 +1007,7 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
        * The reservation already added the requested bytes to the allocators owned and allocated
        * bytes via reserve().
        * This ensures that they can't go away. But when we ask for the buffer here, that will add
-        * to the allocated bytes
+       * to the allocated bytes
        * as well, so we need to return the same number back to avoid double-counting them.
        */
       try {
@@ -1011,8 +1015,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
 
         listener.onAllocation(nBytes);
         if (historicalLog != null) {
-          historicalLog.recordEvent("allocate() => %s", String.format("ArrowBuf[%d]", arrowBuf
-              .getId()));
+          historicalLog.recordEvent(
+              "allocate() => %s", String.format("ArrowBuf[%d]", arrowBuf.getId()));
         }
         success = true;
         return arrowBuf;
@@ -1037,6 +1041,5 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
         historicalLog.recordEvent("releaseReservation(%d)", nBytes);
       }
     }
-
   }
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BoundsChecking.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BoundsChecking.java
@@ -14,19 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
  * Configuration class to determine if bounds checking should be turned on or off.
  *
- * <p>
- * Bounds checking is on by default.  You can disable it by setting either the system property or
- * the environmental variable to "true". The system property can be "arrow.enable_unsafe_memory_access"
- * or "drill.enable_unsafe_memory_access". The latter is deprecated. The environmental variable is named
- * "ARROW_ENABLE_UNSAFE_MEMORY_ACCESS".
- * When both the system property and the environmental variable are set, the system property takes precedence.
- * </p>
+ * <p>Bounds checking is on by default. You can disable it by setting either the system property or
+ * the environmental variable to "true". The system property can be
+ * "arrow.enable_unsafe_memory_access" or "drill.enable_unsafe_memory_access". The latter is
+ * deprecated. The environmental variable is named "ARROW_ENABLE_UNSAFE_MEMORY_ACCESS". When both
+ * the system property and the environmental variable are set, the system property takes precedence.
  */
 public class BoundsChecking {
 
@@ -37,9 +34,11 @@ public class BoundsChecking {
     String envProperty = System.getenv("ARROW_ENABLE_UNSAFE_MEMORY_ACCESS");
     String oldProperty = System.getProperty("drill.enable_unsafe_memory_access");
     if (oldProperty != null) {
-      logger.warn("\"drill.enable_unsafe_memory_access\" has been renamed to \"arrow.enable_unsafe_memory_access\"");
-      logger.warn("\"arrow.enable_unsafe_memory_access\" can be set to: " +
-              " true (to not check) or false (to check, default)");
+      logger.warn(
+          "\"drill.enable_unsafe_memory_access\" has been renamed to \"arrow.enable_unsafe_memory_access\"");
+      logger.warn(
+          "\"arrow.enable_unsafe_memory_access\" can be set to: "
+              + " true (to not check) or false (to check, default)");
     }
     String newProperty = System.getProperty("arrow.enable_unsafe_memory_access");
 
@@ -57,7 +56,5 @@ public class BoundsChecking {
     BOUNDS_CHECKING_ENABLED = !"true".equals(unsafeFlagValue);
   }
 
-  private BoundsChecking() {
-  }
-
+  private BoundsChecking() {}
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -14,25 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.util.Collection;
-
 import org.apache.arrow.memory.rounding.DefaultRoundingPolicy;
 import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/**
- * Wrapper class to deal with byte buffer allocation. Ensures users only use designated methods.
- */
+/** Wrapper class to deal with byte buffer allocation. Ensures users only use designated methods. */
 public interface BufferAllocator extends AutoCloseable {
 
   /**
-   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
-   * be larger than the
-   * requested size for rounding purposes. However, the buffer's capacity will be set to the
-   * configured size.
+   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically be
+   * larger than the requested size for rounding purposes. However, the buffer's capacity will be
+   * set to the configured size.
    *
    * @param size The size in bytes.
    * @return a new ArrowBuf, or null if the request can't be satisfied
@@ -41,12 +36,11 @@ public interface BufferAllocator extends AutoCloseable {
   ArrowBuf buffer(long size);
 
   /**
-   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
-   * be larger than the
-   * requested size for rounding purposes. However, the buffer's capacity will be set to the
-   * configured size.
+   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically be
+   * larger than the requested size for rounding purposes. However, the buffer's capacity will be
+   * set to the configured size.
    *
-   * @param size    The size in bytes.
+   * @param size The size in bytes.
    * @param manager A buffer manager to manage reallocation.
    * @return a new ArrowBuf, or null if the request can't be satisfied
    * @throws OutOfMemoryException if buffer cannot be allocated
@@ -54,8 +48,8 @@ public interface BufferAllocator extends AutoCloseable {
   ArrowBuf buffer(long size, BufferManager manager);
 
   /**
-   * Get the root allocator of this allocator. If this allocator is already a root, return
-   * this directly.
+   * Get the root allocator of this allocator. If this allocator is already a root, return this
+   * directly.
    *
    * @return The root allocator
    */
@@ -64,9 +58,9 @@ public interface BufferAllocator extends AutoCloseable {
   /**
    * Create a new child allocator.
    *
-   * @param name            the name of the allocator.
+   * @param name the name of the allocator.
    * @param initReservation the initial space reservation (obtained from this allocator)
-   * @param maxAllocation   maximum amount of space the new allocator can allocate
+   * @param maxAllocation maximum amount of space the new allocator can allocate
    * @return the new allocator, or null if it can't be created
    */
   BufferAllocator newChildAllocator(String name, long initReservation, long maxAllocation);
@@ -74,23 +68,20 @@ public interface BufferAllocator extends AutoCloseable {
   /**
    * Create a new child allocator.
    *
-   * @param name            the name of the allocator.
-   * @param listener        allocation listener for the newly created child
+   * @param name the name of the allocator.
+   * @param listener allocation listener for the newly created child
    * @param initReservation the initial space reservation (obtained from this allocator)
-   * @param maxAllocation   maximum amount of space the new allocator can allocate
+   * @param maxAllocation maximum amount of space the new allocator can allocate
    * @return the new allocator, or null if it can't be created
    */
   BufferAllocator newChildAllocator(
-      String name,
-      AllocationListener listener,
-      long initReservation,
-      long maxAllocation);
+      String name, AllocationListener listener, long initReservation, long maxAllocation);
 
   /**
    * Close and release all buffers generated from this buffer pool.
    *
-   * <p>When assertions are on, complains if there are any outstanding buffers; to avoid
-   * that, release all buffers before the allocator is closed.</p>
+   * <p>When assertions are on, complains if there are any outstanding buffers; to avoid that,
+   * release all buffers before the allocator is closed.
    */
   @Override
   void close();
@@ -131,8 +122,8 @@ public interface BufferAllocator extends AutoCloseable {
   long getPeakMemoryAllocation();
 
   /**
-   * Returns the amount of memory that can probably be allocated at this moment
-   * without exceeding this or any parents allocation maximum.
+   * Returns the amount of memory that can probably be allocated at this moment without exceeding
+   * this or any parents allocation maximum.
    *
    * @return Headroom in bytes
    */
@@ -146,7 +137,6 @@ public interface BufferAllocator extends AutoCloseable {
    */
   boolean forceAllocate(long size);
 
-
   /**
    * Release bytes from this allocator.
    *
@@ -157,8 +147,8 @@ public interface BufferAllocator extends AutoCloseable {
   /**
    * Returns the allocation listener used by this allocator.
    *
-   * @return the {@link AllocationListener} instance. Or {@link AllocationListener#NOOP} by default if no listener
-   *         is configured when this allocator was created.
+   * @return the {@link AllocationListener} instance. Or {@link AllocationListener#NOOP} by default
+   *     if no listener is configured when this allocator was created.
    */
   AllocationListener getListener();
 
@@ -167,7 +157,8 @@ public interface BufferAllocator extends AutoCloseable {
    *
    * @return parent allocator
    */
-  @Nullable BufferAllocator getParentAllocator();
+  @Nullable
+  BufferAllocator getParentAllocator();
 
   /**
    * Returns the set of child allocators.
@@ -177,8 +168,8 @@ public interface BufferAllocator extends AutoCloseable {
   Collection<BufferAllocator> getChildAllocators();
 
   /**
-   * Create an allocation reservation. A reservation is a way of building up
-   * a request for a buffer whose size is not known in advance. See
+   * Create an allocation reservation. A reservation is a way of building up a request for a buffer
+   * whose size is not known in advance. See
    *
    * @return the newly created reservation
    * @see AllocationReservation
@@ -186,10 +177,9 @@ public interface BufferAllocator extends AutoCloseable {
   AllocationReservation newReservation();
 
   /**
-   * Get a reference to the empty buffer associated with this allocator. Empty buffers are
-   * special because we don't
-   * worry about them leaking or managing reference counts on them since they don't actually
-   * point to any memory.
+   * Get a reference to the empty buffer associated with this allocator. Empty buffers are special
+   * because we don't worry about them leaking or managing reference counts on them since they don't
+   * actually point to any memory.
    *
    * @return the empty buffer
    */
@@ -197,8 +187,7 @@ public interface BufferAllocator extends AutoCloseable {
 
   /**
    * Return the name of this allocator. This is a human readable name that can help debugging.
-   * Typically provides
-   * coordinates about where this allocator was created
+   * Typically provides coordinates about where this allocator was created
    *
    * @return the name of the allocator
    */
@@ -206,9 +195,8 @@ public interface BufferAllocator extends AutoCloseable {
 
   /**
    * Return whether or not this allocator (or one if its parents) is over its limits. In the case
-   * that an allocator is
-   * over its limit, all consumers of that allocator should aggressively try to address the
-   * overlimit situation.
+   * that an allocator is over its limit, all consumers of that allocator should aggressively try to
+   * address the overlimit situation.
    *
    * @return whether or not this allocator (or one if its parents) is over its limits
    */
@@ -216,8 +204,7 @@ public interface BufferAllocator extends AutoCloseable {
 
   /**
    * Return a verbose string describing this allocator. If in DEBUG mode, this will also include
-   * relevant stacktraces
-   * and historical logs for underlying objects
+   * relevant stacktraces and historical logs for underlying objects
    *
    * @return A very verbose description of the allocator hierarchy.
    */
@@ -225,14 +212,11 @@ public interface BufferAllocator extends AutoCloseable {
 
   /**
    * Asserts (using java assertions) that the provided allocator is currently open. If assertions
-   * are disabled, this is
-   * a no-op.
+   * are disabled, this is a no-op.
    */
   void assertOpen();
 
-  /**
-   * Gets the rounding policy of the allocator.
-   */
+  /** Gets the rounding policy of the allocator. */
   default RoundingPolicy getRoundingPolicy() {
     return DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY;
   }
@@ -240,12 +224,12 @@ public interface BufferAllocator extends AutoCloseable {
   /**
    * EXPERIMENTAL: Wrap an allocation created outside this BufferAllocator.
    *
-   * <p>This is useful to integrate allocations from native code into the same memory management framework as
-   * Java-allocated buffers, presenting users a consistent API. The created buffer will be tracked by this allocator
-   * and can be transferred like Java-allocated buffers.
+   * <p>This is useful to integrate allocations from native code into the same memory management
+   * framework as Java-allocated buffers, presenting users a consistent API. The created buffer will
+   * be tracked by this allocator and can be transferred like Java-allocated buffers.
    *
-   * <p>The underlying allocation will be closed when all references to the buffer are released. If this method throws,
-   * the underlying allocation will also be closed.
+   * <p>The underlying allocation will be closed when all references to the buffer are released. If
+   * this method throws, the underlying allocation will also be closed.
    *
    * @param allocation The underlying allocation.
    */

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -14,27 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.util.IdentityHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
 import org.apache.arrow.util.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * The reference manager that binds an {@link AllocationManager} to
- * {@link BufferAllocator} and a set of {@link ArrowBuf}. The set of
- * ArrowBufs managed by this reference manager share a common
+ * The reference manager that binds an {@link AllocationManager} to {@link BufferAllocator} and a
+ * set of {@link ArrowBuf}. The set of ArrowBufs managed by this reference manager share a common
  * fate (same reference count).
  */
 public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, ReferenceManager {
   private final @Nullable IdentityHashMap<ArrowBuf, @Nullable Object> buffers =
-          BaseAllocator.DEBUG ? new IdentityHashMap<>() : null;
+      BaseAllocator.DEBUG ? new IdentityHashMap<>() : null;
   private static final AtomicLong LEDGER_ID_GENERATOR = new AtomicLong(0);
   // unique ID assigned to each ledger
   private final long ledgerId = LEDGER_ID_GENERATOR.incrementAndGet();
@@ -45,8 +42,9 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   private final BufferAllocator allocator;
   private final AllocationManager allocationManager;
   private final @Nullable HistoricalLog historicalLog =
-      BaseAllocator.DEBUG ? new HistoricalLog(BaseAllocator.DEBUG_LOG_LENGTH,
-        "BufferLedger[%d]", 1) : null;
+      BaseAllocator.DEBUG
+          ? new HistoricalLog(BaseAllocator.DEBUG_LOG_LENGTH, "BufferLedger[%d]", 1)
+          : null;
   private volatile long lDestructionTime = 0;
 
   BufferLedger(final BufferAllocator allocator, final AllocationManager allocationManager) {
@@ -65,6 +63,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
 
   /**
    * Get the buffer allocator associated with this reference manager.
+   *
    * @return buffer allocator
    */
   @Override
@@ -74,6 +73,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
 
   /**
    * Get this ledger's reference count.
+   *
    * @return reference count
    */
   @Override
@@ -82,23 +82,21 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * Increment the ledger's reference count for the associated
-   * underlying memory chunk. All ArrowBufs managed by this ledger
-   * will share the ref count.
+   * Increment the ledger's reference count for the associated underlying memory chunk. All
+   * ArrowBufs managed by this ledger will share the ref count.
    */
   void increment() {
     bufRefCnt.incrementAndGet();
   }
 
   /**
-   * Decrement the ledger's reference count by 1 for the associated underlying
-   * memory chunk. If the reference count drops to 0, it implies that
-   * no ArrowBufs managed by this reference manager need access to the memory
-   * chunk. In that case, the ledger should inform the allocation manager
-   * about releasing its ownership for the chunk. Whether or not the memory
-   * chunk will be released is something that {@link AllocationManager} will
-   * decide since tracks the usage of memory chunk across multiple reference
-   * managers and allocators.
+   * Decrement the ledger's reference count by 1 for the associated underlying memory chunk. If the
+   * reference count drops to 0, it implies that no ArrowBufs managed by this reference manager need
+   * access to the memory chunk. In that case, the ledger should inform the allocation manager about
+   * releasing its ownership for the chunk. Whether or not the memory chunk will be released is
+   * something that {@link AllocationManager} will decide since tracks the usage of memory chunk
+   * across multiple reference managers and allocators.
+   *
    * @return true if the new ref count has dropped to 0, false otherwise
    */
   @Override
@@ -107,26 +105,24 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * Decrement the ledger's reference count for the associated underlying
-   * memory chunk. If the reference count drops to 0, it implies that
-   * no ArrowBufs managed by this reference manager need access to the memory
-   * chunk. In that case, the ledger should inform the allocation manager
-   * about releasing its ownership for the chunk. Whether or not the memory
-   * chunk will be released is something that {@link AllocationManager} will
-   * decide since tracks the usage of memory chunk across multiple reference
-   * managers and allocators.
+   * Decrement the ledger's reference count for the associated underlying memory chunk. If the
+   * reference count drops to 0, it implies that no ArrowBufs managed by this reference manager need
+   * access to the memory chunk. In that case, the ledger should inform the allocation manager about
+   * releasing its ownership for the chunk. Whether or not the memory chunk will be released is
+   * something that {@link AllocationManager} will decide since tracks the usage of memory chunk
+   * across multiple reference managers and allocators.
+   *
    * @param decrement amount to decrease the reference count by
    * @return true if the new ref count has dropped to 0, false otherwise
    */
   @Override
   public boolean release(int decrement) {
-    Preconditions.checkState(decrement >= 1,
-          "ref count decrement should be greater than or equal to 1");
+    Preconditions.checkState(
+        decrement >= 1, "ref count decrement should be greater than or equal to 1");
     // decrement the ref count
     final int refCnt = decrement(decrement);
     if (historicalLog != null) {
-      historicalLog.recordEvent("release(%d). original value: %d",
-          decrement, refCnt + decrement);
+      historicalLog.recordEvent("release(%d). original value: %d", decrement, refCnt + decrement);
     }
     // the new ref count should be >= 0
     Preconditions.checkState(refCnt >= 0, "RefCnt has gone negative");
@@ -134,14 +130,12 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * Decrement the ledger's reference count for the associated underlying
-   * memory chunk. If the reference count drops to 0, it implies that
-   * no ArrowBufs managed by this reference manager need access to the memory
-   * chunk. In that case, the ledger should inform the allocation manager
-   * about releasing its ownership for the chunk. Whether or not the memory
-   * chunk will be released is something that {@link AllocationManager} will
-   * decide since tracks the usage of memory chunk across multiple reference
-   * managers and allocators.
+   * Decrement the ledger's reference count for the associated underlying memory chunk. If the
+   * reference count drops to 0, it implies that no ArrowBufs managed by this reference manager need
+   * access to the memory chunk. In that case, the ledger should inform the allocation manager about
+   * releasing its ownership for the chunk. Whether or not the memory chunk will be released is
+   * something that {@link AllocationManager} will decide since tracks the usage of memory chunk
+   * across multiple reference managers and allocators.
    *
    * @param decrement amount to decrease the reference count by
    * @return the new reference count
@@ -162,18 +156,15 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
     return outcome;
   }
 
-  /**
-   * Increment the ledger's reference count for associated
-   * underlying memory chunk by 1.
-   */
+  /** Increment the ledger's reference count for associated underlying memory chunk by 1. */
   @Override
   public void retain() {
     retain(1);
   }
 
   /**
-   * Increment the ledger's reference count for associated
-   * underlying memory chunk by the given amount.
+   * Increment the ledger's reference count for associated underlying memory chunk by the given
+   * amount.
    *
    * @param increment amount to increase the reference count by
    */
@@ -188,21 +179,19 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * Derive a new ArrowBuf from a given source ArrowBuf. The new derived
-   * ArrowBuf will share the same reference count as rest of the ArrowBufs
-   * associated with this ledger. This operation is typically used for
-   * slicing -- creating new ArrowBufs from a compound ArrowBuf starting at
-   * a particular index in the underlying memory and having access to a
-   * particular length (in bytes) of data in memory chunk.
-   * <p>
-   * This method is also used as a helper for transferring ownership and retain to target
+   * Derive a new ArrowBuf from a given source ArrowBuf. The new derived ArrowBuf will share the
+   * same reference count as rest of the ArrowBufs associated with this ledger. This operation is
+   * typically used for slicing -- creating new ArrowBufs from a compound ArrowBuf starting at a
+   * particular index in the underlying memory and having access to a particular length (in bytes)
+   * of data in memory chunk.
+   *
+   * <p>This method is also used as a helper for transferring ownership and retain to target
    * allocator.
-   * </p>
+   *
    * @param sourceBuffer source ArrowBuf
-   * @param index index (relative to source ArrowBuf) new ArrowBuf should be
-   *              derived from
-   * @param length length (bytes) of data in underlying memory that derived buffer will
-   *               have access to in underlying memory
+   * @param index index (relative to source ArrowBuf) new ArrowBuf should be derived from
+   * @param length length (bytes) of data in underlying memory that derived buffer will have access
+   *     to in underlying memory
    * @return derived buffer
    */
   @Override
@@ -227,11 +216,13 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
     final long derivedBufferAddress = sourceBuffer.memoryAddress() + index;
 
     // create new ArrowBuf
-    final ArrowBuf derivedBuf = new ArrowBuf(
+    final ArrowBuf derivedBuf =
+        new ArrowBuf(
             this,
             null,
             length, // length (in bytes) in the underlying memory chunk for this new ArrowBuf
-            derivedBufferAddress // starting byte address in the underlying memory for this new ArrowBuf
+            derivedBufferAddress // starting byte address in the underlying memory for this new
+            // ArrowBuf
             );
 
     // logging
@@ -239,16 +230,15 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * Used by an allocator to create a new ArrowBuf. This is provided
-   * as a helper method for the allocator when it allocates a new memory chunk
-   * using a new instance of allocation manager and creates a new reference manager
-   * too.
+   * Used by an allocator to create a new ArrowBuf. This is provided as a helper method for the
+   * allocator when it allocates a new memory chunk using a new instance of allocation manager and
+   * creates a new reference manager too.
    *
-   * @param length  The length in bytes that this ArrowBuf will provide access to.
-   * @param manager An optional BufferManager argument that can be used to manage expansion of
-   *                this ArrowBuf
-   * @return A new ArrowBuf that shares references with all ArrowBufs associated
-   *         with this BufferLedger
+   * @param length The length in bytes that this ArrowBuf will provide access to.
+   * @param manager An optional BufferManager argument that can be used to manage expansion of this
+   *     ArrowBuf
+   * @return A new ArrowBuf that shares references with all ArrowBufs associated with this
+   *     BufferLedger
    */
   ArrowBuf newArrowBuf(final long length, final @Nullable BufferManager manager) {
     allocator.assertOpen();
@@ -266,9 +256,12 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   private ArrowBuf loggingArrowBufHistoricalLog(ArrowBuf buf) {
     if (historicalLog != null) {
       historicalLog.recordEvent(
-          "ArrowBuf(BufferLedger, BufferAllocator[%s], " +
-          "UnsafeDirectLittleEndian[identityHashCode == " + "%d](%s)) => ledger hc == %d",
-          allocator.getName(), System.identityHashCode(buf), buf.toString(),
+          "ArrowBuf(BufferLedger, BufferAllocator[%s], "
+              + "UnsafeDirectLittleEndian[identityHashCode == "
+              + "%d](%s)) => ledger hc == %d",
+          allocator.getName(),
+          System.identityHashCode(buf),
+          buf.toString(),
           System.identityHashCode(this));
       Preconditions.checkState(buffers != null, "IdentityHashMap of buffers must not be null");
       synchronized (buffers) {
@@ -282,15 +275,15 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   /**
    * Create a new ArrowBuf that is associated with an alternative allocator for the purposes of
    * memory ownership and accounting. This has no impact on the reference counting for the current
-   * ArrowBuf except in the situation where the passed in Allocator is the same as the current buffer.
-   * <p>
-   * This operation has no impact on the reference count of this ArrowBuf. The newly created
+   * ArrowBuf except in the situation where the passed in Allocator is the same as the current
+   * buffer.
+   *
+   * <p>This operation has no impact on the reference count of this ArrowBuf. The newly created
    * ArrowBuf with either have a reference count of 1 (in the case that this is the first time this
-   * memory is being associated with the target allocator or in other words allocation manager currently
-   * doesn't hold a mapping for the target allocator) or the current value of the reference count for
-   * the target allocator-reference manager combination + 1 in the case that the provided allocator
-   * already had an association to this underlying memory.
-   * </p>
+   * memory is being associated with the target allocator or in other words allocation manager
+   * currently doesn't hold a mapping for the target allocator) or the current value of the
+   * reference count for the target allocator-reference manager combination + 1 in the case that the
+   * provided allocator already had an association to this underlying memory.
    *
    * @param srcBuffer source ArrowBuf
    * @param target The target allocator to create an association with.
@@ -320,20 +313,21 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * Transfer any balance the current ledger has to the target ledger. In the case
-   * that the current ledger holds no memory, no transfer is made to the new ledger.
+   * Transfer any balance the current ledger has to the target ledger. In the case that the current
+   * ledger holds no memory, no transfer is made to the new ledger.
    *
    * @param targetReferenceManager The ledger to transfer ownership account to.
    * @return Whether transfer fit within target ledgers limits.
    */
   boolean transferBalance(final @Nullable ReferenceManager targetReferenceManager) {
-    Preconditions.checkArgument(targetReferenceManager != null,
-            "Expecting valid target reference manager");
+    Preconditions.checkArgument(
+        targetReferenceManager != null, "Expecting valid target reference manager");
     boolean overlimit = false;
     if (targetReferenceManager != null) {
       final BufferAllocator targetAllocator = targetReferenceManager.getAllocator();
-      Preconditions.checkArgument(allocator.getRoot() == targetAllocator.getRoot(),
-              "You can only transfer between two allocators that share the same root.");
+      Preconditions.checkArgument(
+          allocator.getRoot() == targetAllocator.getRoot(),
+          "You can only transfer between two allocators that share the same root.");
 
       allocator.assertOpen();
       targetReferenceManager.getAllocator().assertOpen();
@@ -355,8 +349,8 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
         }
 
         if (BaseAllocator.DEBUG && this.historicalLog != null) {
-          this.historicalLog.recordEvent("transferBalance(%s)",
-                  targetReferenceManager.getAllocator().getName());
+          this.historicalLog.recordEvent(
+              "transferBalance(%s)", targetReferenceManager.getAllocator().getName());
         }
 
         overlimit = targetAllocator.forceAllocate(allocationManager.getSize());
@@ -371,32 +365,30 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * Transfer the memory accounting ownership of this ArrowBuf to another allocator.
-   * This will generate a new ArrowBuf that carries an association with the underlying memory
-   * of this ArrowBuf. If this ArrowBuf is connected to the owning BufferLedger of this memory,
-   * that memory ownership/accounting will be transferred to the target allocator. If this
-   * ArrowBuf does not currently own the memory underlying it (and is only associated with it),
-   * this does not transfer any ownership to the newly created ArrowBuf.
-   * <p>
-   * This operation has no impact on the reference count of this ArrowBuf. The newly created
-   * ArrowBuf with either have a reference count of 1 (in the case that this is the first time
-   * this memory is being associated with the new allocator) or the current value of the reference
-   * count for the other AllocationManager/BufferLedger combination + 1 in the case that the provided
+   * Transfer the memory accounting ownership of this ArrowBuf to another allocator. This will
+   * generate a new ArrowBuf that carries an association with the underlying memory of this
+   * ArrowBuf. If this ArrowBuf is connected to the owning BufferLedger of this memory, that memory
+   * ownership/accounting will be transferred to the target allocator. If this ArrowBuf does not
+   * currently own the memory underlying it (and is only associated with it), this does not transfer
+   * any ownership to the newly created ArrowBuf.
+   *
+   * <p>This operation has no impact on the reference count of this ArrowBuf. The newly created
+   * ArrowBuf with either have a reference count of 1 (in the case that this is the first time this
+   * memory is being associated with the new allocator) or the current value of the reference count
+   * for the other AllocationManager/BufferLedger combination + 1 in the case that the provided
    * allocator already had an association to this underlying memory.
-   * </p>
-   * <p>
-   * Transfers will always succeed, even if that puts the other allocator into an overlimit
+   *
+   * <p>Transfers will always succeed, even if that puts the other allocator into an overlimit
    * situation. This is possible due to the fact that the original owning allocator may have
    * allocated this memory out of a local reservation whereas the target allocator may need to
    * allocate new memory from a parent or RootAllocator. This operation is done n a mostly-lockless
    * but consistent manner. As such, the overlimit==true situation could occur slightly prematurely
    * to an actual overlimit==true condition. This is simply conservative behavior which means we may
    * return overlimit slightly sooner than is necessary.
-   * </p>
    *
    * @param target The allocator to transfer ownership to.
    * @return A new transfer result with the impact of the transfer (whether it was overlimit) as
-   *         well as the newly created ArrowBuf.
+   *     well as the newly created ArrowBuf.
    */
   @Override
   public TransferResult transferOwnership(final ArrowBuf srcBuffer, final BufferAllocator target) {
@@ -417,9 +409,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
     return new TransferResult(allocationFit, targetArrowBuf);
   }
 
-  /**
-   * The outcome of a Transfer.
-   */
+  /** The outcome of a Transfer. */
   public static class TransferResult implements OwnershipTransferResult {
 
     // Whether this transfer fit within the target allocator's capacity.
@@ -446,6 +436,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
 
   /**
    * Total size (in bytes) of memory underlying this reference manager.
+   *
    * @return Size (in bytes) of the memory chunk
    */
   @Override
@@ -454,9 +445,10 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   }
 
   /**
-   * How much memory is accounted for by this ledger. This is either getSize()
-   * if this is the owning ledger for the memory or zero in the case that this
-   * is not the owning ledger associated with this memory.
+   * How much memory is accounted for by this ledger. This is either getSize() if this is the owning
+   * ledger for the memory or zero in the case that this is not the owning ledger associated with
+   * this memory.
+   *
    * @return Amount of accounted(owned) memory associated with this ledger.
    */
   @Override
@@ -473,8 +465,8 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   /**
    * Print the current ledger state to the provided StringBuilder.
    *
-   * @param sb        The StringBuilder to populate.
-   * @param indent    The level of indentation to position the data.
+   * @param sb The StringBuilder to populate.
+   * @param indent The level of indentation to position the data.
    * @param verbosity The level of verbosity to print.
    */
   void print(StringBuilder sb, int indent, BaseAllocator.Verbosity verbosity) {
@@ -499,9 +491,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
     } else {
       Preconditions.checkArgument(buffers != null, "IdentityHashMap of buffers must not be null");
       synchronized (buffers) {
-        sb.append("] holds ")
-            .append(buffers.size())
-            .append(" buffers. \n");
+        sb.append("] holds ").append(buffers.size()).append(" buffers. \n");
         for (ArrowBuf buf : buffers.keySet()) {
           buf.print(sb, indent + 2, verbosity);
           sb.append('\n');
@@ -518,5 +508,4 @@ public class BufferLedger implements ValueWithKeyIncluded<BufferAllocator>, Refe
   public AllocationManager getAllocationManager() {
     return allocationManager;
   }
-
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferManager.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BufferManager.java
@@ -14,21 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
- * Manages a list of {@link ArrowBuf}s that can be reallocated as needed. Upon
- * re-allocation the old buffer will be freed. Managing a list of these buffers
- * prevents some parts of the system from needing to define a correct location
- * to place the final call to free them.
+ * Manages a list of {@link ArrowBuf}s that can be reallocated as needed. Upon re-allocation the old
+ * buffer will be freed. Managing a list of these buffers prevents some parts of the system from
+ * needing to define a correct location to place the final call to free them.
  */
 public interface BufferManager extends AutoCloseable {
 
   /**
    * Replace an old buffer with a new version at least of the provided size. Does not copy data.
    *
-   * @param old     Old Buffer that the user is no longer going to use.
+   * @param old Old Buffer that the user is no longer going to use.
    * @param newSize Size of new replacement buffer.
    * @return A new version of the buffer.
    */
@@ -49,5 +47,6 @@ public interface BufferManager extends AutoCloseable {
    */
   ArrowBuf getManagedBuffer(long size);
 
-  @Override void close();
+  @Override
+  void close();
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/CheckAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/CheckAllocator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.io.IOException;
@@ -22,7 +21,6 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,24 +37,24 @@ final class CheckAllocator {
   private static final String ALLOCATOR_PATH_NETTY =
       "org/apache/arrow/memory/netty/DefaultAllocationManagerFactory.class";
 
-  private CheckAllocator() {
-  }
+  private CheckAllocator() {}
 
   static String check() {
     Set<URL> urls = scanClasspath();
     URL rootAllocator = assertOnlyOne(urls);
     reportResult(rootAllocator);
-    if (rootAllocator.getPath().contains("memory-core") ||
-        rootAllocator.getPath().contains("/org/apache/arrow/memory/core/")) {
+    if (rootAllocator.getPath().contains("memory-core")
+        || rootAllocator.getPath().contains("/org/apache/arrow/memory/core/")) {
       return "org.apache.arrow.memory.DefaultAllocationManagerFactory";
-    } else if (rootAllocator.getPath().contains("memory-unsafe") ||
-        rootAllocator.getPath().contains("/org/apache/arrow/memory/unsafe/")) {
+    } else if (rootAllocator.getPath().contains("memory-unsafe")
+        || rootAllocator.getPath().contains("/org/apache/arrow/memory/unsafe/")) {
       return "org.apache.arrow.memory.unsafe.DefaultAllocationManagerFactory";
-    } else if (rootAllocator.getPath().contains("memory-netty") ||
-        rootAllocator.getPath().contains("/org/apache/arrow/memory/netty/")) {
+    } else if (rootAllocator.getPath().contains("memory-netty")
+        || rootAllocator.getPath().contains("/org/apache/arrow/memory/netty/")) {
       return "org.apache.arrow.memory.netty.DefaultAllocationManagerFactory";
     } else {
-      throw new IllegalStateException("Unknown allocation manager type to infer. Current: " + rootAllocator.getPath());
+      throw new IllegalStateException(
+          "Unknown allocation manager type to infer. Current: " + rootAllocator.getPath());
     }
   }
 
@@ -106,10 +104,10 @@ final class CheckAllocator {
       logger.warn("More than one DefaultAllocationManager on classpath. Choosing first found");
     }
     if (urls.isEmpty()) {
-      throw new RuntimeException("No DefaultAllocationManager found on classpath. Can't allocate Arrow buffers." +
-          " Please consider adding arrow-memory-netty or arrow-memory-unsafe as a dependency.");
+      throw new RuntimeException(
+          "No DefaultAllocationManager found on classpath. Can't allocate Arrow buffers."
+              + " Please consider adding arrow-memory-netty or arrow-memory-unsafe as a dependency.");
     }
     return urls.iterator().next();
   }
-
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ChildAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ChildAllocator.java
@@ -14,17 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
-
 /**
- * Child allocator class. Only slightly different from the {@see RootAllocator},
- * in that these can't be created directly, but must be obtained from
- * {@link BufferAllocator#newChildAllocator(String, AllocationListener, long, long)}.
+ * Child allocator class. Only slightly different from the {@see RootAllocator}, in that these can't
+ * be created directly, but must be obtained from {@link BufferAllocator#newChildAllocator(String,
+ * AllocationListener, long, long)}.
  *
- * <p>Child allocators can only be created by the root, or other children, so
- * this class is package private.</p>
+ * <p>Child allocators can only be created by the root, or other children, so this class is package
+ * private.
  */
 class ChildAllocator extends BaseAllocator {
 
@@ -32,13 +30,10 @@ class ChildAllocator extends BaseAllocator {
    * Constructor.
    *
    * @param parentAllocator parent allocator -- the one creating this child
-   * @param name            the name of this child allocator
-   * @param config          configuration of this child allocator
+   * @param name the name of this child allocator
+   * @param config configuration of this child allocator
    */
-  ChildAllocator(
-          BaseAllocator parentAllocator,
-          String name,
-          Config config) {
+  ChildAllocator(BaseAllocator parentAllocator, String name, Config config) {
     super(parentAllocator, name, config);
   }
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerOption.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerOption.java
@@ -14,62 +14,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.lang.reflect.Field;
-
 import org.apache.arrow.util.VisibleForTesting;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-
-/**
- * A class for choosing the default allocation manager.
- */
+/** A class for choosing the default allocation manager. */
 public class DefaultAllocationManagerOption {
 
-  /**
-   * The environmental variable to set the default allocation manager type.
-   */
+  /** The environmental variable to set the default allocation manager type. */
   public static final String ALLOCATION_MANAGER_TYPE_ENV_NAME = "ARROW_ALLOCATION_MANAGER_TYPE";
 
-  /**
-   * The system property to set the default allocation manager type.
-   */
-  public static final String ALLOCATION_MANAGER_TYPE_PROPERTY_NAME = "arrow.allocation.manager.type";
+  /** The system property to set the default allocation manager type. */
+  public static final String ALLOCATION_MANAGER_TYPE_PROPERTY_NAME =
+      "arrow.allocation.manager.type";
 
-  static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(DefaultAllocationManagerOption.class);
+  static final org.slf4j.Logger LOGGER =
+      org.slf4j.LoggerFactory.getLogger(DefaultAllocationManagerOption.class);
 
-  /**
-   * The default allocation manager factory.
-   */
+  /** The default allocation manager factory. */
   private static AllocationManager.@Nullable Factory DEFAULT_ALLOCATION_MANAGER_FACTORY = null;
 
-  /**
-   * The allocation manager type.
-   */
+  /** The allocation manager type. */
   public enum AllocationManagerType {
-    /**
-     * Netty based allocation manager.
-     */
+    /** Netty based allocation manager. */
     Netty,
 
-    /**
-     * Unsafe based allocation manager.
-     */
+    /** Unsafe based allocation manager. */
     Unsafe,
 
-    /**
-     * Unknown type.
-     */
+    /** Unknown type. */
     Unknown,
   }
 
   /**
    * Returns the default allocation manager type.
+   *
    * @return the default allocation manager type.
    */
-  @SuppressWarnings("nullness:argument") //enum types valueOf are implicitly non-null
+  @SuppressWarnings("nullness:argument") // enum types valueOf are implicitly non-null
   @VisibleForTesting
   public static AllocationManagerType getDefaultAllocationManagerType() {
     AllocationManagerType ret = AllocationManagerType.Unknown;
@@ -114,7 +98,7 @@ public class DefaultAllocationManagerOption {
   }
 
   @SuppressWarnings({"nullness:argument", "nullness:return"})
-  //incompatible argument for parameter obj of Field.get
+  // incompatible argument for parameter obj of Field.get
   // Static member qualifying type may not be annotated
   private static AllocationManager.Factory getFactory(String clazzName) {
     try {
@@ -130,8 +114,10 @@ public class DefaultAllocationManagerOption {
     try {
       return getFactory("org.apache.arrow.memory.unsafe.UnsafeAllocationManager");
     } catch (RuntimeException e) {
-      throw new RuntimeException("Please add arrow-memory-unsafe to your classpath," +
-          " No DefaultAllocationManager found to instantiate an UnsafeAllocationManager", e);
+      throw new RuntimeException(
+          "Please add arrow-memory-unsafe to your classpath,"
+              + " No DefaultAllocationManager found to instantiate an UnsafeAllocationManager",
+          e);
     }
   }
 
@@ -139,8 +125,10 @@ public class DefaultAllocationManagerOption {
     try {
       return getFactory("org.apache.arrow.memory.netty.NettyAllocationManager");
     } catch (RuntimeException e) {
-      throw new RuntimeException("Please add arrow-memory-netty to your classpath," +
-          " No DefaultAllocationManager found to instantiate an NettyAllocationManager", e);
+      throw new RuntimeException(
+          "Please add arrow-memory-netty to your classpath,"
+              + " No DefaultAllocationManager found to instantiate an NettyAllocationManager",
+          e);
     }
   }
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ForeignAllocation.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ForeignAllocation.java
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
- * EXPERIMENTAL: a memory allocation that does not come from a BufferAllocator, but rather an outside source (like JNI).
+ * EXPERIMENTAL: a memory allocation that does not come from a BufferAllocator, but rather an
+ * outside source (like JNI).
  *
  * <p>To use this, subclass this class and implement {@link #release0()} to free the allocation.
  */
@@ -37,22 +37,16 @@ public abstract class ForeignAllocation {
     this.size = size;
   }
 
-  /**
-   * Get the size of this allocation.
-   */
+  /** Get the size of this allocation. */
   public long getSize() {
     return size;
   }
 
-  /**
-   * Get the address of this allocation.
-   */
+  /** Get the address of this allocation. */
   protected long memoryAddress() {
     return memoryAddress;
   }
 
-  /**
-   * Free this allocation. Will only be called once.
-   */
+  /** Free this allocation. Will only be called once. */
   protected abstract void release0();
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ForeignAllocationManager.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ForeignAllocationManager.java
@@ -14,16 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
-/**
- * An AllocationManager wrapping a ForeignAllocation.
- */
+/** An AllocationManager wrapping a ForeignAllocation. */
 class ForeignAllocationManager extends AllocationManager {
   private final ForeignAllocation allocation;
 
-  protected ForeignAllocationManager(BufferAllocator accountingAllocator, ForeignAllocation allocation) {
+  protected ForeignAllocationManager(
+      BufferAllocator accountingAllocator, ForeignAllocation allocation) {
     super(accountingAllocator);
     this.allocation = allocation;
   }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import org.apache.arrow.util.Preconditions;
@@ -24,11 +23,9 @@ import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Highly specialized IdentityHashMap that implements only partial
- * Map APIs.
- * It incurs low initial cost (just two elements by default).
- * It assumes Value includes the Key - Implements @ValueWithKeyIncluded iface
- * that provides "getKey" method.
+ * Highly specialized IdentityHashMap that implements only partial Map APIs. It incurs low initial
+ * cost (just two elements by default). It assumes Value includes the Key -
+ * Implements @ValueWithKeyIncluded iface that provides "getKey" method.
  *
  * @param <K> Key type
  * @param <V> Value type
@@ -38,7 +35,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
   /*
    * The internal data structure to hold values.
    */
-  private @Nullable Object [] elementData; // elementData[index] = null;
+  private @Nullable Object[] elementData; // elementData[index] = null;
 
   /* Actual number of values. */
   private int size;
@@ -54,9 +51,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
   /* Default load factor of 0.75; */
   private static final int LOAD_FACTOR = 7500;
 
-  /**
-   * Creates a Map with default expected maximum size.
-   */
+  /** Creates a Map with default expected maximum size. */
   public LowCostIdentityHashMap() {
     this(DEFAULT_MIN_SIZE);
   }
@@ -64,9 +59,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
   /**
    * Creates a Map with the specified maximum size parameter.
    *
-   * @param maxSize
-   *            The estimated maximum number of entries that will be put in
-   *            this map.
+   * @param maxSize The estimated maximum number of entries that will be put in this map.
    */
   public LowCostIdentityHashMap(int maxSize) {
     if (maxSize >= 0) {
@@ -78,8 +71,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     }
   }
 
-  private int getThreshold(@UnderInitialization LowCostIdentityHashMap<K, V> this,
-                           int maxSize) {
+  private int getThreshold(@UnderInitialization LowCostIdentityHashMap<K, V> this, int maxSize) {
     // assign the threshold to maxSize initially, this will change to a
     // higher value if rehashing occurs.
     return maxSize > 2 ? maxSize : 2;
@@ -95,22 +87,22 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
   /**
    * Create a new element array.
    *
-   * @param s
-   *            the number of elements
+   * @param s the number of elements
    * @return Reference to the element array
    */
-  private Object[] newElementArrayInitialized(@Initialized LowCostIdentityHashMap<K, V> this, int s) {
+  private Object[] newElementArrayInitialized(
+      @Initialized LowCostIdentityHashMap<K, V> this, int s) {
     return new Object[s];
   }
 
   /**
    * Create a new element array.
    *
-   * @param s
-   *            the number of elements
+   * @param s the number of elements
    * @return Reference to the element array
    */
-  private Object[] newElementArrayUnderInitialized(@UnderInitialization LowCostIdentityHashMap<K, V> this, int s) {
+  private Object[] newElementArrayUnderInitialized(
+      @UnderInitialization LowCostIdentityHashMap<K, V> this, int s) {
     return new Object[s];
   }
 
@@ -130,10 +122,8 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
   /**
    * Returns whether this map contains the specified key.
    *
-   * @param key
-   *            the key to search for.
-   * @return {@code true} if this map contains the specified key,
-   *         {@code false} otherwise.
+   * @param key the key to search for.
+   * @return {@code true} if this map contains the specified key, {@code false} otherwise.
    */
   public boolean containsKey(K key) {
     Preconditions.checkNotNull(key);
@@ -145,10 +135,8 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
   /**
    * Returns whether this map contains the specified value.
    *
-   * @param value
-   *            the value to search for.
-   * @return {@code true} if this map contains the specified value,
-   *         {@code false} otherwise.
+   * @param value the value to search for.
+   * @return {@code true} if this map contains the specified value, {@code false} otherwise.
    */
   public boolean containsValue(V value) {
     Preconditions.checkNotNull(value);
@@ -172,13 +160,14 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
 
     int index = findIndex(key, elementData);
 
-    return (elementData[index] == null) ? null :
-      (((V) elementData[index]).getKey() == key) ? (V) elementData[index] : null;
+    return (elementData[index] == null)
+        ? null
+        : (((V) elementData[index]).getKey() == key) ? (V) elementData[index] : null;
   }
 
   /**
-   * Returns the index where the key is found at, or the index of the next
-   * empty spot if the key is not found in this table.
+   * Returns the index where the key is found at, or the index of the next empty spot if the key is
+   * not found in this table.
    */
   @VisibleForTesting
   int findIndex(@Nullable Object key, @Nullable Object[] array) {
@@ -207,8 +196,8 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
    * Maps the specified key to the specified value.
    *
    * @param value the value.
-   * @return the value of any previous mapping with the specified key or
-   *         {@code null} if there was no such mapping.
+   * @return the value of any previous mapping with the specified key or {@code null} if there was
+   *     no such mapping.
    */
   public V put(V value) {
     Preconditions.checkNotNull(value);
@@ -262,8 +251,8 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
    * Removes the mapping with the specified key from this map.
    *
    * @param key the key of the mapping to remove.
-   * @return the value of the removed mapping, or {@code null} if no mapping
-   *         for the specified key was found.
+   * @return the value of the removed mapping, or {@code null} if no mapping for the specified key
+   *     was found.
    */
   public @Nullable V remove(K key) {
     Preconditions.checkNotNull(key);
@@ -312,13 +301,10 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     return (V) result;
   }
 
-
-
   /**
    * Returns whether this Map has no elements.
    *
-   * @return {@code true} if this Map has no elements,
-   *         {@code false} otherwise.
+   * @return {@code true} if this Map has no elements, {@code false} otherwise.
    * @see #size()
    */
   public boolean isEmpty() {

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/OutOfMemoryException.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/OutOfMemoryException.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.util.Optional;
@@ -22,14 +21,14 @@ import java.util.Optional;
 /**
  * Indicates memory could not be allocated for Arrow buffers.
  *
- * <p>This is different from {@linkplain OutOfMemoryError} which indicates the JVM
- * is out of memory.  This error indicates that static limit of one of Arrow's
- * allocators (e.g. {@linkplain BaseAllocator}) has been exceeded.
+ * <p>This is different from {@linkplain OutOfMemoryError} which indicates the JVM is out of memory.
+ * This error indicates that static limit of one of Arrow's allocators (e.g. {@linkplain
+ * BaseAllocator}) has been exceeded.
  */
 public class OutOfMemoryException extends RuntimeException {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OutOfMemoryException
-      .class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(OutOfMemoryException.class);
   private static final long serialVersionUID = -6858052345185793382L;
   private Optional<AllocationOutcomeDetails> outcomeDetails = Optional.empty();
 
@@ -37,14 +36,13 @@ public class OutOfMemoryException extends RuntimeException {
     super();
   }
 
-  public OutOfMemoryException(String message, Throwable cause, boolean enableSuppression, boolean
-      writableStackTrace) {
+  public OutOfMemoryException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
   }
 
   public OutOfMemoryException(String message, Throwable cause) {
     super(message, cause);
-
   }
 
   public OutOfMemoryException(String message) {
@@ -58,7 +56,6 @@ public class OutOfMemoryException extends RuntimeException {
 
   public OutOfMemoryException(Throwable cause) {
     super(cause);
-
   }
 
   public Optional<AllocationOutcomeDetails> getOutcomeDetails() {

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/OwnershipTransferNOOP.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/OwnershipTransferNOOP.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
-/**
- * An {@link OwnershipTransferResult} indicating no transfer needed.
- */
+/** An {@link OwnershipTransferResult} indicating no transfer needed. */
 public class OwnershipTransferNOOP implements OwnershipTransferResult {
   private final ArrowBuf buffer;
 

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/OwnershipTransferResult.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/OwnershipTransferResult.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
-/**
- * The result of transferring an {@link ArrowBuf} between {@linkplain BufferAllocator}s.
- */
+/** The result of transferring an {@link ArrowBuf} between {@linkplain BufferAllocator}s. */
 public interface OwnershipTransferResult {
 
   boolean getAllocationFit();

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ReferenceManager.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ReferenceManager.java
@@ -14,49 +14,52 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
  * ReferenceManager is the reference count for one or more allocations.
  *
- * <p>In order to integrate with the core {@link BufferAllocator} implementation, the allocation itself should
- * be represented by an {@link AllocationManager}, though this is not required by the API.
+ * <p>In order to integrate with the core {@link BufferAllocator} implementation, the allocation
+ * itself should be represented by an {@link AllocationManager}, though this is not required by the
+ * API.
  */
 public interface ReferenceManager {
 
   /**
    * Return the reference count.
+   *
    * @return reference count
    */
   int getRefCount();
 
   /**
-   * Decrement this reference manager's reference count by 1 for the associated underlying
-   * memory. If the reference count drops to 0, it implies that ArrowBufs managed by this
-   * reference manager no longer need access to the underlying memory
+   * Decrement this reference manager's reference count by 1 for the associated underlying memory.
+   * If the reference count drops to 0, it implies that ArrowBufs managed by this reference manager
+   * no longer need access to the underlying memory
+   *
    * @return true if ref count has dropped to 0, false otherwise
    */
   boolean release();
 
   /**
-   * Decrement this reference manager's reference count for the associated underlying
-   * memory. If the reference count drops to 0, it implies that ArrowBufs managed by this
-   * reference manager no longer need access to the underlying memory
+   * Decrement this reference manager's reference count for the associated underlying memory. If the
+   * reference count drops to 0, it implies that ArrowBufs managed by this reference manager no
+   * longer need access to the underlying memory
+   *
    * @param decrement the count to decrease the reference count by
    * @return the new reference count
    */
   boolean release(int decrement);
 
   /**
-   * Increment this reference manager's reference count by 1 for the associated underlying
-   * memory.
+   * Increment this reference manager's reference count by 1 for the associated underlying memory.
    */
   void retain();
 
   /**
-   * Increment this reference manager's reference count by a given amount for the
-   * associated underlying memory.
+   * Increment this reference manager's reference count by a given amount for the associated
+   * underlying memory.
+   *
    * @param increment the count to increase the reference count by
    */
   void retain(int increment);
@@ -64,13 +67,13 @@ public interface ReferenceManager {
   /**
    * Create a new ArrowBuf that is associated with an alternative allocator for the purposes of
    * memory ownership and accounting. This has no impact on the reference counting for the current
-   * ArrowBuf except in the situation where the passed in Allocator is the same as the current buffer.
-   * This operation has no impact on the reference count of this ArrowBuf. The newly created
+   * ArrowBuf except in the situation where the passed in Allocator is the same as the current
+   * buffer. This operation has no impact on the reference count of this ArrowBuf. The newly created
    * ArrowBuf with either have a reference count of 1 (in the case that this is the first time this
-   * memory is being associated with the target allocator or in other words allocation manager currently
-   * doesn't hold a mapping for the target allocator) or the current value of the reference count for
-   * the target allocator-reference manager combination + 1 in the case that the provided allocator
-   * already had an association to this underlying memory.
+   * memory is being associated with the target allocator or in other words allocation manager
+   * currently doesn't hold a mapping for the target allocator) or the current value of the
+   * reference count for the target allocator-reference manager combination + 1 in the case that the
+   * provided allocator already had an association to this underlying memory.
    *
    * <p>The underlying allocation ({@link AllocationManager}) will not be copied.
    *
@@ -81,21 +84,21 @@ public interface ReferenceManager {
   ArrowBuf retain(ArrowBuf srcBuffer, BufferAllocator targetAllocator);
 
   /**
-   * Derive a new ArrowBuf from a given source ArrowBuf. The new derived
-   * ArrowBuf will share the same reference count as rest of the ArrowBufs
-   * associated with this reference manager.
+   * Derive a new ArrowBuf from a given source ArrowBuf. The new derived ArrowBuf will share the
+   * same reference count as rest of the ArrowBufs associated with this reference manager.
+   *
    * @param sourceBuffer source ArrowBuf
    * @param index index (relative to source ArrowBuf) new ArrowBuf should be derived from
-   * @param length length (bytes) of data in underlying memory that derived buffer will
-   *               have access to in underlying memory
+   * @param length length (bytes) of data in underlying memory that derived buffer will have access
+   *     to in underlying memory
    * @return derived buffer
    */
   ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, long index, long length);
 
   /**
-   * Duplicate the memory accounting ownership of the backing allocation of the given ArrowBuf in another allocator.
-   * This will generate a new ArrowBuf that carries an association with the same underlying memory
-   * ({@link AllocationManager}s) as the given ArrowBuf.
+   * Duplicate the memory accounting ownership of the backing allocation of the given ArrowBuf in
+   * another allocator. This will generate a new ArrowBuf that carries an association with the same
+   * underlying memory ({@link AllocationManager}s) as the given ArrowBuf.
    *
    * @param sourceBuffer source ArrowBuf
    * @param targetAllocator The target allocator to create an association with
@@ -105,18 +108,21 @@ public interface ReferenceManager {
 
   /**
    * Get the buffer allocator associated with this reference manager.
+   *
    * @return buffer allocator.
    */
   BufferAllocator getAllocator();
 
   /**
    * Total size (in bytes) of memory underlying this reference manager.
+   *
    * @return Size (in bytes) of the memory chunk.
    */
   long getSize();
 
   /**
    * Get the total accounted size (in bytes).
+   *
    * @return accounted size.
    */
   long getAccountedSize();
@@ -124,59 +130,58 @@ public interface ReferenceManager {
   String NO_OP_ERROR_MESSAGE = "Operation not supported on NO_OP Reference Manager";
 
   // currently used for empty ArrowBufs
-  ReferenceManager NO_OP = new ReferenceManager() {
-    @Override
-    public int getRefCount() {
-      return 1;
-    }
+  ReferenceManager NO_OP =
+      new ReferenceManager() {
+        @Override
+        public int getRefCount() {
+          return 1;
+        }
 
-    @Override
-    public boolean release() {
-      return false;
-    }
+        @Override
+        public boolean release() {
+          return false;
+        }
 
-    @Override
-    public boolean release(int decrement) {
-      return false;
-    }
+        @Override
+        public boolean release(int decrement) {
+          return false;
+        }
 
-    @Override
-    public void retain() {
-    }
+        @Override
+        public void retain() {}
 
-    @Override
-    public void retain(int increment) {
-    }
+        @Override
+        public void retain(int increment) {}
 
-    @Override
-    public ArrowBuf retain(ArrowBuf srcBuffer, BufferAllocator targetAllocator) {
-      return srcBuffer;
-    }
+        @Override
+        public ArrowBuf retain(ArrowBuf srcBuffer, BufferAllocator targetAllocator) {
+          return srcBuffer;
+        }
 
-    @Override
-    public ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, long index, long length) {
-      return sourceBuffer;
-    }
+        @Override
+        public ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, long index, long length) {
+          return sourceBuffer;
+        }
 
-    @Override
-    public OwnershipTransferResult transferOwnership(ArrowBuf sourceBuffer, BufferAllocator targetAllocator) {
-      return new OwnershipTransferNOOP(sourceBuffer);
-    }
+        @Override
+        public OwnershipTransferResult transferOwnership(
+            ArrowBuf sourceBuffer, BufferAllocator targetAllocator) {
+          return new OwnershipTransferNOOP(sourceBuffer);
+        }
 
-    @Override
-    public BufferAllocator getAllocator() {
-      return new RootAllocator(0);
-    }
+        @Override
+        public BufferAllocator getAllocator() {
+          return new RootAllocator(0);
+        }
 
-    @Override
-    public long getSize() {
-      return 0L;
-    }
+        @Override
+        public long getSize() {
+          return 0L;
+        }
 
-    @Override
-    public long getAccountedSize() {
-      return 0L;
-    }
-
-  };
+        @Override
+        public long getAccountedSize() {
+          return 0L;
+        }
+      };
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ReusableBuffer.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ReusableBuffer.java
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
  * A lightweight, automatically expanding container for holding byte data.
+ *
  * @param <T> The type of the underlying buffer.
  */
 public interface ReusableBuffer<T> {
@@ -29,19 +29,16 @@ public interface ReusableBuffer<T> {
    */
   long getLength();
 
-  /**
-   * Get the buffer backing this ReusableBuffer.
-   */
+  /** Get the buffer backing this ReusableBuffer. */
   T getBuffer();
 
   /**
-   * Set the buffer to the contents of the given ArrowBuf.
-   * The internal buffer must resize if it cannot fit the contents
-   * of the data.
+   * Set the buffer to the contents of the given ArrowBuf. The internal buffer must resize if it
+   * cannot fit the contents of the data.
    *
-   * @param srcBytes  the data to copy from
-   * @param start     the first position of the new data
-   * @param len       the number of bytes of the new data
+   * @param srcBytes the data to copy from
+   * @param start the first position of the new data
+   * @param len the number of bytes of the new data
    */
   void set(ArrowBuf srcBytes, long start, long len);
 

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/RootAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/RootAllocator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import org.apache.arrow.memory.rounding.DefaultRoundingPolicy;
@@ -22,9 +21,8 @@ import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.arrow.util.VisibleForTesting;
 
 /**
- * A root allocator for using direct memory for Arrow Vectors/Arrays. Supports creating a
- * tree of descendant child allocators to facilitate better instrumentation of memory
- * allocations.
+ * A root allocator for using direct memory for Arrow Vectors/Arrays. Supports creating a tree of
+ * descendant child allocators to facilitate better instrumentation of memory allocations.
  */
 public class RootAllocator extends BaseAllocator {
 
@@ -37,33 +35,32 @@ public class RootAllocator extends BaseAllocator {
   }
 
   public RootAllocator(final AllocationListener listener, final long limit) {
-    //todo fix DefaultRoundingPolicy when using Netty
+    // todo fix DefaultRoundingPolicy when using Netty
     this(listener, limit, DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY);
   }
 
   /**
    * Constructor.
    *
-   * @param listener        the allocation listener
-   * @param limit           max allocation size in bytes
-   * @param roundingPolicy  the policy for rounding the buffer size
+   * @param listener the allocation listener
+   * @param limit max allocation size in bytes
+   * @param roundingPolicy the policy for rounding the buffer size
    */
-  public RootAllocator(final AllocationListener listener, final long limit, RoundingPolicy roundingPolicy) {
-    this(configBuilder()
-        .listener(listener)
-        .maxAllocation(limit)
-        .roundingPolicy(roundingPolicy)
-        .build()
-    );
+  public RootAllocator(
+      final AllocationListener listener, final long limit, RoundingPolicy roundingPolicy) {
+    this(
+        configBuilder()
+            .listener(listener)
+            .maxAllocation(limit)
+            .roundingPolicy(roundingPolicy)
+            .build());
   }
 
   public RootAllocator(Config config) {
     super(null, "ROOT", config);
   }
 
-  /**
-   * Verify the accounting state of the allocation system.
-   */
+  /** Verify the accounting state of the allocation system. */
   @VisibleForTesting
   public void verify() {
     verifyAllocator();

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ValueWithKeyIncluded.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ValueWithKeyIncluded.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 /**
- * Helper interface to generify a value to be included in the map where
- * key is part of the value.
+ * Helper interface to generify a value to be included in the map where key is part of the value.
  *
  * @param <K> The type of the key.
  */

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/package-info.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/package-info.java
@@ -16,9 +16,7 @@
  */
 
 /**
- *  Memory Allocation, Accounting and Management.
- *  See the Arrow Java documentation for details: <a href="https://arrow.apache.org/docs/java/memory.html">Memory Management</a>
- *
+ * Memory Allocation, Accounting and Management. See the Arrow Java documentation for details: <a
+ * href="https://arrow.apache.org/docs/java/memory.html">Memory Management</a>
  */
-
 package org.apache.arrow.memory;

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.rounding;
 
 import org.apache.arrow.memory.util.CommonUtil;
@@ -22,9 +21,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The default rounding policy. That is, if the requested size is within the chunk size,
- * the rounded size will be the next power of two. Otherwise, the rounded size
- * will be identical to the requested size.
+ * The default rounding policy. That is, if the requested size is within the chunk size, the rounded
+ * size will be the next power of two. Otherwise, the rounded size will be identical to the
+ * requested size.
  */
 public class DefaultRoundingPolicy implements RoundingPolicy {
   private static final Logger logger = LoggerFactory.getLogger(DefaultRoundingPolicy.class);
@@ -33,14 +32,12 @@ public class DefaultRoundingPolicy implements RoundingPolicy {
   /**
    * The variables here and the static block calculates the DEFAULT_CHUNK_SIZE.
    *
-   * <p>
-   *   It was copied from {@link io.netty.buffer.PooledByteBufAllocator}.
-   * </p>
+   * <p>It was copied from {@link io.netty.buffer.PooledByteBufAllocator}.
    */
   private static final int MIN_PAGE_SIZE = 4096;
+
   private static final int MAX_CHUNK_SIZE = (int) (((long) Integer.MAX_VALUE + 1) / 2);
   private static final long DEFAULT_CHUNK_SIZE;
-
 
   static {
     int defaultPageSize = Integer.getInteger("org.apache.memory.allocator.pageSize", 8192);
@@ -65,7 +62,8 @@ public class DefaultRoundingPolicy implements RoundingPolicy {
 
   private static int validateAndCalculatePageShifts(int pageSize) {
     if (pageSize < MIN_PAGE_SIZE) {
-      throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: " + MIN_PAGE_SIZE + ")");
+      throw new IllegalArgumentException(
+          "pageSize: " + pageSize + " (expected: " + MIN_PAGE_SIZE + ")");
     }
 
     if ((pageSize & pageSize - 1) != 0) {
@@ -83,20 +81,21 @@ public class DefaultRoundingPolicy implements RoundingPolicy {
 
     // Ensure the resulting chunkSize does not overflow.
     int chunkSize = pageSize;
-    for (int i = maxOrder; i > 0; i --) {
+    for (int i = maxOrder; i > 0; i--) {
       if (chunkSize > MAX_CHUNK_SIZE / 2) {
-        throw new IllegalArgumentException(String.format(
-            "pageSize (%d) << maxOrder (%d) must not exceed %d", pageSize, maxOrder, MAX_CHUNK_SIZE));
+        throw new IllegalArgumentException(
+            String.format(
+                "pageSize (%d) << maxOrder (%d) must not exceed %d",
+                pageSize, maxOrder, MAX_CHUNK_SIZE));
       }
       chunkSize <<= 1;
     }
     return chunkSize;
   }
 
-  /**
-   * The singleton instance.
-   */
-  public static final DefaultRoundingPolicy DEFAULT_ROUNDING_POLICY = new DefaultRoundingPolicy(DEFAULT_CHUNK_SIZE);
+  /** The singleton instance. */
+  public static final DefaultRoundingPolicy DEFAULT_ROUNDING_POLICY =
+      new DefaultRoundingPolicy(DEFAULT_CHUNK_SIZE);
 
   private DefaultRoundingPolicy(long chunkSize) {
     this.chunkSize = chunkSize;
@@ -104,7 +103,6 @@ public class DefaultRoundingPolicy implements RoundingPolicy {
 
   @Override
   public long getRoundedSize(long requestSize) {
-    return requestSize < chunkSize ?
-            CommonUtil.nextPowerOfTwo(requestSize) : requestSize;
+    return requestSize < chunkSize ? CommonUtil.nextPowerOfTwo(requestSize) : requestSize;
   }
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/rounding/RoundingPolicy.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/rounding/RoundingPolicy.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.rounding;
 
 /**

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/rounding/SegmentRoundingPolicy.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/rounding/SegmentRoundingPolicy.java
@@ -14,38 +14,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.rounding;
 
 import org.apache.arrow.util.Preconditions;
 
-/**
- * The rounding policy that each buffer size must a multiple of the segment size.
- */
+/** The rounding policy that each buffer size must a multiple of the segment size. */
 public class SegmentRoundingPolicy implements RoundingPolicy {
 
-  /**
-   * The minimal segment size.
-   */
+  /** The minimal segment size. */
   public static final long MIN_SEGMENT_SIZE = 1024L;
 
   /**
-   * The segment size. It must be at least {@link SegmentRoundingPolicy#MIN_SEGMENT_SIZE},
-   * and be a power of 2.
+   * The segment size. It must be at least {@link SegmentRoundingPolicy#MIN_SEGMENT_SIZE}, and be a
+   * power of 2.
    */
   private int segmentSize;
 
   /**
    * Constructor for the segment rounding policy.
+   *
    * @param segmentSize the segment size.
-   * @throws IllegalArgumentException if the segment size is smaller than
-   * {@link SegmentRoundingPolicy#MIN_SEGMENT_SIZE}, or is not a power of 2.
+   * @throws IllegalArgumentException if the segment size is smaller than {@link
+   *     SegmentRoundingPolicy#MIN_SEGMENT_SIZE}, or is not a power of 2.
    */
   public SegmentRoundingPolicy(int segmentSize) {
-    Preconditions.checkArgument(segmentSize >= MIN_SEGMENT_SIZE,
-            "The segment size cannot be smaller than %s", MIN_SEGMENT_SIZE);
-    Preconditions.checkArgument((segmentSize & (segmentSize - 1)) == 0,
-            "The segment size must be a power of 2");
+    Preconditions.checkArgument(
+        segmentSize >= MIN_SEGMENT_SIZE,
+        "The segment size cannot be smaller than %s",
+        MIN_SEGMENT_SIZE);
+    Preconditions.checkArgument(
+        (segmentSize & (segmentSize - 1)) == 0, "The segment size must be a power of 2");
     this.segmentSize = segmentSize;
   }
 

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/ArrowBufPointer.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/ArrowBufPointer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import org.apache.arrow.memory.ArrowBuf;
@@ -24,14 +23,12 @@ import org.apache.arrow.util.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Pointer to a memory region within an {@link ArrowBuf}.
- * It will be used as the basis for calculating hash code within a vector, and equality determination.
+ * Pointer to a memory region within an {@link ArrowBuf}. It will be used as the basis for
+ * calculating hash code within a vector, and equality determination.
  */
 public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
 
-  /**
-   * The hash code when the arrow buffer is null.
-   */
+  /** The hash code when the arrow buffer is null. */
   public static final int NULL_HASH_CODE = 0;
 
   private @Nullable ArrowBuf buf;
@@ -44,20 +41,17 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
 
   private final ArrowBufHasher hasher;
 
-  /**
-   * A flag indicating if the underlying memory region has changed.
-   */
+  /** A flag indicating if the underlying memory region has changed. */
   private boolean hashCodeChanged = false;
 
-  /**
-   * The default constructor.
-   */
+  /** The default constructor. */
   public ArrowBufPointer() {
     this(SimpleHasher.INSTANCE);
   }
 
   /**
    * Constructs an arrow buffer pointer with the specified hasher.
+   *
    * @param hasher the hasher to use.
    */
   public ArrowBufPointer(ArrowBufHasher hasher) {
@@ -68,6 +62,7 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
 
   /**
    * Constructs an Arrow buffer pointer.
+   *
    * @param buf the underlying {@link ArrowBuf}, which can be null.
    * @param offset the start off set of the memory region pointed to.
    * @param length the length off set of the memory region pointed to.
@@ -78,6 +73,7 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
 
   /**
    * Constructs an Arrow buffer pointer.
+   *
    * @param buf the underlying {@link ArrowBuf}, which can be null.
    * @param offset the start off set of the memory region pointed to.
    * @param length the length off set of the memory region pointed to.
@@ -91,11 +87,11 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
 
   /**
    * Sets this pointer.
+   *
    * @param buf the underlying {@link ArrowBuf}, which can be null.
    * @param offset the start off set of the memory region pointed to.
    * @param length the length off set of the memory region pointed to.
    */
-
   public void set(ArrowBuf buf, long offset, long length) {
     this.buf = buf;
     this.offset = offset;
@@ -106,6 +102,7 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
 
   /**
    * Gets the underlying buffer, or null if the underlying data is invalid or null.
+   *
    * @return the underlying buffer, if any, or null if the underlying data is invalid or null.
    */
   public @Nullable ArrowBuf getBuf() {
@@ -145,8 +142,9 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
       }
     }
 
-    return ByteFunctionHelpers.equal(buf, offset, offset + length,
-            other.buf, other.offset, other.offset + other.length) != 0;
+    return ByteFunctionHelpers.equal(
+            buf, offset, offset + length, other.buf, other.offset, other.offset + other.length)
+        != 0;
   }
 
   @Override
@@ -167,12 +165,11 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
   }
 
   /**
-   * Compare two arrow buffer pointers.
-   * The comparison is based on lexicographic order.
+   * Compare two arrow buffer pointers. The comparison is based on lexicographic order.
+   *
    * @param that the other pointer to compare.
-   * @return 0 if the two pointers are equal;
-   *     a positive integer if this pointer is larger;
-   *     a negative integer if this pointer is smaller.
+   * @return 0 if the two pointers are equal; a positive integer if this pointer is larger; a
+   *     negative integer if this pointer is smaller.
    */
   @Override
   public int compareTo(ArrowBufPointer that) {
@@ -185,7 +182,12 @@ public final class ArrowBufPointer implements Comparable<ArrowBufPointer> {
       }
     }
 
-    return ByteFunctionHelpers.compare(this.buf, this.offset, this.offset + this.length,
-            that.buf, that.offset, that.offset + that.length);
+    return ByteFunctionHelpers.compare(
+        this.buf,
+        this.offset,
+        this.offset + this.length,
+        that.buf,
+        that.offset,
+        that.offset + that.length);
   }
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/AssertionUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/AssertionUtil.java
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 /**
- * Utility class to that provides {@link #ASSERT_ENABLED} constant to determine if assertions are enabled.
+ * Utility class to that provides {@link #ASSERT_ENABLED} constant to determine if assertions are
+ * enabled.
  */
 public class AssertionUtil {
 
@@ -31,8 +31,7 @@ public class AssertionUtil {
     ASSERT_ENABLED = isAssertEnabled;
   }
 
-  private AssertionUtil() {
-  }
+  private AssertionUtil() {}
 
   public static boolean isAssertionsEnabled() {
     return ASSERT_ENABLED;

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/AutoCloseableLock.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/AutoCloseableLock.java
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import java.util.concurrent.locks.Lock;
 
-/**
- * Simple wrapper class that allows Locks to be released via a try-with-resources block.
- */
+/** Simple wrapper class that allows Locks to be released via a try-with-resources block. */
 public class AutoCloseableLock implements AutoCloseable {
 
   private final Lock lock;
@@ -39,5 +36,4 @@ public class AutoCloseableLock implements AutoCloseable {
   public void close() {
     lock.unlock();
   }
-
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -14,39 +14,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import java.nio.ByteOrder;
-
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BoundsChecking;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.memory.util.hash.SimpleHasher;
 
-/**
- * Utility methods for memory comparison at a byte level.
- */
+/** Utility methods for memory comparison at a byte level. */
 public class ByteFunctionHelpers {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ByteFunctionHelpers.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(ByteFunctionHelpers.class);
 
   private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
-  private ByteFunctionHelpers() {
-  }
+  private ByteFunctionHelpers() {}
 
   /**
    * Helper function to check for equality of bytes in two ArrowBufs.
    *
-   * @param left   Left ArrowBuf for comparison
+   * @param left Left ArrowBuf for comparison
    * @param lStart start offset in the buffer
-   * @param lEnd   end offset in the buffer
-   * @param right  Right ArrowBuf for comparison
+   * @param lEnd end offset in the buffer
+   * @param right Right ArrowBuf for comparison
    * @param rStart start offset in the buffer
-   * @param rEnd   end offset in the buffer
+   * @param rEnd end offset in the buffer
    * @return 1 if equals, 0 otherwise
    */
-  public static int equal(final ArrowBuf left, long lStart, long lEnd, final ArrowBuf right, long rStart, long rEnd) {
+  public static int equal(
+      final ArrowBuf left, long lStart, long lEnd, final ArrowBuf right, long rStart, long rEnd) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       left.checkBytes(lStart, lEnd);
       right.checkBytes(rStart, rEnd);
@@ -54,8 +51,8 @@ public class ByteFunctionHelpers {
     return memEqual(left.memoryAddress(), lStart, lEnd, right.memoryAddress(), rStart, rEnd);
   }
 
-  private static int memEqual(final long laddr, long lStart, long lEnd, final long raddr, long rStart,
-                                    final long rEnd) {
+  private static int memEqual(
+      final long laddr, long lStart, long lEnd, final long raddr, long rStart, final long rEnd) {
 
     long n = lEnd - lStart;
     if (n == rEnd - rStart) {
@@ -117,21 +114,16 @@ public class ByteFunctionHelpers {
    *
    * <p>Function will check data before completing in the case that
    *
-   * @param left   Left ArrowBuf to compare
+   * @param left Left ArrowBuf to compare
    * @param lStart start offset in the buffer
-   * @param lEnd   end offset in the buffer
-   * @param right  Right ArrowBuf to compare
+   * @param lEnd end offset in the buffer
+   * @param right Right ArrowBuf to compare
    * @param rStart start offset in the buffer
-   * @param rEnd   end offset in the buffer
+   * @param rEnd end offset in the buffer
    * @return 1 if left input is greater, -1 if left input is smaller, 0 otherwise
    */
   public static int compare(
-      final ArrowBuf left,
-      long lStart,
-      long lEnd,
-      final ArrowBuf right,
-      long rStart,
-      long rEnd) {
+      final ArrowBuf left, long lStart, long lEnd, final ArrowBuf right, long rStart, long rEnd) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       left.checkBytes(lStart, lEnd);
       right.checkBytes(rStart, rEnd);
@@ -140,12 +132,7 @@ public class ByteFunctionHelpers {
   }
 
   private static int memcmp(
-      final long laddr,
-      long lStart,
-      long lEnd,
-      final long raddr,
-      long rStart,
-      final long rEnd) {
+      final long laddr, long lStart, long lEnd, final long raddr, long rStart, final long rEnd) {
     long lLen = lEnd - lStart;
     long rLen = rEnd - rStart;
     long n = Math.min(rLen, lLen);
@@ -214,37 +201,30 @@ public class ByteFunctionHelpers {
     }
 
     return lLen > rLen ? 1 : -1;
-
   }
 
   /**
    * Helper function to compare a set of bytes in ArrowBuf to a ByteArray.
    *
-   * @param left   Left ArrowBuf for comparison purposes
+   * @param left Left ArrowBuf for comparison purposes
    * @param lStart start offset in the buffer
-   * @param lEnd   end offset in the buffer
-   * @param right  second input to be compared
+   * @param lEnd end offset in the buffer
+   * @param right second input to be compared
    * @param rStart start offset in the byte array
-   * @param rEnd   end offset in the byte array
+   * @param rEnd end offset in the byte array
    * @return 1 if left input is greater, -1 if left input is smaller, 0 otherwise
    */
   public static int compare(
-      final ArrowBuf left,
-      int lStart,
-      int lEnd,
-      final byte[] right,
-      int rStart,
-      final int rEnd) {
+      final ArrowBuf left, int lStart, int lEnd, final byte[] right, int rStart, final int rEnd) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       left.checkBytes(lStart, lEnd);
     }
     return memcmp(left.memoryAddress(), lStart, lEnd, right, rStart, rEnd);
   }
 
-
   /**
-   * Compares the two specified {@code long} values, treating them as unsigned values between
-   * {@code 0} and {@code 2^64 - 1} inclusive.
+   * Compares the two specified {@code long} values, treating them as unsigned values between {@code
+   * 0} and {@code 2^64 - 1} inclusive.
    *
    * @param a the first unsigned {@code long} to compare
    * @param b the second unsigned {@code long} to compare
@@ -260,12 +240,7 @@ public class ByteFunctionHelpers {
   }
 
   private static int memcmp(
-      final long laddr,
-      int lStart,
-      int lEnd,
-      final byte[] right,
-      int rStart,
-      final int rEnd) {
+      final long laddr, int lStart, int lEnd, final byte[] right, int rStart, final int rEnd) {
     int lLen = lEnd - lStart;
     int rLen = rEnd - rStart;
     int n = Math.min(rLen, lLen);
@@ -319,9 +294,7 @@ public class ByteFunctionHelpers {
     return lLen > rLen ? 1 : -1;
   }
 
-  /**
-   * Compute hashCode with the given {@link ArrowBuf} and start/end index.
-   */
+  /** Compute hashCode with the given {@link ArrowBuf} and start/end index. */
   public static int hash(final ArrowBuf buf, long start, long end) {
 
     return hash(SimpleHasher.INSTANCE, buf, start, end);
@@ -339,9 +312,7 @@ public class ByteFunctionHelpers {
     return hasher.hashCode(buf, start, end - start);
   }
 
-  /**
-   * Generate a new hashCode with the given current hashCode and new hashCode.
-   */
+  /** Generate a new hashCode with the given current hashCode and new hashCode. */
   public static int combineHash(int currentHash, int newHash) {
     return currentHash * 31 + newHash;
   }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/CommonUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/CommonUtil.java
@@ -14,18 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import java.util.Arrays;
 
-/**
- * Utilities and static methods needed for arrow-memory.
- */
+/** Utilities and static methods needed for arrow-memory. */
 public final class CommonUtil {
 
-  private CommonUtil() {
-  }
+  private CommonUtil() {}
 
   /**
    * Rounds up the provided value to the nearest power of two.
@@ -77,4 +73,3 @@ public final class CommonUtil {
     return sb;
   }
 }
-

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/Float16.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/Float16.java
@@ -14,34 +14,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
-
 
 import org.apache.arrow.util.VisibleForTesting;
 
 /**
  * Lifted from Apache Parquet MR project:
  * https://github.com/apache/parquet-mr/blob/e87b80308869b77f914fcfd04364686e11158950/parquet-column/src/main/java/org/apache/parquet/schema/Float16.java
+ *
  * <ul>
- * Changes made:
- * <li>Modify the data type input from Parquet-MR Binary (toFloat(Binary b)) to Arrow Java short (toFloat(short b))</li>
- * <li>Expose NAN and POSITIVE_INFINITY variables</li>
+ *   Changes made:
+ *   <li>Modify the data type input from Parquet-MR Binary (toFloat(Binary b)) to Arrow Java short
+ *       (toFloat(short b))
+ *   <li>Expose NAN and POSITIVE_INFINITY variables
  * </ul>
  *
+ * The class is a utility class to manipulate half-precision 16-bit <a
+ * href="https://en.wikipedia.org/wiki/Half-precision_floating-point_format">IEEE 754</a> floating
+ * point data types (also called fp16 or binary16). A half-precision float can be created from or
+ * converted to single-precision floats, and is stored in a short data type. The IEEE 754 standard
+ * specifies an float16 as having the following format:
  *
- * The class is a utility class to manipulate half-precision 16-bit
- * <a href="https://en.wikipedia.org/wiki/Half-precision_floating-point_format">IEEE 754</a>
- * floating point data types (also called fp16 or binary16). A half-precision float can be
- * created from or converted to single-precision floats, and is stored in a short data type.
- * The IEEE 754 standard specifies an float16 as having the following format:
  * <ul>
- * <li>Sign bit: 1 bit</li>
- * <li>Exponent width: 5 bits</li>
- * <li>Significand: 10 bits</li>
+ *   <li>Sign bit: 1 bit
+ *   <li>Exponent width: 5 bits
+ *   <li>Significand: 10 bits
  * </ul>
  *
- * <p>The format is laid out as follows:</p>
+ * <p>The format is laid out as follows:
+ *
  * <pre>
  * 1   11111   1111111111
  * ^   --^--   -----^----
@@ -49,10 +50,10 @@ import org.apache.arrow.util.VisibleForTesting;
  *       |
  *      -- exponent
  * </pre>
- * Half-precision floating points can be useful to save memory and/or
- * bandwidth at the expense of range and precision when compared to single-precision
- * floating points (float32).
- * Ref: https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/libcore/util/FP16.java
+ *
+ * Half-precision floating points can be useful to save memory and/or bandwidth at the expense of
+ * range and precision when compared to single-precision floating points (float32). Ref:
+ * https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/libcore/util/FP16.java
  */
 public class Float16 {
   // Positive infinity of type half-precision float.
@@ -84,12 +85,11 @@ public class Float16 {
   private static final float FP32_DENORMAL_FLOAT = Float.intBitsToFloat(FP32_DENORMAL_MAGIC);
 
   /**
-   * Returns true if the specified half-precision float value represents
-   * a Not-a-Number, false otherwise.
+   * Returns true if the specified half-precision float value represents a Not-a-Number, false
+   * otherwise.
    *
    * @param h A half-precision float value
    * @return True if the value is a NaN, false otherwise
-   *
    */
   @VisibleForTesting
   public static boolean isNaN(short h) {
@@ -97,23 +97,20 @@ public class Float16 {
   }
 
   /**
-   * <p>Compares the two specified half-precision float values. The following
-   * conditions apply during the comparison:</p>
+   * Compares the two specified half-precision float values. The following conditions apply during
+   * the comparison:
    *
    * <ul>
-   * <li>NaN is considered by this method to be equal to itself and greater
-   * than all other half-precision float values (including {@code #POSITIVE_INFINITY})</li>
-   * <li>POSITIVE_ZERO is considered by this method to be greater than NEGATIVE_ZERO.</li>
+   *   <li>NaN is considered by this method to be equal to itself and greater than all other
+   *       half-precision float values (including {@code #POSITIVE_INFINITY})
+   *   <li>POSITIVE_ZERO is considered by this method to be greater than NEGATIVE_ZERO.
    * </ul>
    *
    * @param x The first half-precision float value to compare.
    * @param y The second half-precision float value to compare
-   *
-   * @return  The value {@code 0} if {@code x} is numerically equal to {@code y}, a
-   *          value less than {@code 0} if {@code x} is numerically less than {@code y},
-   *          and a value greater than {@code 0} if {@code x} is numerically greater
-   *          than {@code y}
-   *
+   * @return The value {@code 0} if {@code x} is numerically equal to {@code y}, a value less than
+   *     {@code 0} if {@code x} is numerically less than {@code y}, and a value greater than {@code
+   *     0} if {@code x} is numerically greater than {@code y}
    */
   @VisibleForTesting
   public static int compare(short x, short y) {
@@ -145,13 +142,12 @@ public class Float16 {
   }
 
   /**
-   * Converts the specified half-precision float value into a
-   * single-precision float value. The following special cases are handled:
-   * If the input is NaN, the returned value is Float NaN.
-   * If the input is POSITIVE_INFINITY or NEGATIVE_INFINITY, the returned value is respectively
-   *   Float POSITIVE_INFINITY or Float NEGATIVE_INFINITY.
-   * If the input is 0 (positive or negative), the returned value is +/-0.0f.
-   * Otherwise, the returned value is a normalized single-precision float value.
+   * Converts the specified half-precision float value into a single-precision float value. The
+   * following special cases are handled: If the input is NaN, the returned value is Float NaN. If
+   * the input is POSITIVE_INFINITY or NEGATIVE_INFINITY, the returned value is respectively Float
+   * POSITIVE_INFINITY or Float NEGATIVE_INFINITY. If the input is 0 (positive or negative), the
+   * returned value is +/-0.0f. Otherwise, the returned value is a normalized single-precision float
+   * value.
    *
    * @param b The half-precision float value to convert to single-precision
    * @return A normalized single-precision float value
@@ -187,20 +183,16 @@ public class Float16 {
   }
 
   /**
-   * Converts the specified single-precision float value into a
-   * half-precision float value. The following special cases are handled:
+   * Converts the specified single-precision float value into a half-precision float value. The
+   * following special cases are handled:
    *
-   * If the input is NaN, the returned value is NaN.
-   * If the input is Float POSITIVE_INFINITY or Float NEGATIVE_INFINITY,
-   *   the returned value is respectively POSITIVE_INFINITY or NEGATIVE_INFINITY.
-   * If the input is 0 (positive or negative), the returned value is
-   *   POSITIVE_ZERO or NEGATIVE_ZERO.
-   * If the input is a less than MIN_VALUE, the returned value
-   *   is flushed to POSITIVE_ZERO or NEGATIVE_ZERO.
-   * If the input is a less than MIN_NORMAL, the returned value
-   *   is a denorm half-precision float.
-   * Otherwise, the returned value is rounded to the nearest
-   *   representable half-precision float value.
+   * <p>If the input is NaN, the returned value is NaN. If the input is Float POSITIVE_INFINITY or
+   * Float NEGATIVE_INFINITY, the returned value is respectively POSITIVE_INFINITY or
+   * NEGATIVE_INFINITY. If the input is 0 (positive or negative), the returned value is
+   * POSITIVE_ZERO or NEGATIVE_ZERO. If the input is a less than MIN_VALUE, the returned value is
+   * flushed to POSITIVE_ZERO or NEGATIVE_ZERO. If the input is a less than MIN_NORMAL, the returned
+   * value is a denorm half-precision float. Otherwise, the returned value is rounded to the nearest
+   * representable half-precision float value.
    *
    * @param f The single-precision float value to convert to half-precision
    * @return A half-precision float value
@@ -256,10 +248,9 @@ public class Float16 {
   }
 
   /**
-   * Returns a string representation of the specified half-precision
-   * float value. Calling this method is equivalent to calling
-   * <code>Float.toString(toFloat(h))</code>. See {@link Float#toString(float)}
-   * for more information on the format of the string representation.
+   * Returns a string representation of the specified half-precision float value. Calling this
+   * method is equivalent to calling <code>Float.toString(toFloat(h))</code>. See {@link
+   * Float#toString(float)} for more information on the format of the string representation.
    *
    * @param h A half-precision float value in binary little-endian format
    * @return A string representation of the specified value

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/HistoricalLog.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/HistoricalLog.java
@@ -14,20 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 
 /**
- * Utility class that can be used to log activity within a class
- * for later logging and debugging. Supports recording events and
- * recording the stack at the time they occur.
+ * Utility class that can be used to log activity within a class for later logging and debugging.
+ * Supports recording events and recording the stack at the time they occur.
  */
 public class HistoricalLog {
 
@@ -37,13 +34,13 @@ public class HistoricalLog {
   private @Nullable Event firstEvent; // the first stack trace recorded
 
   /**
-   * Constructor. The format string will be formatted and have its arguments
-   * substituted at the time this is called.
+   * Constructor. The format string will be formatted and have its arguments substituted at the time
+   * this is called.
    *
    * @param idStringFormat {@link String#format} format string that can be used to identify this
-   *                       object in a log. Including some kind of unique identifier that can be
-   *                       associated with the object instance is best.
-   * @param args           for the format string, or nothing if none are required
+   *     object in a log. Including some kind of unique identifier that can be associated with the
+   *     object instance is best.
+   * @param args for the format string, or nothing if none are required
    */
   @SuppressWarnings("FormatStringAnnotation")
   /* Remove @SuppressWarnings after fixing https://github.com/apache/arrow/issues/41951 */
@@ -52,22 +49,21 @@ public class HistoricalLog {
   }
 
   /**
-   * Constructor. The format string will be formatted and have its arguments
-   * substituted at the time this is called.
+   * Constructor. The format string will be formatted and have its arguments substituted at the time
+   * this is called.
    *
-   * <p>This form supports the specification of a limit that will limit the
-   * number of historical entries kept (which keeps down the amount of memory
-   * used). With the limit, the first entry made is always kept (under the
-   * assumption that this is the creation site of the object, which is usually
-   * interesting), and then up to the limit number of entries are kept after that.
-   * Each time a new entry is made, the oldest that is not the first is dropped.
+   * <p>This form supports the specification of a limit that will limit the number of historical
+   * entries kept (which keeps down the amount of memory used). With the limit, the first entry made
+   * is always kept (under the assumption that this is the creation site of the object, which is
+   * usually interesting), and then up to the limit number of entries are kept after that. Each time
+   * a new entry is made, the oldest that is not the first is dropped.
    *
-   * @param limit          the maximum number of historical entries that will be kept, not including
-   *                       the first entry made
+   * @param limit the maximum number of historical entries that will be kept, not including the
+   *     first entry made
    * @param idStringFormat {@link String#format} format string that can be used to identify this
-   *                       object in a log. Including some kind of unique identifier that can be
-   *                       associated with the object instance is best.
-   * @param args           for the format string, or nothing if none are required
+   *     object in a log. Including some kind of unique identifier that can be associated with the
+   *     object instance is best.
+   * @param args for the format string, or nothing if none are required
    */
   @SuppressWarnings("AnnotateFormatMethod")
   public HistoricalLog(final int limit, final String idStringFormat, Object... args) {
@@ -78,12 +74,11 @@ public class HistoricalLog {
   }
 
   /**
-   * Record an event. Automatically captures the stack trace at the time this is
-   * called. The format string will be formatted and have its arguments substituted
-   * at the time this is called.
+   * Record an event. Automatically captures the stack trace at the time this is called. The format
+   * string will be formatted and have its arguments substituted at the time this is called.
    *
    * @param noteFormat {@link String#format} format string that describes the event
-   * @param args       for the format string, or nothing if none are required
+   * @param args for the format string, or nothing if none are required
    */
   @SuppressWarnings("AnnotateFormatMethod")
   public synchronized void recordEvent(final String noteFormat, Object... args) {
@@ -100,11 +95,11 @@ public class HistoricalLog {
   }
 
   /**
-   * Write the history of this object to the given {@link StringBuilder}. The history
-   * includes the identifying string provided at construction time, and all the recorded
-   * events with their stack traces.
+   * Write the history of this object to the given {@link StringBuilder}. The history includes the
+   * identifying string provided at construction time, and all the recorded events with their stack
+   * traces.
    *
-   * @param sb                {@link StringBuilder} to write to
+   * @param sb {@link StringBuilder} to write to
    * @param includeStackTrace whether to include the stacktrace of each event in the history
    */
   public void buildHistory(final StringBuilder sb, boolean includeStackTrace) {
@@ -114,8 +109,8 @@ public class HistoricalLog {
   /**
    * Build the history and write it to sb.
    *
-   * @param sb                output
-   * @param indent            starting indent (usually "")
+   * @param sb output
+   * @param indent starting indent (usually "")
    * @param includeStackTrace whether to include the stacktrace of each event.
    */
   public synchronized void buildHistory(
@@ -125,20 +120,13 @@ public class HistoricalLog {
     Arrays.fill(indentation, ' ');
     Arrays.fill(innerIndentation, ' ');
 
-    sb.append(indentation)
-        .append("event log for: ")
-        .append(idString)
-        .append('\n');
+    sb.append(indentation).append("event log for: ").append(idString).append('\n');
 
     if (firstEvent != null) {
       long time = firstEvent.time;
       String note = firstEvent.note;
       final StackTrace stackTrace = firstEvent.stackTrace;
-      sb.append(innerIndentation)
-          .append(time)
-          .append(' ')
-          .append(note)
-          .append('\n');
+      sb.append(innerIndentation).append(time).append(' ').append(note).append('\n');
       if (includeStackTrace) {
         stackTrace.writeToBuilder(sb, indent + 2);
       }
@@ -163,9 +151,9 @@ public class HistoricalLog {
   }
 
   /**
-   * Write the history of this object to the given {@link Logger}. The history
-   * includes the identifying string provided at construction time, and all the recorded
-   * events with their stack traces.
+   * Write the history of this object to the given {@link Logger}. The history includes the
+   * identifying string provided at construction time, and all the recorded events with their stack
+   * traces.
    *
    * @param logger {@link Logger} to write to
    */

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import org.apache.arrow.memory.BoundsChecking;
@@ -22,13 +21,9 @@ import org.apache.arrow.memory.BoundsChecking;
 /** Contains utilities for dealing with a 64-bit address base. */
 public final class LargeMemoryUtil {
 
-  private LargeMemoryUtil() {
-  }
+  private LargeMemoryUtil() {}
 
-  /**
-   * Casts length to an int, but raises an exception the value is outside
-   * the range of an int.
-   */
+  /** Casts length to an int, but raises an exception the value is outside the range of an int. */
   public static int checkedCastToInt(long length) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       return Math.toIntExact(length);
@@ -36,9 +31,7 @@ public final class LargeMemoryUtil {
     return (int) length;
   }
 
-  /**
-   * Returns a min(Integer.MAX_VALUE, length).
-   */
+  /** Returns a min(Integer.MAX_VALUE, length). */
   public static int capAtMaxInt(long length) {
     return (int) Math.min(length, Integer.MAX_VALUE);
   }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import java.lang.reflect.Constructor;
@@ -24,37 +23,25 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
-
 import sun.misc.Unsafe;
 
-
-/**
- * Utilities for memory related operations.
- */
+/** Utilities for memory related operations. */
 public class MemoryUtil {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(MemoryUtil.class);
+  private static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(MemoryUtil.class);
 
   private static final @Nullable Constructor<?> DIRECT_BUFFER_CONSTRUCTOR;
-  /**
-   * The unsafe object from which to access the off-heap memory.
-   */
+  /** The unsafe object from which to access the off-heap memory. */
   public static final Unsafe UNSAFE;
 
-  /**
-   * The start offset of array data relative to the start address of the array object.
-   */
+  /** The start offset of array data relative to the start address of the array object. */
   public static final long BYTE_ARRAY_BASE_OFFSET;
 
-  /**
-   * The offset of the address field with the {@link java.nio.ByteBuffer} object.
-   */
+  /** The offset of the address field with the {@link java.nio.ByteBuffer} object. */
   static final long BYTE_BUFFER_ADDRESS_OFFSET;
 
-  /**
-   * If the native byte order is little-endian.
-   */
+  /** If the native byte order is little-endian. */
   public static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   // Java 1.8, 9, 11, 17, 21 becomes 1, 9, 11, 17, and 21.
@@ -65,21 +52,23 @@ public class MemoryUtil {
   static {
     try {
       // try to get the unsafe object
-      final Object maybeUnsafe = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-        @Override
-        @SuppressWarnings({"nullness:argument", "nullness:return"})
-        // incompatible argument for parameter obj of Field.get
-        // incompatible types in return
-        public Object run() {
-          try {
-            final Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
-            unsafeField.setAccessible(true);
-            return unsafeField.get(null);
-          } catch (Throwable e) {
-            return e;
-          }
-        }
-      });
+      final Object maybeUnsafe =
+          AccessController.doPrivileged(
+              new PrivilegedAction<Object>() {
+                @Override
+                @SuppressWarnings({"nullness:argument", "nullness:return"})
+                // incompatible argument for parameter obj of Field.get
+                // incompatible types in return
+                public Object run() {
+                  try {
+                    final Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+                    unsafeField.setAccessible(true);
+                    return unsafeField.get(null);
+                  } catch (Throwable e) {
+                    return e;
+                  }
+                }
+              });
 
       if (maybeUnsafe instanceof Throwable) {
         throw (Throwable) maybeUnsafe;
@@ -101,25 +90,27 @@ public class MemoryUtil {
       try {
 
         final Object maybeDirectBufferConstructor =
-            AccessController.doPrivileged(new PrivilegedAction<Object>() {
-              @Override
-              public Object run() {
-                try {
-                  final Constructor<?> constructor = (majorVersion >= 21) ?
-                      direct.getClass().getDeclaredConstructor(long.class, long.class) :
-                      direct.getClass().getDeclaredConstructor(long.class, int.class);
-                  constructor.setAccessible(true);
-                  logger.debug("Constructor for direct buffer found and made accessible");
-                  return constructor;
-                } catch (NoSuchMethodException e) {
-                  logger.debug("Cannot get constructor for direct buffer allocation", e);
-                  return e;
-                } catch (SecurityException e) {
-                  logger.debug("Cannot get constructor for direct buffer allocation", e);
-                  return e;
-                }
-              }
-            });
+            AccessController.doPrivileged(
+                new PrivilegedAction<Object>() {
+                  @Override
+                  public Object run() {
+                    try {
+                      final Constructor<?> constructor =
+                          (majorVersion >= 21)
+                              ? direct.getClass().getDeclaredConstructor(long.class, long.class)
+                              : direct.getClass().getDeclaredConstructor(long.class, int.class);
+                      constructor.setAccessible(true);
+                      logger.debug("Constructor for direct buffer found and made accessible");
+                      return constructor;
+                    } catch (NoSuchMethodException e) {
+                      logger.debug("Cannot get constructor for direct buffer allocation", e);
+                      return e;
+                    } catch (SecurityException e) {
+                      logger.debug("Cannot get constructor for direct buffer allocation", e);
+                      return e;
+                    }
+                  }
+                });
 
         if (maybeDirectBufferConstructor instanceof Constructor<?>) {
           address = UNSAFE.allocateMemory(1);
@@ -134,8 +125,7 @@ public class MemoryUtil {
           }
         } else {
           logger.debug(
-              "direct buffer constructor: unavailable",
-              (Throwable) maybeDirectBufferConstructor);
+              "direct buffer constructor: unavailable", (Throwable) maybeDirectBufferConstructor);
           directBufferConstructor = null;
         }
       } finally {
@@ -147,10 +137,12 @@ public class MemoryUtil {
     } catch (Throwable e) {
       // This exception will get swallowed, but it's necessary for the static analysis that ensures
       // the static fields above get initialized
-      final RuntimeException failure = new RuntimeException(
-          "Failed to initialize MemoryUtil. You must start Java with " +
-              "`--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED` " +
-              "(See https://arrow.apache.org/docs/java/install.html)", e);
+      final RuntimeException failure =
+          new RuntimeException(
+              "Failed to initialize MemoryUtil. You must start Java with "
+                  + "`--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED` "
+                  + "(See https://arrow.apache.org/docs/java/install.html)",
+              e);
       failure.printStackTrace();
       throw failure;
     }
@@ -166,12 +158,9 @@ public class MemoryUtil {
     return UNSAFE.getLong(buf, BYTE_BUFFER_ADDRESS_OFFSET);
   }
 
-  private MemoryUtil() {
-  }
+  private MemoryUtil() {}
 
-  /**
-   * Create nio byte buffer.
-   */
+  /** Create nio byte buffer. */
   public static ByteBuffer directBuffer(long address, int capacity) {
     if (DIRECT_BUFFER_CONSTRUCTOR != null) {
       if (capacity < 0) {
@@ -187,10 +176,14 @@ public class MemoryUtil {
         "sun.misc.Unsafe or java.nio.DirectByteBuffer.<init>(long, int) not available");
   }
 
-  @SuppressWarnings("nullness:argument") //to handle null assignment on third party dependency: Unsafe
-  public static void copyMemory(@Nullable Object srcBase, long srcOffset,
-                                @Nullable Object destBase, long destOffset,
-                                long bytes) {
+  @SuppressWarnings(
+      "nullness:argument") // to handle null assignment on third party dependency: Unsafe
+  public static void copyMemory(
+      @Nullable Object srcBase,
+      long srcOffset,
+      @Nullable Object destBase,
+      long destOffset,
+      long bytes) {
     UNSAFE.copyMemory(srcBase, srcOffset, destBase, destOffset, bytes);
   }
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/StackTrace.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/StackTrace.java
@@ -14,24 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import java.util.Arrays;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-
-/**
- * Convenient way of obtaining and manipulating stack traces for debugging.
- */
+/** Convenient way of obtaining and manipulating stack traces for debugging. */
 public class StackTrace {
 
-  private final @Nullable StackTraceElement [] stackTraceElements;
+  private final @Nullable StackTraceElement[] stackTraceElements;
 
-  /**
-   * Constructor. Captures the current stack trace.
-   */
+  /** Constructor. Captures the current stack trace. */
   public StackTrace() {
     final StackTraceElement[] stack = Thread.currentThread().getStackTrace();
     // Skip first two elements to remove getStackTrace/StackTrace.<init>
@@ -41,7 +34,7 @@ public class StackTrace {
   /**
    * Write the stack trace to a StringBuilder.
    *
-   * @param sb     where to write it
+   * @param sb where to write it
    * @param indent how many double spaces to indent each line
    */
   public void writeToBuilder(final StringBuilder sb, final int indent) {

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/ArrowBufHasher.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/ArrowBufHasher.java
@@ -14,22 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util.hash;
 
 import org.apache.arrow.memory.ArrowBuf;
 
 /**
- * Utility for calculating the hash code for a consecutive memory region.
- * This class provides the basic framework for efficiently calculating the hash code.
- * <p>
- *   A default light-weight implementation is given in {@link SimpleHasher}.
- * </p>
+ * Utility for calculating the hash code for a consecutive memory region. This class provides the
+ * basic framework for efficiently calculating the hash code.
+ *
+ * <p>A default light-weight implementation is given in {@link SimpleHasher}.
  */
 public interface ArrowBufHasher {
 
   /**
    * Calculates the hash code for a memory region.
+   *
    * @param address start address of the memory region.
    * @param length length of the memory region.
    * @return the hash code.
@@ -38,6 +37,7 @@ public interface ArrowBufHasher {
 
   /**
    * Calculates the hash code for a memory region.
+   *
    * @param buf the buffer for the memory region.
    * @param offset offset within the buffer for the memory region.
    * @param length length of the memory region.

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util.hash;
 
 import org.apache.arrow.memory.ArrowBuf;
@@ -22,32 +21,28 @@ import org.apache.arrow.memory.util.MemoryUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Implementation of the Murmur hashing algorithm.
- * Details of the algorithm can be found in
+ * Implementation of the Murmur hashing algorithm. Details of the algorithm can be found in
  * https://en.wikipedia.org/wiki/MurmurHash
- * <p>
- *   Murmur hashing is computationally expensive, as it involves several
- *   integer multiplications. However, the produced hash codes have
- *   good quality in the sense that they are uniformly distributed in the universe.
- * </p>
- * <p>
- *   Therefore, this algorithm is suitable for scenarios where uniform hashing
- *   is desired (e.g. in an open addressing hash table/hash set).
- * </p>
+ *
+ * <p>Murmur hashing is computationally expensive, as it involves several integer multiplications.
+ * However, the produced hash codes have good quality in the sense that they are uniformly
+ * distributed in the universe.
+ *
+ * <p>Therefore, this algorithm is suitable for scenarios where uniform hashing is desired (e.g. in
+ * an open addressing hash table/hash set).
  */
 public class MurmurHasher implements ArrowBufHasher {
 
   private final int seed;
 
-  /**
-   * Creates a default Murmur hasher, with seed 0.
-   */
+  /** Creates a default Murmur hasher, with seed 0. */
   public MurmurHasher() {
     this(0);
   }
 
   /**
    * Creates a Murmur hasher.
+   *
    * @param seed the seed for the hasher.
    */
   public MurmurHasher(int seed) {
@@ -67,6 +62,7 @@ public class MurmurHasher implements ArrowBufHasher {
 
   /**
    * Calculates the hash code for a memory region.
+   *
    * @param buf the buffer for the memory region.
    * @param offset offset within the buffer for the memory region.
    * @param length length of the memory region.
@@ -80,6 +76,7 @@ public class MurmurHasher implements ArrowBufHasher {
 
   /**
    * Calculates the hash code for a memory region.
+   *
    * @param address start address of the memory region.
    * @param length length of the memory region.
    * @param seed the seed.
@@ -108,8 +105,8 @@ public class MurmurHasher implements ArrowBufHasher {
   }
 
   /**
-   * Combine the current hash code and a new int value to calculate
-   * a new hash code.
+   * Combine the current hash code and a new int value to calculate a new hash code.
+   *
    * @param currentHashCode the current hash code.
    * @param intValue the new int value.
    * @return the new hah code.
@@ -137,6 +134,7 @@ public class MurmurHasher implements ArrowBufHasher {
 
   /**
    * Finalizing the hash code.
+   *
    * @param hashCode the current hash code.
    * @param length the length of the memory region.
    * @return the finalized hash code.

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
@@ -14,41 +14,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util.hash;
-
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.util.MemoryUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * A simple hasher that calculates the hash code of integers as is,
- * and does not perform any finalization. So the computation is extremely
- * efficient.
- * <p>
- *   This algorithm only provides the most basic semantics for the hash code. That is,
- *   if two objects are equal, they must have equal hash code. However, the quality of the
- *   produced hash code may not be good. In other words, the generated hash codes are
- *   far from being uniformly distributed in the universe.
- * </p>
- * <p>
- *   Therefore, this algorithm is suitable only for scenarios where the most basic semantics
- *   of the hash code is required (e.g. in scenarios that require fast and proactive data pruning)
- * </p>
- * <p>
- *   An object of this class is stateless, so it can be shared between threads.
- * </p>
+ * A simple hasher that calculates the hash code of integers as is, and does not perform any
+ * finalization. So the computation is extremely efficient.
+ *
+ * <p>This algorithm only provides the most basic semantics for the hash code. That is, if two
+ * objects are equal, they must have equal hash code. However, the quality of the produced hash code
+ * may not be good. In other words, the generated hash codes are far from being uniformly
+ * distributed in the universe.
+ *
+ * <p>Therefore, this algorithm is suitable only for scenarios where the most basic semantics of the
+ * hash code is required (e.g. in scenarios that require fast and proactive data pruning)
+ *
+ * <p>An object of this class is stateless, so it can be shared between threads.
  */
 public class SimpleHasher implements ArrowBufHasher {
 
   public static SimpleHasher INSTANCE = new SimpleHasher();
 
-  protected SimpleHasher() {
-  }
+  protected SimpleHasher() {}
 
   /**
    * Calculates the hash code for a memory region.
+   *
    * @param address start address of the memory region.
    * @param length length of the memory region.
    * @return the hash code.
@@ -83,6 +77,7 @@ public class SimpleHasher implements ArrowBufHasher {
 
   /**
    * Calculates the hash code for a memory region.
+   *
    * @param buf the buffer for the memory region.
    * @param offset offset within the buffer for the memory region.
    * @param length length of the memory region.

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/util/AutoCloseables.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/util/AutoCloseables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.util;
 
 import java.util.ArrayList;
@@ -25,17 +24,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
-/**
- * Utilities for AutoCloseable classes.
- */
+/** Utilities for AutoCloseable classes. */
 public final class AutoCloseables {
   // Utility class. Should not be instantiated
-  private AutoCloseables() {
-  }
+  private AutoCloseables() {}
 
   /**
-   * Returns a new {@link AutoCloseable} that calls {@link #close(Iterable)} on <code>autoCloseables</code>
-   * when close is called.
+   * Returns a new {@link AutoCloseable} that calls {@link #close(Iterable)} on <code>autoCloseables
+   * </code> when close is called.
    */
   public static AutoCloseable all(final Collection<? extends AutoCloseable> autoCloseables) {
     return new AutoCloseable() {
@@ -48,6 +44,7 @@ public final class AutoCloseables {
 
   /**
    * Closes all autoCloseables if not null and suppresses exceptions by adding them to t.
+   *
    * @param t the throwable to add suppressed exception to
    * @param autoCloseables the closeables to close
    */
@@ -57,6 +54,7 @@ public final class AutoCloseables {
 
   /**
    * Closes all autoCloseables if not null and suppresses exceptions by adding them to t.
+   *
    * @param t the throwable to add suppressed exception to
    * @param autoCloseables the closeables to close
    */
@@ -70,6 +68,7 @@ public final class AutoCloseables {
 
   /**
    * Closes all autoCloseables if not null and suppresses subsequent exceptions if more than one.
+   *
    * @param autoCloseables the closeables to close
    */
   public static void close(AutoCloseable... autoCloseables) throws Exception {
@@ -78,6 +77,7 @@ public final class AutoCloseables {
 
   /**
    * Closes all autoCloseables if not null and suppresses subsequent exceptions if more than one.
+   *
    * @param ac the closeables to close
    */
   public static void close(Iterable<? extends AutoCloseable> ac) throws Exception {
@@ -109,33 +109,32 @@ public final class AutoCloseables {
     }
   }
 
-  /**
-   * Calls {@link #close(Iterable)} on the flattened list of closeables.
-   */
+  /** Calls {@link #close(Iterable)} on the flattened list of closeables. */
   @SafeVarargs
-  public static void close(Iterable<? extends AutoCloseable>...closeables) throws Exception {
+  public static void close(Iterable<? extends AutoCloseable>... closeables) throws Exception {
     close(flatten(closeables));
   }
 
   @SafeVarargs
   private static Iterable<AutoCloseable> flatten(Iterable<? extends AutoCloseable>... closeables) {
     return new Iterable<AutoCloseable>() {
-      // Cast from Iterable<? extends AutoCloseable> to Iterable<AutoCloseable> is safe in this context
+      // Cast from Iterable<? extends AutoCloseable> to Iterable<AutoCloseable> is safe in this
+      // context
       // since there's no modification of the original collection
       @SuppressWarnings("unchecked")
       @Override
       public Iterator<AutoCloseable> iterator() {
         return Arrays.stream(closeables)
-            .flatMap((Iterable<? extends AutoCloseable> i)
-                -> StreamSupport.stream(((Iterable<AutoCloseable>) i).spliterator(), /*parallel=*/false))
+            .flatMap(
+                (Iterable<? extends AutoCloseable> i) ->
+                    StreamSupport.stream(
+                        ((Iterable<AutoCloseable>) i).spliterator(), /*parallel=*/ false))
             .iterator();
       }
     };
   }
 
-  /**
-   * Converts <code>ac</code> to a {@link Iterable} filtering out any null values.
-   */
+  /** Converts <code>ac</code> to a {@link Iterable} filtering out any null values. */
   public static Iterable<AutoCloseable> iter(AutoCloseable... ac) {
     if (ac.length == 0) {
       return Collections.emptyList();
@@ -150,9 +149,7 @@ public final class AutoCloseables {
     }
   }
 
-  /**
-   * A closeable wrapper that will close the underlying closeables if a commit does not occur.
-   */
+  /** A closeable wrapper that will close the underlying closeables if a commit does not occur. */
   public static class RollbackCloseable implements AutoCloseable {
 
     private boolean commit = false;
@@ -167,16 +164,12 @@ public final class AutoCloseables {
       return t;
     }
 
-    /**
-     * Add all of <code>list</code> to the rollback list.
-     */
+    /** Add all of <code>list</code> to the rollback list. */
     public void addAll(AutoCloseable... list) {
       closeables.addAll(Arrays.asList(list));
     }
 
-    /**
-     * Add all of <code>list</code> to the rollback list.
-     */
+    /** Add all of <code>list</code> to the rollback list. */
     public void addAll(Iterable<? extends AutoCloseable> list) {
       for (AutoCloseable ac : list) {
         closeables.add(ac);
@@ -193,26 +186,22 @@ public final class AutoCloseables {
         AutoCloseables.close(closeables);
       }
     }
-
   }
 
-  /**
-   * Creates an {@link RollbackCloseable} from the given closeables.
-   */
+  /** Creates an {@link RollbackCloseable} from the given closeables. */
   public static RollbackCloseable rollbackable(AutoCloseable... closeables) {
     return new RollbackCloseable(closeables);
   }
 
   /**
-   * close() an {@link java.lang.AutoCloseable} without throwing a (checked)
-   * {@link java.lang.Exception}. This wraps the close() call with a
-   * try-catch that will rethrow an Exception wrapped with a
-   * {@link java.lang.RuntimeException}, providing a way to call close()
+   * close() an {@link java.lang.AutoCloseable} without throwing a (checked) {@link
+   * java.lang.Exception}. This wraps the close() call with a try-catch that will rethrow an
+   * Exception wrapped with a {@link java.lang.RuntimeException}, providing a way to call close()
    * without having to do the try-catch everywhere or propagate the Exception.
    *
    * @param autoCloseable the AutoCloseable to close; may be null
-   * @throws RuntimeException if an Exception occurs; the Exception is
-   *         wrapped by the RuntimeException
+   * @throws RuntimeException if an Exception occurs; the Exception is wrapped by the
+   *     RuntimeException
    */
   public static void closeNoChecked(final AutoCloseable autoCloseable) {
     if (autoCloseable != null) {
@@ -224,11 +213,11 @@ public final class AutoCloseables {
     }
   }
 
-  private static final AutoCloseable noOpAutocloseable = new AutoCloseable() {
-    @Override
-    public void close() {
-    }
-  };
+  private static final AutoCloseable noOpAutocloseable =
+      new AutoCloseable() {
+        @Override
+        public void close() {}
+      };
 
   /**
    * Get an AutoCloseable that does nothing.
@@ -239,4 +228,3 @@ public final class AutoCloseables {
     return noOpAutocloseable;
   }
 }
-

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/util/Collections2.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/util/Collections2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.util;
 
 import java.util.ArrayList;
@@ -31,24 +30,20 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
- * Utility methods for manipulating {@link java.util.Collections} and their subclasses/implementations.
+ * Utility methods for manipulating {@link java.util.Collections} and their
+ * subclasses/implementations.
  */
 public final class Collections2 {
-  private Collections2() {
-  }
+  private Collections2() {}
 
-  /**
-   * Creates a {@link List} from the elements remaining in iterator.
-   */
+  /** Creates a {@link List} from the elements remaining in iterator. */
   public static <T> List<T> toList(Iterator<T> iterator) {
     List<T> target = new ArrayList<>();
     iterator.forEachRemaining(target::add);
     return target;
   }
 
-  /**
-   * Converts the iterable into a new {@link List}.
-   */
+  /** Converts the iterable into a new {@link List}. */
   public static <T> List<T> toList(Iterable<T> iterable) {
     if (iterable instanceof Collection<?>) {
       // If iterable is a collection, take advantage of it for a more efficient copy
@@ -57,13 +52,10 @@ public final class Collections2 {
     return toList(iterable.iterator());
   }
 
-  /**
-   * Converts the iterable into a new immutable {@link List}.
-   */
+  /** Converts the iterable into a new immutable {@link List}. */
   public static <T> List<T> toImmutableList(Iterable<T> iterable) {
     return Collections.unmodifiableList(toList(iterable));
   }
-
 
   /** Copies the elements of <code>map</code> to a new unmodifiable map. */
   public static <K, V> Map<K, V> immutableMapCopy(Map<K, V> map) {
@@ -76,17 +68,18 @@ public final class Collections2 {
   }
 
   /** Copies the values to a new unmodifiable list. */
-  public static <V> List<V> asImmutableList(V...values) {
+  public static <V> List<V> asImmutableList(V... values) {
     return Collections.unmodifiableList(Arrays.asList(values));
   }
 
   /**
    * Creates a human readable string from the remaining elements in iterator.
    *
-   * The output should be similar to {@code Arrays#toString(Object[])}
+   * <p>The output should be similar to {@code Arrays#toString(Object[])}
    */
   public static String toString(Iterator<?> iterator) {
-    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+    return StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
         .map(String::valueOf)
         .collect(Collectors.joining(", ", "[", "]"));
   }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/util/Preconditions.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/util/Preconditions.java
@@ -14,23 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * Lifted from Guava 20.0 to avoid dependency for core Arrow libraries.
- *
- * Copyright (C) 2007 The Guava Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package org.apache.arrow.util;
 
 import org.checkerframework.dataflow.qual.AssertMethod;
@@ -42,21 +25,23 @@ import org.checkerframework.dataflow.qual.AssertMethod;
  * checkNotNull}, an object reference which is expected to be non-null). When {@code false} (or
  * {@code null}) is passed instead, the {@code Preconditions} method throws an unchecked exception,
  * which helps the calling method communicate to <i>its</i> caller that <i>that</i> caller has made
- * a mistake. Example: <pre>   {@code
+ * a mistake. Example:
  *
- *   /**
- *    * Returns the positive square root of the given value.
- *    *
- *    * @throws IllegalArgumentException if the value is negative
- *    *}{@code /
- *   public static double sqrt(double value) {
- *     Preconditions.checkArgument(value >= 0.0, "negative value: %s", value);
- *     // calculate the square root
- *   }
+ * <pre>{@code
+ * /**
+ *  * Returns the positive square root of the given value.
+ *  *
+ *  * @throws IllegalArgumentException if the value is negative
+ *  *}{@code /
+ * public static double sqrt(double value) {
+ *   Preconditions.checkArgument(value >= 0.0, "negative value: %s", value);
+ *   // calculate the square root
+ * }
  *
- *   void exampleBadCaller() {
- *     double d = sqrt(-1.0);
- *   }}</pre>
+ * void exampleBadCaller() {
+ *   double d = sqrt(-1.0);
+ * }
+ * }</pre>
  *
  * <p>In this example, {@code checkArgument} throws an {@code IllegalArgumentException} to indicate
  * that {@code exampleBadCaller} made an error in <i>its</i> call to {@code sqrt}.
@@ -69,32 +54,33 @@ import org.checkerframework.dataflow.qual.AssertMethod;
  * when the precondition check then succeeds (as it should almost always do in production). In some
  * circumstances these wasted CPU cycles and allocations can add up to a real problem.
  * Performance-sensitive precondition checks can always be converted to the customary form:
- * <pre>   {@code
  *
- *   if (value < 0.0) {
- *     throw new IllegalArgumentException("negative value: " + value);
- *   }}</pre>
+ * <pre>{@code
+ * if (value < 0.0) {
+ *   throw new IllegalArgumentException("negative value: " + value);
+ * }
+ * }</pre>
  *
  * <h3>Other types of preconditions</h3>
  *
  * <p>Not every type of precondition failure is supported by these methods. Continue to throw
- * standard JDK exceptions such as {@link java.util.NoSuchElementException} or
- * {@link UnsupportedOperationException} in the situations they are intended for.
+ * standard JDK exceptions such as {@link java.util.NoSuchElementException} or {@link
+ * UnsupportedOperationException} in the situations they are intended for.
  *
  * <h3>Non-preconditions</h3>
  *
  * <p>It is of course possible to use the methods of this class to check for invalid conditions
  * which are <i>not the caller's fault</i>. Doing so is <b>not recommended</b> because it is
- * misleading to future readers of the code and of stack traces. See
- * <a href="https://github.com/google/guava/wiki/ConditionalFailuresExplained">Conditional failures
+ * misleading to future readers of the code and of stack traces. See <a
+ * href="https://github.com/google/guava/wiki/ConditionalFailuresExplained">Conditional failures
  * explained</a> in the Guava User Guide for more advice.
  *
  * <h3>{@code java.util.Objects.requireNonNull()}</h3>
  *
- * <p>Projects which use {@code com.google.common} should generally avoid the use of
- * {@link java.util.Objects#requireNonNull(Object)}. Instead, use whichever of
- * {@link #checkNotNull(Object)} or {@link Verify#verifyNotNull(Object)} is appropriate to the
- * situation. (The same goes for the message-accepting overloads.)
+ * <p>Projects which use {@code com.google.common} should generally avoid the use of {@link
+ * java.util.Objects#requireNonNull(Object)}. Instead, use whichever of {@link
+ * #checkNotNull(Object)} or {@link Verify#verifyNotNull(Object)} is appropriate to the situation.
+ * (The same goes for the message-accepting overloads.)
  *
  * <h3>Only {@code %s} is supported</h3>
  *
@@ -103,16 +89,15 @@ import org.checkerframework.dataflow.qual.AssertMethod;
  *
  * <h3>More information</h3>
  *
- * <p>See the Guava User Guide on
- * <a href="https://github.com/google/guava/wiki/PreconditionsExplained">using {@code
+ * <p>See the Guava User Guide on <a
+ * href="https://github.com/google/guava/wiki/PreconditionsExplained">using {@code
  * Preconditions}</a>.
  *
  * @author Kevin Bourrillion
  * @since 2.0
  */
 public final class Preconditions {
-  private Preconditions() {
-  }
+  private Preconditions() {}
 
   /**
    * Ensures the truth of an expression involving one or more parameters to the calling method.
@@ -158,9 +143,7 @@ public final class Preconditions {
    *     {@code errorMessageArgs} is null (don't let this happen)
    */
   public static void checkArgument(
-      boolean expression,
-      String errorMessageTemplate,
-      Object... errorMessageArgs) {
+      boolean expression, String errorMessageTemplate, Object... errorMessageArgs) {
     if (!expression) {
       throw new IllegalArgumentException(format(errorMessageTemplate, errorMessageArgs));
     }
@@ -204,8 +187,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
    */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, Object p1) {
+  public static void checkArgument(boolean b, String errorMessageTemplate, Object p1) {
     if (!b) {
       throw new IllegalArgumentException(format(errorMessageTemplate, p1));
     }
@@ -216,8 +198,172 @@ public final class Preconditions {
    *
    * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
    */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, char p1, char p2) {
+  public static void checkArgument(boolean b, String errorMessageTemplate, char p1, char p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, char p1, int p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, char p1, long p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, char p1, Object p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, int p1, char p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, int p1, int p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, int p1, long p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, int p1, Object p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, long p1, char p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, long p1, int p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, long p1, long p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, long p1, Object p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, Object p1, char p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, Object p1, int p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, Object p1, long p2) {
+    if (!b) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
+   */
+  public static void checkArgument(boolean b, String errorMessageTemplate, Object p1, Object p2) {
     if (!b) {
       throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
     }
@@ -229,191 +375,7 @@ public final class Preconditions {
    * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
    */
   public static void checkArgument(
-      boolean b, String errorMessageTemplate, char p1, int p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, char p1, long p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, char p1, Object p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, int p1, char p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, int p1, int p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, int p1, long p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, int p1, Object p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, long p1, char p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, long p1, int p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, long p1, long p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, long p1, Object p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, Object p1, char p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, Object p1, int p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, Object p1, long p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b, String errorMessageTemplate, Object p1, Object p2) {
-    if (!b) {
-      throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving one or more parameters to the calling method.
-   *
-   * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
-   */
-  public static void checkArgument(
-      boolean b,
-      String errorMessageTemplate,
-      Object p1,
-      Object p2,
-      Object p3) {
+      boolean b, String errorMessageTemplate, Object p1, Object p2, Object p3) {
     if (!b) {
       throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2, p3));
     }
@@ -425,12 +387,7 @@ public final class Preconditions {
    * <p>See {@link #checkArgument(boolean, String, Object...)} for details.
    */
   public static void checkArgument(
-      boolean b,
-      String errorMessageTemplate,
-      Object p1,
-      Object p2,
-      Object p3,
-      Object p4) {
+      boolean b, String errorMessageTemplate, Object p1, Object p2, Object p3, Object p4) {
     if (!b) {
       throw new IllegalArgumentException(format(errorMessageTemplate, p1, p2, p3, p4));
     }
@@ -483,9 +440,7 @@ public final class Preconditions {
    *     {@code errorMessageArgs} is null (don't let this happen)
    */
   public static void checkState(
-      boolean expression,
-      String errorMessageTemplate,
-      Object... errorMessageArgs) {
+      boolean expression, String errorMessageTemplate, Object... errorMessageArgs) {
     if (!expression) {
       throw new IllegalStateException(format(errorMessageTemplate, errorMessageArgs));
     }
@@ -533,8 +488,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, Object p1) {
+  public static void checkState(boolean b, String errorMessageTemplate, Object p1) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1));
     }
@@ -546,8 +500,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, char p1, char p2) {
+  public static void checkState(boolean b, String errorMessageTemplate, char p1, char p2) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
     }
@@ -571,8 +524,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, char p1, long p2) {
+  public static void checkState(boolean b, String errorMessageTemplate, char p1, long p2) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
     }
@@ -584,8 +536,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, char p1, Object p2) {
+  public static void checkState(boolean b, String errorMessageTemplate, char p1, Object p2) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
     }
@@ -633,8 +584,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, int p1, Object p2) {
+  public static void checkState(boolean b, String errorMessageTemplate, int p1, Object p2) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
     }
@@ -646,8 +596,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, long p1, char p2) {
+  public static void checkState(boolean b, String errorMessageTemplate, long p1, char p2) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
     }
@@ -671,8 +620,67 @@ public final class Preconditions {
    *
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, long p1, long p2) {
+  public static void checkState(boolean b, String errorMessageTemplate, long p1, long p2) {
+    if (!b) {
+      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * <p>See {@link #checkState(boolean, String, Object...)} for details.
+   */
+  public static void checkState(boolean b, String errorMessageTemplate, long p1, Object p2) {
+    if (!b) {
+      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * <p>See {@link #checkState(boolean, String, Object...)} for details.
+   */
+  public static void checkState(boolean b, String errorMessageTemplate, Object p1, char p2) {
+    if (!b) {
+      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * <p>See {@link #checkState(boolean, String, Object...)} for details.
+   */
+  public static void checkState(boolean b, String errorMessageTemplate, Object p1, int p2) {
+    if (!b) {
+      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * <p>See {@link #checkState(boolean, String, Object...)} for details.
+   */
+  public static void checkState(boolean b, String errorMessageTemplate, Object p1, long p2) {
+    if (!b) {
+      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
+    }
+  }
+
+  /**
+   * Ensures the truth of an expression involving the state of the calling instance, but not
+   * involving any parameters to the calling method.
+   *
+   * <p>See {@link #checkState(boolean, String, Object...)} for details.
+   */
+  public static void checkState(boolean b, String errorMessageTemplate, Object p1, Object p2) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
     }
@@ -685,76 +693,7 @@ public final class Preconditions {
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
   public static void checkState(
-      boolean b, String errorMessageTemplate, long p1, Object p2) {
-    if (!b) {
-      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving the state of the calling instance, but not
-   * involving any parameters to the calling method.
-   *
-   * <p>See {@link #checkState(boolean, String, Object...)} for details.
-   */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, Object p1, char p2) {
-    if (!b) {
-      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving the state of the calling instance, but not
-   * involving any parameters to the calling method.
-   *
-   * <p>See {@link #checkState(boolean, String, Object...)} for details.
-   */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, Object p1, int p2) {
-    if (!b) {
-      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving the state of the calling instance, but not
-   * involving any parameters to the calling method.
-   *
-   * <p>See {@link #checkState(boolean, String, Object...)} for details.
-   */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, Object p1, long p2) {
-    if (!b) {
-      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving the state of the calling instance, but not
-   * involving any parameters to the calling method.
-   *
-   * <p>See {@link #checkState(boolean, String, Object...)} for details.
-   */
-  public static void checkState(
-      boolean b, String errorMessageTemplate, Object p1, Object p2) {
-    if (!b) {
-      throw new IllegalStateException(format(errorMessageTemplate, p1, p2));
-    }
-  }
-
-  /**
-   * Ensures the truth of an expression involving the state of the calling instance, but not
-   * involving any parameters to the calling method.
-   *
-   * <p>See {@link #checkState(boolean, String, Object...)} for details.
-   */
-  public static void checkState(
-      boolean b,
-      String errorMessageTemplate,
-      Object p1,
-      Object p2,
-      Object p3) {
+      boolean b, String errorMessageTemplate, Object p1, Object p2, Object p3) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2, p3));
     }
@@ -767,12 +706,7 @@ public final class Preconditions {
    * <p>See {@link #checkState(boolean, String, Object...)} for details.
    */
   public static void checkState(
-      boolean b,
-      String errorMessageTemplate,
-      Object p1,
-      Object p2,
-      Object p3,
-      Object p4) {
+      boolean b, String errorMessageTemplate, Object p1, Object p2, Object p3, Object p4) {
     if (!b) {
       throw new IllegalStateException(format(errorMessageTemplate, p1, p2, p3, p4));
     }
@@ -785,7 +719,6 @@ public final class Preconditions {
    * @return the non-null reference that was validated
    * @throws NullPointerException if {@code reference} is null
    */
-
   public static <T> T checkNotNull(T reference) {
     if (reference == null) {
       throw new NullPointerException();
@@ -802,7 +735,6 @@ public final class Preconditions {
    * @return the non-null reference that was validated
    * @throws NullPointerException if {@code reference} is null
    */
-
   public static <T> T checkNotNull(T reference, Object errorMessage) {
     if (reference == null) {
       throw new NullPointerException(String.valueOf(errorMessage));
@@ -824,7 +756,6 @@ public final class Preconditions {
    * @return the non-null reference that was validated
    * @throws NullPointerException if {@code reference} is null
    */
-
   public static <T> T checkNotNull(
       T reference, String errorMessageTemplate, Object... errorMessageArgs) {
     if (reference == null) {
@@ -839,7 +770,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, char p1) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1));
@@ -852,7 +782,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, int p1) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1));
@@ -865,7 +794,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, long p1) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1));
@@ -878,9 +806,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, Object p1) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, Object p1) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1));
     }
@@ -892,7 +818,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, char p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -905,7 +830,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, char p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -918,7 +842,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, char p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -931,9 +854,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, char p1, Object p2) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, char p1, Object p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
     }
@@ -945,7 +866,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, int p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -958,7 +878,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, int p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -971,7 +890,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, int p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -984,9 +902,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, int p1, Object p2) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, int p1, Object p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
     }
@@ -998,7 +914,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, long p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -1011,7 +926,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, long p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -1024,7 +938,6 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(T obj, String errorMessageTemplate, long p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
@@ -1037,9 +950,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, long p1, Object p2) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, long p1, Object p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
     }
@@ -1051,9 +962,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, Object p1, char p2) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, Object p1, char p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
     }
@@ -1065,9 +974,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, Object p1, int p2) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, Object p1, int p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
     }
@@ -1079,9 +986,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, Object p1, long p2) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, Object p1, long p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
     }
@@ -1093,9 +998,7 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
-  public static <T> T checkNotNull(
-      T obj, String errorMessageTemplate, Object p1, Object p2) {
+  public static <T> T checkNotNull(T obj, String errorMessageTemplate, Object p1, Object p2) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2));
     }
@@ -1107,13 +1010,8 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(
-      T obj,
-      String errorMessageTemplate,
-      Object p1,
-      Object p2,
-      Object p3) {
+      T obj, String errorMessageTemplate, Object p1, Object p2, Object p3) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2, p3));
     }
@@ -1125,14 +1023,8 @@ public final class Preconditions {
    *
    * <p>See {@link #checkNotNull(Object, String, Object...)} for details.
    */
-
   public static <T> T checkNotNull(
-      T obj,
-      String errorMessageTemplate,
-      Object p1,
-      Object p2,
-      Object p3,
-      Object p4) {
+      T obj, String errorMessageTemplate, Object p1, Object p2, Object p3, Object p4) {
     if (obj == null) {
       throw new NullPointerException(format(errorMessageTemplate, p1, p2, p3, p4));
     }
@@ -1175,7 +1067,6 @@ public final class Preconditions {
    * @throws IndexOutOfBoundsException if {@code index} is negative or is not less than {@code size}
    * @throws IllegalArgumentException if {@code size} is negative
    */
-
   public static int checkElementIndex(int index, int size) {
     return checkElementIndex(index, size, "index");
   }
@@ -1191,7 +1082,6 @@ public final class Preconditions {
    * @throws IndexOutOfBoundsException if {@code index} is negative or is not less than {@code size}
    * @throws IllegalArgumentException if {@code size} is negative
    */
-
   public static int checkElementIndex(int index, int size, String desc) {
     // Carefully optimized for execution by hotspot (explanatory comment above)
     if (index < 0 || index >= size) {
@@ -1220,7 +1110,6 @@ public final class Preconditions {
    * @throws IndexOutOfBoundsException if {@code index} is negative or is greater than {@code size}
    * @throws IllegalArgumentException if {@code size} is negative
    */
-
   public static long checkPositionIndex(long index, long size) {
     return checkPositionIndex(index, size, "index");
   }
@@ -1236,7 +1125,6 @@ public final class Preconditions {
    * @throws IndexOutOfBoundsException if {@code index} is negative or is greater than {@code size}
    * @throws IllegalArgumentException if {@code size} is negative
    */
-
   public static long checkPositionIndex(long index, long size, String desc) {
     // Carefully optimized for execution by hotspot (explanatory comment above)
     if (index < 0 || index > size) {

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/util/VisibleForTesting.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/util/VisibleForTesting.java
@@ -14,13 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.util;
 
 /**
- * Annotation to indicate a class member or class is visible
- * only for the purposes of testing and otherwise should not
- * be referenced by other classes.
+ * Annotation to indicate a class member or class is visible only for the purposes of testing and
+ * otherwise should not be referenced by other classes.
  */
-public @interface VisibleForTesting {
-}
+public @interface VisibleForTesting {}

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/CountingAllocationListener.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/CountingAllocationListener.java
@@ -14,18 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
-import org.apache.arrow.memory.AllocationListener;
-import org.apache.arrow.memory.AllocationOutcome;
-import org.apache.arrow.memory.BufferAllocator;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
- * Counting allocation listener.
- * It counts the number of times it has been invoked, and how much memory allocation it has seen
- * When set to 'expand on fail', it attempts to expand the associated allocator's limit.
+ * Counting allocation listener. It counts the number of times it has been invoked, and how much
+ * memory allocation it has seen When set to 'expand on fail', it attempts to expand the associated
+ * allocator's limit.
  */
 final class CountingAllocationListener implements AllocationListener {
   private int numPreCalls;
@@ -35,8 +31,7 @@ final class CountingAllocationListener implements AllocationListener {
   private long totalMem;
   private long currentMem;
   private boolean expandOnFail;
-  @Nullable
-  BufferAllocator expandAlloc;
+  @Nullable BufferAllocator expandAlloc;
   long expandLimit;
 
   CountingAllocationListener() {
@@ -65,15 +60,14 @@ final class CountingAllocationListener implements AllocationListener {
   public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
     if (expandOnFail) {
       if (expandAlloc == null) {
-        throw new IllegalStateException("expandAlloc must be non-null because this " +
-            "listener is set to expand on failure.");
+        throw new IllegalStateException(
+            "expandAlloc must be non-null because this " + "listener is set to expand on failure.");
       }
       expandAlloc.setLimit(expandLimit);
       return true;
     }
     return false;
   }
-
 
   @Override
   public void onRelease(long size) {

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import org.apache.arrow.memory.util.MemoryUtil;
@@ -22,16 +21,13 @@ import org.apache.arrow.memory.util.MemoryUtil;
 /**
  * The default Allocation Manager Factory for a module.
  *
- * This is only used by tests and contains only a simplistic allocator method.
- *
+ * <p>This is only used by tests and contains only a simplistic allocator method.
  */
 public class DefaultAllocationManagerFactory implements AllocationManager.Factory {
 
   public static final AllocationManager.Factory FACTORY = new DefaultAllocationManagerFactory();
-  private static final ArrowBuf EMPTY = new ArrowBuf(ReferenceManager.NO_OP,
-      null,
-      0,
-      MemoryUtil.UNSAFE.allocateMemory(0));
+  private static final ArrowBuf EMPTY =
+      new ArrowBuf(ReferenceManager.NO_OP, null, 0, MemoryUtil.UNSAFE.allocateMemory(0));
 
   @Override
   public AllocationManager create(BufferAllocator accountingAllocator, long size) {

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestAccountant.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestAccountant.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import static org.junit.Assert.assertEquals;
@@ -46,21 +45,21 @@ public class TestAccountant {
     Thread[] threads = new Thread[numberOfThreads];
 
     for (int i = 0; i < numberOfThreads; i++) {
-      Thread t = new Thread() {
+      Thread t =
+          new Thread() {
 
-        @Override
-        public void run() {
-          try {
-            for (int i = 0; i < loops; i++) {
-              ensureAccurateReservations(parent);
+            @Override
+            public void run() {
+              try {
+                for (int i = 0; i < loops; i++) {
+                  ensureAccurateReservations(parent);
+                }
+              } catch (Exception ex) {
+                ex.printStackTrace();
+                Assert.fail(ex.getMessage());
+              }
             }
-          } catch (Exception ex) {
-            ex.printStackTrace();
-            Assert.fail(ex.getMessage());
-          }
-        }
-
-      };
+          };
       threads[i] = t;
       t.start();
     }

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestAllocationManager.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestAllocationManager.java
@@ -14,16 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
-/**
- * Test cases for {@link AllocationManager}.
- */
+/** Test cases for {@link AllocationManager}. */
 public class TestAllocationManager {
 
   @Test

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -23,26 +22,23 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
-
 import org.apache.arrow.memory.util.Float16;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
-
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 
 public class TestArrowBuf {
 
   @Test(expected = IndexOutOfBoundsException.class)
   public void testSliceOutOfBoundsLength_RaisesIndexOutOfBoundsException() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(2)
-    ) {
+        ArrowBuf buf = allocator.buffer(2)) {
       assertEquals(2, buf.capacity());
       buf.slice(0, 3);
     }
@@ -51,8 +47,7 @@ public class TestArrowBuf {
   @Test(expected = IndexOutOfBoundsException.class)
   public void testSliceOutOfBoundsIndexPlusLength_RaisesIndexOutOfBoundsException() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(2)
-    ) {
+        ArrowBuf buf = allocator.buffer(2)) {
       assertEquals(2, buf.capacity());
       buf.slice(1, 2);
     }
@@ -61,8 +56,7 @@ public class TestArrowBuf {
   @Test(expected = IndexOutOfBoundsException.class)
   public void testSliceOutOfBoundsIndex_RaisesIndexOutOfBoundsException() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(2)
-    ) {
+        ArrowBuf buf = allocator.buffer(2)) {
       assertEquals(2, buf.capacity());
       buf.slice(3, 0);
     }
@@ -71,8 +65,7 @@ public class TestArrowBuf {
   @Test
   public void testSliceWithinBoundsLength_ReturnsSlice() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(2)
-    ) {
+        ArrowBuf buf = allocator.buffer(2)) {
       assertEquals(2, buf.capacity());
       assertEquals(1, buf.slice(1, 1).capacity());
       assertEquals(2, buf.slice(0, 2).capacity());
@@ -88,7 +81,7 @@ public class TestArrowBuf {
     }
     ByteBuffer data = ByteBuffer.wrap(expected);
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(expected.length)) {
+        ArrowBuf buf = allocator.buffer(expected.length)) {
       buf.setBytes(0, data, 0, data.capacity());
 
       byte[] actual = new byte[expected.length];
@@ -126,7 +119,8 @@ public class TestArrowBuf {
     for (int i = 0; i < expected.length; i++) {
       expected[i] = (byte) i;
     }
-    // Only this code path is susceptible: others use unsafe or byte-by-byte copies, while this override copies longs.
+    // Only this code path is susceptible: others use unsafe or byte-by-byte copies, while this
+    // override copies longs.
     final ByteBuffer data = ByteBuffer.wrap(expected).asReadOnlyBuffer();
     assertFalse(data.hasArray());
     assertFalse(data.isDirect());
@@ -169,13 +163,15 @@ public class TestArrowBuf {
       try (BufferAllocator allocator = new RootAllocator(128)) {
         allocator.buffer(2);
         Exception e = assertThrows(IllegalStateException.class, allocator::close);
-        assertTrue("Exception had the following message: " + e.getMessage(),
+        assertTrue(
+            "Exception had the following message: " + e.getMessage(),
             e.getMessage().contains("event log for:")); // JDK8, JDK11
       } finally {
         fieldDebug.set(null, false);
       }
     } catch (Exception e) {
-      assertTrue("Exception had the following toString(): " + e.toString(),
+      assertTrue(
+          "Exception had the following toString(): " + e.toString(),
           e.toString().contains("java.lang.NoSuchFieldException: modifiers")); // JDK17+
     } finally {
       ((Logger) LoggerFactory.getLogger("org.apache.arrow")).setLevel(null);
@@ -185,8 +181,7 @@ public class TestArrowBuf {
   @Test
   public void testArrowBufFloat16() {
     try (BufferAllocator allocator = new RootAllocator();
-         ArrowBuf buf = allocator.buffer(1024)
-    ) {
+        ArrowBuf buf = allocator.buffer(1024)) {
       buf.setShort(0, Float16.toFloat16(+32.875f));
       assertEquals((short) 0x501c, buf.getShort(0));
     }

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -14,9 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
-
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -31,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-
 import org.apache.arrow.memory.AllocationOutcomeDetails.Entry;
 import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.arrow.memory.rounding.SegmentRoundingPolicy;
@@ -40,7 +37,6 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-
 import sun.misc.Unsafe;
 
 public class TestBaseAllocator {
@@ -69,16 +65,14 @@ public class TestBaseAllocator {
   // ---------------------------------------- DEBUG ------------------------------------
   */
 
-
   @Test
   public void test_privateMax() throws Exception {
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       final ArrowBuf arrowBuf1 = rootAllocator.buffer(MAX_ALLOCATION / 2);
       assertNotNull("allocation failed", arrowBuf1);
 
       try (final BufferAllocator childAllocator =
-               rootAllocator.newChildAllocator("noLimits", 0, MAX_ALLOCATION)) {
+          rootAllocator.newChildAllocator("noLimits", 0, MAX_ALLOCATION)) {
         final ArrowBuf arrowBuf2 = childAllocator.buffer(MAX_ALLOCATION / 2);
         assertNotNull("allocation failed", arrowBuf2);
         arrowBuf2.getReferenceManager().release();
@@ -91,8 +85,7 @@ public class TestBaseAllocator {
   @Test(expected = IllegalStateException.class)
   public void testRootAllocator_closeWithOutstanding() throws Exception {
     try {
-      try (final RootAllocator rootAllocator =
-               new RootAllocator(MAX_ALLOCATION)) {
+      try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
         final ArrowBuf arrowBuf = rootAllocator.buffer(512);
         assertNotNull("allocation failed", arrowBuf);
       }
@@ -114,8 +107,7 @@ public class TestBaseAllocator {
   @Test
   @Ignore
   public void testRootAllocator_getEmpty() throws Exception {
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       final ArrowBuf arrowBuf = rootAllocator.buffer(0);
       assertNotNull("allocation failed", arrowBuf);
       assertEquals("capacity was non-zero", 0, arrowBuf.capacity());
@@ -127,8 +119,7 @@ public class TestBaseAllocator {
   @Ignore // TODO(DRILL-2740)
   @Test(expected = IllegalStateException.class)
   public void testAllocator_unreleasedEmpty() throws Exception {
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       @SuppressWarnings("unused")
       final ArrowBuf arrowBuf = rootAllocator.buffer(0);
     }
@@ -136,8 +127,7 @@ public class TestBaseAllocator {
 
   @Test
   public void testAllocator_transferOwnership() throws Exception {
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       final BufferAllocator childAllocator1 =
           rootAllocator.newChildAllocator("changeOwnership1", 0, MAX_ALLOCATION);
       final BufferAllocator childAllocator2 =
@@ -146,7 +136,8 @@ public class TestBaseAllocator {
       final ArrowBuf arrowBuf1 = childAllocator1.buffer(MAX_ALLOCATION / 4);
       rootAllocator.verify();
       final ReferenceManager referenceManager = arrowBuf1.getReferenceManager();
-      OwnershipTransferResult transferOwnership = referenceManager.transferOwnership(arrowBuf1, childAllocator2);
+      OwnershipTransferResult transferOwnership =
+          referenceManager.transferOwnership(arrowBuf1, childAllocator2);
       assertEquiv(arrowBuf1, transferOwnership.getTransferredBuffer());
       final boolean allocationFit = transferOwnership.getAllocationFit();
       rootAllocator.verify();
@@ -179,14 +170,17 @@ public class TestBaseAllocator {
         try (final BufferAllocator childAllocator2 =
             rootAllocator.newChildAllocator("child2", 0, MAX_ALLOCATION)) {
           assertEquals(childAllocator2.getParentAllocator(), rootAllocator);
-          assertTrue(equalsIgnoreOrder(Arrays.asList(childAllocator1, childAllocator2),
-              rootAllocator.getChildAllocators()));
+          assertTrue(
+              equalsIgnoreOrder(
+                  Arrays.asList(childAllocator1, childAllocator2),
+                  rootAllocator.getChildAllocators()));
 
           try (final BufferAllocator grandChildAllocator =
               childAllocator1.newChildAllocator("grand-child", 0, MAX_ALLOCATION)) {
             assertEquals(grandChildAllocator.getParentAllocator(), childAllocator1);
-            assertTrue(equalsIgnoreOrder(Arrays.asList(grandChildAllocator),
-                childAllocator1.getChildAllocators()));
+            assertTrue(
+                equalsIgnoreOrder(
+                    Arrays.asList(grandChildAllocator), childAllocator1.getChildAllocators()));
           }
         }
       }
@@ -202,15 +196,18 @@ public class TestBaseAllocator {
             rootAllocator.newChildAllocator("child2", 0, MAX_ALLOCATION)) {
 
           // root has two child allocators
-          assertTrue(equalsIgnoreOrder(Arrays.asList(childAllocator1, childAllocator2),
-              rootAllocator.getChildAllocators()));
+          assertTrue(
+              equalsIgnoreOrder(
+                  Arrays.asList(childAllocator1, childAllocator2),
+                  rootAllocator.getChildAllocators()));
 
           try (final BufferAllocator grandChildAllocator =
               childAllocator1.newChildAllocator("grand-child", 0, MAX_ALLOCATION)) {
 
             // child1 has one allocator i.e grand-child
-            assertTrue(equalsIgnoreOrder(Arrays.asList(grandChildAllocator),
-                childAllocator1.getChildAllocators()));
+            assertTrue(
+                equalsIgnoreOrder(
+                    Arrays.asList(grandChildAllocator), childAllocator1.getChildAllocators()));
           }
 
           // grand-child closed
@@ -229,10 +226,10 @@ public class TestBaseAllocator {
   @Test
   public void testAllocator_shareOwnership() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      final BufferAllocator childAllocator1 = rootAllocator.newChildAllocator("shareOwnership1", 0,
-          MAX_ALLOCATION);
-      final BufferAllocator childAllocator2 = rootAllocator.newChildAllocator("shareOwnership2", 0,
-          MAX_ALLOCATION);
+      final BufferAllocator childAllocator1 =
+          rootAllocator.newChildAllocator("shareOwnership1", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator2 =
+          rootAllocator.newChildAllocator("shareOwnership2", 0, MAX_ALLOCATION);
       final ArrowBuf arrowBuf1 = childAllocator1.buffer(MAX_ALLOCATION / 4);
       rootAllocator.verify();
 
@@ -250,8 +247,8 @@ public class TestBaseAllocator {
       childAllocator1.close();
       rootAllocator.verify();
 
-      final BufferAllocator childAllocator3 = rootAllocator.newChildAllocator("shareOwnership3", 0,
-          MAX_ALLOCATION);
+      final BufferAllocator childAllocator3 =
+          rootAllocator.newChildAllocator("shareOwnership3", 0, MAX_ALLOCATION);
       final ArrowBuf arrowBuf3 = arrowBuf1.getReferenceManager().retain(arrowBuf1, childAllocator3);
       assertNotNull(arrowBuf3);
       assertNotEquals(arrowBuf3, arrowBuf1);
@@ -273,8 +270,8 @@ public class TestBaseAllocator {
   @Test
   public void testRootAllocator_createChildAndUse() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      try (final BufferAllocator childAllocator = rootAllocator.newChildAllocator(
-          "createChildAndUse", 0, MAX_ALLOCATION)) {
+      try (final BufferAllocator childAllocator =
+          rootAllocator.newChildAllocator("createChildAndUse", 0, MAX_ALLOCATION)) {
         final ArrowBuf arrowBuf = childAllocator.buffer(512);
         assertNotNull("allocation failed", arrowBuf);
         arrowBuf.getReferenceManager().release();
@@ -286,8 +283,8 @@ public class TestBaseAllocator {
   public void testRootAllocator_createChildDontClose() throws Exception {
     try {
       try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-        final BufferAllocator childAllocator = rootAllocator.newChildAllocator(
-            "createChildDontClose", 0, MAX_ALLOCATION);
+        final BufferAllocator childAllocator =
+            rootAllocator.newChildAllocator("createChildDontClose", 0, MAX_ALLOCATION);
         final ArrowBuf arrowBuf = childAllocator.buffer(512);
         assertNotNull("allocation failed", arrowBuf);
       }
@@ -309,7 +306,8 @@ public class TestBaseAllocator {
   @Test
   public void testSegmentAllocator() {
     RoundingPolicy policy = new SegmentRoundingPolicy(1024);
-    try (RootAllocator allocator = new RootAllocator(AllocationListener.NOOP, 1024 * 1024, policy)) {
+    try (RootAllocator allocator =
+        new RootAllocator(AllocationListener.NOOP, 1024 * 1024, policy)) {
       ArrowBuf buf = allocator.buffer(798);
       assertEquals(1024, buf.capacity());
       buf.setInt(333, 959);
@@ -348,19 +346,17 @@ public class TestBaseAllocator {
 
   @Test
   public void testSegmentAllocator_smallSegment() {
-    IllegalArgumentException e = Assertions.assertThrows(
-            IllegalArgumentException.class,
-        () -> new SegmentRoundingPolicy(128)
-    );
+    IllegalArgumentException e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new SegmentRoundingPolicy(128));
     assertEquals("The segment size cannot be smaller than 1024", e.getMessage());
   }
 
   @Test
   public void testSegmentAllocator_segmentSizeNotPowerOf2() {
-    IllegalArgumentException e = Assertions.assertThrows(
-            IllegalArgumentException.class,
-        () -> new SegmentRoundingPolicy(4097)
-    );
+    IllegalArgumentException e =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> new SegmentRoundingPolicy(4097));
     assertEquals("The segment size must be a power of 2", e.getMessage());
   }
 
@@ -391,53 +387,57 @@ public class TestBaseAllocator {
   }
 
   private BaseAllocator createAllocatorWithCustomizedAllocationManager() {
-    return new RootAllocator(BaseAllocator.configBuilder()
-        .maxAllocation(MAX_ALLOCATION)
-        .allocationManagerFactory(new AllocationManager.Factory() {
-          @Override
-          public AllocationManager create(BufferAllocator accountingAllocator, long requestedSize) {
-            return new AllocationManager(accountingAllocator) {
-              private final Unsafe unsafe = getUnsafe();
-              private final long address = unsafe.allocateMemory(requestedSize);
+    return new RootAllocator(
+        BaseAllocator.configBuilder()
+            .maxAllocation(MAX_ALLOCATION)
+            .allocationManagerFactory(
+                new AllocationManager.Factory() {
+                  @Override
+                  public AllocationManager create(
+                      BufferAllocator accountingAllocator, long requestedSize) {
+                    return new AllocationManager(accountingAllocator) {
+                      private final Unsafe unsafe = getUnsafe();
+                      private final long address = unsafe.allocateMemory(requestedSize);
 
-              @Override
-              protected long memoryAddress() {
-                return address;
-              }
+                      @Override
+                      protected long memoryAddress() {
+                        return address;
+                      }
 
-              @Override
-              protected void release0() {
-                unsafe.setMemory(address, requestedSize, (byte) 0);
-                unsafe.freeMemory(address);
-              }
+                      @Override
+                      protected void release0() {
+                        unsafe.setMemory(address, requestedSize, (byte) 0);
+                        unsafe.freeMemory(address);
+                      }
 
-              @Override
-              public long getSize() {
-                return requestedSize;
-              }
+                      @Override
+                      public long getSize() {
+                        return requestedSize;
+                      }
 
-              private Unsafe getUnsafe() {
-                Field f = null;
-                try {
-                  f = Unsafe.class.getDeclaredField("theUnsafe");
-                  f.setAccessible(true);
-                  return (Unsafe) f.get(null);
-                } catch (NoSuchFieldException | IllegalAccessException e) {
-                  throw new RuntimeException(e);
-                } finally {
-                  if (f != null) {
-                    f.setAccessible(false);
+                      private Unsafe getUnsafe() {
+                        Field f = null;
+                        try {
+                          f = Unsafe.class.getDeclaredField("theUnsafe");
+                          f.setAccessible(true);
+                          return (Unsafe) f.get(null);
+                        } catch (NoSuchFieldException | IllegalAccessException e) {
+                          throw new RuntimeException(e);
+                        } finally {
+                          if (f != null) {
+                            f.setAccessible(false);
+                          }
+                        }
+                      }
+                    };
                   }
-                }
-              }
-            };
-          }
 
-          @Override
-          public ArrowBuf empty() {
-            return null;
-          }
-        }).build());
+                  @Override
+                  public ArrowBuf empty() {
+                    return null;
+                  }
+                })
+            .build());
   }
 
   @Test
@@ -467,7 +467,8 @@ public class TestBaseAllocator {
         Assert.assertEquals(16, listener1.getTotalMem());
         buf1.getReferenceManager().release();
         try (final BufferAllocator c2 = c1.newChildAllocator("c2", listener2, 0, MAX_ALLOCATION)) {
-          Assert.assertEquals(2, listener1.getNumChildren()); // c1 got a new child, so listener1 is notified.
+          Assert.assertEquals(
+              2, listener1.getNumChildren()); // c1 got a new child, so listener1 is notified.
           Assert.assertEquals(0, listener2.getNumChildren());
           final ArrowBuf buf2 = c2.buffer(32);
           assertNotNull("allocation failed", buf2);
@@ -514,8 +515,8 @@ public class TestBaseAllocator {
     // allocation. The listener's callback triggers, expanding the child allocator's limit, so then
     // the allocation succeeds.
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      try (final BufferAllocator c1 = rootAllocator.newChildAllocator("c1", listener1, 0,
-          MAX_ALLOCATION / 2)) {
+      try (final BufferAllocator c1 =
+          rootAllocator.newChildAllocator("c1", listener1, 0, MAX_ALLOCATION / 2)) {
         try {
           c1.buffer(MAX_ALLOCATION);
           fail("allocated memory beyond max allowed");
@@ -558,10 +559,9 @@ public class TestBaseAllocator {
 
   @Test
   public void testAllocator_manyAllocations() throws Exception {
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       try (final BufferAllocator childAllocator =
-               rootAllocator.newChildAllocator("manyAllocations", 0, MAX_ALLOCATION)) {
+          rootAllocator.newChildAllocator("manyAllocations", 0, MAX_ALLOCATION)) {
         allocateAndFree(childAllocator);
       }
     }
@@ -569,10 +569,9 @@ public class TestBaseAllocator {
 
   @Test
   public void testAllocator_overAllocate() throws Exception {
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       try (final BufferAllocator childAllocator =
-               rootAllocator.newChildAllocator("overAllocate", 0, MAX_ALLOCATION)) {
+          rootAllocator.newChildAllocator("overAllocate", 0, MAX_ALLOCATION)) {
         allocateAndFree(childAllocator);
 
         try {
@@ -587,10 +586,9 @@ public class TestBaseAllocator {
 
   @Test
   public void testAllocator_overAllocateParent() throws Exception {
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       try (final BufferAllocator childAllocator =
-               rootAllocator.newChildAllocator("overAllocateParent", 0, MAX_ALLOCATION)) {
+          rootAllocator.newChildAllocator("overAllocateParent", 0, MAX_ALLOCATION)) {
         final ArrowBuf arrowBuf1 = rootAllocator.buffer(MAX_ALLOCATION / 2);
         assertNotNull("allocation failed", arrowBuf1);
         final ArrowBuf arrowBuf2 = childAllocator.buffer(MAX_ALLOCATION / 2);
@@ -611,14 +609,14 @@ public class TestBaseAllocator {
 
   @Test
   public void testAllocator_failureAtParentLimitOutcomeDetails() throws Exception {
-    try (final RootAllocator rootAllocator =
-        new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       try (final BufferAllocator childAllocator =
           rootAllocator.newChildAllocator("child", 0, MAX_ALLOCATION / 2)) {
         try (final BufferAllocator grandChildAllocator =
             childAllocator.newChildAllocator("grandchild", MAX_ALLOCATION / 4, MAX_ALLOCATION)) {
-          OutOfMemoryException e = assertThrows(OutOfMemoryException.class,
-              () -> grandChildAllocator.buffer(MAX_ALLOCATION));
+          OutOfMemoryException e =
+              assertThrows(
+                  OutOfMemoryException.class, () -> grandChildAllocator.buffer(MAX_ALLOCATION));
           // expected
           assertTrue(e.getMessage().contains("Unable to allocate buffer"));
 
@@ -648,14 +646,14 @@ public class TestBaseAllocator {
 
   @Test
   public void testAllocator_failureAtRootLimitOutcomeDetails() throws Exception {
-    try (final RootAllocator rootAllocator =
-        new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       try (final BufferAllocator childAllocator =
           rootAllocator.newChildAllocator("child", MAX_ALLOCATION / 2, Long.MAX_VALUE)) {
         try (final BufferAllocator grandChildAllocator =
             childAllocator.newChildAllocator("grandchild", MAX_ALLOCATION / 4, Long.MAX_VALUE)) {
-          OutOfMemoryException e = assertThrows(OutOfMemoryException.class,
-              () -> grandChildAllocator.buffer(MAX_ALLOCATION * 2));
+          OutOfMemoryException e =
+              assertThrows(
+                  OutOfMemoryException.class, () -> grandChildAllocator.buffer(MAX_ALLOCATION * 2));
 
           assertTrue(e.getMessage().contains("Unable to allocate buffer"));
           assertTrue("missing outcome details", e.getOutcomeDetails().isPresent());
@@ -699,7 +697,9 @@ public class TestBaseAllocator {
     final ArrowBuf arrowBuf4 = arrowBuf3.slice(16, arrowBuf3.capacity() - 32);
     rootAllocator.verify();
 
-    arrowBuf3.getReferenceManager().release(); // since they share refcounts, one is enough to release them all
+    arrowBuf3
+        .getReferenceManager()
+        .release(); // since they share refcounts, one is enough to release them all
     rootAllocator.verify();
   }
 
@@ -708,18 +708,18 @@ public class TestBaseAllocator {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       testAllocator_sliceUpBufferAndRelease(rootAllocator, rootAllocator);
 
-      try (final BufferAllocator childAllocator = rootAllocator.newChildAllocator("createSlices", 0,
-          MAX_ALLOCATION)) {
+      try (final BufferAllocator childAllocator =
+          rootAllocator.newChildAllocator("createSlices", 0, MAX_ALLOCATION)) {
         testAllocator_sliceUpBufferAndRelease(rootAllocator, childAllocator);
       }
       rootAllocator.verify();
 
       testAllocator_sliceUpBufferAndRelease(rootAllocator, rootAllocator);
 
-      try (final BufferAllocator childAllocator = rootAllocator.newChildAllocator("createSlices", 0,
-          MAX_ALLOCATION)) {
+      try (final BufferAllocator childAllocator =
+          rootAllocator.newChildAllocator("createSlices", 0, MAX_ALLOCATION)) {
         try (final BufferAllocator childAllocator2 =
-                 childAllocator.newChildAllocator("createSlices", 0, MAX_ALLOCATION)) {
+            childAllocator.newChildAllocator("createSlices", 0, MAX_ALLOCATION)) {
           final ArrowBuf arrowBuf1 = childAllocator2.buffer(MAX_ALLOCATION / 8);
           @SuppressWarnings("unused")
           final ArrowBuf arrowBuf2 = arrowBuf1.slice(MAX_ALLOCATION / 16, MAX_ALLOCATION / 16);
@@ -738,8 +738,7 @@ public class TestBaseAllocator {
   @Test
   public void testAllocator_sliceRanges() throws Exception {
     // final AllocatorOwner allocatorOwner = new NamedOwner("sliceRanges");
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       // Populate a buffer with byte values corresponding to their indices.
       final ArrowBuf arrowBuf = rootAllocator.buffer(256);
       assertEquals(256, arrowBuf.capacity());
@@ -797,8 +796,7 @@ public class TestBaseAllocator {
   @Test
   public void testAllocator_slicesOfSlices() throws Exception {
     // final AllocatorOwner allocatorOwner = new NamedOwner("slicesOfSlices");
-    try (final RootAllocator rootAllocator =
-             new RootAllocator(MAX_ALLOCATION)) {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       // Populate a buffer with byte values corresponding to their indices.
       final ArrowBuf arrowBuf = rootAllocator.buffer(256);
       for (int i = 0; i < 256; ++i) {
@@ -833,8 +831,10 @@ public class TestBaseAllocator {
   @Test
   public void testAllocator_transferSliced() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      final BufferAllocator childAllocator1 = rootAllocator.newChildAllocator("transferSliced1", 0, MAX_ALLOCATION);
-      final BufferAllocator childAllocator2 = rootAllocator.newChildAllocator("transferSliced2", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator1 =
+          rootAllocator.newChildAllocator("transferSliced1", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator2 =
+          rootAllocator.newChildAllocator("transferSliced2", 0, MAX_ALLOCATION);
 
       final ArrowBuf arrowBuf1 = childAllocator1.buffer(MAX_ALLOCATION / 8);
       final ArrowBuf arrowBuf2 = childAllocator2.buffer(MAX_ALLOCATION / 8);
@@ -844,10 +844,12 @@ public class TestBaseAllocator {
 
       rootAllocator.verify();
 
-      OwnershipTransferResult result1 = arrowBuf2s.getReferenceManager().transferOwnership(arrowBuf2s, childAllocator1);
+      OwnershipTransferResult result1 =
+          arrowBuf2s.getReferenceManager().transferOwnership(arrowBuf2s, childAllocator1);
       assertEquiv(arrowBuf2s, result1.getTransferredBuffer());
       rootAllocator.verify();
-      OwnershipTransferResult result2 = arrowBuf1s.getReferenceManager().transferOwnership(arrowBuf1s, childAllocator2);
+      OwnershipTransferResult result2 =
+          arrowBuf1s.getReferenceManager().transferOwnership(arrowBuf1s, childAllocator2);
       assertEquiv(arrowBuf1s, result2.getTransferredBuffer());
       rootAllocator.verify();
 
@@ -865,8 +867,10 @@ public class TestBaseAllocator {
   @Test
   public void testAllocator_shareSliced() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      final BufferAllocator childAllocator1 = rootAllocator.newChildAllocator("transferSliced", 0, MAX_ALLOCATION);
-      final BufferAllocator childAllocator2 = rootAllocator.newChildAllocator("transferSliced", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator1 =
+          rootAllocator.newChildAllocator("transferSliced", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator2 =
+          rootAllocator.newChildAllocator("transferSliced", 0, MAX_ALLOCATION);
 
       final ArrowBuf arrowBuf1 = childAllocator1.buffer(MAX_ALLOCATION / 8);
       final ArrowBuf arrowBuf2 = childAllocator2.buffer(MAX_ALLOCATION / 8);
@@ -876,9 +880,11 @@ public class TestBaseAllocator {
 
       rootAllocator.verify();
 
-      final ArrowBuf arrowBuf2s1 = arrowBuf2s.getReferenceManager().retain(arrowBuf2s, childAllocator1);
+      final ArrowBuf arrowBuf2s1 =
+          arrowBuf2s.getReferenceManager().retain(arrowBuf2s, childAllocator1);
       assertEquiv(arrowBuf2s, arrowBuf2s1);
-      final ArrowBuf arrowBuf1s2 = arrowBuf1s.getReferenceManager().retain(arrowBuf1s, childAllocator2);
+      final ArrowBuf arrowBuf1s2 =
+          arrowBuf1s.getReferenceManager().retain(arrowBuf1s, childAllocator2);
       assertEquiv(arrowBuf1s, arrowBuf1s2);
       rootAllocator.verify();
 
@@ -897,9 +903,12 @@ public class TestBaseAllocator {
   @Test
   public void testAllocator_transferShared() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      final BufferAllocator childAllocator1 = rootAllocator.newChildAllocator("transferShared1", 0, MAX_ALLOCATION);
-      final BufferAllocator childAllocator2 = rootAllocator.newChildAllocator("transferShared2", 0, MAX_ALLOCATION);
-      final BufferAllocator childAllocator3 = rootAllocator.newChildAllocator("transferShared3", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator1 =
+          rootAllocator.newChildAllocator("transferShared1", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator2 =
+          rootAllocator.newChildAllocator("transferShared2", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator3 =
+          rootAllocator.newChildAllocator("transferShared3", 0, MAX_ALLOCATION);
 
       final ArrowBuf arrowBuf1 = childAllocator1.buffer(MAX_ALLOCATION / 8);
 
@@ -912,7 +921,8 @@ public class TestBaseAllocator {
       assertEquiv(arrowBuf1, arrowBuf2);
 
       final ReferenceManager refManager1 = arrowBuf1.getReferenceManager();
-      final OwnershipTransferResult result1 = refManager1.transferOwnership(arrowBuf1, childAllocator3);
+      final OwnershipTransferResult result1 =
+          refManager1.transferOwnership(arrowBuf1, childAllocator3);
       allocationFit = result1.getAllocationFit();
       final ArrowBuf arrowBuf3 = result1.getTransferredBuffer();
       assertTrue(allocationFit);
@@ -928,9 +938,11 @@ public class TestBaseAllocator {
       childAllocator2.close();
       rootAllocator.verify();
 
-      final BufferAllocator childAllocator4 = rootAllocator.newChildAllocator("transferShared4", 0, MAX_ALLOCATION);
+      final BufferAllocator childAllocator4 =
+          rootAllocator.newChildAllocator("transferShared4", 0, MAX_ALLOCATION);
       final ReferenceManager refManager3 = arrowBuf3.getReferenceManager();
-      final OwnershipTransferResult result3 = refManager3.transferOwnership(arrowBuf3, childAllocator4);
+      final OwnershipTransferResult result3 =
+          refManager3.transferOwnership(arrowBuf3, childAllocator4);
       allocationFit = result3.getAllocationFit();
       final ArrowBuf arrowBuf4 = result3.getTransferredBuffer();
       assertTrue(allocationFit);
@@ -951,7 +963,7 @@ public class TestBaseAllocator {
   public void testAllocator_unclaimedReservation() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
       try (final BufferAllocator childAllocator1 =
-               rootAllocator.newChildAllocator("unclaimedReservation", 0, MAX_ALLOCATION)) {
+          rootAllocator.newChildAllocator("unclaimedReservation", 0, MAX_ALLOCATION)) {
         try (final AllocationReservation reservation = childAllocator1.newReservation()) {
           assertTrue(reservation.add(64));
         }
@@ -964,8 +976,8 @@ public class TestBaseAllocator {
   public void testAllocator_claimedReservation() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
 
-      try (final BufferAllocator childAllocator1 = rootAllocator.newChildAllocator(
-          "claimedReservation", 0, MAX_ALLOCATION)) {
+      try (final BufferAllocator childAllocator1 =
+          rootAllocator.newChildAllocator("claimedReservation", 0, MAX_ALLOCATION)) {
 
         try (final AllocationReservation reservation = childAllocator1.newReservation()) {
           assertTrue(reservation.add(32));
@@ -986,8 +998,8 @@ public class TestBaseAllocator {
   @Test
   public void testInitReservationAndLimit() throws Exception {
     try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      try (final BufferAllocator childAllocator = rootAllocator.newChildAllocator(
-              "child", 2048, 4096)) {
+      try (final BufferAllocator childAllocator =
+          rootAllocator.newChildAllocator("child", 2048, 4096)) {
         assertEquals(2048, childAllocator.getInitReservation());
         assertEquals(4096, childAllocator.getLimit());
       }
@@ -1055,11 +1067,11 @@ public class TestBaseAllocator {
       frag1.close();
       frag2.close();
       frag3.close();
-
     }
   }
 
-  // This test needs to run in non-debug mode. So disabling the assertion status through class loader for this.
+  // This test needs to run in non-debug mode. So disabling the assertion status through class
+  // loader for this.
   // The test passes if run individually with -Dtest=TestBaseAllocator#testMemoryLeakWithReservation
   // but fails generally since the assertion status cannot be changed once the class is initialized.
   // So setting the test to @ignore
@@ -1067,27 +1079,35 @@ public class TestBaseAllocator {
   @Ignore
   public void testMemoryLeakWithReservation() throws Exception {
     // disabling assertion status
-    AssertionUtil.class.getClassLoader().setClassAssertionStatus(AssertionUtil.class.getName(), false);
+    AssertionUtil.class
+        .getClassLoader()
+        .setClassAssertionStatus(AssertionUtil.class.getName(), false);
     try (RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
-      ChildAllocator childAllocator1 = (ChildAllocator) rootAllocator.newChildAllocator(
-          "child1", 1024, MAX_ALLOCATION);
+      ChildAllocator childAllocator1 =
+          (ChildAllocator) rootAllocator.newChildAllocator("child1", 1024, MAX_ALLOCATION);
       rootAllocator.verify();
 
-      ChildAllocator childAllocator2 = (ChildAllocator) childAllocator1.newChildAllocator(
-          "child2", 1024, MAX_ALLOCATION);
+      ChildAllocator childAllocator2 =
+          (ChildAllocator) childAllocator1.newChildAllocator("child2", 1024, MAX_ALLOCATION);
       rootAllocator.verify();
 
       childAllocator2.buffer(256);
 
-      Exception exception = assertThrows(IllegalStateException.class, () -> {
-        childAllocator2.close();
-      });
+      Exception exception =
+          assertThrows(
+              IllegalStateException.class,
+              () -> {
+                childAllocator2.close();
+              });
       String exMessage = exception.getMessage();
       assertTrue(exMessage.contains("Memory leaked: (256)"));
 
-      exception = assertThrows(IllegalStateException.class, () -> {
-        childAllocator1.close();
-      });
+      exception =
+          assertThrows(
+              IllegalStateException.class,
+              () -> {
+                childAllocator1.close();
+              });
       exMessage = exception.getMessage();
       assertTrue(exMessage.contains("Memory leaked: (256)"));
     }
@@ -1097,11 +1117,13 @@ public class TestBaseAllocator {
   public void testOverlimit() {
     try (BufferAllocator allocator = new RootAllocator(1024)) {
       try (BufferAllocator child1 = allocator.newChildAllocator("ChildA", 0, 1024);
-           BufferAllocator child2 = allocator.newChildAllocator("ChildB", 1024, 1024)) {
-        assertThrows(OutOfMemoryException.class, () -> {
-          ArrowBuf buf1 = child1.buffer(8);
-          buf1.close();
-        });
+          BufferAllocator child2 = allocator.newChildAllocator("ChildB", 1024, 1024)) {
+        assertThrows(
+            OutOfMemoryException.class,
+            () -> {
+              ArrowBuf buf1 = child1.buffer(8);
+              buf1.close();
+            });
         assertEquals(0, child1.getAllocatedMemory());
         assertEquals(0, child2.getAllocatedMemory());
         assertEquals(1024, allocator.getAllocatedMemory());
@@ -1114,11 +1136,14 @@ public class TestBaseAllocator {
     // Regression test for https://github.com/apache/arrow/issues/35960
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
       try (BufferAllocator child1 = allocator.newChildAllocator("ChildA", 0, Long.MAX_VALUE);
-           BufferAllocator child2 = allocator.newChildAllocator("ChildB", Long.MAX_VALUE, Long.MAX_VALUE)) {
-        assertThrows(OutOfMemoryException.class, () -> {
-          ArrowBuf buf1 = child1.buffer(1024);
-          buf1.close();
-        });
+          BufferAllocator child2 =
+              allocator.newChildAllocator("ChildB", Long.MAX_VALUE, Long.MAX_VALUE)) {
+        assertThrows(
+            OutOfMemoryException.class,
+            () -> {
+              ArrowBuf buf1 = child1.buffer(1024);
+              buf1.close();
+            });
         assertEquals(0, child1.getAllocatedMemory());
         assertEquals(0, child2.getAllocatedMemory());
         assertEquals(Long.MAX_VALUE, allocator.getAllocatedMemory());

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestBoundaryChecking.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestBoundaryChecking.java
@@ -14,22 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import java.lang.reflect.Field;
 import java.net.URLClassLoader;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test cases for evaluating the value of {@link BoundsChecking#BOUNDS_CHECKING_ENABLED}.
- */
+/** Test cases for evaluating the value of {@link BoundsChecking#BOUNDS_CHECKING_ENABLED}. */
 public class TestBoundaryChecking {
 
   /**
    * Get a copy of the current class loader.
+   *
    * @return the newly created class loader.
    */
   private ClassLoader copyClassLoader() {
@@ -44,7 +41,8 @@ public class TestBoundaryChecking {
   }
 
   /**
-   * Get the value of flag  {@link BoundsChecking#BOUNDS_CHECKING_ENABLED}.
+   * Get the value of flag {@link BoundsChecking#BOUNDS_CHECKING_ENABLED}.
+   *
    * @param classLoader the class loader from which to get the flag value.
    * @return value of the flag.
    */
@@ -55,8 +53,8 @@ public class TestBoundaryChecking {
   }
 
   /**
-   * Ensure the flag for bounds checking is enabled by default.
-   * This will protect users from JVM crashes.
+   * Ensure the flag for bounds checking is enabled by default. This will protect users from JVM
+   * crashes.
    */
   @Test
   public void testDefaultValue() throws Exception {
@@ -69,6 +67,7 @@ public class TestBoundaryChecking {
 
   /**
    * Test setting the bounds checking flag by the old property.
+   *
    * @throws Exception if loading class {@link BoundsChecking#BOUNDS_CHECKING_ENABLED} fails.
    */
   @Test
@@ -92,6 +91,7 @@ public class TestBoundaryChecking {
 
   /**
    * Test setting the bounds checking flag by the new property.
+   *
    * @throws Exception if loading class {@link BoundsChecking#BOUNDS_CHECKING_ENABLED} fails.
    */
   @Test
@@ -115,8 +115,9 @@ public class TestBoundaryChecking {
   }
 
   /**
-   * Test setting the bounds checking flag by both old and new properties.
-   * In this case, the new property should take precedence.
+   * Test setting the bounds checking flag by both old and new properties. In this case, the new
+   * property should take precedence.
+   *
    * @throws Exception if loading class {@link BoundsChecking#BOUNDS_CHECKING_ENABLED} fails.
    */
   @Test

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestForeignAllocation.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestForeignAllocation.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import static org.junit.Assert.assertEquals;
@@ -22,14 +21,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.arrow.memory.AllocationListener;
-import org.apache.arrow.memory.AllocationOutcome;
-import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.ForeignAllocation;
-import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.memory.util.MemoryUtil;
 import org.junit.After;
 import org.junit.Before;
@@ -118,13 +109,14 @@ public class TestForeignAllocation {
     final long limit = 2 * bufferSize - 1;
 
     final List<ArrowBuf> buffersToBeFreed = new ArrayList<>();
-    final AllocationListener listener = new AllocationListener() {
-      @Override
-      public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
-        buffersToBeFreed.forEach(ArrowBuf::close);
-        return true;
-      }
-    };
+    final AllocationListener listener =
+        new AllocationListener() {
+          @Override
+          public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
+            buffersToBeFreed.forEach(ArrowBuf::close);
+            return true;
+          }
+        };
 
     try (BufferAllocator listenedAllocator =
         allocator.newChildAllocator("child", listener, 0L, limit)) {
@@ -133,7 +125,8 @@ public class TestForeignAllocation {
       UnsafeForeignAllocation allocation = new UnsafeForeignAllocation(bufferSize);
       try (final ArrowBuf buffer2 = listenedAllocator.wrapForeignAllocation(allocation)) {
         assertEquals(bufferSize, buffer2.capacity());
-        assertEquals(0, buffer1.getReferenceManager().getRefCount()); // buffer1 was closed by listener
+        assertEquals(
+            0, buffer1.getReferenceManager().getRefCount()); // buffer1 was closed by listener
       }
     }
   }

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestLowCostIdentityHashMap.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestLowCostIdentityHashMap.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import static junit.framework.TestCase.assertNotNull;
@@ -24,9 +23,7 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
-/**
- * To test simplified implementation of IdentityHashMap.
- */
+/** To test simplified implementation of IdentityHashMap. */
 public class TestLowCostIdentityHashMap {
 
   @Test
@@ -61,8 +58,10 @@ public class TestLowCostIdentityHashMap {
 
     assertNotNull(nextValue);
 
-    assertTrue((hashMap.get("s1key") == nextValue || hashMap.get("s2key") == nextValue ||
-        hashMap.get("s5key") == nextValue));
+    assertTrue(
+        (hashMap.get("s1key") == nextValue
+            || hashMap.get("s2key") == nextValue
+            || hashMap.get("s5key") == nextValue));
 
     assertTrue(hashMap.containsValue(obj4));
     assertTrue(hashMap.containsValue(obj2));
@@ -90,7 +89,7 @@ public class TestLowCostIdentityHashMap {
   public void testLargeMap() throws Exception {
     LowCostIdentityHashMap<String, StringWithKey> hashMap = new LowCostIdentityHashMap<>();
 
-    String [] keys = new String[200];
+    String[] keys = new String[200];
     for (int i = 0; i < 200; i++) {
       keys[i] = "s" + i + "key";
     }

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestOpens.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/TestOpens.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,14 +28,18 @@ public class TestOpens {
     // This test is configured by Maven to run WITHOUT add-opens. So this should fail on JDK16+
     // (where JEP396 means that add-opens is required to access JDK internals).
     // The test will likely fail in your IDE if it doesn't correctly pick this up.
-    Throwable e = assertThrows(Throwable.class, () -> {
-      BufferAllocator allocator = new RootAllocator();
-      allocator.close();
-    });
+    Throwable e =
+        assertThrows(
+            Throwable.class,
+            () -> {
+              BufferAllocator allocator = new RootAllocator();
+              allocator.close();
+            });
     boolean found = false;
     while (e != null) {
       e = e.getCause();
-      if (e instanceof RuntimeException && e.getMessage().contains("Failed to initialize MemoryUtil")) {
+      if (e instanceof RuntimeException
+          && e.getMessage().contains("Failed to initialize MemoryUtil")) {
         found = true;
         break;
       }

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/TestArrowBufPointer.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/TestArrowBufPointer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import static junit.framework.TestCase.assertEquals;
@@ -31,9 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Test cases for {@link ArrowBufPointer}.
- */
+/** Test cases for {@link ArrowBufPointer}. */
 public class TestArrowBufPointer {
 
   private final int BUFFER_LENGTH = 1024;
@@ -74,7 +71,7 @@ public class TestArrowBufPointer {
   public void testArrowBufPointersHashCode() {
     final int vectorLength = 100;
     try (ArrowBuf buf1 = allocator.buffer(vectorLength * 4);
-         ArrowBuf buf2 = allocator.buffer(vectorLength * 4)) {
+        ArrowBuf buf2 = allocator.buffer(vectorLength * 4)) {
       for (int i = 0; i < vectorLength; i++) {
         buf1.setInt(i * 4L, i);
         buf2.setInt(i * 4L, i);
@@ -155,7 +152,7 @@ public class TestArrowBufPointer {
   public void testArrowBufPointersComparison() {
     final int vectorLength = 100;
     try (ArrowBuf buf1 = allocator.buffer(vectorLength);
-         ArrowBuf buf2 = allocator.buffer(vectorLength)) {
+        ArrowBuf buf2 = allocator.buffer(vectorLength)) {
       for (int i = 0; i < vectorLength; i++) {
         buf1.setByte(i, i);
         buf2.setByte(i, i);
@@ -185,8 +182,8 @@ public class TestArrowBufPointer {
   }
 
   /**
-   * Hasher with a counter that increments each time a hash code is calculated.
-   * This is to validate that the hash code in {@link ArrowBufPointer} is reused.
+   * Hasher with a counter that increments each time a hash code is calculated. This is to validate
+   * that the hash code in {@link ArrowBufPointer} is reused.
    */
   static class CounterHasher implements ArrowBufHasher {
 

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/TestByteFunctionHelpers.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/TestByteFunctionHelpers.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.StandardCharsets;
-
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -37,7 +35,6 @@ public class TestByteFunctionHelpers {
   @Before
   public void init() {
     allocator = new RootAllocator(Long.MAX_VALUE);
-
   }
 
   @After
@@ -55,28 +52,21 @@ public class TestByteFunctionHelpers {
       buffer2.setByte(i, i);
     }
 
-    //test three cases, length>8, length>3, length<3
+    // test three cases, length>8, length>3, length<3
 
-    assertEquals(1, ByteFunctionHelpers.equal(buffer1, 0, SIZE - 1,
-        buffer2, 0, SIZE - 1));
-    assertEquals(1, ByteFunctionHelpers.equal(buffer1, 0, 6,
-        buffer2, 0, 6));
-    assertEquals(1, ByteFunctionHelpers.equal(buffer1, 0, 2,
-        buffer2, 0, 2));
+    assertEquals(1, ByteFunctionHelpers.equal(buffer1, 0, SIZE - 1, buffer2, 0, SIZE - 1));
+    assertEquals(1, ByteFunctionHelpers.equal(buffer1, 0, 6, buffer2, 0, 6));
+    assertEquals(1, ByteFunctionHelpers.equal(buffer1, 0, 2, buffer2, 0, 2));
 
-    //change value at index1
+    // change value at index1
     buffer1.setByte(1, 10);
 
-    assertEquals(0, ByteFunctionHelpers.equal(buffer1, 0, SIZE - 1,
-        buffer2, 0, SIZE - 1));
-    assertEquals(0, ByteFunctionHelpers.equal(buffer1, 0, 6,
-        buffer2, 0, 6));
-    assertEquals(0, ByteFunctionHelpers.equal(buffer1, 0, 2,
-        buffer2, 0, 2));
+    assertEquals(0, ByteFunctionHelpers.equal(buffer1, 0, SIZE - 1, buffer2, 0, SIZE - 1));
+    assertEquals(0, ByteFunctionHelpers.equal(buffer1, 0, 6, buffer2, 0, 6));
+    assertEquals(0, ByteFunctionHelpers.equal(buffer1, 0, 2, buffer2, 0, 2));
 
     buffer1.close();
     buffer2.close();
-
   }
 
   @Test
@@ -89,28 +79,21 @@ public class TestByteFunctionHelpers {
       buffer2.setByte(i, i);
     }
 
-    //test three cases, length>8, length>3, length<3
+    // test three cases, length>8, length>3, length<3
 
-    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1,
-        buffer2, 0, SIZE - 1));
-    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 6,
-        buffer2, 0, 6));
-    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 2,
-        buffer2, 0, 2));
+    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1, buffer2, 0, SIZE - 1));
+    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 6, buffer2, 0, 6));
+    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 2, buffer2, 0, 2));
 
-    //change value at index 1
+    // change value at index 1
     buffer1.setByte(1, 0);
 
-    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1,
-        buffer2, 0, SIZE - 1));
-    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 6,
-        buffer2, 0, 6));
-    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 2,
-        buffer2, 0, 2));
+    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1, buffer2, 0, SIZE - 1));
+    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 6, buffer2, 0, 6));
+    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 2, buffer2, 0, 2));
 
     buffer1.close();
     buffer2.close();
-
   }
 
   @Test
@@ -127,7 +110,8 @@ public class TestByteFunctionHelpers {
       ArrowBuf right = allocator.buffer(SIZE);
       right.setBytes(0, rightStr.getBytes(StandardCharsets.UTF_8));
 
-      assertEquals(leftStr.compareTo(rightStr) < 0 ? -1 : 1,
+      assertEquals(
+          leftStr.compareTo(rightStr) < 0 ? -1 : 1,
           ByteFunctionHelpers.compare(left, 0, leftStr.length(), right, 0, rightStr.length()));
 
       left.close();
@@ -145,24 +129,18 @@ public class TestByteFunctionHelpers {
       buffer2[i] = (byte) i;
     }
 
-    //test three cases, length>8, length>3, length<3
+    // test three cases, length>8, length>3, length<3
 
-    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1,
-        buffer2, 0, SIZE - 1));
-    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 6,
-        buffer2, 0, 6));
-    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 2,
-        buffer2, 0, 2));
+    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1, buffer2, 0, SIZE - 1));
+    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 6, buffer2, 0, 6));
+    assertEquals(0, ByteFunctionHelpers.compare(buffer1, 0, 2, buffer2, 0, 2));
 
-    //change value at index 1
+    // change value at index 1
     buffer1.setByte(1, 0);
 
-    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1,
-        buffer2, 0, SIZE - 1));
-    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 6,
-        buffer2, 0, 6));
-    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 2,
-        buffer2, 0, 2));
+    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, SIZE - 1, buffer2, 0, SIZE - 1));
+    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 6, buffer2, 0, 6));
+    assertEquals(-1, ByteFunctionHelpers.compare(buffer1, 0, 2, buffer2, 0, 2));
 
     buffer1.close();
   }

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/TestLargeMemoryUtil.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/TestLargeMemoryUtil.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -29,6 +27,7 @@ public class TestLargeMemoryUtil {
 
   /**
    * Get a copy of the current class loader.
+   *
    * @return the newly created class loader.
    */
   private ClassLoader copyClassLoader() {
@@ -44,6 +43,7 @@ public class TestLargeMemoryUtil {
 
   /**
    * Use the checkedCastToInt method from the current classloader.
+   *
    * @param classLoader the class loader from which to call the method.
    * @return the return value of the method.
    */
@@ -54,9 +54,12 @@ public class TestLargeMemoryUtil {
   }
 
   private void checkExpectedOverflow(ClassLoader classLoader, long value) {
-    InvocationTargetException ex = Assertions.assertThrows(InvocationTargetException.class, () -> {
-      checkedCastToInt(classLoader, value);
-    });
+    InvocationTargetException ex =
+        Assertions.assertThrows(
+            InvocationTargetException.class,
+            () -> {
+              checkedCastToInt(classLoader, value);
+            });
     Assert.assertTrue(ex.getCause() instanceof ArithmeticException);
     Assert.assertEquals("integer overflow", ex.getCause().getMessage());
   }
@@ -90,8 +93,10 @@ public class TestLargeMemoryUtil {
       ClassLoader classLoader = copyClassLoader();
       if (classLoader != null) {
         Assert.assertEquals(Integer.MAX_VALUE, checkedCastToInt(classLoader, Integer.MAX_VALUE));
-        Assert.assertEquals(Integer.MIN_VALUE, checkedCastToInt(classLoader, Integer.MAX_VALUE + 1L));
-        Assert.assertEquals(Integer.MAX_VALUE, checkedCastToInt(classLoader, Integer.MIN_VALUE - 1L));
+        Assert.assertEquals(
+            Integer.MIN_VALUE, checkedCastToInt(classLoader, Integer.MAX_VALUE + 1L));
+        Assert.assertEquals(
+            Integer.MAX_VALUE, checkedCastToInt(classLoader, Integer.MIN_VALUE - 1L));
       }
     } finally {
       // restore system property

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/hash/TestArrowBufHasher.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/memory/util/hash/TestArrowBufHasher.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.util.hash;
 
 import static org.junit.Assert.assertEquals;
@@ -24,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
-
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -34,9 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-/**
- * Test cases for {@link ArrowBufHasher} and its subclasses.
- */
+/** Test cases for {@link ArrowBufHasher} and its subclasses. */
 @RunWith(Parameterized.class)
 public class TestArrowBufHasher {
 
@@ -63,7 +59,7 @@ public class TestArrowBufHasher {
   @Test
   public void testHasher() {
     try (ArrowBuf buf1 = allocator.buffer(BUFFER_LENGTH);
-         ArrowBuf buf2 = allocator.buffer(BUFFER_LENGTH)) {
+        ArrowBuf buf2 = allocator.buffer(BUFFER_LENGTH)) {
       // prepare data
       for (int i = 0; i < BUFFER_LENGTH / 4; i++) {
         buf1.setFloat(i * 4L, i / 10.0f);
@@ -83,8 +79,8 @@ public class TestArrowBufHasher {
     }
   }
 
-  private void verifyHashCodesEqual(ArrowBuf buf1, int offset1, int length1,
-                                    ArrowBuf buf2, int offset2, int length2) {
+  private void verifyHashCodesEqual(
+      ArrowBuf buf1, int offset1, int length1, ArrowBuf buf2, int offset2, int length2) {
     int hashCode1 = hasher.hashCode(buf1, offset1, length1);
     int hashCode2 = hasher.hashCode(buf2, offset2, length2);
     assertEquals(hashCode1, hashCode2);
@@ -98,35 +94,40 @@ public class TestArrowBufHasher {
         buf.setFloat(i * 4L, i / 10.0f);
       }
 
-      assertThrows(IllegalArgumentException.class, () -> {
-        hasher.hashCode(buf, 0, -1);
-      });
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            hasher.hashCode(buf, 0, -1);
+          });
 
-      assertThrows(IndexOutOfBoundsException.class, () -> {
-        hasher.hashCode(buf, 0, 1028);
-      });
+      assertThrows(
+          IndexOutOfBoundsException.class,
+          () -> {
+            hasher.hashCode(buf, 0, 1028);
+          });
 
-      assertThrows(IndexOutOfBoundsException.class, () -> {
-        hasher.hashCode(buf, 500, 1000);
-      });
+      assertThrows(
+          IndexOutOfBoundsException.class,
+          () -> {
+            hasher.hashCode(buf, 500, 1000);
+          });
     }
   }
 
   @Test
   public void testHasherLessThanInt() {
     try (ArrowBuf buf1 = allocator.buffer(4);
-         ArrowBuf buf2 = allocator.buffer(4)) {
+        ArrowBuf buf2 = allocator.buffer(4)) {
       buf1.writeBytes("foo1".getBytes(StandardCharsets.UTF_8));
       buf2.writeBytes("bar2".getBytes(StandardCharsets.UTF_8));
 
-      for (int i = 1; i <= 4; i ++) {
+      for (int i = 1; i <= 4; i++) {
         verifyHashCodeNotEqual(buf1, i, buf2, i);
       }
     }
   }
 
-  private void verifyHashCodeNotEqual(ArrowBuf buf1, int length1,
-                                      ArrowBuf buf2, int length2) {
+  private void verifyHashCodeNotEqual(ArrowBuf buf1, int length1, ArrowBuf buf2, int length2) {
     int hashCode1 = hasher.hashCode(buf1, 0, length1);
     int hashCode2 = hasher.hashCode(buf2, 0, length2);
     assertNotEquals(hashCode1, hashCode2);
@@ -135,11 +136,7 @@ public class TestArrowBufHasher {
   @Parameterized.Parameters(name = "hasher = {0}")
   public static Collection<Object[]> getHasher() {
     return Arrays.asList(
-      new Object[] {SimpleHasher.class.getSimpleName(),
-        SimpleHasher.INSTANCE},
-      new Object[] {MurmurHasher.class.getSimpleName(),
-        new MurmurHasher()
-      }
-    );
+        new Object[] {SimpleHasher.class.getSimpleName(), SimpleHasher.INSTANCE},
+        new Object[] {MurmurHasher.class.getSimpleName(), new MurmurHasher()});
   }
 }

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/util/TestCollections2.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/util/TestCollections2.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.util;
 
 import static org.junit.Assert.fail;
@@ -25,14 +24,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
 import org.junit.Test;
 
-/**
- * Tests for {@code Collections2} class.
- */
+/** Tests for {@code Collections2} class. */
 public class TestCollections2 {
-
 
   @Test
   public void testToImmutableListFromIterable() {
@@ -65,7 +60,6 @@ public class TestCollections2 {
     assertEquals("bar", copy.get(1));
     assertEquals(3, copy.size());
   }
-
 
   @Test
   public void testStringFromEmptyIterator() {

--- a/java/memory/memory-core/src/test/java/org/apache/arrow/util/TestStackTrace.java
+++ b/java/memory/memory-core/src/test/java/org/apache/arrow/util/TestStackTrace.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.util;
 
 import org.apache.arrow.memory.util.StackTrace;
@@ -22,22 +21,19 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestStackTrace {
-  /**
-   * Check that the stack trace includes the origin line.
-   */
+  /** Check that the stack trace includes the origin line. */
   @Test
   public void testStackTraceComplete() {
     final String stackTrace = new StackTrace().toString();
     Assertions.assertTrue(stackTrace.contains("TestStackTrace.testStackTraceComplete"), stackTrace);
   }
 
-  /**
-   * Check that the stack trace doesn't include getStackTrace or StackTrace.
-   */
+  /** Check that the stack trace doesn't include getStackTrace or StackTrace. */
   @Test
   public void testStackTraceOmit() {
     final String stackTrace = new StackTrace().toString();
     Assertions.assertFalse(stackTrace.contains("Thread.getStackTrace"), stackTrace);
-    Assertions.assertFalse(stackTrace.contains("org.apache.arrow.memory.util.StackTrace"), stackTrace);
+    Assertions.assertFalse(
+        stackTrace.contains("org.apache.arrow.memory.util.StackTrace"), stackTrace);
   }
 }

--- a/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/ExpandableByteBuf.java
+++ b/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/ExpandableByteBuf.java
@@ -14,15 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
 
 import org.apache.arrow.memory.BufferAllocator;
 
 /**
  * Allows us to decorate ArrowBuf to make it expandable so that we can use them in the context of
- * the Netty framework
- * (thus supporting RPC level memory accounting).
+ * the Netty framework (thus supporting RPC level memory accounting).
  */
 public class ExpandableByteBuf extends MutableWrappedByteBuf {
 
@@ -52,5 +50,4 @@ public class ExpandableByteBuf extends MutableWrappedByteBuf {
       return super.capacity(newCapacity);
     }
   }
-
 }

--- a/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/LargeBuffer.java
+++ b/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/LargeBuffer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
 
 /**

--- a/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/MutableWrappedByteBuf.java
+++ b/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/MutableWrappedByteBuf.java
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
 
+import io.netty.util.ByteProcessor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -26,11 +26,9 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
-import io.netty.util.ByteProcessor;
-
 /**
- * This is basically a complete copy of netty's DuplicatedByteBuf. We copy because we want to override
- * some behaviors and make buffer mutable.
+ * This is basically a complete copy of netty's DuplicatedByteBuf. We copy because we want to
+ * override some behaviors and make buffer mutable.
  */
 abstract class MutableWrappedByteBuf extends AbstractByteBuf {
 
@@ -343,40 +341,33 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
-  public int setBytes(int index, FileChannel in, long position, int length)
-      throws IOException {
+  public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
     return buffer.setBytes(index, in, position, length);
   }
 
   @Override
-  public ByteBuf getBytes(int index, OutputStream out, int length)
-      throws IOException {
+  public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
     buffer.getBytes(index, out, length);
     return this;
   }
 
   @Override
-  public int getBytes(int index, GatheringByteChannel out, int length)
-      throws IOException {
+  public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
     return buffer.getBytes(index, out, length);
   }
 
   @Override
-  public int setBytes(int index, InputStream in, int length)
-      throws IOException {
+  public int setBytes(int index, InputStream in, int length) throws IOException {
     return buffer.setBytes(index, in, length);
   }
 
   @Override
-  public int setBytes(int index, ScatteringByteChannel in, int length)
-      throws IOException {
+  public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
     return buffer.setBytes(index, in, length);
   }
 
-
   @Override
-  public int getBytes(int index, FileChannel out, long position, int length)
-      throws IOException {
+  public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
     return buffer.getBytes(index, out, position, length);
   }
 
@@ -444,5 +435,4 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
     boolean released = unwrap().release(decrement);
     return released;
   }
-
 }

--- a/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
 
+import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,7 +25,6 @@ import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
-
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BoundsChecking;
 import org.apache.arrow.memory.BufferAllocator;
@@ -34,11 +33,7 @@ import org.apache.arrow.memory.util.LargeMemoryUtil;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.util.VisibleForTesting;
 
-import io.netty.util.internal.PlatformDependent;
-
-/**
- * Netty specific wrapper over ArrowBuf for use in Netty framework.
- */
+/** Netty specific wrapper over ArrowBuf for use in Netty framework. */
 public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
 
   private final ArrowBuf arrowBuf;
@@ -49,14 +44,12 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   /**
    * Constructs a new instance.
    *
-   * @param arrowBuf        The buffer to wrap.
+   * @param arrowBuf The buffer to wrap.
    * @param bufferAllocator The allocator for the buffer.
-   * @param length          The length of this buffer.
+   * @param length The length of this buffer.
    */
   public NettyArrowBuf(
-      final ArrowBuf arrowBuf,
-      final BufferAllocator bufferAllocator,
-      final int length) {
+      final ArrowBuf arrowBuf, final BufferAllocator bufferAllocator, final int length) {
     super(length);
     this.arrowBuf = arrowBuf;
     this.arrowByteBufAllocator = new ArrowByteBufAllocator(bufferAllocator);
@@ -105,13 +98,15 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
       length = newCapacity;
       return this;
     }
-    throw new UnsupportedOperationException("Buffers don't support resizing that increases the size.");
+    throw new UnsupportedOperationException(
+        "Buffers don't support resizing that increases the size.");
   }
 
   @Override
   public ByteBuf unwrap() {
 
-    // According to Netty's ByteBuf interface, unwrap() should return null if the buffer cannot be unwrapped
+    // According to Netty's ByteBuf interface, unwrap() should return null if the buffer cannot be
+    // unwrapped
     // https://github.com/netty/netty/blob/9fe796e10a433b6cd20ad78b2c39cd56b86ccd2e/buffer/src/main/java/io/netty/buffer/ByteBuf.java#L305
 
     // Throwing here breaks toString() in AbstractByteBuf
@@ -234,10 +229,9 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return nioBuffer(readerIndex(), readableBytes());
   }
 
-
   /**
-   * Returns a buffer that is zero positioned but points
-   * to a slice of the original buffer starting at given index.
+   * Returns a buffer that is zero positioned but points to a slice of the original buffer starting
+   * at given index.
    */
   @Override
   public ByteBuffer nioBuffer(int index, int length) {
@@ -248,8 +242,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   /**
-   * Returns a buffer that is zero positioned but points
-   * to a slice of the original buffer starting at given index.
+   * Returns a buffer that is zero positioned but points to a slice of the original buffer starting
+   * at given index.
    */
   public ByteBuffer nioBuffer(long index, int length) {
     chk(index, length);
@@ -264,7 +258,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
    * @return ByteBuffer
    */
   private ByteBuffer getDirectBuffer(long index) {
-    return PlatformDependent.directBuffer(addr(index), LargeMemoryUtil.checkedCastToInt(length - index));
+    return PlatformDependent.directBuffer(
+        addr(index), LargeMemoryUtil.checkedCastToInt(length - index));
   }
 
   @Override
@@ -294,11 +289,11 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   /**
    * Determine if the requested {@code index} and {@code length} will fit within {@code capacity}.
    *
-   * @param index    The starting index.
-   * @param length   The length which will be utilized (starting from {@code index}).
+   * @param index The starting index.
+   * @param length The length which will be utilized (starting from {@code index}).
    * @param capacity The capacity that {@code index + length} is allowed to be within.
-   * @return {@code true} if the requested {@code index} and {@code length} will fit within {@code capacity}.
-   * {@code false} if this would result in an index out of bounds exception.
+   * @return {@code true} if the requested {@code index} and {@code length} will fit within {@code
+   *     capacity}. {@code false} if this would result in an index out of bounds exception.
    */
   private static boolean isOutOfBounds(int index, int length, int capacity) {
     return (index | length | (index + length) | (capacity - (index + length))) < 0;
@@ -413,17 +408,15 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   protected int _getUnsignedMediumLE(int index) {
     this.chk(index, 3);
     long addr = this.addr(index);
-    return (PlatformDependent.getByte(addr) & 255) |
-        (Short.reverseBytes(PlatformDependent.getShort(addr + 1L)) & '\uffff') << 8;
+    return (PlatformDependent.getByte(addr) & 255)
+        | (Short.reverseBytes(PlatformDependent.getShort(addr + 1L)) & '\uffff') << 8;
   }
 
-
   /*-------------------------------------------------*
-   |                                                 |
-   |            get() APIs                           |
-   |                                                 |
-   *-------------------------------------------------*/
-
+  |                                                 |
+  |            get() APIs                           |
+  |                                                 |
+  *-------------------------------------------------*/
 
   @Override
   protected byte _getByte(int index) {
@@ -483,13 +476,11 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return arrowBuf.getLong(index);
   }
 
-
   /*-------------------------------------------------*
-   |                                                 |
-   |            set() APIs                           |
-   |                                                 |
-   *-------------------------------------------------*/
-
+  |                                                 |
+  |            set() APIs                           |
+  |                                                 |
+  *-------------------------------------------------*/
 
   @Override
   protected void _setByte(int index, int value) {
@@ -524,10 +515,9 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   /**
-   * Helper function to do bounds checking at a particular
-   * index for particular length of data.
+   * Helper function to do bounds checking at a particular index for particular length of data.
    *
-   * @param index       index (0 based relative to this ArrowBuf)
+   * @param index index (0 based relative to this ArrowBuf)
    * @param fieldLength provided length of data for get/set
    */
   private void chk(long index, long fieldLength) {
@@ -539,8 +529,9 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
         throw new IllegalArgumentException("length: " + fieldLength + " (expected: >= 0)");
       }
       if (index < 0 || index > capacity() - fieldLength) {
-        throw new IndexOutOfBoundsException(String.format(
-            "index: %d, length: %d (expected: range(0, %d))", index, fieldLength, capacity()));
+        throw new IndexOutOfBoundsException(
+            String.format(
+                "index: %d, length: %d (expected: range(0, %d))", index, fieldLength, capacity()));
       }
     }
   }
@@ -615,17 +606,15 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
-  /**
-   * unwrap arrow buffer into a netty buffer.
-   */
+  /** unwrap arrow buffer into a netty buffer. */
   public static NettyArrowBuf unwrapBuffer(ArrowBuf buf) {
-    final NettyArrowBuf nettyArrowBuf = new NettyArrowBuf(
-        buf,
-        buf.getReferenceManager().getAllocator(),
-        LargeMemoryUtil.checkedCastToInt(buf.capacity()));
+    final NettyArrowBuf nettyArrowBuf =
+        new NettyArrowBuf(
+            buf,
+            buf.getReferenceManager().getAllocator(),
+            LargeMemoryUtil.checkedCastToInt(buf.capacity()));
     nettyArrowBuf.readerIndex(LargeMemoryUtil.checkedCastToInt(buf.readerIndex()));
     nettyArrowBuf.writerIndex(LargeMemoryUtil.checkedCastToInt(buf.writerIndex()));
     return nettyArrowBuf;
   }
-
 }

--- a/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -14,19 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
-
-import java.lang.reflect.Field;
-import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.memory.util.AssertionUtil;
-import org.apache.arrow.memory.util.LargeMemoryUtil;
 
 import io.netty.util.internal.OutOfDirectMemoryError;
 import io.netty.util.internal.StringUtil;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.arrow.memory.OutOfMemoryException;
+import org.apache.arrow.memory.util.AssertionUtil;
+import org.apache.arrow.memory.util.LargeMemoryUtil;
 
 /**
  * The base allocator that we use for all of Arrow's memory management. Returns
@@ -34,7 +31,8 @@ import io.netty.util.internal.StringUtil;
  */
 public class PooledByteBufAllocatorL {
 
-  private static final org.slf4j.Logger memoryLogger = org.slf4j.LoggerFactory.getLogger("arrow.allocator");
+  private static final org.slf4j.Logger memoryLogger =
+      org.slf4j.LoggerFactory.getLogger("arrow.allocator");
 
   private static final int MEMORY_LOGGER_FREQUENCY_SECONDS = 60;
   public final UnsafeDirectLittleEndian empty;
@@ -49,9 +47,7 @@ public class PooledByteBufAllocatorL {
     empty = new UnsafeDirectLittleEndian(new DuplicatedByteBuf(Unpooled.EMPTY_BUFFER));
   }
 
-  /**
-   * Returns a {@linkplain UnsafeDirectLittleEndian} of the given size.
-   */
+  /** Returns a {@linkplain UnsafeDirectLittleEndian} of the given size. */
   public UnsafeDirectLittleEndian allocate(long size) {
     try {
       return allocator.directBuffer(LargeMemoryUtil.checkedCastToInt(size), Integer.MAX_VALUE);
@@ -102,8 +98,8 @@ public class PooledByteBufAllocatorL {
       this.size = size;
     }
 
-    private AccountedUnsafeDirectLittleEndian(PooledUnsafeDirectByteBuf buf, AtomicLong count,
-                                              AtomicLong size) {
+    private AccountedUnsafeDirectLittleEndian(
+        PooledUnsafeDirectByteBuf buf, AtomicLong count, AtomicLong size) {
       super(buf);
       this.initialCapacity = buf.capacity();
       this.count = count;
@@ -129,7 +125,6 @@ public class PooledByteBufAllocatorL {
       }
       return released;
     }
-
   }
 
   private class InnerAllocator extends PooledByteBufAllocator {
@@ -145,7 +140,8 @@ public class PooledByteBufAllocatorL {
         f.setAccessible(true);
         this.directArenas = (PoolArena<ByteBuffer>[]) f.get(this);
       } catch (Exception e) {
-        throw new RuntimeException("Failure while initializing allocator.  Unable to retrieve direct arenas field.", e);
+        throw new RuntimeException(
+            "Failure while initializing allocator.  Unable to retrieve direct arenas field.", e);
       }
 
       if (memoryLogger.isTraceEnabled()) {
@@ -170,8 +166,8 @@ public class PooledByteBufAllocatorL {
           hugeBufferCount.incrementAndGet();
 
           // logger.debug("Allocating huge buffer of size {}", initialCapacity, new Exception());
-          return new AccountedUnsafeDirectLittleEndian(new LargeBuffer(buf), hugeBufferCount,
-              hugeBufferSize);
+          return new AccountedUnsafeDirectLittleEndian(
+              new LargeBuffer(buf), hugeBufferCount, hugeBufferSize);
         } else {
           // within chunk, use arena.
           ByteBuf buf = directArena.allocate(cache, initialCapacity, maxCapacity);
@@ -186,8 +182,8 @@ public class PooledByteBufAllocatorL {
           normalBufferSize.addAndGet(buf.capacity());
           normalBufferCount.incrementAndGet();
 
-          return new AccountedUnsafeDirectLittleEndian((PooledUnsafeDirectByteBuf) buf,
-              normalBufferCount, normalBufferSize);
+          return new AccountedUnsafeDirectLittleEndian(
+              (PooledUnsafeDirectByteBuf) buf, normalBufferCount, normalBufferSize);
         }
 
       } else {
@@ -197,8 +193,8 @@ public class PooledByteBufAllocatorL {
 
     private UnsupportedOperationException fail() {
       return new UnsupportedOperationException(
-          "Arrow requires that the JVM used supports access sun.misc.Unsafe.  This platform " +
-              "didn't provide that functionality.");
+          "Arrow requires that the JVM used supports access sun.misc.Unsafe.  This platform "
+              + "didn't provide that functionality.");
     }
 
     @Override
@@ -215,15 +211,16 @@ public class PooledByteBufAllocatorL {
       throw new UnsupportedOperationException("Arrow doesn't support using heap buffers.");
     }
 
-
     private void validate(int initialCapacity, int maxCapacity) {
       if (initialCapacity < 0) {
-        throw new IllegalArgumentException("initialCapacity: " + initialCapacity + " (expected: 0+)");
+        throw new IllegalArgumentException(
+            "initialCapacity: " + initialCapacity + " (expected: 0+)");
       }
       if (initialCapacity > maxCapacity) {
-        throw new IllegalArgumentException(String.format(
-            "initialCapacity: %d (expected: not greater than maxCapacity(%d)",
-            initialCapacity, maxCapacity));
+        throw new IllegalArgumentException(
+            String.format(
+                "initialCapacity: %d (expected: not greater than maxCapacity(%d)",
+                initialCapacity, maxCapacity));
       }
     }
 
@@ -272,7 +269,5 @@ public class PooledByteBufAllocatorL {
         }
       }
     }
-
-
   }
 }

--- a/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty-buffer-patch/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -14,21 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
 
+import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicLong;
 
-import io.netty.util.internal.PlatformDependent;
-
 /**
- * The underlying class we use for little-endian access to memory. Is used underneath ArrowBufs
- * to abstract away the
- * Netty classes and underlying Netty memory management.
+ * The underlying class we use for little-endian access to memory. Is used underneath ArrowBufs to
+ * abstract away the Netty classes and underlying Netty memory management.
  */
 public class UnsafeDirectLittleEndian extends WrappedByteBuf {
   private static final AtomicLong ID_GENERATOR = new AtomicLong(0);

--- a/java/memory/memory-netty-buffer-patch/src/main/java/org/apache/arrow/memory/patch/ArrowByteBufAllocator.java
+++ b/java/memory/memory-netty-buffer-patch/src/main/java/org/apache/arrow/memory/patch/ArrowByteBufAllocator.java
@@ -14,25 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.patch;
-
-import org.apache.arrow.memory.BufferAllocator;
 
 import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.ExpandableByteBuf;
 import io.netty.buffer.NettyArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
 
 /**
  * An implementation of ByteBufAllocator that wraps a Arrow BufferAllocator. This allows the RPC
- * layer to be accounted
- * and managed using Arrow's BufferAllocator infrastructure. The only thin different from a
- * typical BufferAllocator is
- * the signature and the fact that this Allocator returns ExpandableByteBufs which enable
- * otherwise non-expandable
- * ArrowBufs to be expandable.
+ * layer to be accounted and managed using Arrow's BufferAllocator infrastructure. The only thin
+ * different from a typical BufferAllocator is the signature and the fact that this Allocator
+ * returns ExpandableByteBufs which enable otherwise non-expandable ArrowBufs to be expandable.
  *
  * @deprecated This class may be removed in a future release.
  */
@@ -59,7 +54,8 @@ public class ArrowByteBufAllocator extends AbstractByteBufAllocator {
 
   @Override
   public ByteBuf buffer(int initialCapacity) {
-    return new ExpandableByteBuf(NettyArrowBuf.unwrapBuffer(allocator.buffer(initialCapacity)), allocator);
+    return new ExpandableByteBuf(
+        NettyArrowBuf.unwrapBuffer(allocator.buffer(initialCapacity)), allocator);
   }
 
   @Override

--- a/java/memory/memory-netty-buffer-patch/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty-buffer-patch/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
@@ -14,9 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
-
 
 import static org.junit.Assert.assertEquals;
 
@@ -24,13 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-
 import org.junit.Test;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.LargeBuffer;
-import io.netty.buffer.Unpooled;
-import io.netty.buffer.UnsafeDirectLittleEndian;
 
 public class TestUnsafeDirectLittleEndian {
 
@@ -70,7 +62,7 @@ public class TestUnsafeDirectLittleEndian {
 
     byte[] inBytes = "1234567".getBytes(StandardCharsets.UTF_8);
     try (ByteArrayInputStream bais = new ByteArrayInputStream(inBytes);
-         ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       assertEquals(5, unsafeDirect.setBytes(56, bais, 5));
       unsafeDirect.getBytes(56, baos, 5);
       assertEquals("12345", new String(baos.toByteArray(), StandardCharsets.UTF_8));

--- a/java/memory/memory-netty/src/main/java/org/apache/arrow/memory/netty/DefaultAllocationManagerFactory.java
+++ b/java/memory/memory-netty/src/main/java/org/apache/arrow/memory/netty/DefaultAllocationManagerFactory.java
@@ -14,17 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
 import org.apache.arrow.memory.AllocationManager;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 
-/**
- * The default Allocation Manager Factory for a module.
- *
- */
+/** The default Allocation Manager Factory for a module. */
 public class DefaultAllocationManagerFactory implements AllocationManager.Factory {
 
   public static final AllocationManager.Factory FACTORY = NettyAllocationManager.FACTORY;
@@ -38,5 +34,4 @@ public class DefaultAllocationManagerFactory implements AllocationManager.Factor
   public ArrowBuf empty() {
     return FACTORY.empty();
   }
-
 }

--- a/java/memory/memory-netty/src/main/java/org/apache/arrow/memory/netty/NettyAllocationManager.java
+++ b/java/memory/memory-netty/src/main/java/org/apache/arrow/memory/netty/NettyAllocationManager.java
@@ -14,62 +14,56 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
+import io.netty.buffer.PooledByteBufAllocatorL;
+import io.netty.buffer.UnsafeDirectLittleEndian;
+import io.netty.util.internal.PlatformDependent;
 import org.apache.arrow.memory.AllocationManager;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
 
-import io.netty.buffer.PooledByteBufAllocatorL;
-import io.netty.buffer.UnsafeDirectLittleEndian;
-import io.netty.util.internal.PlatformDependent;
-
 /**
- * The default implementation of {@link AllocationManager}. The implementation is responsible for managing when memory
- * is allocated and returned to the Netty-based PooledByteBufAllocatorL.
+ * The default implementation of {@link AllocationManager}. The implementation is responsible for
+ * managing when memory is allocated and returned to the Netty-based PooledByteBufAllocatorL.
  */
 public class NettyAllocationManager extends AllocationManager {
 
-  public static final AllocationManager.Factory FACTORY = new AllocationManager.Factory() {
+  public static final AllocationManager.Factory FACTORY =
+      new AllocationManager.Factory() {
 
-    @Override
-    public AllocationManager create(BufferAllocator accountingAllocator, long size) {
-      return new NettyAllocationManager(accountingAllocator, size);
-    }
+        @Override
+        public AllocationManager create(BufferAllocator accountingAllocator, long size) {
+          return new NettyAllocationManager(accountingAllocator, size);
+        }
 
-    @Override
-    public ArrowBuf empty() {
-      return EMPTY_BUFFER;
-    }
-  };
+        @Override
+        public ArrowBuf empty() {
+          return EMPTY_BUFFER;
+        }
+      };
 
   /**
-   * The default cut-off value for switching allocation strategies.
-   * If the request size is not greater than the cut-off value, we will allocate memory by
-   * {@link PooledByteBufAllocatorL} APIs,
-   * otherwise, we will use {@link PlatformDependent} APIs.
+   * The default cut-off value for switching allocation strategies. If the request size is not
+   * greater than the cut-off value, we will allocate memory by {@link PooledByteBufAllocatorL}
+   * APIs, otherwise, we will use {@link PlatformDependent} APIs.
    */
   public static final int DEFAULT_ALLOCATION_CUTOFF_VALUE = Integer.MAX_VALUE;
 
   private static final PooledByteBufAllocatorL INNER_ALLOCATOR = new PooledByteBufAllocatorL();
   static final UnsafeDirectLittleEndian EMPTY = INNER_ALLOCATOR.empty;
-  static final ArrowBuf EMPTY_BUFFER = new ArrowBuf(ReferenceManager.NO_OP,
-      null,
-      0,
-      NettyAllocationManager.EMPTY.memoryAddress());
+  static final ArrowBuf EMPTY_BUFFER =
+      new ArrowBuf(ReferenceManager.NO_OP, null, 0, NettyAllocationManager.EMPTY.memoryAddress());
   static final long CHUNK_SIZE = INNER_ALLOCATOR.getChunkSize();
 
   private final long allocatedSize;
   private final UnsafeDirectLittleEndian memoryChunk;
   private final long allocatedAddress;
 
-  /**
-   * The cut-off value for switching allocation strategies.
-   */
-
-  NettyAllocationManager(BufferAllocator accountingAllocator, long requestedSize, int allocationCutOffValue) {
+  /** The cut-off value for switching allocation strategies. */
+  NettyAllocationManager(
+      BufferAllocator accountingAllocator, long requestedSize, int allocationCutOffValue) {
     super(accountingAllocator);
 
     if (requestedSize > allocationCutOffValue) {
@@ -89,9 +83,9 @@ public class NettyAllocationManager extends AllocationManager {
 
   /**
    * Get the underlying memory chunk managed by this AllocationManager.
-   * @return the underlying memory chunk if the request size is not greater than the
-   *          cutoff value provided in the constructor , or null otherwise.
    *
+   * @return the underlying memory chunk if the request size is not greater than the cutoff value
+   *     provided in the constructor , or null otherwise.
    * @deprecated this method will be removed in a future release.
    */
   @Deprecated
@@ -122,5 +116,4 @@ public class NettyAllocationManager extends AllocationManager {
   public long getSize() {
     return allocatedSize;
   }
-
 }

--- a/java/memory/memory-netty/src/test/java/io/netty/buffer/TestExpandableByteBuf.java
+++ b/java/memory/memory-netty/src/test/java/io/netty/buffer/TestExpandableByteBuf.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
 
 import org.apache.arrow.memory.ArrowBuf;
@@ -23,17 +22,12 @@ import org.apache.arrow.memory.RootAllocator;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ExpandableByteBuf;
-import io.netty.buffer.NettyArrowBuf;
-
 public class TestExpandableByteBuf {
 
   @Test
   public void testCapacity() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf srcByteBuf = NettyArrowBuf.unwrapBuffer(buf);
       ExpandableByteBuf expandableByteBuf = new ExpandableByteBuf(srcByteBuf, allocator);
       ByteBuf newByteBuf = expandableByteBuf.capacity(31);
@@ -45,8 +39,7 @@ public class TestExpandableByteBuf {
   @Test
   public void testCapacity1() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf srcByteBuf = NettyArrowBuf.unwrapBuffer(buf);
       ExpandableByteBuf expandableByteBuf = new ExpandableByteBuf(srcByteBuf, allocator);
       ByteBuf newByteBuf = expandableByteBuf.capacity(32);
@@ -58,13 +51,20 @@ public class TestExpandableByteBuf {
   @Test
   public void testSetAndGetIntValues() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf srcByteBuf = NettyArrowBuf.unwrapBuffer(buf);
       ExpandableByteBuf expandableByteBuf = new ExpandableByteBuf(srcByteBuf, allocator);
-      int [] intVals = new int[] {Integer.MIN_VALUE, Short.MIN_VALUE - 1, Short.MIN_VALUE, 0 ,
-        Short.MAX_VALUE , Short.MAX_VALUE + 1, Integer.MAX_VALUE};
-      for (int intValue :intVals) {
+      int[] intVals =
+          new int[] {
+            Integer.MIN_VALUE,
+            Short.MIN_VALUE - 1,
+            Short.MIN_VALUE,
+            0,
+            Short.MAX_VALUE,
+            Short.MAX_VALUE + 1,
+            Integer.MAX_VALUE
+          };
+      for (int intValue : intVals) {
         expandableByteBuf.setInt(0, intValue);
         Assert.assertEquals(expandableByteBuf.getInt(0), intValue);
         Assert.assertEquals(expandableByteBuf.getIntLE(0), Integer.reverseBytes(intValue));
@@ -75,12 +75,11 @@ public class TestExpandableByteBuf {
   @Test
   public void testSetAndGetLongValues() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf srcByteBuf = NettyArrowBuf.unwrapBuffer(buf);
       ExpandableByteBuf expandableByteBuf = new ExpandableByteBuf(srcByteBuf, allocator);
-      long [] longVals = new long[] {Long.MIN_VALUE, 0 , Long.MAX_VALUE};
-      for (long longValue :longVals) {
+      long[] longVals = new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE};
+      for (long longValue : longVals) {
         expandableByteBuf.setLong(0, longValue);
         Assert.assertEquals(expandableByteBuf.getLong(0), longValue);
         Assert.assertEquals(expandableByteBuf.getLongLE(0), Long.reverseBytes(longValue));
@@ -91,12 +90,11 @@ public class TestExpandableByteBuf {
   @Test
   public void testSetAndGetShortValues() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf srcByteBuf = NettyArrowBuf.unwrapBuffer(buf);
       ExpandableByteBuf expandableByteBuf = new ExpandableByteBuf(srcByteBuf, allocator);
-      short [] shortVals = new short[] {Short.MIN_VALUE, 0 , Short.MAX_VALUE};
-      for (short shortValue :shortVals) {
+      short[] shortVals = new short[] {Short.MIN_VALUE, 0, Short.MAX_VALUE};
+      for (short shortValue : shortVals) {
         expandableByteBuf.setShort(0, shortValue);
         Assert.assertEquals(expandableByteBuf.getShort(0), shortValue);
         Assert.assertEquals(expandableByteBuf.getShortLE(0), Short.reverseBytes(shortValue));
@@ -107,12 +105,11 @@ public class TestExpandableByteBuf {
   @Test
   public void testSetAndGetByteValues() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf srcByteBuf = NettyArrowBuf.unwrapBuffer(buf);
       ExpandableByteBuf expandableByteBuf = new ExpandableByteBuf(srcByteBuf, allocator);
-      byte [] byteVals = new byte[] {Byte.MIN_VALUE, 0 , Byte.MAX_VALUE};
-      for (short byteValue :byteVals) {
+      byte[] byteVals = new byte[] {Byte.MIN_VALUE, 0, Byte.MAX_VALUE};
+      for (short byteValue : byteVals) {
         expandableByteBuf.setByte(0, byteValue);
         Assert.assertEquals(expandableByteBuf.getByte(0), byteValue);
       }

--- a/java/memory/memory-netty/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/memory-netty/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.netty.buffer;
 
 import java.nio.ByteBuffer;
-
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -26,16 +24,12 @@ import org.apache.arrow.memory.patch.ArrowByteBufAllocator;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.NettyArrowBuf;
-
 public class TestNettyArrowBuf {
 
   @Test
   public void testSliceWithoutArgs() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       nettyBuf.writerIndex(20);
       nettyBuf.readerIndex(10);
@@ -48,8 +42,7 @@ public class TestNettyArrowBuf {
   @Test
   public void testNioBuffer() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       ByteBuffer byteBuffer = nettyBuf.nioBuffer(4, 6);
       // Nio Buffers should always be 0 indexed
@@ -57,46 +50,50 @@ public class TestNettyArrowBuf {
       Assert.assertEquals(6, byteBuffer.limit());
       // Underlying buffer has size 32 excluding 4 should have capacity of 28.
       Assert.assertEquals(28, byteBuffer.capacity());
-
     }
   }
 
   @Test
   public void testInternalNioBuffer() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       ByteBuffer byteBuffer = nettyBuf.internalNioBuffer(4, 6);
       Assert.assertEquals(0, byteBuffer.position());
       Assert.assertEquals(6, byteBuffer.limit());
       // Underlying buffer has size 32 excluding 4 should have capacity of 28.
       Assert.assertEquals(28, byteBuffer.capacity());
-
     }
   }
 
   @Test
   public void testSetLEValues() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
-      int [] intVals = new int[] {Integer.MIN_VALUE, Short.MIN_VALUE - 1, Short.MIN_VALUE, 0 ,
-        Short.MAX_VALUE , Short.MAX_VALUE + 1, Integer.MAX_VALUE};
-      for (int intValue :intVals ) {
+      int[] intVals =
+          new int[] {
+            Integer.MIN_VALUE,
+            Short.MIN_VALUE - 1,
+            Short.MIN_VALUE,
+            0,
+            Short.MAX_VALUE,
+            Short.MAX_VALUE + 1,
+            Integer.MAX_VALUE
+          };
+      for (int intValue : intVals) {
         nettyBuf._setInt(0, intValue);
         Assert.assertEquals(nettyBuf._getIntLE(0), Integer.reverseBytes(intValue));
       }
 
-      long [] longVals = new long[] {Long.MIN_VALUE, 0 , Long.MAX_VALUE};
-      for (long longValue :longVals ) {
+      long[] longVals = new long[] {Long.MIN_VALUE, 0, Long.MAX_VALUE};
+      for (long longValue : longVals) {
         nettyBuf._setLong(0, longValue);
         Assert.assertEquals(nettyBuf._getLongLE(0), Long.reverseBytes(longValue));
       }
 
-      short [] shortVals = new short[] {Short.MIN_VALUE, 0 , Short.MAX_VALUE};
-      for (short shortValue :shortVals ) {
+      short[] shortVals = new short[] {Short.MIN_VALUE, 0, Short.MAX_VALUE};
+      for (short shortValue : shortVals) {
         nettyBuf._setShort(0, shortValue);
         Assert.assertEquals(nettyBuf._getShortLE(0), Short.reverseBytes(shortValue));
       }
@@ -106,11 +103,10 @@ public class TestNettyArrowBuf {
   @Test
   public void testSetCompositeBuffer() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-         NettyArrowBuf buf2 = NettyArrowBuf.unwrapBuffer(allocator.buffer(20));
-    ) {
-      CompositeByteBuf byteBufs = new CompositeByteBuf(new ArrowByteBufAllocator(allocator),
-              true, 1);
+        ArrowBuf buf = allocator.buffer(20);
+        NettyArrowBuf buf2 = NettyArrowBuf.unwrapBuffer(allocator.buffer(20)); ) {
+      CompositeByteBuf byteBufs =
+          new CompositeByteBuf(new ArrowByteBufAllocator(allocator), true, 1);
       int expected = 4;
       buf2.setInt(0, expected);
       buf2.writerIndex(4);
@@ -124,10 +120,9 @@ public class TestNettyArrowBuf {
   @Test
   public void testGetCompositeBuffer() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
-      CompositeByteBuf byteBufs = new CompositeByteBuf(new ArrowByteBufAllocator(allocator),
-              true, 1);
+        ArrowBuf buf = allocator.buffer(20); ) {
+      CompositeByteBuf byteBufs =
+          new CompositeByteBuf(new ArrowByteBufAllocator(allocator), true, 1);
       int expected = 4;
       buf.setInt(0, expected);
       NettyArrowBuf buf2 = NettyArrowBuf.unwrapBuffer(allocator.buffer(20));
@@ -145,8 +140,7 @@ public class TestNettyArrowBuf {
   @Test
   public void testUnwrapReturnsNull() {
     try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
+        ArrowBuf buf = allocator.buffer(20); ) {
       NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       // NettyArrowBuf cannot be unwrapped, so unwrap() should return null per the Netty ByteBuf API
       Assert.assertNull(nettyBuf.unwrap());

--- a/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/ITTestLargeArrowBuf.java
+++ b/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/ITTestLargeArrowBuf.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
 import static org.junit.Assert.assertEquals;
@@ -26,17 +25,16 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
- * Integration test for large (more than 2GB) {@link org.apache.arrow.memory.ArrowBuf}.
- * To run this test, please make sure there is at least 4GB memory in the system.
+ * Integration test for large (more than 2GB) {@link org.apache.arrow.memory.ArrowBuf}. To run this
+ * test, please make sure there is at least 4GB memory in the system.
  */
 public class ITTestLargeArrowBuf {
   private static final Logger logger = LoggerFactory.getLogger(ITTestLargeArrowBuf.class);
 
   private void run(long bufSize) {
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         ArrowBuf largeBuf = allocator.buffer(bufSize)) {
+        ArrowBuf largeBuf = allocator.buffer(bufSize)) {
       assertEquals(bufSize, largeBuf.capacity());
       logger.trace("Successfully allocated a buffer with capacity {}", largeBuf.capacity());
 
@@ -71,5 +69,4 @@ public class ITTestLargeArrowBuf {
   public void testMaxIntArrowBuf() {
     run(Integer.MAX_VALUE);
   }
-
 }

--- a/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestAllocationManagerNetty.java
+++ b/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestAllocationManagerNetty.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
 import static org.junit.Assert.assertEquals;
@@ -23,9 +22,7 @@ import org.apache.arrow.memory.AllocationManager;
 import org.apache.arrow.memory.DefaultAllocationManagerOption;
 import org.junit.Test;
 
-/**
- * Test cases for {@link AllocationManager}.
- */
+/** Test cases for {@link AllocationManager}. */
 public class TestAllocationManagerNetty {
 
   @Test

--- a/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestEmptyArrowBuf.java
+++ b/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestEmptyArrowBuf.java
@@ -14,19 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
 import static org.junit.Assert.assertEquals;
 
+import io.netty.buffer.PooledByteBufAllocatorL;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import io.netty.buffer.PooledByteBufAllocatorL;
 
 public class TestEmptyArrowBuf {
 
@@ -37,7 +35,7 @@ public class TestEmptyArrowBuf {
   public static void beforeClass() {
     allocator = new RootAllocator(MAX_ALLOCATION);
   }
-  
+
   /** Ensure the allocator is closed. */
   @AfterClass
   public static void afterClass() {
@@ -48,16 +46,22 @@ public class TestEmptyArrowBuf {
 
   @Test
   public void testZeroBuf() {
-    // Exercise the historical log inside the empty ArrowBuf. This is initialized statically, and there is a circular
-    // dependency between ArrowBuf and BaseAllocator, so if the initialization happens in the wrong order, the
+    // Exercise the historical log inside the empty ArrowBuf. This is initialized statically, and
+    // there is a circular
+    // dependency between ArrowBuf and BaseAllocator, so if the initialization happens in the wrong
+    // order, the
     // historical log will be null even though RootAllocator.DEBUG is true.
     allocator.getEmpty().print(new StringBuilder(), 0, RootAllocator.Verbosity.LOG_WITH_STACKTRACE);
   }
 
   @Test
   public void testEmptyArrowBuf() {
-    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,
-        1024, new PooledByteBufAllocatorL().empty.memoryAddress());
+    ArrowBuf buf =
+        new ArrowBuf(
+            ReferenceManager.NO_OP,
+            null,
+            1024,
+            new PooledByteBufAllocatorL().empty.memoryAddress());
 
     buf.getReferenceManager().retain();
     buf.getReferenceManager().retain(8);
@@ -74,7 +78,8 @@ public class TestEmptyArrowBuf {
     assertEquals(false, buf.getReferenceManager().release());
     assertEquals(false, buf.getReferenceManager().release(2));
     assertEquals(0, buf.getReferenceManager().getAllocator().getLimit());
-    assertEquals(buf, buf.getReferenceManager().transferOwnership(buf, allocator).getTransferredBuffer());
+    assertEquals(
+        buf, buf.getReferenceManager().transferOwnership(buf, allocator).getTransferredBuffer());
     assertEquals(0, buf.readerIndex());
     assertEquals(0, buf.writerIndex());
     assertEquals(1, buf.refCnt());
@@ -85,7 +90,5 @@ public class TestEmptyArrowBuf {
     assertEquals(1, derive.refCnt());
 
     buf.close();
-
   }
-
 }

--- a/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestEndianness.java
+++ b/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestEndianness.java
@@ -14,19 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
 import static org.junit.Assert.assertEquals;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.NettyArrowBuf;
 import java.nio.ByteOrder;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.Test;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.NettyArrowBuf;
 
 public class TestEndianness {
 
@@ -49,5 +46,4 @@ public class TestEndianness {
     b.release();
     a.close();
   }
-
 }

--- a/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestNettyAllocationManager.java
+++ b/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestNettyAllocationManager.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
 import static org.junit.Assert.assertEquals;
@@ -29,26 +28,28 @@ import org.apache.arrow.memory.BufferLedger;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.Test;
 
-/**
- * Test cases for {@link NettyAllocationManager}.
- */
+/** Test cases for {@link NettyAllocationManager}. */
 public class TestNettyAllocationManager {
 
   static int CUSTOMIZED_ALLOCATION_CUTOFF_VALUE = 1024;
 
   private RootAllocator createCustomizedAllocator() {
-    return new RootAllocator(RootAllocator.configBuilder()
-        .allocationManagerFactory(new AllocationManager.Factory() {
-          @Override
-          public AllocationManager create(BufferAllocator accountingAllocator, long size) {
-            return new NettyAllocationManager(accountingAllocator, size, CUSTOMIZED_ALLOCATION_CUTOFF_VALUE);
-          }
+    return new RootAllocator(
+        RootAllocator.configBuilder()
+            .allocationManagerFactory(
+                new AllocationManager.Factory() {
+                  @Override
+                  public AllocationManager create(BufferAllocator accountingAllocator, long size) {
+                    return new NettyAllocationManager(
+                        accountingAllocator, size, CUSTOMIZED_ALLOCATION_CUTOFF_VALUE);
+                  }
 
-          @Override
-          public ArrowBuf empty() {
-            return null;
-          }
-        }).build());
+                  @Override
+                  public ArrowBuf empty() {
+                    return null;
+                  }
+                })
+            .build());
   }
 
   private void readWriteArrowBuf(ArrowBuf buffer) {
@@ -64,14 +65,12 @@ public class TestNettyAllocationManager {
     }
   }
 
-  /**
-   * Test the allocation strategy for small buffers..
-   */
+  /** Test the allocation strategy for small buffers.. */
   @Test
   public void testSmallBufferAllocation() {
     final long bufSize = CUSTOMIZED_ALLOCATION_CUTOFF_VALUE - 512L;
     try (RootAllocator allocator = createCustomizedAllocator();
-         ArrowBuf buffer = allocator.buffer(bufSize)) {
+        ArrowBuf buffer = allocator.buffer(bufSize)) {
 
       assertTrue(buffer.getReferenceManager() instanceof BufferLedger);
       BufferLedger bufferLedger = (BufferLedger) buffer.getReferenceManager();
@@ -88,14 +87,12 @@ public class TestNettyAllocationManager {
     }
   }
 
-  /**
-   * Test the allocation strategy for large buffers..
-   */
+  /** Test the allocation strategy for large buffers.. */
   @Test
   public void testLargeBufferAllocation() {
     final long bufSize = CUSTOMIZED_ALLOCATION_CUTOFF_VALUE + 1024L;
     try (RootAllocator allocator = createCustomizedAllocator();
-         ArrowBuf buffer = allocator.buffer(bufSize)) {
+        ArrowBuf buffer = allocator.buffer(bufSize)) {
       assertTrue(buffer.getReferenceManager() instanceof BufferLedger);
       BufferLedger bufferLedger = (BufferLedger) buffer.getReferenceManager();
 

--- a/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestNettyAllocator.java
+++ b/java/memory/memory-netty/src/test/java/org/apache/arrow/memory/netty/TestNettyAllocator.java
@@ -14,28 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.netty;
 
 import static org.junit.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.stream.Collectors;
-
-import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.ReferenceManager;
-import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import io.netty.buffer.PooledByteBufAllocatorL;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.ReferenceManager;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
-/**
- * Test netty allocators.
- */
+/** Test netty allocators. */
 public class TestNettyAllocator {
 
   @Test
@@ -48,31 +43,42 @@ public class TestNettyAllocator {
       logger.setLevel(Level.TRACE);
       logger.addAppender(memoryLogsAppender);
       memoryLogsAppender.start();
-      try (ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,
-          1024, new PooledByteBufAllocatorL().empty.memoryAddress())) {
+      try (ArrowBuf buf =
+          new ArrowBuf(
+              ReferenceManager.NO_OP,
+              null,
+              1024,
+              new PooledByteBufAllocatorL().empty.memoryAddress())) {
         buf.memoryAddress();
       }
       boolean result = false;
       long startTime = System.currentTimeMillis();
-      while ((System.currentTimeMillis() - startTime) < 10000) { // 10 seconds maximum for time to read logs
-        // Lock on the list backing the appender since a background thread might try to add more logs
-        // while stream() is iterating over list elements. This would throw a flakey ConcurrentModificationException.
+      while ((System.currentTimeMillis() - startTime)
+          < 10000) { // 10 seconds maximum for time to read logs
+        // Lock on the list backing the appender since a background thread might try to add more
+        // logs
+        // while stream() is iterating over list elements. This would throw a flakey
+        // ConcurrentModificationException.
         synchronized (memoryLogsAppender.list) {
-          result = memoryLogsAppender.list.stream()
-              .anyMatch(
-                  log -> log.toString().contains("Memory Usage: \n") &&
-                      log.toString().contains("Large buffers outstanding: ") &&
-                      log.toString().contains("Normal buffers outstanding: ") &&
-                      log.getLevel().equals(Level.TRACE)
-              );
+          result =
+              memoryLogsAppender.list.stream()
+                  .anyMatch(
+                      log ->
+                          log.toString().contains("Memory Usage: \n")
+                              && log.toString().contains("Large buffers outstanding: ")
+                              && log.toString().contains("Normal buffers outstanding: ")
+                              && log.getLevel().equals(Level.TRACE));
         }
         if (result) {
           break;
         }
       }
       synchronized (memoryLogsAppender.list) {
-        assertTrue("Log messages are:\n" +
-              memoryLogsAppender.list.stream().map(ILoggingEvent::toString).collect(Collectors.joining("\n")),
+        assertTrue(
+            "Log messages are:\n"
+                + memoryLogsAppender.list.stream()
+                    .map(ILoggingEvent::toString)
+                    .collect(Collectors.joining("\n")),
             result);
       }
 

--- a/java/memory/memory-unsafe/src/main/java/module-info.java
+++ b/java/memory/memory-unsafe/src/main/java/module-info.java
@@ -16,7 +16,8 @@
  */
 
 module org.apache.arrow.memory.unsafe {
-  exports org.apache.arrow.memory.unsafe to org.apache.arrow.memory.core;
-  
+  exports org.apache.arrow.memory.unsafe to
+      org.apache.arrow.memory.core;
+
   requires org.apache.arrow.memory.core;
 }

--- a/java/memory/memory-unsafe/src/main/java/org/apache/arrow/memory/unsafe/DefaultAllocationManagerFactory.java
+++ b/java/memory/memory-unsafe/src/main/java/org/apache/arrow/memory/unsafe/DefaultAllocationManagerFactory.java
@@ -14,17 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.unsafe;
 
 import org.apache.arrow.memory.AllocationManager;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 
-/**
- * The default Allocation Manager Factory for a module.
- *
- */
+/** The default Allocation Manager Factory for a module. */
 public class DefaultAllocationManagerFactory implements AllocationManager.Factory {
 
   public static final AllocationManager.Factory FACTORY = UnsafeAllocationManager.FACTORY;

--- a/java/memory/memory-unsafe/src/main/java/org/apache/arrow/memory/unsafe/UnsafeAllocationManager.java
+++ b/java/memory/memory-unsafe/src/main/java/org/apache/arrow/memory/unsafe/UnsafeAllocationManager.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.unsafe;
 
 import org.apache.arrow.memory.AllocationManager;
@@ -23,28 +22,24 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.memory.util.MemoryUtil;
 
-/**
- * Allocation manager based on unsafe API.
- */
+/** Allocation manager based on unsafe API. */
 public final class UnsafeAllocationManager extends AllocationManager {
 
-  private static final ArrowBuf EMPTY = new ArrowBuf(ReferenceManager.NO_OP,
-      null,
-      0,
-      MemoryUtil.UNSAFE.allocateMemory(0)
-  );
+  private static final ArrowBuf EMPTY =
+      new ArrowBuf(ReferenceManager.NO_OP, null, 0, MemoryUtil.UNSAFE.allocateMemory(0));
 
-  public static final AllocationManager.Factory FACTORY = new Factory() {
-    @Override
-    public AllocationManager create(BufferAllocator accountingAllocator, long size) {
-      return new UnsafeAllocationManager(accountingAllocator, size);
-    }
+  public static final AllocationManager.Factory FACTORY =
+      new Factory() {
+        @Override
+        public AllocationManager create(BufferAllocator accountingAllocator, long size) {
+          return new UnsafeAllocationManager(accountingAllocator, size);
+        }
 
-    @Override
-    public ArrowBuf empty() {
-      return EMPTY;
-    }
-  };
+        @Override
+        public ArrowBuf empty() {
+          return EMPTY;
+        }
+      };
 
   private final long allocatedSize;
 
@@ -70,5 +65,4 @@ public final class UnsafeAllocationManager extends AllocationManager {
   protected void release0() {
     MemoryUtil.UNSAFE.freeMemory(allocatedAddress);
   }
-
 }

--- a/java/memory/memory-unsafe/src/test/java/org/apache/arrow/memory/unsafe/TestAllocationManagerUnsafe.java
+++ b/java/memory/memory-unsafe/src/test/java/org/apache/arrow/memory/unsafe/TestAllocationManagerUnsafe.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.unsafe;
 
 import static org.junit.Assert.assertEquals;
@@ -23,9 +22,7 @@ import org.apache.arrow.memory.AllocationManager;
 import org.apache.arrow.memory.DefaultAllocationManagerOption;
 import org.junit.Test;
 
-/**
- * Test cases for {@link AllocationManager}.
- */
+/** Test cases for {@link AllocationManager}. */
 public class TestAllocationManagerUnsafe {
 
   @Test
@@ -38,6 +35,5 @@ public class TestAllocationManagerUnsafe {
         DefaultAllocationManagerOption.getDefaultAllocationManagerType();
 
     assertEquals(DefaultAllocationManagerOption.AllocationManagerType.Unsafe, mgrType);
-
   }
 }

--- a/java/memory/memory-unsafe/src/test/java/org/apache/arrow/memory/unsafe/TestUnsafeAllocationManager.java
+++ b/java/memory/memory-unsafe/src/test/java/org/apache/arrow/memory/unsafe/TestUnsafeAllocationManager.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.memory.unsafe;
 
 import static org.junit.Assert.assertEquals;
@@ -27,14 +26,14 @@ import org.apache.arrow.memory.BufferLedger;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.Test;
 
-/**
- * Test cases for {@link UnsafeAllocationManager}.
- */
+/** Test cases for {@link UnsafeAllocationManager}. */
 public class TestUnsafeAllocationManager {
 
   private BufferAllocator createUnsafeAllocator() {
-    return new RootAllocator(RootAllocator.configBuilder().allocationManagerFactory(UnsafeAllocationManager.FACTORY)
-        .build());
+    return new RootAllocator(
+        RootAllocator.configBuilder()
+            .allocationManagerFactory(UnsafeAllocationManager.FACTORY)
+            .build());
   }
 
   private void readWriteArrowBuf(ArrowBuf buffer) {
@@ -50,14 +49,12 @@ public class TestUnsafeAllocationManager {
     }
   }
 
-  /**
-   * Test the memory allocation for {@link UnsafeAllocationManager}.
-   */
+  /** Test the memory allocation for {@link UnsafeAllocationManager}. */
   @Test
   public void testBufferAllocation() {
     final long bufSize = 4096L;
     try (BufferAllocator allocator = createUnsafeAllocator();
-         ArrowBuf buffer = allocator.buffer(bufSize)) {
+        ArrowBuf buffer = allocator.buffer(bufSize)) {
       assertTrue(buffer.getReferenceManager() instanceof BufferLedger);
       BufferLedger bufferLedger = (BufferLedger) buffer.getReferenceManager();
 

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -27,4 +27,9 @@
     <module>memory-netty</module>
   </modules>
 
+  <properties>
+    <checkstyle.config.location>dev/checkstyle/checkstyle-spotless.xml</checkstyle.config.location>
+    <spotless.java.excludes>none</spotless.java.excludes>
+  </properties>
+
 </project>


### PR DESCRIPTION
### Rationale for this change

Applying Java code style and formatting options to Memory modules.
- [x] memory-core
- [x] memory-netty
- [x] memory-netty-buffer-patch
- [x] memory-unsafe

### What changes are included in this PR?

Java code formatting via spotless plugin has been enabled.

Checkstyle configuration has been changed to remove the 120 line character limit as g-j-f does not wrap long strings

### Are these changes tested?

Yes, but doesn't involve test cases, the plugin itself corrects.

### Are there any user-facing changes?

No

* GitHub Issue: #40829