### PR TITLE
GH-40825:  [Java] Adding Spotless to Flight module 

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Action.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Action.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-import org.apache.arrow.flight.impl.Flight;
-
 import com.google.protobuf.ByteString;
+import org.apache.arrow.flight.impl.Flight;
 
 /**
  * An opaque action for the service to perform.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ActionType.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ActionType.java
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import org.apache.arrow.flight.impl.Flight;
 
-/**
- * POJO wrapper around protocol specifics for Flight actions.
- */
+/** POJO wrapper around protocol specifics for Flight actions. */
 public class ActionType {
   private final String type;
   private final String description;
@@ -38,9 +35,7 @@ public class ActionType {
     this.description = description;
   }
 
-  /**
-   * Constructs a new instance from the corresponding protocol buffer object.
-   */
+  /** Constructs a new instance from the corresponding protocol buffer object. */
   ActionType(Flight.ActionType type) {
     this.type = type.getType();
     this.description = type.getDescription();
@@ -50,21 +45,13 @@ public class ActionType {
     return type;
   }
 
-  /**
-   *  Converts the POJO to the corresponding protocol buffer type.
-   */
+  /** Converts the POJO to the corresponding protocol buffer type. */
   Flight.ActionType toProtocol() {
-    return Flight.ActionType.newBuilder()
-        .setType(type)
-        .setDescription(description)
-        .build();
+    return Flight.ActionType.newBuilder().setType(type).setDescription(description).build();
   }
 
   @Override
   public String toString() {
-    return "ActionType{" +
-        "type='" + type + '\'' +
-        ", description='" + description + '\'' +
-        '}';
+    return "ActionType{" + "type='" + type + '\'' + ", description='" + description + '\'' + '}';
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/AsyncPutListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/AsyncPutListener.java
@@ -14,19 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-
 import org.apache.arrow.flight.grpc.StatusUtils;
 
 /**
  * A handler for server-sent application metadata messages during a Flight DoPut operation.
  *
- * <p>To handle messages, create an instance of this class overriding {@link #onNext(PutResult)}. The other methods
- * should not be overridden.
+ * <p>To handle messages, create an instance of this class overriding {@link #onNext(PutResult)}.
+ * The other methods should not be overridden.
  */
 public class AsyncPutListener implements FlightClient.PutListener {
 
@@ -37,8 +35,8 @@ public class AsyncPutListener implements FlightClient.PutListener {
   }
 
   /**
-   * Wait for the stream to finish on the server side. You must call this to be notified of any errors that may have
-   * happened during the upload.
+   * Wait for the stream to finish on the server side. You must call this to be notified of any
+   * errors that may have happened during the upload.
    */
   @Override
   public final void getResult() {
@@ -52,8 +50,7 @@ public class AsyncPutListener implements FlightClient.PutListener {
   }
 
   @Override
-  public void onNext(PutResult val) {
-  }
+  public void onNext(PutResult val) {}
 
   @Override
   public final void onError(Throwable t) {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
@@ -14,49 +14,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.common.base.Preconditions;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
-import com.google.common.base.Preconditions;
-
 /**
- * Helper interface to dynamically handle backpressure when implementing FlightProducers.
- * This must only be used in FlightProducer implementations that are non-blocking.
+ * Helper interface to dynamically handle backpressure when implementing FlightProducers. This must
+ * only be used in FlightProducer implementations that are non-blocking.
  */
 public interface BackpressureStrategy {
-  /**
-   * The state of the client after a call to waitForListener.
-   */
+  /** The state of the client after a call to waitForListener. */
   enum WaitResult {
-    /**
-     * Listener is ready.
-     */
+    /** Listener is ready. */
     READY,
 
-    /**
-     * Listener was cancelled by the client.
-     */
+    /** Listener was cancelled by the client. */
     CANCELLED,
 
-    /**
-     * Timed out waiting for the listener to change state.
-     */
+    /** Timed out waiting for the listener to change state. */
     TIMEOUT,
 
-    /**
-     * Indicates that the wait was interrupted for a reason
-     * unrelated to the listener itself.
-     */
+    /** Indicates that the wait was interrupted for a reason unrelated to the listener itself. */
     OTHER
   }
 
   /**
    * Set up operations to work against the given listener.
    *
-   * This must be called exactly once and before any calls to {@link #waitForListener(long)} and
+   * <p>This must be called exactly once and before any calls to {@link #waitForListener(long)} and
    * {@link OutboundStreamListener#start(VectorSchemaRoot)}
+   *
    * @param listener The listener this strategy applies to.
    */
   void register(FlightProducer.ServerStreamListener listener);
@@ -121,9 +109,9 @@ public interface BackpressureStrategy {
     /**
      * Interrupt waiting on the listener to change state.
      *
-     * This method can be used in conjunction with
-     * {@link #shouldContinueWaiting(FlightProducer.ServerStreamListener, long)} to allow FlightProducers to
-     * terminate streams internally and notify clients.
+     * <p>This method can be used in conjunction with {@link
+     * #shouldContinueWaiting(FlightProducer.ServerStreamListener, long)} to allow FlightProducers
+     * to terminate streams internally and notify clients.
      */
     public void interruptWait() {
       synchronized (lock) {
@@ -132,28 +120,23 @@ public interface BackpressureStrategy {
     }
 
     /**
-     * Callback function to run to check if the listener should continue
-     * to be waited on if it leaves the waiting state without being cancelled,
-     * ready, or timed out.
+     * Callback function to run to check if the listener should continue to be waited on if it
+     * leaves the waiting state without being cancelled, ready, or timed out.
      *
-     * This method should be used to determine if the wait on the listener was interrupted explicitly using a
-     * call to {@link #interruptWait()} or if it was woken up due to a spurious wake.
+     * <p>This method should be used to determine if the wait on the listener was interrupted
+     * explicitly using a call to {@link #interruptWait()} or if it was woken up due to a spurious
+     * wake.
      */
-    protected boolean shouldContinueWaiting(FlightProducer.ServerStreamListener listener, long remainingTimeout) {
+    protected boolean shouldContinueWaiting(
+        FlightProducer.ServerStreamListener listener, long remainingTimeout) {
       return true;
     }
 
-    /**
-     * Callback to execute when the listener becomes ready.
-     */
-    protected void readyCallback() {
-    }
+    /** Callback to execute when the listener becomes ready. */
+    protected void readyCallback() {}
 
-    /**
-     * Callback to execute when the listener is cancelled.
-     */
-    protected void cancelCallback() {
-    }
+    /** Callback to execute when the listener is cancelled. */
+    protected void cancelCallback() {}
 
     private void onReady() {
       synchronized (lock) {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallHeaders.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallHeaders.java
@@ -14,33 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.Set;
 
-/**
- * A set of metadata key value pairs for a call (request or response).
- */
+/** A set of metadata key value pairs for a call (request or response). */
 public interface CallHeaders {
-  /**
-   * Get the value of a metadata key. If multiple values are present, then get the last one.
-   */
+  /** Get the value of a metadata key. If multiple values are present, then get the last one. */
   String get(String key);
 
-  /**
-   * Get the value of a metadata key. If multiple values are present, then get the last one.
-   */
+  /** Get the value of a metadata key. If multiple values are present, then get the last one. */
   byte[] getByte(String key);
 
-  /**
-   * Get all values present for the given metadata key.
-   */
+  /** Get all values present for the given metadata key. */
   Iterable<String> getAll(String key);
 
-  /**
-   * Get all values present for the given metadata key.
-   */
+  /** Get all values present for the given metadata key. */
   Iterable<byte[]> getAllByte(String key);
 
   /**

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallInfo.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallInfo.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-/**
- * A description of a Flight call for middleware to inspect.
- */
+/** A description of a Flight call for middleware to inspect. */
 public final class CallInfo {
   private final FlightMethod method;
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallOption.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallOption.java
@@ -14,11 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-/**
- * Per-call RPC options. These are hints to the underlying RPC layer and may not be respected.
- */
-public interface CallOption {
-}
+/** Per-call RPC options. These are hints to the underlying RPC layer and may not be respected. */
+public interface CallOption {}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallOptions.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallOptions.java
@@ -14,16 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import io.grpc.stub.AbstractStub;
 import java.util.concurrent.TimeUnit;
 
-import io.grpc.stub.AbstractStub;
-
-/**
- * Common call options.
- */
+/** Common call options. */
 public class CallOptions {
   public static CallOption timeout(long duration, TimeUnit unit) {
     return new Timeout(duration, unit);
@@ -53,9 +49,7 @@ public class CallOptions {
     }
   }
 
-  /**
-   * CallOptions specific to GRPC stubs.
-   */
+  /** CallOptions specific to GRPC stubs. */
   public interface GrpcCallOption extends CallOption {
     <T extends AbstractStub<T>> T wrapStub(T stub);
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallStatus.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallStatus.java
@@ -14,22 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.Objects;
-
 import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import org.apache.arrow.flight.FlightProducer.StreamListener;
 
 /**
- * The result of a Flight RPC, consisting of a status code with an optional description and/or exception that led
- * to the status.
+ * The result of a Flight RPC, consisting of a status code with an optional description and/or
+ * exception that led to the status.
  *
- * <p>If raised or sent through {@link StreamListener#onError(Throwable)} or
- * {@link ServerStreamListener#error(Throwable)}, the client call will raise the same error (a
- * {@link FlightRuntimeException} with the same {@link FlightStatusCode} and description). The exception within, if
- * present, will not be sent to the client.
+ * <p>If raised or sent through {@link StreamListener#onError(Throwable)} or {@link
+ * ServerStreamListener#error(Throwable)}, the client call will raise the same error (a {@link
+ * FlightRuntimeException} with the same {@link FlightStatusCode} and description). The exception
+ * within, if present, will not be sent to the client.
  */
 public class CallStatus {
 
@@ -49,7 +47,8 @@ public class CallStatus {
   public static final CallStatus UNAUTHORIZED = FlightStatusCode.UNAUTHORIZED.toStatus();
   public static final CallStatus UNIMPLEMENTED = FlightStatusCode.UNIMPLEMENTED.toStatus();
   public static final CallStatus UNAVAILABLE = FlightStatusCode.UNAVAILABLE.toStatus();
-  public static final CallStatus RESOURCE_EXHAUSTED = FlightStatusCode.RESOURCE_EXHAUSTED.toStatus();
+  public static final CallStatus RESOURCE_EXHAUSTED =
+      FlightStatusCode.RESOURCE_EXHAUSTED.toStatus();
 
   /**
    * Create a new status.
@@ -58,7 +57,8 @@ public class CallStatus {
    * @param cause An exception that resulted in this status (or null).
    * @param description A description of the status (or null).
    */
-  public CallStatus(FlightStatusCode code, Throwable cause, String description, ErrorFlightMetadata metadata) {
+  public CallStatus(
+      FlightStatusCode code, Throwable cause, String description, ErrorFlightMetadata metadata) {
     this.code = Objects.requireNonNull(code);
     this.cause = cause;
     this.description = description == null ? "" : description;
@@ -74,23 +74,17 @@ public class CallStatus {
     this(code, /* no cause */ null, /* no description */ null, /* no metadata */ null);
   }
 
-  /**
-   * The status code describing the result of the RPC.
-   */
+  /** The status code describing the result of the RPC. */
   public FlightStatusCode code() {
     return code;
   }
 
-  /**
-   * The exception that led to this result. May be null.
-   */
+  /** The exception that led to this result. May be null. */
   public Throwable cause() {
     return cause;
   }
 
-  /**
-   * A description of the result.
-   */
+  /** A description of the result. */
   public String description() {
     return description;
   }
@@ -98,47 +92,47 @@ public class CallStatus {
   /**
    * Metadata associated with the exception.
    *
-   * May be null.
+   * <p>May be null.
    */
   public ErrorFlightMetadata metadata() {
     return metadata;
   }
 
-  /**
-   * Return a copy of this status with an error message.
-   */
+  /** Return a copy of this status with an error message. */
   public CallStatus withDescription(String message) {
     return new CallStatus(code, cause, message, metadata);
   }
 
   /**
-   * Return a copy of this status with the given exception as the cause. This will not be sent over the wire.
+   * Return a copy of this status with the given exception as the cause. This will not be sent over
+   * the wire.
    */
   public CallStatus withCause(Throwable t) {
     return new CallStatus(code, t, description, metadata);
   }
 
-  /**
-   * Return a copy of this status with associated exception metadata.
-   */
+  /** Return a copy of this status with associated exception metadata. */
   public CallStatus withMetadata(ErrorFlightMetadata metadata) {
     return new CallStatus(code, cause, description, metadata);
   }
 
-  /**
-   * Convert the status to an equivalent exception.
-   */
+  /** Convert the status to an equivalent exception. */
   public FlightRuntimeException toRuntimeException() {
     return new FlightRuntimeException(this);
   }
 
   @Override
   public String toString() {
-    return "CallStatus{" +
-        "code=" + code +
-        ", cause=" + cause +
-        ", description='" + description +
-        "', metadata='" + metadata + '\'' +
-        '}';
+    return "CallStatus{"
+        + "code="
+        + code
+        + ", cause="
+        + cause
+        + ", description='"
+        + description
+        + "', metadata='"
+        + metadata
+        + '\''
+        + '}';
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CancelFlightInfoRequest.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CancelFlightInfoRequest.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** A request to cancel a FlightInfo. */
@@ -49,7 +47,8 @@ public class CancelFlightInfoRequest {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -58,13 +57,15 @@ public class CancelFlightInfoRequest {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.
    * @throws IOException if the serialized form is invalid.
    */
-  public static CancelFlightInfoRequest deserialize(ByteBuffer serialized) throws IOException, URISyntaxException {
+  public static CancelFlightInfoRequest deserialize(ByteBuffer serialized)
+      throws IOException, URISyntaxException {
     return new CancelFlightInfoRequest(Flight.CancelFlightInfoRequest.parseFrom(serialized));
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CancelFlightInfoResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CancelFlightInfoResult.java
@@ -14,18 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
-
 import org.apache.arrow.flight.impl.Flight;
 
-/**
- * The result of cancelling a FlightInfo.
- */
+/** The result of cancelling a FlightInfo. */
 public class CancelFlightInfoResult {
   private final CancelStatus status;
 
@@ -81,7 +77,8 @@ public class CancelFlightInfoResult {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -90,7 +87,8 @@ public class CancelFlightInfoResult {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.
@@ -119,8 +117,6 @@ public class CancelFlightInfoResult {
 
   @Override
   public String toString() {
-    return "CancelFlightInfoResult{" +
-        "status=" + status +
-        '}';
+    return "CancelFlightInfoResult{" + "status=" + status + '}';
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CancelStatus.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CancelStatus.java
@@ -14,31 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 /** The result of cancelling a FlightInfo. */
 public enum CancelStatus {
   /**
-   * The cancellation status is unknown. Servers should avoid using
-   * this value (send a NOT_FOUND error if the requested query is
-   * not known). Clients can retry the request.
+   * The cancellation status is unknown. Servers should avoid using this value (send a NOT_FOUND
+   * error if the requested query is not known). Clients can retry the request.
    */
   UNSPECIFIED,
   /**
-   * The cancellation request is complete. Subsequent requests with
-   * the same payload may return CANCELLED or a NOT_FOUND error.
+   * The cancellation request is complete. Subsequent requests with the same payload may return
+   * CANCELLED or a NOT_FOUND error.
    */
   CANCELLED,
-  /**
-   * The cancellation request is in progress. The client may retry
-   * the cancellation request.
-   */
+  /** The cancellation request is in progress. The client may retry the cancellation request. */
   CANCELLING,
-  /**
-   * The query is not cancellable. The client should not retry the
-   * cancellation request.
-   */
+  /** The query is not cancellable. The client should not retry the cancellation request. */
   NOT_CANCELLABLE,
   ;
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CloseSessionRequest.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CloseSessionRequest.java
@@ -14,21 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** A request to close/invalidate a server session context. */
 public class CloseSessionRequest {
-  public CloseSessionRequest() {
-  }
+  public CloseSessionRequest() {}
 
-  CloseSessionRequest(Flight.CloseSessionRequest proto) {
-  }
+  CloseSessionRequest(Flight.CloseSessionRequest proto) {}
 
   Flight.CloseSessionRequest toProtocol() {
     return Flight.CloseSessionRequest.getDefaultInstance();
@@ -37,7 +33,8 @@ public class CloseSessionRequest {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -46,7 +43,8 @@ public class CloseSessionRequest {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CloseSessionResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CloseSessionResult.java
@@ -14,37 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** The result of attempting to close/invalidate a server session context. */
 public class CloseSessionResult {
-  /**
-   * Close operation result status values.
-   */
+  /** Close operation result status values. */
   public enum Status {
     /**
-     * The session close status is unknown. Servers should avoid using this value
-     * (send a NOT_FOUND error if the requested session is not known). Clients can
-     * retry the request.
+     * The session close status is unknown. Servers should avoid using this value (send a NOT_FOUND
+     * error if the requested session is not known). Clients can retry the request.
      */
     UNSPECIFIED,
-    /**
-     * The session close request is complete.
-     */
+    /** The session close request is complete. */
     CLOSED,
-    /**
-     * The session close request is in progress. The client may retry the request.
-     */
+    /** The session close request is in progress. The client may retry the request. */
     CLOSING,
-    /**
-     * The session is not closeable.
-     */
+    /** The session is not closeable. */
     NOT_CLOSABLE,
     ;
 
@@ -84,7 +73,8 @@ public class CloseSessionResult {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -93,7 +83,8 @@ public class CloseSessionResult {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.
@@ -102,5 +93,4 @@ public class CloseSessionResult {
   public static CloseSessionResult deserialize(ByteBuffer serialized) throws IOException {
     return new CloseSessionResult(Flight.CloseSessionResult.parseFrom(serialized));
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Criteria.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Criteria.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-import org.apache.arrow.flight.impl.Flight;
-
 import com.google.protobuf.ByteString;
+import org.apache.arrow.flight.impl.Flight;
 
 /**
  * An opaque object that can be used to filter a list of streams available from a server.
@@ -40,9 +38,7 @@ public class Criteria {
     this.bytes = criteria.getExpression().toByteArray();
   }
 
-  /**
-   * Get the contained filter criteria.
-   */
+  /** Get the contained filter criteria. */
   public byte[] getExpression() {
     return bytes;
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ErrorFlightMetadata.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ErrorFlightMetadata.java
@@ -14,27 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
-
-/**
- * metadata container specific to the binary metadata held in the grpc trailer.
- */
+/** metadata container specific to the binary metadata held in the grpc trailer. */
 public class ErrorFlightMetadata implements CallHeaders {
   private final Multimap<String, byte[]> metadata = LinkedListMultimap.create();
 
-  public ErrorFlightMetadata() {
-  }
-
+  public ErrorFlightMetadata() {}
 
   @Override
   public String get(String key) {
@@ -48,8 +42,7 @@ public class ErrorFlightMetadata implements CallHeaders {
 
   @Override
   public Iterable<String> getAll(String key) {
-    return StreamSupport.stream(
-        getAllByte(key).spliterator(), false)
+    return StreamSupport.stream(getAllByte(key).spliterator(), false)
         .map(b -> new String(b, StandardCharsets.US_ASCII))
         .collect(Collectors.toList());
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightCallHeaders.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightCallHeaders.java
@@ -14,24 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
-
 import io.grpc.Metadata;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-/**
- * An implementation of the Flight headers interface for headers.
- */
+/** An implementation of the Flight headers interface for headers. */
 public class FlightCallHeaders implements CallHeaders {
   private final Multimap<String, Object> keysAndValues;
 
@@ -70,7 +65,8 @@ public class FlightCallHeaders implements CallHeaders {
   @Override
   public Iterable<String> getAll(String key) {
     if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-      return this.keysAndValues.get(key).stream().map(o -> new String((byte[]) o, StandardCharsets.UTF_8))
+      return this.keysAndValues.get(key).stream()
+          .map(o -> new String((byte[]) o, StandardCharsets.UTF_8))
           .collect(Collectors.toList());
     }
     return (Collection<String>) (Collection<?>) this.keysAndValues.get(key);
@@ -81,7 +77,8 @@ public class FlightCallHeaders implements CallHeaders {
     if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
       return (Collection<byte[]>) (Collection<?>) this.keysAndValues.get(key);
     }
-    return this.keysAndValues.get(key).stream().map(o -> ((String) o).getBytes(StandardCharsets.UTF_8))
+    return this.keysAndValues.get(key).stream()
+        .map(o -> ((String) o).getBytes(StandardCharsets.UTF_8))
         .collect(Collectors.toList());
   }
 
@@ -92,7 +89,8 @@ public class FlightCallHeaders implements CallHeaders {
 
   @Override
   public void insert(String key, byte[] value) {
-    Preconditions.checkArgument(key.endsWith("-bin"), "Binary header is named %s. It must end with %s", key, "-bin");
+    Preconditions.checkArgument(
+        key.endsWith("-bin"), "Binary header is named %s. It must end with %s", key, "-bin");
     Preconditions.checkArgument(key.length() > "-bin".length(), "empty key name");
 
     this.keysAndValues.put(key, value);

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -14,9 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.ClientResponseObserver;
+import io.grpc.stub.StreamObserver;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
@@ -29,9 +45,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
-
 import javax.net.ssl.SSLException;
-
 import org.apache.arrow.flight.FlightProducer.StreamListener;
 import org.apache.arrow.flight.auth.BasicClientAuthHandler;
 import org.apache.arrow.flight.auth.ClientAuthHandler;
@@ -55,31 +69,15 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.dictionary.DictionaryProvider.MapDictionaryProvider;
 
-import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptor;
-import io.grpc.ClientInterceptors;
-import io.grpc.ManagedChannel;
-import io.grpc.MethodDescriptor;
-import io.grpc.StatusRuntimeException;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyChannelBuilder;
-import io.grpc.stub.ClientCallStreamObserver;
-import io.grpc.stub.ClientCalls;
-import io.grpc.stub.ClientResponseObserver;
-import io.grpc.stub.StreamObserver;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-
-/**
- * Client for Flight services.
- */
+/** Client for Flight services. */
 public class FlightClient implements AutoCloseable {
   private static final int PENDING_REQUESTS = 5;
-  /** The maximum number of trace events to keep on the gRPC Channel. This value disables channel tracing. */
+  /**
+   * The maximum number of trace events to keep on the gRPC Channel. This value disables channel
+   * tracing.
+   */
   private static final int MAX_CHANNEL_TRACE_EVENTS = 0;
+
   private final BufferAllocator allocator;
   private final ManagedChannel channel;
 
@@ -91,17 +89,18 @@ public class FlightClient implements AutoCloseable {
   private final MethodDescriptor<ArrowMessage, ArrowMessage> doExchangeDescriptor;
   private final List<FlightClientMiddleware.Factory> middleware;
 
-  /**
-   * Create a Flight client from an allocator and a gRPC channel.
-   */
-  FlightClient(BufferAllocator incomingAllocator, ManagedChannel channel,
+  /** Create a Flight client from an allocator and a gRPC channel. */
+  FlightClient(
+      BufferAllocator incomingAllocator,
+      ManagedChannel channel,
       List<FlightClientMiddleware.Factory> middleware) {
     this.allocator = incomingAllocator.newChildAllocator("flight-client", 0, Long.MAX_VALUE);
     this.channel = channel;
     this.middleware = middleware;
 
     final ClientInterceptor[] interceptors;
-    interceptors = new ClientInterceptor[]{authInterceptor, new ClientInterceptorAdapter(middleware)};
+    interceptors =
+        new ClientInterceptor[] {authInterceptor, new ClientInterceptorAdapter(middleware)};
 
     // Create a channel with interceptors pre-applied for DoGet and DoPut
     Channel interceptedChannel = ClientInterceptors.intercept(channel, interceptors);
@@ -123,20 +122,23 @@ public class FlightClient implements AutoCloseable {
   public Iterable<FlightInfo> listFlights(Criteria criteria, CallOption... options) {
     final Iterator<Flight.FlightInfo> flights;
     try {
-      flights = CallOptions.wrapStub(blockingStub, options)
-          .listFlights(criteria.asCriteria());
+      flights = CallOptions.wrapStub(blockingStub, options).listFlights(criteria.asCriteria());
     } catch (StatusRuntimeException sre) {
       throw StatusUtils.fromGrpcRuntimeException(sre);
     }
-    return () -> StatusUtils.wrapIterator(flights, t -> {
-      try {
-        return new FlightInfo(t);
-      } catch (URISyntaxException e) {
-        // We don't expect this will happen for conforming Flight implementations. For instance, a Java server
-        // itself wouldn't be able to construct an invalid Location.
-        throw new RuntimeException(e);
-      }
-    });
+    return () ->
+        StatusUtils.wrapIterator(
+            flights,
+            t -> {
+              try {
+                return new FlightInfo(t);
+              } catch (URISyntaxException e) {
+                // We don't expect this will happen for conforming Flight implementations. For
+                // instance, a Java server
+                // itself wouldn't be able to construct an invalid Location.
+                throw new RuntimeException(e);
+              }
+            });
   }
 
   /**
@@ -147,8 +149,7 @@ public class FlightClient implements AutoCloseable {
   public Iterable<ActionType> listActions(CallOption... options) {
     final Iterator<Flight.ActionType> actions;
     try {
-      actions = CallOptions.wrapStub(blockingStub, options)
-          .listActions(Empty.getDefaultInstance());
+      actions = CallOptions.wrapStub(blockingStub, options).listActions(Empty.getDefaultInstance());
     } catch (StatusRuntimeException sre) {
       throw StatusUtils.fromGrpcRuntimeException(sre);
     }
@@ -163,13 +164,11 @@ public class FlightClient implements AutoCloseable {
    * @return An iterator of results.
    */
   public Iterator<Result> doAction(Action action, CallOption... options) {
-    return StatusUtils
-        .wrapIterator(CallOptions.wrapStub(blockingStub, options).doAction(action.toProtocol()), Result::new);
+    return StatusUtils.wrapIterator(
+        CallOptions.wrapStub(blockingStub, options).doAction(action.toProtocol()), Result::new);
   }
 
-  /**
-   * Authenticates with a username and password.
-   */
+  /** Authenticates with a username and password. */
   public void authenticateBasic(String username, String password) {
     BasicClientAuthHandler basicClient = new BasicClientAuthHandler(username, password);
     authenticate(basicClient);
@@ -192,12 +191,12 @@ public class FlightClient implements AutoCloseable {
    *
    * @param username the username.
    * @param password the password.
-   * @return a CredentialCallOption containing a bearer token if the server emitted one, or
-   *     empty if no bearer token was returned. This can be used in subsequent API calls.
+   * @return a CredentialCallOption containing a bearer token if the server emitted one, or empty if
+   *     no bearer token was returned. This can be used in subsequent API calls.
    */
   public Optional<CredentialCallOption> authenticateBasicToken(String username, String password) {
     final ClientIncomingAuthHeaderMiddleware.Factory clientAuthMiddleware =
-            new ClientIncomingAuthHeaderMiddleware.Factory(new ClientBearerHeaderHandler());
+        new ClientIncomingAuthHeaderMiddleware.Factory(new ClientBearerHeaderHandler());
     middleware.add(clientAuthMiddleware);
     handshake(new CredentialCallOption(new BasicAuthCredentialWriter(username, password)));
 
@@ -218,27 +217,36 @@ public class FlightClient implements AutoCloseable {
    *
    * @param descriptor FlightDescriptor the descriptor for the data
    * @param root VectorSchemaRoot the root containing data
-   * @param metadataListener A handler for metadata messages from the server. This will be passed buffers that will be
-   *     freed after {@link StreamListener#onNext(Object)} is called!
+   * @param metadataListener A handler for metadata messages from the server. This will be passed
+   *     buffers that will be freed after {@link StreamListener#onNext(Object)} is called!
    * @param options RPC-layer hints for this call.
    * @return ClientStreamListener an interface to control uploading data
    */
-  public ClientStreamListener startPut(FlightDescriptor descriptor, VectorSchemaRoot root,
-      PutListener metadataListener, CallOption... options) {
+  public ClientStreamListener startPut(
+      FlightDescriptor descriptor,
+      VectorSchemaRoot root,
+      PutListener metadataListener,
+      CallOption... options) {
     return startPut(descriptor, root, new MapDictionaryProvider(), metadataListener, options);
   }
 
   /**
    * Create or append a descriptor with another stream.
+   *
    * @param descriptor FlightDescriptor the descriptor for the data
    * @param root VectorSchemaRoot the root containing data
    * @param metadataListener A handler for metadata messages from the server.
    * @param options RPC-layer hints for this call.
-   * @return ClientStreamListener an interface to control uploading data.
-   *     {@link ClientStreamListener#start(VectorSchemaRoot, DictionaryProvider)} will already have been called.
+   * @return ClientStreamListener an interface to control uploading data. {@link
+   *     ClientStreamListener#start(VectorSchemaRoot, DictionaryProvider)} will already have been
+   *     called.
    */
-  public ClientStreamListener startPut(FlightDescriptor descriptor, VectorSchemaRoot root, DictionaryProvider provider,
-      PutListener metadataListener, CallOption... options) {
+  public ClientStreamListener startPut(
+      FlightDescriptor descriptor,
+      VectorSchemaRoot root,
+      DictionaryProvider provider,
+      PutListener metadataListener,
+      CallOption... options) {
     Preconditions.checkNotNull(root, "root must not be null");
     Preconditions.checkNotNull(provider, "provider must not be null");
     final ClientStreamListener writer = startPut(descriptor, metadataListener, options);
@@ -248,22 +256,26 @@ public class FlightClient implements AutoCloseable {
 
   /**
    * Create or append a descriptor with another stream.
+   *
    * @param descriptor FlightDescriptor the descriptor for the data
    * @param metadataListener A handler for metadata messages from the server.
    * @param options RPC-layer hints for this call.
-   * @return ClientStreamListener an interface to control uploading data.
-   *     {@link ClientStreamListener#start(VectorSchemaRoot, DictionaryProvider)} will NOT already have been called.
+   * @return ClientStreamListener an interface to control uploading data. {@link
+   *     ClientStreamListener#start(VectorSchemaRoot, DictionaryProvider)} will NOT already have
+   *     been called.
    */
-  public ClientStreamListener startPut(FlightDescriptor descriptor, PutListener metadataListener,
-                                       CallOption... options) {
+  public ClientStreamListener startPut(
+      FlightDescriptor descriptor, PutListener metadataListener, CallOption... options) {
     Preconditions.checkNotNull(descriptor, "descriptor must not be null");
     Preconditions.checkNotNull(metadataListener, "metadataListener must not be null");
 
     try {
-      final ClientCall<ArrowMessage, Flight.PutResult> call = asyncStubNewCall(doPutDescriptor, options);
+      final ClientCall<ArrowMessage, Flight.PutResult> call =
+          asyncStubNewCall(doPutDescriptor, options);
       final SetStreamObserver resultObserver = new SetStreamObserver(allocator, metadataListener);
-      ClientCallStreamObserver<ArrowMessage> observer = (ClientCallStreamObserver<ArrowMessage>)
-          ClientCalls.asyncBidiStreamingCall(call, resultObserver);
+      ClientCallStreamObserver<ArrowMessage> observer =
+          (ClientCallStreamObserver<ArrowMessage>)
+              ClientCalls.asyncBidiStreamingCall(call, resultObserver);
       return new PutObserver(
           descriptor, observer, metadataListener::isCancelled, metadataListener::getResult);
     } catch (StatusRuntimeException sre) {
@@ -273,14 +285,17 @@ public class FlightClient implements AutoCloseable {
 
   /**
    * Get info on a stream.
+   *
    * @param descriptor The descriptor for the stream.
    * @param options RPC-layer hints for this call.
    */
   public FlightInfo getInfo(FlightDescriptor descriptor, CallOption... options) {
     try {
-      return new FlightInfo(CallOptions.wrapStub(blockingStub, options).getFlightInfo(descriptor.toProtocol()));
+      return new FlightInfo(
+          CallOptions.wrapStub(blockingStub, options).getFlightInfo(descriptor.toProtocol()));
     } catch (URISyntaxException e) {
-      // We don't expect this will happen for conforming Flight implementations. For instance, a Java server
+      // We don't expect this will happen for conforming Flight implementations. For instance, a
+      // Java server
       // itself wouldn't be able to construct an invalid Location.
       throw new RuntimeException(e);
     } catch (StatusRuntimeException sre) {
@@ -297,7 +312,8 @@ public class FlightClient implements AutoCloseable {
    */
   public PollInfo pollInfo(FlightDescriptor descriptor, CallOption... options) {
     try {
-      return new PollInfo(CallOptions.wrapStub(blockingStub, options).pollFlightInfo(descriptor.toProtocol()));
+      return new PollInfo(
+          CallOptions.wrapStub(blockingStub, options).pollFlightInfo(descriptor.toProtocol()));
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
     } catch (StatusRuntimeException sre) {
@@ -307,13 +323,14 @@ public class FlightClient implements AutoCloseable {
 
   /**
    * Get schema for a stream.
+   *
    * @param descriptor The descriptor for the stream.
    * @param options RPC-layer hints for this call.
    */
   public SchemaResult getSchema(FlightDescriptor descriptor, CallOption... options) {
     try {
-      return SchemaResult.fromProtocol(CallOptions.wrapStub(blockingStub, options)
-          .getSchema(descriptor.toProtocol()));
+      return SchemaResult.fromProtocol(
+          CallOptions.wrapStub(blockingStub, options).getSchema(descriptor.toProtocol()));
     } catch (StatusRuntimeException sre) {
       throw StatusUtils.fromGrpcRuntimeException(sre);
     }
@@ -321,23 +338,26 @@ public class FlightClient implements AutoCloseable {
 
   /**
    * Retrieve a stream from the server.
+   *
    * @param ticket The ticket granting access to the data stream.
    * @param options RPC-layer hints for this call.
    */
   public FlightStream getStream(Ticket ticket, CallOption... options) {
     final ClientCall<Flight.Ticket, ArrowMessage> call = asyncStubNewCall(doGetDescriptor, options);
-    FlightStream stream = new FlightStream(
-        allocator,
-        PENDING_REQUESTS,
-        (String message, Throwable cause) -> call.cancel(message, cause),
-        (count) -> call.request(count));
+    FlightStream stream =
+        new FlightStream(
+            allocator,
+            PENDING_REQUESTS,
+            (String message, Throwable cause) -> call.cancel(message, cause),
+            (count) -> call.request(count));
 
     final StreamObserver<ArrowMessage> delegate = stream.asObserver();
     ClientResponseObserver<Flight.Ticket, ArrowMessage> clientResponseObserver =
         new ClientResponseObserver<Flight.Ticket, ArrowMessage>() {
 
           @Override
-          public void beforeStart(ClientCallStreamObserver<org.apache.arrow.flight.impl.Flight.Ticket> requestStream) {
+          public void beforeStart(
+              ClientCallStreamObserver<org.apache.arrow.flight.impl.Flight.Ticket> requestStream) {
             requestStream.disableAutoInboundFlowControl();
           }
 
@@ -355,7 +375,6 @@ public class FlightClient implements AutoCloseable {
           public void onCompleted() {
             delegate.onCompleted();
           }
-
         };
 
     ClientCalls.asyncServerStreamingCall(call, ticket.toProtocol(), clientResponseObserver);
@@ -373,28 +392,34 @@ public class FlightClient implements AutoCloseable {
     Preconditions.checkNotNull(descriptor, "descriptor must not be null");
 
     try {
-      final ClientCall<ArrowMessage, ArrowMessage> call = asyncStubNewCall(doExchangeDescriptor, options);
-      final FlightStream stream = new FlightStream(allocator, PENDING_REQUESTS, call::cancel, call::request);
-      final ClientCallStreamObserver<ArrowMessage> observer = (ClientCallStreamObserver<ArrowMessage>)
+      final ClientCall<ArrowMessage, ArrowMessage> call =
+          asyncStubNewCall(doExchangeDescriptor, options);
+      final FlightStream stream =
+          new FlightStream(allocator, PENDING_REQUESTS, call::cancel, call::request);
+      final ClientCallStreamObserver<ArrowMessage> observer =
+          (ClientCallStreamObserver<ArrowMessage>)
               ClientCalls.asyncBidiStreamingCall(call, stream.asObserver());
-      final ClientStreamListener writer = new PutObserver(
-          descriptor, observer, stream.cancelled::isDone,
-          () -> {
-            try {
-              stream.completed.get();
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-              throw CallStatus.INTERNAL
-                  .withDescription("Client error: interrupted while completing call")
-                  .withCause(e)
-                  .toRuntimeException();
-            } catch (ExecutionException e) {
-              throw CallStatus.INTERNAL
-                  .withDescription("Client error: internal while completing call")
-                  .withCause(e)
-                  .toRuntimeException();
-            }
-          });
+      final ClientStreamListener writer =
+          new PutObserver(
+              descriptor,
+              observer,
+              stream.cancelled::isDone,
+              () -> {
+                try {
+                  stream.completed.get();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw CallStatus.INTERNAL
+                      .withDescription("Client error: interrupted while completing call")
+                      .withCause(e)
+                      .toRuntimeException();
+                } catch (ExecutionException e) {
+                  throw CallStatus.INTERNAL
+                      .withDescription("Client error: internal while completing call")
+                      .withCause(e)
+                      .toRuntimeException();
+                }
+              });
       // Send the descriptor to start.
       try (final ArrowMessage message = new ArrowMessage(descriptor.toProtocol())) {
         observer.onNext(message);
@@ -432,13 +457,12 @@ public class FlightClient implements AutoCloseable {
 
     /**
      * Make sure stream is drained. You must call this to be notified of any errors that may have
-     * happened after the exchange is complete. This should be called after `getWriter().completed()`
-     * and instead of `getWriter().getResult()`.
+     * happened after the exchange is complete. This should be called after
+     * `getWriter().completed()` and instead of `getWriter().getResult()`.
      */
     public void getResult() {
       // After exchange is complete, make sure stream is drained to propagate errors through reader
-      while (reader.next()) {
-      }
+      while (reader.next()) {}
     }
 
     /** Shut down the streams in this call. */
@@ -448,9 +472,7 @@ public class FlightClient implements AutoCloseable {
     }
   }
 
-  /**
-   * A stream observer for Flight.PutResult
-   */
+  /** A stream observer for Flight.PutResult */
   private static class SetStreamObserver implements StreamObserver<Flight.PutResult> {
     private final BufferAllocator allocator;
     private final StreamListener<PutResult> listener;
@@ -479,9 +501,7 @@ public class FlightClient implements AutoCloseable {
     }
   }
 
-  /**
-   * The implementation of a {@link ClientStreamListener} for writing data to a Flight server.
-   */
+  /** The implementation of a {@link ClientStreamListener} for writing data to a Flight server. */
   static class PutObserver extends OutboundStreamListenerImpl implements ClientStreamListener {
     private final BooleanSupplier isCancelled;
     private final Runnable getResult;
@@ -494,8 +514,11 @@ public class FlightClient implements AutoCloseable {
      * @param isCancelled A flag to check if the call has been cancelled.
      * @param getResult A flag that blocks until the overall call completes.
      */
-    PutObserver(FlightDescriptor descriptor, ClientCallStreamObserver<ArrowMessage> observer,
-                BooleanSupplier isCancelled, Runnable getResult) {
+    PutObserver(
+        FlightDescriptor descriptor,
+        ClientCallStreamObserver<ArrowMessage> observer,
+        BooleanSupplier isCancelled,
+        Runnable getResult) {
       super(descriptor, observer);
       Preconditions.checkNotNull(descriptor, "descriptor must be provided");
       Preconditions.checkNotNull(isCancelled, "isCancelled must be provided");
@@ -527,8 +550,10 @@ public class FlightClient implements AutoCloseable {
    * @param options Call options.
    * @return The server response.
    */
-  public CancelFlightInfoResult cancelFlightInfo(CancelFlightInfoRequest request, CallOption... options) {
-    Action action = new Action(FlightConstants.CANCEL_FLIGHT_INFO.getType(), request.serialize().array());
+  public CancelFlightInfoResult cancelFlightInfo(
+      CancelFlightInfoRequest request, CallOption... options) {
+    Action action =
+        new Action(FlightConstants.CANCEL_FLIGHT_INFO.getType(), request.serialize().array());
     Iterator<Result> results = doAction(action, options);
     if (!results.hasNext()) {
       throw CallStatus.INTERNAL
@@ -545,8 +570,7 @@ public class FlightClient implements AutoCloseable {
           .withCause(e)
           .toRuntimeException();
     }
-    results.forEachRemaining((ignored) -> {
-    });
+    results.forEachRemaining((ignored) -> {});
     return result;
   }
 
@@ -557,8 +581,10 @@ public class FlightClient implements AutoCloseable {
    * @param options Call options.
    * @return The new endpoint with an updated expiration time.
    */
-  public FlightEndpoint renewFlightEndpoint(RenewFlightEndpointRequest request, CallOption... options) {
-    Action action = new Action(FlightConstants.RENEW_FLIGHT_ENDPOINT.getType(), request.serialize().array());
+  public FlightEndpoint renewFlightEndpoint(
+      RenewFlightEndpointRequest request, CallOption... options) {
+    Action action =
+        new Action(FlightConstants.RENEW_FLIGHT_ENDPOINT.getType(), request.serialize().array());
     Iterator<Result> results = doAction(action, options);
     if (!results.hasNext()) {
       throw CallStatus.INTERNAL
@@ -575,22 +601,23 @@ public class FlightClient implements AutoCloseable {
           .withCause(e)
           .toRuntimeException();
     }
-    results.forEachRemaining((ignored) -> {
-    });
+    results.forEachRemaining((ignored) -> {});
     return result;
   }
 
   /**
    * Set server session option(s) by name/value.
    *
-   * Sessions are generally persisted via HTTP cookies.
+   * <p>Sessions are generally persisted via HTTP cookies.
    *
    * @param request The session options to set on the server.
    * @param options Call options.
    * @return The result containing per-value error statuses, if any.
    */
-  public SetSessionOptionsResult setSessionOptions(SetSessionOptionsRequest request, CallOption... options) {
-    Action action = new Action(FlightConstants.SET_SESSION_OPTIONS.getType(), request.serialize().array());
+  public SetSessionOptionsResult setSessionOptions(
+      SetSessionOptionsRequest request, CallOption... options) {
+    Action action =
+        new Action(FlightConstants.SET_SESSION_OPTIONS.getType(), request.serialize().array());
     Iterator<Result> results = doAction(action, options);
     if (!results.hasNext()) {
       throw CallStatus.INTERNAL
@@ -607,22 +634,23 @@ public class FlightClient implements AutoCloseable {
           .withCause(e)
           .toRuntimeException();
     }
-    results.forEachRemaining((ignored) -> {
-    });
+    results.forEachRemaining((ignored) -> {});
     return result;
   }
 
   /**
    * Get the current server session options.
    *
-   * The session is generally accessed via an HTTP cookie.
+   * <p>The session is generally accessed via an HTTP cookie.
    *
    * @param request The (empty) GetSessionOptionsRequest.
    * @param options Call options.
    * @return The result containing the set of session options configured on the server.
    */
-  public GetSessionOptionsResult getSessionOptions(GetSessionOptionsRequest request, CallOption... options) {
-    Action action = new Action(FlightConstants.GET_SESSION_OPTIONS.getType(), request.serialize().array());
+  public GetSessionOptionsResult getSessionOptions(
+      GetSessionOptionsRequest request, CallOption... options) {
+    Action action =
+        new Action(FlightConstants.GET_SESSION_OPTIONS.getType(), request.serialize().array());
     Iterator<Result> results = doAction(action, options);
     if (!results.hasNext()) {
       throw CallStatus.INTERNAL
@@ -639,22 +667,22 @@ public class FlightClient implements AutoCloseable {
           .withCause(e)
           .toRuntimeException();
     }
-    results.forEachRemaining((ignored) -> {
-    });
+    results.forEachRemaining((ignored) -> {});
     return result;
   }
 
   /**
    * Close/invalidate the current server session.
    *
-   * The session is generally accessed via an HTTP cookie.
+   * <p>The session is generally accessed via an HTTP cookie.
    *
    * @param request The (empty) CloseSessionRequest.
    * @param options Call options.
    * @return The result containing the status of the close operation.
    */
   public CloseSessionResult closeSession(CloseSessionRequest request, CallOption... options) {
-    Action action = new Action(FlightConstants.CLOSE_SESSION.getType(), request.serialize().array());
+    Action action =
+        new Action(FlightConstants.CLOSE_SESSION.getType(), request.serialize().array());
     Iterator<Result> results = doAction(action, options);
     if (!results.hasNext()) {
       throw CallStatus.INTERNAL
@@ -671,19 +699,16 @@ public class FlightClient implements AutoCloseable {
           .withCause(e)
           .toRuntimeException();
     }
-    results.forEachRemaining((ignored) -> {
-    });
+    results.forEachRemaining((ignored) -> {});
     return result;
   }
 
-  /**
-   * Interface for writers to an Arrow data stream.
-   */
+  /** Interface for writers to an Arrow data stream. */
   public interface ClientStreamListener extends OutboundStreamListener {
 
     /**
-     * Wait for the stream to finish on the server side. You must call this to be notified of any errors that may have
-     * happened during the upload.
+     * Wait for the stream to finish on the server side. You must call this to be notified of any
+     * errors that may have happened during the upload.
      */
     void getResult();
   }
@@ -691,22 +716,22 @@ public class FlightClient implements AutoCloseable {
   /**
    * A handler for server-sent application metadata messages during a Flight DoPut operation.
    *
-   * <p>Generally, instead of implementing this yourself, you should use {@link AsyncPutListener} or {@link
-   * SyncPutListener}.
+   * <p>Generally, instead of implementing this yourself, you should use {@link AsyncPutListener} or
+   * {@link SyncPutListener}.
    */
   public interface PutListener extends StreamListener<PutResult> {
 
     /**
-     * Wait for the stream to finish on the server side. You must call this to be notified of any errors that may have
-     * happened during the upload.
+     * Wait for the stream to finish on the server side. You must call this to be notified of any
+     * errors that may have happened during the upload.
      */
     void getResult();
 
     /**
      * Called when a message from the server is received.
      *
-     * @param val The application metadata. This buffer will be reclaimed once onNext returns; you must retain a
-     *     reference to use it outside this method.
+     * @param val The application metadata. This buffer will be reclaimed once onNext returns; you
+     *     must retain a reference to use it outside this method.
      */
     @Override
     void onNext(PutResult val);
@@ -714,32 +739,29 @@ public class FlightClient implements AutoCloseable {
     /**
      * Check if the call has been cancelled.
      *
-     * <p>By default, this always returns false. Implementations should provide an appropriate implementation, as
-     * otherwise, a DoPut operation may inadvertently block forever.
+     * <p>By default, this always returns false. Implementations should provide an appropriate
+     * implementation, as otherwise, a DoPut operation may inadvertently block forever.
      */
     default boolean isCancelled() {
       return false;
     }
   }
 
-  /**
-   * Shut down this client.
-   */
+  /** Shut down this client. */
   @Override
   public void close() throws InterruptedException {
     channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
     allocator.close();
   }
 
-  /**
-   * Create a builder for a Flight client.
-   */
+  /** Create a builder for a Flight client. */
   public static Builder builder() {
     return new Builder();
   }
 
   /**
    * Create a builder for a Flight client.
+   *
    * @param allocator The allocator to use for the client.
    * @param location The location to connect to.
    */
@@ -747,9 +769,7 @@ public class FlightClient implements AutoCloseable {
     return new Builder(allocator, location);
   }
 
-  /**
-   * A builder for Flight clients.
-   */
+  /** A builder for Flight clients. */
   public static final class Builder {
     private BufferAllocator allocator;
     private Location location;
@@ -762,17 +782,14 @@ public class FlightClient implements AutoCloseable {
     private List<FlightClientMiddleware.Factory> middleware = new ArrayList<>();
     private boolean verifyServer = true;
 
-    private Builder() {
-    }
+    private Builder() {}
 
     private Builder(BufferAllocator allocator, Location location) {
       this.allocator = Preconditions.checkNotNull(allocator);
       this.location = Preconditions.checkNotNull(location);
     }
 
-    /**
-     * Force the client to connect over TLS.
-     */
+    /** Force the client to connect over TLS. */
     public Builder useTls() {
       this.forceTls = true;
       return this;
@@ -798,7 +815,8 @@ public class FlightClient implements AutoCloseable {
     }
 
     /** Set the trusted TLS certificates. */
-    public Builder clientCertificate(final InputStream clientCertificate, final InputStream clientKey) {
+    public Builder clientCertificate(
+        final InputStream clientCertificate, final InputStream clientKey) {
       Preconditions.checkNotNull(clientKey);
       this.clientCertificate = Preconditions.checkNotNull(clientCertificate);
       this.clientKey = Preconditions.checkNotNull(clientKey);
@@ -825,51 +843,59 @@ public class FlightClient implements AutoCloseable {
       return this;
     }
 
-    /**
-     * Create the client from this builder.
-     */
+    /** Create the client from this builder. */
     public FlightClient build() {
       final NettyChannelBuilder builder;
 
       switch (location.getUri().getScheme()) {
         case LocationSchemes.GRPC:
         case LocationSchemes.GRPC_INSECURE:
-        case LocationSchemes.GRPC_TLS: {
-          builder = NettyChannelBuilder.forAddress(location.toSocketAddress());
-          break;
-        }
-        case LocationSchemes.GRPC_DOMAIN_SOCKET: {
-          // The implementation is platform-specific, so we have to find the classes at runtime
-          builder = NettyChannelBuilder.forAddress(location.toSocketAddress());
-          try {
-            try {
-              // Linux
-              builder.channelType(
-                  Class.forName("io.netty.channel.epoll.EpollDomainSocketChannel")
-                      .asSubclass(ServerChannel.class));
-              final EventLoopGroup elg =
-                  Class.forName("io.netty.channel.epoll.EpollEventLoopGroup").asSubclass(EventLoopGroup.class)
-                  .getDeclaredConstructor().newInstance();
-              builder.eventLoopGroup(elg);
-            } catch (ClassNotFoundException e) {
-              // BSD
-              builder.channelType(
-                  Class.forName("io.netty.channel.kqueue.KQueueDomainSocketChannel")
-                      .asSubclass(ServerChannel.class));
-              final EventLoopGroup elg = Class.forName("io.netty.channel.kqueue.KQueueEventLoopGroup")
-                  .asSubclass(EventLoopGroup.class)
-                  .getDeclaredConstructor().newInstance();
-              builder.eventLoopGroup(elg);
-            }
-          } catch (ClassNotFoundException | InstantiationException | IllegalAccessException |
-                   NoSuchMethodException | InvocationTargetException e) {
-            throw new UnsupportedOperationException(
-                "Could not find suitable Netty native transport implementation for domain socket address.");
+        case LocationSchemes.GRPC_TLS:
+          {
+            builder = NettyChannelBuilder.forAddress(location.toSocketAddress());
+            break;
           }
-          break;
-        }
+        case LocationSchemes.GRPC_DOMAIN_SOCKET:
+          {
+            // The implementation is platform-specific, so we have to find the classes at runtime
+            builder = NettyChannelBuilder.forAddress(location.toSocketAddress());
+            try {
+              try {
+                // Linux
+                builder.channelType(
+                    Class.forName("io.netty.channel.epoll.EpollDomainSocketChannel")
+                        .asSubclass(ServerChannel.class));
+                final EventLoopGroup elg =
+                    Class.forName("io.netty.channel.epoll.EpollEventLoopGroup")
+                        .asSubclass(EventLoopGroup.class)
+                        .getDeclaredConstructor()
+                        .newInstance();
+                builder.eventLoopGroup(elg);
+              } catch (ClassNotFoundException e) {
+                // BSD
+                builder.channelType(
+                    Class.forName("io.netty.channel.kqueue.KQueueDomainSocketChannel")
+                        .asSubclass(ServerChannel.class));
+                final EventLoopGroup elg =
+                    Class.forName("io.netty.channel.kqueue.KQueueEventLoopGroup")
+                        .asSubclass(EventLoopGroup.class)
+                        .getDeclaredConstructor()
+                        .newInstance();
+                builder.eventLoopGroup(elg);
+              }
+            } catch (ClassNotFoundException
+                | InstantiationException
+                | IllegalAccessException
+                | NoSuchMethodException
+                | InvocationTargetException e) {
+              throw new UnsupportedOperationException(
+                  "Could not find suitable Netty native transport implementation for domain socket address.");
+            }
+            break;
+          }
         default:
-          throw new IllegalArgumentException("Scheme is not supported: " + location.getUri().getScheme());
+          throw new IllegalArgumentException(
+              "Scheme is not supported: " + location.getUri().getScheme());
       }
 
       if (this.forceTls || LocationSchemes.GRPC_TLS.equals(location.getUri().getScheme())) {
@@ -878,15 +904,18 @@ public class FlightClient implements AutoCloseable {
         final boolean hasTrustedCerts = this.trustedCertificates != null;
         final boolean hasKeyCertPair = this.clientCertificate != null && this.clientKey != null;
         if (!this.verifyServer && (hasTrustedCerts || hasKeyCertPair)) {
-          throw new IllegalArgumentException("FlightClient has been configured to disable server verification, " +
-              "but certificate options have been specified.");
+          throw new IllegalArgumentException(
+              "FlightClient has been configured to disable server verification, "
+                  + "but certificate options have been specified.");
         }
 
         final SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
 
         if (!this.verifyServer) {
           sslContextBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE);
-        } else if (this.trustedCertificates != null || this.clientCertificate != null || this.clientKey != null) {
+        } else if (this.trustedCertificates != null
+            || this.clientCertificate != null
+            || this.clientKey != null) {
           if (this.trustedCertificates != null) {
             sslContextBuilder.trustManager(this.trustedCertificates);
           }
@@ -916,11 +945,11 @@ public class FlightClient implements AutoCloseable {
   }
 
   /**
-   * Helper method to create a call from the asyncStub, method descriptor, and list of calling options.
+   * Helper method to create a call from the asyncStub, method descriptor, and list of calling
+   * options.
    */
   private <RequestT, ResponseT> ClientCall<RequestT, ResponseT> asyncStubNewCall(
-          MethodDescriptor<RequestT, ResponseT> descriptor,
-          CallOption... options) {
+      MethodDescriptor<RequestT, ResponseT> descriptor, CallOption... options) {
     FlightServiceStub wrappedStub = CallOptions.wrapStub(asyncStub, options);
     return wrappedStub.getChannel().newCall(descriptor, wrappedStub.getCallOptions());
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClientMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClientMiddleware.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 /**
@@ -23,29 +22,22 @@ package org.apache.arrow.flight;
  * <p>Middleware are instantiated per-call and should store state in the middleware instance.
  */
 public interface FlightClientMiddleware {
-  /**
-   * A callback used before request headers are sent. The headers may be manipulated.
-   */
+  /** A callback used before request headers are sent. The headers may be manipulated. */
   void onBeforeSendingHeaders(CallHeaders outgoingHeaders);
 
-  /**
-   * A callback called after response headers are received. The headers may be manipulated.
-   */
+  /** A callback called after response headers are received. The headers may be manipulated. */
   void onHeadersReceived(CallHeaders incomingHeaders);
 
-  /**
-   * A callback called after the call completes.
-   */
+  /** A callback called after the call completes. */
   void onCallCompleted(CallStatus status);
 
-  /**
-   * A factory for client middleware instances.
-   */
+  /** A factory for client middleware instances. */
   interface Factory {
     /**
      * Create a new middleware instance for the given call.
      *
-     * @throws FlightRuntimeException if the middleware wants to reject the call with the given status
+     * @throws FlightRuntimeException if the middleware wants to reject the call with the given
+     *     status
      */
     FlightClientMiddleware onCallStarted(CallInfo info);
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightConstants.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightConstants.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-/**
- * String constants relevant to flight implementations.
- */
+/** String constants relevant to flight implementations. */
 public interface FlightConstants {
 
   String SERVICE = "arrow.flight.protocol.FlightService";
@@ -27,26 +24,36 @@ public interface FlightConstants {
   FlightServerMiddleware.Key<ServerHeaderMiddleware> HEADER_KEY =
       FlightServerMiddleware.Key.of("org.apache.arrow.flight.ServerHeaderMiddleware");
 
-  ActionType CANCEL_FLIGHT_INFO = new ActionType("CancelFlightInfo",
-      "Explicitly cancel a running FlightInfo.\n" +
-          "Request Message: CancelFlightInfoRequest\n" +
-          "Response Message: CancelFlightInfoResult");
-  ActionType RENEW_FLIGHT_ENDPOINT = new ActionType("RenewFlightEndpoint",
-      "Extend expiration time of the given FlightEndpoint.\n" +
-          "Request Message: RenewFlightEndpointRequest\n" +
-          "Response Message: Renewed FlightEndpoint");
+  ActionType CANCEL_FLIGHT_INFO =
+      new ActionType(
+          "CancelFlightInfo",
+          "Explicitly cancel a running FlightInfo.\n"
+              + "Request Message: CancelFlightInfoRequest\n"
+              + "Response Message: CancelFlightInfoResult");
+  ActionType RENEW_FLIGHT_ENDPOINT =
+      new ActionType(
+          "RenewFlightEndpoint",
+          "Extend expiration time of the given FlightEndpoint.\n"
+              + "Request Message: RenewFlightEndpointRequest\n"
+              + "Response Message: Renewed FlightEndpoint");
 
-  ActionType SET_SESSION_OPTIONS = new ActionType("SetSessionOptions",
-          "Set client session options by name/value pairs.\n" +
-          "Request Message: SetSessionOptionsRequest\n" +
-          "Response Message: SetSessionOptionsResult");
+  ActionType SET_SESSION_OPTIONS =
+      new ActionType(
+          "SetSessionOptions",
+          "Set client session options by name/value pairs.\n"
+              + "Request Message: SetSessionOptionsRequest\n"
+              + "Response Message: SetSessionOptionsResult");
 
-  ActionType GET_SESSION_OPTIONS = new ActionType("GetSessionOptions",
-          "Get current client session options\n" +
-          "Request Message: GetSessionOptionsRequest\n" +
-          "Response Message: GetSessionOptionsResult");
-  ActionType CLOSE_SESSION = new ActionType("CloseSession",
-          "Explicitly close/invalidate the cookie-specified client session.\n" +
-          "Request Message: CloseSessionRequest\n" +
-          "Response Message: CloseSessionResult");
+  ActionType GET_SESSION_OPTIONS =
+      new ActionType(
+          "GetSessionOptions",
+          "Get current client session options\n"
+              + "Request Message: GetSessionOptionsRequest\n"
+              + "Response Message: GetSessionOptionsResult");
+  ActionType CLOSE_SESSION =
+      new ActionType(
+          "CloseSession",
+          "Explicitly close/invalidate the cookie-specified client session.\n"
+              + "Request Message: CloseSessionRequest\n"
+              + "Response Message: CloseSessionResult");
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
@@ -14,25 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.arrow.flight.impl.Flight;
-import org.apache.arrow.flight.impl.Flight.FlightDescriptor.DescriptorType;
-import org.apache.arrow.util.Preconditions;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.arrow.flight.impl.Flight;
+import org.apache.arrow.flight.impl.Flight.FlightDescriptor.DescriptorType;
+import org.apache.arrow.util.Preconditions;
 
 /**
- * An identifier for a particular set of data.  This can either be an opaque command that generates
- * the data or a static "path" to the data.  This is a POJO wrapper around the protobuf message with
+ * An identifier for a particular set of data. This can either be an opaque command that generates
+ * the data or a static "path" to the data. This is a POJO wrapper around the protobuf message with
  * the same name.
  */
 public class FlightDescriptor {
@@ -56,7 +53,7 @@ public class FlightDescriptor {
     return new FlightDescriptor(false, ImmutableList.copyOf(path), null);
   }
 
-  public static FlightDescriptor path(String...path) {
+  public static FlightDescriptor path(String... path) {
     return new FlightDescriptor(false, ImmutableList.copyOf(path), null);
   }
 
@@ -98,7 +95,8 @@ public class FlightDescriptor {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -107,9 +105,11 @@ public class FlightDescriptor {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
-   * @param serialized The serialized form of the FlightDescriptor, as returned by {@link #serialize()}.
+   * @param serialized The serialized form of the FlightDescriptor, as returned by {@link
+   *     #serialize()}.
    * @return The deserialized FlightDescriptor.
    * @throws IOException if the serialized form is invalid.
    */
@@ -175,6 +175,4 @@ public class FlightDescriptor {
     }
     return true;
   }
-
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightEndpoint.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightEndpoint.java
@@ -14,9 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
@@ -28,16 +30,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.apache.arrow.flight.impl.Flight;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
-
-/**
- * POJO to convert to/from the underlying protobuf FlightEndpoint.
- */
+/** POJO to convert to/from the underlying protobuf FlightEndpoint. */
 public class FlightEndpoint {
   private final List<Location> locations;
   private final Ticket ticket;
@@ -48,10 +43,10 @@ public class FlightEndpoint {
    * Constructs a new endpoint with no expiration time.
    *
    * @param ticket A ticket that describe the key of a data stream.
-   * @param locations  The possible locations the stream can be retrieved from.
+   * @param locations The possible locations the stream can be retrieved from.
    */
   public FlightEndpoint(Ticket ticket, Location... locations) {
-    this(ticket, /*expirationTime*/null, locations);
+    this(ticket, /*expirationTime*/ null, locations);
   }
 
   /**
@@ -59,16 +54,19 @@ public class FlightEndpoint {
    *
    * @param ticket A ticket that describe the key of a data stream.
    * @param expirationTime (optional) When this endpoint expires.
-   * @param locations  The possible locations the stream can be retrieved from.
+   * @param locations The possible locations the stream can be retrieved from.
    */
   public FlightEndpoint(Ticket ticket, Instant expirationTime, Location... locations) {
-    this(ticket, expirationTime, null, Collections.unmodifiableList(new ArrayList<>(Arrays.asList(locations))));
+    this(
+        ticket,
+        expirationTime,
+        null,
+        Collections.unmodifiableList(new ArrayList<>(Arrays.asList(locations))));
   }
 
-  /**
-   * Private constructor with all parameters. Should only be called by Builder.
-   */
-  private FlightEndpoint(Ticket ticket, Instant expirationTime, byte[] appMetadata, List<Location> locations) {
+  /** Private constructor with all parameters. Should only be called by Builder. */
+  private FlightEndpoint(
+      Ticket ticket, Instant expirationTime, byte[] appMetadata, List<Location> locations) {
     Objects.requireNonNull(ticket);
     this.locations = locations;
     this.expirationTime = expirationTime;
@@ -76,17 +74,16 @@ public class FlightEndpoint {
     this.appMetadata = appMetadata;
   }
 
-  /**
-   * Constructs from the protocol buffer representation.
-   */
+  /** Constructs from the protocol buffer representation. */
   FlightEndpoint(Flight.FlightEndpoint flt) throws URISyntaxException {
     this.locations = new ArrayList<>();
     for (final Flight.Location location : flt.getLocationList()) {
       this.locations.add(new Location(location.getUri()));
     }
     if (flt.hasExpirationTime()) {
-      this.expirationTime = Instant.ofEpochSecond(
-          flt.getExpirationTime().getSeconds(), Timestamps.toNanos(flt.getExpirationTime()));
+      this.expirationTime =
+          Instant.ofEpochSecond(
+              flt.getExpirationTime().getSeconds(), Timestamps.toNanos(flt.getExpirationTime()));
     } else {
       this.expirationTime = null;
     }
@@ -110,12 +107,10 @@ public class FlightEndpoint {
     return appMetadata;
   }
 
-  /**
-   * Converts to the protocol buffer representation.
-   */
+  /** Converts to the protocol buffer representation. */
   Flight.FlightEndpoint toProtocol() {
-    Flight.FlightEndpoint.Builder b = Flight.FlightEndpoint.newBuilder()
-        .setTicket(ticket.toProtocol());
+    Flight.FlightEndpoint.Builder b =
+        Flight.FlightEndpoint.newBuilder().setTicket(ticket.toProtocol());
 
     for (Location l : locations) {
       b.addLocation(l.toProtocol());
@@ -139,7 +134,8 @@ public class FlightEndpoint {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -148,14 +144,16 @@ public class FlightEndpoint {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.
    * @throws IOException if the serialized form is invalid.
    * @throws URISyntaxException if the serialized form contains an unsupported URI format.
    */
-  public static FlightEndpoint deserialize(ByteBuffer serialized) throws IOException, URISyntaxException {
+  public static FlightEndpoint deserialize(ByteBuffer serialized)
+      throws IOException, URISyntaxException {
     return new FlightEndpoint(Flight.FlightEndpoint.parseFrom(serialized));
   }
 
@@ -168,10 +166,10 @@ public class FlightEndpoint {
       return false;
     }
     FlightEndpoint that = (FlightEndpoint) o;
-    return locations.equals(that.locations) &&
-        ticket.equals(that.ticket) &&
-        Objects.equals(expirationTime, that.expirationTime) &&
-        Arrays.equals(appMetadata, that.appMetadata);
+    return locations.equals(that.locations)
+        && ticket.equals(that.ticket)
+        && Objects.equals(expirationTime, that.expirationTime)
+        && Arrays.equals(appMetadata, that.appMetadata);
   }
 
   @Override
@@ -181,27 +179,29 @@ public class FlightEndpoint {
 
   @Override
   public String toString() {
-    return "FlightEndpoint{" +
-        "locations=" + locations +
-        ", ticket=" + ticket +
-        ", expirationTime=" + (expirationTime == null ? "(none)" : expirationTime.toString()) +
-        ", appMetadata=" + (appMetadata == null ? "(none)" : Base64.getEncoder().encodeToString(appMetadata)) +
-        '}';
+    return "FlightEndpoint{"
+        + "locations="
+        + locations
+        + ", ticket="
+        + ticket
+        + ", expirationTime="
+        + (expirationTime == null ? "(none)" : expirationTime.toString())
+        + ", appMetadata="
+        + (appMetadata == null ? "(none)" : Base64.getEncoder().encodeToString(appMetadata))
+        + '}';
   }
 
   /**
    * Create a builder for FlightEndpoint.
    *
    * @param ticket A ticket that describe the key of a data stream.
-   * @param locations  The possible locations the stream can be retrieved from.
+   * @param locations The possible locations the stream can be retrieved from.
    */
   public static Builder builder(Ticket ticket, Location... locations) {
     return new Builder(ticket, locations);
   }
 
-  /**
-   * Builder for FlightEndpoint.
-   */
+  /** Builder for FlightEndpoint. */
   public static final class Builder {
     private final Ticket ticket;
     private final List<Location> locations;
@@ -233,9 +233,7 @@ public class FlightEndpoint {
       return this;
     }
 
-    /**
-     * Build FlightEndpoint object.
-     */
+    /** Build FlightEndpoint object. */
     public FlightEndpoint build() {
       return new FlightEndpoint(ticket, expirationTime, appMetadata, locations);
     }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
@@ -14,16 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
-
-import java.util.Collections;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.arrow.flight.auth.ServerAuthHandler;
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.VisibleForTesting;
 
 import io.grpc.BindableService;
 import io.grpc.CallOptions;
@@ -31,14 +22,16 @@ import io.grpc.ClientCall;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.arrow.flight.auth.ServerAuthHandler;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.VisibleForTesting;
 
-/**
- * Exposes Flight GRPC service & client.
- */
+/** Exposes Flight GRPC service & client. */
 public class FlightGrpcUtils {
-  /**
-   * Proxy class for ManagedChannel that makes closure a no-op.
-   */
+  /** Proxy class for ManagedChannel that makes closure a no-op. */
   @VisibleForTesting
   static class NonClosingProxyManagedChannel extends ManagedChannel {
     private final ManagedChannel channel;
@@ -107,9 +100,12 @@ public class FlightGrpcUtils {
 
     @Override
     public void notifyWhenStateChanged(ConnectivityState source, Runnable callback) {
-      // The proxy has no insight into the underlying channel state changes, so we'll have to leak the abstraction
-      // a bit here and simply pass to the underlying channel, even though it will never transition to shutdown via
-      // the proxy. This should be fine, since it's mainly targeted at the FlightClient and there's no getter for
+      // The proxy has no insight into the underlying channel state changes, so we'll have to leak
+      // the abstraction
+      // a bit here and simply pass to the underlying channel, even though it will never transition
+      // to shutdown via
+      // the proxy. This should be fine, since it's mainly targeted at the FlightClient and there's
+      // no getter for
       // the channel.
       this.channel.notifyWhenStateChanged(source, callback);
     }
@@ -125,38 +121,46 @@ public class FlightGrpcUtils {
     }
   }
 
-  private FlightGrpcUtils() {
-  }
+  private FlightGrpcUtils() {}
 
   /**
    * Creates a Flight service.
+   *
    * @param allocator Memory allocator
    * @param producer Specifies the service api
    * @param authHandler Authentication handler
    * @param executor Executor service
    * @return FlightBindingService
    */
-  public static BindableService createFlightService(BufferAllocator allocator, FlightProducer producer,
-                                                    ServerAuthHandler authHandler, ExecutorService executor) {
+  public static BindableService createFlightService(
+      BufferAllocator allocator,
+      FlightProducer producer,
+      ServerAuthHandler authHandler,
+      ExecutorService executor) {
     return new FlightBindingService(allocator, producer, authHandler, executor);
   }
 
   /**
    * Creates a Flight client.
-   * @param incomingAllocator  Memory allocator
+   *
+   * @param incomingAllocator Memory allocator
    * @param channel provides a connection to a gRPC server.
    */
-  public static FlightClient createFlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
+  public static FlightClient createFlightClient(
+      BufferAllocator incomingAllocator, ManagedChannel channel) {
     return new FlightClient(incomingAllocator, channel, Collections.emptyList());
   }
 
   /**
    * Creates a Flight client.
-   * @param incomingAllocator  Memory allocator
-   * @param channel provides a connection to a gRPC server. Will not be closed on closure of the returned FlightClient.
+   *
+   * @param incomingAllocator Memory allocator
+   * @param channel provides a connection to a gRPC server. Will not be closed on closure of the
+   *     returned FlightClient.
    */
   public static FlightClient createFlightClientWithSharedChannel(
       BufferAllocator incomingAllocator, ManagedChannel channel) {
-    return new FlightClient(incomingAllocator, new NonClosingProxyManagedChannel(channel), Collections.emptyList());
+    return new FlightClient(
+        incomingAllocator, new NonClosingProxyManagedChannel(channel), Collections.emptyList());
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightMethod.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightMethod.java
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import org.apache.arrow.flight.impl.FlightServiceGrpc;
 
-/**
- * All the RPC methods available in Flight.
- */
+/** All the RPC methods available in Flight. */
 public enum FlightMethod {
   HANDSHAKE,
   LIST_FLIGHTS,

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightProducer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightProducer.java
@@ -14,14 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.Map;
 
-/**
- * API to Implement an Arrow Flight producer.
- */
+/** API to Implement an Arrow Flight producer. */
 public interface FlightProducer {
 
   /**
@@ -40,8 +37,7 @@ public interface FlightProducer {
    * @param criteria Application-defined criteria for filtering streams.
    * @param listener An interface for sending data back to the client.
    */
-  void listFlights(CallContext context, Criteria criteria,
-      StreamListener<FlightInfo> listener);
+  void listFlights(CallContext context, Criteria criteria, StreamListener<FlightInfo> listener);
 
   /**
    * Get information about a particular data stream.
@@ -55,9 +51,9 @@ public interface FlightProducer {
   /**
    * Begin or get an update on execution of a long-running query.
    *
-   * <p>If the descriptor would begin a query, the server should return a response immediately to not
-   * block the client. Otherwise, the server should not return an update until progress is made to
-   * not spam the client with inactionable updates.
+   * <p>If the descriptor would begin a query, the server should return a response immediately to
+   * not block the client. Otherwise, the server should not return an update until progress is made
+   * to not spam the client with inactionable updates.
    *
    * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
@@ -77,14 +73,14 @@ public interface FlightProducer {
    */
   default SchemaResult getSchema(CallContext context, FlightDescriptor descriptor) {
     FlightInfo info = getFlightInfo(context, descriptor);
-    return new SchemaResult(info
-            .getSchemaOptional()
-            .orElseThrow(() ->
-                    CallStatus
-                            .INVALID_ARGUMENT
-                            .withDescription("No schema is present in FlightInfo").toRuntimeException()));
+    return new SchemaResult(
+        info.getSchemaOptional()
+            .orElseThrow(
+                () ->
+                    CallStatus.INVALID_ARGUMENT
+                        .withDescription("No schema is present in FlightInfo")
+                        .toRuntimeException()));
   }
-
 
   /**
    * Accept uploaded data for a particular stream.
@@ -92,11 +88,21 @@ public interface FlightProducer {
    * @param context Per-call context.
    * @param flightStream The data stream being uploaded.
    */
-  Runnable acceptPut(CallContext context,
-      FlightStream flightStream, StreamListener<PutResult> ackStream);
+  Runnable acceptPut(
+      CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream);
 
+  /**
+   * This method is used to perform a bidirectional data exchange between a client and a server.
+   *
+   * @param context Per-call context.
+   * @param reader The FlightStream from which data is read.
+   * @param writer The ServerStreamListener to which data is written.
+   * @throws RuntimeException if the method is not implemented.
+   */
   default void doExchange(CallContext context, FlightStream reader, ServerStreamListener writer) {
-    throw CallStatus.UNIMPLEMENTED.withDescription("DoExchange is unimplemented").toRuntimeException();
+    throw CallStatus.UNIMPLEMENTED
+        .withDescription("DoExchange is unimplemented")
+        .toRuntimeException();
   }
 
   /**
@@ -106,32 +112,29 @@ public interface FlightProducer {
    * @param action Client-supplied parameters.
    * @param listener A stream of responses.
    */
-  void doAction(CallContext context, Action action,
-      StreamListener<Result> listener);
+  void doAction(CallContext context, Action action, StreamListener<Result> listener);
 
   /**
    * List available application-defined RPCs.
+   *
    * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
   void listActions(CallContext context, StreamListener<ActionType> listener);
 
-  /**
-   * An interface for sending Arrow data back to a client.
-   */
+  /** An interface for sending Arrow data back to a client. */
   interface ServerStreamListener extends OutboundStreamListener {
 
-    /**
-     * Check whether the call has been cancelled. If so, stop sending data.
-     */
+    /** Check whether the call has been cancelled. If so, stop sending data. */
     boolean isCancelled();
 
     /**
-     * Set a callback for when the client cancels a call, i.e. {@link #isCancelled()} has become true.
+     * Set a callback for when the client cancels a call, i.e. {@link #isCancelled()} has become
+     * true.
      *
-     * <p>Note that this callback may only be called some time after {@link #isCancelled()} becomes true, and may never
-     * be called if all executor threads on the server are busy, or the RPC method body is implemented in a blocking
-     * fashion.
+     * <p>Note that this callback may only be called some time after {@link #isCancelled()} becomes
+     * true, and may never be called if all executor threads on the server are busy, or the RPC
+     * method body is implemented in a blocking fashion.
      */
     void setOnCancelHandler(Runnable handler);
   }
@@ -143,9 +146,7 @@ public interface FlightProducer {
    */
   interface StreamListener<T> {
 
-    /**
-     * Send the next value to the client.
-     */
+    /** Send the next value to the client. */
     void onNext(T val);
 
     /**
@@ -155,16 +156,11 @@ public interface FlightProducer {
      */
     void onError(Throwable t);
 
-    /**
-     * Indicate that the transmission is finished.
-     */
+    /** Indicate that the transmission is finished. */
     void onCompleted();
-
   }
 
-  /**
-   * Call-specific context.
-   */
+  /** Call-specific context. */
   interface CallContext {
     /** The identity of the authenticated peer. May be the empty string if unknown. */
     String peerIdentity();

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
@@ -14,21 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 /**
  * An exception raised from a Flight RPC.
  *
- * <p>In service implementations, raising an instance of this exception will provide clients with a more detailed
- * message and error code.
+ * <p>In service implementations, raising an instance of this exception will provide clients with a
+ * more detailed message and error code.
  */
 public class FlightRuntimeException extends RuntimeException {
   private final CallStatus status;
 
-  /**
-   * Create a new exception from the given status.
-   */
+  /** Create a new exception from the given status. */
   FlightRuntimeException(CallStatus status) {
     super(status.description(), status.cause());
     this.status = status;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -14,9 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.grpc.Server;
+import io.grpc.ServerInterceptors;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NettyServerBuilder;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -34,9 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-
 import javax.net.ssl.SSLException;
-
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.flight.auth.ServerAuthInterceptor;
 import org.apache.arrow.flight.auth2.Auth2Constants;
@@ -49,33 +56,21 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.util.VisibleForTesting;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
-import io.grpc.Server;
-import io.grpc.ServerInterceptors;
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NettyServerBuilder;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
-import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-
-
 /**
  * Generic server of flight data that is customized via construction with delegate classes for the
- * actual logic.  The server currently uses GRPC as its transport mechanism.
+ * actual logic. The server currently uses GRPC as its transport mechanism.
  */
 public class FlightServer implements AutoCloseable {
 
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FlightServer.class);
+  private static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(FlightServer.class);
 
   private final Location location;
   private final Server server;
-  // The executor used by the gRPC server. We don't use it here, but we do need to clean it up with the server.
+  // The executor used by the gRPC server. We don't use it here, but we do need to clean it up with
+  // the server.
   // May be null, if a user-supplied executor was provided (as we do not want to clean that up)
-  @VisibleForTesting
-  final ExecutorService grpcExecutor;
+  @VisibleForTesting final ExecutorService grpcExecutor;
 
   /** The maximum size of an individual gRPC message. This effectively disables the limit. */
   static final int MAX_GRPC_MESSAGE_SIZE = Integer.MAX_VALUE;
@@ -107,8 +102,15 @@ public class FlightServer implements AutoCloseable {
       // If the server was bound to port 0, replace the port in the location with the real port.
       final URI uri = location.getUri();
       try {
-        return new Location(new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), getPort(),
-            uri.getPath(), uri.getQuery(), uri.getFragment()));
+        return new Location(
+            new URI(
+                uri.getScheme(),
+                uri.getUserInfo(),
+                uri.getHost(),
+                getPort(),
+                uri.getPath(),
+                uri.getQuery(),
+                uri.getFragment()));
       } catch (URISyntaxException e) {
         // We don't expect this to happen
         throw new RuntimeException(e);
@@ -132,9 +134,11 @@ public class FlightServer implements AutoCloseable {
 
   /**
    * Wait for the server to shut down with a timeout.
+   *
    * @return true if the server shut down successfully.
    */
-  public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+  public boolean awaitTermination(final long timeout, final TimeUnit unit)
+      throws InterruptedException {
     return server.awaitTermination(timeout, unit);
   }
 
@@ -169,7 +173,8 @@ public class FlightServer implements AutoCloseable {
   }
 
   /** Create a builder for a Flight server. */
-  public static Builder builder(BufferAllocator allocator, Location location, FlightProducer producer) {
+  public static Builder builder(
+      BufferAllocator allocator, Location location, FlightProducer producer) {
     return new Builder(allocator, location, producer);
   }
 
@@ -209,7 +214,8 @@ public class FlightServer implements AutoCloseable {
     public FlightServer build() {
       // Add the auth middleware if applicable.
       if (headerAuthenticator != CallHeaderAuthenticator.NO_OP) {
-        this.middleware(FlightServerMiddleware.Key.of(Auth2Constants.AUTHORIZATION_HEADER),
+        this.middleware(
+            FlightServerMiddleware.Key.of(Auth2Constants.AUTHORIZATION_HEADER),
             new ServerCallHeaderAuthMiddleware.Factory(headerAuthenticator));
       }
 
@@ -217,58 +223,69 @@ public class FlightServer implements AutoCloseable {
 
       final NettyServerBuilder builder;
       switch (location.getUri().getScheme()) {
-        case LocationSchemes.GRPC_DOMAIN_SOCKET: {
-          // The implementation is platform-specific, so we have to find the classes at runtime
-          builder = NettyServerBuilder.forAddress(location.toSocketAddress());
-          try {
+        case LocationSchemes.GRPC_DOMAIN_SOCKET:
+          {
+            // The implementation is platform-specific, so we have to find the classes at runtime
+            builder = NettyServerBuilder.forAddress(location.toSocketAddress());
             try {
-              // Linux
-              builder.channelType(Class
-                      .forName("io.netty.channel.epoll.EpollServerDomainSocketChannel")
-                      .asSubclass(ServerChannel.class));
-              final EventLoopGroup elg = Class.forName("io.netty.channel.epoll.EpollEventLoopGroup")
-                      .asSubclass(EventLoopGroup.class).getConstructor().newInstance();
-              builder.bossEventLoopGroup(elg).workerEventLoopGroup(elg);
-            } catch (ClassNotFoundException e) {
-              // BSD
-              builder.channelType(
-                      Class.forName("io.netty.channel.kqueue.KQueueServerDomainSocketChannel")
-                              .asSubclass(ServerChannel.class));
-              final EventLoopGroup elg = Class.forName("io.netty.channel.kqueue.KQueueEventLoopGroup")
-                      .asSubclass(EventLoopGroup.class).getConstructor().newInstance();
-              builder.bossEventLoopGroup(elg).workerEventLoopGroup(elg);
+              try {
+                // Linux
+                builder.channelType(
+                    Class.forName("io.netty.channel.epoll.EpollServerDomainSocketChannel")
+                        .asSubclass(ServerChannel.class));
+                final EventLoopGroup elg =
+                    Class.forName("io.netty.channel.epoll.EpollEventLoopGroup")
+                        .asSubclass(EventLoopGroup.class)
+                        .getConstructor()
+                        .newInstance();
+                builder.bossEventLoopGroup(elg).workerEventLoopGroup(elg);
+              } catch (ClassNotFoundException e) {
+                // BSD
+                builder.channelType(
+                    Class.forName("io.netty.channel.kqueue.KQueueServerDomainSocketChannel")
+                        .asSubclass(ServerChannel.class));
+                final EventLoopGroup elg =
+                    Class.forName("io.netty.channel.kqueue.KQueueEventLoopGroup")
+                        .asSubclass(EventLoopGroup.class)
+                        .getConstructor()
+                        .newInstance();
+                builder.bossEventLoopGroup(elg).workerEventLoopGroup(elg);
+              }
+            } catch (ClassNotFoundException
+                | InstantiationException
+                | IllegalAccessException
+                | NoSuchMethodException
+                | InvocationTargetException e) {
+              throw new UnsupportedOperationException(
+                  "Could not find suitable Netty native transport implementation for domain socket address.");
             }
-          } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException |
-                   InvocationTargetException e) {
-            throw new UnsupportedOperationException(
-                "Could not find suitable Netty native transport implementation for domain socket address.");
+            break;
           }
-          break;
-        }
         case LocationSchemes.GRPC:
-        case LocationSchemes.GRPC_INSECURE: {
-          builder = NettyServerBuilder.forAddress(location.toSocketAddress());
-          break;
-        }
-        case LocationSchemes.GRPC_TLS: {
-          if (certChain == null) {
-            throw new IllegalArgumentException("Must provide a certificate and key to serve gRPC over TLS");
+        case LocationSchemes.GRPC_INSECURE:
+          {
+            builder = NettyServerBuilder.forAddress(location.toSocketAddress());
+            break;
           }
-          builder = NettyServerBuilder.forAddress(location.toSocketAddress());
-          break;
-        }
+        case LocationSchemes.GRPC_TLS:
+          {
+            if (certChain == null) {
+              throw new IllegalArgumentException(
+                  "Must provide a certificate and key to serve gRPC over TLS");
+            }
+            builder = NettyServerBuilder.forAddress(location.toSocketAddress());
+            break;
+          }
         default:
-          throw new IllegalArgumentException("Scheme is not supported: " + location.getUri().getScheme());
+          throw new IllegalArgumentException(
+              "Scheme is not supported: " + location.getUri().getScheme());
       }
 
       if (certChain != null) {
-        SslContextBuilder sslContextBuilder = GrpcSslContexts
-                .forServer(certChain, key);
+        SslContextBuilder sslContextBuilder = GrpcSslContexts.forServer(certChain, key);
 
         if (mTlsCACert != null) {
-          sslContextBuilder
-                  .clientAuth(ClientAuth.REQUIRE)
-                  .trustManager(mTlsCACert);
+          sslContextBuilder.clientAuth(ClientAuth.REQUIRE).trustManager(mTlsCACert);
         }
         try {
           sslContext = sslContextBuilder.build();
@@ -285,20 +302,25 @@ public class FlightServer implements AutoCloseable {
 
       // Share one executor between the gRPC service, DoPut, and Handshake
       final ExecutorService exec;
-      // We only want to have FlightServer close the gRPC executor if we created it here. We should not close
+      // We only want to have FlightServer close the gRPC executor if we created it here. We should
+      // not close
       // user-supplied executors.
       final ExecutorService grpcExecutor;
       if (executor != null) {
         exec = executor;
         grpcExecutor = null;
       } else {
-        exec = Executors.newCachedThreadPool(
-            // Name threads for better debuggability
-            new ThreadFactoryBuilder().setNameFormat("flight-server-default-executor-%d").build());
+        exec =
+            Executors.newCachedThreadPool(
+                // Name threads for better debuggability
+                new ThreadFactoryBuilder()
+                    .setNameFormat("flight-server-default-executor-%d")
+                    .build());
         grpcExecutor = exec;
       }
 
-      final FlightBindingService flightService = new FlightBindingService(allocator, producer, authHandler, exec);
+      final FlightBindingService flightService =
+          new FlightBindingService(allocator, producer, authHandler, exec);
       builder
           .executor(exec)
           .maxInboundMessageSize(maxInboundMessageSize)
@@ -308,34 +330,45 @@ public class FlightServer implements AutoCloseable {
                   new ServerBackpressureThresholdInterceptor(backpressureThreshold),
                   new ServerAuthInterceptor(authHandler)));
 
-      // Allow hooking into the gRPC builder. This is not guaranteed to be available on all Arrow versions or
+      // Allow hooking into the gRPC builder. This is not guaranteed to be available on all Arrow
+      // versions or
       // Flight implementations.
-      builderOptions.computeIfPresent("grpc.builderConsumer", (key, builderConsumer) -> {
-        final Consumer<NettyServerBuilder> consumer = (Consumer<NettyServerBuilder>) builderConsumer;
-        consumer.accept(builder);
-        return null;
-      });
+      builderOptions.computeIfPresent(
+          "grpc.builderConsumer",
+          (key, builderConsumer) -> {
+            final Consumer<NettyServerBuilder> consumer =
+                (Consumer<NettyServerBuilder>) builderConsumer;
+            consumer.accept(builder);
+            return null;
+          });
 
       // Allow explicitly setting some Netty-specific options
-      builderOptions.computeIfPresent("netty.channelType", (key, channelType) -> {
-        builder.channelType((Class<? extends ServerChannel>) channelType);
-        return null;
-      });
-      builderOptions.computeIfPresent("netty.bossEventLoopGroup", (key, elg) -> {
-        builder.bossEventLoopGroup((EventLoopGroup) elg);
-        return null;
-      });
-      builderOptions.computeIfPresent("netty.workerEventLoopGroup", (key, elg) -> {
-        builder.workerEventLoopGroup((EventLoopGroup) elg);
-        return null;
-      });
+      builderOptions.computeIfPresent(
+          "netty.channelType",
+          (key, channelType) -> {
+            builder.channelType((Class<? extends ServerChannel>) channelType);
+            return null;
+          });
+      builderOptions.computeIfPresent(
+          "netty.bossEventLoopGroup",
+          (key, elg) -> {
+            builder.bossEventLoopGroup((EventLoopGroup) elg);
+            return null;
+          });
+      builderOptions.computeIfPresent(
+          "netty.workerEventLoopGroup",
+          (key, elg) -> {
+            builder.workerEventLoopGroup((EventLoopGroup) elg);
+            return null;
+          });
 
       builder.intercept(new ServerInterceptorAdapter(interceptors));
       return new FlightServer(location, builder.build(), grpcExecutor);
     }
 
     /**
-     * Set the maximum size of a message. Defaults to "unlimited", depending on the underlying transport.
+     * Set the maximum size of a message. Defaults to "unlimited", depending on the underlying
+     * transport.
      */
     public Builder maxInboundMessageSize(int maxMessageSize) {
       this.maxInboundMessageSize = maxMessageSize;
@@ -343,7 +376,8 @@ public class FlightServer implements AutoCloseable {
     }
 
     /**
-     * Set the number of bytes that may be queued on a server output stream before writes are blocked.
+     * Set the number of bytes that may be queued on a server output stream before writes are
+     * blocked.
      */
     public Builder backpressureThreshold(int backpressureThreshold) {
       Preconditions.checkArgument(backpressureThreshold > 0);
@@ -352,8 +386,9 @@ public class FlightServer implements AutoCloseable {
     }
 
     /**
-     * A small utility function to ensure that InputStream attributes.
-     * are closed if they are not null
+     * A small utility function to ensure that InputStream attributes. are closed if they are not
+     * null
+     *
      * @param stream The InputStream to close (if it is not null).
      */
     private void closeInputStreamIfNotNull(InputStream stream) {
@@ -367,8 +402,8 @@ public class FlightServer implements AutoCloseable {
     }
 
     /**
-     * A small utility function to ensure that the certChain attribute
-     * is closed if it is not null.  It then sets the attribute to null.
+     * A small utility function to ensure that the certChain attribute is closed if it is not null.
+     * It then sets the attribute to null.
      */
     private void closeCertChain() {
       closeInputStreamIfNotNull(certChain);
@@ -376,8 +411,8 @@ public class FlightServer implements AutoCloseable {
     }
 
     /**
-     * A small utility function to ensure that the key attribute
-     * is closed if it is not null.  It then sets the attribute to null.
+     * A small utility function to ensure that the key attribute is closed if it is not null. It
+     * then sets the attribute to null.
      */
     private void closeKey() {
       closeInputStreamIfNotNull(key);
@@ -385,8 +420,8 @@ public class FlightServer implements AutoCloseable {
     }
 
     /**
-     * A small utility function to ensure that the mTlsCACert attribute
-     * is closed if it is not null.  It then sets the attribute to null.
+     * A small utility function to ensure that the mTlsCACert attribute is closed if it is not null.
+     * It then sets the attribute to null.
      */
     private void closeMTlsCACert() {
       closeInputStreamIfNotNull(mTlsCACert);
@@ -395,6 +430,7 @@ public class FlightServer implements AutoCloseable {
 
     /**
      * Enable TLS on the server.
+     *
      * @param certChain The certificate chain to use.
      * @param key The private key to use.
      */
@@ -410,6 +446,7 @@ public class FlightServer implements AutoCloseable {
 
     /**
      * Enable Client Verification via mTLS on the server.
+     *
      * @param mTlsCACert The CA certificate to use for verifying clients.
      */
     public Builder useMTlsClientVerification(final File mTlsCACert) throws IOException {
@@ -420,6 +457,7 @@ public class FlightServer implements AutoCloseable {
 
     /**
      * Enable TLS on the server.
+     *
      * @param certChain The certificate chain to use.
      * @param key The private key to use.
      */
@@ -435,6 +473,7 @@ public class FlightServer implements AutoCloseable {
 
     /**
      * Enable mTLS on the server.
+     *
      * @param mTlsCACert The CA certificate to use for verifying clients.
      */
     public Builder useMTlsClientVerification(final InputStream mTlsCACert) throws IOException {
@@ -446,33 +485,27 @@ public class FlightServer implements AutoCloseable {
     /**
      * Set the executor used by the server.
      *
-     * <p>Flight will NOT take ownership of the executor. The application must clean it up if one is provided. (If not
-     * provided, Flight will use a default executor which it will clean up.)
+     * <p>Flight will NOT take ownership of the executor. The application must clean it up if one is
+     * provided. (If not provided, Flight will use a default executor which it will clean up.)
      */
     public Builder executor(ExecutorService executor) {
       this.executor = executor;
       return this;
     }
 
-    /**
-     * Set the authentication handler.
-     */
+    /** Set the authentication handler. */
     public Builder authHandler(ServerAuthHandler authHandler) {
       this.authHandler = authHandler;
       return this;
     }
 
-    /**
-     * Set the header-based authentication mechanism.
-     */
+    /** Set the header-based authentication mechanism. */
     public Builder headerAuthenticator(CallHeaderAuthenticator headerAuthenticator) {
       this.headerAuthenticator = headerAuthenticator;
       return this;
     }
 
-    /**
-     * Provide a transport-specific option. Not guaranteed to have any effect.
-     */
+    /** Provide a transport-specific option. Not guaranteed to have any effect. */
     public Builder transportHint(final String key, Object option) {
       builderOptions.put(key, option);
       return this;
@@ -481,14 +514,15 @@ public class FlightServer implements AutoCloseable {
     /**
      * Add a Flight middleware component to inspect and modify requests to this service.
      *
-     * @param key An identifier for this middleware component. Service implementations can retrieve the middleware
-     *     instance for the current call using {@link org.apache.arrow.flight.FlightProducer.CallContext}.
+     * @param key An identifier for this middleware component. Service implementations can retrieve
+     *     the middleware instance for the current call using {@link
+     *     org.apache.arrow.flight.FlightProducer.CallContext}.
      * @param factory A factory for the middleware.
      * @param <T> The middleware type.
      * @throws IllegalArgumentException if the key already exists
      */
-    public <T extends FlightServerMiddleware> Builder middleware(final FlightServerMiddleware.Key<T> key,
-        final FlightServerMiddleware.Factory<T> factory) {
+    public <T extends FlightServerMiddleware> Builder middleware(
+        final FlightServerMiddleware.Key<T> key, final FlightServerMiddleware.Factory<T> factory) {
       if (interceptorKeys.contains(key.key)) {
         throw new IllegalArgumentException("Key already exists: " + key.key);
       }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServerMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServerMiddleware.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.Objects;
@@ -24,18 +23,20 @@ import java.util.Objects;
  *
  * <p>Middleware are instantiated per-call.
  *
- * <p>Methods are not guaranteed to be called on any particular thread, relative to the thread that Flight requests are
- * executed on. Do not depend on thread-local storage; instead, use state on the middleware instance. Service
- * implementations may communicate with middleware implementations through
- * {@link org.apache.arrow.flight.FlightProducer.CallContext#getMiddleware(Key)}. Methods on the middleware instance
- * are non-reentrant, that is, a particular RPC will not make multiple concurrent calls to methods on a single
- * middleware instance. However, methods on the factory instance are expected to be thread-safe, and if the factory
- * instance returns the same middleware object more than once, then that middleware object must be thread-safe.
+ * <p>Methods are not guaranteed to be called on any particular thread, relative to the thread that
+ * Flight requests are executed on. Do not depend on thread-local storage; instead, use state on the
+ * middleware instance. Service implementations may communicate with middleware implementations
+ * through {@link org.apache.arrow.flight.FlightProducer.CallContext#getMiddleware(Key)}. Methods on
+ * the middleware instance are non-reentrant, that is, a particular RPC will not make multiple
+ * concurrent calls to methods on a single middleware instance. However, methods on the factory
+ * instance are expected to be thread-safe, and if the factory instance returns the same middleware
+ * object more than once, then that middleware object must be thread-safe.
  */
 public interface FlightServerMiddleware {
 
   /**
    * A factory for Flight server middleware.
+   *
    * @param <T> The middleware type.
    */
   interface Factory<T extends FlightServerMiddleware> {
@@ -45,18 +46,20 @@ public interface FlightServerMiddleware {
      * @param info Details about the call.
      * @param incomingHeaders A mutable set of request headers.
      * @param context Context about the current request.
-     *
-     * @throws FlightRuntimeException if the middleware wants to reject the call with the given status
+     * @throws FlightRuntimeException if the middleware wants to reject the call with the given
+     *     status
      */
     T onCallStarted(CallInfo info, CallHeaders incomingHeaders, RequestContext context);
   }
 
   /**
-   * A key for Flight server middleware. On a server, middleware instances are identified by this key.
+   * A key for Flight server middleware. On a server, middleware instances are identified by this
+   * key.
    *
    * <p>Keys use reference equality, so instances should be shared.
    *
-   * @param <T> The middleware class stored in this key. This provides a compile-time check when retrieving instances.
+   * @param <T> The middleware class stored in this key. This provides a compile-time check when
+   *     retrieving instances.
    */
   class Key<T extends FlightServerMiddleware> {
     final String key;
@@ -65,9 +68,7 @@ public interface FlightServerMiddleware {
       this.key = Objects.requireNonNull(key, "Key must not be null.");
     }
 
-    /**
-     * Create a new key for the given type.
-     */
+    /** Create a new key for the given type. */
     public static <T extends FlightServerMiddleware> Key<T> of(String key) {
       return new Key<>(key);
     }
@@ -76,13 +77,14 @@ public interface FlightServerMiddleware {
   /**
    * Callback for when the underlying transport is about to send response headers.
    *
-   * @param outgoingHeaders A mutable set of response headers. These can be manipulated to send different headers to the
-   *     client.
+   * @param outgoingHeaders A mutable set of response headers. These can be manipulated to send
+   *     different headers to the client.
    */
   void onBeforeSendingHeaders(CallHeaders outgoingHeaders);
 
   /**
    * Callback for when the underlying transport has completed a call.
+   *
    * @param status Whether the call completed successfully or not.
    */
   void onCallCompleted(CallStatus status);
@@ -90,9 +92,10 @@ public interface FlightServerMiddleware {
   /**
    * Callback for when an RPC method implementation throws an uncaught exception.
    *
-   * <p>May be called multiple times, and may be called before or after {@link #onCallCompleted(CallStatus)}.
-   * Generally, an uncaught exception will end the call with a error {@link CallStatus}, and will be reported to {@link
-   * #onCallCompleted(CallStatus)}, but not necessarily this method.
+   * <p>May be called multiple times, and may be called before or after {@link
+   * #onCallCompleted(CallStatus)}. Generally, an uncaught exception will end the call with a error
+   * {@link CallStatus}, and will be reported to {@link #onCallCompleted(CallStatus)}, but not
+   * necessarily this method.
    *
    * @param err The exception that was thrown.
    */

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -14,18 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.common.base.Strings;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-
 import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
-import org.apache.arrow.flight.FlightServerMiddleware.Key;
 import org.apache.arrow.flight.auth.AuthConstants;
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.flight.auth.ServerAuthWrapper;
@@ -41,14 +41,7 @@ import org.apache.arrow.util.AutoCloseables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Strings;
-
-import io.grpc.stub.ServerCallStreamObserver;
-import io.grpc.stub.StreamObserver;
-
-/**
- * GRPC service implementation for a flight server.
- */
+/** GRPC service implementation for a flight server. */
 class FlightService extends FlightServiceImplBase {
 
   private static final Logger logger = LoggerFactory.getLogger(FlightService.class);
@@ -59,7 +52,10 @@ class FlightService extends FlightServiceImplBase {
   private final ServerAuthHandler authHandler;
   private final ExecutorService executors;
 
-  FlightService(BufferAllocator allocator, FlightProducer producer, ServerAuthHandler authHandler,
+  FlightService(
+      BufferAllocator allocator,
+      FlightProducer producer,
+      ServerAuthHandler authHandler,
       ExecutorService executors) {
     this.allocator = allocator;
     this.producer = producer;
@@ -84,16 +80,19 @@ class FlightService extends FlightServiceImplBase {
   }
 
   @Override
-  public StreamObserver<Flight.HandshakeRequest> handshake(StreamObserver<Flight.HandshakeResponse> responseObserver) {
+  public StreamObserver<Flight.HandshakeRequest> handshake(
+      StreamObserver<Flight.HandshakeResponse> responseObserver) {
     // This method is not meaningful with the auth2 interfaces. Authentication would already
     // have happened by header/middleware with the auth2 classes.
     return ServerAuthWrapper.wrapHandshake(authHandler, responseObserver, executors);
   }
 
   @Override
-  public void listFlights(Flight.Criteria criteria, StreamObserver<Flight.FlightInfo> responseObserver) {
-    final StreamPipe<FlightInfo, Flight.FlightInfo> listener = StreamPipe
-        .wrap(responseObserver, FlightInfo::toProtocol, this::handleExceptionWithMiddleware);
+  public void listFlights(
+      Flight.Criteria criteria, StreamObserver<Flight.FlightInfo> responseObserver) {
+    final StreamPipe<FlightInfo, Flight.FlightInfo> listener =
+        StreamPipe.wrap(
+            responseObserver, FlightInfo::toProtocol, this::handleExceptionWithMiddleware);
     try {
       final CallContext context = makeContext((ServerCallStreamObserver<?>) responseObserver);
       producer.listFlights(context, new Criteria(criteria), listener);
@@ -103,11 +102,13 @@ class FlightService extends FlightServiceImplBase {
     // Do NOT call StreamPipe#onCompleted, as the FlightProducer implementation may be asynchronous
   }
 
-  public void doGetCustom(Flight.Ticket ticket, StreamObserver<ArrowMessage> responseObserverSimple) {
+  public void doGetCustom(
+      Flight.Ticket ticket, StreamObserver<ArrowMessage> responseObserverSimple) {
     final ServerCallStreamObserver<ArrowMessage> responseObserver =
         (ServerCallStreamObserver<ArrowMessage>) responseObserverSimple;
 
-    final GetListener listener = new GetListener(responseObserver, this::handleExceptionWithMiddleware);
+    final GetListener listener =
+        new GetListener(responseObserver, this::handleExceptionWithMiddleware);
     try {
       producer.getStream(makeContext(responseObserver), new Ticket(ticket), listener);
     } catch (Exception ex) {
@@ -118,8 +119,8 @@ class FlightService extends FlightServiceImplBase {
 
   @Override
   public void doAction(Flight.Action request, StreamObserver<Flight.Result> responseObserver) {
-    final StreamPipe<Result, Flight.Result> listener = StreamPipe
-        .wrap(responseObserver, Result::toProtocol, this::handleExceptionWithMiddleware);
+    final StreamPipe<Result, Flight.Result> listener =
+        StreamPipe.wrap(responseObserver, Result::toProtocol, this::handleExceptionWithMiddleware);
     try {
       final CallContext context = makeContext((ServerCallStreamObserver<?>) responseObserver);
       producer.doAction(context, new Action(request), listener);
@@ -130,9 +131,11 @@ class FlightService extends FlightServiceImplBase {
   }
 
   @Override
-  public void listActions(Flight.Empty request, StreamObserver<Flight.ActionType> responseObserver) {
-    final StreamPipe<org.apache.arrow.flight.ActionType, Flight.ActionType> listener = StreamPipe
-        .wrap(responseObserver, ActionType::toProtocol, this::handleExceptionWithMiddleware);
+  public void listActions(
+      Flight.Empty request, StreamObserver<Flight.ActionType> responseObserver) {
+    final StreamPipe<org.apache.arrow.flight.ActionType, Flight.ActionType> listener =
+        StreamPipe.wrap(
+            responseObserver, ActionType::toProtocol, this::handleExceptionWithMiddleware);
     try {
       final CallContext context = makeContext((ServerCallStreamObserver<?>) responseObserver);
       producer.listActions(context, listener);
@@ -142,14 +145,16 @@ class FlightService extends FlightServiceImplBase {
     // Do NOT call StreamPipe#onCompleted, as the FlightProducer implementation may be asynchronous
   }
 
-  private static class GetListener extends OutboundStreamListenerImpl implements ServerStreamListener {
+  private static class GetListener extends OutboundStreamListenerImpl
+      implements ServerStreamListener {
     private final ServerCallStreamObserver<ArrowMessage> serverCallResponseObserver;
     private final Consumer<Throwable> errorHandler;
     private Runnable onCancelHandler = null;
     private Runnable onReadyHandler = null;
     private boolean completed;
 
-    public GetListener(ServerCallStreamObserver<ArrowMessage> responseObserver, Consumer<Throwable> errorHandler) {
+    public GetListener(
+        ServerCallStreamObserver<ArrowMessage> responseObserver, Consumer<Throwable> errorHandler) {
       super(null, responseObserver);
       this.errorHandler = errorHandler;
       this.completed = false;
@@ -213,45 +218,54 @@ class FlightService extends FlightServiceImplBase {
     }
   }
 
-  public StreamObserver<ArrowMessage> doPutCustom(final StreamObserver<Flight.PutResult> responseObserverSimple) {
+  public StreamObserver<ArrowMessage> doPutCustom(
+      final StreamObserver<Flight.PutResult> responseObserverSimple) {
     ServerCallStreamObserver<Flight.PutResult> responseObserver =
         (ServerCallStreamObserver<Flight.PutResult>) responseObserverSimple;
     responseObserver.disableAutoInboundFlowControl();
     responseObserver.request(1);
 
-    final StreamPipe<PutResult, Flight.PutResult> ackStream = StreamPipe
-        .wrap(responseObserver, PutResult::toProtocol, this::handleExceptionWithMiddleware);
-    final FlightStream fs = new FlightStream(
-        allocator,
-        PENDING_REQUESTS,
-        /* server-upload streams are not cancellable */null,
-        responseObserver::request);
+    final StreamPipe<PutResult, Flight.PutResult> ackStream =
+        StreamPipe.wrap(
+            responseObserver, PutResult::toProtocol, this::handleExceptionWithMiddleware);
+    final FlightStream fs =
+        new FlightStream(
+            allocator,
+            PENDING_REQUESTS,
+            /* server-upload streams are not cancellable */ null,
+            responseObserver::request);
     // When the ackStream is completed, the FlightStream will be closed with it
     ackStream.setAutoCloseable(fs);
     final StreamObserver<ArrowMessage> observer = fs.asObserver();
-    Future<?> unused = executors.submit(() -> {
-      try {
-        producer.acceptPut(makeContext(responseObserver), fs, ackStream).run();
-      } catch (Throwable ex) {
-        ackStream.onError(ex);
-      } finally {
-        // ARROW-6136: Close the stream if and only if acceptPut hasn't closed it itself
-        // We don't do this for other streams since the implementation may be asynchronous
-        ackStream.ensureCompleted();
-      }
-    });
+    Future<?> unused =
+        executors.submit(
+            () -> {
+              try {
+                producer.acceptPut(makeContext(responseObserver), fs, ackStream).run();
+              } catch (Throwable ex) {
+                ackStream.onError(ex);
+              } finally {
+                // ARROW-6136: Close the stream if and only if acceptPut hasn't closed it itself
+                // We don't do this for other streams since the implementation may be asynchronous
+                ackStream.ensureCompleted();
+              }
+            });
 
     return observer;
   }
 
   @Override
-  public void getFlightInfo(Flight.FlightDescriptor request, StreamObserver<Flight.FlightInfo> responseObserver) {
+  public void getFlightInfo(
+      Flight.FlightDescriptor request, StreamObserver<Flight.FlightInfo> responseObserver) {
     final FlightInfo info;
     try {
-      info = producer
-          .getFlightInfo(makeContext((ServerCallStreamObserver<?>) responseObserver), new FlightDescriptor(request));
+      info =
+          producer.getFlightInfo(
+              makeContext((ServerCallStreamObserver<?>) responseObserver),
+              new FlightDescriptor(request));
     } catch (Exception ex) {
-      // Don't capture exceptions from onNext or onCompleted with this block - because then we can't call onError
+      // Don't capture exceptions from onNext or onCompleted with this block - because then we can't
+      // call onError
       responseObserver.onError(StatusUtils.toGrpcException(ex));
       return;
     }
@@ -260,13 +274,17 @@ class FlightService extends FlightServiceImplBase {
   }
 
   @Override
-  public void pollFlightInfo(Flight.FlightDescriptor request, StreamObserver<Flight.PollInfo> responseObserver) {
+  public void pollFlightInfo(
+      Flight.FlightDescriptor request, StreamObserver<Flight.PollInfo> responseObserver) {
     final PollInfo info;
     try {
-      info = producer
-          .pollFlightInfo(makeContext((ServerCallStreamObserver<?>) responseObserver), new FlightDescriptor(request));
+      info =
+          producer.pollFlightInfo(
+              makeContext((ServerCallStreamObserver<?>) responseObserver),
+              new FlightDescriptor(request));
     } catch (Exception ex) {
-      // Don't capture exceptions from onNext or onCompleted with this block - because then we can't call onError
+      // Don't capture exceptions from onNext or onCompleted with this block - because then we can't
+      // call onError
       responseObserver.onError(StatusUtils.toGrpcException(ex));
       return;
     }
@@ -274,12 +292,10 @@ class FlightService extends FlightServiceImplBase {
     responseObserver.onCompleted();
   }
 
-  /**
-   * Broadcast the given exception to all registered middleware.
-   */
+  /** Broadcast the given exception to all registered middleware. */
   private void handleExceptionWithMiddleware(Throwable t) {
-    final Map<FlightServerMiddleware.Key<?>, FlightServerMiddleware> middleware = ServerInterceptorAdapter
-            .SERVER_MIDDLEWARE_KEY.get();
+    final Map<FlightServerMiddleware.Key<?>, FlightServerMiddleware> middleware =
+        ServerInterceptorAdapter.SERVER_MIDDLEWARE_KEY.get();
     if (middleware == null || middleware.isEmpty()) {
       logger.error("Uncaught exception in Flight method body", t);
       return;
@@ -288,11 +304,13 @@ class FlightService extends FlightServiceImplBase {
   }
 
   @Override
-  public void getSchema(Flight.FlightDescriptor request, StreamObserver<Flight.SchemaResult> responseObserver) {
+  public void getSchema(
+      Flight.FlightDescriptor request, StreamObserver<Flight.SchemaResult> responseObserver) {
     try {
-      SchemaResult result = producer
-              .getSchema(makeContext((ServerCallStreamObserver<?>) responseObserver),
-                      new FlightDescriptor(request));
+      SchemaResult result =
+          producer.getSchema(
+              makeContext((ServerCallStreamObserver<?>) responseObserver),
+              new FlightDescriptor(request));
       responseObserver.onNext(result.toProtocol());
       responseObserver.onCompleted();
     } catch (Exception ex) {
@@ -300,30 +318,33 @@ class FlightService extends FlightServiceImplBase {
     }
   }
 
-  /** Ensures that other resources are cleaned up when the service finishes its call.  */
+  /** Ensures that other resources are cleaned up when the service finishes its call. */
   private static class ExchangeListener extends GetListener {
 
     private AutoCloseable resource;
     private boolean closed = false;
     private Runnable onCancelHandler = null;
 
-    public ExchangeListener(ServerCallStreamObserver<ArrowMessage> responseObserver, Consumer<Throwable> errorHandler) {
+    public ExchangeListener(
+        ServerCallStreamObserver<ArrowMessage> responseObserver, Consumer<Throwable> errorHandler) {
       super(responseObserver, errorHandler);
       this.resource = null;
-      super.setOnCancelHandler(() -> {
-        try {
-          if (onCancelHandler != null) {
-            onCancelHandler.run();
-          }
-        } finally {
-          cleanup();
-        }
-      });
+      super.setOnCancelHandler(
+          () -> {
+            try {
+              if (onCancelHandler != null) {
+                onCancelHandler.run();
+              }
+            } finally {
+              cleanup();
+            }
+          });
     }
 
     private void cleanup() {
       if (closed) {
-        // Prevent double-free. gRPC will call the OnCancelHandler even on a normal call end, which means that
+        // Prevent double-free. gRPC will call the OnCancelHandler even on a normal call end, which
+        // means that
         // we'll double-free without this guard.
         return;
       }
@@ -362,41 +383,44 @@ class FlightService extends FlightServiceImplBase {
     }
   }
 
-  public StreamObserver<ArrowMessage> doExchangeCustom(StreamObserver<ArrowMessage> responseObserverSimple) {
+  public StreamObserver<ArrowMessage> doExchangeCustom(
+      StreamObserver<ArrowMessage> responseObserverSimple) {
     final ServerCallStreamObserver<ArrowMessage> responseObserver =
         (ServerCallStreamObserver<ArrowMessage>) responseObserverSimple;
-    final ExchangeListener listener = new ExchangeListener(
-        responseObserver,
-        this::handleExceptionWithMiddleware);
-    final FlightStream fs = new FlightStream(
-        allocator,
-        PENDING_REQUESTS,
-        /* server-upload streams are not cancellable */null,
-        responseObserver::request);
+    final ExchangeListener listener =
+        new ExchangeListener(responseObserver, this::handleExceptionWithMiddleware);
+    final FlightStream fs =
+        new FlightStream(
+            allocator,
+            PENDING_REQUESTS,
+            /* server-upload streams are not cancellable */ null,
+            responseObserver::request);
     // When service completes the call, this cleans up the FlightStream
     listener.resource = fs;
     responseObserver.disableAutoInboundFlowControl();
     responseObserver.request(1);
     final StreamObserver<ArrowMessage> observer = fs.asObserver();
     try {
-      Future<?> unused = executors.submit(() -> {
-        try {
-          producer.doExchange(makeContext(responseObserver), fs, listener);
-        } catch (Exception ex) {
-          listener.error(ex);
-        }
-        // We do not clean up or close anything here, to allow long-running asynchronous implementations.
-        // It is the service's responsibility to call completed() or error(), which will then clean up the FlightStream.
-      });
+      Future<?> unused =
+          executors.submit(
+              () -> {
+                try {
+                  producer.doExchange(makeContext(responseObserver), fs, listener);
+                } catch (Exception ex) {
+                  listener.error(ex);
+                }
+                // We do not clean up or close anything here, to allow long-running asynchronous
+                // implementations.
+                // It is the service's responsibility to call completed() or error(), which will
+                // then clean up the FlightStream.
+              });
     } catch (Exception ex) {
       listener.error(ex);
     }
     return observer;
   }
 
-  /**
-   * Call context for the service.
-   */
+  /** Call context for the service. */
   static class CallContext implements FlightProducer.CallContext {
 
     private final String peerIdentity;
@@ -419,8 +443,8 @@ class FlightService extends FlightServiceImplBase {
 
     @Override
     public <T extends FlightServerMiddleware> T getMiddleware(FlightServerMiddleware.Key<T> key) {
-      final Map<FlightServerMiddleware.Key<?>, FlightServerMiddleware> middleware = ServerInterceptorAdapter
-              .SERVER_MIDDLEWARE_KEY.get();
+      final Map<FlightServerMiddleware.Key<?>, FlightServerMiddleware> middleware =
+          ServerInterceptorAdapter.SERVER_MIDDLEWARE_KEY.get();
       if (middleware == null) {
         return null;
       }
@@ -428,7 +452,8 @@ class FlightService extends FlightServiceImplBase {
       if (m == null) {
         return null;
       }
-      @SuppressWarnings("unchecked") final T result = (T) m;
+      @SuppressWarnings("unchecked")
+      final T result = (T) m;
       return result;
     }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStatusCode.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStatusCode.java
@@ -14,73 +14,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-/**
- * A status code describing the result of a Flight call.
- */
+/** A status code describing the result of a Flight call. */
 public enum FlightStatusCode {
-  /**
-   * The call completed successfully. Generally clients will not see this, but middleware may.
-   */
+  /** The call completed successfully. Generally clients will not see this, but middleware may. */
   OK,
   /**
-   * An unknown error occurred. This may also be the result of an implementation error on the server-side; by default,
-   * unhandled server exceptions result in this code.
+   * An unknown error occurred. This may also be the result of an implementation error on the
+   * server-side; by default, unhandled server exceptions result in this code.
    */
   UNKNOWN,
-  /**
-   * An internal/implementation error occurred.
-   */
+  /** An internal/implementation error occurred. */
   INTERNAL,
-  /**
-   * One or more of the given arguments was invalid.
-   */
+  /** One or more of the given arguments was invalid. */
   INVALID_ARGUMENT,
-  /**
-   * The operation timed out.
-   */
+  /** The operation timed out. */
   TIMED_OUT,
-  /**
-   * The operation describes a resource that does not exist.
-   */
+  /** The operation describes a resource that does not exist. */
   NOT_FOUND,
-  /**
-   * The operation creates a resource that already exists.
-   */
+  /** The operation creates a resource that already exists. */
   ALREADY_EXISTS,
-  /**
-   * The operation was cancelled.
-   */
+  /** The operation was cancelled. */
   CANCELLED,
-  /**
-   * The client was not authenticated.
-   */
+  /** The client was not authenticated. */
   UNAUTHENTICATED,
-  /**
-   * The client did not have permission to make the call.
-   */
+  /** The client did not have permission to make the call. */
   UNAUTHORIZED,
-  /**
-   * The requested operation is not implemented.
-   */
+  /** The requested operation is not implemented. */
   UNIMPLEMENTED,
   /**
-   * The server cannot currently handle the request. This should be used for retriable requests, i.e. the server
-   * should send this code only if it has not done any work.
+   * The server cannot currently handle the request. This should be used for retriable requests,
+   * i.e. the server should send this code only if it has not done any work.
    */
   UNAVAILABLE,
   /**
-   * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system is out of space.
-   * (see: https://grpc.github.io/grpc/core/md_doc_statuscodes.html)
+   * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
+   * is out of space. (see: https://grpc.github.io/grpc/core/md_doc_statuscodes.html)
    */
-  RESOURCE_EXHAUSTED
-  ;
+  RESOURCE_EXHAUSTED;
 
-  /**
-   * Create a blank {@link CallStatus} with this code.
-   */
+  /** Create a blank {@link CallStatus} with this code. */
   public CallStatus toStatus() {
     return new CallStatus(this);
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/GetSessionOptionsRequest.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/GetSessionOptionsRequest.java
@@ -14,23 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
 import org.apache.arrow.flight.impl.Flight;
 
-/**
- * A request to get current session options.
- */
+/** A request to get current session options. */
 public class GetSessionOptionsRequest {
-  public GetSessionOptionsRequest() {
-  }
+  public GetSessionOptionsRequest() {}
 
-  GetSessionOptionsRequest(Flight.GetSessionOptionsRequest proto) {
-  }
+  GetSessionOptionsRequest(Flight.GetSessionOptionsRequest proto) {}
 
   Flight.GetSessionOptionsRequest toProtocol() {
     return Flight.GetSessionOptionsRequest.getDefaultInstance();
@@ -39,7 +33,8 @@ public class GetSessionOptionsRequest {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -48,7 +43,8 @@ public class GetSessionOptionsRequest {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/GetSessionOptionsResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/GetSessionOptionsResult.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
@@ -23,7 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** A request to view the currently-set options for the current server session. */
@@ -35,9 +33,13 @@ public class GetSessionOptionsResult {
   }
 
   GetSessionOptionsResult(Flight.GetSessionOptionsResult proto) {
-    sessionOptions = Collections.unmodifiableMap(
-        proto.getSessionOptionsMap().entrySet().stream().collect(Collectors.toMap(
-            Map.Entry::getKey, (e) -> SessionOptionValueFactory.makeSessionOptionValue(e.getValue()))));
+    sessionOptions =
+        Collections.unmodifiableMap(
+            proto.getSessionOptionsMap().entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        (e) -> SessionOptionValueFactory.makeSessionOptionValue(e.getValue()))));
   }
 
   /**
@@ -51,15 +53,17 @@ public class GetSessionOptionsResult {
 
   Flight.GetSessionOptionsResult toProtocol() {
     Flight.GetSessionOptionsResult.Builder b = Flight.GetSessionOptionsResult.newBuilder();
-    b.putAllSessionOptions(sessionOptions.entrySet().stream().collect(Collectors.toMap(
-        Map.Entry::getKey, (e) -> e.getValue().toProtocol())));
+    b.putAllSessionOptions(
+        sessionOptions.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, (e) -> e.getValue().toProtocol())));
     return b.build();
   }
 
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -68,7 +72,8 @@ public class GetSessionOptionsResult {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/HeaderCallOption.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/HeaderCallOption.java
@@ -14,24 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import io.grpc.Metadata;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
 
-/**
- * Method option for supplying headers to method calls.
- */
+/** Method option for supplying headers to method calls. */
 public class HeaderCallOption implements CallOptions.GrpcCallOption {
   private final Metadata propertiesMetadata = new Metadata();
 
   /**
    * Header property constructor.
    *
-   * @param headers the headers that should be sent across. If a header is a string, it should only be valid ASCII
-   *                characters. Binary headers should end in "-bin".
+   * @param headers the headers that should be sent across. If a header is a string, it should only
+   *     be valid ASCII characters. Binary headers should end in "-bin".
    */
   public HeaderCallOption(CallHeaders headers) {
     for (String key : headers.keys()) {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Location.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Location.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.lang.reflect.InvocationTargetException;
@@ -23,7 +22,6 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** A URI where a Flight stream is available. */
@@ -64,38 +62,43 @@ public class Location {
     switch (uri.getScheme()) {
       case LocationSchemes.GRPC:
       case LocationSchemes.GRPC_TLS:
-      case LocationSchemes.GRPC_INSECURE: {
-        return new InetSocketAddress(uri.getHost(), uri.getPort());
-      }
+      case LocationSchemes.GRPC_INSECURE:
+        {
+          return new InetSocketAddress(uri.getHost(), uri.getPort());
+        }
 
-      case LocationSchemes.GRPC_DOMAIN_SOCKET: {
-        try {
-          // This dependency is not available on non-Unix platforms.
-          return Class.forName("io.netty.channel.unix.DomainSocketAddress").asSubclass(SocketAddress.class)
-              .getConstructor(String.class)
-              .newInstance(uri.getPath());
-        } catch (InstantiationException | ClassNotFoundException | InvocationTargetException |
-            NoSuchMethodException | IllegalAccessException e) {
+      case LocationSchemes.GRPC_DOMAIN_SOCKET:
+        {
+          try {
+            // This dependency is not available on non-Unix platforms.
+            return Class.forName("io.netty.channel.unix.DomainSocketAddress")
+                .asSubclass(SocketAddress.class)
+                .getConstructor(String.class)
+                .newInstance(uri.getPath());
+          } catch (InstantiationException
+              | ClassNotFoundException
+              | InvocationTargetException
+              | NoSuchMethodException
+              | IllegalAccessException e) {
+            return null;
+          }
+        }
+
+      default:
+        {
           return null;
         }
-      }
-
-      default: {
-        return null;
-      }
     }
   }
 
-  /**
-   * Convert this Location into its protocol-level representation.
-   */
+  /** Convert this Location into its protocol-level representation. */
   Flight.Location toProtocol() {
     return Flight.Location.newBuilder().setUri(uri.toString()).build();
   }
 
   /**
-   * Construct a special URI to indicate to clients that they may fetch data by reusing
-   * an existing connection to a Flight RPC server.
+   * Construct a special URI to indicate to clients that they may fetch data by reusing an existing
+   * connection to a Flight RPC server.
    */
   public static Location reuseConnection() {
     try {
@@ -113,7 +116,8 @@ public class Location {
    */
   public static Location forGrpcInsecure(String host, int port) {
     try {
-      return new Location(new URI(LocationSchemes.GRPC_INSECURE, null, host, port, null, null, null));
+      return new Location(
+          new URI(LocationSchemes.GRPC_INSECURE, null, host, port, null, null, null));
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException(e);
     }
@@ -147,9 +151,7 @@ public class Location {
 
   @Override
   public String toString() {
-    return "Location{" +
-        "uri=" + uri +
-        '}';
+    return "Location{" + "uri=" + uri + '}';
   }
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/LocationSchemes.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/LocationSchemes.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-/**
- * Constants representing well-known URI schemes for Flight services.
- */
+/** Constants representing well-known URI schemes for Flight services. */
 public final class LocationSchemes {
   public static final String GRPC = "grpc";
   public static final String GRPC_INSECURE = "grpc+tcp";

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpFlightProducer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpFlightProducer.java
@@ -14,48 +14,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-/**
- * A {@link FlightProducer} that throws on all operations.
- */
+/** A {@link FlightProducer} that throws on all operations. */
 public class NoOpFlightProducer implements FlightProducer {
 
   @Override
-  public void getStream(CallContext context, Ticket ticket,
-      ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public void listFlights(CallContext context, Criteria criteria,
-      StreamListener<FlightInfo> listener) {
-    listener.onError(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void listFlights(
+      CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
+    listener.onError(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfo(CallContext context,
-      FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public Runnable acceptPut(CallContext context,
-      FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  public Runnable acceptPut(
+      CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void doAction(CallContext context, Action action,
-      StreamListener<Result> listener) {
-    listener.onError(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
+    listener.onError(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public void listActions(CallContext context,
-      StreamListener<ActionType> listener) {
-    listener.onError(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void listActions(CallContext context, StreamListener<ActionType> listener) {
+    listener.onError(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpSessionOptionValueVisitor.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpSessionOptionValueVisitor.java
@@ -14,48 +14,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 /**
  * A helper to facilitate easier anonymous subclass declaration.
  *
- * Implementations need only override callbacks for types they wish to do something with.
+ * <p>Implementations need only override callbacks for types they wish to do something with.
  *
  * @param <T> Return type of the visit operation.
  */
 public class NoOpSessionOptionValueVisitor<T> implements SessionOptionValueVisitor<T> {
-  /**
-   * A callback to handle SessionOptionValue containing a String.
-   */
+  /** A callback to handle SessionOptionValue containing a String. */
   public T visit(String value) {
     return null;
   }
 
-  /**
-   * A callback to handle SessionOptionValue containing a boolean.
-   */
+  /** A callback to handle SessionOptionValue containing a boolean. */
   public T visit(boolean value) {
     return null;
   }
 
-  /**
-   * A callback to handle SessionOptionValue containing a long.
-   */
+  /** A callback to handle SessionOptionValue containing a long. */
   public T visit(long value) {
     return null;
   }
 
-  /**
-   * A callback to handle SessionOptionValue containing a double.
-   */
+  /** A callback to handle SessionOptionValue containing a double. */
   public T visit(double value) {
     return null;
   }
 
-  /**
-   * A callback to handle SessionOptionValue containing an array of String.
-   */
+  /** A callback to handle SessionOptionValue containing an array of String. */
   public T visit(String[] value) {
     return null;
   }
@@ -63,8 +52,8 @@ public class NoOpSessionOptionValueVisitor<T> implements SessionOptionValueVisit
   /**
    * A callback to handle SessionOptionValue containing no value.
    *
-   * By convention, an attempt to set a valueless SessionOptionValue should
-   * attempt to unset or clear the named option value on the server.
+   * <p>By convention, an attempt to set a valueless SessionOptionValue should attempt to unset or
+   * clear the named option value on the server.
    */
   public T visit(Void value) {
     return null;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpStreamListener.java
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import org.apache.arrow.flight.FlightProducer.StreamListener;
 
 /**
  * A {@link StreamListener} that does nothing for all callbacks.
+ *
  * @param <T> The type of the callback object.
  */
 public class NoOpStreamListener<T> implements StreamListener<T> {
@@ -28,18 +28,15 @@ public class NoOpStreamListener<T> implements StreamListener<T> {
 
   /** Ignores the value received. */
   @Override
-  public void onNext(T val) {
-  }
+  public void onNext(T val) {}
 
   /** Ignores the error received. */
   @Override
-  public void onError(Throwable t) {
-  }
+  public void onError(Throwable t) {}
 
   /** Ignores the stream completion event. */
   @Override
-  public void onCompleted() {
-  }
+  public void onCompleted() {}
 
   @SuppressWarnings("unchecked")
   public static <T> StreamListener<T> getInstance() {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import org.apache.arrow.memory.ArrowBuf;
@@ -22,28 +21,26 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.message.IpcOption;
 
-/**
- * An interface for writing data to a peer, client or server.
- */
+/** An interface for writing data to a peer, client or server. */
 public interface OutboundStreamListener {
 
   /**
    * A hint indicating whether the client is ready to receive data without excessive buffering.
    *
-   * <p>Writers should poll this flag before sending data to respect backpressure from the client and
-   * avoid sending data faster than the client can handle. Ignoring this flag may mean that the server
-   * will start consuming excessive amounts of memory, as it may buffer messages in memory.
+   * <p>Writers should poll this flag before sending data to respect backpressure from the client
+   * and avoid sending data faster than the client can handle. Ignoring this flag may mean that the
+   * server will start consuming excessive amounts of memory, as it may buffer messages in memory.
    */
   boolean isReady();
 
   /**
-   * Set a callback for when the listener is ready for new calls to putNext(), i.e. {@link #isReady()}
-   * has become true.
+   * Set a callback for when the listener is ready for new calls to putNext(), i.e. {@link
+   * #isReady()} has become true.
    *
-   * <p>Note that this callback may only be called some time after {@link #isReady()} becomes true, and may never
-   * be called if all executor threads on the server are busy, or the RPC method body is implemented in a blocking
-   * fashion. Note that isReady() must still be checked after the callback is run as it may have been run
-   * spuriously.
+   * <p>Note that this callback may only be called some time after {@link #isReady()} becomes true,
+   * and may never be called if all executor threads on the server are busy, or the RPC method body
+   * is implemented in a blocking fashion. Note that isReady() must still be checked after the
+   * callback is run as it may have been run spuriously.
    */
   default void setOnReadyHandler(Runnable handler) {
     throw new UnsupportedOperationException("Not yet implemented.");
@@ -78,13 +75,17 @@ public interface OutboundStreamListener {
    * Send the current contents of the associated {@link VectorSchemaRoot}.
    *
    * <p>This will not necessarily block until the message is actually sent; it may buffer messages
-   * in memory. Use {@link #isReady()} to check if there is backpressure and avoid excessive buffering.
+   * in memory. Use {@link #isReady()} to check if there is backpressure and avoid excessive
+   * buffering.
    */
   void putNext();
 
   /**
-   * Send the current contents of the associated {@link VectorSchemaRoot} alongside application-defined metadata.
-   * @param metadata The metadata to send. Ownership of the buffer is transferred to the Flight implementation.
+   * Send the current contents of the associated {@link VectorSchemaRoot} alongside
+   * application-defined metadata.
+   *
+   * @param metadata The metadata to send. Ownership of the buffer is transferred to the Flight
+   *     implementation.
    */
   void putNext(ArrowBuf metadata);
 
@@ -96,29 +97,29 @@ public interface OutboundStreamListener {
   void putMetadata(ArrowBuf metadata);
 
   /**
-   * Indicate an error to the client. Terminates the stream; do not call {@link #completed()} afterwards.
+   * Indicate an error to the client. Terminates the stream; do not call {@link #completed()}
+   * afterwards.
    */
   void error(Throwable ex);
 
-  /**
-   * Indicate that transmission is finished.
-   */
+  /** Indicate that transmission is finished. */
   void completed();
 
   /**
    * Toggle whether to use the zero-copy write optimization.
    *
-   * <p>By default or when disabled, Arrow may copy data into a buffer for the underlying implementation to
-   * send. When enabled, Arrow will instead try to directly enqueue the Arrow buffer for sending. Not all
-   * implementations support this optimization, so even if enabled, you may not see a difference.
+   * <p>By default or when disabled, Arrow may copy data into a buffer for the underlying
+   * implementation to send. When enabled, Arrow will instead try to directly enqueue the Arrow
+   * buffer for sending. Not all implementations support this optimization, so even if enabled, you
+   * may not see a difference.
    *
-   * <p>In this mode, buffers must not be reused after they are written with {@link #putNext()}. For example,
-   * you would have to call {@link VectorSchemaRoot#allocateNew()} after every call to {@link #putNext()}.
-   * Hence, this is not enabled by default.
+   * <p>In this mode, buffers must not be reused after they are written with {@link #putNext()}. For
+   * example, you would have to call {@link VectorSchemaRoot#allocateNew()} after every call to
+   * {@link #putNext()}. Hence, this is not enabled by default.
    *
-   * <p>The default value can be toggled globally by setting the JVM property arrow.flight.enable_zero_copy_write
-   * or the environment variable ARROW_FLIGHT_ENABLE_ZERO_COPY_WRITE.
+   * <p>The default value can be toggled globally by setting the JVM property
+   * arrow.flight.enable_zero_copy_write or the environment variable
+   * ARROW_FLIGHT_ENABLE_ZERO_COPY_WRITE.
    */
-  default void setUseZeroCopy(boolean enabled) {
-  }
+  default void setUseZeroCopy(boolean enabled) {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/PollInfo.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/PollInfo.java
@@ -14,24 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.apache.arrow.flight.impl.Flight;
 
-import com.google.protobuf.Timestamp;
-import com.google.protobuf.util.Timestamps;
-
-/**
- * A POJO representation of the execution of a long-running query.
- */
+/** A POJO representation of the execution of a long-running query. */
 public class PollInfo {
   private final FlightInfo flightInfo;
   private final FlightDescriptor flightDescriptor;
@@ -42,11 +37,17 @@ public class PollInfo {
    * Create a new PollInfo.
    *
    * @param flightInfo The FlightInfo (must not be null).
-   * @param flightDescriptor The descriptor used to poll for more information; null if and only if query is finished.
+   * @param flightDescriptor The descriptor used to poll for more information; null if and only if
+   *     query is finished.
    * @param progress Optional progress info in [0.0, 1.0].
-   * @param expirationTime An expiration time, after which the server may no longer recognize the descriptor.
+   * @param expirationTime An expiration time, after which the server may no longer recognize the
+   *     descriptor.
    */
-  public PollInfo(FlightInfo flightInfo, FlightDescriptor flightDescriptor, Double progress, Instant expirationTime) {
+  public PollInfo(
+      FlightInfo flightInfo,
+      FlightDescriptor flightDescriptor,
+      Double progress,
+      Instant expirationTime) {
     this.flightInfo = Objects.requireNonNull(flightInfo);
     this.flightDescriptor = flightDescriptor;
     this.progress = progress;
@@ -55,19 +56,22 @@ public class PollInfo {
 
   PollInfo(Flight.PollInfo flt) throws URISyntaxException {
     this.flightInfo = new FlightInfo(flt.getInfo());
-    this.flightDescriptor = flt.hasFlightDescriptor() ? new FlightDescriptor(flt.getFlightDescriptor()) : null;
+    this.flightDescriptor =
+        flt.hasFlightDescriptor() ? new FlightDescriptor(flt.getFlightDescriptor()) : null;
     this.progress = flt.hasProgress() ? flt.getProgress() : null;
-    this.expirationTime = flt.hasExpirationTime() ?
-        Instant.ofEpochSecond(flt.getExpirationTime().getSeconds(), Timestamps.toNanos(flt.getExpirationTime())) :
-        null;
+    this.expirationTime =
+        flt.hasExpirationTime()
+            ? Instant.ofEpochSecond(
+                flt.getExpirationTime().getSeconds(), Timestamps.toNanos(flt.getExpirationTime()))
+            : null;
   }
 
   /**
    * The FlightInfo describing the result set of the execution of a query.
    *
-   * <p>This is always present and always contains all endpoints for the query execution so far,
-   * not just new endpoints that completed execution since the last call to
-   * {@link FlightClient#pollInfo(FlightDescriptor, CallOption...)}.
+   * <p>This is always present and always contains all endpoints for the query execution so far, not
+   * just new endpoints that completed execution since the last call to {@link
+   * FlightClient#pollInfo(FlightDescriptor, CallOption...)}.
    */
   public FlightInfo getFlightInfo() {
     return flightInfo;
@@ -76,7 +80,7 @@ public class PollInfo {
   /**
    * The FlightDescriptor that should be used to get further updates on this query.
    *
-   * <p>It is present if and only if the query is still running.  If present, it should be passed to
+   * <p>It is present if and only if the query is still running. If present, it should be passed to
    * {@link FlightClient#pollInfo(FlightDescriptor, CallOption...)} to get an update.
    */
   public Optional<FlightDescriptor> getFlightDescriptor() {
@@ -86,7 +90,8 @@ public class PollInfo {
   /**
    * The progress of the query.
    *
-   * <p>If present, should be a value in [0.0, 1.0]. It is not necessarily monotonic or non-decreasing.
+   * <p>If present, should be a value in [0.0, 1.0]. It is not necessarily monotonic or
+   * non-decreasing.
    */
   public Optional<Double> getProgress() {
     return Optional.ofNullable(progress);
@@ -95,8 +100,8 @@ public class PollInfo {
   /**
    * The expiration time of the query execution.
    *
-   * <p>After this passes, the server may not recognize the descriptor anymore and the client will not
-   * be able to track the query anymore.
+   * <p>After this passes, the server may not recognize the descriptor anymore and the client will
+   * not be able to track the query anymore.
    */
   public Optional<Instant> getExpirationTime() {
     return Optional.ofNullable(expirationTime);
@@ -139,10 +144,10 @@ public class PollInfo {
       return false;
     }
     PollInfo pollInfo = (PollInfo) o;
-    return Objects.equals(getFlightInfo(), pollInfo.getFlightInfo()) &&
-        Objects.equals(getFlightDescriptor(), pollInfo.getFlightDescriptor()) &&
-        Objects.equals(getProgress(), pollInfo.getProgress()) &&
-        Objects.equals(getExpirationTime(), pollInfo.getExpirationTime());
+    return Objects.equals(getFlightInfo(), pollInfo.getFlightInfo())
+        && Objects.equals(getFlightDescriptor(), pollInfo.getFlightDescriptor())
+        && Objects.equals(getProgress(), pollInfo.getProgress())
+        && Objects.equals(getExpirationTime(), pollInfo.getExpirationTime());
   }
 
   @Override
@@ -152,11 +157,15 @@ public class PollInfo {
 
   @Override
   public String toString() {
-    return "PollInfo{" +
-        "flightInfo=" + flightInfo +
-        ", flightDescriptor=" + flightDescriptor +
-        ", progress=" + progress +
-        ", expirationTime=" + expirationTime +
-        '}';
+    return "PollInfo{"
+        + "flightInfo="
+        + flightInfo
+        + ", flightDescriptor="
+        + flightDescriptor
+        + ", progress="
+        + progress
+        + ", expirationTime="
+        + expirationTime
+        + '}';
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/PutResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/PutResult.java
@@ -14,15 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.protobuf.ByteString;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
-
-import com.google.protobuf.ByteString;
 
 /**
  * A message from the server during a DoPut operation.
@@ -57,8 +55,8 @@ public class PutResult implements AutoCloseable {
   /**
    * Get the metadata in this message. May be null.
    *
-   * <p>Ownership of the {@link ArrowBuf} is retained by this object. Call {@link ReferenceManager#retain()} to preserve
-   * a reference.
+   * <p>Ownership of the {@link ArrowBuf} is retained by this object. Call {@link
+   * ReferenceManager#retain()} to preserve a reference.
    */
   public ArrowBuf getApplicationMetadata() {
     return applicationMetadata;
@@ -68,22 +66,28 @@ public class PutResult implements AutoCloseable {
     if (applicationMetadata == null) {
       return Flight.PutResult.getDefaultInstance();
     }
-    return Flight.PutResult.newBuilder().setAppMetadata(ByteString.copyFrom(applicationMetadata.nioBuffer())).build();
+    return Flight.PutResult.newBuilder()
+        .setAppMetadata(ByteString.copyFrom(applicationMetadata.nioBuffer()))
+        .build();
   }
 
   /**
    * Construct a PutResult from a Protobuf message.
    *
-   * @param allocator The allocator to use for allocating application metadata memory. The result object owns the
-   *     allocated buffer, if any.
+   * @param allocator The allocator to use for allocating application metadata memory. The result
+   *     object owns the allocated buffer, if any.
    * @param message The gRPC/Protobuf message.
    */
   static PutResult fromProtocol(BufferAllocator allocator, Flight.PutResult message) {
     final ArrowBuf buf = allocator.buffer(message.getAppMetadata().size());
-    message.getAppMetadata().asReadOnlyByteBufferList().forEach(bb -> {
-      buf.setBytes(buf.writerIndex(), bb);
-      buf.writerIndex(buf.writerIndex() + bb.limit());
-    });
+    message
+        .getAppMetadata()
+        .asReadOnlyByteBufferList()
+        .forEach(
+            bb -> {
+              buf.setBytes(buf.writerIndex(), bb);
+              buf.writerIndex(buf.writerIndex() + bb.limit());
+            });
     return new PutResult(buf);
   }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RenewFlightEndpointRequest.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RenewFlightEndpointRequest.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** A request to extend the expiration time of a FlightEndpoint. */
@@ -49,7 +47,8 @@ public class RenewFlightEndpointRequest {
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -58,13 +57,15 @@ public class RenewFlightEndpointRequest {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.
    * @throws IOException if the serialized form is invalid.
    */
-  public static RenewFlightEndpointRequest deserialize(ByteBuffer serialized) throws IOException, URISyntaxException {
+  public static RenewFlightEndpointRequest deserialize(ByteBuffer serialized)
+      throws IOException, URISyntaxException {
     return new RenewFlightEndpointRequest(Flight.RenewFlightEndpointRequest.parseFrom(serialized));
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RequestContext.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RequestContext.java
@@ -14,17 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.Set;
 
-/**
- * Tracks variables about the current request.
- */
+/** Tracks variables about the current request. */
 public interface RequestContext {
   /**
    * Register a variable and a value.
+   *
    * @param key the variable name.
    * @param value the value.
    */
@@ -32,6 +30,7 @@ public interface RequestContext {
 
   /**
    * Retrieve a registered variable.
+   *
    * @param key the variable name.
    * @return the value, or null if not found.
    */
@@ -39,12 +38,14 @@ public interface RequestContext {
 
   /**
    * Retrieves the keys that have been registered to this context.
+   *
    * @return the keys used in this context.
    */
   Set<String> keySet();
 
   /**
    * Deletes a registered variable.
+   *
    * @return the value associated with the deleted variable, or null if the key doesn't exist.
    */
   String remove(String key);

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Result.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Result.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-import org.apache.arrow.flight.impl.Flight;
-
 import com.google.protobuf.ByteString;
+import org.apache.arrow.flight.impl.Flight;
 
 /**
  * Opaque result returned after executing an action.
@@ -43,8 +41,6 @@ public class Result {
   }
 
   Flight.Result toProtocol() {
-    return Flight.Result.newBuilder()
-        .setBody(ByteString.copyFrom(body))
-        .build();
+    return Flight.Result.newBuilder().setBody(ByteString.copyFrom(body)).build();
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SchemaResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SchemaResult.java
@@ -14,15 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.util.Objects;
-
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.WriteChannel;
@@ -30,10 +31,6 @@ import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.validate.MetadataV4UnionChecker;
-
-import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.ByteString;
 
 /**
  * Opaque result returned after executing a getSchema request.
@@ -49,9 +46,7 @@ public class SchemaResult {
     this(schema, IpcOption.DEFAULT);
   }
 
-  /**
-   * Create a schema result with specific IPC options for serialization.
-   */
+  /** Create a schema result with specific IPC options for serialization. */
   public SchemaResult(Schema schema, IpcOption option) {
     Objects.requireNonNull(schema);
     MetadataV4UnionChecker.checkForUnion(schema.getFields().iterator(), option.metadataVersion);
@@ -63,9 +58,7 @@ public class SchemaResult {
     return schema;
   }
 
-  /**
-   * Converts to the protocol buffer representation.
-   */
+  /** Converts to the protocol buffer representation. */
   Flight.SchemaResult toProtocol() {
     // Encode schema in a Message payload
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -75,20 +68,18 @@ public class SchemaResult {
       throw new RuntimeException(e);
     }
     return Flight.SchemaResult.newBuilder()
-            .setSchema(ByteString.copyFrom(baos.toByteArray()))
-            .build();
-
+        .setSchema(ByteString.copyFrom(baos.toByteArray()))
+        .build();
   }
 
-  /**
-   * Converts from the protocol buffer representation.
-   */
+  /** Converts from the protocol buffer representation. */
   static SchemaResult fromProtocol(Flight.SchemaResult pbSchemaResult) {
     try {
       final ByteBuffer schemaBuf = pbSchemaResult.getSchema().asReadOnlyByteBuffer();
-      Schema schema = pbSchemaResult.getSchema().size() > 0 ?
-              MessageSerializer.deserializeSchema(
-                      new ReadChannel(Channels.newChannel(new ByteBufferBackedInputStream(schemaBuf))))
+      Schema schema =
+          pbSchemaResult.getSchema().size() > 0
+              ? MessageSerializer.deserializeSchema(
+                  new ReadChannel(Channels.newChannel(new ByteBufferBackedInputStream(schemaBuf))))
               : new Schema(ImmutableList.of());
       return new SchemaResult(schema);
     } catch (IOException e) {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerHeaderMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerHeaderMiddleware.java
@@ -14,26 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
-/**
- * Middleware that's used to extract and pass headers to the server during requests.
- */
+/** Middleware that's used to extract and pass headers to the server during requests. */
 public class ServerHeaderMiddleware implements FlightServerMiddleware {
-  /**
-   * Factory for accessing ServerHeaderMiddleware.
-   */
+  /** Factory for accessing ServerHeaderMiddleware. */
   public static class Factory implements FlightServerMiddleware.Factory<ServerHeaderMiddleware> {
-    /**
-     * Construct a factory for receiving call headers.
-     */
-    public Factory() {
-    }
+    /** Construct a factory for receiving call headers. */
+    public Factory() {}
 
     @Override
-    public ServerHeaderMiddleware onCallStarted(CallInfo callInfo, CallHeaders incomingHeaders,
-                                                RequestContext context) {
+    public ServerHeaderMiddleware onCallStarted(
+        CallInfo callInfo, CallHeaders incomingHeaders, RequestContext context) {
       return new ServerHeaderMiddleware(incomingHeaders);
     }
   }
@@ -44,22 +36,17 @@ public class ServerHeaderMiddleware implements FlightServerMiddleware {
     this.headers = incomingHeaders;
   }
 
-  /**
-   * Retrieve the headers for this call.
-   */
+  /** Retrieve the headers for this call. */
   public CallHeaders headers() {
     return headers;
   }
 
   @Override
-  public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
-  }
+  public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {}
 
   @Override
-  public void onCallCompleted(CallStatus status) {
-  }
+  public void onCallCompleted(CallStatus status) {}
 
   @Override
-  public void onCallErrored(Throwable err) {
-  }
+  public void onCallErrored(Throwable err) {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValue.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValue.java
@@ -14,23 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.Arrays;
-
 import org.apache.arrow.flight.impl.Flight;
 
-/**
- * A union-like container interface for supported session option value types.
- */
+/** A union-like container interface for supported session option value types. */
 public abstract class SessionOptionValue {
-  SessionOptionValue() {
-  }
+  SessionOptionValue() {}
 
-  /**
-   * Value access via a caller-provided visitor/functor.
-   */
+  /** Value access via a caller-provided visitor/functor. */
   public abstract <T> T acceptVisitor(SessionOptionValueVisitor<T> v);
 
   Flight.SessionOptionValue toProtocol() {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValueFactory.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValueFactory.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** Abstract factory for concrete SessionOptionValue instances. */
@@ -60,9 +58,12 @@ public class SessionOptionValueFactory {
       case DOUBLE_VALUE:
         return new SessionOptionValueDouble(proto.getDoubleValue());
       case STRING_LIST_VALUE:
-        // Using ByteString::toByteArray() here otherwise we still somehow get `ByteArray`s with broken .equals(String)
-        return new SessionOptionValueStringList(proto.getStringListValue().getValuesList().asByteStringList().stream()
-            .map((e) -> new String(e.toByteArray(), StandardCharsets.UTF_8)).toArray(String[]::new));
+        // Using ByteString::toByteArray() here otherwise we still somehow get `ByteArray`s with
+        // broken .equals(String)
+        return new SessionOptionValueStringList(
+            proto.getStringListValue().getValuesList().asByteStringList().stream()
+                .map((e) -> new String(e.toByteArray(), StandardCharsets.UTF_8))
+                .toArray(String[]::new));
       case OPTIONVALUE_NOT_SET:
         return new SessionOptionValueEmpty();
       default:

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValueVisitor.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValueVisitor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 /**
@@ -23,36 +22,26 @@ package org.apache.arrow.flight;
  * @param <T> Return type of the visit operation.
  */
 public interface SessionOptionValueVisitor<T> {
-  /**
-   * A callback to handle SessionOptionValue containing a String.
-   */
+  /** A callback to handle SessionOptionValue containing a String. */
   T visit(String value);
 
-  /**
-   * A callback to handle SessionOptionValue containing a boolean.
-   */
+  /** A callback to handle SessionOptionValue containing a boolean. */
   T visit(boolean value);
 
-  /**
-   * A callback to handle SessionOptionValue containing a long.
-   */
+  /** A callback to handle SessionOptionValue containing a long. */
   T visit(long value);
 
-  /**
-   * A callback to handle SessionOptionValue containing a double.
-   */
+  /** A callback to handle SessionOptionValue containing a double. */
   T visit(double value);
 
-  /**
-   * A callback to handle SessionOptionValue containing an array of String.
-   */
+  /** A callback to handle SessionOptionValue containing an array of String. */
   T visit(String[] value);
 
   /**
    * A callback to handle SessionOptionValue containing no value.
    *
-   * By convention, an attempt to set a valueless SessionOptionValue should
-   * attempt to unset or clear the named option value on the server.
+   * <p>By convention, an attempt to set a valueless SessionOptionValue should attempt to unset or
+   * clear the named option value on the server.
    */
   T visit(Void value);
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SetSessionOptionsRequest.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SetSessionOptionsRequest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
@@ -23,7 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** A request to set option(s) in an existing or implicitly-created server session. */
@@ -31,13 +29,18 @@ public class SetSessionOptionsRequest {
   private final Map<String, SessionOptionValue> sessionOptions;
 
   public SetSessionOptionsRequest(Map<String, SessionOptionValue> sessionOptions) {
-    this.sessionOptions = Collections.unmodifiableMap(new HashMap<String, SessionOptionValue>(sessionOptions));
+    this.sessionOptions =
+        Collections.unmodifiableMap(new HashMap<String, SessionOptionValue>(sessionOptions));
   }
 
   SetSessionOptionsRequest(Flight.SetSessionOptionsRequest proto) {
-    sessionOptions = Collections.unmodifiableMap(
-        proto.getSessionOptionsMap().entrySet().stream().collect(Collectors.toMap(
-            Map.Entry::getKey, (e) -> SessionOptionValueFactory.makeSessionOptionValue(e.getValue()))));
+    sessionOptions =
+        Collections.unmodifiableMap(
+            proto.getSessionOptionsMap().entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        (e) -> SessionOptionValueFactory.makeSessionOptionValue(e.getValue()))));
   }
 
   /**
@@ -51,15 +54,17 @@ public class SetSessionOptionsRequest {
 
   Flight.SetSessionOptionsRequest toProtocol() {
     Flight.SetSessionOptionsRequest.Builder b = Flight.SetSessionOptionsRequest.newBuilder();
-    b.putAllSessionOptions(sessionOptions.entrySet().stream().collect(Collectors.toMap(
-        Map.Entry::getKey, (e) -> e.getValue().toProtocol())));
+    b.putAllSessionOptions(
+        sessionOptions.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, (e) -> e.getValue().toProtocol())));
     return b.build();
   }
 
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -68,7 +73,8 @@ public class SetSessionOptionsRequest {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.
@@ -77,5 +83,4 @@ public class SetSessionOptionsRequest {
   public static SetSessionOptionsRequest deserialize(ByteBuffer serialized) throws IOException {
     return new SetSessionOptionsRequest(Flight.SetSessionOptionsRequest.parseFrom(serialized));
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SetSessionOptionsResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SetSessionOptionsResult.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.IOException;
@@ -23,7 +22,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.flight.impl.Flight;
 
 /** The result of attempting to set a set of session options. */
@@ -31,22 +29,15 @@ public class SetSessionOptionsResult {
   /** Error status value for per-option errors. */
   public enum ErrorValue {
     /**
-     * The status of setting the option is unknown. Servers should avoid using this value
-     * (send a NOT_FOUND error if the requested session is not known). Clients can retry
-     * the request.
-      */
+     * The status of setting the option is unknown. Servers should avoid using this value (send a
+     * NOT_FOUND error if the requested session is not known). Clients can retry the request.
+     */
     UNSPECIFIED,
-    /**
-     * The given session option name is invalid.
-     */
+    /** The given session option name is invalid. */
     INVALID_NAME,
-    /**
-     * The session option value or type is invalid.
-     */
+    /** The session option value or type is invalid. */
     INVALID_VALUE,
-    /**
-     * The session option cannot be set.
-     */
+    /** The session option cannot be set. */
     ERROR,
     ;
 
@@ -72,7 +63,8 @@ public class SetSessionOptionsResult {
     }
 
     Flight.SetSessionOptionsResult.Error toProtocol() {
-      Flight.SetSessionOptionsResult.Error.Builder b = Flight.SetSessionOptionsResult.Error.newBuilder();
+      Flight.SetSessionOptionsResult.Error.Builder b =
+          Flight.SetSessionOptionsResult.Error.newBuilder();
       b.setValue(value.toProtocol());
       return b.build();
     }
@@ -102,8 +94,10 @@ public class SetSessionOptionsResult {
   }
 
   SetSessionOptionsResult(Flight.SetSessionOptionsResult proto) {
-    errors = Collections.unmodifiableMap(proto.getErrors().entrySet().stream().collect(
-        Collectors.toMap(Map.Entry::getKey, (e) -> new Error(e.getValue()))));
+    errors =
+        Collections.unmodifiableMap(
+            proto.getErrors().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, (e) -> new Error(e.getValue()))));
   }
 
   /** Report whether the error map has nonzero length. */
@@ -122,16 +116,17 @@ public class SetSessionOptionsResult {
 
   Flight.SetSessionOptionsResult toProtocol() {
     Flight.SetSessionOptionsResult.Builder b = Flight.SetSessionOptionsResult.newBuilder();
-    b.putAllErrors(errors.entrySet().stream().collect(Collectors.toMap(
-        Map.Entry::getKey,
-        (e) -> e.getValue().toProtocol())));
+    b.putAllErrors(
+        errors.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, (e) -> e.getValue().toProtocol())));
     return b.build();
   }
 
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -140,7 +135,8 @@ public class SetSessionOptionsResult {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the message, as returned by {@link #serialize()}.
    * @return The deserialized message.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/StreamPipe.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/StreamPipe.java
@@ -14,21 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import io.grpc.stub.StreamObserver;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
 import org.apache.arrow.flight.FlightProducer.StreamListener;
 import org.apache.arrow.flight.grpc.StatusUtils;
 import org.apache.arrow.util.AutoCloseables;
 
-import io.grpc.stub.StreamObserver;
-
 /**
  * Shim listener to avoid exposing GRPC internals.
-
+ *
  * @param <FROM> From Type
  * @param <TO> To Type
  */
@@ -45,17 +42,19 @@ class StreamPipe<FROM, TO> implements StreamListener<FROM> {
    *
    * @param delegate The {@link StreamObserver} to wrap.
    * @param func The transformation function.
-   * @param errorHandler A handler for uncaught exceptions (e.g. if something tries to double-close this stream).
+   * @param errorHandler A handler for uncaught exceptions (e.g. if something tries to double-close
+   *     this stream).
    * @param <FROM> The source type.
    * @param <TO> The output type.
    * @return A wrapped listener.
    */
-  public static <FROM, TO> StreamPipe<FROM, TO> wrap(StreamObserver<TO> delegate, Function<FROM, TO> func,
-      Consumer<Throwable> errorHandler) {
+  public static <FROM, TO> StreamPipe<FROM, TO> wrap(
+      StreamObserver<TO> delegate, Function<FROM, TO> func, Consumer<Throwable> errorHandler) {
     return new StreamPipe<>(delegate, func, errorHandler);
   }
 
-  public StreamPipe(StreamObserver<TO> delegate, Function<FROM, TO> func, Consumer<Throwable> errorHandler) {
+  public StreamPipe(
+      StreamObserver<TO> delegate, Function<FROM, TO> func, Consumer<Throwable> errorHandler) {
     super();
     this.delegate = delegate;
     this.mapFunction = func;
@@ -107,9 +106,7 @@ class StreamPipe<FROM, TO> implements StreamListener<FROM> {
     }
   }
 
-  /**
-   * Ensure this stream has been completed.
-   */
+  /** Ensure this stream has been completed. */
   void ensureCompleted() {
     if (!closed) {
       onCompleted();

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SyncPutListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SyncPutListener.java
@@ -14,20 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.arrow.flight.grpc.StatusUtils;
 import org.apache.arrow.memory.ArrowBuf;
 
 /**
- * A listener for server-sent application metadata messages during a Flight DoPut. This class wraps the messages in a
- * synchronous interface.
+ * A listener for server-sent application metadata messages during a Flight DoPut. This class wraps
+ * the messages in a synchronous interface.
  */
 public final class SyncPutListener implements FlightClient.PutListener, AutoCloseable {
 
@@ -55,8 +53,8 @@ public final class SyncPutListener implements FlightClient.PutListener, AutoClos
   /**
    * Get the next message from the server, blocking until it is available.
    *
-   * @return The next message, or null if the server is done sending messages. The caller assumes ownership of the
-   *     metadata and must remember to close it.
+   * @return The next message, or null if the server is done sending messages. The caller assumes
+   *     ownership of the metadata and must remember to close it.
    * @throws InterruptedException if interrupted while waiting.
    * @throws ExecutionException if the server sent an error, or if there was an internal error.
    */
@@ -65,14 +63,17 @@ public final class SyncPutListener implements FlightClient.PutListener, AutoClos
   }
 
   /**
-   * Get the next message from the server, blocking for the specified amount of time until it is available.
+   * Get the next message from the server, blocking for the specified amount of time until it is
+   * available.
    *
-   * @return The next message, or null if the server is done sending messages or no message arrived before the timeout.
-   *     The caller assumes ownership of the metadata and must remember to close it.
+   * @return The next message, or null if the server is done sending messages or no message arrived
+   *     before the timeout. The caller assumes ownership of the metadata and must remember to close
+   *     it.
    * @throws InterruptedException if interrupted while waiting.
    * @throws ExecutionException if the server sent an error, or if there was an internal error.
    */
-  public PutResult poll(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException {
+  public PutResult poll(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException {
     return unwrap(queue.poll(timeout, unit));
   }
 
@@ -108,11 +109,12 @@ public final class SyncPutListener implements FlightClient.PutListener, AutoClos
 
   @Override
   public void close() {
-    queue.forEach(o -> {
-      if (o instanceof PutResult) {
-        ((PutResult) o).close();
-      }
-    });
+    queue.forEach(
+        o -> {
+          if (o instanceof PutResult) {
+            ((PutResult) o).close();
+          }
+        });
   }
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Ticket.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/Ticket.java
@@ -14,20 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-
 import org.apache.arrow.flight.impl.Flight;
 
-import com.google.protobuf.ByteString;
-
-/**
- * Endpoint for a particular stream.
- */
+/** Endpoint for a particular stream. */
 public class Ticket {
   private final byte[] bytes;
 
@@ -45,15 +40,14 @@ public class Ticket {
   }
 
   Flight.Ticket toProtocol() {
-    return Flight.Ticket.newBuilder()
-        .setTicket(ByteString.copyFrom(bytes))
-        .build();
+    return Flight.Ticket.newBuilder().setTicket(ByteString.copyFrom(bytes)).build();
   }
 
   /**
    * Get the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight types.
+   * <p>Intended to help interoperability by allowing non-Flight services to still return Flight
+   * types.
    */
   public ByteBuffer serialize() {
     return ByteBuffer.wrap(toProtocol().toByteArray());
@@ -62,7 +56,8 @@ public class Ticket {
   /**
    * Parse the serialized form of this protocol message.
    *
-   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from non-Flight services.
+   * <p>Intended to help interoperability by allowing Flight clients to obtain stream info from
+   * non-Flight services.
    *
    * @param serialized The serialized form of the Ticket, as returned by {@link #serialize()}.
    * @return The deserialized Ticket.
@@ -97,6 +92,4 @@ public class Ticket {
     }
     return true;
   }
-
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
@@ -14,39 +14,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
-
-import org.apache.arrow.flight.FlightConstants;
 
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Metadata.BinaryMarshaller;
 import io.grpc.MethodDescriptor;
+import org.apache.arrow.flight.FlightConstants;
 
-/**
- * Constants used in authorization of flight connections.
- */
+/** Constants used in authorization of flight connections. */
 public final class AuthConstants {
 
-  public static final String HANDSHAKE_DESCRIPTOR_NAME = MethodDescriptor
-      .generateFullMethodName(FlightConstants.SERVICE, "Handshake");
+  public static final String HANDSHAKE_DESCRIPTOR_NAME =
+      MethodDescriptor.generateFullMethodName(FlightConstants.SERVICE, "Handshake");
   public static final String TOKEN_NAME = "Auth-Token-bin";
-  public static final Metadata.Key<byte[]> TOKEN_KEY = Metadata.Key.of(TOKEN_NAME, new BinaryMarshaller<byte[]>() {
+  public static final Metadata.Key<byte[]> TOKEN_KEY =
+      Metadata.Key.of(
+          TOKEN_NAME,
+          new BinaryMarshaller<byte[]>() {
 
-    @Override
-    public byte[] toBytes(byte[] value) {
-      return value;
-    }
+            @Override
+            public byte[] toBytes(byte[] value) {
+              return value;
+            }
 
-    @Override
-    public byte[] parseBytes(byte[] serialized) {
-      return serialized;
-    }
-  });
+            @Override
+            public byte[] parseBytes(byte[] serialized) {
+              return serialized;
+            }
+          });
 
-  public static final Context.Key<String> PEER_IDENTITY_KEY = Context.keyWithDefault("arrow-flight-peer-identity", "");
+  public static final Context.Key<String> PEER_IDENTITY_KEY =
+      Context.keyWithDefault("arrow-flight-peer-identity", "");
 
-  private AuthConstants() {
-  }
+  private AuthConstants() {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/BasicClientAuthHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/BasicClientAuthHandler.java
@@ -14,16 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
 
 import java.util.Iterator;
-
 import org.apache.arrow.flight.impl.Flight.BasicAuth;
 
-/**
- * A client auth handler that supports username and password.
- */
+/** A client auth handler that supports username and password. */
 public class BasicClientAuthHandler implements ClientAuthHandler {
 
   private final String name;
@@ -54,5 +50,4 @@ public class BasicClientAuthHandler implements ClientAuthHandler {
   public byte[] getCallToken() {
     return token;
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/BasicServerAuthHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/BasicServerAuthHandler.java
@@ -14,21 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.Iterator;
 import java.util.Optional;
-
 import org.apache.arrow.flight.impl.Flight.BasicAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
-/**
- * A ServerAuthHandler for username/password authentication.
- */
+/** A ServerAuthHandler for username/password authentication. */
 public class BasicServerAuthHandler implements ServerAuthHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(BasicServerAuthHandler.class);
@@ -39,15 +34,12 @@ public class BasicServerAuthHandler implements ServerAuthHandler {
     this.authValidator = authValidator;
   }
 
-  /**
-   * Interface that this handler delegates for determining if credentials are valid.
-   */
+  /** Interface that this handler delegates for determining if credentials are valid. */
   public interface BasicAuthValidator {
 
     byte[] getToken(String username, String password) throws Exception;
 
     Optional<String> isValid(byte[] token);
-
   }
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ClientAuthHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ClientAuthHandler.java
@@ -14,49 +14,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
 
 import java.util.Iterator;
-
 import org.apache.arrow.flight.FlightClient;
 
 /**
  * Implement authentication for Flight on the client side.
  *
  * @deprecated As of 14.0.0. This implements a stateful "login" flow that does not play well with
- *     distributed or stateless systems. It will not be removed, but should not be used. Instead
- *     see {@link FlightClient#authenticateBasicToken(String, String)}.
+ *     distributed or stateless systems. It will not be removed, but should not be used. Instead see
+ *     {@link FlightClient#authenticateBasicToken(String, String)}.
  */
 @Deprecated
 public interface ClientAuthHandler {
   /**
    * Handle the initial handshake with the server.
+   *
    * @param outgoing A channel to send data to the server.
    * @param incoming An iterator of incoming data from the server.
    */
   void authenticate(ClientAuthSender outgoing, Iterator<byte[]> incoming);
 
-  /**
-   * Get the per-call authentication token.
-   */
+  /** Get the per-call authentication token. */
   byte[] getCallToken();
 
-  /**
-   * A communication channel to the server during initial connection.
-   */
+  /** A communication channel to the server during initial connection. */
   interface ClientAuthSender {
 
-    /**
-     * Send the server a message.
-     */
+    /** Send the server a message. */
     void send(byte[] payload);
 
-    /**
-     * Signal an error to the server and abort the authentication attempt.
-     */
+    /** Signal an error to the server and abort the authentication attempt. */
     void onError(Throwable cause);
-
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ClientAuthInterceptor.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ClientAuthInterceptor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
 
 import io.grpc.CallOptions;
@@ -25,9 +24,7 @@ import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
-/**
- * GRPC client intercepter that handles authentication with the server.
- */
+/** GRPC client intercepter that handles authentication with the server. */
 public class ClientAuthInterceptor implements ClientInterceptor {
   private volatile ClientAuthHandler authHandler = null;
 
@@ -35,16 +32,15 @@ public class ClientAuthInterceptor implements ClientInterceptor {
     this.authHandler = authHandler;
   }
 
-  public ClientAuthInterceptor() {
-  }
+  public ClientAuthInterceptor() {}
 
   public boolean hasAuthHandler() {
     return authHandler != null;
   }
 
   @Override
-  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> methodDescriptor,
-      CallOptions callOptions, Channel next) {
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions, Channel next) {
     ClientCall<ReqT, RespT> call = next.newCall(methodDescriptor, callOptions);
 
     // once we have an auth header, add that to the calls.
@@ -55,7 +51,8 @@ public class ClientAuthInterceptor implements ClientInterceptor {
     return call;
   }
 
-  private final class HeaderAttachingClientCall<ReqT, RespT> extends SimpleForwardingClientCall<ReqT, RespT> {
+  private final class HeaderAttachingClientCall<ReqT, RespT>
+      extends SimpleForwardingClientCall<ReqT, RespT> {
 
     private HeaderAttachingClientCall(ClientCall<ReqT, RespT> call) {
       super(call);
@@ -69,5 +66,4 @@ public class ClientAuthInterceptor implements ClientInterceptor {
       super.start(responseListener, headers);
     }
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthHandler.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
 
 import java.util.Iterator;
 import java.util.Optional;
-
 import org.apache.arrow.flight.FlightServer;
 import org.apache.arrow.flight.auth2.CallHeaderAuthenticator;
 
@@ -28,8 +26,8 @@ import org.apache.arrow.flight.auth2.CallHeaderAuthenticator;
  *
  * @deprecated As of 14.0.0. This implements a stateful "login" flow that does not play well with
  *     distributed or stateless systems. It will not be removed, but should not be used. Instead,
- *     see {@link FlightServer.Builder#headerAuthenticator(CallHeaderAuthenticator)}
- *     and {@link CallHeaderAuthenticator}.
+ *     see {@link FlightServer.Builder#headerAuthenticator(CallHeaderAuthenticator)} and {@link
+ *     CallHeaderAuthenticator}.
  */
 @Deprecated
 public interface ServerAuthHandler {
@@ -37,8 +35,8 @@ public interface ServerAuthHandler {
   /**
    * Validate the client token provided on each call.
    *
-   * @return An empty optional if the client is not authenticated; the peer identity otherwise (may be the empty
-   *     string).
+   * @return An empty optional if the client is not authenticated; the peer identity otherwise (may
+   *     be the empty string).
    */
   Optional<String> isValid(byte[] token);
 
@@ -52,30 +50,27 @@ public interface ServerAuthHandler {
   boolean authenticate(ServerAuthSender outgoing, Iterator<byte[]> incoming);
 
   /**
-   * Interface for a server implementations to send back authentication messages
-   * back to the client.
+   * Interface for a server implementations to send back authentication messages back to the client.
    */
   interface ServerAuthSender {
 
     void send(byte[] payload);
 
     void onError(Throwable cause);
-
   }
 
-  /**
-   * An auth handler that does nothing.
-   */
-  ServerAuthHandler NO_OP = new ServerAuthHandler() {
+  /** An auth handler that does nothing. */
+  ServerAuthHandler NO_OP =
+      new ServerAuthHandler() {
 
-    @Override
-    public Optional<String> isValid(byte[] token) {
-      return Optional.of("");
-    }
+        @Override
+        public Optional<String> isValid(byte[] token) {
+          return Optional.of("");
+        }
 
-    @Override
-    public boolean authenticate(ServerAuthSender outgoing, Iterator<byte[]> incoming) {
-      return true;
-    }
-  };
+        @Override
+        public boolean authenticate(ServerAuthSender outgoing, Iterator<byte[]> incoming) {
+          return true;
+        }
+      };
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthInterceptor.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth/ServerAuthInterceptor.java
@@ -14,13 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
-
-import java.util.Optional;
-
-import org.apache.arrow.flight.FlightRuntimeException;
-import org.apache.arrow.flight.grpc.StatusUtils;
 
 import io.grpc.Context;
 import io.grpc.Contexts;
@@ -31,10 +25,11 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import java.util.Optional;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.grpc.StatusUtils;
 
-/**
- * GRPC Interceptor for performing authentication.
- */
+/** GRPC Interceptor for performing authentication. */
 public class ServerAuthInterceptor implements ServerInterceptor {
 
   private final ServerAuthHandler authHandler;
@@ -44,9 +39,11 @@ public class ServerAuthInterceptor implements ServerInterceptor {
   }
 
   @Override
-  public <ReqT, RespT> Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
-      ServerCallHandler<ReqT, RespT> next) {
-    if (!call.getMethodDescriptor().getFullMethodName().equals(AuthConstants.HANDSHAKE_DESCRIPTOR_NAME)) {
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    if (!call.getMethodDescriptor()
+        .getFullMethodName()
+        .equals(AuthConstants.HANDSHAKE_DESCRIPTOR_NAME)) {
       final Optional<String> peerIdentity;
 
       // Allow customizing the response code by throwing FlightRuntimeException
@@ -64,12 +61,17 @@ public class ServerAuthInterceptor implements ServerInterceptor {
 
       if (!peerIdentity.isPresent()) {
         // Send back a description along with the status code
-        call.close(Status.UNAUTHENTICATED
-            .withDescription("Unauthenticated (invalid or missing auth token)"), new Metadata());
+        call.close(
+            Status.UNAUTHENTICATED.withDescription(
+                "Unauthenticated (invalid or missing auth token)"),
+            new Metadata());
         return new NoopServerCallListener<>();
       }
-      return Contexts.interceptCall(Context.current().withValue(AuthConstants.PEER_IDENTITY_KEY, peerIdentity.get()),
-          call, headers, next);
+      return Contexts.interceptCall(
+          Context.current().withValue(AuthConstants.PEER_IDENTITY_KEY, peerIdentity.get()),
+          call,
+          headers,
+          next);
     }
 
     return next.startCall(call, headers);
@@ -80,6 +82,5 @@ public class ServerAuthInterceptor implements ServerInterceptor {
     return authHandler.isValid(token);
   }
 
-  private static class NoopServerCallListener<T> extends ServerCall.Listener<T> {
-  }
+  private static class NoopServerCallListener<T> extends ServerCall.Listener<T> {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/Auth2Constants.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/Auth2Constants.java
@@ -14,18 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
-/**
- * Constants used in authorization of flight connections.
- */
+/** Constants used in authorization of flight connections. */
 public final class Auth2Constants {
   public static final String PEER_IDENTITY_KEY = "arrow-flight-peer-identity";
   public static final String BEARER_PREFIX = "Bearer ";
   public static final String BASIC_PREFIX = "Basic ";
   public static final String AUTHORIZATION_HEADER = "Authorization";
 
-  private Auth2Constants() {
-  }
+  private Auth2Constants() {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/AuthUtilities.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/AuthUtilities.java
@@ -14,23 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
 
-/**
- * Utility class for completing the auth process.
- */
+/** Utility class for completing the auth process. */
 public final class AuthUtilities {
-  private AuthUtilities() {
-
-  }
+  private AuthUtilities() {}
 
   /**
    * Helper method for retrieving a value from the Authorization header.
    *
-   * @param headers     The headers to inspect.
+   * @param headers The headers to inspect.
    * @param valuePrefix The prefix within the value portion of the header to extract away.
    * @return The header value.
    */
@@ -43,5 +38,4 @@ public final class AuthUtilities {
     }
     return null;
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BasicAuthCredentialWriter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BasicAuthCredentialWriter.java
@@ -14,18 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.function.Consumer;
-
 import org.apache.arrow.flight.CallHeaders;
 
-/**
- * Client credentials that use a username and password.
- */
+/** Client credentials that use a username and password. */
 public final class BasicAuthCredentialWriter implements Consumer<CallHeaders> {
 
   private final String name;
@@ -38,7 +34,11 @@ public final class BasicAuthCredentialWriter implements Consumer<CallHeaders> {
 
   @Override
   public void accept(CallHeaders outputHeaders) {
-    outputHeaders.insert(Auth2Constants.AUTHORIZATION_HEADER, Auth2Constants.BASIC_PREFIX +
-        Base64.getEncoder().encodeToString(String.format("%s:%s", name, password).getBytes(StandardCharsets.UTF_8)));
+    outputHeaders.insert(
+        Auth2Constants.AUTHORIZATION_HEADER,
+        Auth2Constants.BASIC_PREFIX
+            + Base64.getEncoder()
+                .encodeToString(
+                    String.format("%s:%s", name, password).getBytes(StandardCharsets.UTF_8)));
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BasicCallHeaderAuthenticator.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BasicCallHeaderAuthenticator.java
@@ -14,22 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * A ServerAuthHandler for username/password authentication.
- */
+/** A ServerAuthHandler for username/password authentication. */
 public class BasicCallHeaderAuthenticator implements CallHeaderAuthenticator {
 
   private static final Logger logger = LoggerFactory.getLogger(BasicCallHeaderAuthenticator.class);
@@ -43,13 +39,14 @@ public class BasicCallHeaderAuthenticator implements CallHeaderAuthenticator {
   @Override
   public AuthResult authenticate(CallHeaders incomingHeaders) {
     try {
-      final String authEncoded = AuthUtilities.getValueFromAuthHeader(
-          incomingHeaders, Auth2Constants.BASIC_PREFIX);
+      final String authEncoded =
+          AuthUtilities.getValueFromAuthHeader(incomingHeaders, Auth2Constants.BASIC_PREFIX);
       if (authEncoded == null) {
         throw CallStatus.UNAUTHENTICATED.toRuntimeException();
       }
       // The value has the format Base64(<username>:<password>)
-      final String authDecoded = new String(Base64.getDecoder().decode(authEncoded), StandardCharsets.UTF_8);
+      final String authDecoded =
+          new String(Base64.getDecoder().decode(authEncoded), StandardCharsets.UTF_8);
       final int colonPos = authDecoded.indexOf(':');
       if (colonPos == -1) {
         throw CallStatus.UNAUTHENTICATED.toRuntimeException();
@@ -59,21 +56,21 @@ public class BasicCallHeaderAuthenticator implements CallHeaderAuthenticator {
       final String password = authDecoded.substring(colonPos + 1);
       return authValidator.validate(user, password);
     } catch (UnsupportedEncodingException ex) {
-      // Note: Intentionally discarding the exception cause when reporting back to the client for security purposes.
+      // Note: Intentionally discarding the exception cause when reporting back to the client for
+      // security purposes.
       logger.error("Authentication failed due to missing encoding.", ex);
       throw CallStatus.INTERNAL.toRuntimeException();
     } catch (FlightRuntimeException ex) {
       throw ex;
     } catch (Exception ex) {
-      // Note: Intentionally discarding the exception cause when reporting back to the client for security purposes.
+      // Note: Intentionally discarding the exception cause when reporting back to the client for
+      // security purposes.
       logger.error("Authentication failed.", ex);
       throw CallStatus.UNAUTHENTICATED.toRuntimeException();
     }
   }
 
-  /**
-   * Interface that this handler delegates to for validating the incoming headers.
-   */
+  /** Interface that this handler delegates to for validating the incoming headers. */
   public interface CredentialValidator {
     /**
      * Validate the supplied credentials (username/password) and return the peer identity.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BearerCredentialWriter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BearerCredentialWriter.java
@@ -14,16 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import java.util.function.Consumer;
-
 import org.apache.arrow.flight.CallHeaders;
 
-/**
- * Client credentials that use a bearer token.
- */
+/** Client credentials that use a bearer token. */
 public final class BearerCredentialWriter implements Consumer<CallHeaders> {
 
   private final String bearer;
@@ -34,6 +30,7 @@ public final class BearerCredentialWriter implements Consumer<CallHeaders> {
 
   @Override
   public void accept(CallHeaders outputHeaders) {
-    outputHeaders.insert(Auth2Constants.AUTHORIZATION_HEADER, Auth2Constants.BEARER_PREFIX + bearer);
+    outputHeaders.insert(
+        Auth2Constants.AUTHORIZATION_HEADER, Auth2Constants.BEARER_PREFIX + bearer);
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BearerTokenAuthenticator.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BearerTokenAuthenticator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
@@ -40,22 +39,25 @@ public abstract class BearerTokenAuthenticator implements CallHeaderAuthenticato
     }
 
     // Delegate to the basic auth handler to do the validation.
-    final CallHeaderAuthenticator.AuthResult result = initialAuthenticator.authenticate(incomingHeaders);
+    final CallHeaderAuthenticator.AuthResult result =
+        initialAuthenticator.authenticate(incomingHeaders);
     return getAuthResultWithBearerToken(result);
   }
 
   /**
    * Callback to run when the initial authenticator succeeds.
+   *
    * @param authResult A successful initial authentication result.
-   * @return an alternate AuthResult based on the original AuthResult that will write a bearer token to output headers.
+   * @return an alternate AuthResult based on the original AuthResult that will write a bearer token
+   *     to output headers.
    */
   protected abstract AuthResult getAuthResultWithBearerToken(AuthResult authResult);
 
   /**
    * Validate the bearer token.
+   *
    * @param bearerToken The bearer token to validate.
    * @return A successful AuthResult if validation succeeded.
    */
   protected abstract AuthResult validateBearer(String bearerToken);
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/CallHeaderAuthenticator.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/CallHeaderAuthenticator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
@@ -23,33 +22,38 @@ import org.apache.arrow.flight.FlightRuntimeException;
 /**
  * Interface for Server side authentication handlers.
  *
- * A CallHeaderAuthenticator is used by {@link ServerCallHeaderAuthMiddleware} to validate headers sent by a Flight
- * client for authentication purposes. The headers validated do not necessarily have to be Authorization headers.
+ * <p>A CallHeaderAuthenticator is used by {@link ServerCallHeaderAuthMiddleware} to validate
+ * headers sent by a Flight client for authentication purposes. The headers validated do not
+ * necessarily have to be Authorization headers.
  *
- * The workflow is that the FlightServer will intercept headers on a request, validate the headers, and
- * either send back an UNAUTHENTICATED error, or succeed and potentially send back additional headers to the client.
+ * <p>The workflow is that the FlightServer will intercept headers on a request, validate the
+ * headers, and either send back an UNAUTHENTICATED error, or succeed and potentially send back
+ * additional headers to the client.
  *
- * Implementations of CallHeaderAuthenticator should take care not to provide leak confidential details (such as
- * indicating if usernames are valid or not) for security reasons when reporting errors back to clients.
+ * <p>Implementations of CallHeaderAuthenticator should take care not to provide leak confidential
+ * details (such as indicating if usernames are valid or not) for security reasons when reporting
+ * errors back to clients.
  *
- * Example CallHeaderAuthenticators provided include:
- * The {@link BasicCallHeaderAuthenticator} will authenticate basic HTTP credentials.
+ * <p>Example CallHeaderAuthenticators provided include: The {@link BasicCallHeaderAuthenticator}
+ * will authenticate basic HTTP credentials.
  *
- * The {@link BearerTokenAuthenticator} will authenticate basic HTTP credentials initially, then also send back a
- * bearer token that the client can use for subsequent requests. The {@link GeneratedBearerTokenAuthenticator} will
- * provide internally generated bearer tokens and maintain a cache of them.
+ * <p>The {@link BearerTokenAuthenticator} will authenticate basic HTTP credentials initially, then
+ * also send back a bearer token that the client can use for subsequent requests. The {@link
+ * GeneratedBearerTokenAuthenticator} will provide internally generated bearer tokens and maintain a
+ * cache of them.
  */
 public interface CallHeaderAuthenticator {
 
   /**
    * Encapsulates the result of the {@link CallHeaderAuthenticator} analysis of headers.
    *
-   * This includes the identity of the incoming user and any outbound headers to send as a response to the client.
+   * <p>This includes the identity of the incoming user and any outbound headers to send as a
+   * response to the client.
    */
   interface AuthResult {
     /**
-     * The peer identity that was determined by the handshake process based on the
-     * authentication credentials supplied by the client.
+     * The peer identity that was determined by the handshake process based on the authentication
+     * credentials supplied by the client.
      *
      * @return The peer identity.
      */
@@ -57,11 +61,10 @@ public interface CallHeaderAuthenticator {
 
     /**
      * Appends a header to the outgoing call headers.
+     *
      * @param outgoingHeaders The outgoing headers.
      */
-    default void appendToOutgoingHeaders(CallHeaders outgoingHeaders) {
-
-    }
+    default void appendToOutgoingHeaders(CallHeaders outgoingHeaders) {}
   }
 
   /**
@@ -74,13 +77,12 @@ public interface CallHeaderAuthenticator {
    */
   AuthResult authenticate(CallHeaders incomingHeaders);
 
-  /**
-   * An auth handler that does nothing.
-   */
-  CallHeaderAuthenticator NO_OP = new CallHeaderAuthenticator() {
-    @Override
-    public AuthResult authenticate(CallHeaders incomingHeaders) {
-      return () -> "";
-    }
-  };
+  /** An auth handler that does nothing. */
+  CallHeaderAuthenticator NO_OP =
+      new CallHeaderAuthenticator() {
+        @Override
+        public AuthResult authenticate(CallHeaders incomingHeaders) {
+          return () -> "";
+        }
+      };
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientBearerHeaderHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientBearerHeaderHandler.java
@@ -14,20 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.grpc.CredentialCallOption;
 
-/**
- * A client header handler that parses the incoming headers for a bearer token.
- */
+/** A client header handler that parses the incoming headers for a bearer token. */
 public class ClientBearerHeaderHandler implements ClientHeaderHandler {
 
   @Override
-  public CredentialCallOption getCredentialCallOptionFromIncomingHeaders(CallHeaders incomingHeaders) {
-    final String bearerValue = AuthUtilities.getValueFromAuthHeader(incomingHeaders, Auth2Constants.BEARER_PREFIX);
+  public CredentialCallOption getCredentialCallOptionFromIncomingHeaders(
+      CallHeaders incomingHeaders) {
+    final String bearerValue =
+        AuthUtilities.getValueFromAuthHeader(incomingHeaders, Auth2Constants.BEARER_PREFIX);
     if (bearerValue != null) {
       return new CredentialCallOption(new BearerCredentialWriter(bearerValue));
     }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientHandshakeWrapper.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientHandshakeWrapper.java
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.grpc.StatusUtils;
@@ -27,17 +27,13 @@ import org.apache.arrow.flight.impl.Flight.HandshakeRequest;
 import org.apache.arrow.flight.impl.Flight.HandshakeResponse;
 import org.apache.arrow.flight.impl.FlightServiceGrpc.FlightServiceStub;
 
-import io.grpc.StatusRuntimeException;
-import io.grpc.stub.StreamObserver;
-
-/**
- * Utility class for executing a handshake with a FlightServer.
- */
+/** Utility class for executing a handshake with a FlightServer. */
 public class ClientHandshakeWrapper {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ClientHandshakeWrapper.class);
+  private static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(ClientHandshakeWrapper.class);
 
   /**
-   * Do handshake for a client.  The stub will be authenticated after this method returns.
+   * Do handshake for a client. The stub will be authenticated after this method returns.
    *
    * @param stub The service stub.
    */
@@ -83,8 +79,7 @@ public class ClientHandshakeWrapper {
     }
 
     @Override
-    public void onNext(HandshakeResponse value) {
-    }
+    public void onNext(HandshakeResponse value) {}
 
     @Override
     public void onError(Throwable t) {
@@ -96,5 +91,4 @@ public class ClientHandshakeWrapper {
       completed.complete(true);
     }
   }
-
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientHeaderHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientHeaderHandler.java
@@ -14,30 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.grpc.CredentialCallOption;
 
-/**
- * Interface for client side header parsing and conversion to CredentialCallOption.
- */
+/** Interface for client side header parsing and conversion to CredentialCallOption. */
 public interface ClientHeaderHandler {
   /**
    * Parses the incoming headers and converts them into a CredentialCallOption.
+   *
    * @param incomingHeaders Incoming headers to parse.
    * @return An instance of CredentialCallOption.
    */
   CredentialCallOption getCredentialCallOptionFromIncomingHeaders(CallHeaders incomingHeaders);
-  
-  /**
-   * An client header handler that does nothing.
-   */
-  ClientHeaderHandler NO_OP = new ClientHeaderHandler() {
-    @Override
-    public CredentialCallOption getCredentialCallOptionFromIncomingHeaders(CallHeaders incomingHeaders) {
-      return null;
-    }
-  };
+
+  /** An client header handler that does nothing. */
+  ClientHeaderHandler NO_OP =
+      new ClientHeaderHandler() {
+        @Override
+        public CredentialCallOption getCredentialCallOptionFromIncomingHeaders(
+            CallHeaders incomingHeaders) {
+          return null;
+        }
+      };
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientIncomingAuthHeaderMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ClientIncomingAuthHeaderMiddleware.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
@@ -23,22 +22,20 @@ import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightClientMiddleware;
 import org.apache.arrow.flight.grpc.CredentialCallOption;
 
-/**
- * Middleware for capturing bearer tokens sent back from the Flight server.
- */
+/** Middleware for capturing bearer tokens sent back from the Flight server. */
 public class ClientIncomingAuthHeaderMiddleware implements FlightClientMiddleware {
   private final Factory factory;
 
-  /**
-   * Factory used within FlightClient.
-   */
+  /** Factory used within FlightClient. */
   public static class Factory implements FlightClientMiddleware.Factory {
     private final ClientHeaderHandler headerHandler;
     private CredentialCallOption credentialCallOption = null;
 
     /**
      * Construct a factory with the given header handler.
-     * @param headerHandler The header handler that will be used for handling incoming headers from the flight server.
+     *
+     * @param headerHandler The header handler that will be used for handling incoming headers from
+     *     the flight server.
      */
     public Factory(ClientHeaderHandler headerHandler) {
       this.headerHandler = headerHandler;
@@ -63,16 +60,14 @@ public class ClientIncomingAuthHeaderMiddleware implements FlightClientMiddlewar
   }
 
   @Override
-  public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
-  }
+  public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {}
 
   @Override
   public void onHeadersReceived(CallHeaders incomingHeaders) {
     factory.setCredentialCallOption(
-            factory.headerHandler.getCredentialCallOptionFromIncomingHeaders(incomingHeaders));
+        factory.headerHandler.getCredentialCallOptionFromIncomingHeaders(incomingHeaders));
   }
 
   @Override
-  public void onCallCompleted(CallStatus status) {
-  }
+  public void onCallCompleted(CallStatus status) {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/GeneratedBearerTokenAuthenticator.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/GeneratedBearerTokenAuthenticator.java
@@ -14,32 +14,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
-
-import java.nio.ByteBuffer;
-import java.util.Base64;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.arrow.flight.CallHeaders;
-import org.apache.arrow.flight.CallStatus;
-import org.apache.arrow.flight.grpc.MetadataAdapter;
 
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-
 import io.grpc.Metadata;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.grpc.MetadataAdapter;
 
-/**
- * Generates and caches bearer tokens from user credentials.
- */
+/** Generates and caches bearer tokens from user credentials. */
 public class GeneratedBearerTokenAuthenticator extends BearerTokenAuthenticator {
   private final Cache<String, String> bearerToIdentityCache;
 
   /**
    * Generate bearer tokens for the given basic call authenticator.
+   *
    * @param authenticator The authenticator to initial validate inputs with.
    */
   public GeneratedBearerTokenAuthenticator(CallHeaderAuthenticator authenticator) {
@@ -48,20 +43,25 @@ public class GeneratedBearerTokenAuthenticator extends BearerTokenAuthenticator 
 
   /**
    * Generate bearer tokens for the given basic call authenticator.
+   *
    * @param authenticator The authenticator to initial validate inputs with.
    * @param timeoutMinutes The time before tokens expire after being accessed.
    */
-  public GeneratedBearerTokenAuthenticator(CallHeaderAuthenticator authenticator, int timeoutMinutes) {
-    this(authenticator, CacheBuilder.newBuilder().expireAfterAccess(timeoutMinutes, TimeUnit.MINUTES));
+  public GeneratedBearerTokenAuthenticator(
+      CallHeaderAuthenticator authenticator, int timeoutMinutes) {
+    this(
+        authenticator,
+        CacheBuilder.newBuilder().expireAfterAccess(timeoutMinutes, TimeUnit.MINUTES));
   }
 
   /**
    * Generate bearer tokens for the given basic call authenticator.
+   *
    * @param authenticator The authenticator to initial validate inputs with.
    * @param cacheBuilder The configuration of the cache of bearer tokens.
    */
-  public GeneratedBearerTokenAuthenticator(CallHeaderAuthenticator authenticator,
-      CacheBuilder<Object, Object> cacheBuilder) {
+  public GeneratedBearerTokenAuthenticator(
+      CallHeaderAuthenticator authenticator, CacheBuilder<Object, Object> cacheBuilder) {
     super(authenticator);
     bearerToIdentityCache = cacheBuilder.build();
   }
@@ -81,8 +81,11 @@ public class GeneratedBearerTokenAuthenticator extends BearerTokenAuthenticator 
 
       @Override
       public void appendToOutgoingHeaders(CallHeaders outgoingHeaders) {
-        if (null == AuthUtilities.getValueFromAuthHeader(outgoingHeaders, Auth2Constants.BEARER_PREFIX)) {
-          outgoingHeaders.insert(Auth2Constants.AUTHORIZATION_HEADER, Auth2Constants.BEARER_PREFIX + bearerToken);
+        if (null
+            == AuthUtilities.getValueFromAuthHeader(
+                outgoingHeaders, Auth2Constants.BEARER_PREFIX)) {
+          outgoingHeaders.insert(
+              Auth2Constants.AUTHORIZATION_HEADER, Auth2Constants.BEARER_PREFIX + bearerToken);
         }
       }
     };
@@ -96,7 +99,7 @@ public class GeneratedBearerTokenAuthenticator extends BearerTokenAuthenticator 
     final CallHeaders dummyHeaders = new MetadataAdapter(new Metadata());
     authResult.appendToOutgoingHeaders(dummyHeaders);
     String bearerToken =
-            AuthUtilities.getValueFromAuthHeader(dummyHeaders, Auth2Constants.BEARER_PREFIX);
+        AuthUtilities.getValueFromAuthHeader(dummyHeaders, Auth2Constants.BEARER_PREFIX);
     final AuthResult authResultWithBearerToken;
     if (Strings.isNullOrEmpty(bearerToken)) {
       // Generate a new bearer token and return an AuthResult that can write it.
@@ -106,18 +109,20 @@ public class GeneratedBearerTokenAuthenticator extends BearerTokenAuthenticator 
       byteBuffer.putLong(uuid.getLeastSignificantBits());
       final String newToken = Base64.getEncoder().encodeToString(byteBuffer.array());
       bearerToken = newToken;
-      authResultWithBearerToken = new AuthResult() {
-        @Override
-        public String getPeerIdentity() {
-          return authResult.getPeerIdentity();
-        }
+      authResultWithBearerToken =
+          new AuthResult() {
+            @Override
+            public String getPeerIdentity() {
+              return authResult.getPeerIdentity();
+            }
 
-        @Override
-        public void appendToOutgoingHeaders(CallHeaders outgoingHeaders) {
-          authResult.appendToOutgoingHeaders(outgoingHeaders);
-          outgoingHeaders.insert(Auth2Constants.AUTHORIZATION_HEADER, Auth2Constants.BEARER_PREFIX + newToken);
-        }
-      };
+            @Override
+            public void appendToOutgoingHeaders(CallHeaders outgoingHeaders) {
+              authResult.appendToOutgoingHeaders(outgoingHeaders);
+              outgoingHeaders.insert(
+                  Auth2Constants.AUTHORIZATION_HEADER, Auth2Constants.BEARER_PREFIX + newToken);
+            }
+          };
     } else {
       // Use the bearer token supplied by the original auth result.
       authResultWithBearerToken = authResult;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ServerCallHeaderAuthMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ServerCallHeaderAuthMiddleware.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import static org.apache.arrow.flight.auth2.CallHeaderAuthenticator.AuthResult;
@@ -26,18 +25,18 @@ import org.apache.arrow.flight.FlightServerMiddleware;
 import org.apache.arrow.flight.RequestContext;
 
 /**
- * Middleware that's used to validate credentials during the handshake and verify
- * the bearer token in subsequent requests.
+ * Middleware that's used to validate credentials during the handshake and verify the bearer token
+ * in subsequent requests.
  */
 public class ServerCallHeaderAuthMiddleware implements FlightServerMiddleware {
-  /**
-   * Factory for accessing ServerAuthMiddleware.
-   */
-  public static class Factory implements FlightServerMiddleware.Factory<ServerCallHeaderAuthMiddleware> {
+  /** Factory for accessing ServerAuthMiddleware. */
+  public static class Factory
+      implements FlightServerMiddleware.Factory<ServerCallHeaderAuthMiddleware> {
     private final CallHeaderAuthenticator authHandler;
 
     /**
      * Construct a factory with the given auth handler.
+     *
      * @param authHandler The auth handler what will be used for authenticating requests.
      */
     public Factory(CallHeaderAuthenticator authHandler) {
@@ -45,8 +44,8 @@ public class ServerCallHeaderAuthMiddleware implements FlightServerMiddleware {
     }
 
     @Override
-    public ServerCallHeaderAuthMiddleware onCallStarted(CallInfo callInfo, CallHeaders incomingHeaders,
-                                                        RequestContext context) {
+    public ServerCallHeaderAuthMiddleware onCallStarted(
+        CallInfo callInfo, CallHeaders incomingHeaders, RequestContext context) {
       final AuthResult result = authHandler.authenticate(incomingHeaders);
       context.put(Auth2Constants.PEER_IDENTITY_KEY, result.getPeerIdentity());
       return new ServerCallHeaderAuthMiddleware(result);
@@ -65,10 +64,8 @@ public class ServerCallHeaderAuthMiddleware implements FlightServerMiddleware {
   }
 
   @Override
-  public void onCallCompleted(CallStatus status) {
-  }
+  public void onCallCompleted(CallStatus status) {}
 
   @Override
-  public void onCallErrored(Throwable err) {
-  }
+  public void onCallErrored(Throwable err) {}
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.client;
 
 import java.net.HttpCookie;
@@ -23,7 +22,6 @@ import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallInfo;
 import org.apache.arrow.flight.CallStatus;
@@ -33,13 +31,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A client middleware for receiving and sending cookie information.
- * Note that this class will not persist permanent cookies beyond the lifetime
- * of this session.
+ * A client middleware for receiving and sending cookie information. Note that this class will not
+ * persist permanent cookies beyond the lifetime of this session.
  *
- * This middleware will automatically remove cookies that have expired.
- * <b>Note</b>: Negative max-age values currently do not get marked as expired due to
- * a JDK issue. Use max-age=0 to explicitly remove an existing cookie.
+ * <p>This middleware will automatically remove cookies that have expired. <b>Note</b>: Negative
+ * max-age values currently do not get marked as expired due to a JDK issue. Use max-age=0 to
+ * explicitly remove an existing cookie.
  */
 public class ClientCookieMiddleware implements FlightClientMiddleware {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientCookieMiddleware.class);
@@ -54,9 +51,7 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
     this.factory = factory;
   }
 
-  /**
-   * Factory used within FlightClient.
-   */
+  /** Factory used within FlightClient. */
   public static class Factory implements FlightClientMiddleware.Factory {
     // Use a map to track the most recent version of a cookie from the server.
     // Note that cookie names are case-sensitive (but header names aren't).
@@ -74,21 +69,24 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
       // with a different value and the client will use the new value in future requests.
       // The server can also update a cookie to have an Expiry in the past or negative age
       // to signal that the client should stop using the cookie immediately.
-      newCookieHeaderValues.forEach(headerValue -> {
-        try {
-          final List<HttpCookie> parsedCookies = HttpCookie.parse(headerValue);
-          parsedCookies.forEach(parsedCookie -> {
-            final String cookieNameLc = parsedCookie.getName().toLowerCase(Locale.ENGLISH);
-            if (parsedCookie.hasExpired()) {
-              cookies.remove(cookieNameLc);
-            } else {
-              cookies.put(parsedCookie.getName().toLowerCase(Locale.ENGLISH), parsedCookie);
+      newCookieHeaderValues.forEach(
+          headerValue -> {
+            try {
+              final List<HttpCookie> parsedCookies = HttpCookie.parse(headerValue);
+              parsedCookies.forEach(
+                  parsedCookie -> {
+                    final String cookieNameLc = parsedCookie.getName().toLowerCase(Locale.ENGLISH);
+                    if (parsedCookie.hasExpired()) {
+                      cookies.remove(cookieNameLc);
+                    } else {
+                      cookies.put(parsedCookie.getName().toLowerCase(Locale.ENGLISH), parsedCookie);
+                    }
+                  });
+            } catch (IllegalArgumentException ex) {
+              LOGGER.warn(
+                  "Skipping incorrectly formatted Set-Cookie header with value '{}'.", headerValue);
             }
           });
-        } catch (IllegalArgumentException ex) {
-          LOGGER.warn("Skipping incorrectly formatted Set-Cookie header with value '{}'.", headerValue);
-        }
-      });
     }
   }
 
@@ -109,13 +107,9 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
   }
 
   @Override
-  public void onCallCompleted(CallStatus status) {
+  public void onCallCompleted(CallStatus status) {}
 
-  }
-
-  /**
-   * Discards expired cookies and returns the valid cookies as a String delimited by ';'.
-   */
+  /** Discards expired cookies and returns the valid cookies as a String delimited by ';'. */
   @VisibleForTesting
   String getValidCookiesAsString() {
     // Discard expired cookies.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
 
+import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Constructor;
@@ -24,8 +24,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
-
-import io.netty.buffer.ByteBuf;
 
 /**
  * Allow a user to add a ByteBuf based InputStream directly into GRPC WritableBuffer to avoid an
@@ -41,7 +39,6 @@ public class AddWritableBuffer {
   private static final Class<?> bufChainOut;
 
   static {
-
     Constructor<?> tmpConstruct = null;
     Field tmpBufferList = null;
     Field tmpCurrent = null;
@@ -54,7 +51,8 @@ public class AddWritableBuffer {
       Constructor<?> tmpConstruct2 = nwb.getDeclaredConstructor(ByteBuf.class);
       tmpConstruct2.setAccessible(true);
 
-      Class<?> tmpBufChainOut2 = Class.forName("io.grpc.internal.MessageFramer$BufferChainOutputStream");
+      Class<?> tmpBufChainOut2 =
+          Class.forName("io.grpc.internal.MessageFramer$BufferChainOutputStream");
 
       Field tmpBufferList2 = tmpBufChainOut2.getDeclaredField("bufferList");
       tmpBufferList2.setAccessible(true);
@@ -72,7 +70,8 @@ public class AddWritableBuffer {
       tmpBufChainOut = tmpBufChainOut2;
 
     } catch (Exception ex) {
-      new RuntimeException("Failed to initialize AddWritableBuffer, falling back to slow path", ex).printStackTrace();
+      new RuntimeException("Failed to initialize AddWritableBuffer, falling back to slow path", ex)
+          .printStackTrace();
     }
 
     bufConstruct = tmpConstruct;
@@ -80,18 +79,22 @@ public class AddWritableBuffer {
     current = tmpCurrent;
     listAdd = tmpListAdd;
     bufChainOut = tmpBufChainOut;
-
   }
 
   /**
-   * Add the provided ByteBuf to the gRPC BufferChainOutputStream if possible, else copy the buffer to the stream.
+   * Add the provided ByteBuf to the gRPC BufferChainOutputStream if possible, else copy the buffer
+   * to the stream.
+   *
    * @param buf The buffer to add.
    * @param stream The Candidate OutputStream to add to.
-   * @param tryZeroCopy If true, try to zero-copy append the buffer to the stream. This may not succeed.
+   * @param tryZeroCopy If true, try to zero-copy append the buffer to the stream. This may not
+   *     succeed.
    * @return True if buffer was zero-copy added to the stream. False if the buffer was copied.
-   * @throws IOException if the fast path is not enabled and there was an error copying the buffer to the stream.
+   * @throws IOException if the fast path is not enabled and there was an error copying the buffer
+   *     to the stream.
    */
-  public static boolean add(ByteBuf buf, OutputStream stream, boolean tryZeroCopy) throws IOException {
+  public static boolean add(ByteBuf buf, OutputStream stream, boolean tryZeroCopy)
+      throws IOException {
     if (!tryZeroCopy || !tryAddBuffer(buf, stream)) {
       buf.getBytes(0, stream, buf.readableBytes());
       return false;
@@ -120,7 +123,10 @@ public class AddWritableBuffer {
       listAdd.invoke(list, obj);
       current.set(stream, obj);
       return true;
-    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | InstantiationException e) {
+    } catch (IllegalAccessException
+        | IllegalArgumentException
+        | InvocationTargetException
+        | InstantiationException e) {
       e.printStackTrace();
       return false;
     }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/CallCredentialAdapter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/CallCredentialAdapter.java
@@ -14,20 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
-
-import java.util.concurrent.Executor;
-import java.util.function.Consumer;
-
-import org.apache.arrow.flight.CallHeaders;
 
 import io.grpc.CallCredentials;
 import io.grpc.Metadata;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import org.apache.arrow.flight.CallHeaders;
 
-/**
- * Adapter class to utilize a CredentialWriter to implement Grpc CallCredentials.
- */
+/** Adapter class to utilize a CredentialWriter to implement Grpc CallCredentials. */
 public class CallCredentialAdapter extends CallCredentials {
 
   private final Consumer<CallHeaders> credentialWriter;
@@ -37,13 +32,14 @@ public class CallCredentialAdapter extends CallCredentials {
   }
 
   @Override
-  public void applyRequestMetadata(RequestInfo requestInfo, Executor executor, MetadataApplier metadataApplier) {
-    executor.execute(() ->
-    {
-      final Metadata headers = new Metadata();
-      credentialWriter.accept(new MetadataAdapter(headers));
-      metadataApplier.apply(headers);
-    });
+  public void applyRequestMetadata(
+      RequestInfo requestInfo, Executor executor, MetadataApplier metadataApplier) {
+    executor.execute(
+        () -> {
+          final Metadata headers = new Metadata();
+          credentialWriter.accept(new MetadataAdapter(headers));
+          metadataApplier.apply(headers);
+        });
   }
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/ContextPropagatingExecutorService.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/ContextPropagatingExecutorService.java
@@ -14,9 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
 
+import io.grpc.Context;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -27,14 +27,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import io.grpc.Context;
-
 /**
  * An {@link ExecutorService} that propagates the {@link Context}.
  *
- * <p>Context is used to propagate per-call state, like the authenticated user, between threads (as gRPC makes no
- * guarantees about what thread things execute on). This wrapper makes it easy to preserve this when using an Executor.
- * The Context itself is immutable, so it is thread-safe.
+ * <p>Context is used to propagate per-call state, like the authenticated user, between threads (as
+ * gRPC makes no guarantees about what thread things execute on). This wrapper makes it easy to
+ * preserve this when using an Executor. The Context itself is immutable, so it is thread-safe.
  */
 public class ContextPropagatingExecutorService implements ExecutorService {
 
@@ -89,25 +87,32 @@ public class ContextPropagatingExecutorService implements ExecutorService {
   }
 
   @Override
-  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-    return delegate.invokeAll(tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()));
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    return delegate.invokeAll(
+        tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()));
   }
 
   @Override
-  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
-      TimeUnit unit) throws InterruptedException {
-    return delegate.invokeAll(tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()), timeout, unit);
+  public <T> List<Future<T>> invokeAll(
+      Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    return delegate.invokeAll(
+        tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override
-  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-    return delegate.invokeAny(tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()));
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException, ExecutionException {
+    return delegate.invokeAny(
+        tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()));
   }
 
   @Override
   public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return delegate.invokeAny(tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()), timeout, unit);
+    return delegate.invokeAny(
+        tasks.stream().map(Context.current()::wrap).collect(Collectors.toList()), timeout, unit);
   }
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/CredentialCallOption.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/CredentialCallOption.java
@@ -14,19 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
 
+import io.grpc.stub.AbstractStub;
 import java.util.function.Consumer;
-
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallOptions;
 
-import io.grpc.stub.AbstractStub;
-
-/**
- * Method option for supplying credentials to method calls.
- */
+/** Method option for supplying credentials to method calls. */
 public class CredentialCallOption implements CallOptions.GrpcCallOption {
   private final Consumer<CallHeaders> credentialWriter;
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
@@ -14,19 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-
-import org.apache.arrow.memory.ArrowBuf;
 
 import com.google.common.base.Throwables;
 import com.google.common.io.ByteStreams;
-
 import io.grpc.internal.ReadableBuffer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import org.apache.arrow.memory.ArrowBuf;
 
 /**
  * Enable access to ReadableBuffer directly to copy data from a BufferInputStream into a target
@@ -51,7 +47,8 @@ public class GetReadableBuffer {
       tmpField = f;
       tmpClazz = clazz;
     } catch (Exception e) {
-      new RuntimeException("Failed to initialize GetReadableBuffer, falling back to slow path", e).printStackTrace();
+      new RuntimeException("Failed to initialize GetReadableBuffer, falling back to slow path", e)
+          .printStackTrace();
     }
     READABLE_BUFFER = tmpField;
     BUFFER_INPUT_STREAM = tmpClazz;
@@ -60,8 +57,8 @@ public class GetReadableBuffer {
   /**
    * Extracts the ReadableBuffer for the given input stream.
    *
-   * @param is Must be an instance of io.grpc.internal.ReadableBuffers$BufferInputStream or
-   *     null will be returned.
+   * @param is Must be an instance of io.grpc.internal.ReadableBuffers$BufferInputStream or null
+   *     will be returned.
    */
   public static ReadableBuffer getReadableBuffer(InputStream is) {
 
@@ -78,14 +75,17 @@ public class GetReadableBuffer {
 
   /**
    * Helper method to read a gRPC-provided InputStream into an ArrowBuf.
+   *
    * @param stream The stream to read from. Should be an instance of {@link #BUFFER_INPUT_STREAM}.
    * @param buf The buffer to read into.
    * @param size The number of bytes to read.
-   * @param fastPath Whether to enable the fast path (i.e. detect whether the stream is a {@link #BUFFER_INPUT_STREAM}).
+   * @param fastPath Whether to enable the fast path (i.e. detect whether the stream is a {@link
+   *     #BUFFER_INPUT_STREAM}).
    * @throws IOException if there is an error reading form the stream
    */
-  public static void readIntoBuffer(final InputStream stream, final ArrowBuf buf, final int size,
-      final boolean fastPath) throws IOException {
+  public static void readIntoBuffer(
+      final InputStream stream, final ArrowBuf buf, final int size, final boolean fastPath)
+      throws IOException {
     ReadableBuffer readableBuffer = fastPath ? getReadableBuffer(stream) : null;
     if (readableBuffer != null) {
       readableBuffer.readBytes(buf.nioBuffer(0, size));

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/MetadataAdapter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/MetadataAdapter.java
@@ -14,24 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
 
+import io.grpc.Metadata;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
 import org.apache.arrow.flight.CallHeaders;
-
-import io.grpc.Metadata;
-import io.grpc.Metadata.Key;
 
 /**
  * A mutable adapter between the gRPC Metadata object and the Flight headers interface.
  *
- * <p>This allows us to present the headers (metadata) from gRPC without copying to/from our own object.
+ * <p>This allows us to present the headers (metadata) from gRPC without copying to/from our own
+ * object.
  */
 public class MetadataAdapter implements CallHeaders {
 
@@ -65,7 +62,8 @@ public class MetadataAdapter implements CallHeaders {
       return this.metadata.getAll(Metadata.Key.of(key, Metadata.BINARY_BYTE_MARSHALLER));
     }
     return StreamSupport.stream(getAll(key).spliterator(), false)
-        .map(String::getBytes).collect(Collectors.toList());
+        .map(String::getBytes)
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/RequestContextAdapter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/RequestContextAdapter.java
@@ -14,29 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
 
+import io.grpc.Context;
 import java.util.HashMap;
 import java.util.Set;
-
 import org.apache.arrow.flight.RequestContext;
 
-import io.grpc.Context;
-
-
-/**
- * Adapter for holding key value pairs.
- */
+/** Adapter for holding key value pairs. */
 public class RequestContextAdapter implements RequestContext {
   public static final Context.Key<RequestContext> REQUEST_CONTEXT_KEY =
-          Context.key("arrow-flight-request-context");
+      Context.key("arrow-flight-request-context");
   private final HashMap<String, String> map = new HashMap<>();
 
   @Override
   public void put(String key, String value) {
     if (map.putIfAbsent(key, value) != null) {
-      throw new IllegalArgumentException("Duplicate write to a RequestContext at key " + key + " not allowed.");
+      throw new IllegalArgumentException(
+          "Duplicate write to a RequestContext at key " + key + " not allowed.");
     }
   }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/ServerBackpressureThresholdInterceptor.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/ServerBackpressureThresholdInterceptor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
 
 import io.grpc.Metadata;
@@ -23,8 +22,8 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 
 /**
- * An interceptor for specifying the number of bytes that can be queued before a call with an output stream
- * gets blocked by backpressure.
+ * An interceptor for specifying the number of bytes that can be queued before a call with an output
+ * stream gets blocked by backpressure.
  */
 public class ServerBackpressureThresholdInterceptor implements ServerInterceptor {
 
@@ -35,8 +34,8 @@ public class ServerBackpressureThresholdInterceptor implements ServerInterceptor
   }
 
   @Override
-  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers,
-       ServerCallHandler<ReqT, RespT> next) {
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
     call.setOnReadyThreshold(numBytes);
     return next.startCall(call, headers);
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/StatusUtils.java
@@ -14,18 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
-import java.util.Objects;
-import java.util.function.Function;
-
-import org.apache.arrow.flight.CallStatus;
-import org.apache.arrow.flight.ErrorFlightMetadata;
-import org.apache.arrow.flight.FlightRuntimeException;
-import org.apache.arrow.flight.FlightStatusCode;
 
 import io.grpc.InternalMetadata;
 import io.grpc.Metadata;
@@ -33,6 +22,14 @@ import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.Function;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.ErrorFlightMetadata;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.FlightStatusCode;
 
 /**
  * Utilities to adapt gRPC and Flight status objects.
@@ -45,9 +42,7 @@ public class StatusUtils {
     throw new AssertionError("Do not instantiate this class.");
   }
 
-  /**
-   * Convert from a Flight status code to a gRPC status code.
-   */
+  /** Convert from a Flight status code to a gRPC status code. */
   public static Status.Code toGrpcStatusCode(FlightStatusCode code) {
     switch (code) {
       case OK:
@@ -81,9 +76,7 @@ public class StatusUtils {
     }
   }
 
-  /**
-   * Convert from a gRPC status code to a Flight status code.
-   */
+  /** Convert from a gRPC status code to a Flight status code. */
   public static FlightStatusCode fromGrpcStatusCode(Status.Code code) {
     switch (code) {
       case OK:
@@ -138,28 +131,29 @@ public class StatusUtils {
 
   /** Convert from a gRPC Status & trailers to a Flight status. */
   public static CallStatus fromGrpcStatusAndTrailers(Status status, Metadata trailers) {
-    // gRPC may not always have trailers - this happens when the server internally generates an error, which is rare,
+    // gRPC may not always have trailers - this happens when the server internally generates an
+    // error, which is rare,
     // but can happen.
     final ErrorFlightMetadata errorMetadata = trailers == null ? null : parseTrailers(trailers);
     return new CallStatus(
-              fromGrpcStatusCode(status.getCode()),
-              status.getCause(),
-              status.getDescription(),
-              errorMetadata);
+        fromGrpcStatusCode(status.getCode()),
+        status.getCause(),
+        status.getDescription(),
+        errorMetadata);
   }
 
   /** Convert from a gRPC status to a Flight status. */
   public static CallStatus fromGrpcStatus(Status status) {
     return new CallStatus(
-              fromGrpcStatusCode(status.getCode()),
-              status.getCause(),
-              status.getDescription(),
-              null);
+        fromGrpcStatusCode(status.getCode()), status.getCause(), status.getDescription(), null);
   }
 
   /** Convert from a Flight status to a gRPC status. */
   public static Status toGrpcStatus(CallStatus status) {
-    return toGrpcStatusCode(status.code()).toStatus().withDescription(status.description()).withCause(status.cause());
+    return toGrpcStatusCode(status.code())
+        .toStatus()
+        .withDescription(status.description())
+        .withCause(status.cause());
   }
 
   /** Convert from a gRPC exception to a Flight exception. */
@@ -174,15 +168,15 @@ public class StatusUtils {
       if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
         metadata.insert(key, trailers.get(keyOfBinary(key)));
       } else {
-        metadata.insert(key, Objects.requireNonNull(trailers.get(keyOfAscii(key))).getBytes(StandardCharsets.UTF_8));
+        metadata.insert(
+            key,
+            Objects.requireNonNull(trailers.get(keyOfAscii(key))).getBytes(StandardCharsets.UTF_8));
       }
     }
     return metadata;
   }
 
-  /**
-   * Convert arbitrary exceptions to a {@link FlightRuntimeException}.
-   */
+  /** Convert arbitrary exceptions to a {@link FlightRuntimeException}. */
   public static FlightRuntimeException fromThrowable(Throwable t) {
     if (t instanceof StatusRuntimeException) {
       return fromGrpcRuntimeException((StatusRuntimeException) t);
@@ -195,8 +189,8 @@ public class StatusUtils {
   /**
    * Convert arbitrary exceptions to a {@link StatusRuntimeException} or {@link StatusException}.
    *
-   * <p>Such exceptions can be passed to {@link io.grpc.stub.StreamObserver#onError(Throwable)} and will give the client
-   * a reasonable error message.
+   * <p>Such exceptions can be passed to {@link io.grpc.stub.StreamObserver#onError(Throwable)} and
+   * will give the client a reasonable error message.
    */
   public static Throwable toGrpcException(Throwable ex) {
     if (ex instanceof StatusRuntimeException) {
@@ -211,7 +205,9 @@ public class StatusUtils {
       }
       return toGrpcStatus(fre.status()).asRuntimeException();
     }
-    return Status.INTERNAL.withCause(ex).withDescription("There was an error servicing your request.")
+    return Status.INTERNAL
+        .withCause(ex)
+        .withDescription("There was an error servicing your request.")
         .asRuntimeException();
   }
 
@@ -228,11 +224,11 @@ public class StatusUtils {
   }
 
   /**
-   * Maps a transformation function to the elements of an iterator, while wrapping exceptions in {@link
-   * FlightRuntimeException}.
+   * Maps a transformation function to the elements of an iterator, while wrapping exceptions in
+   * {@link FlightRuntimeException}.
    */
-  public static <FROM, TO> Iterator<TO> wrapIterator(Iterator<FROM> fromIterator,
-      Function<? super FROM, ? extends TO> transformer) {
+  public static <FROM, TO> Iterator<TO> wrapIterator(
+      Iterator<FROM> fromIterator, Function<? super FROM, ? extends TO> transformer) {
     Objects.requireNonNull(fromIterator);
     Objects.requireNonNull(transformer);
     return new Iterator<TO>() {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/FlightTestUtil.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import java.io.File;
@@ -23,14 +22,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.arrow.vector.test.util.ArrowTestDataUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
 
-/**
- * Utility methods and constants for testing flight servers.
- */
+/** Utility methods and constants for testing flight servers. */
 public class FlightTestUtil {
 
   public static final String LOCALHOST = "localhost";
@@ -47,9 +43,12 @@ public class FlightTestUtil {
     final Path root = getFlightTestDataRoot();
     final Path cert0Pem = root.resolve("cert0.pem");
     if (!Files.exists(cert0Pem)) {
-      throw new RuntimeException(cert0Pem + " doesn't exist. Make sure submodules are initialized (see https://arrow.apache.org/docs/dev/developers/java/building.html#building)");
+      throw new RuntimeException(
+          cert0Pem
+              + " doesn't exist. Make sure submodules are initialized (see https://arrow.apache.org/docs/dev/developers/java/building.html#building)");
     }
-    return Arrays.asList(new CertKeyPair(cert0Pem.toFile(), root.resolve("cert0.pkcs1").toFile()),
+    return Arrays.asList(
+        new CertKeyPair(cert0Pem.toFile(), root.resolve("cert0.pkcs1").toFile()),
         new CertKeyPair(root.resolve("cert1.pem").toFile(), root.resolve("cert1.pkcs1").toFile()));
   }
 
@@ -57,7 +56,10 @@ public class FlightTestUtil {
     try {
       Class<?> epoll = Class.forName("io.netty.channel.epoll.Epoll");
       return (Boolean) epoll.getMethod("isAvailable").invoke(null);
-    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException e) {
       return false;
     }
   }
@@ -66,7 +68,10 @@ public class FlightTestUtil {
     try {
       Class<?> kqueue = Class.forName("io.netty.channel.kqueue.KQueue");
       return (Boolean) kqueue.getMethod("isAvailable").invoke(null);
-    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException e) {
       return false;
     }
   }
@@ -77,6 +82,7 @@ public class FlightTestUtil {
 
   /**
    * Assert that the given runnable fails with a Flight exception of the given code.
+   *
    * @param code The expected Flight status code.
    * @param r The code to run.
    * @return The thrown status.
@@ -98,6 +104,5 @@ public class FlightTestUtil {
     }
   }
 
-  private FlightTestUtil() {
-  }
+  private FlightTestUtil() {}
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestApplicationMetadata.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestApplicationMetadata.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
@@ -26,7 +25,6 @@ import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
-
 import org.apache.arrow.flight.FlightClient.PutListener;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
@@ -40,9 +38,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for application-specific metadata support in Flight.
- */
+/** Tests for application-specific metadata support in Flight. */
 public class TestApplicationMetadata {
 
   // The command used to trigger the test for ARROW-6136.
@@ -50,171 +46,186 @@ public class TestApplicationMetadata {
   // The expected error message.
   private static final String MESSAGE_ARROW_6136 = "The stream should not be double-closed.";
 
-  /**
-   * Ensure that a client can read the metadata sent from the server.
-   */
+  /** Ensure that a client can read the metadata sent from the server. */
   @Test
   // This test is consistently flaky on CI, unfortunately.
   @Disabled
   public void retrieveMetadata() {
-    test((allocator, client) -> {
-      try (final FlightStream stream = client.getStream(new Ticket(new byte[0]))) {
-        byte i = 0;
-        while (stream.next()) {
-          final IntVector vector = (IntVector) stream.getRoot().getVector("a");
-          Assertions.assertEquals(1, vector.getValueCount());
-          Assertions.assertEquals(10, vector.get(0));
-          Assertions.assertEquals(i, stream.getLatestMetadata().getByte(0));
-          i++;
-        }
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
+    test(
+        (allocator, client) -> {
+          try (final FlightStream stream = client.getStream(new Ticket(new byte[0]))) {
+            byte i = 0;
+            while (stream.next()) {
+              final IntVector vector = (IntVector) stream.getRoot().getVector("a");
+              Assertions.assertEquals(1, vector.getValueCount());
+              Assertions.assertEquals(10, vector.get(0));
+              Assertions.assertEquals(i, stream.getLatestMetadata().getByte(0));
+              i++;
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
-  /** ARROW-6136: make sure that the Flight implementation doesn't double-close the server-to-client stream. */
+  /**
+   * ARROW-6136: make sure that the Flight implementation doesn't double-close the server-to-client
+   * stream.
+   */
   @Test
   public void arrow6136() {
     final Schema schema = new Schema(Collections.emptyList());
-    test((allocator, client) -> {
-      try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
-        final FlightDescriptor descriptor = FlightDescriptor.command(COMMAND_ARROW_6136);
+    test(
+        (allocator, client) -> {
+          try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            final FlightDescriptor descriptor = FlightDescriptor.command(COMMAND_ARROW_6136);
 
-        final PutListener listener = new SyncPutListener();
-        final FlightClient.ClientStreamListener writer = client.startPut(descriptor, root, listener);
-        // Must attempt to retrieve the result to get any server-side errors.
-        final CallStatus status = FlightTestUtil.assertCode(FlightStatusCode.INTERNAL, writer::getResult);
-        Assertions.assertEquals(MESSAGE_ARROW_6136, status.description());
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
+            final PutListener listener = new SyncPutListener();
+            final FlightClient.ClientStreamListener writer =
+                client.startPut(descriptor, root, listener);
+            // Must attempt to retrieve the result to get any server-side errors.
+            final CallStatus status =
+                FlightTestUtil.assertCode(FlightStatusCode.INTERNAL, writer::getResult);
+            Assertions.assertEquals(MESSAGE_ARROW_6136, status.description());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
-  /**
-   * Ensure that a client can send metadata to the server.
-   */
+  /** Ensure that a client can send metadata to the server. */
   @Test
   @Disabled
   public void uploadMetadataAsync() {
-    final Schema schema = new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
-    test((allocator, client) -> {
-      try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
-        final FlightDescriptor descriptor = FlightDescriptor.path("test");
+    final Schema schema =
+        new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
+    test(
+        (allocator, client) -> {
+          try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            final FlightDescriptor descriptor = FlightDescriptor.path("test");
 
-        final PutListener listener = new AsyncPutListener() {
-          int counter = 0;
+            final PutListener listener =
+                new AsyncPutListener() {
+                  int counter = 0;
 
-          @Override
-          public void onNext(PutResult val) {
-            Assertions.assertNotNull(val);
-            Assertions.assertEquals(counter, val.getApplicationMetadata().getByte(0));
-            counter++;
+                  @Override
+                  public void onNext(PutResult val) {
+                    Assertions.assertNotNull(val);
+                    Assertions.assertEquals(counter, val.getApplicationMetadata().getByte(0));
+                    counter++;
+                  }
+                };
+            final FlightClient.ClientStreamListener writer =
+                client.startPut(descriptor, root, listener);
+
+            root.allocateNew();
+            for (byte i = 0; i < 10; i++) {
+              final IntVector vector = (IntVector) root.getVector("a");
+              final ArrowBuf metadata = allocator.buffer(1);
+              metadata.writeByte(i);
+              vector.set(0, 10);
+              vector.setValueCount(1);
+              root.setRowCount(1);
+              writer.putNext(metadata);
+            }
+            writer.completed();
+            // Must attempt to retrieve the result to get any server-side errors.
+            writer.getResult();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
           }
-        };
-        final FlightClient.ClientStreamListener writer = client.startPut(descriptor, root, listener);
-
-        root.allocateNew();
-        for (byte i = 0; i < 10; i++) {
-          final IntVector vector = (IntVector) root.getVector("a");
-          final ArrowBuf metadata = allocator.buffer(1);
-          metadata.writeByte(i);
-          vector.set(0, 10);
-          vector.setValueCount(1);
-          root.setRowCount(1);
-          writer.putNext(metadata);
-        }
-        writer.completed();
-        // Must attempt to retrieve the result to get any server-side errors.
-        writer.getResult();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
+        });
   }
 
-  /**
-   * Ensure that a client can send metadata to the server. Uses the synchronous API.
-   */
+  /** Ensure that a client can send metadata to the server. Uses the synchronous API. */
   @Test
   @Disabled
   public void uploadMetadataSync() {
-    final Schema schema = new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
-    test((allocator, client) -> {
-      try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
-          final SyncPutListener listener = new SyncPutListener()) {
-        final FlightDescriptor descriptor = FlightDescriptor.path("test");
-        final FlightClient.ClientStreamListener writer = client.startPut(descriptor, root, listener);
+    final Schema schema =
+        new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
+    test(
+        (allocator, client) -> {
+          try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+              final SyncPutListener listener = new SyncPutListener()) {
+            final FlightDescriptor descriptor = FlightDescriptor.path("test");
+            final FlightClient.ClientStreamListener writer =
+                client.startPut(descriptor, root, listener);
 
-        root.allocateNew();
-        for (byte i = 0; i < 10; i++) {
-          final IntVector vector = (IntVector) root.getVector("a");
-          final ArrowBuf metadata = allocator.buffer(1);
-          metadata.writeByte(i);
-          vector.set(0, 10);
-          vector.setValueCount(1);
-          root.setRowCount(1);
-          writer.putNext(metadata);
-          try (final PutResult message = listener.poll(5000, TimeUnit.SECONDS)) {
-            Assertions.assertNotNull(message);
-            Assertions.assertEquals(i, message.getApplicationMetadata().getByte(0));
-          } catch (InterruptedException | ExecutionException e) {
-            throw new RuntimeException(e);
+            root.allocateNew();
+            for (byte i = 0; i < 10; i++) {
+              final IntVector vector = (IntVector) root.getVector("a");
+              final ArrowBuf metadata = allocator.buffer(1);
+              metadata.writeByte(i);
+              vector.set(0, 10);
+              vector.setValueCount(1);
+              root.setRowCount(1);
+              writer.putNext(metadata);
+              try (final PutResult message = listener.poll(5000, TimeUnit.SECONDS)) {
+                Assertions.assertNotNull(message);
+                Assertions.assertEquals(i, message.getApplicationMetadata().getByte(0));
+              } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+              }
+            }
+            writer.completed();
+            // Must attempt to retrieve the result to get any server-side errors.
+            writer.getResult();
           }
-        }
-        writer.completed();
-        // Must attempt to retrieve the result to get any server-side errors.
-        writer.getResult();
-      }
-    });
+        });
   }
 
-  /**
-   * Make sure that a {@link SyncPutListener} properly reclaims memory if ignored.
-   */
+  /** Make sure that a {@link SyncPutListener} properly reclaims memory if ignored. */
   @Test
   @Disabled
   public void syncMemoryReclaimed() {
-    final Schema schema = new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
-    test((allocator, client) -> {
-      try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
-          final SyncPutListener listener = new SyncPutListener()) {
-        final FlightDescriptor descriptor = FlightDescriptor.path("test");
-        final FlightClient.ClientStreamListener writer = client.startPut(descriptor, root, listener);
+    final Schema schema =
+        new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
+    test(
+        (allocator, client) -> {
+          try (final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+              final SyncPutListener listener = new SyncPutListener()) {
+            final FlightDescriptor descriptor = FlightDescriptor.path("test");
+            final FlightClient.ClientStreamListener writer =
+                client.startPut(descriptor, root, listener);
 
-        root.allocateNew();
-        for (byte i = 0; i < 10; i++) {
-          final IntVector vector = (IntVector) root.getVector("a");
-          final ArrowBuf metadata = allocator.buffer(1);
-          metadata.writeByte(i);
-          vector.set(0, 10);
-          vector.setValueCount(1);
-          root.setRowCount(1);
-          writer.putNext(metadata);
-        }
-        writer.completed();
-        // Must attempt to retrieve the result to get any server-side errors.
-        writer.getResult();
-      }
-    });
+            root.allocateNew();
+            for (byte i = 0; i < 10; i++) {
+              final IntVector vector = (IntVector) root.getVector("a");
+              final ArrowBuf metadata = allocator.buffer(1);
+              metadata.writeByte(i);
+              vector.set(0, 10);
+              vector.setValueCount(1);
+              root.setRowCount(1);
+              writer.putNext(metadata);
+            }
+            writer.completed();
+            // Must attempt to retrieve the result to get any server-side errors.
+            writer.getResult();
+          }
+        });
   }
 
   /**
-   * ARROW-9221: Flight copies metadata from the byte buffer of a Protobuf ByteString,
-   * which is in big-endian by default, thus mangling metadata.
+   * ARROW-9221: Flight copies metadata from the byte buffer of a Protobuf ByteString, which is in
+   * big-endian by default, thus mangling metadata.
    */
   @Test
   public void testMetadataEndianness() throws Exception {
     try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         final BufferAllocator serverAllocator = allocator.newChildAllocator("flight-server", 0, Long.MAX_VALUE);
-         final FlightServer server = FlightServer.builder(serverAllocator, forGrpcInsecure(LOCALHOST, 0),
-             new EndianFlightProducer(serverAllocator)).build().start();
-         final FlightClient client = FlightClient.builder(allocator, server.getLocation()).build()) {
+        final BufferAllocator serverAllocator =
+            allocator.newChildAllocator("flight-server", 0, Long.MAX_VALUE);
+        final FlightServer server =
+            FlightServer.builder(
+                    serverAllocator,
+                    forGrpcInsecure(LOCALHOST, 0),
+                    new EndianFlightProducer(serverAllocator))
+                .build()
+                .start();
+        final FlightClient client = FlightClient.builder(allocator, server.getLocation()).build()) {
       final Schema schema = new Schema(Collections.emptyList());
       final FlightDescriptor descriptor = FlightDescriptor.command(new byte[0]);
       try (final SyncPutListener reader = new SyncPutListener();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+          final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
         final FlightClient.ClientStreamListener writer = client.startPut(descriptor, root, reader);
         writer.completed();
         try (final PutResult metadata = reader.read()) {
@@ -230,18 +241,19 @@ public class TestApplicationMetadata {
 
   private void test(BiConsumer<BufferAllocator, FlightClient> fun) {
     try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         final FlightServer s = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0),
-             new MetadataFlightProducer(allocator)).build().start();
-         final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
+        final FlightServer s =
+            FlightServer.builder(
+                    allocator, forGrpcInsecure(LOCALHOST, 0), new MetadataFlightProducer(allocator))
+                .build()
+                .start();
+        final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
       fun.accept(allocator, client);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
-  /**
-   * A FlightProducer that always produces a fixed data stream with metadata on the side.
-   */
+  /** A FlightProducer that always produces a fixed data stream with metadata on the side. */
   private static class MetadataFlightProducer extends NoOpFlightProducer {
 
     private final BufferAllocator allocator;
@@ -252,7 +264,8 @@ public class TestApplicationMetadata {
 
     @Override
     public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
-      final Schema schema = new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
+      final Schema schema =
+          new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
       try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
         root.allocateNew();
         listener.start(root);
@@ -270,12 +283,13 @@ public class TestApplicationMetadata {
     }
 
     @Override
-    public Runnable acceptPut(CallContext context, FlightStream stream, StreamListener<PutResult> ackStream) {
+    public Runnable acceptPut(
+        CallContext context, FlightStream stream, StreamListener<PutResult> ackStream) {
       return () -> {
         // Wait for the descriptor to be sent
         stream.getRoot();
-        if (stream.getDescriptor().isCommand() &&
-            Arrays.equals(stream.getDescriptor().getCommand(), COMMAND_ARROW_6136)) {
+        if (stream.getDescriptor().isCommand()
+            && Arrays.equals(stream.getDescriptor().getCommand(), COMMAND_ARROW_6136)) {
           // ARROW-6136: Try closing the stream
           ackStream.onError(
               CallStatus.INTERNAL.withDescription(MESSAGE_ARROW_6136).toRuntimeException());
@@ -286,16 +300,22 @@ public class TestApplicationMetadata {
           while (stream.next()) {
             final ArrowBuf metadata = stream.getLatestMetadata();
             if (current != metadata.getByte(0)) {
-              ackStream.onError(CallStatus.INVALID_ARGUMENT.withDescription(String
-                  .format("Metadata does not match expected value; got %d but expected %d.", metadata.getByte(0),
-                      current)).toRuntimeException());
+              ackStream.onError(
+                  CallStatus.INVALID_ARGUMENT
+                      .withDescription(
+                          String.format(
+                              "Metadata does not match expected value; got %d but expected %d.",
+                              metadata.getByte(0), current))
+                      .toRuntimeException());
               return;
             }
             ackStream.onNext(PutResult.metadata(metadata));
             current++;
           }
           if (current != 10) {
-            throw CallStatus.INVALID_ARGUMENT.withDescription("Wrong number of messages sent.").toRuntimeException();
+            throw CallStatus.INVALID_ARGUMENT
+                .withDescription("Wrong number of messages sent.")
+                .toRuntimeException();
           }
         } catch (Exception e) {
           throw CallStatus.INTERNAL.withCause(e).withDescription(e.toString()).toRuntimeException();
@@ -313,7 +333,8 @@ public class TestApplicationMetadata {
     }
 
     @Override
-    public Runnable acceptPut(CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    public Runnable acceptPut(
+        CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
       return () -> {
         while (flightStream.next()) {
           // Ignore any data

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -14,13 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
-
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
 import static org.apache.arrow.flight.Location.forGrpcInsecure;
 
+import com.google.common.base.Charsets;
+import com.google.protobuf.ByteString;
+import io.grpc.MethodDescriptor;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -39,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-
 import org.apache.arrow.flight.FlightClient.ClientStreamListener;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.Flight.FlightDescriptor.DescriptorType;
@@ -63,14 +63,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import com.google.common.base.Charsets;
-import com.google.protobuf.ByteString;
-
-import io.grpc.MethodDescriptor;
-
-/**
- * Test the operations of a basic flight service.
- */
+/** Test the operations of a basic flight service. */
 public class TestBasicOperation {
 
   @Test
@@ -81,13 +74,11 @@ public class TestBasicOperation {
 
   @Test
   public void fallbackLocation() {
-    Assertions.assertEquals("arrow-flight-reuse-connection://?",
-            Location.reuseConnection().getUri().toString());
+    Assertions.assertEquals(
+        "arrow-flight-reuse-connection://?", Location.reuseConnection().getUri().toString());
   }
 
-  /**
-   * ARROW-6017: we should be able to construct locations for unknown schemes.
-   */
+  /** ARROW-6017: we should be able to construct locations for unknown schemes. */
   @Test
   public void unknownScheme() throws URISyntaxException {
     final Location location = new Location("s3://unknown");
@@ -96,19 +87,22 @@ public class TestBasicOperation {
 
   @Test
   public void unknownSchemeRemote() throws Exception {
-    test(c -> {
-      try {
-        final FlightInfo info = c.getInfo(FlightDescriptor.path("test"));
-        Assertions.assertEquals(new URI("https://example.com"), info.getEndpoints().get(0).getLocations().get(0).getUri());
-      } catch (URISyntaxException e) {
-        throw new RuntimeException(e);
-      }
-    });
+    test(
+        c -> {
+          try {
+            final FlightInfo info = c.getInfo(FlightDescriptor.path("test"));
+            Assertions.assertEquals(
+                new URI("https://example.com"),
+                info.getEndpoints().get(0).getLocations().get(0).getUri());
+          } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   @Test
   public void roundTripTicket() throws Exception {
-    final Ticket ticket = new Ticket(new byte[]{0, 1, 2, 3, 4, 5});
+    final Ticket ticket = new Ticket(new byte[] {0, 1, 2, 3, 4, 5});
     Assertions.assertEquals(ticket, Ticket.deserialize(ticket.serialize()));
   }
 
@@ -116,31 +110,55 @@ public class TestBasicOperation {
   public void roundTripInfo() throws Exception {
     final Map<String, String> metadata = new HashMap<>();
     metadata.put("foo", "bar");
-    final Schema schema = new Schema(Arrays.asList(
-        Field.nullable("a", new ArrowType.Int(32, true)),
-        Field.nullable("b", new ArrowType.FixedSizeBinary(32))
-    ), metadata);
-    final FlightInfo info1 = FlightInfo.builder(schema, FlightDescriptor.path(), Collections.emptyList())
-            .setAppMetadata("foo".getBytes(StandardCharsets.UTF_8)).build();
-    final FlightInfo info2 = new FlightInfo(schema, FlightDescriptor.command(new byte[2]),
-        Collections.singletonList(
-                FlightEndpoint.builder(new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock"))
-                        .setAppMetadata("bar".getBytes(StandardCharsets.UTF_8)).build()
-        ), 200, 500);
-    final FlightInfo info3 = new FlightInfo(schema, FlightDescriptor.path("a", "b"),
-        Arrays.asList(new FlightEndpoint(
-                new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock")),
-            new FlightEndpoint(
-                new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock"),
-                forGrpcInsecure("localhost", 50051))
-        ), 200, 500);
-    final FlightInfo info4 = new FlightInfo(schema, FlightDescriptor.path("a", "b"),
-            Arrays.asList(new FlightEndpoint(
-                            new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock")),
-                    new FlightEndpoint(
-                            new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock"),
-                            forGrpcInsecure("localhost", 50051))
-            ), 200, 500, /*ordered*/ true, IpcOption.DEFAULT);
+    final Schema schema =
+        new Schema(
+            Arrays.asList(
+                Field.nullable("a", new ArrowType.Int(32, true)),
+                Field.nullable("b", new ArrowType.FixedSizeBinary(32))),
+            metadata);
+    final FlightInfo info1 =
+        FlightInfo.builder(schema, FlightDescriptor.path(), Collections.emptyList())
+            .setAppMetadata("foo".getBytes(StandardCharsets.UTF_8))
+            .build();
+    final FlightInfo info2 =
+        new FlightInfo(
+            schema,
+            FlightDescriptor.command(new byte[2]),
+            Collections.singletonList(
+                FlightEndpoint.builder(
+                        new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock"))
+                    .setAppMetadata("bar".getBytes(StandardCharsets.UTF_8))
+                    .build()),
+            200,
+            500);
+    final FlightInfo info3 =
+        new FlightInfo(
+            schema,
+            FlightDescriptor.path("a", "b"),
+            Arrays.asList(
+                new FlightEndpoint(
+                    new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock")),
+                new FlightEndpoint(
+                    new Ticket(new byte[10]),
+                    Location.forGrpcDomainSocket("/tmp/test.sock"),
+                    forGrpcInsecure("localhost", 50051))),
+            200,
+            500);
+    final FlightInfo info4 =
+        new FlightInfo(
+            schema,
+            FlightDescriptor.path("a", "b"),
+            Arrays.asList(
+                new FlightEndpoint(
+                    new Ticket(new byte[10]), Location.forGrpcDomainSocket("/tmp/test.sock")),
+                new FlightEndpoint(
+                    new Ticket(new byte[10]),
+                    Location.forGrpcDomainSocket("/tmp/test.sock"),
+                    forGrpcInsecure("localhost", 50051))),
+            200,
+            500, /*ordered*/
+            true,
+            IpcOption.DEFAULT);
 
     Assertions.assertEquals(info1, FlightInfo.deserialize(info1.serialize()));
     Assertions.assertEquals(info2, FlightInfo.deserialize(info2.serialize()));
@@ -157,7 +175,8 @@ public class TestBasicOperation {
 
   @Test
   public void roundTripDescriptor() throws Exception {
-    final FlightDescriptor cmd = FlightDescriptor.command("test command".getBytes(StandardCharsets.UTF_8));
+    final FlightDescriptor cmd =
+        FlightDescriptor.command("test command".getBytes(StandardCharsets.UTF_8));
     Assertions.assertEquals(cmd, FlightDescriptor.deserialize(cmd.serialize()));
     final FlightDescriptor path = FlightDescriptor.path("foo", "bar", "test.arrow");
     Assertions.assertEquals(path, FlightDescriptor.deserialize(path.serialize()));
@@ -165,156 +184,172 @@ public class TestBasicOperation {
 
   @Test
   public void getDescriptors() throws Exception {
-    test(c -> {
-      int count = 0;
-      for (FlightInfo unused : c.listFlights(Criteria.ALL)) {
-        count += 1;
-      }
-      Assertions.assertEquals(1, count);
-    });
+    test(
+        c -> {
+          int count = 0;
+          for (FlightInfo unused : c.listFlights(Criteria.ALL)) {
+            count += 1;
+          }
+          Assertions.assertEquals(1, count);
+        });
   }
 
   @Test
   public void getDescriptorsWithCriteria() throws Exception {
-    test(c -> {
-      int count = 0;
-      for (FlightInfo unused : c.listFlights(new Criteria(new byte[]{1}))) {
+    test(
+        c -> {
+          int count = 0;
+          for (FlightInfo unused : c.listFlights(new Criteria(new byte[] {1}))) {
 
-        count += 1;
-      }
-      Assertions.assertEquals(0, count);
-    });
+            count += 1;
+          }
+          Assertions.assertEquals(0, count);
+        });
   }
 
   @Test
   public void getDescriptor() throws Exception {
-    test(c -> {
-      System.out.println(c.getInfo(FlightDescriptor.path("hello")).getDescriptor());
-    });
+    test(
+        c -> {
+          System.out.println(c.getInfo(FlightDescriptor.path("hello")).getDescriptor());
+        });
   }
 
   @Test
   public void getSchema() throws Exception {
-    test(c -> {
-      System.out.println(c.getSchema(FlightDescriptor.path("hello")).getSchema());
-    });
+    test(
+        c -> {
+          System.out.println(c.getSchema(FlightDescriptor.path("hello")).getSchema());
+        });
   }
-
 
   @Test
   public void listActions() throws Exception {
-    test(c -> {
-      for (ActionType at : c.listActions()) {
-        System.out.println(at.getType());
-      }
-    });
+    test(
+        c -> {
+          for (ActionType at : c.listActions()) {
+            System.out.println(at.getType());
+          }
+        });
   }
 
   @Test
   public void doAction() throws Exception {
-    test(c -> {
-      Iterator<Result> stream = c.doAction(new Action("hello"));
+    test(
+        c -> {
+          Iterator<Result> stream = c.doAction(new Action("hello"));
 
-      Assertions.assertTrue(stream.hasNext());
-      Result r = stream.next();
-      Assertions.assertArrayEquals("world".getBytes(Charsets.UTF_8), r.getBody());
-    });
-    test(c -> {
-      Iterator<Result> stream = c.doAction(new Action("hellooo"));
+          Assertions.assertTrue(stream.hasNext());
+          Result r = stream.next();
+          Assertions.assertArrayEquals("world".getBytes(Charsets.UTF_8), r.getBody());
+        });
+    test(
+        c -> {
+          Iterator<Result> stream = c.doAction(new Action("hellooo"));
 
-      Assertions.assertTrue(stream.hasNext());
-      Result r = stream.next();
-      Assertions.assertArrayEquals("world".getBytes(Charsets.UTF_8), r.getBody());
+          Assertions.assertTrue(stream.hasNext());
+          Result r = stream.next();
+          Assertions.assertArrayEquals("world".getBytes(Charsets.UTF_8), r.getBody());
 
-      Assertions.assertTrue(stream.hasNext());
-      r = stream.next();
-      Assertions.assertArrayEquals("!".getBytes(Charsets.UTF_8), r.getBody());
-      Assertions.assertFalse(stream.hasNext());
-    });
+          Assertions.assertTrue(stream.hasNext());
+          r = stream.next();
+          Assertions.assertArrayEquals("!".getBytes(Charsets.UTF_8), r.getBody());
+          Assertions.assertFalse(stream.hasNext());
+        });
   }
 
   @Test
   public void putStream() throws Exception {
-    test((c, a) -> {
-      final int size = 10;
+    test(
+        (c, a) -> {
+          final int size = 10;
 
-      IntVector iv = new IntVector("c1", a);
+          IntVector iv = new IntVector("c1", a);
 
-      try (VectorSchemaRoot root = VectorSchemaRoot.of(iv)) {
-        ClientStreamListener listener = c
-            .startPut(FlightDescriptor.path("hello"), root, new AsyncPutListener());
+          try (VectorSchemaRoot root = VectorSchemaRoot.of(iv)) {
+            ClientStreamListener listener =
+                c.startPut(FlightDescriptor.path("hello"), root, new AsyncPutListener());
 
-        //batch 1
-        root.allocateNew();
-        for (int i = 0; i < size; i++) {
-          iv.set(i, i);
-        }
-        iv.setValueCount(size);
-        root.setRowCount(size);
-        listener.putNext();
+            // batch 1
+            root.allocateNew();
+            for (int i = 0; i < size; i++) {
+              iv.set(i, i);
+            }
+            iv.setValueCount(size);
+            root.setRowCount(size);
+            listener.putNext();
 
-        // batch 2
+            // batch 2
 
-        root.allocateNew();
-        for (int i = 0; i < size; i++) {
-          iv.set(i, i + size);
-        }
-        iv.setValueCount(size);
-        root.setRowCount(size);
-        listener.putNext();
-        root.clear();
-        listener.completed();
+            root.allocateNew();
+            for (int i = 0; i < size; i++) {
+              iv.set(i, i + size);
+            }
+            iv.setValueCount(size);
+            root.setRowCount(size);
+            listener.putNext();
+            root.clear();
+            listener.completed();
 
-        // wait for ack to avoid memory leaks.
-        listener.getResult();
-      }
-    });
+            // wait for ack to avoid memory leaks.
+            listener.getResult();
+          }
+        });
   }
 
   @Test
   public void propagateErrors() throws Exception {
-    test(client -> {
-      FlightTestUtil.assertCode(FlightStatusCode.UNIMPLEMENTED, () -> {
-        client.doAction(new Action("invalid-action")).forEachRemaining(action -> Assertions.fail());
-      });
-    });
+    test(
+        client -> {
+          FlightTestUtil.assertCode(
+              FlightStatusCode.UNIMPLEMENTED,
+              () -> {
+                client
+                    .doAction(new Action("invalid-action"))
+                    .forEachRemaining(action -> Assertions.fail());
+              });
+        });
   }
 
   @Test
   public void getStream() throws Exception {
-    test(c -> {
-      try (final FlightStream stream = c.getStream(new Ticket(new byte[0]))) {
-        VectorSchemaRoot root = stream.getRoot();
-        IntVector iv = (IntVector) root.getVector("c1");
-        int value = 0;
-        while (stream.next()) {
-          for (int i = 0; i < root.getRowCount(); i++) {
-            Assertions.assertEquals(value, iv.get(i));
-            value++;
+    test(
+        c -> {
+          try (final FlightStream stream = c.getStream(new Ticket(new byte[0]))) {
+            VectorSchemaRoot root = stream.getRoot();
+            IntVector iv = (IntVector) root.getVector("c1");
+            int value = 0;
+            while (stream.next()) {
+              for (int i = 0; i < root.getRowCount(); i++) {
+                Assertions.assertEquals(value, iv.get(i));
+                value++;
+              }
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
           }
-        }
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
+        });
   }
 
   /** Ensure the client is configured to accept large messages. */
   @Test
-  @DisabledOnOs(value = {OS.WINDOWS}, disabledReason = "https://github.com/apache/arrow/issues/33237: flaky test")
+  @DisabledOnOs(
+      value = {OS.WINDOWS},
+      disabledReason = "https://github.com/apache/arrow/issues/33237: flaky test")
   public void getStreamLargeBatch() throws Exception {
-    test(c -> {
-      try (final FlightStream stream = c.getStream(new Ticket(Producer.TICKET_LARGE_BATCH))) {
-        Assertions.assertEquals(128, stream.getRoot().getFieldVectors().size());
-        Assertions.assertTrue(stream.next());
-        Assertions.assertEquals(65536, stream.getRoot().getRowCount());
-        Assertions.assertTrue(stream.next());
-        Assertions.assertEquals(65536, stream.getRoot().getRowCount());
-        Assertions.assertFalse(stream.next());
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
+    test(
+        c -> {
+          try (final FlightStream stream = c.getStream(new Ticket(Producer.TICKET_LARGE_BATCH))) {
+            Assertions.assertEquals(128, stream.getRoot().getFieldVectors().size());
+            Assertions.assertTrue(stream.next());
+            Assertions.assertEquals(65536, stream.getRoot().getRowCount());
+            Assertions.assertTrue(stream.next());
+            Assertions.assertEquals(65536, stream.getRoot().getRowCount());
+            Assertions.assertFalse(stream.next());
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   /** Ensure the server is configured to accept large messages. */
@@ -329,36 +364,37 @@ public class TestBasicOperation {
         }
         vectors.add(vector);
       }
-      test(c -> {
-        try (final VectorSchemaRoot root = new VectorSchemaRoot(vectors)) {
-          root.setRowCount(65536);
-          final ClientStreamListener stream = c.startPut(FlightDescriptor.path(""), root, new SyncPutListener());
-          stream.putNext();
-          stream.putNext();
-          stream.completed();
-          stream.getResult();
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
-      });
+      test(
+          c -> {
+            try (final VectorSchemaRoot root = new VectorSchemaRoot(vectors)) {
+              root.setRowCount(65536);
+              final ClientStreamListener stream =
+                  c.startPut(FlightDescriptor.path(""), root, new SyncPutListener());
+              stream.putNext();
+              stream.putNext();
+              stream.completed();
+              stream.getResult();
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          });
     }
   }
 
   private void test(Consumer<FlightClient> consumer) throws Exception {
-    test((c, a) -> {
-      consumer.accept(c);
-    });
+    test(
+        (c, a) -> {
+          consumer.accept(c);
+        });
   }
 
   private void test(BiConsumer<FlightClient, BufferAllocator> consumer) throws Exception {
-    try (
-        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+    try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer(a);
-        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
+        FlightServer s =
+            FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
 
-      try (
-          FlightClient c = FlightClient.builder(a, s.getLocation()).build()
-      ) {
+      try (FlightClient c = FlightClient.builder(a, s.getLocation()).build()) {
         try (BufferAllocator testAllocator = a.newChildAllocator("testcase", 0, Long.MAX_VALUE)) {
           consumer.accept(c, testAllocator);
         }
@@ -368,7 +404,8 @@ public class TestBasicOperation {
 
   /** Helper method to convert an ArrowMessage into a Protobuf message. */
   private Flight.FlightData arrowMessageToProtobuf(
-      MethodDescriptor.Marshaller<ArrowMessage> marshaller, ArrowMessage message) throws IOException {
+      MethodDescriptor.Marshaller<ArrowMessage> marshaller, ArrowMessage message)
+      throws IOException {
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try (final InputStream serialized = marshaller.stream(message)) {
       final byte[] buf = new byte[1024];
@@ -384,35 +421,44 @@ public class TestBasicOperation {
     return Flight.FlightData.parseFrom(serializedMessage);
   }
 
-  /** ARROW-10962: accept FlightData messages generated by Protobuf (which can omit empty fields). */
+  /**
+   * ARROW-10962: accept FlightData messages generated by Protobuf (which can omit empty fields).
+   */
   @Test
   public void testProtobufRecordBatchCompatibility() throws Exception {
-    final Schema schema = new Schema(Collections.singletonList(Field.nullable("foo", new ArrowType.Int(32, true))));
+    final Schema schema =
+        new Schema(Collections.singletonList(Field.nullable("foo", new ArrowType.Int(32, true))));
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-         final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
       final VectorUnloader unloader = new VectorUnloader(root);
       root.setRowCount(0);
-      final MethodDescriptor.Marshaller<ArrowMessage> marshaller = ArrowMessage.createMarshaller(allocator);
-      try (final ArrowMessage message = new ArrowMessage(
-              unloader.getRecordBatch(), /* appMetadata */ null, /* tryZeroCopy */ false, IpcOption.DEFAULT)) {
+      final MethodDescriptor.Marshaller<ArrowMessage> marshaller =
+          ArrowMessage.createMarshaller(allocator);
+      try (final ArrowMessage message =
+          new ArrowMessage(
+              unloader.getRecordBatch(), /* appMetadata */
+              null, /* tryZeroCopy */
+              false,
+              IpcOption.DEFAULT)) {
         Assertions.assertEquals(ArrowMessage.HeaderType.RECORD_BATCH, message.getMessageType());
-        // Should have at least one empty body buffer (there may be multiple for e.g. data and validity)
+        // Should have at least one empty body buffer (there may be multiple for e.g. data and
+        // validity)
         Iterator<ArrowBuf> iterator = message.getBufs().iterator();
         Assertions.assertTrue(iterator.hasNext());
         while (iterator.hasNext()) {
           Assertions.assertEquals(0, iterator.next().capacity());
         }
-        final Flight.FlightData protobufData = arrowMessageToProtobuf(marshaller, message)
-            .toBuilder()
-            .clearDataBody()
-            .build();
+        final Flight.FlightData protobufData =
+            arrowMessageToProtobuf(marshaller, message).toBuilder().clearDataBody().build();
         Assertions.assertEquals(0, protobufData.getDataBody().size());
-        ArrowMessage parsedMessage = marshaller.parse(new ByteArrayInputStream(protobufData.toByteArray()));
+        ArrowMessage parsedMessage =
+            marshaller.parse(new ByteArrayInputStream(protobufData.toByteArray()));
         // Should have an empty body buffer
         Iterator<ArrowBuf> parsedIterator = parsedMessage.getBufs().iterator();
         Assertions.assertTrue(parsedIterator.hasNext());
         Assertions.assertEquals(0, parsedIterator.next().capacity());
-        // Should have only one (the parser synthesizes exactly one); in the case of empty buffers, this is equivalent
+        // Should have only one (the parser synthesizes exactly one); in the case of empty buffers,
+        // this is equivalent
         Assertions.assertFalse(parsedIterator.hasNext());
         // Should not throw
         final ArrowRecordBatch rb = parsedMessage.asRecordBatch();
@@ -421,23 +467,29 @@ public class TestBasicOperation {
     }
   }
 
-  /** ARROW-10962: accept FlightData messages generated by Protobuf (which can omit empty fields). */
+  /**
+   * ARROW-10962: accept FlightData messages generated by Protobuf (which can omit empty fields).
+   */
   @Test
   public void testProtobufSchemaCompatibility() throws Exception {
-    final Schema schema = new Schema(Collections.singletonList(Field.nullable("foo", new ArrowType.Int(32, true))));
+    final Schema schema =
+        new Schema(Collections.singletonList(Field.nullable("foo", new ArrowType.Int(32, true))));
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE)) {
-      final MethodDescriptor.Marshaller<ArrowMessage> marshaller = ArrowMessage.createMarshaller(allocator);
+      final MethodDescriptor.Marshaller<ArrowMessage> marshaller =
+          ArrowMessage.createMarshaller(allocator);
       Flight.FlightDescriptor descriptor = FlightDescriptor.command(new byte[0]).toProtocol();
       try (final ArrowMessage message = new ArrowMessage(descriptor, schema, IpcOption.DEFAULT)) {
         Assertions.assertEquals(ArrowMessage.HeaderType.SCHEMA, message.getMessageType());
         // Should have no body buffers
         Assertions.assertFalse(message.getBufs().iterator().hasNext());
-        final Flight.FlightData protobufData = arrowMessageToProtobuf(marshaller, message)
-            .toBuilder()
-            .setDataBody(ByteString.EMPTY)
-            .build();
+        final Flight.FlightData protobufData =
+            arrowMessageToProtobuf(marshaller, message)
+                .toBuilder()
+                .setDataBody(ByteString.EMPTY)
+                .build();
         Assertions.assertEquals(0, protobufData.getDataBody().size());
-        final ArrowMessage parsedMessage = marshaller.parse(new ByteArrayInputStream(protobufData.toByteArray()));
+        final ArrowMessage parsedMessage =
+            marshaller.parse(new ByteArrayInputStream(protobufData.toByteArray()));
         // Should have no body buffers
         Assertions.assertFalse(parsedMessage.getBufs().iterator().hasNext());
         // Should not throw
@@ -459,14 +511,12 @@ public class TestBasicOperation {
   public void testGrpcTlsLocation() throws Exception {
     Location location = Location.forGrpcTls(LOCALHOST, 9000);
     Assertions.assertEquals(
-            new URI(LocationSchemes.GRPC_TLS, null, LOCALHOST, 9000, null, null, null),
-            location.getUri());
+        new URI(LocationSchemes.GRPC_TLS, null, LOCALHOST, 9000, null, null, null),
+        location.getUri());
     Assertions.assertEquals(new InetSocketAddress(LOCALHOST, 9000), location.toSocketAddress());
   }
 
-  /**
-   * An example FlightProducer for test purposes.
-   */
+  /** An example FlightProducer for test purposes. */
   public static class Producer implements FlightProducer, AutoCloseable {
     static final byte[] TICKET_LARGE_BATCH = "large-batch".getBytes(StandardCharsets.UTF_8);
 
@@ -478,18 +528,20 @@ public class TestBasicOperation {
     }
 
     @Override
-    public void listFlights(CallContext context, Criteria criteria,
-        StreamListener<FlightInfo> listener) {
+    public void listFlights(
+        CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
       if (criteria.getExpression().length > 0) {
         // Don't send anything if criteria are set
         listener.onCompleted();
       }
 
-      Flight.FlightInfo getInfo = Flight.FlightInfo.newBuilder()
-          .setFlightDescriptor(Flight.FlightDescriptor.newBuilder()
-              .setType(DescriptorType.CMD)
-              .setCmd(ByteString.copyFrom("cool thing", Charsets.UTF_8)))
-          .build();
+      Flight.FlightInfo getInfo =
+          Flight.FlightInfo.newBuilder()
+              .setFlightDescriptor(
+                  Flight.FlightDescriptor.newBuilder()
+                      .setType(DescriptorType.CMD)
+                      .setCmd(ByteString.copyFrom("cool thing", Charsets.UTF_8)))
+              .build();
       try {
         listener.onNext(new FlightInfo(getInfo));
       } catch (URISyntaxException e) {
@@ -500,7 +552,8 @@ public class TestBasicOperation {
     }
 
     @Override
-    public Runnable acceptPut(CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    public Runnable acceptPut(
+        CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
       return () -> {
         while (flightStream.next()) {
           // Drain the stream
@@ -520,7 +573,7 @@ public class TestBasicOperation {
       VectorSchemaRoot root = VectorSchemaRoot.of(iv);
       listener.start(root);
 
-      //batch 1
+      // batch 1
       root.allocateNew();
       for (int i = 0; i < size; i++) {
         iv.set(i, i);
@@ -566,27 +619,29 @@ public class TestBasicOperation {
     }
 
     @Override
-    public FlightInfo getFlightInfo(CallContext context,
-        FlightDescriptor descriptor) {
+    public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
       try {
-        Flight.FlightInfo getInfo = Flight.FlightInfo.newBuilder()
-            .setSchema(schemaToByteString(new Schema(Collections.emptyList())))
-            .setFlightDescriptor(Flight.FlightDescriptor.newBuilder()
-                .setType(DescriptorType.CMD)
-                .setCmd(ByteString.copyFrom("cool thing", Charsets.UTF_8)))
-            .addEndpoint(
-                Flight.FlightEndpoint.newBuilder().addLocation(new Location("https://example.com").toProtocol()))
-            .build();
+        Flight.FlightInfo getInfo =
+            Flight.FlightInfo.newBuilder()
+                .setSchema(schemaToByteString(new Schema(Collections.emptyList())))
+                .setFlightDescriptor(
+                    Flight.FlightDescriptor.newBuilder()
+                        .setType(DescriptorType.CMD)
+                        .setCmd(ByteString.copyFrom("cool thing", Charsets.UTF_8)))
+                .addEndpoint(
+                    Flight.FlightEndpoint.newBuilder()
+                        .addLocation(new Location("https://example.com").toProtocol()))
+                .build();
         return new FlightInfo(getInfo);
       } catch (URISyntaxException e) {
         throw new RuntimeException(e);
       }
     }
 
-    private static ByteString schemaToByteString(Schema schema)
-    {
+    private static ByteString schemaToByteString(Schema schema) {
       try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-        MessageSerializer.serialize(new WriteChannel(Channels.newChannel(baos)), schema, IpcOption.DEFAULT);
+        MessageSerializer.serialize(
+            new WriteChannel(Channels.newChannel(baos)), schema, IpcOption.DEFAULT);
         return ByteString.copyFrom(baos.toByteArray());
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -594,36 +649,35 @@ public class TestBasicOperation {
     }
 
     @Override
-    public void doAction(CallContext context, Action action,
-        StreamListener<Result> listener) {
+    public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
       switch (action.getType()) {
-        case "hello": {
-          listener.onNext(new Result("world".getBytes(Charsets.UTF_8)));
-          listener.onCompleted();
-          break;
-        }
-        case "hellooo": {
-          listener.onNext(new Result("world".getBytes(Charsets.UTF_8)));
-          listener.onNext(new Result("!".getBytes(Charsets.UTF_8)));
-          listener.onCompleted();
-          break;
-        }
+        case "hello":
+          {
+            listener.onNext(new Result("world".getBytes(Charsets.UTF_8)));
+            listener.onCompleted();
+            break;
+          }
+        case "hellooo":
+          {
+            listener.onNext(new Result("world".getBytes(Charsets.UTF_8)));
+            listener.onNext(new Result("!".getBytes(Charsets.UTF_8)));
+            listener.onCompleted();
+            break;
+          }
         default:
-          listener.onError(CallStatus.UNIMPLEMENTED.withDescription("Action not implemented: " + action.getType())
-              .toRuntimeException());
+          listener.onError(
+              CallStatus.UNIMPLEMENTED
+                  .withDescription("Action not implemented: " + action.getType())
+                  .toRuntimeException());
       }
     }
 
     @Override
-    public void listActions(CallContext context,
-        StreamListener<ActionType> listener) {
+    public void listActions(CallContext context, StreamListener<ActionType> listener) {
       listener.onNext(new ActionType("get", ""));
       listener.onNext(new ActionType("put", ""));
       listener.onNext(new ActionType("hello", ""));
       listener.onCompleted();
     }
-
   }
-
-
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestCallOptions.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestCallOptions.java
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
 import static org.apache.arrow.flight.Location.forGrpcInsecure;
 
+import io.grpc.Metadata;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -27,14 +27,11 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import io.grpc.Metadata;
 
 public class TestCallOptions {
 
@@ -42,32 +39,40 @@ public class TestCallOptions {
   @Disabled
   public void timeoutFires() {
     // Ignored due to CI flakiness
-    test((client) -> {
-      Instant start = Instant.now();
-      Iterator<Result> results = client.doAction(new Action("hang"), CallOptions.timeout(1, TimeUnit.SECONDS));
-      try {
-        results.next();
-        Assertions.fail("Call should have failed");
-      } catch (RuntimeException e) {
-        Assertions.assertTrue(e.getMessage().contains("deadline exceeded"), e.getMessage());
-      }
-      Instant end = Instant.now();
-      Assertions.assertTrue(Duration.between(start, end).toMillis() < 1500, "Call took over 1500 ms despite timeout");
-    });
+    test(
+        (client) -> {
+          Instant start = Instant.now();
+          Iterator<Result> results =
+              client.doAction(new Action("hang"), CallOptions.timeout(1, TimeUnit.SECONDS));
+          try {
+            results.next();
+            Assertions.fail("Call should have failed");
+          } catch (RuntimeException e) {
+            Assertions.assertTrue(e.getMessage().contains("deadline exceeded"), e.getMessage());
+          }
+          Instant end = Instant.now();
+          Assertions.assertTrue(
+              Duration.between(start, end).toMillis() < 1500,
+              "Call took over 1500 ms despite timeout");
+        });
   }
 
   @Test
   @Disabled
   public void underTimeout() {
     // Ignored due to CI flakiness
-    test((client) -> {
-      Instant start = Instant.now();
-      // This shouldn't fail and it should complete within the timeout
-      Iterator<Result> results = client.doAction(new Action("fast"), CallOptions.timeout(2, TimeUnit.SECONDS));
-      Assertions.assertArrayEquals(new byte[]{42, 42}, results.next().getBody());
-      Instant end = Instant.now();
-      Assertions.assertTrue(Duration.between(start, end).toMillis() < 2500, "Call took over 2500 ms despite timeout");
-    });
+    test(
+        (client) -> {
+          Instant start = Instant.now();
+          // This shouldn't fail and it should complete within the timeout
+          Iterator<Result> results =
+              client.doAction(new Action("fast"), CallOptions.timeout(2, TimeUnit.SECONDS));
+          Assertions.assertArrayEquals(new byte[] {42, 42}, results.next().getBody());
+          Instant end = Instant.now();
+          Assertions.assertTrue(
+              Duration.between(start, end).toMillis() < 2500,
+              "Call took over 2500 ms despite timeout");
+        });
   }
 
   @Test
@@ -102,12 +107,13 @@ public class TestCallOptions {
   }
 
   private void testHeaders(CallHeaders headers) {
-    try (
-        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+    try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         HeaderProducer producer = new HeaderProducer();
-        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start();
+        FlightServer s =
+            FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start();
         FlightClient client = FlightClient.builder(a, s.getLocation()).build()) {
-      Assertions.assertFalse(client.doAction(new Action(""), new HeaderCallOption(headers)).hasNext());
+      Assertions.assertFalse(
+          client.doAction(new Action(""), new HeaderCallOption(headers)).hasNext());
       final CallHeaders incomingHeaders = producer.headers();
       for (String key : headers.keys()) {
         if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
@@ -122,10 +128,10 @@ public class TestCallOptions {
   }
 
   void test(Consumer<FlightClient> testFn) {
-    try (
-        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+    try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer();
-        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start();
+        FlightServer s =
+            FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start();
         FlightClient client = FlightClient.builder(a, s.getLocation()).build()) {
       testFn.accept(client);
     } catch (InterruptedException | IOException e) {
@@ -137,8 +143,7 @@ public class TestCallOptions {
     CallHeaders headers;
 
     @Override
-    public void close() {
-    }
+    public void close() {}
 
     public CallHeaders headers() {
       return headers;
@@ -153,39 +158,40 @@ public class TestCallOptions {
 
   static class Producer extends NoOpFlightProducer implements AutoCloseable {
 
-    Producer() {
-    }
+    Producer() {}
 
     @Override
-    public void close() {
-    }
+    public void close() {}
 
     @Override
     public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
       switch (action.getType()) {
-        case "hang": {
-          try {
-            Thread.sleep(25000);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        case "hang":
+          {
+            try {
+              Thread.sleep(25000);
+            } catch (InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+            listener.onNext(new Result(new byte[] {}));
+            listener.onCompleted();
+            return;
           }
-          listener.onNext(new Result(new byte[]{}));
-          listener.onCompleted();
-          return;
-        }
-        case "fast": {
-          try {
-            Thread.sleep(500);
-          } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        case "fast":
+          {
+            try {
+              Thread.sleep(500);
+            } catch (InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+            listener.onNext(new Result(new byte[] {42, 42}));
+            listener.onCompleted();
+            return;
           }
-          listener.onNext(new Result(new byte[]{42, 42}));
-          listener.onCompleted();
-          return;
-        }
-        default: {
-          throw new UnsupportedOperationException(action.getType());
-        }
+        default:
+          {
+            throw new UnsupportedOperationException(action.getType());
+          }
       }
     }
   }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestClientMiddleware.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestClientMiddleware.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
@@ -28,61 +27,69 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-/**
- * A basic test of client middleware using a simplified OpenTracing-like example.
- */
+/** A basic test of client middleware using a simplified OpenTracing-like example. */
 public class TestClientMiddleware {
 
   /**
-   * Test that a client middleware can fail a call before it starts by throwing a {@link FlightRuntimeException}.
+   * Test that a client middleware can fail a call before it starts by throwing a {@link
+   * FlightRuntimeException}.
    */
   @Test
   public void clientMiddleware_failCallBeforeSending() {
-    test(new NoOpFlightProducer(), null, Collections.singletonList(new CallRejector.Factory()),
+    test(
+        new NoOpFlightProducer(),
+        null,
+        Collections.singletonList(new CallRejector.Factory()),
         (allocator, client) -> {
           FlightTestUtil.assertCode(FlightStatusCode.UNAVAILABLE, client::listActions);
         });
   }
 
   /**
-   * Test an OpenTracing-like scenario where client and server middleware work together to propagate a request ID
-   * without explicit intervention from the service implementation.
+   * Test an OpenTracing-like scenario where client and server middleware work together to propagate
+   * a request ID without explicit intervention from the service implementation.
    */
   @Test
   public void middleware_propagateHeader() {
     final Context context = new Context("span id");
-    test(new NoOpFlightProducer(),
+    test(
+        new NoOpFlightProducer(),
         new TestServerMiddleware.ServerMiddlewarePair<>(
             FlightServerMiddleware.Key.of("test"), new ServerSpanInjector.Factory()),
         Collections.singletonList(new ClientSpanInjector.Factory(context)),
         (allocator, client) -> {
-          FlightTestUtil.assertCode(FlightStatusCode.UNIMPLEMENTED, () -> client.listActions().forEach(actionType -> {
-          }));
+          FlightTestUtil.assertCode(
+              FlightStatusCode.UNIMPLEMENTED, () -> client.listActions().forEach(actionType -> {}));
         });
     Assertions.assertEquals(context.outgoingSpanId, context.incomingSpanId);
     Assertions.assertNotNull(context.finalStatus);
     Assertions.assertEquals(FlightStatusCode.UNIMPLEMENTED, context.finalStatus.code());
   }
 
-  /** Ensure both server and client can send and receive multi-valued headers (both binary and text values). */
+  /**
+   * Ensure both server and client can send and receive multi-valued headers (both binary and text
+   * values).
+   */
   @Test
   public void testMultiValuedHeaders() {
-    final MultiHeaderClientMiddlewareFactory clientFactory = new MultiHeaderClientMiddlewareFactory();
-    test(new NoOpFlightProducer(),
+    final MultiHeaderClientMiddlewareFactory clientFactory =
+        new MultiHeaderClientMiddlewareFactory();
+    test(
+        new NoOpFlightProducer(),
         new TestServerMiddleware.ServerMiddlewarePair<>(
             FlightServerMiddleware.Key.of("test"), new MultiHeaderServerMiddlewareFactory()),
         Collections.singletonList(clientFactory),
         (allocator, client) -> {
-          FlightTestUtil.assertCode(FlightStatusCode.UNIMPLEMENTED, () -> client.listActions().forEach(actionType -> {
-          }));
+          FlightTestUtil.assertCode(
+              FlightStatusCode.UNIMPLEMENTED, () -> client.listActions().forEach(actionType -> {}));
         });
-    // The server echoes the headers we send back to us, so ensure all the ones we sent are present with the correct
+    // The server echoes the headers we send back to us, so ensure all the ones we sent are present
+    // with the correct
     // values in the correct order.
     for (final Map.Entry<String, List<byte[]>> entry : EXPECTED_BINARY_HEADERS.entrySet()) {
       // Compare header values entry-by-entry because byte arrays don't compare via equals
@@ -90,7 +97,8 @@ public class TestClientMiddleware {
       Assertions.assertNotNull(receivedValues, "Missing for header: " + entry.getKey());
       Assertions.assertEquals(
           entry.getValue().size(),
-          receivedValues.size(), "Missing or wrong value for header: " + entry.getKey());
+          receivedValues.size(),
+          "Missing or wrong value for header: " + entry.getKey());
       for (int i = 0; i < entry.getValue().size(); i++) {
         Assertions.assertArrayEquals(entry.getValue().get(i), receivedValues.get(i));
       }
@@ -99,12 +107,12 @@ public class TestClientMiddleware {
       Assertions.assertEquals(
           entry.getValue(),
           clientFactory.lastTextHeaders.get(entry.getKey()),
-          "Missing or wrong value for header: " + entry.getKey()
-      );
+          "Missing or wrong value for header: " + entry.getKey());
     }
   }
 
-  private static <T extends FlightServerMiddleware> void test(FlightProducer producer,
+  private static <T extends FlightServerMiddleware> void test(
+      FlightProducer producer,
       TestServerMiddleware.ServerMiddlewarePair<T> serverMiddleware,
       List<FlightClientMiddleware.Factory> clientMiddleware,
       BiConsumer<BufferAllocator, FlightClient> body) {
@@ -119,8 +127,7 @@ public class TestClientMiddleware {
       FlightClient.Builder clientBuilder = FlightClient.builder(allocator, server.getLocation());
       clientMiddleware.forEach(clientBuilder::intercept);
       try (final FlightServer ignored = server;
-           final FlightClient client = clientBuilder.build()
-      ) {
+          final FlightClient client = clientBuilder.build()) {
         body.accept(allocator, client);
       }
     } catch (InterruptedException | IOException e) {
@@ -129,8 +136,8 @@ public class TestClientMiddleware {
   }
 
   /**
-   * A server middleware component that reads a request ID from incoming headers and sends the request ID back on
-   * outgoing headers.
+   * A server middleware component that reads a request ID from incoming headers and sends the
+   * request ID back on outgoing headers.
    */
   static class ServerSpanInjector implements FlightServerMiddleware {
 
@@ -146,27 +153,24 @@ public class TestClientMiddleware {
     }
 
     @Override
-    public void onCallCompleted(CallStatus status) {
-
-    }
+    public void onCallCompleted(CallStatus status) {}
 
     @Override
-    public void onCallErrored(Throwable err) {
-
-    }
+    public void onCallErrored(Throwable err) {}
 
     static class Factory implements FlightServerMiddleware.Factory<ServerSpanInjector> {
 
       @Override
-      public ServerSpanInjector onCallStarted(CallInfo info, CallHeaders incomingHeaders, RequestContext context) {
+      public ServerSpanInjector onCallStarted(
+          CallInfo info, CallHeaders incomingHeaders, RequestContext context) {
         return new ServerSpanInjector(incomingHeaders.get("x-span"));
       }
     }
   }
 
   /**
-   * A client middleware component that, given a mock OpenTracing-like "request context", sends the request ID in the
-   * context on outgoing headers and reads it from incoming headers.
+   * A client middleware component that, given a mock OpenTracing-like "request context", sends the
+   * request ID in the context on outgoing headers and reads it from incoming headers.
    */
   static class ClientSpanInjector implements FlightClientMiddleware {
 
@@ -206,9 +210,7 @@ public class TestClientMiddleware {
     }
   }
 
-  /**
-   * A mock OpenTracing-like "request context".
-   */
+  /** A mock OpenTracing-like "request context". */
   static class Context {
 
     final String outgoingSpanId;
@@ -220,22 +222,17 @@ public class TestClientMiddleware {
     }
   }
 
-  /**
-   * A client middleware that fails outgoing calls.
-   */
+  /** A client middleware that fails outgoing calls. */
   static class CallRejector implements FlightClientMiddleware {
 
     @Override
-    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
-    }
+    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {}
 
     @Override
-    public void onHeadersReceived(CallHeaders incomingHeaders) {
-    }
+    public void onHeadersReceived(CallHeaders incomingHeaders) {}
 
     @Override
-    public void onCallCompleted(CallStatus status) {
-    }
+    public void onCallCompleted(CallStatus status) {}
 
     static class Factory implements FlightClientMiddleware.Factory {
 
@@ -251,36 +248,41 @@ public class TestClientMiddleware {
   static Map<String, List<String>> EXPECTED_TEXT_HEADERS = new HashMap<String, List<String>>();
 
   static {
-    EXPECTED_BINARY_HEADERS.put("x-binary-bin", Arrays.asList(new byte[] {0}, new byte[]{1}));
+    EXPECTED_BINARY_HEADERS.put("x-binary-bin", Arrays.asList(new byte[] {0}, new byte[] {1}));
     EXPECTED_TEXT_HEADERS.put("x-text", Arrays.asList("foo", "bar"));
   }
 
-  static class MultiHeaderServerMiddlewareFactory implements
-      FlightServerMiddleware.Factory<MultiHeaderServerMiddleware> {
+  static class MultiHeaderServerMiddlewareFactory
+      implements FlightServerMiddleware.Factory<MultiHeaderServerMiddleware> {
     @Override
-    public MultiHeaderServerMiddleware onCallStarted(CallInfo info, CallHeaders incomingHeaders,
-        RequestContext context) {
-      // Echo the headers back to the client. Copy values out of CallHeaders since the underlying gRPC metadata
+    public MultiHeaderServerMiddleware onCallStarted(
+        CallInfo info, CallHeaders incomingHeaders, RequestContext context) {
+      // Echo the headers back to the client. Copy values out of CallHeaders since the underlying
+      // gRPC metadata
       // object isn't safe to use after this function returns.
       Map<String, List<byte[]>> binaryHeaders = new HashMap<>();
       Map<String, List<String>> textHeaders = new HashMap<>();
       for (final String key : incomingHeaders.keys()) {
         if (key.endsWith("-bin")) {
-          binaryHeaders.compute(key, (ignored, values) -> {
-            if (values == null) {
-              values = new ArrayList<>();
-            }
-            incomingHeaders.getAllByte(key).forEach(values::add);
-            return values;
-          });
+          binaryHeaders.compute(
+              key,
+              (ignored, values) -> {
+                if (values == null) {
+                  values = new ArrayList<>();
+                }
+                incomingHeaders.getAllByte(key).forEach(values::add);
+                return values;
+              });
         } else {
-          textHeaders.compute(key, (ignored, values) -> {
-            if (values == null) {
-              values = new ArrayList<>();
-            }
-            incomingHeaders.getAll(key).forEach(values::add);
-            return values;
-          });
+          textHeaders.compute(
+              key,
+              (ignored, values) -> {
+                if (values == null) {
+                  values = new ArrayList<>();
+                }
+                incomingHeaders.getAll(key).forEach(values::add);
+                return values;
+              });
         }
       }
       return new MultiHeaderServerMiddleware(binaryHeaders, textHeaders);
@@ -291,24 +293,25 @@ public class TestClientMiddleware {
     private final Map<String, List<byte[]>> binaryHeaders;
     private final Map<String, List<String>> textHeaders;
 
-    MultiHeaderServerMiddleware(Map<String, List<byte[]>> binaryHeaders, Map<String, List<String>> textHeaders) {
+    MultiHeaderServerMiddleware(
+        Map<String, List<byte[]>> binaryHeaders, Map<String, List<String>> textHeaders) {
       this.binaryHeaders = binaryHeaders;
       this.textHeaders = textHeaders;
     }
 
     @Override
     public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
-      binaryHeaders.forEach((key, values) -> values.forEach(value -> outgoingHeaders.insert(key, value)));
-      textHeaders.forEach((key, values) -> values.forEach(value -> outgoingHeaders.insert(key, value)));
+      binaryHeaders.forEach(
+          (key, values) -> values.forEach(value -> outgoingHeaders.insert(key, value)));
+      textHeaders.forEach(
+          (key, values) -> values.forEach(value -> outgoingHeaders.insert(key, value)));
     }
 
     @Override
-    public void onCallCompleted(CallStatus status) {
-    }
+    public void onCallCompleted(CallStatus status) {}
 
     @Override
-    public void onCallErrored(Throwable err) {
-    }
+    public void onCallErrored(Throwable err) {}
   }
 
   static class MultiHeaderClientMiddlewareFactory implements FlightClientMiddleware.Factory {
@@ -344,21 +347,23 @@ public class TestClientMiddleware {
     public void onHeadersReceived(CallHeaders incomingHeaders) {
       factory.lastBinaryHeaders = new HashMap<>();
       factory.lastTextHeaders = new HashMap<>();
-      incomingHeaders.keys().forEach(header -> {
-        if (header.endsWith("-bin")) {
-          final List<byte[]> values = new ArrayList<>();
-          incomingHeaders.getAllByte(header).forEach(values::add);
-          factory.lastBinaryHeaders.put(header, values);
-        } else {
-          final List<String> values = new ArrayList<>();
-          incomingHeaders.getAll(header).forEach(values::add);
-          factory.lastTextHeaders.put(header, values);
-        }
-      });
+      incomingHeaders
+          .keys()
+          .forEach(
+              header -> {
+                if (header.endsWith("-bin")) {
+                  final List<byte[]> values = new ArrayList<>();
+                  incomingHeaders.getAllByte(header).forEach(values::add);
+                  factory.lastBinaryHeaders.put(header, values);
+                } else {
+                  final List<String> values = new ArrayList<>();
+                  incomingHeaders.getAll(header).forEach(values::add);
+                  factory.lastTextHeaders.put(header, values);
+                }
+              });
     }
 
     @Override
-    public void onCallCompleted(CallStatus status) {
-    }
+    public void onCallCompleted(CallStatus status) {}
   }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestDictionaryUtils.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestDictionaryUtils.java
@@ -14,15 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.google.common.collect.ImmutableList;
 import java.util.TreeSet;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VarCharVector;
@@ -35,11 +34,7 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableList;
-
-/**
- * Test cases for {@link DictionaryUtils}.
- */
+/** Test cases for {@link DictionaryUtils}. */
 public class TestDictionaryUtils {
 
   @Test
@@ -47,9 +42,9 @@ public class TestDictionaryUtils {
     FieldType varcharType = new FieldType(true, new ArrowType.Utf8(), null);
     FieldType intType = new FieldType(true, new ArrowType.Int(32, true), null);
 
-    ImmutableList<Field> build = ImmutableList.of(
-            new Field("stringCol", varcharType, null),
-            new Field("intCol", intType, null));
+    ImmutableList<Field> build =
+        ImmutableList.of(
+            new Field("stringCol", varcharType, null), new Field("intCol", intType, null));
 
     Schema schema = new Schema(build);
     Schema newSchema = DictionaryUtils.generateSchema(schema, null, new TreeSet<>());
@@ -62,18 +57,19 @@ public class TestDictionaryUtils {
   public void testCreateSchema() {
     try (BufferAllocator allocator = new RootAllocator(1024)) {
       DictionaryEncoding dictionaryEncoding =
-              new DictionaryEncoding(0, true, new ArrowType.Int(8, true));
+          new DictionaryEncoding(0, true, new ArrowType.Int(8, true));
       VarCharVector dictVec = new VarCharVector("dict vector", allocator);
       Dictionary dictionary = new Dictionary(dictVec, dictionaryEncoding);
       DictionaryProvider dictProvider = new DictionaryProvider.MapDictionaryProvider(dictionary);
       TreeSet<Long> dictionaryUsed = new TreeSet<>();
 
-      FieldType encodedVarcharType = new FieldType(true, new ArrowType.Int(8, true), dictionaryEncoding);
+      FieldType encodedVarcharType =
+          new FieldType(true, new ArrowType.Int(8, true), dictionaryEncoding);
       FieldType intType = new FieldType(true, new ArrowType.Int(32, true), null);
 
-      ImmutableList<Field> build = ImmutableList.of(
-              new Field("stringCol", encodedVarcharType, null),
-              new Field("intCol", intType, null));
+      ImmutableList<Field> build =
+          ImmutableList.of(
+              new Field("stringCol", encodedVarcharType, null), new Field("intCol", intType, null));
 
       Schema schema = new Schema(build);
       Schema newSchema = DictionaryUtils.generateSchema(schema, dictProvider, dictionaryUsed);

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestErrorMetadata.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestErrorMetadata.java
@@ -14,50 +14,53 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
 import static org.apache.arrow.flight.Location.forGrpcInsecure;
 
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.rpc.Status;
+import io.grpc.Metadata;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.ProtoUtils;
+import io.grpc.protobuf.StatusProto;
 import java.nio.charset.StandardCharsets;
-
 import org.apache.arrow.flight.perf.impl.PerfOuterClass;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.google.protobuf.Any;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.rpc.Status;
-
-import io.grpc.Metadata;
-import io.grpc.StatusRuntimeException;
-import io.grpc.protobuf.ProtoUtils;
-import io.grpc.protobuf.StatusProto;
-
 public class TestErrorMetadata {
   private static final Metadata.BinaryMarshaller<Status> marshaller =
-          ProtoUtils.metadataMarshaller(Status.getDefaultInstance());
+      ProtoUtils.metadataMarshaller(Status.getDefaultInstance());
 
   /** Ensure metadata attached to a gRPC error is propagated. */
   @Test
   public void testGrpcMetadata() throws Exception {
-    PerfOuterClass.Perf perf = PerfOuterClass.Perf.newBuilder()
-                .setStreamCount(12)
-                .setRecordsPerBatch(1000)
-                .setRecordsPerStream(1000000L)
-                .build();
+    PerfOuterClass.Perf perf =
+        PerfOuterClass.Perf.newBuilder()
+            .setStreamCount(12)
+            .setRecordsPerBatch(1000)
+            .setRecordsPerStream(1000000L)
+            .build();
     StatusRuntimeExceptionProducer producer = new StatusRuntimeExceptionProducer(perf);
     try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         final FlightServer s = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), producer).build()
-             .start();
-         final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
-      final CallStatus flightStatus = FlightTestUtil.assertCode(FlightStatusCode.CANCELLED, () -> {
-        FlightStream stream = client.getStream(new Ticket("abs".getBytes(StandardCharsets.UTF_8)));
-        stream.next();
-      });
+        final FlightServer s =
+            FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), producer)
+                .build()
+                .start();
+        final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
+      final CallStatus flightStatus =
+          FlightTestUtil.assertCode(
+              FlightStatusCode.CANCELLED,
+              () -> {
+                FlightStream stream =
+                    client.getStream(new Ticket("abs".getBytes(StandardCharsets.UTF_8)));
+                stream.next();
+              });
       PerfOuterClass.Perf newPerf = null;
       ErrorFlightMetadata metadata = flightStatus.metadata();
       Assertions.assertNotNull(metadata);
@@ -82,25 +85,33 @@ public class TestErrorMetadata {
   @Test
   public void testFlightMetadata() throws Exception {
     try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         final FlightServer s = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), new CallStatusProducer())
-             .build().start();
-         final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
-      CallStatus flightStatus = FlightTestUtil.assertCode(FlightStatusCode.INVALID_ARGUMENT, () -> {
-        FlightStream stream = client.getStream(new Ticket(new byte[0]));
-        stream.next();
-      });
+        final FlightServer s =
+            FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), new CallStatusProducer())
+                .build()
+                .start();
+        final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
+      CallStatus flightStatus =
+          FlightTestUtil.assertCode(
+              FlightStatusCode.INVALID_ARGUMENT,
+              () -> {
+                FlightStream stream = client.getStream(new Ticket(new byte[0]));
+                stream.next();
+              });
       ErrorFlightMetadata metadata = flightStatus.metadata();
       Assertions.assertNotNull(metadata);
       Assertions.assertEquals("foo", metadata.get("x-foo"));
-      Assertions.assertArrayEquals(new byte[]{1}, metadata.getByte("x-bar-bin"));
+      Assertions.assertArrayEquals(new byte[] {1}, metadata.getByte("x-bar-bin"));
 
-      flightStatus = FlightTestUtil.assertCode(FlightStatusCode.INVALID_ARGUMENT, () -> {
-        client.getInfo(FlightDescriptor.command(new byte[0]));
-      });
+      flightStatus =
+          FlightTestUtil.assertCode(
+              FlightStatusCode.INVALID_ARGUMENT,
+              () -> {
+                client.getInfo(FlightDescriptor.command(new byte[0]));
+              });
       metadata = flightStatus.metadata();
       Assertions.assertNotNull(metadata);
       Assertions.assertEquals("foo", metadata.get("x-foo"));
-      Assertions.assertArrayEquals(new byte[]{1}, metadata.getByte("x-bar-bin"));
+      Assertions.assertArrayEquals(new byte[] {1}, metadata.getByte("x-bar-bin"));
     }
   }
 
@@ -113,11 +124,13 @@ public class TestErrorMetadata {
 
     @Override
     public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
-      StatusRuntimeException sre = StatusProto.toStatusRuntimeException(Status.newBuilder()
-              .setCode(1)
-              .setMessage("Testing 1 2 3")
-              .addDetails(Any.pack(perf, "arrow/meta/types"))
-              .build());
+      StatusRuntimeException sre =
+          StatusProto.toStatusRuntimeException(
+              Status.newBuilder()
+                  .setCode(1)
+                  .setMessage("Testing 1 2 3")
+                  .addDetails(Any.pack(perf, "arrow/meta/types"))
+                  .build());
       listener.error(sre);
     }
   }
@@ -128,17 +141,24 @@ public class TestErrorMetadata {
     CallStatusProducer() {
       this.metadata = new ErrorFlightMetadata();
       metadata.insert("x-foo", "foo");
-      metadata.insert("x-bar-bin", new byte[]{1});
+      metadata.insert("x-bar-bin", new byte[] {1});
     }
 
     @Override
     public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
-      listener.error(CallStatus.INVALID_ARGUMENT.withDescription("Failed").withMetadata(metadata).toRuntimeException());
+      listener.error(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription("Failed")
+              .withMetadata(metadata)
+              .toRuntimeException());
     }
 
     @Override
     public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
-      throw CallStatus.INVALID_ARGUMENT.withDescription("Failed").withMetadata(metadata).toRuntimeException();
+      throw CallStatus.INVALID_ARGUMENT
+          .withDescription("Failed")
+          .withMetadata(metadata)
+          .toRuntimeException();
     }
   }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightClient.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightClient.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
@@ -23,7 +22,6 @@ import static org.apache.arrow.flight.Location.forGrpcInsecure;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.arrow.flight.FlightClient.ClientStreamListener;
 import org.apache.arrow.flight.TestBasicOperation.Producer;
 import org.apache.arrow.memory.BufferAllocator;
@@ -48,22 +46,27 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class TestFlightClient {
-  /**
-   * ARROW-5063: make sure two clients to the same location can be closed independently.
-   */
+  /** ARROW-5063: make sure two clients to the same location can be closed independently. */
   @Test
   public void independentShutdown() throws Exception {
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-         final FlightServer server = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0),
-             new Producer(allocator)).build().start()) {
-      final Schema schema = new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
-      try (final FlightClient client1 = FlightClient.builder(allocator, server.getLocation()).build();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+        final FlightServer server =
+            FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), new Producer(allocator))
+                .build()
+                .start()) {
+      final Schema schema =
+          new Schema(Collections.singletonList(Field.nullable("a", new ArrowType.Int(32, true))));
+      try (final FlightClient client1 =
+              FlightClient.builder(allocator, server.getLocation()).build();
+          final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
         // Use startPut as this ensures the RPC won't finish until we want it to
-        final ClientStreamListener listener = client1.startPut(FlightDescriptor.path("test"), root,
-            new AsyncPutListener());
-        try (final FlightClient client2 = FlightClient.builder(allocator, server.getLocation()).build()) {
-          client2.listActions().forEach(actionType -> Assertions.assertNotNull(actionType.getType()));
+        final ClientStreamListener listener =
+            client1.startPut(FlightDescriptor.path("test"), root, new AsyncPutListener());
+        try (final FlightClient client2 =
+            FlightClient.builder(allocator, server.getLocation()).build()) {
+          client2
+              .listActions()
+              .forEach(actionType -> Assertions.assertNotNull(actionType.getType()));
         }
         listener.completed();
         listener.getResult();
@@ -77,45 +80,65 @@ public class TestFlightClient {
   @Disabled // Unfortunately this test is flaky in CI.
   @Test
   public void freeDictionaries() throws Exception {
-    final Schema expectedSchema = new Schema(Collections
-        .singletonList(new Field("encoded",
-            new FieldType(true, new ArrowType.Int(32, true), new DictionaryEncoding(1L, false, null)), null)));
+    final Schema expectedSchema =
+        new Schema(
+            Collections.singletonList(
+                new Field(
+                    "encoded",
+                    new FieldType(
+                        true, new ArrowType.Int(32, true), new DictionaryEncoding(1L, false, null)),
+                    null)));
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-         final BufferAllocator serverAllocator = allocator.newChildAllocator("flight-server", 0, Integer.MAX_VALUE);
-         final FlightServer server = FlightServer.builder(serverAllocator, forGrpcInsecure(LOCALHOST, 0),
-             new DictionaryProducer(serverAllocator)).build().start()) {
-      try (final FlightClient client = FlightClient.builder(allocator, server.getLocation()).build()) {
+        final BufferAllocator serverAllocator =
+            allocator.newChildAllocator("flight-server", 0, Integer.MAX_VALUE);
+        final FlightServer server =
+            FlightServer.builder(
+                    serverAllocator,
+                    forGrpcInsecure(LOCALHOST, 0),
+                    new DictionaryProducer(serverAllocator))
+                .build()
+                .start()) {
+      try (final FlightClient client =
+          FlightClient.builder(allocator, server.getLocation()).build()) {
         try (final FlightStream stream = client.getStream(new Ticket(new byte[0]))) {
           Assertions.assertTrue(stream.next());
           Assertions.assertNotNull(stream.getDictionaryProvider().lookup(1));
           final VectorSchemaRoot root = stream.getRoot();
           Assertions.assertEquals(expectedSchema, root.getSchema());
           Assertions.assertEquals(6, root.getVector("encoded").getValueCount());
-          try (final ValueVector decoded = DictionaryEncoder
-              .decode(root.getVector("encoded"), stream.getDictionaryProvider().lookup(1))) {
+          try (final ValueVector decoded =
+              DictionaryEncoder.decode(
+                  root.getVector("encoded"), stream.getDictionaryProvider().lookup(1))) {
             Assertions.assertFalse(decoded.isNull(1));
             Assertions.assertTrue(decoded instanceof VarCharVector);
-            Assertions.assertArrayEquals("one".getBytes(StandardCharsets.UTF_8), ((VarCharVector) decoded).get(1));
+            Assertions.assertArrayEquals(
+                "one".getBytes(StandardCharsets.UTF_8), ((VarCharVector) decoded).get(1));
           }
           Assertions.assertFalse(stream.next());
         }
-        // Closing stream fails if it doesn't free dictionaries; closing dictionaries fails (refcount goes negative)
+        // Closing stream fails if it doesn't free dictionaries; closing dictionaries fails
+        // (refcount goes negative)
         // if reference isn't retained in ArrowMessage
       }
     }
   }
 
-  /**
-   * ARROW-5978: make sure that dictionary ownership can't be claimed twice.
-   */
+  /** ARROW-5978: make sure that dictionary ownership can't be claimed twice. */
   @Disabled // Unfortunately this test is flaky in CI.
   @Test
   public void ownDictionaries() throws Exception {
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-         final BufferAllocator serverAllocator = allocator.newChildAllocator("flight-server", 0, Integer.MAX_VALUE);
-         final FlightServer server = FlightServer.builder(serverAllocator, forGrpcInsecure(LOCALHOST, 0),
-             new DictionaryProducer(serverAllocator)).build().start()) {
-      try (final FlightClient client = FlightClient.builder(allocator, server.getLocation()).build()) {
+        final BufferAllocator serverAllocator =
+            allocator.newChildAllocator("flight-server", 0, Integer.MAX_VALUE);
+        final FlightServer server =
+            FlightServer.builder(
+                    serverAllocator,
+                    forGrpcInsecure(LOCALHOST, 0),
+                    new DictionaryProducer(serverAllocator))
+                .build()
+                .start()) {
+      try (final FlightClient client =
+          FlightClient.builder(allocator, server.getLocation()).build()) {
         try (final FlightStream stream = client.getStream(new Ticket(new byte[0]))) {
           Assertions.assertTrue(stream.next());
           Assertions.assertFalse(stream.next());
@@ -128,18 +151,22 @@ public class TestFlightClient {
     }
   }
 
-  /**
-   * ARROW-5978: make sure that dictionaries can be used after closing the stream.
-   */
+  /** ARROW-5978: make sure that dictionaries can be used after closing the stream. */
   @Disabled // Unfortunately this test is flaky in CI.
   @Test
   public void useDictionariesAfterClose() throws Exception {
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-         final BufferAllocator serverAllocator = allocator.newChildAllocator("flight-server", 0, Integer.MAX_VALUE);
-         final FlightServer server = FlightServer.builder(serverAllocator, forGrpcInsecure(LOCALHOST, 0),
-                 new DictionaryProducer(serverAllocator))
-             .build().start()) {
-      try (final FlightClient client = FlightClient.builder(allocator, server.getLocation()).build()) {
+        final BufferAllocator serverAllocator =
+            allocator.newChildAllocator("flight-server", 0, Integer.MAX_VALUE);
+        final FlightServer server =
+            FlightServer.builder(
+                    serverAllocator,
+                    forGrpcInsecure(LOCALHOST, 0),
+                    new DictionaryProducer(serverAllocator))
+                .build()
+                .start()) {
+      try (final FlightClient client =
+          FlightClient.builder(allocator, server.getLocation()).build()) {
         final VectorSchemaRoot root;
         final DictionaryProvider provider;
         try (final FlightStream stream = client.getStream(new Ticket(new byte[0]))) {
@@ -153,11 +180,12 @@ public class TestFlightClient {
           }
           provider = stream.takeDictionaryOwnership();
         }
-        try (final ValueVector decoded = DictionaryEncoder
-            .decode(root.getVector("encoded"), provider.lookup(1))) {
+        try (final ValueVector decoded =
+            DictionaryEncoder.decode(root.getVector("encoded"), provider.lookup(1))) {
           Assertions.assertFalse(decoded.isNull(1));
           Assertions.assertTrue(decoded instanceof VarCharVector);
-          Assertions.assertArrayEquals("one".getBytes(StandardCharsets.UTF_8), ((VarCharVector) decoded).get(1));
+          Assertions.assertArrayEquals(
+              "one".getBytes(StandardCharsets.UTF_8), ((VarCharVector) decoded).get(1));
         }
         root.close();
         DictionaryUtils.closeDictionaries(root.getSchema(), provider);
@@ -179,7 +207,8 @@ public class TestFlightClient {
       final byte[] one = "one".getBytes(StandardCharsets.UTF_8);
       final byte[] two = "two".getBytes(StandardCharsets.UTF_8);
       try (final VarCharVector dictionaryVector = newVarCharVector("dictionary", allocator)) {
-        final DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
+        final DictionaryProvider.MapDictionaryProvider provider =
+            new DictionaryProvider.MapDictionaryProvider();
 
         dictionaryVector.allocateNew(512, 3);
         dictionaryVector.setSafe(0, zero, 0, zero.length);
@@ -187,7 +216,8 @@ public class TestFlightClient {
         dictionaryVector.setSafe(2, two, 0, two.length);
         dictionaryVector.setValueCount(3);
 
-        final Dictionary dictionary = new Dictionary(dictionaryVector, new DictionaryEncoding(1L, false, null));
+        final Dictionary dictionary =
+            new Dictionary(dictionaryVector, new DictionaryEncoding(1L, false, null));
         provider.put(dictionary);
 
         final FieldVector encodedVector;
@@ -204,7 +234,8 @@ public class TestFlightClient {
         final List<Field> fields = Collections.singletonList(encodedVector.getField());
         final List<FieldVector> vectors = Collections.singletonList(encodedVector);
 
-        try (final VectorSchemaRoot root = new VectorSchemaRoot(fields, vectors, encodedVector.getValueCount())) {
+        try (final VectorSchemaRoot root =
+            new VectorSchemaRoot(fields, vectors, encodedVector.getValueCount())) {
           listener.start(root, provider);
           listener.putNext();
           listener.completed();

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
@@ -14,15 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.protobuf.Empty;
+import io.grpc.BindableService;
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -31,19 +37,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.google.protobuf.Empty;
-
-import io.grpc.BindableService;
-import io.grpc.ConnectivityState;
-import io.grpc.ManagedChannel;
-import io.grpc.Server;
-import io.grpc.inprocess.InProcessChannelBuilder;
-import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.stub.StreamObserver;
-
-/**
- * Unit test which adds 2 services to same server end point.
- */
+/** Unit test which adds 2 services to same server end point. */
 public class TestFlightGrpcUtils {
   private Server server;
   private BufferAllocator allocator;
@@ -51,21 +45,22 @@ public class TestFlightGrpcUtils {
 
   @BeforeEach
   public void setup() throws IOException {
-    //Defines flight service
+    // Defines flight service
     allocator = new RootAllocator(Integer.MAX_VALUE);
     final NoOpFlightProducer producer = new NoOpFlightProducer();
     final ServerAuthHandler authHandler = ServerAuthHandler.NO_OP;
     final ExecutorService exec = Executors.newCachedThreadPool();
-    final BindableService flightBindingService = FlightGrpcUtils.createFlightService(allocator, producer,
-        authHandler, exec);
+    final BindableService flightBindingService =
+        FlightGrpcUtils.createFlightService(allocator, producer, authHandler, exec);
 
-    //initializes server with 2 services - FlightBindingService & TestService
+    // initializes server with 2 services - FlightBindingService & TestService
     serverName = InProcessServerBuilder.generateName();
-    server = InProcessServerBuilder.forName(serverName)
-        .directExecutor()
-        .addService(flightBindingService)
-        .addService(new TestServiceAdapter())
-        .build();
+    server =
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(flightBindingService)
+            .addService(new TestServiceAdapter())
+            .build();
     server.start();
   }
 
@@ -75,39 +70,45 @@ public class TestFlightGrpcUtils {
   }
 
   /**
-   * This test checks if multiple gRPC services can be added to the same
-   * server endpoint and if they can be used by different clients via the same channel.
+   * This test checks if multiple gRPC services can be added to the same server endpoint and if they
+   * can be used by different clients via the same channel.
+   *
    * @throws IOException If server fails to start.
    */
   @Test
   public void testMultipleGrpcServices() throws IOException {
-    //Initializes channel so that multiple clients can communicate with server
-    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
-            .directExecutor()
-            .build();
+    // Initializes channel so that multiple clients can communicate with server
+    final ManagedChannel managedChannel =
+        InProcessChannelBuilder.forName(serverName).directExecutor().build();
 
-    //Defines flight client and calls service method. Since we use a NoOpFlightProducer we expect the service
-    //to throw a RunTimeException
+    // Defines flight client and calls service method. Since we use a NoOpFlightProducer we expect
+    // the service
+    // to throw a RunTimeException
     final FlightClient flightClient = FlightGrpcUtils.createFlightClient(allocator, managedChannel);
     final Iterable<ActionType> actionTypes = flightClient.listActions();
-    assertThrows(FlightRuntimeException.class, () -> actionTypes.forEach(
-        actionType -> System.out.println(actionType.toString())));
+    assertThrows(
+        FlightRuntimeException.class,
+        () -> actionTypes.forEach(actionType -> System.out.println(actionType.toString())));
 
-    //Define Test client as a blocking stub and call test method which correctly returns an empty protobuf object
-    final TestServiceGrpc.TestServiceBlockingStub blockingStub = TestServiceGrpc.newBlockingStub(managedChannel);
-    Assertions.assertEquals(Empty.newBuilder().build(), blockingStub.test(Empty.newBuilder().build()));
+    // Define Test client as a blocking stub and call test method which correctly returns an empty
+    // protobuf object
+    final TestServiceGrpc.TestServiceBlockingStub blockingStub =
+        TestServiceGrpc.newBlockingStub(managedChannel);
+    Assertions.assertEquals(
+        Empty.newBuilder().build(), blockingStub.test(Empty.newBuilder().build()));
   }
 
   @Test
   public void testShutdown() throws IOException, InterruptedException {
-    //Initializes channel so that multiple clients can communicate with server
-    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
-        .directExecutor()
-        .build();
+    // Initializes channel so that multiple clients can communicate with server
+    final ManagedChannel managedChannel =
+        InProcessChannelBuilder.forName(serverName).directExecutor().build();
 
-    //Defines flight client and calls service method. Since we use a NoOpFlightProducer we expect the service
-    //to throw a RunTimeException
-    final FlightClient flightClient = FlightGrpcUtils.createFlightClientWithSharedChannel(allocator, managedChannel);
+    // Defines flight client and calls service method. Since we use a NoOpFlightProducer we expect
+    // the service
+    // to throw a RunTimeException
+    final FlightClient flightClient =
+        FlightGrpcUtils.createFlightClientWithSharedChannel(allocator, managedChannel);
 
     // Should be a no-op.
     flightClient.close();
@@ -119,10 +120,9 @@ public class TestFlightGrpcUtils {
 
   @Test
   public void testProxyChannel() throws IOException, InterruptedException {
-    //Initializes channel so that multiple clients can communicate with server
-    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
-        .directExecutor()
-        .build();
+    // Initializes channel so that multiple clients can communicate with server
+    final ManagedChannel managedChannel =
+        InProcessChannelBuilder.forName(serverName).directExecutor().build();
 
     final FlightGrpcUtils.NonClosingProxyManagedChannel proxyChannel =
         new FlightGrpcUtils.NonClosingProxyManagedChannel(managedChannel);
@@ -148,10 +148,9 @@ public class TestFlightGrpcUtils {
 
   @Test
   public void testProxyChannelWithClosedChannel() throws IOException, InterruptedException {
-    //Initializes channel so that multiple clients can communicate with server
-    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
-        .directExecutor()
-        .build();
+    // Initializes channel so that multiple clients can communicate with server
+    final ManagedChannel managedChannel =
+        InProcessChannelBuilder.forName(serverName).directExecutor().build();
 
     final FlightGrpcUtils.NonClosingProxyManagedChannel proxyChannel =
         new FlightGrpcUtils.NonClosingProxyManagedChannel(managedChannel);
@@ -173,13 +172,12 @@ public class TestFlightGrpcUtils {
     Assertions.assertEquals(ConnectivityState.SHUTDOWN, managedChannel.getState(false));
   }
 
-  /**
-   * Private class used for testing purposes that overrides service behavior.
-   */
+  /** Private class used for testing purposes that overrides service behavior. */
   private static class TestServiceAdapter extends TestServiceGrpc.TestServiceImplBase {
 
     /**
      * gRPC service that receives an empty object & returns and empty protobuf object.
+     *
      * @param request google.protobuf.Empty
      * @param responseObserver google.protobuf.Empty
      */
@@ -190,4 +188,3 @@ public class TestFlightGrpcUtils {
     }
   }
 }
-

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLargeMessage.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLargeMessage.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -24,7 +23,6 @@ import static org.apache.arrow.flight.Location.forGrpcInsecure;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
@@ -37,17 +35,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class TestLargeMessage {
-  /**
-   * Make sure a Flight client accepts large message payloads by default.
-   */
+  /** Make sure a Flight client accepts large message payloads by default. */
   @Test
   public void getLargeMessage() throws Exception {
     try (final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
-         final Producer producer = new Producer(a);
-         final FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
+        final Producer producer = new Producer(a);
+        final FlightServer s =
+            FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
 
       try (FlightClient client = FlightClient.builder(a, s.getLocation()).build()) {
-        try (FlightStream stream = client.getStream(new Ticket(new byte[]{}));
+        try (FlightStream stream = client.getStream(new Ticket(new byte[] {}));
             VectorSchemaRoot root = stream.getRoot()) {
           while (stream.next()) {
             for (final Field field : root.getSchema().getFields()) {
@@ -64,19 +61,18 @@ public class TestLargeMessage {
     }
   }
 
-  /**
-   * Make sure a Flight server accepts large message payloads by default.
-   */
+  /** Make sure a Flight server accepts large message payloads by default. */
   @Test
   public void putLargeMessage() throws Exception {
     try (final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
-         final Producer producer = new Producer(a);
-         final FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
+        final Producer producer = new Producer(a);
+        final FlightServer s =
+            FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer).build().start()) {
       try (FlightClient client = FlightClient.builder(a, s.getLocation()).build();
-           BufferAllocator testAllocator = a.newChildAllocator("testcase", 0, Long.MAX_VALUE);
-           VectorSchemaRoot root = generateData(testAllocator)) {
-        final FlightClient.ClientStreamListener listener = client.startPut(FlightDescriptor.path("hello"), root,
-            new AsyncPutListener());
+          BufferAllocator testAllocator = a.newChildAllocator("testcase", 0, Long.MAX_VALUE);
+          VectorSchemaRoot root = generateData(testAllocator)) {
+        final FlightClient.ClientStreamListener listener =
+            client.startPut(FlightDescriptor.path("hello"), root, new AsyncPutListener());
         listener.putNext();
         listener.completed();
         listener.getResult();
@@ -86,10 +82,13 @@ public class TestLargeMessage {
 
   private static VectorSchemaRoot generateData(BufferAllocator allocator) {
     final int size = 128 * 1024;
-    final List<String> fieldNames = Arrays.asList("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10");
-    final Stream<Field> fields = fieldNames
-        .stream()
-        .map(fieldName -> new Field(fieldName, FieldType.nullable(new ArrowType.Int(32, true)), null));
+    final List<String> fieldNames =
+        Arrays.asList("c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10");
+    final Stream<Field> fields =
+        fieldNames.stream()
+            .map(
+                fieldName ->
+                    new Field(fieldName, FieldType.nullable(new ArrowType.Int(32, true)), null));
     final Schema schema = new Schema(fields.collect(toImmutableList()), null);
 
     final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
@@ -113,8 +112,7 @@ public class TestLargeMessage {
     }
 
     @Override
-    public void getStream(CallContext context, Ticket ticket,
-        ServerStreamListener listener) {
+    public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
       try (VectorSchemaRoot root = generateData(allocator)) {
         listener.start(root);
         listener.putNext();
@@ -123,39 +121,32 @@ public class TestLargeMessage {
     }
 
     @Override
-    public void listFlights(CallContext context, Criteria criteria,
-        StreamListener<FlightInfo> listener) {
-
-    }
+    public void listFlights(
+        CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {}
 
     @Override
-    public FlightInfo getFlightInfo(CallContext context,
-        FlightDescriptor descriptor) {
+    public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
       return null;
     }
 
     @Override
-    public Runnable acceptPut(CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    public Runnable acceptPut(
+        CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
       return () -> {
         try (VectorSchemaRoot root = flightStream.getRoot()) {
-          while (flightStream.next()) {
-            ;
+          while (flightStream.next()) {;
           }
         }
       };
     }
 
     @Override
-    public void doAction(CallContext context, Action action,
-        StreamListener<Result> listener) {
+    public void doAction(CallContext context, Action action, StreamListener<Result> listener) {
       listener.onCompleted();
     }
 
     @Override
-    public void listActions(CallContext context,
-        StreamListener<ActionType> listener) {
-
-    }
+    public void listActions(CallContext context, StreamListener<ActionType> listener) {}
 
     @Override
     public void close() throws Exception {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLeak.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLeak.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
@@ -23,7 +22,6 @@ import static org.apache.arrow.flight.Location.forGrpcInsecure;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.Float8Vector;
@@ -34,50 +32,53 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for scenarios where Flight could leak memory.
- */
+/** Tests for scenarios where Flight could leak memory. */
 public class TestLeak {
 
   private static final int ROWS = 2048;
 
   private static Schema getSchema() {
-    return new Schema(Arrays.asList(
-        Field.nullable("0", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("1", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("2", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("3", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("4", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("5", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("6", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("7", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("8", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("9", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
-        Field.nullable("10", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))
-    ));
+    return new Schema(
+        Arrays.asList(
+            Field.nullable("0", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("1", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("2", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("3", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("4", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("5", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("6", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("7", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("8", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("9", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            Field.nullable("10", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))));
   }
 
   /**
    * Ensure that if the client cancels, the server does not leak memory.
    *
-   * <p>In gRPC, canceling the stream from the client sends an event to the server. Once processed, gRPC will start
-   * silently rejecting messages sent by the server. However, Flight depends on gRPC processing these messages in order
-   * to free the associated memory.
+   * <p>In gRPC, canceling the stream from the client sends an event to the server. Once processed,
+   * gRPC will start silently rejecting messages sent by the server. However, Flight depends on gRPC
+   * processing these messages in order to free the associated memory.
    */
   @Test
   public void testCancelingDoGetDoesNotLeak() throws Exception {
     final CountDownLatch callFinished = new CountDownLatch(1);
     try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         final FlightServer s = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0),
-                 new LeakFlightProducer(allocator, callFinished))
-             .build().start();
-         final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
+        final FlightServer s =
+            FlightServer.builder(
+                    allocator,
+                    forGrpcInsecure(LOCALHOST, 0),
+                    new LeakFlightProducer(allocator, callFinished))
+                .build()
+                .start();
+        final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
 
       final FlightStream stream = client.getStream(new Ticket(new byte[0]));
       stream.getRoot();
       stream.cancel("Cancel", null);
 
-      // Wait for the call to finish. (Closing the allocator while a call is ongoing is a guaranteed leak.)
+      // Wait for the call to finish. (Closing the allocator while a call is ongoing is a guaranteed
+      // leak.)
       callFinished.await(60, TimeUnit.SECONDS);
 
       s.shutdown();
@@ -89,15 +90,20 @@ public class TestLeak {
   public void testCancelingDoPutDoesNotBlock() throws Exception {
     final CountDownLatch callFinished = new CountDownLatch(1);
     try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         final FlightServer s = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0),
-                 new LeakFlightProducer(allocator, callFinished))
-             .build().start();
-         final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
+        final FlightServer s =
+            FlightServer.builder(
+                    allocator,
+                    forGrpcInsecure(LOCALHOST, 0),
+                    new LeakFlightProducer(allocator, callFinished))
+                .build()
+                .start();
+        final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
 
       try (final VectorSchemaRoot root = VectorSchemaRoot.create(getSchema(), allocator)) {
         final FlightDescriptor descriptor = FlightDescriptor.command(new byte[0]);
         final SyncPutListener listener = new SyncPutListener();
-        final FlightClient.ClientStreamListener stream = client.startPut(descriptor, root, listener);
+        final FlightClient.ClientStreamListener stream =
+            client.startPut(descriptor, root, listener);
         // Wait for the server to cancel
         callFinished.await(60, TimeUnit.SECONDS);
 
@@ -109,7 +115,8 @@ public class TestLeak {
           }
         }
         root.setRowCount(ROWS);
-        // Unlike DoGet, this method fairly reliably will write the message to the stream, so even without the fix
+        // Unlike DoGet, this method fairly reliably will write the message to the stream, so even
+        // without the fix
         // for ARROW-7343, this won't leak memory.
         // However, it will block if FlightClient doesn't check for cancellation.
         stream.putNext();
@@ -121,9 +128,7 @@ public class TestLeak {
     }
   }
 
-  /**
-   * A FlightProducer that always produces a fixed data stream with metadata on the side.
-   */
+  /** A FlightProducer that always produces a fixed data stream with metadata on the side. */
   private static class LeakFlightProducer extends NoOpFlightProducer {
 
     private final BufferAllocator allocator;
@@ -143,35 +148,38 @@ public class TestLeak {
 
       // We can't poll listener#isCancelled since gRPC has two distinct "is cancelled" flags.
       // TODO: should we continue leaking gRPC semantics? Can we even avoid this?
-      listener.setOnCancelHandler(() -> {
-        try {
-          for (int col = 0; col < 11; col++) {
-            final Float8Vector vector = (Float8Vector) root.getVector(Integer.toString(col));
-            vector.allocateNew();
-            for (int row = 0; row < ROWS; row++) {
-              vector.setSafe(row, 10.);
+      listener.setOnCancelHandler(
+          () -> {
+            try {
+              for (int col = 0; col < 11; col++) {
+                final Float8Vector vector = (Float8Vector) root.getVector(Integer.toString(col));
+                vector.allocateNew();
+                for (int row = 0; row < ROWS; row++) {
+                  vector.setSafe(row, 10.);
+                }
+              }
+              root.setRowCount(ROWS);
+              // Once the call is "really cancelled" (setOnCancelListener has run/is running), this
+              // call is actually a
+              // no-op on the gRPC side and will leak the ArrowMessage unless Flight checks for
+              // this.
+              listener.putNext();
+              listener.completed();
+            } finally {
+              try {
+                root.close();
+                childAllocator.close();
+              } finally {
+                // Don't let the test hang if we throw above
+                callFinished.countDown();
+              }
             }
-          }
-          root.setRowCount(ROWS);
-          // Once the call is "really cancelled" (setOnCancelListener has run/is running), this call is actually a
-          // no-op on the gRPC side and will leak the ArrowMessage unless Flight checks for this.
-          listener.putNext();
-          listener.completed();
-        } finally {
-          try {
-            root.close();
-            childAllocator.close();
-          } finally {
-            // Don't let the test hang if we throw above
-            callFinished.countDown();
-          }
-        }
-      });
+          });
     }
 
     @Override
-    public Runnable acceptPut(CallContext context,
-        FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    public Runnable acceptPut(
+        CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
       return () -> {
         flightStream.getRoot();
         ackStream.onError(CallStatus.CANCELLED.withDescription("CANCELLED").toRuntimeException());

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerMiddleware.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerMiddleware.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
@@ -25,10 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-
 import org.apache.arrow.flight.FlightClient.ClientStreamListener;
-import org.apache.arrow.flight.FlightServerMiddleware.Factory;
-import org.apache.arrow.flight.FlightServerMiddleware.Key;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -38,44 +34,48 @@ import org.junit.jupiter.api.Test;
 
 public class TestServerMiddleware {
 
-  /**
-   * Make sure errors in DoPut are intercepted.
-   */
+  /** Make sure errors in DoPut are intercepted. */
   @Test
   public void doPutErrors() {
     test(
         new ErrorProducer(new RuntimeException("test")),
         (allocator, client) -> {
           final FlightDescriptor descriptor = FlightDescriptor.path("test");
-          try (final VectorSchemaRoot root = VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
-            final ClientStreamListener listener = client.startPut(descriptor, root, new SyncPutListener());
+          try (final VectorSchemaRoot root =
+              VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
+            final ClientStreamListener listener =
+                client.startPut(descriptor, root, new SyncPutListener());
             listener.completed();
             FlightTestUtil.assertCode(FlightStatusCode.INTERNAL, listener::getResult);
           }
-        }, (recorder) -> {
+        },
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           Assertions.assertNotNull(status);
           Assertions.assertNotNull(status.cause());
           Assertions.assertEquals(FlightStatusCode.INTERNAL, status.code());
         });
-    // Check the status after server shutdown (to make sure gRPC finishes pending calls on the server side)
+    // Check the status after server shutdown (to make sure gRPC finishes pending calls on the
+    // server side)
   }
 
-  /**
-   * Make sure custom error codes in DoPut are intercepted.
-   */
+  /** Make sure custom error codes in DoPut are intercepted. */
   @Test
   public void doPutCustomCode() {
     test(
-        new ErrorProducer(CallStatus.UNAVAILABLE.withDescription("description").toRuntimeException()),
+        new ErrorProducer(
+            CallStatus.UNAVAILABLE.withDescription("description").toRuntimeException()),
         (allocator, client) -> {
           final FlightDescriptor descriptor = FlightDescriptor.path("test");
-          try (final VectorSchemaRoot root = VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
-            final ClientStreamListener listener = client.startPut(descriptor, root, new SyncPutListener());
+          try (final VectorSchemaRoot root =
+              VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
+            final ClientStreamListener listener =
+                client.startPut(descriptor, root, new SyncPutListener());
             listener.completed();
             FlightTestUtil.assertCode(FlightStatusCode.UNAVAILABLE, listener::getResult);
           }
-        }, (recorder) -> {
+        },
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           Assertions.assertNotNull(status);
           Assertions.assertNull(status.cause());
@@ -84,20 +84,22 @@ public class TestServerMiddleware {
         });
   }
 
-  /**
-   * Make sure uncaught exceptions in DoPut are intercepted.
-   */
+  /** Make sure uncaught exceptions in DoPut are intercepted. */
   @Test
   public void doPutUncaught() {
-    test(new ServerErrorProducer(new RuntimeException("test")),
+    test(
+        new ServerErrorProducer(new RuntimeException("test")),
         (allocator, client) -> {
           final FlightDescriptor descriptor = FlightDescriptor.path("test");
-          try (final VectorSchemaRoot root = VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
-            final ClientStreamListener listener = client.startPut(descriptor, root, new SyncPutListener());
+          try (final VectorSchemaRoot root =
+              VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
+            final ClientStreamListener listener =
+                client.startPut(descriptor, root, new SyncPutListener());
             listener.completed();
             listener.getResult();
           }
-        }, (recorder) -> {
+        },
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           final Throwable err = recorder.errFuture.get();
           Assertions.assertNotNull(status);
@@ -110,9 +112,11 @@ public class TestServerMiddleware {
 
   @Test
   public void listFlightsUncaught() {
-    test(new ServerErrorProducer(new RuntimeException("test")),
-        (allocator, client) -> client.listFlights(new Criteria(new byte[0])).forEach((action) -> {
-        }), (recorder) -> {
+    test(
+        new ServerErrorProducer(new RuntimeException("test")),
+        (allocator, client) ->
+            client.listFlights(new Criteria(new byte[0])).forEach((action) -> {}),
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           final Throwable err = recorder.errFuture.get();
           Assertions.assertNotNull(status);
@@ -125,9 +129,10 @@ public class TestServerMiddleware {
 
   @Test
   public void doActionUncaught() {
-    test(new ServerErrorProducer(new RuntimeException("test")),
-        (allocator, client) -> client.doAction(new Action("test")).forEachRemaining(result -> {
-        }), (recorder) -> {
+    test(
+        new ServerErrorProducer(new RuntimeException("test")),
+        (allocator, client) -> client.doAction(new Action("test")).forEachRemaining(result -> {}),
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           final Throwable err = recorder.errFuture.get();
           Assertions.assertNotNull(status);
@@ -140,9 +145,10 @@ public class TestServerMiddleware {
 
   @Test
   public void listActionsUncaught() {
-    test(new ServerErrorProducer(new RuntimeException("test")),
-        (allocator, client) -> client.listActions().forEach(result -> {
-        }), (recorder) -> {
+    test(
+        new ServerErrorProducer(new RuntimeException("test")),
+        (allocator, client) -> client.listActions().forEach(result -> {}),
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           final Throwable err = recorder.errFuture.get();
           Assertions.assertNotNull(status);
@@ -155,29 +161,34 @@ public class TestServerMiddleware {
 
   @Test
   public void getFlightInfoUncaught() {
-    test(new ServerErrorProducer(new RuntimeException("test")),
+    test(
+        new ServerErrorProducer(new RuntimeException("test")),
         (allocator, client) -> {
-          FlightTestUtil.assertCode(FlightStatusCode.INTERNAL, () -> client.getInfo(FlightDescriptor.path("test")));
-        }, (recorder) -> {
+          FlightTestUtil.assertCode(
+              FlightStatusCode.INTERNAL, () -> client.getInfo(FlightDescriptor.path("test")));
+        },
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           Assertions.assertNotNull(status);
           Assertions.assertEquals(FlightStatusCode.INTERNAL, status.code());
           Assertions.assertNotNull(status.cause());
-          Assertions.assertEquals(new RuntimeException("test").getMessage(), status.cause().getMessage());
+          Assertions.assertEquals(
+              new RuntimeException("test").getMessage(), status.cause().getMessage());
         });
   }
 
   @Test
   public void doGetUncaught() {
-    test(new ServerErrorProducer(new RuntimeException("test")),
+    test(
+        new ServerErrorProducer(new RuntimeException("test")),
         (allocator, client) -> {
           try (final FlightStream stream = client.getStream(new Ticket(new byte[0]))) {
-            while (stream.next()) {
-            }
+            while (stream.next()) {}
           } catch (Exception e) {
             Assertions.fail(e.toString());
           }
-        }, (recorder) -> {
+        },
+        (recorder) -> {
           final CallStatus status = recorder.statusFuture.get();
           final Throwable err = recorder.errFuture.get();
           Assertions.assertNotNull(status);
@@ -188,17 +199,14 @@ public class TestServerMiddleware {
         });
   }
 
-  /**
-   * A middleware that records the last error on any call.
-   */
+  /** A middleware that records the last error on any call. */
   static class ErrorRecorder implements FlightServerMiddleware {
 
     CompletableFuture<CallStatus> statusFuture = new CompletableFuture<>();
     CompletableFuture<Throwable> errFuture = new CompletableFuture<>();
 
     @Override
-    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
-    }
+    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {}
 
     @Override
     public void onCallCompleted(CallStatus status) {
@@ -215,15 +223,14 @@ public class TestServerMiddleware {
       ErrorRecorder instance = new ErrorRecorder();
 
       @Override
-      public ErrorRecorder onCallStarted(CallInfo info, CallHeaders incomingHeaders, RequestContext context) {
+      public ErrorRecorder onCallStarted(
+          CallInfo info, CallHeaders incomingHeaders, RequestContext context) {
         return instance;
       }
     }
   }
 
-  /**
-   * A producer that throws the given exception on a call.
-   */
+  /** A producer that throws the given exception on a call. */
   static class ErrorProducer extends NoOpFlightProducer {
 
     final RuntimeException error;
@@ -233,18 +240,19 @@ public class TestServerMiddleware {
     }
 
     @Override
-    public Runnable acceptPut(CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    public Runnable acceptPut(
+        CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
       return () -> {
         // Drain queue to avoid FlightStream#close cancelling the call
-        while (flightStream.next()) {
-        }
+        while (flightStream.next()) {}
         throw error;
       };
     }
   }
 
   /**
-   * A producer that throws the given exception on a call, but only after sending a success to the client.
+   * A producer that throws the given exception on a call, but only after sending a success to the
+   * client.
    */
   static class ServerErrorProducer extends NoOpFlightProducer {
 
@@ -257,7 +265,8 @@ public class TestServerMiddleware {
     @Override
     public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
       try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-          final VectorSchemaRoot root = VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
+          final VectorSchemaRoot root =
+              VectorSchemaRoot.create(new Schema(Collections.emptyList()), allocator)) {
         listener.start(root);
         listener.completed();
       }
@@ -265,7 +274,8 @@ public class TestServerMiddleware {
     }
 
     @Override
-    public void listFlights(CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
+    public void listFlights(
+        CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
       listener.onCompleted();
       throw error;
     }
@@ -276,10 +286,10 @@ public class TestServerMiddleware {
     }
 
     @Override
-    public Runnable acceptPut(CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+    public Runnable acceptPut(
+        CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
       return () -> {
-        while (flightStream.next()) {
-        }
+        while (flightStream.next()) {}
         ackStream.onCompleted();
         throw error;
       };
@@ -303,7 +313,8 @@ public class TestServerMiddleware {
     final FlightServerMiddleware.Key<T> key;
     final FlightServerMiddleware.Factory<T> factory;
 
-    ServerMiddlewarePair(FlightServerMiddleware.Key<T> key, FlightServerMiddleware.Factory<T> factory) {
+    ServerMiddlewarePair(
+        FlightServerMiddleware.Key<T> key, FlightServerMiddleware.Factory<T> factory) {
       this.key = key;
       this.factory = factory;
     }
@@ -317,15 +328,18 @@ public class TestServerMiddleware {
    * @param body A function to run as the body of the test.
    * @param <T> The middleware type.
    */
-  static <T extends FlightServerMiddleware> void test(FlightProducer producer, List<ServerMiddlewarePair<T>> middleware,
+  static <T extends FlightServerMiddleware> void test(
+      FlightProducer producer,
+      List<ServerMiddlewarePair<T>> middleware,
       BiConsumer<BufferAllocator, FlightClient> body) {
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE)) {
-      final FlightServer.Builder builder = FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), producer);
+      final FlightServer.Builder builder =
+          FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), producer);
       middleware.forEach(pair -> builder.middleware(pair.key, pair.factory));
       final FlightServer server = builder.build().start();
       try (final FlightServer ignored = server;
-          final FlightClient client = FlightClient.builder(allocator, server.getLocation()).build()
-      ) {
+          final FlightClient client =
+              FlightClient.builder(allocator, server.getLocation()).build()) {
         body.accept(allocator, client);
       }
     } catch (InterruptedException | IOException e) {
@@ -333,19 +347,25 @@ public class TestServerMiddleware {
     }
   }
 
-  static void test(FlightProducer producer, BiConsumer<BufferAllocator, FlightClient> body,
+  static void test(
+      FlightProducer producer,
+      BiConsumer<BufferAllocator, FlightClient> body,
       ErrorConsumer<ErrorRecorder> verify) {
     final ErrorRecorder.Factory factory = new ErrorRecorder.Factory();
-    final List<ServerMiddlewarePair<ErrorRecorder>> middleware = Collections
-        .singletonList(new ServerMiddlewarePair<>(FlightServerMiddleware.Key.of("m"), factory));
-    test(producer, middleware, (allocator, client) -> {
-      body.accept(allocator, client);
-      try {
-        verify.accept(factory.instance);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    });
+    final List<ServerMiddlewarePair<ErrorRecorder>> middleware =
+        Collections.singletonList(
+            new ServerMiddlewarePair<>(FlightServerMiddleware.Key.of("m"), factory));
+    test(
+        producer,
+        middleware,
+        (allocator, client) -> {
+          body.accept(allocator, client);
+          try {
+            verify.accept(factory.instance);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   @FunctionalInterface

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerOptions.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerOptions.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
@@ -22,6 +21,15 @@ import static org.apache.arrow.flight.Location.forGrpcInsecure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import io.grpc.Channel;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
+import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.NettyServerBuilder;
+import io.grpc.protobuf.services.HealthStatusManager;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-
 import org.apache.arrow.flight.TestBasicOperation.Producer;
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.flight.impl.FlightServiceGrpc;
@@ -41,16 +48,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
-import io.grpc.Channel;
-import io.grpc.MethodDescriptor;
-import io.grpc.ServerServiceDefinition;
-import io.grpc.health.v1.HealthCheckRequest;
-import io.grpc.health.v1.HealthCheckResponse;
-import io.grpc.health.v1.HealthGrpc;
-import io.grpc.netty.NettyChannelBuilder;
-import io.grpc.netty.NettyServerBuilder;
-import io.grpc.protobuf.services.HealthStatusManager;
-
 public class TestServerOptions {
 
   @Test
@@ -58,46 +55,46 @@ public class TestServerOptions {
     final AtomicBoolean consumerCalled = new AtomicBoolean();
     final Consumer<NettyServerBuilder> consumer = (builder) -> consumerCalled.set(true);
 
-    try (
-        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+    try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer(a);
-        FlightServer s = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer)
-            .transportHint("grpc.builderConsumer", consumer).build().start()
-    ) {
+        FlightServer s =
+            FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), producer)
+                .transportHint("grpc.builderConsumer", consumer)
+                .build()
+                .start()) {
       Assertions.assertTrue(consumerCalled.get());
     }
   }
 
   /**
-   * Make sure that if Flight supplies a default executor to gRPC, then it is closed along with the server.
+   * Make sure that if Flight supplies a default executor to gRPC, then it is closed along with the
+   * server.
    */
   @Test
   public void defaultExecutorClosed() throws Exception {
     final ExecutorService executor;
-    try (
-        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
-        FlightServer server = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), new NoOpFlightProducer())
-            .build().start()
-    ) {
+    try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+        FlightServer server =
+            FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), new NoOpFlightProducer())
+                .build()
+                .start()) {
       assertNotNull(server.grpcExecutor);
       executor = server.grpcExecutor;
     }
     Assertions.assertTrue(executor.isShutdown());
   }
 
-  /**
-   * Make sure that if the user provides an executor to gRPC, then Flight does not close it.
-   */
+  /** Make sure that if the user provides an executor to gRPC, then Flight does not close it. */
   @Test
   public void suppliedExecutorNotClosed() throws Exception {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
-      try (
-          BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
-          FlightServer server = FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), new NoOpFlightProducer())
-              .executor(executor)
-              .build().start()
-      ) {
+      try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+          FlightServer server =
+              FlightServer.builder(a, forGrpcInsecure(LOCALHOST, 0), new NoOpFlightProducer())
+                  .executor(executor)
+                  .build()
+                  .start()) {
         Assertions.assertNull(server.grpcExecutor);
       }
       Assertions.assertFalse(executor.isShutdown());
@@ -108,18 +105,20 @@ public class TestServerOptions {
 
   @Test
   public void domainSocket() throws Exception {
-    Assumptions.assumeTrue(FlightTestUtil.isNativeTransportAvailable(), "We have a native transport available");
+    Assumptions.assumeTrue(
+        FlightTestUtil.isNativeTransportAvailable(), "We have a native transport available");
     final File domainSocket = File.createTempFile("flight-unit-test-", ".sock");
     Assertions.assertTrue(domainSocket.delete());
-    // Domain socket paths have a platform-dependent limit. Set a conservative limit and skip the test if the temporary
-    // file name is too long. (We do not assume a particular platform-dependent temporary directory path.)
-    Assumptions.assumeTrue(domainSocket.getAbsolutePath().length() < 100, "The domain socket path is not too long");
+    // Domain socket paths have a platform-dependent limit. Set a conservative limit and skip the
+    // test if the temporary
+    // file name is too long. (We do not assume a particular platform-dependent temporary directory
+    // path.)
+    Assumptions.assumeTrue(
+        domainSocket.getAbsolutePath().length() < 100, "The domain socket path is not too long");
     final Location location = Location.forGrpcDomainSocket(domainSocket.getAbsolutePath());
-    try (
-        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+    try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer(a);
-        FlightServer s = FlightServer.builder(a, location, producer).build().start();
-    ) {
+        FlightServer s = FlightServer.builder(a, location, producer).build().start(); ) {
       try (FlightClient c = FlightClient.builder(a, location).build()) {
         try (FlightStream stream = c.getStream(new Ticket(new byte[0]))) {
           VectorSchemaRoot root = stream.getRoot();
@@ -141,30 +140,45 @@ public class TestServerOptions {
     // This metadata is needed for gRPC reflection to work.
     final ExecutorService executorService = Executors.newSingleThreadExecutor();
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE)) {
-      final FlightBindingService service = new FlightBindingService(allocator, new NoOpFlightProducer(),
-          ServerAuthHandler.NO_OP, executorService);
+      final FlightBindingService service =
+          new FlightBindingService(
+              allocator, new NoOpFlightProducer(), ServerAuthHandler.NO_OP, executorService);
       final ServerServiceDefinition definition = service.bindService();
-      assertEquals(FlightServiceGrpc.getServiceDescriptor().getSchemaDescriptor(),
+      assertEquals(
+          FlightServiceGrpc.getServiceDescriptor().getSchemaDescriptor(),
           definition.getServiceDescriptor().getSchemaDescriptor());
 
       final Map<String, MethodDescriptor<?, ?>> definedMethods = new HashMap<>();
       final Map<String, MethodDescriptor<?, ?>> serviceMethods = new HashMap<>();
 
-      // Make sure that the reflection metadata object is identical across all the places where it's accessible
-      definition.getMethods().forEach(
-          method -> definedMethods.put(method.getMethodDescriptor().getFullMethodName(), method.getMethodDescriptor()));
-      definition.getServiceDescriptor().getMethods().forEach(
-          method -> serviceMethods.put(method.getFullMethodName(), method));
+      // Make sure that the reflection metadata object is identical across all the places where it's
+      // accessible
+      definition
+          .getMethods()
+          .forEach(
+              method ->
+                  definedMethods.put(
+                      method.getMethodDescriptor().getFullMethodName(),
+                      method.getMethodDescriptor()));
+      definition
+          .getServiceDescriptor()
+          .getMethods()
+          .forEach(method -> serviceMethods.put(method.getFullMethodName(), method));
 
-      for (final MethodDescriptor<?, ?> descriptor : FlightServiceGrpc.getServiceDescriptor().getMethods()) {
+      for (final MethodDescriptor<?, ?> descriptor :
+          FlightServiceGrpc.getServiceDescriptor().getMethods()) {
         final String methodName = descriptor.getFullMethodName();
-        Assertions.assertTrue(definedMethods.containsKey(methodName),
+        Assertions.assertTrue(
+            definedMethods.containsKey(methodName),
             "Method is missing from ServerServiceDefinition: " + methodName);
-        Assertions.assertTrue(definedMethods.containsKey(methodName),
+        Assertions.assertTrue(
+            definedMethods.containsKey(methodName),
             "Method is missing from ServiceDescriptor: " + methodName);
 
-        assertEquals(descriptor.getSchemaDescriptor(), definedMethods.get(methodName).getSchemaDescriptor());
-        assertEquals(descriptor.getSchemaDescriptor(), serviceMethods.get(methodName).getSchemaDescriptor());
+        assertEquals(
+            descriptor.getSchemaDescriptor(), definedMethods.get(methodName).getSchemaDescriptor());
+        assertEquals(
+            descriptor.getSchemaDescriptor(), serviceMethods.get(methodName).getSchemaDescriptor());
       }
     } finally {
       executorService.shutdown();
@@ -178,20 +192,22 @@ public class TestServerOptions {
   @Test
   public void addHealthCheckService() throws Exception {
     final HealthStatusManager statusManager = new HealthStatusManager();
-    final Consumer<NettyServerBuilder> consumer = (builder) -> {
-      builder.addService(statusManager.getHealthService());
-    };
+    final Consumer<NettyServerBuilder> consumer =
+        (builder) -> {
+          builder.addService(statusManager.getHealthService());
+        };
     final Location location = forGrpcInsecure(LOCALHOST, 5555);
-    try (
-        BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
+    try (BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         Producer producer = new Producer(a);
-        FlightServer s = FlightServer.builder(a, location, producer)
-            .transportHint("grpc.builderConsumer", consumer).build().start();
-    ) {
-      Channel channel = NettyChannelBuilder.forAddress(location.toSocketAddress()).usePlaintext().build();
-      HealthCheckResponse response = HealthGrpc
-              .newBlockingStub(channel)
-              .check(HealthCheckRequest.getDefaultInstance());
+        FlightServer s =
+            FlightServer.builder(a, location, producer)
+                .transportHint("grpc.builderConsumer", consumer)
+                .build()
+                .start(); ) {
+      Channel channel =
+          NettyChannelBuilder.forAddress(location.toSocketAddress()).usePlaintext().build();
+      HealthCheckResponse response =
+          HealthGrpc.newBlockingStub(channel).check(HealthCheckRequest.getDefaultInstance());
 
       assertEquals(response.getStatus(), HealthCheckResponse.ServingStatus.SERVING);
     }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
@@ -14,17 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
 import static org.apache.arrow.flight.Location.forGrpcInsecure;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
-
 import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightInfo;
@@ -47,8 +46,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.ImmutableList;
 
 public class TestBasicAuth {
 
@@ -79,20 +76,26 @@ public class TestBasicAuth {
 
   @Test
   public void invalidAuth() {
-    FlightTestUtil.assertCode(FlightStatusCode.UNAUTHENTICATED, () -> {
-      client.authenticateBasic(USERNAME, "WRONG");
-    });
+    FlightTestUtil.assertCode(
+        FlightStatusCode.UNAUTHENTICATED,
+        () -> {
+          client.authenticateBasic(USERNAME, "WRONG");
+        });
 
-    FlightTestUtil.assertCode(FlightStatusCode.UNAUTHENTICATED, () -> {
-      client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail());
-    });
+    FlightTestUtil.assertCode(
+        FlightStatusCode.UNAUTHENTICATED,
+        () -> {
+          client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail());
+        });
   }
 
   @Test
   public void didntAuth() {
-    FlightTestUtil.assertCode(FlightStatusCode.UNAUTHENTICATED, () -> {
-      client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail());
-    });
+    FlightTestUtil.assertCode(
+        FlightStatusCode.UNAUTHENTICATED,
+        () -> {
+          client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail());
+        });
   }
 
   @BeforeEach
@@ -103,56 +106,65 @@ public class TestBasicAuth {
   @BeforeAll
   public static void setup() throws IOException {
     allocator = new RootAllocator(Long.MAX_VALUE);
-    final BasicServerAuthHandler.BasicAuthValidator validator = new BasicServerAuthHandler.BasicAuthValidator() {
+    final BasicServerAuthHandler.BasicAuthValidator validator =
+        new BasicServerAuthHandler.BasicAuthValidator() {
 
-      @Override
-      public Optional<String> isValid(byte[] token) {
-        if (Arrays.equals(token, VALID_TOKEN)) {
-          return Optional.of(USERNAME);
-        }
-        return Optional.empty();
-      }
-
-      @Override
-      public byte[] getToken(String username, String password) {
-        if (USERNAME.equals(username) && PASSWORD.equals(password)) {
-          return VALID_TOKEN;
-        } else {
-          throw new IllegalArgumentException("invalid credentials");
-        }
-      }
-    };
-
-    server = FlightServer.builder(
-        allocator, forGrpcInsecure(LOCALHOST, 0),
-        new NoOpFlightProducer() {
           @Override
-          public void listFlights(CallContext context, Criteria criteria,
-              StreamListener<FlightInfo> listener) {
-            if (!context.peerIdentity().equals(USERNAME)) {
-              listener.onError(new IllegalArgumentException("Invalid username"));
-              return;
+          public Optional<String> isValid(byte[] token) {
+            if (Arrays.equals(token, VALID_TOKEN)) {
+              return Optional.of(USERNAME);
             }
-            listener.onCompleted();
+            return Optional.empty();
           }
 
           @Override
-          public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
-            if (!context.peerIdentity().equals(USERNAME)) {
-              listener.error(new IllegalArgumentException("Invalid username"));
-              return;
-            }
-            final Schema pojoSchema = new Schema(ImmutableList.of(Field.nullable("a",
-                Types.MinorType.BIGINT.getType())));
-            try (VectorSchemaRoot root = VectorSchemaRoot.create(pojoSchema, allocator)) {
-              listener.start(root);
-              root.allocateNew();
-              root.setRowCount(4095);
-              listener.putNext();
-              listener.completed();
+          public byte[] getToken(String username, String password) {
+            if (USERNAME.equals(username) && PASSWORD.equals(password)) {
+              return VALID_TOKEN;
+            } else {
+              throw new IllegalArgumentException("invalid credentials");
             }
           }
-        }).authHandler(new BasicServerAuthHandler(validator)).build().start();
+        };
+
+    server =
+        FlightServer.builder(
+                allocator,
+                forGrpcInsecure(LOCALHOST, 0),
+                new NoOpFlightProducer() {
+                  @Override
+                  public void listFlights(
+                      CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
+                    if (!context.peerIdentity().equals(USERNAME)) {
+                      listener.onError(new IllegalArgumentException("Invalid username"));
+                      return;
+                    }
+                    listener.onCompleted();
+                  }
+
+                  @Override
+                  public void getStream(
+                      CallContext context, Ticket ticket, ServerStreamListener listener) {
+                    if (!context.peerIdentity().equals(USERNAME)) {
+                      listener.error(new IllegalArgumentException("Invalid username"));
+                      return;
+                    }
+                    final Schema pojoSchema =
+                        new Schema(
+                            ImmutableList.of(
+                                Field.nullable("a", Types.MinorType.BIGINT.getType())));
+                    try (VectorSchemaRoot root = VectorSchemaRoot.create(pojoSchema, allocator)) {
+                      listener.start(root);
+                      root.allocateNew();
+                      root.setRowCount(4095);
+                      listener.putNext();
+                      listener.completed();
+                    }
+                  }
+                })
+            .authHandler(new BasicServerAuthHandler(validator))
+            .build()
+            .start();
   }
 
   @AfterEach
@@ -167,5 +179,4 @@ public class TestBasicAuth {
     allocator.getChildAllocators().forEach(BufferAllocator::close);
     AutoCloseables.close(allocator);
   }
-
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth2/TestBasicAuth2.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth2/TestBasicAuth2.java
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.auth2;
 
 import static org.apache.arrow.flight.FlightTestUtil.LOCALHOST;
 import static org.apache.arrow.flight.Location.forGrpcInsecure;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.FlightClient;
@@ -46,9 +46,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-
 public class TestBasicAuth2 {
 
   private static final String USERNAME_1 = "flight1";
@@ -70,9 +67,10 @@ public class TestBasicAuth2 {
   private static FlightProducer getFlightProducer() {
     return new NoOpFlightProducer() {
       @Override
-      public void listFlights(CallContext context, Criteria criteria,
-          StreamListener<FlightInfo> listener) {
-        if (!context.peerIdentity().equals(USERNAME_1) && !context.peerIdentity().equals(USERNAME_2)) {
+      public void listFlights(
+          CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
+        if (!context.peerIdentity().equals(USERNAME_1)
+            && !context.peerIdentity().equals(USERNAME_2)) {
           listener.onError(new IllegalArgumentException("Invalid username"));
           return;
         }
@@ -81,12 +79,13 @@ public class TestBasicAuth2 {
 
       @Override
       public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
-        if (!context.peerIdentity().equals(USERNAME_1) && !context.peerIdentity().equals(USERNAME_2)) {
+        if (!context.peerIdentity().equals(USERNAME_1)
+            && !context.peerIdentity().equals(USERNAME_2)) {
           listener.error(new IllegalArgumentException("Invalid username"));
           return;
         }
-        final Schema pojoSchema = new Schema(ImmutableList.of(Field.nullable("a",
-                Types.MinorType.BIGINT.getType())));
+        final Schema pojoSchema =
+            new Schema(ImmutableList.of(Field.nullable("a", Types.MinorType.BIGINT.getType())));
         try (VectorSchemaRoot root = VectorSchemaRoot.create(pojoSchema, allocator)) {
           listener.start(root);
           root.allocateNew();
@@ -100,13 +99,14 @@ public class TestBasicAuth2 {
 
   private static void startServerAndClient() throws IOException {
     final FlightProducer flightProducer = getFlightProducer();
-    server = FlightServer
-        .builder(allocator, forGrpcInsecure(LOCALHOST, 0), flightProducer)
-        .headerAuthenticator(new GeneratedBearerTokenAuthenticator(
-            new BasicCallHeaderAuthenticator(TestBasicAuth2::validate)))
-        .build().start();
-    client = FlightClient.builder(allocator, server.getLocation())
-        .build();
+    server =
+        FlightServer.builder(allocator, forGrpcInsecure(LOCALHOST, 0), flightProducer)
+            .headerAuthenticator(
+                new GeneratedBearerTokenAuthenticator(
+                    new BasicCallHeaderAuthenticator(TestBasicAuth2::validate)))
+            .build()
+            .start();
+    client = FlightClient.builder(allocator, server.getLocation()).build();
   }
 
   @AfterAll
@@ -122,13 +122,14 @@ public class TestBasicAuth2 {
   }
 
   private void startClient2() throws IOException {
-    client2 = FlightClient.builder(allocator, server.getLocation())
-        .build();
+    client2 = FlightClient.builder(allocator, server.getLocation()).build();
   }
 
   private static CallHeaderAuthenticator.AuthResult validate(String username, String password) {
     if (Strings.isNullOrEmpty(username)) {
-      throw CallStatus.UNAUTHENTICATED.withDescription("Credentials not supplied.").toRuntimeException();
+      throw CallStatus.UNAUTHENTICATED
+          .withDescription("Credentials not supplied.")
+          .toRuntimeException();
     }
     final String identity;
     if (USERNAME_1.equals(username) && PASSWORD_1.equals(password)) {
@@ -136,7 +137,9 @@ public class TestBasicAuth2 {
     } else if (USERNAME_2.equals(username) && PASSWORD_2.equals(password)) {
       identity = USERNAME_2;
     } else {
-      throw CallStatus.UNAUTHENTICATED.withDescription("Username or password is invalid.").toRuntimeException();
+      throw CallStatus.UNAUTHENTICATED
+          .withDescription("Username or password is invalid.")
+          .toRuntimeException();
     }
     return () -> identity;
   }
@@ -147,21 +150,23 @@ public class TestBasicAuth2 {
   }
 
   @Test
-  public void validAuthWithMultipleClientsWithSameCredentialsWithBearerAuthServer() throws IOException {
+  public void validAuthWithMultipleClientsWithSameCredentialsWithBearerAuthServer()
+      throws IOException {
     startClient2();
     testValidAuthWithMultipleClientsWithSameCredentials(client, client2);
   }
 
   @Test
-  public void validAuthWithMultipleClientsWithDifferentCredentialsWithBearerAuthServer() throws IOException {
+  public void validAuthWithMultipleClientsWithDifferentCredentialsWithBearerAuthServer()
+      throws IOException {
     startClient2();
     testValidAuthWithMultipleClientsWithDifferentCredentials(client, client2);
   }
 
   @Test
   public void asyncCall() throws Exception {
-    final CredentialCallOption bearerToken = client
-        .authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
+    final CredentialCallOption bearerToken =
+        client.authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
     client.listFlights(Criteria.ALL, bearerToken);
     try (final FlightStream s = client.getStream(new Ticket(new byte[1]), bearerToken)) {
       while (s.next()) {
@@ -181,54 +186,52 @@ public class TestBasicAuth2 {
   }
 
   private void testValidAuth(FlightClient client) {
-    final CredentialCallOption bearerToken = client
-            .authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
-    Assertions.assertTrue(ImmutableList.copyOf(client
-            .listFlights(Criteria.ALL, bearerToken))
-            .isEmpty());
+    final CredentialCallOption bearerToken =
+        client.authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
+    Assertions.assertTrue(
+        ImmutableList.copyOf(client.listFlights(Criteria.ALL, bearerToken)).isEmpty());
   }
 
   private void testValidAuthWithMultipleClientsWithSameCredentials(
-          FlightClient client1, FlightClient client2) {
-    final CredentialCallOption bearerToken1 = client1
-            .authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
-    final CredentialCallOption bearerToken2 = client2
-            .authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
-    Assertions.assertTrue(ImmutableList.copyOf(client1
-            .listFlights(Criteria.ALL, bearerToken1))
-            .isEmpty());
-    Assertions.assertTrue(ImmutableList.copyOf(client2
-            .listFlights(Criteria.ALL, bearerToken2))
-            .isEmpty());
+      FlightClient client1, FlightClient client2) {
+    final CredentialCallOption bearerToken1 =
+        client1.authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
+    final CredentialCallOption bearerToken2 =
+        client2.authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
+    Assertions.assertTrue(
+        ImmutableList.copyOf(client1.listFlights(Criteria.ALL, bearerToken1)).isEmpty());
+    Assertions.assertTrue(
+        ImmutableList.copyOf(client2.listFlights(Criteria.ALL, bearerToken2)).isEmpty());
   }
 
   private void testValidAuthWithMultipleClientsWithDifferentCredentials(
-          FlightClient client1, FlightClient client2) {
-    final CredentialCallOption bearerToken1 = client1
-            .authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
-    final CredentialCallOption bearerToken2 = client2
-            .authenticateBasicToken(USERNAME_2, PASSWORD_2).get();
-    Assertions.assertTrue(ImmutableList.copyOf(client1
-            .listFlights(Criteria.ALL, bearerToken1))
-            .isEmpty());
-    Assertions.assertTrue(ImmutableList.copyOf(client2
-            .listFlights(Criteria.ALL, bearerToken2))
-            .isEmpty());
+      FlightClient client1, FlightClient client2) {
+    final CredentialCallOption bearerToken1 =
+        client1.authenticateBasicToken(USERNAME_1, PASSWORD_1).get();
+    final CredentialCallOption bearerToken2 =
+        client2.authenticateBasicToken(USERNAME_2, PASSWORD_2).get();
+    Assertions.assertTrue(
+        ImmutableList.copyOf(client1.listFlights(Criteria.ALL, bearerToken1)).isEmpty());
+    Assertions.assertTrue(
+        ImmutableList.copyOf(client2.listFlights(Criteria.ALL, bearerToken2)).isEmpty());
   }
 
   private void testInvalidAuth(FlightClient client) {
-    FlightTestUtil.assertCode(FlightStatusCode.UNAUTHENTICATED, () ->
-            client.authenticateBasicToken(USERNAME_1, "WRONG"));
+    FlightTestUtil.assertCode(
+        FlightStatusCode.UNAUTHENTICATED, () -> client.authenticateBasicToken(USERNAME_1, "WRONG"));
 
-    FlightTestUtil.assertCode(FlightStatusCode.UNAUTHENTICATED, () ->
-            client.authenticateBasicToken(NO_USERNAME, PASSWORD_1));
+    FlightTestUtil.assertCode(
+        FlightStatusCode.UNAUTHENTICATED,
+        () -> client.authenticateBasicToken(NO_USERNAME, PASSWORD_1));
 
-    FlightTestUtil.assertCode(FlightStatusCode.UNAUTHENTICATED, () ->
-            client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail()));
+    FlightTestUtil.assertCode(
+        FlightStatusCode.UNAUTHENTICATED,
+        () -> client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail()));
   }
 
   private void didntAuth(FlightClient client) {
-    FlightTestUtil.assertCode(FlightStatusCode.UNAUTHENTICATED, () ->
-            client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail()));
+    FlightTestUtil.assertCode(
+        FlightStatusCode.UNAUTHENTICATED,
+        () -> client.listFlights(Criteria.ALL).forEach(action -> Assertions.fail()));
   }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/CustomHeaderTest.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/CustomHeaderTest.java
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.client;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallInfo;
@@ -48,23 +47,18 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
-
-/**
- * Tests to ensure custom headers are passed along to the server for each command.
- */
+/** Tests to ensure custom headers are passed along to the server for each command. */
 public class CustomHeaderTest {
   FlightServer server;
   FlightClient client;
   BufferAllocator allocator;
   TestCustomHeaderMiddleware.Factory headersMiddleware;
   HeaderCallOption headers;
-  Map<String, String> testHeaders = ImmutableMap.of(
+  Map<String, String> testHeaders =
+      ImmutableMap.of(
           "foo", "bar",
           "bar", "foo",
-          "answer", "42"
-  );
+          "answer", "42");
 
   @Before
   public void setUp() throws Exception {
@@ -75,11 +69,13 @@ public class CustomHeaderTest {
       callHeaders.insert(entry.getKey(), entry.getValue());
     }
     headers = new HeaderCallOption(callHeaders);
-    server = FlightServer.builder(allocator,
-            Location.forGrpcInsecure(FlightTestUtil.LOCALHOST, /*port*/ 0),
-            new NoOpFlightProducer())
-        .middleware(FlightServerMiddleware.Key.of("customHeader"), headersMiddleware)
-        .build();
+    server =
+        FlightServer.builder(
+                allocator,
+                Location.forGrpcInsecure(FlightTestUtil.LOCALHOST, /*port*/ 0),
+                new NoOpFlightProducer())
+            .middleware(FlightServerMiddleware.Key.of("customHeader"), headersMiddleware)
+            .build();
     server.start();
     client = FlightClient.builder(allocator, server.getLocation()).build();
   }
@@ -94,7 +90,8 @@ public class CustomHeaderTest {
   public void testHandshake() {
     try {
       client.handshake(headers);
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.HANDSHAKE);
   }
@@ -103,7 +100,8 @@ public class CustomHeaderTest {
   public void testGetSchema() {
     try {
       client.getSchema(FlightDescriptor.command(new byte[0]), headers);
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.GET_SCHEMA);
   }
@@ -112,7 +110,8 @@ public class CustomHeaderTest {
   public void testGetFlightInfo() {
     try {
       client.getInfo(FlightDescriptor.command(new byte[0]), headers);
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.GET_FLIGHT_INFO);
   }
@@ -121,7 +120,8 @@ public class CustomHeaderTest {
   public void testListActions() {
     try {
       client.listActions(headers).iterator().next();
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.LIST_ACTIONS);
   }
@@ -129,8 +129,9 @@ public class CustomHeaderTest {
   @Test
   public void testListFlights() {
     try {
-      client.listFlights(new Criteria(new byte[]{1}), headers).iterator().next();
-    } catch (Exception ignored) { }
+      client.listFlights(new Criteria(new byte[] {1}), headers).iterator().next();
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.LIST_FLIGHTS);
   }
@@ -139,7 +140,8 @@ public class CustomHeaderTest {
   public void testDoAction() {
     try {
       client.doAction(new Action("test"), headers).next();
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.DO_ACTION);
   }
@@ -147,11 +149,11 @@ public class CustomHeaderTest {
   @Test
   public void testStartPut() {
     try {
-      final ClientStreamListener listener = client.startPut(FlightDescriptor.command(new byte[0]),
-              new SyncPutListener(),
-              headers);
+      final ClientStreamListener listener =
+          client.startPut(FlightDescriptor.command(new byte[0]), new SyncPutListener(), headers);
       listener.getResult();
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.DO_PUT);
   }
@@ -160,62 +162,54 @@ public class CustomHeaderTest {
   public void testGetStream() {
     try (final FlightStream stream = client.getStream(new Ticket(new byte[0]), headers)) {
       stream.next();
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.DO_GET);
   }
 
   @Test
   public void testDoExchange() {
-    try (final FlightClient.ExchangeReaderWriter stream = client.doExchange(
-            FlightDescriptor.command(new byte[0]),
-            headers)
-    ) {
+    try (final FlightClient.ExchangeReaderWriter stream =
+        client.doExchange(FlightDescriptor.command(new byte[0]), headers)) {
       stream.getReader().next();
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+    }
 
     assertHeadersMatch(FlightMethod.DO_EXCHANGE);
   }
 
   private void assertHeadersMatch(FlightMethod method) {
     for (Map.Entry<String, String> entry : testHeaders.entrySet()) {
-      Assert.assertEquals(entry.getValue(), headersMiddleware.getCustomHeader(method, entry.getKey()));
+      Assert.assertEquals(
+          entry.getValue(), headersMiddleware.getCustomHeader(method, entry.getKey()));
     }
   }
 
-  /**
-   * A middleware used to test if customHeaders are being sent to the server properly.
-   */
+  /** A middleware used to test if customHeaders are being sent to the server properly. */
   static class TestCustomHeaderMiddleware implements FlightServerMiddleware {
 
-    public TestCustomHeaderMiddleware() {
-    }
+    public TestCustomHeaderMiddleware() {}
 
     @Override
-    public void onBeforeSendingHeaders(CallHeaders callHeaders) {
-
-    }
+    public void onBeforeSendingHeaders(CallHeaders callHeaders) {}
 
     @Override
-    public void onCallCompleted(CallStatus callStatus) {
-
-    }
+    public void onCallCompleted(CallStatus callStatus) {}
 
     @Override
-    public void onCallErrored(Throwable throwable) {
-
-    }
+    public void onCallErrored(Throwable throwable) {}
 
     /**
-     * A factory for the middleware that keeps track of the received headers and provides a way
-     * to check those values for a given Flight Method.
+     * A factory for the middleware that keeps track of the received headers and provides a way to
+     * check those values for a given Flight Method.
      */
     static class Factory implements FlightServerMiddleware.Factory<TestCustomHeaderMiddleware> {
       private final Map<FlightMethod, CallHeaders> receivedCallHeaders = new HashMap<>();
 
       @Override
-      public TestCustomHeaderMiddleware onCallStarted(CallInfo callInfo, CallHeaders callHeaders,
-                                                      RequestContext requestContext) {
+      public TestCustomHeaderMiddleware onCallStarted(
+          CallInfo callInfo, CallHeaders callHeaders, RequestContext requestContext) {
 
         receivedCallHeaders.put(callInfo.method(), callHeaders);
         return new TestCustomHeaderMiddleware();
@@ -229,5 +223,5 @@ public class CustomHeaderTest {
         return headers.get(key);
       }
     }
-  }   
+  }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/grpc/TestStatusUtils.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/grpc/TestStatusUtils.java
@@ -14,16 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.grpc;
 
+import io.grpc.Metadata;
+import io.grpc.Status;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightStatusCode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import io.grpc.Metadata;
-import io.grpc.Status;
 
 public class TestStatusUtils {
 

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/perf/PerformanceTestServer.java
@@ -14,16 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.perf;
 
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-
 import org.apache.arrow.flight.BackpressureStrategy;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
@@ -44,9 +44,6 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.InvalidProtocolBufferException;
-
 public class PerformanceTestServer implements AutoCloseable {
 
   private final FlightServer flightServer;
@@ -55,26 +52,33 @@ public class PerformanceTestServer implements AutoCloseable {
   private final boolean isNonBlocking;
 
   public PerformanceTestServer(BufferAllocator incomingAllocator, Location location) {
-    this(incomingAllocator, location, new BackpressureStrategy() {
-      private FlightProducer.ServerStreamListener listener;
+    this(
+        incomingAllocator,
+        location,
+        new BackpressureStrategy() {
+          private FlightProducer.ServerStreamListener listener;
 
-      @Override
-      public void register(FlightProducer.ServerStreamListener listener) {
-        this.listener = listener;
-      }
+          @Override
+          public void register(FlightProducer.ServerStreamListener listener) {
+            this.listener = listener;
+          }
 
-      @Override
-      public WaitResult waitForListener(long timeout) {
-        while (!listener.isReady() && !listener.isCancelled()) {
-          // busy wait
-        }
-        return WaitResult.READY;
-      }
-    }, false);
+          @Override
+          public WaitResult waitForListener(long timeout) {
+            while (!listener.isReady() && !listener.isCancelled()) {
+              // busy wait
+            }
+            return WaitResult.READY;
+          }
+        },
+        false);
   }
 
-  public PerformanceTestServer(BufferAllocator incomingAllocator, Location location, BackpressureStrategy bpStrategy,
-                               boolean isNonBlocking) {
+  public PerformanceTestServer(
+      BufferAllocator incomingAllocator,
+      Location location,
+      BackpressureStrategy bpStrategy,
+      boolean isNonBlocking) {
     this.allocator = incomingAllocator.newChildAllocator("perf-server", 0, Long.MAX_VALUE);
     this.producer = new PerfProducer(bpStrategy);
     this.flightServer = FlightServer.builder(this.allocator, location, producer).build();
@@ -103,62 +107,60 @@ public class PerformanceTestServer implements AutoCloseable {
     }
 
     @Override
-    public void getStream(CallContext context, Ticket ticket,
-        ServerStreamListener listener) {
+    public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
       bpStrategy.register(listener);
-      final Runnable loadData = () -> {
-        Token token = null;
-        try {
-          token = Token.parseFrom(ticket.getBytes());
-        } catch (InvalidProtocolBufferException e) {
-          throw new RuntimeException(e);
-        }
-        Perf perf = token.getDefinition();
-        Schema schema = Schema.deserializeMessage(perf.getSchema().asReadOnlyByteBuffer());
-        try (
-            VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
-            BigIntVector a = (BigIntVector) root.getVector("a")
-        ) {
-          listener.setUseZeroCopy(true);
-          listener.start(root);
-          root.allocateNew();
-
-          int current = 0;
-          long i = token.getStart();
-          while (i < token.getEnd()) {
-            if (listener.isCancelled()) {
-              root.clear();
-              return;
+      final Runnable loadData =
+          () -> {
+            Token token = null;
+            try {
+              token = Token.parseFrom(ticket.getBytes());
+            } catch (InvalidProtocolBufferException e) {
+              throw new RuntimeException(e);
             }
-
-            if (TestPerf.VALIDATE) {
-              a.setSafe(current, i);
-            }
-
-            i++;
-            current++;
-            if (i % perf.getRecordsPerBatch() == 0) {
-              root.setRowCount(current);
-
-              bpStrategy.waitForListener(0);
-              if (listener.isCancelled()) {
-                root.clear();
-                return;
-              }
-              listener.putNext();
-              current = 0;
+            Perf perf = token.getDefinition();
+            Schema schema = Schema.deserializeMessage(perf.getSchema().asReadOnlyByteBuffer());
+            try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+                BigIntVector a = (BigIntVector) root.getVector("a")) {
+              listener.setUseZeroCopy(true);
+              listener.start(root);
               root.allocateNew();
-            }
-          }
 
-          // send last partial batch.
-          if (current != 0) {
-            root.setRowCount(current);
-            listener.putNext();
-          }
-          listener.completed();
-        }
-      };
+              int current = 0;
+              long i = token.getStart();
+              while (i < token.getEnd()) {
+                if (listener.isCancelled()) {
+                  root.clear();
+                  return;
+                }
+
+                if (TestPerf.VALIDATE) {
+                  a.setSafe(current, i);
+                }
+
+                i++;
+                current++;
+                if (i % perf.getRecordsPerBatch() == 0) {
+                  root.setRowCount(current);
+
+                  bpStrategy.waitForListener(0);
+                  if (listener.isCancelled()) {
+                    root.clear();
+                    return;
+                  }
+                  listener.putNext();
+                  current = 0;
+                  root.allocateNew();
+                }
+              }
+
+              // send last partial batch.
+              if (current != 0) {
+                root.setRowCount(current);
+                listener.putNext();
+              }
+              listener.completed();
+            }
+          };
 
       if (!isNonBlocking) {
         loadData.run();
@@ -170,23 +172,25 @@ public class PerformanceTestServer implements AutoCloseable {
     }
 
     @Override
-    public FlightInfo getFlightInfo(CallContext context,
-        FlightDescriptor descriptor) {
+    public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
       try {
         Preconditions.checkArgument(descriptor.isCommand());
         Perf exec = Perf.parseFrom(descriptor.getCommand());
 
-        final Schema pojoSchema = new Schema(ImmutableList.of(
-            Field.nullable("a", MinorType.BIGINT.getType()),
-            Field.nullable("b", MinorType.BIGINT.getType()),
-            Field.nullable("c", MinorType.BIGINT.getType()),
-            Field.nullable("d", MinorType.BIGINT.getType())
-            ));
+        final Schema pojoSchema =
+            new Schema(
+                ImmutableList.of(
+                    Field.nullable("a", MinorType.BIGINT.getType()),
+                    Field.nullable("b", MinorType.BIGINT.getType()),
+                    Field.nullable("c", MinorType.BIGINT.getType()),
+                    Field.nullable("d", MinorType.BIGINT.getType())));
 
-        Token token = Token.newBuilder().setDefinition(exec)
-            .setStart(0)
-            .setEnd(exec.getRecordsPerStream())
-            .build();
+        Token token =
+            Token.newBuilder()
+                .setDefinition(exec)
+                .setStart(0)
+                .setEnd(exec.getRecordsPerStream())
+                .build();
         final Ticket ticket = new Ticket(token.toByteArray());
 
         List<FlightEndpoint> endpoints = new ArrayList<>();
@@ -194,7 +198,11 @@ public class PerformanceTestServer implements AutoCloseable {
           endpoints.add(new FlightEndpoint(ticket, getLocation()));
         }
 
-        return new FlightInfo(pojoSchema, descriptor, endpoints, -1,
+        return new FlightInfo(
+            pojoSchema,
+            descriptor,
+            endpoints,
+            -1,
             exec.getRecordsPerStream() * exec.getStreamCount());
       } catch (InvalidProtocolBufferException e) {
         throw new RuntimeException(e);
@@ -202,6 +210,3 @@ public class PerformanceTestServer implements AutoCloseable {
     }
   }
 }
-
-
-

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/AppMetadataFlightInfoEndpointScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/AppMetadataFlightInfoEndpointScenario.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
@@ -43,11 +41,11 @@ final class AppMetadataFlightInfoEndpointScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) throws Exception {
-  }
+  public void buildServer(FlightServer.Builder builder) throws Exception {}
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient client) throws Exception {
+  public void client(BufferAllocator allocator, Location location, FlightClient client)
+      throws Exception {
     byte[] cmd = "foobar".getBytes(StandardCharsets.UTF_8);
     FlightInfo info = client.getInfo(FlightDescriptor.command(cmd));
     IntegrationAssertions.assertEquals(info.getAppMetadata(), cmd);
@@ -60,17 +58,19 @@ final class AppMetadataFlightInfoEndpointScenario implements Scenario {
     @Override
     public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
       byte[] cmd = descriptor.getCommand();
-      
-      Schema schema = new Schema(
-              Collections.singletonList(Field.notNullable("number", Types.MinorType.UINT4.getType())));
 
-      List<FlightEndpoint> endpoints = Collections.singletonList(
-              FlightEndpoint.builder(
-                      new Ticket("".getBytes(StandardCharsets.UTF_8))).setAppMetadata(cmd).build());
+      Schema schema =
+          new Schema(
+              Collections.singletonList(
+                  Field.notNullable("number", Types.MinorType.UINT4.getType())));
+
+      List<FlightEndpoint> endpoints =
+          Collections.singletonList(
+              FlightEndpoint.builder(new Ticket("".getBytes(StandardCharsets.UTF_8)))
+                  .setAppMetadata(cmd)
+                  .build());
 
       return FlightInfo.builder(schema, descriptor, endpoints).setAppMetadata(cmd).build();
     }
   }
 }
-
-

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/AuthBasicProtoScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/AuthBasicProtoScenario.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
-
 import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightClient;
@@ -35,9 +33,7 @@ import org.apache.arrow.flight.auth.BasicClientAuthHandler;
 import org.apache.arrow.flight.auth.BasicServerAuthHandler;
 import org.apache.arrow.memory.BufferAllocator;
 
-/**
- * A scenario testing the built-in basic authentication Protobuf.
- */
+/** A scenario testing the built-in basic authentication Protobuf. */
 final class AuthBasicProtoScenario implements Scenario {
 
   static final String USERNAME = "arrow";
@@ -56,34 +52,40 @@ final class AuthBasicProtoScenario implements Scenario {
 
   @Override
   public void buildServer(FlightServer.Builder builder) {
-    builder.authHandler(new BasicServerAuthHandler(new BasicServerAuthHandler.BasicAuthValidator() {
-      @Override
-      public byte[] getToken(String username, String password) throws Exception {
-        if (!USERNAME.equals(username) || !PASSWORD.equals(password)) {
-          throw CallStatus.UNAUTHENTICATED.withDescription("Username or password is invalid.").toRuntimeException();
-        }
-        return ("valid:" + username).getBytes(StandardCharsets.UTF_8);
-      }
+    builder.authHandler(
+        new BasicServerAuthHandler(
+            new BasicServerAuthHandler.BasicAuthValidator() {
+              @Override
+              public byte[] getToken(String username, String password) throws Exception {
+                if (!USERNAME.equals(username) || !PASSWORD.equals(password)) {
+                  throw CallStatus.UNAUTHENTICATED
+                      .withDescription("Username or password is invalid.")
+                      .toRuntimeException();
+                }
+                return ("valid:" + username).getBytes(StandardCharsets.UTF_8);
+              }
 
-      @Override
-      public Optional<String> isValid(byte[] token) {
-        if (token != null) {
-          final String credential = new String(token, StandardCharsets.UTF_8);
-          if (credential.startsWith("valid:")) {
-            return Optional.of(credential.substring(6));
-          }
-        }
-        return Optional.empty();
-      }
-    }));
+              @Override
+              public Optional<String> isValid(byte[] token) {
+                if (token != null) {
+                  final String credential = new String(token, StandardCharsets.UTF_8);
+                  if (credential.startsWith("valid:")) {
+                    return Optional.of(credential.substring(6));
+                  }
+                }
+                return Optional.empty();
+              }
+            }));
   }
 
   @Override
   public void client(BufferAllocator allocator, Location location, FlightClient client) {
-    final FlightRuntimeException e = IntegrationAssertions.assertThrows(FlightRuntimeException.class, () -> {
-      client.listActions().forEach(act -> {
-      });
-    });
+    final FlightRuntimeException e =
+        IntegrationAssertions.assertThrows(
+            FlightRuntimeException.class,
+            () -> {
+              client.listActions().forEach(act -> {});
+            });
     if (!FlightStatusCode.UNAUTHENTICATED.equals(e.status().code())) {
       throw new AssertionError("Expected UNAUTHENTICATED but found " + e.status().code(), e);
     }
@@ -91,7 +93,8 @@ final class AuthBasicProtoScenario implements Scenario {
     client.authenticate(new BasicClientAuthHandler(USERNAME, PASSWORD));
     final Result result = client.doAction(new Action("")).next();
     if (!USERNAME.equals(new String(result.getBody(), StandardCharsets.UTF_8))) {
-      throw new AssertionError("Expected " + USERNAME + " but got " + Arrays.toString(result.getBody()));
+      throw new AssertionError(
+          "Expected " + USERNAME + " but got " + Arrays.toString(result.getBody()));
     }
   }
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeCancelFlightInfoScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeCancelFlightInfoScenario.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
-
 import org.apache.arrow.flight.CancelFlightInfoRequest;
 import org.apache.arrow.flight.CancelFlightInfoResult;
 import org.apache.arrow.flight.CancelStatus;
@@ -41,24 +39,26 @@ final class ExpirationTimeCancelFlightInfoScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) {
-  }
+  public void buildServer(FlightServer.Builder builder) {}
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient client) throws Exception {
-    FlightInfo info = client.getInfo(FlightDescriptor.command("expiration".getBytes(StandardCharsets.UTF_8)));
+  public void client(BufferAllocator allocator, Location location, FlightClient client)
+      throws Exception {
+    FlightInfo info =
+        client.getInfo(FlightDescriptor.command("expiration".getBytes(StandardCharsets.UTF_8)));
     CancelFlightInfoRequest request = new CancelFlightInfoRequest(info);
     CancelFlightInfoResult result = client.cancelFlightInfo(request);
     IntegrationAssertions.assertEquals(CancelStatus.CANCELLED, result.getStatus());
 
     // All requests should fail
     for (FlightEndpoint endpoint : info.getEndpoints()) {
-      IntegrationAssertions.assertThrows(FlightRuntimeException.class, () -> {
-        try (FlightStream stream = client.getStream(endpoint.getTicket())) {
-          while (stream.next()) {
-          }
-        }
-      });
+      IntegrationAssertions.assertThrows(
+          FlightRuntimeException.class,
+          () -> {
+            try (FlightStream stream = client.getStream(endpoint.getTicket())) {
+              while (stream.next()) {}
+            }
+          });
     }
   }
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeDoGetScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeDoGetScenario.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
@@ -45,22 +43,26 @@ final class ExpirationTimeDoGetScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) {
-  }
+  public void buildServer(FlightServer.Builder builder) {}
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient client) throws Exception {
-    FlightInfo info = client.getInfo(FlightDescriptor.command("expiration_time".getBytes(StandardCharsets.UTF_8)));
+  public void client(BufferAllocator allocator, Location location, FlightClient client)
+      throws Exception {
+    FlightInfo info =
+        client.getInfo(
+            FlightDescriptor.command("expiration_time".getBytes(StandardCharsets.UTF_8)));
 
     List<ArrowRecordBatch> batches = new ArrayList<>();
 
     try {
       for (FlightEndpoint endpoint : info.getEndpoints()) {
         if (batches.size() == 0) {
-          IntegrationAssertions.assertFalse("endpoints[0] must not have expiration time",
+          IntegrationAssertions.assertFalse(
+              "endpoints[0] must not have expiration time",
               endpoint.getExpirationTime().isPresent());
         } else {
-          IntegrationAssertions.assertTrue("endpoints[" + batches.size() + "] must have expiration time",
+          IntegrationAssertions.assertTrue(
+              "endpoints[" + batches.size() + "] must have expiration time",
               endpoint.getExpirationTime().isPresent());
         }
         try (FlightStream stream = client.getStream(endpoint.getTicket())) {
@@ -72,7 +74,8 @@ final class ExpirationTimeDoGetScenario implements Scenario {
 
       // Check data
       IntegrationAssertions.assertEquals(3, batches.size());
-      try (final VectorSchemaRoot root = VectorSchemaRoot.create(ExpirationTimeProducer.SCHEMA, allocator)) {
+      try (final VectorSchemaRoot root =
+          VectorSchemaRoot.create(ExpirationTimeProducer.SCHEMA, allocator)) {
         final VectorLoader loader = new VectorLoader(root);
 
         loader.load(batches.get(0));

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeListActionsScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeListActionsScenario.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.util.Iterator;
-
 import org.apache.arrow.flight.ActionType;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightConstants;
@@ -35,19 +33,21 @@ final class ExpirationTimeListActionsScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) {
-  }
+  public void buildServer(FlightServer.Builder builder) {}
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient client) throws Exception {
+  public void client(BufferAllocator allocator, Location location, FlightClient client)
+      throws Exception {
     Iterator<ActionType> actions = client.listActions().iterator();
     IntegrationAssertions.assertTrue("Expected 2 actions", actions.hasNext());
     ActionType action = actions.next();
-    IntegrationAssertions.assertEquals(FlightConstants.CANCEL_FLIGHT_INFO.getType(), action.getType());
+    IntegrationAssertions.assertEquals(
+        FlightConstants.CANCEL_FLIGHT_INFO.getType(), action.getType());
 
     IntegrationAssertions.assertTrue("Expected 2 actions", actions.hasNext());
     action = actions.next();
-    IntegrationAssertions.assertEquals(FlightConstants.RENEW_FLIGHT_ENDPOINT.getType(), action.getType());
+    IntegrationAssertions.assertEquals(
+        FlightConstants.RENEW_FLIGHT_ENDPOINT.getType(), action.getType());
 
     IntegrationAssertions.assertFalse("Expected 2 actions", actions.hasNext());
   }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeRenewFlightEndpointScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/ExpirationTimeRenewFlightEndpointScenario.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
@@ -38,12 +36,13 @@ final class ExpirationTimeRenewFlightEndpointScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) {
-  }
+  public void buildServer(FlightServer.Builder builder) {}
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient client) throws Exception {
-    FlightInfo info = client.getInfo(FlightDescriptor.command("expiration".getBytes(StandardCharsets.UTF_8)));
+  public void client(BufferAllocator allocator, Location location, FlightClient client)
+      throws Exception {
+    FlightInfo info =
+        client.getInfo(FlightDescriptor.command("expiration".getBytes(StandardCharsets.UTF_8)));
 
     // Renew all endpoints with expiration time
     for (FlightEndpoint endpoint : info.getEndpoints()) {
@@ -53,11 +52,12 @@ final class ExpirationTimeRenewFlightEndpointScenario implements Scenario {
       Instant expiration = endpoint.getExpirationTime().get();
       FlightEndpoint renewed = client.renewFlightEndpoint(new RenewFlightEndpointRequest(endpoint));
 
-      IntegrationAssertions.assertTrue("Renewed FlightEndpoint must have expiration time",
+      IntegrationAssertions.assertTrue(
+          "Renewed FlightEndpoint must have expiration time",
           renewed.getExpirationTime().isPresent());
-      IntegrationAssertions.assertTrue("Renewed FlightEndpoint must have newer expiration time",
+      IntegrationAssertions.assertTrue(
+          "Renewed FlightEndpoint must have newer expiration time",
           renewed.getExpirationTime().get().isAfter(expiration));
-
     }
   }
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlExtensionScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlExtensionScenario.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.FlightStream;
@@ -38,9 +36,9 @@ import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 /**
- * Integration test scenario for validating Flight SQL specs across multiple implementations.
- * This should ensure that RPC objects are being built and parsed correctly for multiple languages
- * and that the Arrow schemas are returned as expected.
+ * Integration test scenario for validating Flight SQL specs across multiple implementations. This
+ * should ensure that RPC objects are being built and parsed correctly for multiple languages and
+ * that the Arrow schemas are returned as expected.
  */
 public class FlightSqlExtensionScenario extends FlightSqlScenario {
   @Override
@@ -61,7 +59,8 @@ public class FlightSqlExtensionScenario extends FlightSqlScenario {
     Map<Integer, Object> infoValues = new HashMap<>();
     try (FlightStream stream = sqlClient.getStream(ticket)) {
       Schema actualSchema = stream.getSchema();
-      IntegrationAssertions.assertEquals(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA, actualSchema);
+      IntegrationAssertions.assertEquals(
+          FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA, actualSchema);
 
       while (stream.next()) {
         UInt4Vector infoName = (UInt4Vector) stream.getRoot().getVector(0);
@@ -76,9 +75,10 @@ public class FlightSqlExtensionScenario extends FlightSqlScenario {
           byte typeId = value.getTypeId(i);
           switch (typeId) {
             case 0: // string
-              object = Preconditions.checkNotNull(value.getVarCharVector(typeId)
-                  .getObject(value.getOffset(i)))
-                  .toString();
+              object =
+                  Preconditions.checkNotNull(
+                          value.getVarCharVector(typeId).getObject(value.getOffset(i)))
+                      .toString();
               break;
             case 1: // bool
               object = value.getBitVector(typeId).getObject(value.getOffset(i));
@@ -97,22 +97,25 @@ public class FlightSqlExtensionScenario extends FlightSqlScenario {
       }
     }
 
-    IntegrationAssertions.assertEquals(Boolean.FALSE,
-        infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_SQL_VALUE));
-    IntegrationAssertions.assertEquals(Boolean.TRUE,
-        infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_SUBSTRAIT_VALUE));
-    IntegrationAssertions.assertEquals("min_version",
+    IntegrationAssertions.assertEquals(
+        Boolean.FALSE, infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_SQL_VALUE));
+    IntegrationAssertions.assertEquals(
+        Boolean.TRUE, infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_SUBSTRAIT_VALUE));
+    IntegrationAssertions.assertEquals(
+        "min_version",
         infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_SUBSTRAIT_MIN_VERSION_VALUE));
-    IntegrationAssertions.assertEquals("max_version",
+    IntegrationAssertions.assertEquals(
+        "max_version",
         infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_SUBSTRAIT_MAX_VERSION_VALUE));
-    IntegrationAssertions.assertEquals(FlightSql.SqlSupportedTransaction.SQL_SUPPORTED_TRANSACTION_SAVEPOINT_VALUE,
+    IntegrationAssertions.assertEquals(
+        FlightSql.SqlSupportedTransaction.SQL_SUPPORTED_TRANSACTION_SAVEPOINT_VALUE,
         infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_TRANSACTION_VALUE));
-    IntegrationAssertions.assertEquals(Boolean.TRUE,
-        infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_CANCEL_VALUE));
-    IntegrationAssertions.assertEquals(42,
-        infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_STATEMENT_TIMEOUT_VALUE));
-    IntegrationAssertions.assertEquals(7,
-        infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_TRANSACTION_TIMEOUT_VALUE));
+    IntegrationAssertions.assertEquals(
+        Boolean.TRUE, infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_CANCEL_VALUE));
+    IntegrationAssertions.assertEquals(
+        42, infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_STATEMENT_TIMEOUT_VALUE));
+    IntegrationAssertions.assertEquals(
+        7, infoValues.get(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_TRANSACTION_TIMEOUT_VALUE));
   }
 
   private void validateStatementExecution(FlightSqlClient sqlClient) throws Exception {
@@ -124,15 +127,15 @@ public class FlightSqlExtensionScenario extends FlightSqlScenario {
 
     IntegrationAssertions.assertEquals(CancelResult.CANCELLED, sqlClient.cancelQuery(info));
 
-    IntegrationAssertions.assertEquals(sqlClient.executeSubstraitUpdate(SUBSTRAIT_PLAN),
-        UPDATE_STATEMENT_EXPECTED_ROWS);
+    IntegrationAssertions.assertEquals(
+        sqlClient.executeSubstraitUpdate(SUBSTRAIT_PLAN), UPDATE_STATEMENT_EXPECTED_ROWS);
   }
 
-  private void validatePreparedStatementExecution(BufferAllocator allocator,
-                                                  FlightSqlClient sqlClient) throws Exception {
+  private void validatePreparedStatementExecution(
+      BufferAllocator allocator, FlightSqlClient sqlClient) throws Exception {
     try (FlightSqlClient.PreparedStatement preparedStatement = sqlClient.prepare(SUBSTRAIT_PLAN);
-         VectorSchemaRoot parameters = VectorSchemaRoot.create(
-             FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
+        VectorSchemaRoot parameters =
+            VectorSchemaRoot.create(FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
       parameters.setRowCount(1);
       preparedStatement.setParameters(parameters);
       validate(FlightSqlScenarioProducer.getQuerySchema(), preparedStatement.execute(), sqlClient);
@@ -140,16 +143,18 @@ public class FlightSqlExtensionScenario extends FlightSqlScenario {
     }
 
     try (FlightSqlClient.PreparedStatement preparedStatement = sqlClient.prepare(SUBSTRAIT_PLAN)) {
-      IntegrationAssertions.assertEquals(preparedStatement.executeUpdate(),
-          UPDATE_PREPARED_STATEMENT_EXPECTED_ROWS);
+      IntegrationAssertions.assertEquals(
+          preparedStatement.executeUpdate(), UPDATE_PREPARED_STATEMENT_EXPECTED_ROWS);
     }
   }
 
-  private void validateTransactions(BufferAllocator allocator, FlightSqlClient sqlClient) throws Exception {
+  private void validateTransactions(BufferAllocator allocator, FlightSqlClient sqlClient)
+      throws Exception {
     final FlightSqlClient.Transaction transaction = sqlClient.beginTransaction();
     IntegrationAssertions.assertEquals(TRANSACTION_ID, transaction.getTransactionId());
 
-    final FlightSqlClient.Savepoint savepoint = sqlClient.beginSavepoint(transaction, SAVEPOINT_NAME);
+    final FlightSqlClient.Savepoint savepoint =
+        sqlClient.beginSavepoint(transaction, SAVEPOINT_NAME);
     IntegrationAssertions.assertEquals(SAVEPOINT_ID, savepoint.getSavepointId());
 
     FlightInfo info = sqlClient.execute("SELECT STATEMENT", transaction);
@@ -164,47 +169,59 @@ public class FlightSqlExtensionScenario extends FlightSqlScenario {
     schema = sqlClient.getExecuteSubstraitSchema(SUBSTRAIT_PLAN, transaction);
     validateSchema(FlightSqlScenarioProducer.getQueryWithTransactionSchema(), schema);
 
-    IntegrationAssertions.assertEquals(sqlClient.executeUpdate("UPDATE STATEMENT", transaction),
+    IntegrationAssertions.assertEquals(
+        sqlClient.executeUpdate("UPDATE STATEMENT", transaction),
         UPDATE_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
-    IntegrationAssertions.assertEquals(sqlClient.executeSubstraitUpdate(SUBSTRAIT_PLAN, transaction),
+    IntegrationAssertions.assertEquals(
+        sqlClient.executeSubstraitUpdate(SUBSTRAIT_PLAN, transaction),
         UPDATE_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
 
-    try (FlightSqlClient.PreparedStatement preparedStatement = sqlClient.prepare(
-        "SELECT PREPARED STATEMENT", transaction);
-         VectorSchemaRoot parameters = VectorSchemaRoot.create(
-             FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
+    try (FlightSqlClient.PreparedStatement preparedStatement =
+            sqlClient.prepare("SELECT PREPARED STATEMENT", transaction);
+        VectorSchemaRoot parameters =
+            VectorSchemaRoot.create(FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
       parameters.setRowCount(1);
       preparedStatement.setParameters(parameters);
-      validate(FlightSqlScenarioProducer.getQueryWithTransactionSchema(), preparedStatement.execute(), sqlClient);
-      schema = preparedStatement.fetchSchema();
-      validateSchema(FlightSqlScenarioProducer.getQueryWithTransactionSchema(), schema);
-    }
-
-    try (FlightSqlClient.PreparedStatement preparedStatement = sqlClient.prepare(SUBSTRAIT_PLAN, transaction);
-         VectorSchemaRoot parameters = VectorSchemaRoot.create(
-             FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
-      parameters.setRowCount(1);
-      preparedStatement.setParameters(parameters);
-      validate(FlightSqlScenarioProducer.getQueryWithTransactionSchema(), preparedStatement.execute(), sqlClient);
+      validate(
+          FlightSqlScenarioProducer.getQueryWithTransactionSchema(),
+          preparedStatement.execute(),
+          sqlClient);
       schema = preparedStatement.fetchSchema();
       validateSchema(FlightSqlScenarioProducer.getQueryWithTransactionSchema(), schema);
     }
 
     try (FlightSqlClient.PreparedStatement preparedStatement =
-             sqlClient.prepare("UPDATE PREPARED STATEMENT", transaction)) {
-      IntegrationAssertions.assertEquals(preparedStatement.executeUpdate(),
+            sqlClient.prepare(SUBSTRAIT_PLAN, transaction);
+        VectorSchemaRoot parameters =
+            VectorSchemaRoot.create(FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
+      parameters.setRowCount(1);
+      preparedStatement.setParameters(parameters);
+      validate(
+          FlightSqlScenarioProducer.getQueryWithTransactionSchema(),
+          preparedStatement.execute(),
+          sqlClient);
+      schema = preparedStatement.fetchSchema();
+      validateSchema(FlightSqlScenarioProducer.getQueryWithTransactionSchema(), schema);
+    }
+
+    try (FlightSqlClient.PreparedStatement preparedStatement =
+        sqlClient.prepare("UPDATE PREPARED STATEMENT", transaction)) {
+      IntegrationAssertions.assertEquals(
+          preparedStatement.executeUpdate(),
           UPDATE_PREPARED_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
     }
 
     try (FlightSqlClient.PreparedStatement preparedStatement =
-             sqlClient.prepare(SUBSTRAIT_PLAN, transaction)) {
-      IntegrationAssertions.assertEquals(preparedStatement.executeUpdate(),
+        sqlClient.prepare(SUBSTRAIT_PLAN, transaction)) {
+      IntegrationAssertions.assertEquals(
+          preparedStatement.executeUpdate(),
           UPDATE_PREPARED_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
     }
 
     sqlClient.rollback(savepoint);
 
-    final FlightSqlClient.Savepoint savepoint2 = sqlClient.beginSavepoint(transaction, SAVEPOINT_NAME);
+    final FlightSqlClient.Savepoint savepoint2 =
+        sqlClient.beginSavepoint(transaction, SAVEPOINT_NAME);
     IntegrationAssertions.assertEquals(SAVEPOINT_ID, savepoint2.getSavepointId());
     sqlClient.release(savepoint);
 

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlScenario.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-
 import org.apache.arrow.flight.CallOption;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightInfo;
@@ -38,9 +36,9 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 /**
- * Integration test scenario for validating Flight SQL specs across multiple implementations.
- * This should ensure that RPC objects are being built and parsed correctly for multiple languages
- * and that the Arrow schemas are returned as expected.
+ * Integration test scenario for validating Flight SQL specs across multiple implementations. This
+ * should ensure that RPC objects are being built and parsed correctly for multiple languages and
+ * that the Arrow schemas are returned as expected.
  */
 public class FlightSqlScenario implements Scenario {
   public static final long UPDATE_STATEMENT_EXPECTED_ROWS = 10000L;
@@ -61,9 +59,7 @@ public class FlightSqlScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) throws Exception {
-
-  }
+  public void buildServer(FlightServer.Builder builder) throws Exception {}
 
   @Override
   public void client(BufferAllocator allocator, Location location, FlightClient client)
@@ -78,72 +74,111 @@ public class FlightSqlScenario implements Scenario {
   private void validateMetadataRetrieval(FlightSqlClient sqlClient) throws Exception {
     final CallOption[] options = new CallOption[0];
 
-    validate(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA, sqlClient.getCatalogs(options),
-        sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA, sqlClient.getCatalogsSchema(options));
+    validate(
+        FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA, sqlClient.getCatalogs(options), sqlClient);
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA, sqlClient.getCatalogsSchema(options));
 
-    validate(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA,
+    validate(
+        FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA,
         sqlClient.getSchemas("catalog", "db_schema_filter_pattern", options),
         sqlClient);
     validateSchema(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA, sqlClient.getSchemasSchema());
 
-    validate(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA,
-        sqlClient.getTables("catalog", "db_schema_filter_pattern", "table_filter_pattern",
-            Arrays.asList("table", "view"), true, options), sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA,
-        sqlClient.getTablesSchema(/*includeSchema*/true, options));
-    validateSchema(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA,
-        sqlClient.getTablesSchema(/*includeSchema*/false, options));
+    validate(
+        FlightSqlProducer.Schemas.GET_TABLES_SCHEMA,
+        sqlClient.getTables(
+            "catalog",
+            "db_schema_filter_pattern",
+            "table_filter_pattern",
+            Arrays.asList("table", "view"),
+            true,
+            options),
+        sqlClient);
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_TABLES_SCHEMA,
+        sqlClient.getTablesSchema(/*includeSchema*/ true, options));
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA,
+        sqlClient.getTablesSchema(/*includeSchema*/ false, options));
 
-    validate(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA, sqlClient.getTableTypes(options), sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA, sqlClient.getTableTypesSchema(options));
+    validate(
+        FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA,
+        sqlClient.getTableTypes(options),
+        sqlClient);
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA, sqlClient.getTableTypesSchema(options));
 
-    validate(FlightSqlProducer.Schemas.GET_PRIMARY_KEYS_SCHEMA,
+    validate(
+        FlightSqlProducer.Schemas.GET_PRIMARY_KEYS_SCHEMA,
         sqlClient.getPrimaryKeys(TableRef.of("catalog", "db_schema", "table"), options),
         sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_PRIMARY_KEYS_SCHEMA, sqlClient.getPrimaryKeysSchema(options));
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_PRIMARY_KEYS_SCHEMA, sqlClient.getPrimaryKeysSchema(options));
 
-    validate(FlightSqlProducer.Schemas.GET_EXPORTED_KEYS_SCHEMA,
+    validate(
+        FlightSqlProducer.Schemas.GET_EXPORTED_KEYS_SCHEMA,
         sqlClient.getExportedKeys(TableRef.of("catalog", "db_schema", "table"), options),
         sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_EXPORTED_KEYS_SCHEMA, sqlClient.getExportedKeysSchema(options));
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_EXPORTED_KEYS_SCHEMA,
+        sqlClient.getExportedKeysSchema(options));
 
-    validate(FlightSqlProducer.Schemas.GET_IMPORTED_KEYS_SCHEMA,
+    validate(
+        FlightSqlProducer.Schemas.GET_IMPORTED_KEYS_SCHEMA,
         sqlClient.getImportedKeys(TableRef.of("catalog", "db_schema", "table"), options),
         sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_IMPORTED_KEYS_SCHEMA, sqlClient.getImportedKeysSchema(options));
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_IMPORTED_KEYS_SCHEMA,
+        sqlClient.getImportedKeysSchema(options));
 
-    validate(FlightSqlProducer.Schemas.GET_CROSS_REFERENCE_SCHEMA,
-        sqlClient.getCrossReference(TableRef.of("pk_catalog", "pk_db_schema", "pk_table"),
-            TableRef.of("fk_catalog", "fk_db_schema", "fk_table"), options),
+    validate(
+        FlightSqlProducer.Schemas.GET_CROSS_REFERENCE_SCHEMA,
+        sqlClient.getCrossReference(
+            TableRef.of("pk_catalog", "pk_db_schema", "pk_table"),
+            TableRef.of("fk_catalog", "fk_db_schema", "fk_table"),
+            options),
         sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_CROSS_REFERENCE_SCHEMA, sqlClient.getCrossReferenceSchema(options));
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_CROSS_REFERENCE_SCHEMA,
+        sqlClient.getCrossReferenceSchema(options));
 
-    validate(FlightSqlProducer.Schemas.GET_TYPE_INFO_SCHEMA, sqlClient.getXdbcTypeInfo(options), sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_TYPE_INFO_SCHEMA, sqlClient.getXdbcTypeInfoSchema(options));
+    validate(
+        FlightSqlProducer.Schemas.GET_TYPE_INFO_SCHEMA,
+        sqlClient.getXdbcTypeInfo(options),
+        sqlClient);
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_TYPE_INFO_SCHEMA, sqlClient.getXdbcTypeInfoSchema(options));
 
-    validate(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA,
-        sqlClient.getSqlInfo(new FlightSql.SqlInfo[] {FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME,
-            FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY}, options), sqlClient);
-    validateSchema(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA, sqlClient.getSqlInfoSchema(options));
+    validate(
+        FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA,
+        sqlClient.getSqlInfo(
+            new FlightSql.SqlInfo[] {
+              FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME,
+              FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY
+            },
+            options),
+        sqlClient);
+    validateSchema(
+        FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA, sqlClient.getSqlInfoSchema(options));
   }
 
   private void validateStatementExecution(FlightSqlClient sqlClient) throws Exception {
     FlightInfo info = sqlClient.execute("SELECT STATEMENT");
     validate(FlightSqlScenarioProducer.getQuerySchema(), info, sqlClient);
-    validateSchema(FlightSqlScenarioProducer.getQuerySchema(),
-        sqlClient.getExecuteSchema("SELECT STATEMENT"));
+    validateSchema(
+        FlightSqlScenarioProducer.getQuerySchema(), sqlClient.getExecuteSchema("SELECT STATEMENT"));
 
-    IntegrationAssertions.assertEquals(sqlClient.executeUpdate("UPDATE STATEMENT"),
-        UPDATE_STATEMENT_EXPECTED_ROWS);
+    IntegrationAssertions.assertEquals(
+        sqlClient.executeUpdate("UPDATE STATEMENT"), UPDATE_STATEMENT_EXPECTED_ROWS);
   }
 
-  private void validatePreparedStatementExecution(BufferAllocator allocator,
-                                                  FlightSqlClient sqlClient) throws Exception {
-    try (FlightSqlClient.PreparedStatement preparedStatement = sqlClient.prepare(
-        "SELECT PREPARED STATEMENT");
-         VectorSchemaRoot parameters = VectorSchemaRoot.create(
-             FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
+  private void validatePreparedStatementExecution(
+      BufferAllocator allocator, FlightSqlClient sqlClient) throws Exception {
+    try (FlightSqlClient.PreparedStatement preparedStatement =
+            sqlClient.prepare("SELECT PREPARED STATEMENT");
+        VectorSchemaRoot parameters =
+            VectorSchemaRoot.create(FlightSqlScenarioProducer.getQuerySchema(), allocator)) {
       parameters.setRowCount(1);
       preparedStatement.setParameters(parameters);
       validate(FlightSqlScenarioProducer.getQuerySchema(), preparedStatement.execute(), sqlClient);
@@ -151,14 +186,14 @@ public class FlightSqlScenario implements Scenario {
     }
 
     try (FlightSqlClient.PreparedStatement preparedStatement =
-             sqlClient.prepare("UPDATE PREPARED STATEMENT")) {
-      IntegrationAssertions.assertEquals(preparedStatement.executeUpdate(),
-          UPDATE_PREPARED_STATEMENT_EXPECTED_ROWS);
+        sqlClient.prepare("UPDATE PREPARED STATEMENT")) {
+      IntegrationAssertions.assertEquals(
+          preparedStatement.executeUpdate(), UPDATE_PREPARED_STATEMENT_EXPECTED_ROWS);
     }
   }
 
-  protected void validate(Schema expectedSchema, FlightInfo flightInfo,
-                        FlightSqlClient sqlClient) throws Exception {
+  protected void validate(Schema expectedSchema, FlightInfo flightInfo, FlightSqlClient sqlClient)
+      throws Exception {
     Ticket ticket = flightInfo.getEndpoints().get(0).getTicket();
     try (FlightStream stream = sqlClient.getStream(ticket)) {
       Schema actualSchema = stream.getSchema();

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlScenarioProducer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/FlightSqlScenarioProducer.java
@@ -14,13 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.FlightDescriptor;
@@ -44,14 +46,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import com.google.protobuf.Any;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Message;
-
-/**
- * Hardcoded Flight SQL producer used for cross-language integration tests.
- */
+/** Hardcoded Flight SQL producer used for cross-language integration tests. */
 public class FlightSqlScenarioProducer implements FlightSqlProducer {
   private final BufferAllocator allocator;
 
@@ -60,157 +55,200 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   /**
-   * Schema to be returned for mocking the statement/prepared statement results.
-   * Must be the same across all languages.
+   * Schema to be returned for mocking the statement/prepared statement results. Must be the same
+   * across all languages.
    */
   static Schema getQuerySchema() {
     return new Schema(
         Collections.singletonList(
-            new Field("id", new FieldType(true, new ArrowType.Int(64, true),
-                null, new FlightSqlColumnMetadata.Builder()
-                .tableName("test")
-                .isAutoIncrement(true)
-                .isCaseSensitive(false)
-                .typeName("type_test")
-                .schemaName("schema_test")
-                .isSearchable(true)
-                .catalogName("catalog_test")
-                .precision(100)
-                .build().getMetadataMap()), null)
-        )
-    );
+            new Field(
+                "id",
+                new FieldType(
+                    true,
+                    new ArrowType.Int(64, true),
+                    null,
+                    new FlightSqlColumnMetadata.Builder()
+                        .tableName("test")
+                        .isAutoIncrement(true)
+                        .isCaseSensitive(false)
+                        .typeName("type_test")
+                        .schemaName("schema_test")
+                        .isSearchable(true)
+                        .catalogName("catalog_test")
+                        .precision(100)
+                        .build()
+                        .getMetadataMap()),
+                null)));
   }
 
   /**
    * The expected schema for queries with transactions.
-   * <p>
-   * Must be the same across all languages.
+   *
+   * <p>Must be the same across all languages.
    */
   static Schema getQueryWithTransactionSchema() {
     return new Schema(
         Collections.singletonList(
-            new Field("pkey", new FieldType(true, new ArrowType.Int(32, true),
-                null, new FlightSqlColumnMetadata.Builder()
-                .tableName("test")
-                .isAutoIncrement(true)
-                .isCaseSensitive(false)
-                .typeName("type_test")
-                .schemaName("schema_test")
-                .isSearchable(true)
-                .catalogName("catalog_test")
-                .precision(100)
-                .build().getMetadataMap()), null)
-        )
-    );
+            new Field(
+                "pkey",
+                new FieldType(
+                    true,
+                    new ArrowType.Int(32, true),
+                    null,
+                    new FlightSqlColumnMetadata.Builder()
+                        .tableName("test")
+                        .isAutoIncrement(true)
+                        .isCaseSensitive(false)
+                        .typeName("type_test")
+                        .schemaName("schema_test")
+                        .isSearchable(true)
+                        .catalogName("catalog_test")
+                        .precision(100)
+                        .build()
+                        .getMetadataMap()),
+                null)));
   }
 
   @Override
-  public void beginSavepoint(FlightSql.ActionBeginSavepointRequest request, CallContext context,
-                             StreamListener<FlightSql.ActionBeginSavepointResult> listener) {
+  public void beginSavepoint(
+      FlightSql.ActionBeginSavepointRequest request,
+      CallContext context,
+      StreamListener<FlightSql.ActionBeginSavepointResult> listener) {
     if (!request.getName().equals(FlightSqlScenario.SAVEPOINT_NAME)) {
-      listener.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription(String.format("Expected name '%s', not '%s'",
-              FlightSqlScenario.SAVEPOINT_NAME, request.getName()))
-          .toRuntimeException());
+      listener.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription(
+                  String.format(
+                      "Expected name '%s', not '%s'",
+                      FlightSqlScenario.SAVEPOINT_NAME, request.getName()))
+              .toRuntimeException());
       return;
     }
-    if (!Arrays.equals(request.getTransactionId().toByteArray(), FlightSqlScenario.TRANSACTION_ID)) {
-      listener.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription(String.format("Expected transaction ID '%s', not '%s'",
-              Arrays.toString(FlightSqlScenario.TRANSACTION_ID),
-              Arrays.toString(request.getTransactionId().toByteArray())))
-          .toRuntimeException());
+    if (!Arrays.equals(
+        request.getTransactionId().toByteArray(), FlightSqlScenario.TRANSACTION_ID)) {
+      listener.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription(
+                  String.format(
+                      "Expected transaction ID '%s', not '%s'",
+                      Arrays.toString(FlightSqlScenario.TRANSACTION_ID),
+                      Arrays.toString(request.getTransactionId().toByteArray())))
+              .toRuntimeException());
       return;
     }
-    listener.onNext(FlightSql.ActionBeginSavepointResult.newBuilder()
-        .setSavepointId(ByteString.copyFrom(FlightSqlScenario.SAVEPOINT_ID))
-        .build());
+    listener.onNext(
+        FlightSql.ActionBeginSavepointResult.newBuilder()
+            .setSavepointId(ByteString.copyFrom(FlightSqlScenario.SAVEPOINT_ID))
+            .build());
     listener.onCompleted();
   }
 
   @Override
-  public void beginTransaction(FlightSql.ActionBeginTransactionRequest request, CallContext context,
-                               StreamListener<FlightSql.ActionBeginTransactionResult> listener) {
-    listener.onNext(FlightSql.ActionBeginTransactionResult.newBuilder()
-        .setTransactionId(ByteString.copyFrom(FlightSqlScenario.TRANSACTION_ID))
-        .build());
+  public void beginTransaction(
+      FlightSql.ActionBeginTransactionRequest request,
+      CallContext context,
+      StreamListener<FlightSql.ActionBeginTransactionResult> listener) {
+    listener.onNext(
+        FlightSql.ActionBeginTransactionResult.newBuilder()
+            .setTransactionId(ByteString.copyFrom(FlightSqlScenario.TRANSACTION_ID))
+            .build());
     listener.onCompleted();
   }
 
   @Override
-  public void cancelQuery(FlightInfo info, CallContext context, StreamListener<CancelResult> listener) {
+  public void cancelQuery(
+      FlightInfo info, CallContext context, StreamListener<CancelResult> listener) {
     final String expectedTicket = "PLAN HANDLE";
     if (info.getEndpoints().size() != 1) {
-      listener.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription(String.format("Expected 1 endpoint, got %d", info.getEndpoints().size()))
-          .toRuntimeException());
+      listener.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription(
+                  String.format("Expected 1 endpoint, got %d", info.getEndpoints().size()))
+              .toRuntimeException());
     }
     final FlightEndpoint endpoint = info.getEndpoints().get(0);
     try {
       final Any any = Any.parseFrom(endpoint.getTicket().getBytes());
       if (!any.is(FlightSql.TicketStatementQuery.class)) {
-        listener.onError(CallStatus.INVALID_ARGUMENT
-            .withDescription(String.format("Expected TicketStatementQuery, found '%s'", any.getTypeUrl()))
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INVALID_ARGUMENT
+                .withDescription(
+                    String.format("Expected TicketStatementQuery, found '%s'", any.getTypeUrl()))
+                .toRuntimeException());
       }
-      final FlightSql.TicketStatementQuery ticket = any.unpack(FlightSql.TicketStatementQuery.class);
+      final FlightSql.TicketStatementQuery ticket =
+          any.unpack(FlightSql.TicketStatementQuery.class);
       if (!ticket.getStatementHandle().toStringUtf8().equals(expectedTicket)) {
-        listener.onError(CallStatus.INVALID_ARGUMENT
-            .withDescription(String.format("Expected ticket '%s'", expectedTicket))
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INVALID_ARGUMENT
+                .withDescription(String.format("Expected ticket '%s'", expectedTicket))
+                .toRuntimeException());
       }
       listener.onNext(CancelResult.CANCELLED);
       listener.onCompleted();
     } catch (InvalidProtocolBufferException e) {
-      listener.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription("Invalid Protobuf:" + e)
-          .withCause(e)
-          .toRuntimeException());
+      listener.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription("Invalid Protobuf:" + e)
+              .withCause(e)
+              .toRuntimeException());
     }
   }
 
   @Override
-  public void createPreparedStatement(FlightSql.ActionCreatePreparedStatementRequest request,
-                                      CallContext context, StreamListener<Result> listener) {
-    IntegrationAssertions.assertTrue("Expect to be one of the two queries used on tests",
-        request.getQuery().equals("SELECT PREPARED STATEMENT") ||
-            request.getQuery().equals("UPDATE PREPARED STATEMENT"));
+  public void createPreparedStatement(
+      FlightSql.ActionCreatePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
+    IntegrationAssertions.assertTrue(
+        "Expect to be one of the two queries used on tests",
+        request.getQuery().equals("SELECT PREPARED STATEMENT")
+            || request.getQuery().equals("UPDATE PREPARED STATEMENT"));
 
     String text = request.getQuery();
     if (!request.getTransactionId().isEmpty()) {
       text += " WITH TXN";
     }
     text += " HANDLE";
-    final FlightSql.ActionCreatePreparedStatementResult
-        result = FlightSql.ActionCreatePreparedStatementResult.newBuilder()
-        .setPreparedStatementHandle(ByteString.copyFromUtf8(text))
-        .build();
+    final FlightSql.ActionCreatePreparedStatementResult result =
+        FlightSql.ActionCreatePreparedStatementResult.newBuilder()
+            .setPreparedStatementHandle(ByteString.copyFromUtf8(text))
+            .build();
     listener.onNext(new Result(Any.pack(result).toByteArray()));
     listener.onCompleted();
   }
 
   @Override
-  public void createPreparedSubstraitPlan(FlightSql.ActionCreatePreparedSubstraitPlanRequest request,
-                                          CallContext context,
-                                          StreamListener<FlightSql.ActionCreatePreparedStatementResult> listener) {
-    if (!Arrays.equals(request.getPlan().getPlan().toByteArray(), FlightSqlScenario.SUBSTRAIT_PLAN_TEXT)) {
-      listener.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription(String.format("Expected plan '%s', not '%s'",
-              Arrays.toString(FlightSqlScenario.SUBSTRAIT_PLAN_TEXT),
-              Arrays.toString(request.getPlan().getPlan().toByteArray())))
-          .toRuntimeException());
+  public void createPreparedSubstraitPlan(
+      FlightSql.ActionCreatePreparedSubstraitPlanRequest request,
+      CallContext context,
+      StreamListener<FlightSql.ActionCreatePreparedStatementResult> listener) {
+    if (!Arrays.equals(
+        request.getPlan().getPlan().toByteArray(), FlightSqlScenario.SUBSTRAIT_PLAN_TEXT)) {
+      listener.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription(
+                  String.format(
+                      "Expected plan '%s', not '%s'",
+                      Arrays.toString(FlightSqlScenario.SUBSTRAIT_PLAN_TEXT),
+                      Arrays.toString(request.getPlan().getPlan().toByteArray())))
+              .toRuntimeException());
       return;
     }
     if (!FlightSqlScenario.SUBSTRAIT_VERSION.equals(request.getPlan().getVersion())) {
-      listener.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription(String.format("Expected version '%s', not '%s'",
-              FlightSqlScenario.SUBSTRAIT_VERSION,
-              request.getPlan().getVersion()))
-          .toRuntimeException());
+      listener.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription(
+                  String.format(
+                      "Expected version '%s', not '%s'",
+                      FlightSqlScenario.SUBSTRAIT_VERSION, request.getPlan().getVersion()))
+              .toRuntimeException());
       return;
     }
-    final String handle = request.getTransactionId().isEmpty() ?
-        "PREPARED PLAN HANDLE" : "PREPARED PLAN WITH TXN HANDLE";
+    final String handle =
+        request.getTransactionId().isEmpty()
+            ? "PREPARED PLAN HANDLE"
+            : "PREPARED PLAN WITH TXN HANDLE";
     final FlightSql.ActionCreatePreparedStatementResult result =
         FlightSql.ActionCreatePreparedStatementResult.newBuilder()
             .setPreparedStatementHandle(ByteString.copyFromUtf8(handle))
@@ -220,116 +258,141 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public void closePreparedStatement(FlightSql.ActionClosePreparedStatementRequest request,
-                                     CallContext context, StreamListener<Result> listener) {
+  public void closePreparedStatement(
+      FlightSql.ActionClosePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
     final String handle = request.getPreparedStatementHandle().toStringUtf8();
-    IntegrationAssertions.assertTrue("Expect to be one of the queries used on tests",
-        handle.equals("SELECT PREPARED STATEMENT HANDLE") ||
-            handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE") ||
-            handle.equals("UPDATE PREPARED STATEMENT HANDLE") ||
-            handle.equals("UPDATE PREPARED STATEMENT WITH TXN HANDLE") ||
-            handle.equals("PREPARED PLAN HANDLE") ||
-            handle.equals("PREPARED PLAN WITH TXN HANDLE"));
+    IntegrationAssertions.assertTrue(
+        "Expect to be one of the queries used on tests",
+        handle.equals("SELECT PREPARED STATEMENT HANDLE")
+            || handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE")
+            || handle.equals("UPDATE PREPARED STATEMENT HANDLE")
+            || handle.equals("UPDATE PREPARED STATEMENT WITH TXN HANDLE")
+            || handle.equals("PREPARED PLAN HANDLE")
+            || handle.equals("PREPARED PLAN WITH TXN HANDLE"));
     listener.onCompleted();
   }
 
   @Override
-  public void endSavepoint(FlightSql.ActionEndSavepointRequest request, CallContext context,
-                           StreamListener<Result> listener) {
+  public void endSavepoint(
+      FlightSql.ActionEndSavepointRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
     switch (request.getAction()) {
       case END_SAVEPOINT_RELEASE:
       case END_SAVEPOINT_ROLLBACK:
-        if (!Arrays.equals(request.getSavepointId().toByteArray(), FlightSqlScenario.SAVEPOINT_ID)) {
-          listener.onError(CallStatus.INVALID_ARGUMENT
-              .withDescription("Unexpected ID: " + Arrays.toString(request.getSavepointId().toByteArray()))
-              .toRuntimeException());
+        if (!Arrays.equals(
+            request.getSavepointId().toByteArray(), FlightSqlScenario.SAVEPOINT_ID)) {
+          listener.onError(
+              CallStatus.INVALID_ARGUMENT
+                  .withDescription(
+                      "Unexpected ID: " + Arrays.toString(request.getSavepointId().toByteArray()))
+                  .toRuntimeException());
         }
         break;
       case UNRECOGNIZED:
-      default: {
-        listener.onError(CallStatus.INVALID_ARGUMENT
-            .withDescription("Unknown action: " + request.getAction())
-            .toRuntimeException());
-        return;
-      }
+      default:
+        {
+          listener.onError(
+              CallStatus.INVALID_ARGUMENT
+                  .withDescription("Unknown action: " + request.getAction())
+                  .toRuntimeException());
+          return;
+        }
     }
     listener.onCompleted();
   }
 
   @Override
-  public void endTransaction(FlightSql.ActionEndTransactionRequest request, CallContext context,
-                             StreamListener<Result> listener) {
+  public void endTransaction(
+      FlightSql.ActionEndTransactionRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
     switch (request.getAction()) {
       case END_TRANSACTION_COMMIT:
       case END_TRANSACTION_ROLLBACK:
-        if (!Arrays.equals(request.getTransactionId().toByteArray(), FlightSqlScenario.TRANSACTION_ID)) {
-          listener.onError(CallStatus.INVALID_ARGUMENT
-              .withDescription("Unexpected ID: " + Arrays.toString(request.getTransactionId().toByteArray()))
-              .toRuntimeException());
+        if (!Arrays.equals(
+            request.getTransactionId().toByteArray(), FlightSqlScenario.TRANSACTION_ID)) {
+          listener.onError(
+              CallStatus.INVALID_ARGUMENT
+                  .withDescription(
+                      "Unexpected ID: " + Arrays.toString(request.getTransactionId().toByteArray()))
+                  .toRuntimeException());
         }
         break;
       case UNRECOGNIZED:
-      default: {
-        listener.onError(CallStatus.INVALID_ARGUMENT
-            .withDescription("Unknown action: " + request.getAction())
-            .toRuntimeException());
-        return;
-      }
+      default:
+        {
+          listener.onError(
+              CallStatus.INVALID_ARGUMENT
+                  .withDescription("Unknown action: " + request.getAction())
+                  .toRuntimeException());
+          return;
+        }
     }
     listener.onCompleted();
   }
 
   @Override
-  public FlightInfo getFlightInfoStatement(FlightSql.CommandStatementQuery command,
-                                           CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoStatement(
+      FlightSql.CommandStatementQuery command, CallContext context, FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(command.getQuery(), "SELECT STATEMENT");
     if (command.getTransactionId().isEmpty()) {
       String handle = "SELECT STATEMENT HANDLE";
-      FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
-          .setStatementHandle(ByteString.copyFromUtf8(handle))
-          .build();
+      FlightSql.TicketStatementQuery ticket =
+          FlightSql.TicketStatementQuery.newBuilder()
+              .setStatementHandle(ByteString.copyFromUtf8(handle))
+              .build();
       return getFlightInfoForSchema(ticket, descriptor, getQuerySchema());
     } else {
       String handle = "SELECT STATEMENT WITH TXN HANDLE";
-      FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
-          .setStatementHandle(ByteString.copyFromUtf8(handle))
-          .build();
+      FlightSql.TicketStatementQuery ticket =
+          FlightSql.TicketStatementQuery.newBuilder()
+              .setStatementHandle(ByteString.copyFromUtf8(handle))
+              .build();
       return getFlightInfoForSchema(ticket, descriptor, getQueryWithTransactionSchema());
     }
   }
 
   @Override
-  public FlightInfo getFlightInfoSubstraitPlan(FlightSql.CommandStatementSubstraitPlan command, CallContext context,
-                                               FlightDescriptor descriptor) {
-    IntegrationAssertions.assertEquals(command.getPlan().getPlan().toByteArray(),
-        FlightSqlScenario.SUBSTRAIT_PLAN_TEXT);
-    IntegrationAssertions.assertEquals(command.getPlan().getVersion(), FlightSqlScenario.SUBSTRAIT_VERSION);
-    String handle = command.getTransactionId().isEmpty() ?
-        "PLAN HANDLE" : "PLAN WITH TXN HANDLE";
-    FlightSql.TicketStatementQuery ticket = FlightSql.TicketStatementQuery.newBuilder()
-        .setStatementHandle(ByteString.copyFromUtf8(handle))
-        .build();
+  public FlightInfo getFlightInfoSubstraitPlan(
+      FlightSql.CommandStatementSubstraitPlan command,
+      CallContext context,
+      FlightDescriptor descriptor) {
+    IntegrationAssertions.assertEquals(
+        command.getPlan().getPlan().toByteArray(), FlightSqlScenario.SUBSTRAIT_PLAN_TEXT);
+    IntegrationAssertions.assertEquals(
+        command.getPlan().getVersion(), FlightSqlScenario.SUBSTRAIT_VERSION);
+    String handle = command.getTransactionId().isEmpty() ? "PLAN HANDLE" : "PLAN WITH TXN HANDLE";
+    FlightSql.TicketStatementQuery ticket =
+        FlightSql.TicketStatementQuery.newBuilder()
+            .setStatementHandle(ByteString.copyFromUtf8(handle))
+            .build();
     return getFlightInfoForSchema(ticket, descriptor, getQuerySchema());
   }
 
   @Override
-  public FlightInfo getFlightInfoPreparedStatement(FlightSql.CommandPreparedStatementQuery command,
-                                                   CallContext context,
-                                                   FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPreparedStatement(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightDescriptor descriptor) {
     String handle = command.getPreparedStatementHandle().toStringUtf8();
-    if (handle.equals("SELECT PREPARED STATEMENT HANDLE") ||
-        handle.equals("PREPARED PLAN HANDLE")) {
+    if (handle.equals("SELECT PREPARED STATEMENT HANDLE")
+        || handle.equals("PREPARED PLAN HANDLE")) {
       return getFlightInfoForSchema(command, descriptor, getQuerySchema());
-    } else if (handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE") ||
-        handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
+    } else if (handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE")
+        || handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
       return getFlightInfoForSchema(command, descriptor, getQueryWithTransactionSchema());
     }
-    throw CallStatus.INVALID_ARGUMENT.withDescription("Unknown handle: " + handle).toRuntimeException();
+    throw CallStatus.INVALID_ARGUMENT
+        .withDescription("Unknown handle: " + handle)
+        .toRuntimeException();
   }
 
   @Override
-  public SchemaResult getSchemaStatement(FlightSql.CommandStatementQuery command,
-                                         CallContext context, FlightDescriptor descriptor) {
+  public SchemaResult getSchemaStatement(
+      FlightSql.CommandStatementQuery command, CallContext context, FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(command.getQuery(), "SELECT STATEMENT");
     if (command.getTransactionId().isEmpty()) {
       return new SchemaResult(getQuerySchema());
@@ -338,34 +401,44 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public SchemaResult getSchemaPreparedStatement(FlightSql.CommandPreparedStatementQuery command, CallContext context,
-                                                 FlightDescriptor descriptor) {
+  public SchemaResult getSchemaPreparedStatement(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightDescriptor descriptor) {
     String handle = command.getPreparedStatementHandle().toStringUtf8();
-    if (handle.equals("SELECT PREPARED STATEMENT HANDLE") ||
-        handle.equals("PREPARED PLAN HANDLE")) {
+    if (handle.equals("SELECT PREPARED STATEMENT HANDLE")
+        || handle.equals("PREPARED PLAN HANDLE")) {
       return new SchemaResult(getQuerySchema());
-    } else if (handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE") ||
-        handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
+    } else if (handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE")
+        || handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
       return new SchemaResult(getQueryWithTransactionSchema());
     }
-    throw CallStatus.INVALID_ARGUMENT.withDescription("Unknown handle: " + handle).toRuntimeException();
+    throw CallStatus.INVALID_ARGUMENT
+        .withDescription("Unknown handle: " + handle)
+        .toRuntimeException();
   }
 
   @Override
-  public SchemaResult getSchemaSubstraitPlan(FlightSql.CommandStatementSubstraitPlan command, CallContext context,
-                                             FlightDescriptor descriptor) {
-    if (!Arrays.equals(command.getPlan().getPlan().toByteArray(), FlightSqlScenario.SUBSTRAIT_PLAN_TEXT)) {
+  public SchemaResult getSchemaSubstraitPlan(
+      FlightSql.CommandStatementSubstraitPlan command,
+      CallContext context,
+      FlightDescriptor descriptor) {
+    if (!Arrays.equals(
+        command.getPlan().getPlan().toByteArray(), FlightSqlScenario.SUBSTRAIT_PLAN_TEXT)) {
       throw CallStatus.INVALID_ARGUMENT
-          .withDescription(String.format("Expected plan '%s', not '%s'",
-              Arrays.toString(FlightSqlScenario.SUBSTRAIT_PLAN_TEXT),
-              Arrays.toString(command.getPlan().getPlan().toByteArray())))
+          .withDescription(
+              String.format(
+                  "Expected plan '%s', not '%s'",
+                  Arrays.toString(FlightSqlScenario.SUBSTRAIT_PLAN_TEXT),
+                  Arrays.toString(command.getPlan().getPlan().toByteArray())))
           .toRuntimeException();
     }
     if (!FlightSqlScenario.SUBSTRAIT_VERSION.equals(command.getPlan().getVersion())) {
       throw CallStatus.INVALID_ARGUMENT
-          .withDescription(String.format("Expected version '%s', not '%s'",
-              FlightSqlScenario.SUBSTRAIT_VERSION,
-              command.getPlan().getVersion()))
+          .withDescription(
+              String.format(
+                  "Expected version '%s', not '%s'",
+                  FlightSqlScenario.SUBSTRAIT_VERSION, command.getPlan().getVersion()))
           .toRuntimeException();
     }
     if (command.getTransactionId().isEmpty()) {
@@ -375,31 +448,39 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public void getStreamStatement(FlightSql.TicketStatementQuery ticket, CallContext context,
-                                 ServerStreamListener listener) {
+  public void getStreamStatement(
+      FlightSql.TicketStatementQuery ticket, CallContext context, ServerStreamListener listener) {
     final String handle = ticket.getStatementHandle().toStringUtf8();
     if (handle.equals("SELECT STATEMENT HANDLE") || handle.equals("PLAN HANDLE")) {
       putEmptyBatchToStreamListener(listener, getQuerySchema());
-    } else if (handle.equals("SELECT STATEMENT WITH TXN HANDLE") || handle.equals("PLAN WITH TXN HANDLE")) {
+    } else if (handle.equals("SELECT STATEMENT WITH TXN HANDLE")
+        || handle.equals("PLAN WITH TXN HANDLE")) {
       putEmptyBatchToStreamListener(listener, getQueryWithTransactionSchema());
     } else {
-      listener.error(CallStatus.INVALID_ARGUMENT.withDescription("Unknown handle: " + handle).toRuntimeException());
+      listener.error(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription("Unknown handle: " + handle)
+              .toRuntimeException());
     }
   }
 
   @Override
-  public void getStreamPreparedStatement(FlightSql.CommandPreparedStatementQuery command,
-                                         CallContext context, ServerStreamListener listener) {
+  public void getStreamPreparedStatement(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      ServerStreamListener listener) {
     String handle = command.getPreparedStatementHandle().toStringUtf8();
-    if (handle.equals("SELECT PREPARED STATEMENT HANDLE") || handle.equals("PREPARED PLAN HANDLE")) {
+    if (handle.equals("SELECT PREPARED STATEMENT HANDLE")
+        || handle.equals("PREPARED PLAN HANDLE")) {
       putEmptyBatchToStreamListener(listener, getQuerySchema());
-    } else if (handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE") ||
-        handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
+    } else if (handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE")
+        || handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
       putEmptyBatchToStreamListener(listener, getQueryWithTransactionSchema());
     } else {
-      listener.error(CallStatus.INVALID_ARGUMENT
-          .withDescription("Unknown handle: " + handle)
-          .toRuntimeException());
+      listener.error(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription("Unknown handle: " + handle)
+              .toRuntimeException());
     }
   }
 
@@ -417,113 +498,134 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public Runnable acceptPutStatement(FlightSql.CommandStatementUpdate command, CallContext context,
-                                     FlightStream flightStream,
-                                     StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutStatement(
+      FlightSql.CommandStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     IntegrationAssertions.assertEquals(command.getQuery(), "UPDATE STATEMENT");
-    return acceptPutReturnConstant(ackStream,
-        command.getTransactionId().isEmpty() ? FlightSqlScenario.UPDATE_STATEMENT_EXPECTED_ROWS :
-            FlightSqlScenario.UPDATE_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
+    return acceptPutReturnConstant(
+        ackStream,
+        command.getTransactionId().isEmpty()
+            ? FlightSqlScenario.UPDATE_STATEMENT_EXPECTED_ROWS
+            : FlightSqlScenario.UPDATE_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
   }
 
   @Override
-  public Runnable acceptPutSubstraitPlan(FlightSql.CommandStatementSubstraitPlan command, CallContext context,
-                                         FlightStream flightStream, StreamListener<PutResult> ackStream) {
-    IntegrationAssertions.assertEquals(command.getPlan().getPlan().toByteArray(),
-        FlightSqlScenario.SUBSTRAIT_PLAN_TEXT);
-    IntegrationAssertions.assertEquals(command.getPlan().getVersion(), FlightSqlScenario.SUBSTRAIT_VERSION);
-    return acceptPutReturnConstant(ackStream,
-        command.getTransactionId().isEmpty() ? FlightSqlScenario.UPDATE_STATEMENT_EXPECTED_ROWS :
-            FlightSqlScenario.UPDATE_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
+  public Runnable acceptPutSubstraitPlan(
+      FlightSql.CommandStatementSubstraitPlan command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
+    IntegrationAssertions.assertEquals(
+        command.getPlan().getPlan().toByteArray(), FlightSqlScenario.SUBSTRAIT_PLAN_TEXT);
+    IntegrationAssertions.assertEquals(
+        command.getPlan().getVersion(), FlightSqlScenario.SUBSTRAIT_VERSION);
+    return acceptPutReturnConstant(
+        ackStream,
+        command.getTransactionId().isEmpty()
+            ? FlightSqlScenario.UPDATE_STATEMENT_EXPECTED_ROWS
+            : FlightSqlScenario.UPDATE_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
   }
 
   @Override
-  public Runnable acceptPutPreparedStatementUpdate(FlightSql.CommandPreparedStatementUpdate command,
-                                                   CallContext context, FlightStream flightStream,
-                                                   StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutPreparedStatementUpdate(
+      FlightSql.CommandPreparedStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     final String handle = command.getPreparedStatementHandle().toStringUtf8();
-    if (handle.equals("UPDATE PREPARED STATEMENT HANDLE") ||
-        handle.equals("PREPARED PLAN HANDLE")) {
-      return acceptPutReturnConstant(ackStream, FlightSqlScenario.UPDATE_PREPARED_STATEMENT_EXPECTED_ROWS);
-    } else if (handle.equals("UPDATE PREPARED STATEMENT WITH TXN HANDLE") ||
-        handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
+    if (handle.equals("UPDATE PREPARED STATEMENT HANDLE")
+        || handle.equals("PREPARED PLAN HANDLE")) {
+      return acceptPutReturnConstant(
+          ackStream, FlightSqlScenario.UPDATE_PREPARED_STATEMENT_EXPECTED_ROWS);
+    } else if (handle.equals("UPDATE PREPARED STATEMENT WITH TXN HANDLE")
+        || handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
       return acceptPutReturnConstant(
           ackStream, FlightSqlScenario.UPDATE_PREPARED_STATEMENT_WITH_TRANSACTION_EXPECTED_ROWS);
     }
     return () -> {
-      ackStream.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription("Unknown handle: " + handle)
-          .toRuntimeException());
+      ackStream.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription("Unknown handle: " + handle)
+              .toRuntimeException());
     };
   }
 
   @Override
-  public Runnable acceptPutPreparedStatementQuery(FlightSql.CommandPreparedStatementQuery command,
-                                                  CallContext context, FlightStream flightStream,
-                                                  StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutPreparedStatementQuery(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     final String handle = command.getPreparedStatementHandle().toStringUtf8();
-    if (handle.equals("SELECT PREPARED STATEMENT HANDLE") ||
-        handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE") ||
-        handle.equals("PREPARED PLAN HANDLE") ||
-        handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
+    if (handle.equals("SELECT PREPARED STATEMENT HANDLE")
+        || handle.equals("SELECT PREPARED STATEMENT WITH TXN HANDLE")
+        || handle.equals("PREPARED PLAN HANDLE")
+        || handle.equals("PREPARED PLAN WITH TXN HANDLE")) {
       IntegrationAssertions.assertEquals(getQuerySchema(), flightStream.getSchema());
       return ackStream::onCompleted;
     }
     return () -> {
-      ackStream.onError(CallStatus.INVALID_ARGUMENT
-          .withDescription("Unknown handle: " + handle)
-          .toRuntimeException());
+      ackStream.onError(
+          CallStatus.INVALID_ARGUMENT
+              .withDescription("Unknown handle: " + handle)
+              .toRuntimeException());
     };
   }
 
   @Override
-  public FlightInfo getFlightInfoSqlInfo(FlightSql.CommandGetSqlInfo request, CallContext context,
-                                         FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSqlInfo(
+      FlightSql.CommandGetSqlInfo request, CallContext context, FlightDescriptor descriptor) {
     if (request.getInfoCount() == 2) {
       // Integration test for the protocol messages
-      IntegrationAssertions.assertEquals(request.getInfo(0),
-          FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE);
-      IntegrationAssertions.assertEquals(request.getInfo(1),
-          FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY_VALUE);
+      IntegrationAssertions.assertEquals(
+          request.getInfo(0), FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE);
+      IntegrationAssertions.assertEquals(
+          request.getInfo(1), FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY_VALUE);
     }
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_SQL_INFO_SCHEMA);
   }
 
   @Override
-  public void getStreamSqlInfo(FlightSql.CommandGetSqlInfo command, CallContext context,
-                               ServerStreamListener listener) {
+  public void getStreamSqlInfo(
+      FlightSql.CommandGetSqlInfo command, CallContext context, ServerStreamListener listener) {
     if (command.getInfoCount() == 2) {
       // Integration test for the protocol messages
       putEmptyBatchToStreamListener(listener, Schemas.GET_SQL_INFO_SCHEMA);
       return;
     }
-    SqlInfoBuilder sqlInfoBuilder = new SqlInfoBuilder()
-        .withFlightSqlServerSql(false)
-        .withFlightSqlServerSubstrait(true)
-        .withFlightSqlServerSubstraitMinVersion("min_version")
-        .withFlightSqlServerSubstraitMaxVersion("max_version")
-        .withFlightSqlServerTransaction(FlightSql.SqlSupportedTransaction.SQL_SUPPORTED_TRANSACTION_SAVEPOINT)
-        .withFlightSqlServerCancel(true)
-        .withFlightSqlServerStatementTimeout(42)
-        .withFlightSqlServerTransactionTimeout(7);
+    SqlInfoBuilder sqlInfoBuilder =
+        new SqlInfoBuilder()
+            .withFlightSqlServerSql(false)
+            .withFlightSqlServerSubstrait(true)
+            .withFlightSqlServerSubstraitMinVersion("min_version")
+            .withFlightSqlServerSubstraitMaxVersion("max_version")
+            .withFlightSqlServerTransaction(
+                FlightSql.SqlSupportedTransaction.SQL_SUPPORTED_TRANSACTION_SAVEPOINT)
+            .withFlightSqlServerCancel(true)
+            .withFlightSqlServerStatementTimeout(42)
+            .withFlightSqlServerTransactionTimeout(7);
     sqlInfoBuilder.send(command.getInfoList(), listener);
   }
 
   @Override
-  public void getStreamTypeInfo(FlightSql.CommandGetXdbcTypeInfo request,
-                                CallContext context, ServerStreamListener listener) {
+  public void getStreamTypeInfo(
+      FlightSql.CommandGetXdbcTypeInfo request,
+      CallContext context,
+      ServerStreamListener listener) {
     putEmptyBatchToStreamListener(listener, Schemas.GET_TYPE_INFO_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoTypeInfo(FlightSql.CommandGetXdbcTypeInfo request, CallContext context,
-                                          FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTypeInfo(
+      FlightSql.CommandGetXdbcTypeInfo request, CallContext context, FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_TYPE_INFO_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoCatalogs(FlightSql.CommandGetCatalogs request, CallContext context,
-                                          FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCatalogs(
+      FlightSql.CommandGetCatalogs request, CallContext context, FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_CATALOGS_SCHEMA);
   }
 
@@ -541,27 +643,27 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public FlightInfo getFlightInfoSchemas(FlightSql.CommandGetDbSchemas request, CallContext context,
-                                         FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSchemas(
+      FlightSql.CommandGetDbSchemas request, CallContext context, FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(request.getCatalog(), "catalog");
-    IntegrationAssertions.assertEquals(request.getDbSchemaFilterPattern(),
-        "db_schema_filter_pattern");
+    IntegrationAssertions.assertEquals(
+        request.getDbSchemaFilterPattern(), "db_schema_filter_pattern");
 
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_SCHEMAS_SCHEMA);
   }
 
   @Override
-  public void getStreamSchemas(FlightSql.CommandGetDbSchemas command, CallContext context,
-                               ServerStreamListener listener) {
+  public void getStreamSchemas(
+      FlightSql.CommandGetDbSchemas command, CallContext context, ServerStreamListener listener) {
     putEmptyBatchToStreamListener(listener, Schemas.GET_SCHEMAS_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoTables(FlightSql.CommandGetTables request, CallContext context,
-                                        FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTables(
+      FlightSql.CommandGetTables request, CallContext context, FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(request.getCatalog(), "catalog");
-    IntegrationAssertions.assertEquals(request.getDbSchemaFilterPattern(),
-        "db_schema_filter_pattern");
+    IntegrationAssertions.assertEquals(
+        request.getDbSchemaFilterPattern(), "db_schema_filter_pattern");
     IntegrationAssertions.assertEquals(request.getTableNameFilterPattern(), "table_filter_pattern");
     IntegrationAssertions.assertEquals(request.getTableTypesCount(), 2);
     IntegrationAssertions.assertEquals(request.getTableTypes(0), "table");
@@ -571,14 +673,14 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public void getStreamTables(FlightSql.CommandGetTables command, CallContext context,
-                              ServerStreamListener listener) {
+  public void getStreamTables(
+      FlightSql.CommandGetTables command, CallContext context, ServerStreamListener listener) {
     putEmptyBatchToStreamListener(listener, Schemas.GET_TABLES_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoTableTypes(FlightSql.CommandGetTableTypes request,
-                                            CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTableTypes(
+      FlightSql.CommandGetTableTypes request, CallContext context, FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_TABLE_TYPES_SCHEMA);
   }
 
@@ -588,8 +690,8 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public FlightInfo getFlightInfoPrimaryKeys(FlightSql.CommandGetPrimaryKeys request,
-                                             CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPrimaryKeys(
+      FlightSql.CommandGetPrimaryKeys request, CallContext context, FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(request.getCatalog(), "catalog");
     IntegrationAssertions.assertEquals(request.getDbSchema(), "db_schema");
     IntegrationAssertions.assertEquals(request.getTable(), "table");
@@ -598,14 +700,14 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public void getStreamPrimaryKeys(FlightSql.CommandGetPrimaryKeys command, CallContext context,
-                                   ServerStreamListener listener) {
+  public void getStreamPrimaryKeys(
+      FlightSql.CommandGetPrimaryKeys command, CallContext context, ServerStreamListener listener) {
     putEmptyBatchToStreamListener(listener, Schemas.GET_PRIMARY_KEYS_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoExportedKeys(FlightSql.CommandGetExportedKeys request,
-                                              CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoExportedKeys(
+      FlightSql.CommandGetExportedKeys request, CallContext context, FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(request.getCatalog(), "catalog");
     IntegrationAssertions.assertEquals(request.getDbSchema(), "db_schema");
     IntegrationAssertions.assertEquals(request.getTable(), "table");
@@ -614,8 +716,8 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public FlightInfo getFlightInfoImportedKeys(FlightSql.CommandGetImportedKeys request,
-                                              CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoImportedKeys(
+      FlightSql.CommandGetImportedKeys request, CallContext context, FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(request.getCatalog(), "catalog");
     IntegrationAssertions.assertEquals(request.getDbSchema(), "db_schema");
     IntegrationAssertions.assertEquals(request.getTable(), "table");
@@ -624,8 +726,10 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public FlightInfo getFlightInfoCrossReference(FlightSql.CommandGetCrossReference request,
-                                                CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCrossReference(
+      FlightSql.CommandGetCrossReference request,
+      CallContext context,
+      FlightDescriptor descriptor) {
     IntegrationAssertions.assertEquals(request.getPkCatalog(), "pk_catalog");
     IntegrationAssertions.assertEquals(request.getPkDbSchema(), "pk_db_schema");
     IntegrationAssertions.assertEquals(request.getPkTable(), "pk_table");
@@ -637,37 +741,38 @@ public class FlightSqlScenarioProducer implements FlightSqlProducer {
   }
 
   @Override
-  public void getStreamExportedKeys(FlightSql.CommandGetExportedKeys command, CallContext context,
-                                    ServerStreamListener listener) {
+  public void getStreamExportedKeys(
+      FlightSql.CommandGetExportedKeys command,
+      CallContext context,
+      ServerStreamListener listener) {
     putEmptyBatchToStreamListener(listener, Schemas.GET_EXPORTED_KEYS_SCHEMA);
   }
 
   @Override
-  public void getStreamImportedKeys(FlightSql.CommandGetImportedKeys command, CallContext context,
-                                    ServerStreamListener listener) {
+  public void getStreamImportedKeys(
+      FlightSql.CommandGetImportedKeys command,
+      CallContext context,
+      ServerStreamListener listener) {
     putEmptyBatchToStreamListener(listener, Schemas.GET_IMPORTED_KEYS_SCHEMA);
   }
 
   @Override
-  public void getStreamCrossReference(FlightSql.CommandGetCrossReference command,
-                                      CallContext context, ServerStreamListener listener) {
+  public void getStreamCrossReference(
+      FlightSql.CommandGetCrossReference command,
+      CallContext context,
+      ServerStreamListener listener) {
     putEmptyBatchToStreamListener(listener, Schemas.GET_CROSS_REFERENCE_SCHEMA);
   }
 
   @Override
-  public void close() throws Exception {
-
-  }
+  public void close() throws Exception {}
 
   @Override
-  public void listFlights(CallContext context, Criteria criteria,
-                          StreamListener<FlightInfo> listener) {
+  public void listFlights(
+      CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {}
 
-  }
-
-  private <T extends Message> FlightInfo getFlightInfoForSchema(final T request,
-                                                                final FlightDescriptor descriptor,
-                                                                final Schema schema) {
+  private <T extends Message> FlightInfo getFlightInfoForSchema(
+      final T request, final FlightDescriptor descriptor, final Schema schema) {
     final Ticket ticket = new Ticket(Any.pack(request).toByteArray());
     final List<FlightEndpoint> endpoints = Collections.singletonList(new FlightEndpoint(ticket));
 

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationAssertions.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationAssertions.java
@@ -14,20 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Objects;
-
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightRuntimeException;
 
-/**
- * Utility methods to implement integration tests without using JUnit assertions.
- */
+/** Utility methods to implement integration tests without using JUnit assertions. */
 final class IntegrationAssertions {
 
   /**
@@ -46,42 +42,36 @@ final class IntegrationAssertions {
       if (clazz.isInstance(t)) {
         return (T) t;
       }
-      throw new AssertionError("Expected exception of class " + clazz + " but got " + t.getClass(), t);
+      throw new AssertionError(
+          "Expected exception of class " + clazz + " but got " + t.getClass(), t);
     }
     throw new AssertionError("Expected exception of class " + clazz + " but did not throw.");
   }
 
-  /**
-   * Assert that the two (non-array) objects are equal.
-   */
+  /** Assert that the two (non-array) objects are equal. */
   static void assertEquals(Object expected, Object actual) {
     if (!Objects.equals(expected, actual)) {
       throw new AssertionError("Expected:\n" + expected + "\nbut got:\n" + actual);
     }
   }
 
-  /**
-   * Assert that the two arrays are equal.
-   */
+  /** Assert that the two arrays are equal. */
   static void assertEquals(byte[] expected, byte[] actual) {
     if (!Arrays.equals(expected, actual)) {
       throw new AssertionError(
-          String.format("Expected:\n%s\nbut got:\n%s", Arrays.toString(expected), Arrays.toString(actual)));
+          String.format(
+              "Expected:\n%s\nbut got:\n%s", Arrays.toString(expected), Arrays.toString(actual)));
     }
   }
 
-  /**
-   * Assert that the value is false, using the given message as an error otherwise.
-   */
+  /** Assert that the value is false, using the given message as an error otherwise. */
   static void assertFalse(String message, boolean value) {
     if (value) {
       throw new AssertionError("Expected false: " + message);
     }
   }
 
-  /**
-   * Assert that the value is true, using the given message as an error otherwise.
-   */
+  /** Assert that the value is true, using the given message as an error otherwise. */
   static void assertTrue(String message, boolean value) {
     if (!value) {
       throw new AssertionError("Expected true: " + message);
@@ -94,22 +84,18 @@ final class IntegrationAssertions {
     }
   }
 
-  /**
-   * Convert a throwable into a FlightRuntimeException with error details, for debugging.
-   */
+  /** Convert a throwable into a FlightRuntimeException with error details, for debugging. */
   static FlightRuntimeException toFlightRuntimeException(Throwable t) {
     final StringWriter stringWriter = new StringWriter();
     final PrintWriter writer = new PrintWriter(stringWriter);
     t.printStackTrace(writer);
     return CallStatus.UNKNOWN
-            .withCause(t)
-            .withDescription("Unknown error: " + t + "\n. Stack trace:\n" + stringWriter.toString())
-            .toRuntimeException();
+        .withCause(t)
+        .withDescription("Unknown error: " + t + "\n. Stack trace:\n" + stringWriter.toString())
+        .toRuntimeException();
   }
 
-  /**
-   * An interface used with {@link #assertThrows(Class, AssertThrows)}.
-   */
+  /** An interface used with {@link #assertThrows(Class, AssertThrows)}. */
   @FunctionalInterface
   interface AssertThrows {
 

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationProducer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationProducer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.ByteBuffer;
@@ -27,7 +26,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
@@ -81,10 +79,14 @@ public class IntegrationProducer extends NoOpFlightProducer implements AutoClose
   @Override
   public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
     try {
-      FlightDescriptor descriptor = FlightDescriptor.deserialize(ByteBuffer.wrap(ticket.getBytes()));
+      FlightDescriptor descriptor =
+          FlightDescriptor.deserialize(ByteBuffer.wrap(ticket.getBytes()));
       Dataset dataset = datasets.get(descriptor);
       if (dataset == null) {
-        listener.error(CallStatus.NOT_FOUND.withDescription("Unknown ticket: " + descriptor).toRuntimeException());
+        listener.error(
+            CallStatus.NOT_FOUND
+                .withDescription("Unknown ticket: " + descriptor)
+                .toRuntimeException());
         return;
       }
       dataset.streamTo(allocator, listener);
@@ -97,14 +99,18 @@ public class IntegrationProducer extends NoOpFlightProducer implements AutoClose
   public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
     Dataset h = datasets.get(descriptor);
     if (h == null) {
-      throw CallStatus.NOT_FOUND.withDescription("Unknown descriptor: " + descriptor).toRuntimeException();
+      throw CallStatus.NOT_FOUND
+          .withDescription("Unknown descriptor: " + descriptor)
+          .toRuntimeException();
     }
     return h.getFlightInfo(location);
   }
 
   @Override
-  public Runnable acceptPut(CallContext context,
-      final FlightStream flightStream, final StreamListener<PutResult> ackStream) {
+  public Runnable acceptPut(
+      CallContext context,
+      final FlightStream flightStream,
+      final StreamListener<PutResult> ackStream) {
     return () -> {
       List<ArrowRecordBatch> batches = new ArrayList<>();
       try {
@@ -115,7 +121,8 @@ public class IntegrationProducer extends NoOpFlightProducer implements AutoClose
             batches.add(unloader.getRecordBatch());
           }
           // Closing the stream will release the dictionaries, take ownership
-          final Dataset dataset = new Dataset(
+          final Dataset dataset =
+              new Dataset(
                   flightStream.getDescriptor(),
                   flightStream.getSchema(),
                   flightStream.takeDictionaryOwnership(),
@@ -143,10 +150,11 @@ public class IntegrationProducer extends NoOpFlightProducer implements AutoClose
     private final DictionaryProvider dictionaryProvider;
     private final List<ArrowRecordBatch> batches;
 
-    private Dataset(FlightDescriptor descriptor,
-                    Schema schema,
-                    DictionaryProvider dictionaryProvider,
-                    List<ArrowRecordBatch> batches) {
+    private Dataset(
+        FlightDescriptor descriptor,
+        Schema schema,
+        DictionaryProvider dictionaryProvider,
+        List<ArrowRecordBatch> batches) {
       this.descriptor = descriptor;
       this.schema = schema;
       this.dictionaryProvider = dictionaryProvider;
@@ -157,20 +165,20 @@ public class IntegrationProducer extends NoOpFlightProducer implements AutoClose
       ByteBuffer serializedDescriptor = descriptor.serialize();
       byte[] descriptorBytes = new byte[serializedDescriptor.remaining()];
       serializedDescriptor.get(descriptorBytes);
-      final List<FlightEndpoint> endpoints = Collections.singletonList(
-              new FlightEndpoint(new Ticket(descriptorBytes), location));
+      final List<FlightEndpoint> endpoints =
+          Collections.singletonList(new FlightEndpoint(new Ticket(descriptorBytes), location));
       return new FlightInfo(
-              messageFormatSchema(),
-              descriptor,
-              endpoints,
-              batches.stream().mapToLong(ArrowRecordBatch::computeBodyLength).sum(),
-              batches.stream().mapToInt(ArrowRecordBatch::getLength).sum());
+          messageFormatSchema(),
+          descriptor,
+          endpoints,
+          batches.stream().mapToLong(ArrowRecordBatch::computeBodyLength).sum(),
+          batches.stream().mapToInt(ArrowRecordBatch::getLength).sum());
     }
 
     private Schema messageFormatSchema() {
       final Set<Long> dictionaryIdsUsed = new HashSet<>();
-      final List<Field> messageFormatFields = schema.getFields()
-              .stream()
+      final List<Field> messageFormatFields =
+          schema.getFields().stream()
               .map(f -> DictionaryUtility.toMessageFormat(f, dictionaryProvider, dictionaryIdsUsed))
               .collect(Collectors.toList());
       return new Schema(messageFormatFields, schema.getCustomMetadata());

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestClient.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestClient.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
@@ -23,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
 import org.apache.arrow.flight.AsyncPutListener;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
@@ -49,11 +47,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-/**
- * A Flight client for integration testing.
- */
+/** A Flight client for integration testing. */
 class IntegrationTestClient {
-  private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(IntegrationTestClient.class);
+  private static final org.slf4j.Logger LOGGER =
+      org.slf4j.LoggerFactory.getLogger(IntegrationTestClient.class);
   private final Options options;
 
   private IntegrationTestClient() {
@@ -92,10 +89,11 @@ class IntegrationTestClient {
 
     final Location defaultLocation = Location.forGrpcInsecure(host, port);
     try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-         final FlightClient client = FlightClient.builder(allocator, defaultLocation).build()) {
+        final FlightClient client = FlightClient.builder(allocator, defaultLocation).build()) {
 
       if (cmd.hasOption("scenario")) {
-        Scenarios.getScenario(cmd.getOptionValue("scenario")).client(allocator, defaultLocation, client);
+        Scenarios.getScenario(cmd.getOptionValue("scenario"))
+            .client(allocator, defaultLocation, client);
       } else {
         final String inputPath = cmd.getOptionValue("j");
         testStream(allocator, client, inputPath);
@@ -110,23 +108,30 @@ class IntegrationTestClient {
     // 1. Read data from JSON and upload to server.
     FlightDescriptor descriptor = FlightDescriptor.path(inputPath);
     try (JsonFileReader reader = new JsonFileReader(new File(inputPath), allocator);
-         VectorSchemaRoot root = VectorSchemaRoot.create(reader.start(), allocator)) {
-      FlightClient.ClientStreamListener stream = client.startPut(descriptor, root, reader,
-          new AsyncPutListener() {
-            int counter = 0;
+        VectorSchemaRoot root = VectorSchemaRoot.create(reader.start(), allocator)) {
+      FlightClient.ClientStreamListener stream =
+          client.startPut(
+              descriptor,
+              root,
+              reader,
+              new AsyncPutListener() {
+                int counter = 0;
 
-            @Override
-            public void onNext(PutResult val) {
-              final byte[] metadataRaw = new byte[checkedCastToInt(val.getApplicationMetadata().readableBytes())];
-              val.getApplicationMetadata().readBytes(metadataRaw);
-              final String metadata = new String(metadataRaw, StandardCharsets.UTF_8);
-              if (!Integer.toString(counter).equals(metadata)) {
-                throw new RuntimeException(
-                    String.format("Invalid ACK from server. Expected '%d' but got '%s'.", counter, metadata));
-              }
-              counter++;
-            }
-          });
+                @Override
+                public void onNext(PutResult val) {
+                  final byte[] metadataRaw =
+                      new byte[checkedCastToInt(val.getApplicationMetadata().readableBytes())];
+                  val.getApplicationMetadata().readBytes(metadataRaw);
+                  final String metadata = new String(metadataRaw, StandardCharsets.UTF_8);
+                  if (!Integer.toString(counter).equals(metadata)) {
+                    throw new RuntimeException(
+                        String.format(
+                            "Invalid ACK from server. Expected '%d' but got '%s'.",
+                            counter, metadata));
+                  }
+                  counter++;
+                }
+              });
       int counter = 0;
       while (reader.read(root)) {
         final byte[] rawMetadata = Integer.toString(counter).getBytes(StandardCharsets.UTF_8);
@@ -168,11 +173,12 @@ class IntegrationTestClient {
     }
   }
 
-  private static void testTicket(BufferAllocator allocator, FlightClient readClient, Ticket ticket, String inputPath) {
+  private static void testTicket(
+      BufferAllocator allocator, FlightClient readClient, Ticket ticket, String inputPath) {
     try (FlightStream stream = readClient.getStream(ticket);
-         VectorSchemaRoot root = stream.getRoot();
-         VectorSchemaRoot downloadedRoot = VectorSchemaRoot.create(root.getSchema(), allocator);
-         JsonFileReader reader = new JsonFileReader(new File(inputPath), allocator)) {
+        VectorSchemaRoot root = stream.getRoot();
+        VectorSchemaRoot downloadedRoot = VectorSchemaRoot.create(root.getSchema(), allocator);
+        JsonFileReader reader = new JsonFileReader(new File(inputPath), allocator)) {
       VectorLoader loader = new VectorLoader(downloadedRoot);
       VectorUnloader unloader = new VectorUnloader(root);
 

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestServer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestServer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import org.apache.arrow.flight.FlightServer;
@@ -28,11 +27,10 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-/**
- * Flight server for integration testing.
- */
+/** Flight server for integration testing. */
 class IntegrationTestServer {
-  private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(IntegrationTestServer.class);
+  private static final org.slf4j.Logger LOGGER =
+      org.slf4j.LoggerFactory.getLogger(IntegrationTestServer.class);
   private final Options options;
 
   private IntegrationTestServer() {
@@ -48,7 +46,8 @@ class IntegrationTestServer {
     final Location location = Location.forGrpcInsecure("localhost", port);
 
     final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-    final FlightServer.Builder builder = FlightServer.builder().allocator(allocator).location(location);
+    final FlightServer.Builder builder =
+        FlightServer.builder().allocator(allocator).location(location);
 
     final FlightServer server;
     if (cmd.hasOption("scenario")) {
@@ -64,14 +63,17 @@ class IntegrationTestServer {
     // Print out message for integration test script
     System.out.println("Server listening on localhost:" + server.getPort());
 
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      try {
-        System.out.println("\nExiting...");
-        AutoCloseables.close(server, allocator);
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
-    }));
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    System.out.println("\nExiting...");
+                    AutoCloseables.close(server, allocator);
+                  } catch (Exception e) {
+                    e.printStackTrace();
+                  }
+                }));
 
     server.awaitTermination();
   }
@@ -92,5 +94,4 @@ class IntegrationTestServer {
     LOGGER.error(message, e);
     System.exit(1);
   }
-
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/LocationReuseConnectionScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/LocationReuseConnectionScenario.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
@@ -41,13 +39,13 @@ public class LocationReuseConnectionScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) throws Exception {
-  }
+  public void buildServer(FlightServer.Builder builder) throws Exception {}
 
   @Override
   public void client(BufferAllocator allocator, Location location, FlightClient client)
       throws Exception {
-    final FlightInfo info = client.getInfo(FlightDescriptor.command("reuse".getBytes(StandardCharsets.UTF_8)));
+    final FlightInfo info =
+        client.getInfo(FlightDescriptor.command("reuse".getBytes(StandardCharsets.UTF_8)));
     IntegrationAssertions.assertEquals(1, info.getEndpoints().size());
     IntegrationAssertions.assertEquals(1, info.getEndpoints().get(0).getLocations().size());
     Location actual = info.getEndpoints().get(0).getLocations().get(0);
@@ -57,7 +55,8 @@ public class LocationReuseConnectionScenario implements Scenario {
   private static class ReuseConnectionProducer extends NoOpFlightProducer {
     @Override
     public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
-      List<FlightEndpoint> endpoints = Collections.singletonList(
+      List<FlightEndpoint> endpoints =
+          Collections.singletonList(
               new FlightEndpoint(new Ticket(new byte[0]), Location.reuseConnection()));
       return new FlightInfo(
           new Schema(Collections.emptyList()), descriptor, endpoints, /*bytes*/ -1, /*records*/ -1);

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/MiddlewareScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/MiddlewareScenario.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
-
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallInfo;
 import org.apache.arrow.flight.CallStatus;
@@ -39,9 +37,9 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 /**
- * Test an edge case in middleware: gRPC-Java consolidates headers and trailers if a call fails immediately. On the
- * gRPC implementation side, we need to watch for this, or else we'll have a call with "no headers" if we only look
- * for headers.
+ * Test an edge case in middleware: gRPC-Java consolidates headers and trailers if a call fails
+ * immediately. On the gRPC implementation side, we need to watch for this, or else we'll have a
+ * call with "no headers" if we only look for headers.
  */
 final class MiddlewareScenario implements Scenario {
 
@@ -56,7 +54,8 @@ final class MiddlewareScenario implements Scenario {
       public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
         if (descriptor.isCommand()) {
           if (Arrays.equals(COMMAND_SUCCESS, descriptor.getCommand())) {
-            return new FlightInfo(new Schema(Collections.emptyList()), descriptor, Collections.emptyList(), -1, -1);
+            return new FlightInfo(
+                new Schema(Collections.emptyList()), descriptor, Collections.emptyList(), -1, -1);
           }
         }
         throw CallStatus.UNIMPLEMENTED.toRuntimeException();
@@ -66,22 +65,26 @@ final class MiddlewareScenario implements Scenario {
 
   @Override
   public void buildServer(FlightServer.Builder builder) {
-    builder.middleware(FlightServerMiddleware.Key.of("test"), new InjectingServerMiddleware.Factory());
+    builder.middleware(
+        FlightServerMiddleware.Key.of("test"), new InjectingServerMiddleware.Factory());
   }
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient ignored) throws Exception {
+  public void client(BufferAllocator allocator, Location location, FlightClient ignored)
+      throws Exception {
     final ExtractingClientMiddleware.Factory factory = new ExtractingClientMiddleware.Factory();
-    try (final FlightClient client = FlightClient.builder(allocator, location).intercept(factory).build()) {
+    try (final FlightClient client =
+        FlightClient.builder(allocator, location).intercept(factory).build()) {
       // Should fail immediately
-      IntegrationAssertions.assertThrows(FlightRuntimeException.class,
+      IntegrationAssertions.assertThrows(
+          FlightRuntimeException.class,
           () -> client.getInfo(FlightDescriptor.command(new byte[0])));
       if (!EXPECTED_HEADER_VALUE.equals(factory.extractedHeader)) {
         throw new AssertionError(
-            "Expected to extract the header value '" +
-                EXPECTED_HEADER_VALUE +
-                "', but found: " +
-                factory.extractedHeader);
+            "Expected to extract the header value '"
+                + EXPECTED_HEADER_VALUE
+                + "', but found: "
+                + factory.extractedHeader);
       }
 
       // Should not fail
@@ -89,10 +92,10 @@ final class MiddlewareScenario implements Scenario {
       client.getInfo(FlightDescriptor.command(COMMAND_SUCCESS));
       if (!EXPECTED_HEADER_VALUE.equals(factory.extractedHeader)) {
         throw new AssertionError(
-            "Expected to extract the header value '" +
-                EXPECTED_HEADER_VALUE +
-                "', but found: " +
-                factory.extractedHeader);
+            "Expected to extract the header value '"
+                + EXPECTED_HEADER_VALUE
+                + "', but found: "
+                + factory.extractedHeader);
       }
     }
   }
@@ -112,19 +115,17 @@ final class MiddlewareScenario implements Scenario {
     }
 
     @Override
-    public void onCallCompleted(CallStatus status) {
-    }
+    public void onCallCompleted(CallStatus status) {}
 
     @Override
-    public void onCallErrored(Throwable err) {
-    }
+    public void onCallErrored(Throwable err) {}
 
     /** The factory for the server middleware. */
     static class Factory implements FlightServerMiddleware.Factory<InjectingServerMiddleware> {
 
       @Override
-      public InjectingServerMiddleware onCallStarted(CallInfo info, CallHeaders incomingHeaders,
-          RequestContext context) {
+      public InjectingServerMiddleware onCallStarted(
+          CallInfo info, CallHeaders incomingHeaders, RequestContext context) {
         String incoming = incomingHeaders.get(HEADER);
         return new InjectingServerMiddleware(incoming == null ? "" : incoming);
       }
@@ -151,8 +152,7 @@ final class MiddlewareScenario implements Scenario {
     }
 
     @Override
-    public void onCallCompleted(CallStatus status) {
-    }
+    public void onCallCompleted(CallStatus status) {}
 
     /** The factory for the client middleware. */
     static class Factory implements FlightClientMiddleware.Factory {

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/OrderedScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/OrderedScenario.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
@@ -22,7 +21,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
@@ -55,8 +53,7 @@ public class OrderedScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) throws Exception {
-  }
+  public void buildServer(FlightServer.Builder builder) throws Exception {}
 
   @Override
   public void client(BufferAllocator allocator, Location location, FlightClient client)
@@ -125,7 +122,8 @@ public class OrderedScenario implements Scenario {
           listener.error(
               CallStatus.INVALID_ARGUMENT
                   .withDescription(
-                      "Could not find flight: " + new String(ticket.getBytes(), StandardCharsets.UTF_8))
+                      "Could not find flight: "
+                          + new String(ticket.getBytes(), StandardCharsets.UTF_8))
                   .toRuntimeException());
           return;
         }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/PollFlightInfoProducer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/PollFlightInfoProducer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
@@ -23,7 +22,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
 import org.apache.arrow.flight.FlightInfo;
@@ -40,17 +38,22 @@ class PollFlightInfoProducer extends NoOpFlightProducer {
 
   @Override
   public PollInfo pollFlightInfo(CallContext context, FlightDescriptor descriptor) {
-    Schema schema = new Schema(
-        Collections.singletonList(Field.notNullable("number", Types.MinorType.UINT4.getType())));
-    List<FlightEndpoint> endpoints = Collections.singletonList(
-        new FlightEndpoint(
-            new Ticket("long-running query".getBytes(StandardCharsets.UTF_8))));
-    FlightInfo info = new FlightInfo(schema, descriptor, endpoints, -1, -1 );
+    Schema schema =
+        new Schema(
+            Collections.singletonList(
+                Field.notNullable("number", Types.MinorType.UINT4.getType())));
+    List<FlightEndpoint> endpoints =
+        Collections.singletonList(
+            new FlightEndpoint(new Ticket("long-running query".getBytes(StandardCharsets.UTF_8))));
+    FlightInfo info = new FlightInfo(schema, descriptor, endpoints, -1, -1);
     if (descriptor.isCommand() && Arrays.equals(descriptor.getCommand(), POLL_DESCRIPTOR)) {
       return new PollInfo(info, null, 1.0, null);
     } else {
       return new PollInfo(
-          info, FlightDescriptor.command(POLL_DESCRIPTOR), 0.1, Instant.now().plus(10, ChronoUnit.SECONDS));
+          info,
+          FlightDescriptor.command(POLL_DESCRIPTOR),
+          0.1,
+          Instant.now().plus(10, ChronoUnit.SECONDS));
     }
   }
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/PollFlightInfoScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/PollFlightInfoScenario.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightProducer;
@@ -36,27 +34,31 @@ final class PollFlightInfoScenario implements Scenario {
   }
 
   @Override
-  public void buildServer(FlightServer.Builder builder) throws Exception {
-  }
+  public void buildServer(FlightServer.Builder builder) throws Exception {}
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient client) throws Exception {
-    PollInfo info = client.pollInfo(FlightDescriptor.command("heavy query".getBytes(StandardCharsets.UTF_8)));
+  public void client(BufferAllocator allocator, Location location, FlightClient client)
+      throws Exception {
+    PollInfo info =
+        client.pollInfo(FlightDescriptor.command("heavy query".getBytes(StandardCharsets.UTF_8)));
     IntegrationAssertions.assertNotNull(info.getFlightInfo());
     Optional<Double> progress = info.getProgress();
     IntegrationAssertions.assertTrue("progress is missing", progress.isPresent());
-    IntegrationAssertions.assertTrue("progress is invalid", progress.get() >= 0.0 && progress.get() <= 1.0);
+    IntegrationAssertions.assertTrue(
+        "progress is invalid", progress.get() >= 0.0 && progress.get() <= 1.0);
     IntegrationAssertions.assertTrue("expiration is missing", info.getExpirationTime().isPresent());
-    IntegrationAssertions.assertTrue("descriptor is missing",
-        info.getFlightDescriptor().isPresent());
+    IntegrationAssertions.assertTrue(
+        "descriptor is missing", info.getFlightDescriptor().isPresent());
 
     info = client.pollInfo(info.getFlightDescriptor().get());
     IntegrationAssertions.assertNotNull(info.getFlightInfo());
     progress = info.getProgress();
     IntegrationAssertions.assertTrue("progress is missing in finished query", progress.isPresent());
-    IntegrationAssertions.assertTrue("progress isn't 1.0 in finished query",
-        Math.abs(progress.get() - 1.0) < Math.ulp(1.0));
-    IntegrationAssertions.assertFalse("expiration is set in finished query", info.getExpirationTime().isPresent());
-    IntegrationAssertions.assertFalse("descriptor is set in finished query", info.getFlightDescriptor().isPresent());
+    IntegrationAssertions.assertTrue(
+        "progress isn't 1.0 in finished query", Math.abs(progress.get() - 1.0) < Math.ulp(1.0));
+    IntegrationAssertions.assertFalse(
+        "expiration is set in finished query", info.getExpirationTime().isPresent());
+    IntegrationAssertions.assertFalse(
+        "descriptor is set in finished query", info.getFlightDescriptor().isPresent());
   }
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/Scenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/Scenario.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import org.apache.arrow.flight.FlightClient;
@@ -23,23 +22,15 @@ import org.apache.arrow.flight.FlightServer;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.memory.BufferAllocator;
 
-/**
- * A particular scenario in integration testing.
- */
+/** A particular scenario in integration testing. */
 interface Scenario {
 
-  /**
-   * Construct the FlightProducer for a server in this scenario.
-   */
+  /** Construct the FlightProducer for a server in this scenario. */
   FlightProducer producer(BufferAllocator allocator, Location location) throws Exception;
 
-  /**
-   * Set any other server options.
-   */
+  /** Set any other server options. */
   void buildServer(FlightServer.Builder builder) throws Exception;
 
-  /**
-   * Run as the client in the scenario.
-   */
+  /** Run as the client in the scenario. */
   void client(BufferAllocator allocator, Location location, FlightClient client) throws Exception;
 }

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/Scenarios.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/Scenarios.java
@@ -14,23 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightServer;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 
-/**
- * Scenarios for integration testing.
- */
+/** Scenarios for integration testing. */
 final class Scenarios {
 
   private static Scenarios INSTANCE;
@@ -40,8 +36,10 @@ final class Scenarios {
   private Scenarios() {
     scenarios = new TreeMap<>();
     scenarios.put("auth:basic_proto", AuthBasicProtoScenario::new);
-    scenarios.put("expiration_time:cancel_flight_info", ExpirationTimeCancelFlightInfoScenario::new);
-    scenarios.put("expiration_time:renew_flight_endpoint", ExpirationTimeRenewFlightEndpointScenario::new);
+    scenarios.put(
+        "expiration_time:cancel_flight_info", ExpirationTimeCancelFlightInfoScenario::new);
+    scenarios.put(
+        "expiration_time:renew_flight_endpoint", ExpirationTimeRenewFlightEndpointScenario::new);
     scenarios.put("expiration_time:do_get", ExpirationTimeDoGetScenario::new);
     scenarios.put("expiration_time:list_actions", ExpirationTimeListActionsScenario::new);
     scenarios.put("location:reuse_connection", LocationReuseConnectionScenario::new);
@@ -78,8 +76,8 @@ final class Scenarios {
       System.out.println("Running test scenario: " + entry.getKey());
       final Scenario scenario = entry.getValue().get();
       try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE)) {
-        final FlightServer.Builder builder = FlightServer
-            .builder(allocator, location, scenario.producer(allocator, location));
+        final FlightServer.Builder builder =
+            FlightServer.builder(allocator, location, scenario.producer(allocator, location));
         scenario.buildServer(builder);
         try (final FlightServer server = builder.build()) {
           server.start();

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/SessionOptionsProducer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/SessionOptionsProducer.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.arrow.flight.CloseSessionRequest;
 import org.apache.arrow.flight.CloseSessionResult;
 import org.apache.arrow.flight.FlightRuntimeException;
@@ -33,10 +31,11 @@ import org.apache.arrow.flight.SetSessionOptionsRequest;
 import org.apache.arrow.flight.SetSessionOptionsResult;
 import org.apache.arrow.flight.sql.NoOpFlightSqlProducer;
 
-/** The server used for testing Sessions.
- * <p>
- * SetSessionOptions(), GetSessionOptions(), and CloseSession() operate on a
- * simple SessionOptionValue store.
+/**
+ * The server used for testing Sessions.
+ *
+ * <p>SetSessionOptions(), GetSessionOptions(), and CloseSession() operate on a simple
+ * SessionOptionValue store.
  */
 final class SessionOptionsProducer extends NoOpFlightSqlProducer {
   private static final SessionOptionValue invalidOptionValue =
@@ -48,8 +47,10 @@ final class SessionOptionsProducer extends NoOpFlightSqlProducer {
   }
 
   @Override
-  public void setSessionOptions(SetSessionOptionsRequest request, CallContext context,
-                         StreamListener<SetSessionOptionsResult> listener) {
+  public void setSessionOptions(
+      SetSessionOptionsRequest request,
+      CallContext context,
+      StreamListener<SetSessionOptionsResult> listener) {
     Map<String, SetSessionOptionsResult.Error> errors = new HashMap();
 
     ServerSessionMiddleware middleware = context.getMiddleware(sessionMiddlewareKey);
@@ -57,14 +58,16 @@ final class SessionOptionsProducer extends NoOpFlightSqlProducer {
     for (Map.Entry<String, SessionOptionValue> entry : request.getSessionOptions().entrySet()) {
       // Blacklisted option name
       if (entry.getKey().equals("lol_invalid")) {
-        errors.put(entry.getKey(),
+        errors.put(
+            entry.getKey(),
             new SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_NAME));
         continue;
       }
       // Blacklisted option value
       // Recommend using a visitor to check polymorphic equality, but this check is easy
       if (entry.getValue().equals(invalidOptionValue)) {
-        errors.put(entry.getKey(),
+        errors.put(
+            entry.getKey(),
             new SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_VALUE));
         continue;
       }
@@ -80,17 +83,22 @@ final class SessionOptionsProducer extends NoOpFlightSqlProducer {
   }
 
   @Override
-  public void getSessionOptions(GetSessionOptionsRequest request, CallContext context,
-                         StreamListener<GetSessionOptionsResult> listener) {
+  public void getSessionOptions(
+      GetSessionOptionsRequest request,
+      CallContext context,
+      StreamListener<GetSessionOptionsResult> listener) {
     ServerSessionMiddleware middleware = context.getMiddleware(sessionMiddlewareKey);
-    final Map<String, SessionOptionValue> sessionOptions = middleware.getSession().getSessionOptions();
+    final Map<String, SessionOptionValue> sessionOptions =
+        middleware.getSession().getSessionOptions();
     listener.onNext(new GetSessionOptionsResult(sessionOptions));
     listener.onCompleted();
   }
 
   @Override
-  public void closeSession(CloseSessionRequest request, CallContext context,
-                    StreamListener<CloseSessionResult> listener) {
+  public void closeSession(
+      CloseSessionRequest request,
+      CallContext context,
+      StreamListener<CloseSessionResult> listener) {
     ServerSessionMiddleware middleware = context.getMiddleware(sessionMiddlewareKey);
     try {
       middleware.closeSession();

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/SessionOptionsScenario.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/SessionOptionsScenario.java
@@ -14,11 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.flight.FlightServer;
@@ -35,11 +34,7 @@ import org.apache.arrow.flight.client.ClientCookieMiddleware;
 import org.apache.arrow.flight.sql.FlightSqlClient;
 import org.apache.arrow.memory.BufferAllocator;
 
-import com.google.common.collect.ImmutableMap;
-
-/**
- * Scenario to exercise Session Options functionality.
- */
+/** Scenario to exercise Session Options functionality. */
 final class SessionOptionsScenario implements Scenario {
   private final FlightServerMiddleware.Key<ServerSessionMiddleware> key =
       FlightServerMiddleware.Key.of("sessionmiddleware");
@@ -52,55 +47,82 @@ final class SessionOptionsScenario implements Scenario {
   @Override
   public void buildServer(FlightServer.Builder builder) {
     AtomicInteger counter = new AtomicInteger(1000);
-    builder.middleware(key, new ServerSessionMiddleware.Factory(() -> String.valueOf(counter.getAndIncrement())));
+    builder.middleware(
+        key, new ServerSessionMiddleware.Factory(() -> String.valueOf(counter.getAndIncrement())));
   }
 
   @Override
-  public void client(BufferAllocator allocator, Location location, FlightClient ignored) throws Exception {
+  public void client(BufferAllocator allocator, Location location, FlightClient ignored)
+      throws Exception {
     final ClientCookieMiddleware.Factory factory = new ClientCookieMiddleware.Factory();
-    try (final FlightClient flightClient = FlightClient.builder(allocator, location).intercept(factory).build()) {
+    try (final FlightClient flightClient =
+        FlightClient.builder(allocator, location).intercept(factory).build()) {
       final FlightSqlClient client = new FlightSqlClient(flightClient);
 
       // Set
-      SetSessionOptionsRequest req1 = new SetSessionOptionsRequest(ImmutableMap.<String, SessionOptionValue>builder()
-          .put("foolong", SessionOptionValueFactory.makeSessionOptionValue(123L))
-          .put("bardouble", SessionOptionValueFactory.makeSessionOptionValue(456.0))
-          .put("lol_invalid", SessionOptionValueFactory.makeSessionOptionValue("this won't get set"))
-          .put("key_with_invalid_value", SessionOptionValueFactory.makeSessionOptionValue("lol_invalid"))
-          .put("big_ol_string_list", SessionOptionValueFactory.makeSessionOptionValue(
-              new String[]{"a", "b", "sea", "dee", " ", "  ", "geee", "(づ｡◕‿‿◕｡)づ"}))
-          .build());
+      SetSessionOptionsRequest req1 =
+          new SetSessionOptionsRequest(
+              ImmutableMap.<String, SessionOptionValue>builder()
+                  .put("foolong", SessionOptionValueFactory.makeSessionOptionValue(123L))
+                  .put("bardouble", SessionOptionValueFactory.makeSessionOptionValue(456.0))
+                  .put(
+                      "lol_invalid",
+                      SessionOptionValueFactory.makeSessionOptionValue("this won't get set"))
+                  .put(
+                      "key_with_invalid_value",
+                      SessionOptionValueFactory.makeSessionOptionValue("lol_invalid"))
+                  .put(
+                      "big_ol_string_list",
+                      SessionOptionValueFactory.makeSessionOptionValue(
+                          new String[] {"a", "b", "sea", "dee", " ", "  ", "geee", "(づ｡◕‿‿◕｡)づ"}))
+                  .build());
       SetSessionOptionsResult res1 = client.setSessionOptions(req1);
       // Some errors
-      IntegrationAssertions.assertEquals(ImmutableMap.<String, SetSessionOptionsResult.Error>builder()
-            .put("lol_invalid", new SetSessionOptionsResult.Error(SetSessionOptionsResult.ErrorValue.INVALID_NAME))
-            .put("key_with_invalid_value", new SetSessionOptionsResult.Error(
-                SetSessionOptionsResult.ErrorValue.INVALID_VALUE))
-            .build(),
+      IntegrationAssertions.assertEquals(
+          ImmutableMap.<String, SetSessionOptionsResult.Error>builder()
+              .put(
+                  "lol_invalid",
+                  new SetSessionOptionsResult.Error(
+                      SetSessionOptionsResult.ErrorValue.INVALID_NAME))
+              .put(
+                  "key_with_invalid_value",
+                  new SetSessionOptionsResult.Error(
+                      SetSessionOptionsResult.ErrorValue.INVALID_VALUE))
+              .build(),
           res1.getErrors());
       // Some set, some omitted due to above errors
       GetSessionOptionsResult res2 = client.getSessionOptions(new GetSessionOptionsRequest());
-      IntegrationAssertions.assertEquals(ImmutableMap.<String, SessionOptionValue>builder()
-            .put("foolong", SessionOptionValueFactory.makeSessionOptionValue(123L))
-            .put("bardouble", SessionOptionValueFactory.makeSessionOptionValue(456.0))
-            .put("big_ol_string_list", SessionOptionValueFactory.makeSessionOptionValue(
-                new String[]{"a", "b", "sea", "dee", " ", "  ", "geee", "(づ｡◕‿‿◕｡)づ"}))
-            .build(),
+      IntegrationAssertions.assertEquals(
+          ImmutableMap.<String, SessionOptionValue>builder()
+              .put("foolong", SessionOptionValueFactory.makeSessionOptionValue(123L))
+              .put("bardouble", SessionOptionValueFactory.makeSessionOptionValue(456.0))
+              .put(
+                  "big_ol_string_list",
+                  SessionOptionValueFactory.makeSessionOptionValue(
+                      new String[] {"a", "b", "sea", "dee", " ", "  ", "geee", "(づ｡◕‿‿◕｡)づ"}))
+              .build(),
           res2.getSessionOptions());
       // Update
-      client.setSessionOptions(new SetSessionOptionsRequest(ImmutableMap.<String, SessionOptionValue>builder()
-          // Delete
-          .put("foolong", SessionOptionValueFactory.makeEmptySessionOptionValue())
-          // Update
-          .put("big_ol_string_list",
-              SessionOptionValueFactory.makeSessionOptionValue("a,b,sea,dee, ,  ,geee,(づ｡◕‿‿◕｡)づ"))
-          .build()));
+      client.setSessionOptions(
+          new SetSessionOptionsRequest(
+              ImmutableMap.<String, SessionOptionValue>builder()
+                  // Delete
+                  .put("foolong", SessionOptionValueFactory.makeEmptySessionOptionValue())
+                  // Update
+                  .put(
+                      "big_ol_string_list",
+                      SessionOptionValueFactory.makeSessionOptionValue(
+                          "a,b,sea,dee, ,  ,geee,(づ｡◕‿‿◕｡)づ"))
+                  .build()));
       GetSessionOptionsResult res4 = client.getSessionOptions(new GetSessionOptionsRequest());
-      IntegrationAssertions.assertEquals(ImmutableMap.<String, SessionOptionValue>builder()
-            .put("bardouble", SessionOptionValueFactory.makeSessionOptionValue(456.0))
-            .put("big_ol_string_list",
-                SessionOptionValueFactory.makeSessionOptionValue("a,b,sea,dee, ,  ,geee,(づ｡◕‿‿◕｡)づ"))
-            .build(),
+      IntegrationAssertions.assertEquals(
+          ImmutableMap.<String, SessionOptionValue>builder()
+              .put("bardouble", SessionOptionValueFactory.makeSessionOptionValue(456.0))
+              .put(
+                  "big_ol_string_list",
+                  SessionOptionValueFactory.makeSessionOptionValue(
+                      "a,b,sea,dee, ,  ,geee,(づ｡◕‿‿◕｡)づ"))
+              .build(),
           res4.getSessionOptions());
     }
   }

--- a/java/flight/flight-integration-tests/src/test/java/org/apache/arrow/flight/integration/tests/IntegrationTest.java
+++ b/java/flight/flight-integration-tests/src/test/java/org/apache/arrow/flight/integration/tests/IntegrationTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.integration.tests;
 
 import org.apache.arrow.flight.FlightClient;
@@ -24,9 +23,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.Test;
 
-/**
- * Run the integration test scenarios in-process.
- */
+/** Run the integration test scenarios in-process. */
 class IntegrationTest {
   @Test
   void authBasicProto() throws Exception {
@@ -95,9 +92,10 @@ class IntegrationTest {
 
   void testScenario(String scenarioName) throws Exception {
     try (final BufferAllocator allocator = new RootAllocator()) {
-      final FlightServer.Builder builder = FlightServer.builder()
-          .allocator(allocator)
-          .location(Location.forGrpcInsecure("0.0.0.0", 0));
+      final FlightServer.Builder builder =
+          FlightServer.builder()
+              .allocator(allocator)
+              .location(Location.forGrpcInsecure("0.0.0.0", 0));
       final Scenario scenario = Scenarios.getScenario(scenarioName);
       scenario.buildServer(builder);
       builder.producer(scenario.producer(allocator, Location.forGrpcInsecure("0.0.0.0", 0)));

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadata.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadata.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static java.sql.Types.BIGINT;
@@ -35,6 +34,7 @@ import static java.sql.Types.TINYINT;
 import static java.sql.Types.VARCHAR;
 import static org.apache.arrow.flight.sql.util.SqlInfoOptionsUtils.doesBitmaskTranslateToEnum;
 
+import com.google.protobuf.ProtocolMessageEnum;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
@@ -53,7 +53,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.driver.jdbc.utils.SqlTypes;
 import org.apache.arrow.driver.jdbc.utils.VectorSchemaRootTransformer;
 import org.apache.arrow.flight.FlightInfo;
@@ -86,11 +85,7 @@ import org.apache.arrow.vector.util.Text;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaDatabaseMetaData;
 
-import com.google.protobuf.ProtocolMessageEnum;
-
-/**
- * Arrow Flight JDBC's implementation of {@link DatabaseMetaData}.
- */
+/** Arrow Flight JDBC's implementation of {@link DatabaseMetaData}. */
 public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
   private static final String JAVA_REGEX_SPECIALS = "[]()|^-+*?{}$\\.";
   private static final Charset CHARSET = StandardCharsets.UTF_8;
@@ -119,33 +114,33 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
   static final int DECIMAL_DIGITS_TIME_MILLISECONDS = 3;
   static final int DECIMAL_DIGITS_TIME_MICROSECONDS = 6;
   static final int DECIMAL_DIGITS_TIME_NANOSECONDS = 9;
-  private static final Schema GET_COLUMNS_SCHEMA = new Schema(
-      Arrays.asList(
-          Field.nullable("TABLE_CAT", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("TABLE_SCHEM", Types.MinorType.VARCHAR.getType()),
-          Field.notNullable("TABLE_NAME", Types.MinorType.VARCHAR.getType()),
-          Field.notNullable("COLUMN_NAME", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("DATA_TYPE", Types.MinorType.INT.getType()),
-          Field.nullable("TYPE_NAME", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("COLUMN_SIZE", Types.MinorType.INT.getType()),
-          Field.nullable("BUFFER_LENGTH", Types.MinorType.INT.getType()),
-          Field.nullable("DECIMAL_DIGITS", Types.MinorType.INT.getType()),
-          Field.nullable("NUM_PREC_RADIX", Types.MinorType.INT.getType()),
-          Field.notNullable("NULLABLE", Types.MinorType.INT.getType()),
-          Field.nullable("REMARKS", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("COLUMN_DEF", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("SQL_DATA_TYPE", Types.MinorType.INT.getType()),
-          Field.nullable("SQL_DATETIME_SUB", Types.MinorType.INT.getType()),
-          Field.notNullable("CHAR_OCTET_LENGTH", Types.MinorType.INT.getType()),
-          Field.notNullable("ORDINAL_POSITION", Types.MinorType.INT.getType()),
-          Field.notNullable("IS_NULLABLE", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("SCOPE_CATALOG", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("SCOPE_SCHEMA", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("SCOPE_TABLE", Types.MinorType.VARCHAR.getType()),
-          Field.nullable("SOURCE_DATA_TYPE", Types.MinorType.SMALLINT.getType()),
-          Field.notNullable("IS_AUTOINCREMENT", Types.MinorType.VARCHAR.getType()),
-          Field.notNullable("IS_GENERATEDCOLUMN", Types.MinorType.VARCHAR.getType())
-      ));
+  private static final Schema GET_COLUMNS_SCHEMA =
+      new Schema(
+          Arrays.asList(
+              Field.nullable("TABLE_CAT", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("TABLE_SCHEM", Types.MinorType.VARCHAR.getType()),
+              Field.notNullable("TABLE_NAME", Types.MinorType.VARCHAR.getType()),
+              Field.notNullable("COLUMN_NAME", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("DATA_TYPE", Types.MinorType.INT.getType()),
+              Field.nullable("TYPE_NAME", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("COLUMN_SIZE", Types.MinorType.INT.getType()),
+              Field.nullable("BUFFER_LENGTH", Types.MinorType.INT.getType()),
+              Field.nullable("DECIMAL_DIGITS", Types.MinorType.INT.getType()),
+              Field.nullable("NUM_PREC_RADIX", Types.MinorType.INT.getType()),
+              Field.notNullable("NULLABLE", Types.MinorType.INT.getType()),
+              Field.nullable("REMARKS", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("COLUMN_DEF", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("SQL_DATA_TYPE", Types.MinorType.INT.getType()),
+              Field.nullable("SQL_DATETIME_SUB", Types.MinorType.INT.getType()),
+              Field.notNullable("CHAR_OCTET_LENGTH", Types.MinorType.INT.getType()),
+              Field.notNullable("ORDINAL_POSITION", Types.MinorType.INT.getType()),
+              Field.notNullable("IS_NULLABLE", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("SCOPE_CATALOG", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("SCOPE_SCHEMA", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("SCOPE_TABLE", Types.MinorType.VARCHAR.getType()),
+              Field.nullable("SOURCE_DATA_TYPE", Types.MinorType.SMALLINT.getType()),
+              Field.notNullable("IS_AUTOINCREMENT", Types.MinorType.VARCHAR.getType()),
+              Field.notNullable("IS_GENERATEDCOLUMN", Types.MinorType.VARCHAR.getType())));
   private final AtomicBoolean isCachePopulated = new AtomicBoolean(false);
   private final Map<SqlInfo, Object> cachedSqlInfo = new EnumMap<>(SqlInfo.class);
   private static final Map<Integer, Integer> sqlTypesToFlightEnumConvertTypes = new HashMap<>();
@@ -161,12 +156,12 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
     sqlTypesToFlightEnumConvertTypes.put(REAL, SqlSupportsConvert.SQL_CONVERT_REAL_VALUE);
     sqlTypesToFlightEnumConvertTypes.put(DECIMAL, SqlSupportsConvert.SQL_CONVERT_DECIMAL_VALUE);
     sqlTypesToFlightEnumConvertTypes.put(BINARY, SqlSupportsConvert.SQL_CONVERT_BINARY_VALUE);
-    sqlTypesToFlightEnumConvertTypes.put(LONGVARBINARY,
-        SqlSupportsConvert.SQL_CONVERT_LONGVARBINARY_VALUE);
+    sqlTypesToFlightEnumConvertTypes.put(
+        LONGVARBINARY, SqlSupportsConvert.SQL_CONVERT_LONGVARBINARY_VALUE);
     sqlTypesToFlightEnumConvertTypes.put(CHAR, SqlSupportsConvert.SQL_CONVERT_CHAR_VALUE);
     sqlTypesToFlightEnumConvertTypes.put(VARCHAR, SqlSupportsConvert.SQL_CONVERT_VARCHAR_VALUE);
-    sqlTypesToFlightEnumConvertTypes.put(LONGNVARCHAR,
-        SqlSupportsConvert.SQL_CONVERT_LONGVARCHAR_VALUE);
+    sqlTypesToFlightEnumConvertTypes.put(
+        LONGNVARCHAR, SqlSupportsConvert.SQL_CONVERT_LONGVARCHAR_VALUE);
     sqlTypesToFlightEnumConvertTypes.put(DATE, SqlSupportsConvert.SQL_CONVERT_DATE_VALUE);
     sqlTypesToFlightEnumConvertTypes.put(TIMESTAMP, SqlSupportsConvert.SQL_CONVERT_TIMESTAMP_VALUE);
   }
@@ -198,35 +193,35 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
   @Override
   public String getSQLKeywords() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_KEYWORDS, List.class))
+            getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_KEYWORDS, List.class))
         .orElse("");
   }
 
   @Override
   public String getNumericFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_NUMERIC_FUNCTIONS, List.class))
+            getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_NUMERIC_FUNCTIONS, List.class))
         .orElse("");
   }
 
   @Override
   public String getStringFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_STRING_FUNCTIONS, List.class))
+            getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_STRING_FUNCTIONS, List.class))
         .orElse("");
   }
 
   @Override
   public String getSystemFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SYSTEM_FUNCTIONS, List.class))
+            getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SYSTEM_FUNCTIONS, List.class))
         .orElse("");
   }
 
   @Override
   public String getTimeDateFunctions() throws SQLException {
     return convertListSqlInfoToString(
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DATETIME_FUNCTIONS, List.class))
+            getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DATETIME_FUNCTIONS, List.class))
         .orElse("");
   }
 
@@ -272,20 +267,20 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean supportsTableCorrelationNames() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTS_TABLE_CORRELATION_NAMES,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTS_TABLE_CORRELATION_NAMES, Boolean.class);
   }
 
   @Override
   public boolean supportsDifferentTableCorrelationNames() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES, Boolean.class);
   }
 
   @Override
   public boolean supportsExpressionsInOrderBy() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTS_EXPRESSIONS_IN_ORDER_BY,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTS_EXPRESSIONS_IN_ORDER_BY, Boolean.class);
   }
 
   @Override
@@ -302,8 +297,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean supportsGroupByUnrelated() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_GROUP_BY,
-        SqlSupportedGroupBy.SQL_GROUP_BY_UNRELATED);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_GROUP_BY, SqlSupportedGroupBy.SQL_GROUP_BY_UNRELATED);
   }
 
   @Override
@@ -313,66 +308,75 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean supportsNonNullableColumns() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTS_NON_NULLABLE_COLUMNS,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTS_NON_NULLABLE_COLUMNS, Boolean.class);
   }
 
   @Override
   public boolean supportsMinimumSQLGrammar() throws SQLException {
     return checkEnumLevel(
-        Arrays.asList(getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_GRAMMAR,
-                SupportedSqlGrammar.SQL_EXTENDED_GRAMMAR),
-            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_GRAMMAR,
-                SupportedSqlGrammar.SQL_CORE_GRAMMAR),
-            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_GRAMMAR,
-                SupportedSqlGrammar.SQL_MINIMUM_GRAMMAR)));
+        Arrays.asList(
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_SUPPORTED_GRAMMAR, SupportedSqlGrammar.SQL_EXTENDED_GRAMMAR),
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_SUPPORTED_GRAMMAR, SupportedSqlGrammar.SQL_CORE_GRAMMAR),
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_SUPPORTED_GRAMMAR, SupportedSqlGrammar.SQL_MINIMUM_GRAMMAR)));
   }
 
   @Override
   public boolean supportsCoreSQLGrammar() throws SQLException {
     return checkEnumLevel(
-        Arrays.asList(getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_GRAMMAR,
-                SupportedSqlGrammar.SQL_EXTENDED_GRAMMAR),
-            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_GRAMMAR,
-                SupportedSqlGrammar.SQL_CORE_GRAMMAR)));
+        Arrays.asList(
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_SUPPORTED_GRAMMAR, SupportedSqlGrammar.SQL_EXTENDED_GRAMMAR),
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_SUPPORTED_GRAMMAR, SupportedSqlGrammar.SQL_CORE_GRAMMAR)));
   }
 
   @Override
   public boolean supportsExtendedSQLGrammar() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_GRAMMAR,
-        SupportedSqlGrammar.SQL_EXTENDED_GRAMMAR);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_GRAMMAR, SupportedSqlGrammar.SQL_EXTENDED_GRAMMAR);
   }
 
   @Override
   public boolean supportsANSI92EntryLevelSQL() throws SQLException {
     return checkEnumLevel(
-        Arrays.asList(getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
+        Arrays.asList(
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
                 SupportedAnsi92SqlGrammarLevel.ANSI92_ENTRY_SQL),
-            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
                 SupportedAnsi92SqlGrammarLevel.ANSI92_INTERMEDIATE_SQL),
-            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
                 SupportedAnsi92SqlGrammarLevel.ANSI92_FULL_SQL)));
   }
 
   @Override
   public boolean supportsANSI92IntermediateSQL() throws SQLException {
     return checkEnumLevel(
-        Arrays.asList(getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
+        Arrays.asList(
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
                 SupportedAnsi92SqlGrammarLevel.ANSI92_ENTRY_SQL),
-            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
+            getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+                SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
                 SupportedAnsi92SqlGrammarLevel.ANSI92_INTERMEDIATE_SQL)));
   }
 
   @Override
   public boolean supportsANSI92FullSQL() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL,
-        SupportedAnsi92SqlGrammarLevel.ANSI92_FULL_SQL);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL, SupportedAnsi92SqlGrammarLevel.ANSI92_FULL_SQL);
   }
 
   @Override
   public boolean supportsIntegrityEnhancementFacility() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY, Boolean.class);
   }
 
   @Override
@@ -384,14 +388,14 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean supportsFullOuterJoins() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_OUTER_JOINS_SUPPORT_LEVEL,
-        SqlOuterJoinsSupportLevel.SQL_FULL_OUTER_JOINS);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_OUTER_JOINS_SUPPORT_LEVEL, SqlOuterJoinsSupportLevel.SQL_FULL_OUTER_JOINS);
   }
 
   @Override
   public boolean supportsLimitedOuterJoins() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_OUTER_JOINS_SUPPORT_LEVEL,
-        SqlOuterJoinsSupportLevel.SQL_LIMITED_OUTER_JOINS);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_OUTER_JOINS_SUPPORT_LEVEL, SqlOuterJoinsSupportLevel.SQL_LIMITED_OUTER_JOINS);
   }
 
   @Override
@@ -416,43 +420,50 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean supportsSchemasInProcedureCalls() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SCHEMAS_SUPPORTED_ACTIONS,
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SCHEMAS_SUPPORTED_ACTIONS,
         SqlSupportedElementActions.SQL_ELEMENT_IN_PROCEDURE_CALLS);
   }
 
   @Override
   public boolean supportsSchemasInIndexDefinitions() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SCHEMAS_SUPPORTED_ACTIONS,
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SCHEMAS_SUPPORTED_ACTIONS,
         SqlSupportedElementActions.SQL_ELEMENT_IN_INDEX_DEFINITIONS);
   }
 
   @Override
   public boolean supportsSchemasInPrivilegeDefinitions() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SCHEMAS_SUPPORTED_ACTIONS,
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SCHEMAS_SUPPORTED_ACTIONS,
         SqlSupportedElementActions.SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS);
   }
 
   @Override
   public boolean supportsCatalogsInIndexDefinitions() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_CATALOGS_SUPPORTED_ACTIONS,
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_CATALOGS_SUPPORTED_ACTIONS,
         SqlSupportedElementActions.SQL_ELEMENT_IN_INDEX_DEFINITIONS);
   }
 
   @Override
   public boolean supportsCatalogsInPrivilegeDefinitions() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_CATALOGS_SUPPORTED_ACTIONS,
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_CATALOGS_SUPPORTED_ACTIONS,
         SqlSupportedElementActions.SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS);
   }
 
   @Override
   public boolean supportsPositionedDelete() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_POSITIONED_COMMANDS,
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_POSITIONED_COMMANDS,
         SqlSupportedPositionedCommands.SQL_POSITIONED_DELETE);
   }
 
   @Override
   public boolean supportsPositionedUpdate() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_POSITIONED_COMMANDS,
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_POSITIONED_COMMANDS,
         SqlSupportedPositionedCommands.SQL_POSITIONED_UPDATE);
   }
 
@@ -463,14 +474,14 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
     switch (type) {
       case ResultSet.TYPE_FORWARD_ONLY:
-        return doesBitmaskTranslateToEnum(SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_FORWARD_ONLY,
-            bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_FORWARD_ONLY, bitmask);
       case ResultSet.TYPE_SCROLL_INSENSITIVE:
-        return doesBitmaskTranslateToEnum(SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE,
-            bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE, bitmask);
       case ResultSet.TYPE_SCROLL_SENSITIVE:
-        return doesBitmaskTranslateToEnum(SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE,
-            bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE, bitmask);
       default:
         throw new SQLException(
             "Invalid result set type argument. The informed type is not defined in java.sql.ResultSet.");
@@ -489,32 +500,32 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean supportsSubqueriesInComparisons() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_SUBQUERIES,
-        SqlSupportedSubqueries.SQL_SUBQUERIES_IN_COMPARISONS);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_SUBQUERIES, SqlSupportedSubqueries.SQL_SUBQUERIES_IN_COMPARISONS);
   }
 
   @Override
   public boolean supportsSubqueriesInExists() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_SUBQUERIES,
-        SqlSupportedSubqueries.SQL_SUBQUERIES_IN_EXISTS);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_SUBQUERIES, SqlSupportedSubqueries.SQL_SUBQUERIES_IN_EXISTS);
   }
 
   @Override
   public boolean supportsSubqueriesInIns() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_SUBQUERIES,
-        SqlSupportedSubqueries.SQL_SUBQUERIES_IN_INS);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_SUBQUERIES, SqlSupportedSubqueries.SQL_SUBQUERIES_IN_INS);
   }
 
   @Override
   public boolean supportsSubqueriesInQuantifieds() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_SUBQUERIES,
-        SqlSupportedSubqueries.SQL_SUBQUERIES_IN_QUANTIFIEDS);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_SUBQUERIES, SqlSupportedSubqueries.SQL_SUBQUERIES_IN_QUANTIFIEDS);
   }
 
   @Override
   public boolean supportsCorrelatedSubqueries() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_CORRELATED_SUBQUERIES_SUPPORTED,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_CORRELATED_SUBQUERIES_SUPPORTED, Boolean.class);
   }
 
   @Override
@@ -526,56 +537,56 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean supportsUnionAll() throws SQLException {
-    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_UNIONS,
-        SqlSupportedUnions.SQL_UNION_ALL);
+    return getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_SUPPORTED_UNIONS, SqlSupportedUnions.SQL_UNION_ALL);
   }
 
   @Override
   public int getMaxBinaryLiteralLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_BINARY_LITERAL_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_BINARY_LITERAL_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxCharLiteralLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_CHAR_LITERAL_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_CHAR_LITERAL_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxColumnNameLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMN_NAME_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMN_NAME_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxColumnsInGroupBy() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_GROUP_BY,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_GROUP_BY, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxColumnsInIndex() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_INDEX,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_INDEX, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxColumnsInOrderBy() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_ORDER_BY,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_ORDER_BY, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxColumnsInSelect() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_SELECT,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_SELECT, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxColumnsInTable() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_TABLE,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_COLUMNS_IN_TABLE, Long.class)
+        .intValue();
   }
 
   @Override
@@ -585,8 +596,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public int getMaxCursorNameLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_CURSOR_NAME_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_CURSOR_NAME_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
@@ -596,20 +607,20 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public int getMaxSchemaNameLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DB_SCHEMA_NAME_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DB_SCHEMA_NAME_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxProcedureNameLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_PROCEDURE_NAME_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_PROCEDURE_NAME_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxCatalogNameLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_CATALOG_NAME_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_CATALOG_NAME_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
@@ -624,8 +635,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public int getMaxStatementLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_STATEMENT_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_STATEMENT_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
@@ -635,14 +646,14 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public int getMaxTableNameLength() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_TABLE_NAME_LENGTH,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_TABLE_NAME_LENGTH, Long.class)
+        .intValue();
   }
 
   @Override
   public int getMaxTablesInSelect() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_TABLES_IN_SELECT,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_MAX_TABLES_IN_SELECT, Long.class)
+        .intValue();
   }
 
   @Override
@@ -652,8 +663,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public int getDefaultTransactionIsolation() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DEFAULT_TRANSACTION_ISOLATION,
-        Long.class).intValue();
+    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DEFAULT_TRANSACTION_ISOLATION, Long.class)
+        .intValue();
   }
 
   @Override
@@ -664,24 +675,25 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
   @Override
   public boolean supportsTransactionIsolationLevel(final int level) throws SQLException {
     final int bitmask =
-        getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS,
-            Integer.class);
+        getSqlInfoAndCacheIfCacheIsEmpty(
+            SqlInfo.SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS, Integer.class);
 
     switch (level) {
       case Connection.TRANSACTION_NONE:
-        return doesBitmaskTranslateToEnum(SqlTransactionIsolationLevel.SQL_TRANSACTION_NONE, bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlTransactionIsolationLevel.SQL_TRANSACTION_NONE, bitmask);
       case Connection.TRANSACTION_READ_COMMITTED:
-        return doesBitmaskTranslateToEnum(SqlTransactionIsolationLevel.SQL_TRANSACTION_READ_COMMITTED,
-            bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlTransactionIsolationLevel.SQL_TRANSACTION_READ_COMMITTED, bitmask);
       case Connection.TRANSACTION_READ_UNCOMMITTED:
-        return doesBitmaskTranslateToEnum(SqlTransactionIsolationLevel.SQL_TRANSACTION_READ_UNCOMMITTED,
-            bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlTransactionIsolationLevel.SQL_TRANSACTION_READ_UNCOMMITTED, bitmask);
       case Connection.TRANSACTION_REPEATABLE_READ:
-        return doesBitmaskTranslateToEnum(SqlTransactionIsolationLevel.SQL_TRANSACTION_REPEATABLE_READ,
-            bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlTransactionIsolationLevel.SQL_TRANSACTION_REPEATABLE_READ, bitmask);
       case Connection.TRANSACTION_SERIALIZABLE:
-        return doesBitmaskTranslateToEnum(SqlTransactionIsolationLevel.SQL_TRANSACTION_SERIALIZABLE,
-            bitmask);
+        return doesBitmaskTranslateToEnum(
+            SqlTransactionIsolationLevel.SQL_TRANSACTION_SERIALIZABLE, bitmask);
       default:
         throw new SQLException(
             "Invalid transaction isolation level argument. The informed level is not defined in java.sql.Connection.");
@@ -690,14 +702,14 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   @Override
   public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT, Boolean.class);
   }
 
   @Override
   public boolean dataDefinitionIgnoredInTransactions() throws SQLException {
-    return getSqlInfoAndCacheIfCacheIsEmpty(SqlInfo.SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED,
-        Boolean.class);
+    return getSqlInfoAndCacheIfCacheIsEmpty(
+        SqlInfo.SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED, Boolean.class);
   }
 
   @Override
@@ -731,24 +743,25 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
     return (ArrowFlightConnection) super.getConnection();
   }
 
-  private <T> T getSqlInfoAndCacheIfCacheIsEmpty(final SqlInfo sqlInfoCommand,
-                                                 final Class<T> desiredType)
-      throws SQLException {
+  private <T> T getSqlInfoAndCacheIfCacheIsEmpty(
+      final SqlInfo sqlInfoCommand, final Class<T> desiredType) throws SQLException {
     final ArrowFlightConnection connection = getConnection();
     if (!isCachePopulated.get()) {
       // Lock-and-populate the cache. Only issue the call to getSqlInfo() once,
       // populate the cache, then mark it as populated.
-      // Note that multiple callers from separate threads can see that the cache is not populated, but only
-      // one thread will try to populate the cache. Other threads will see the cache is non-empty when acquiring
+      // Note that multiple callers from separate threads can see that the cache is not populated,
+      // but only
+      // one thread will try to populate the cache. Other threads will see the cache is non-empty
+      // when acquiring
       // the lock on the cache and skip population.
       synchronized (cachedSqlInfo) {
         if (cachedSqlInfo.isEmpty()) {
           final FlightInfo sqlInfo = connection.getClientHandler().getSqlInfo();
           try (final ResultSet resultSet =
-                   ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
-                       connection, sqlInfo, null)) {
+              ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, sqlInfo, null)) {
             while (resultSet.next()) {
-              cachedSqlInfo.put(SqlInfo.forNumber((Integer) resultSet.getObject("info_name")),
+              cachedSqlInfo.put(
+                  SqlInfo.forNumber((Integer) resultSet.getObject("info_name")),
                   resultSet.getObject("value"));
             }
           }
@@ -763,14 +776,13 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
     if (sqlInfoList == null) {
       return Optional.empty();
     } else {
-      return Optional.of(sqlInfoList.stream().map(Object::toString).collect(Collectors.joining(", ")));
+      return Optional.of(
+          sqlInfoList.stream().map(Object::toString).collect(Collectors.joining(", ")));
     }
   }
 
   private boolean getSqlInfoEnumOptionAndCacheIfCacheIsEmpty(
-      final SqlInfo sqlInfoCommand,
-      final ProtocolMessageEnum enumInstance
-  ) throws SQLException {
+      final SqlInfo sqlInfoCommand, final ProtocolMessageEnum enumInstance) throws SQLException {
     final int bitmask = getSqlInfoAndCacheIfCacheIsEmpty(sqlInfoCommand, Integer.class);
     return doesBitmaskTranslateToEnum(enumInstance, bitmask);
   }
@@ -789,8 +801,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
         new VectorSchemaRootTransformer.Builder(Schemas.GET_CATALOGS_SCHEMA, allocator)
             .renameFieldVector("catalog_name", "TABLE_CAT")
             .build();
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoCatalogs,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoCatalogs, transformer);
   }
 
   @Override
@@ -802,8 +814,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
     final BufferAllocator allocator = connection.getBufferAllocator();
     final VectorSchemaRootTransformer transformer = getForeignKeysTransformer(allocator);
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoImportedKeys,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoImportedKeys, transformer);
   }
 
   @Override
@@ -815,33 +827,43 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
     final BufferAllocator allocator = connection.getBufferAllocator();
     final VectorSchemaRootTransformer transformer = getForeignKeysTransformer(allocator);
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoExportedKeys,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoExportedKeys, transformer);
   }
 
   @Override
-  public ResultSet getCrossReference(final String parentCatalog, final String parentSchema,
-                                     final String parentTable,
-                                     final String foreignCatalog, final String foreignSchema,
-                                     final String foreignTable)
+  public ResultSet getCrossReference(
+      final String parentCatalog,
+      final String parentSchema,
+      final String parentTable,
+      final String foreignCatalog,
+      final String foreignSchema,
+      final String foreignTable)
       throws SQLException {
     final ArrowFlightConnection connection = getConnection();
-    final FlightInfo flightInfoCrossReference = connection.getClientHandler().getCrossReference(
-        parentCatalog, parentSchema, parentTable, foreignCatalog, foreignSchema, foreignTable);
+    final FlightInfo flightInfoCrossReference =
+        connection
+            .getClientHandler()
+            .getCrossReference(
+                parentCatalog,
+                parentSchema,
+                parentTable,
+                foreignCatalog,
+                foreignSchema,
+                foreignTable);
 
     final BufferAllocator allocator = connection.getBufferAllocator();
     final VectorSchemaRootTransformer transformer = getForeignKeysTransformer(allocator);
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoCrossReference,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoCrossReference, transformer);
   }
 
   /**
-   * Transformer used on getImportedKeys, getExportedKeys and getCrossReference methods, since
-   * all three share the same schema.
+   * Transformer used on getImportedKeys, getExportedKeys and getCrossReference methods, since all
+   * three share the same schema.
    */
   private VectorSchemaRootTransformer getForeignKeysTransformer(final BufferAllocator allocator) {
-    return new VectorSchemaRootTransformer.Builder(Schemas.GET_IMPORTED_KEYS_SCHEMA,
-        allocator)
+    return new VectorSchemaRootTransformer.Builder(Schemas.GET_IMPORTED_KEYS_SCHEMA, allocator)
         .renameFieldVector("pk_catalog_name", "PKTABLE_CAT")
         .renameFieldVector("pk_db_schema_name", "PKTABLE_SCHEM")
         .renameFieldVector("pk_table_name", "PKTABLE_NAME")
@@ -872,8 +894,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
             .renameFieldVector("db_schema_name", "TABLE_SCHEM")
             .renameFieldVector("catalog_name", "TABLE_CATALOG")
             .build();
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoSchemas,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoSchemas, transformer);
   }
 
   @Override
@@ -886,19 +908,22 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
         new VectorSchemaRootTransformer.Builder(Schemas.GET_TABLE_TYPES_SCHEMA, allocator)
             .renameFieldVector("table_type", "TABLE_TYPE")
             .build();
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoTableTypes,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoTableTypes, transformer);
   }
 
   @Override
-  public ResultSet getTables(final String catalog, final String schemaPattern,
-                             final String tableNamePattern,
-                             final String[] types)
+  public ResultSet getTables(
+      final String catalog,
+      final String schemaPattern,
+      final String tableNamePattern,
+      final String[] types)
       throws SQLException {
     final ArrowFlightConnection connection = getConnection();
     final List<String> typesList = types == null ? null : Arrays.asList(types);
     final FlightInfo flightInfoTables =
-        connection.getClientHandler()
+        connection
+            .getClientHandler()
             .getTables(catalog, schemaPattern, tableNamePattern, typesList, false);
 
     final BufferAllocator allocator = connection.getBufferAllocator();
@@ -915,8 +940,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
             .addEmptyField("SELF_REFERENCING_COL_NAME", Types.MinorType.VARBINARY)
             .addEmptyField("REF_GENERATION", Types.MinorType.VARBINARY)
             .build();
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoTables,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoTables, transformer);
   }
 
   @Override
@@ -936,18 +961,21 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
             .renameFieldVector("key_sequence", "KEY_SEQ")
             .renameFieldVector("key_name", "PK_NAME")
             .build();
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoPrimaryKeys,
-        transformer);
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection, flightInfoPrimaryKeys, transformer);
   }
 
   @Override
-  public ResultSet getColumns(final String catalog, final String schemaPattern,
-                              final String tableNamePattern,
-                              final String columnNamePattern)
+  public ResultSet getColumns(
+      final String catalog,
+      final String schemaPattern,
+      final String tableNamePattern,
+      final String columnNamePattern)
       throws SQLException {
     final ArrowFlightConnection connection = getConnection();
     final FlightInfo flightInfoTables =
-        connection.getClientHandler()
+        connection
+            .getClientHandler()
             .getTables(catalog, schemaPattern, tableNamePattern, null, true);
 
     final BufferAllocator allocator = connection.getBufferAllocator();
@@ -955,7 +983,9 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
     final Pattern columnNamePat =
         columnNamePattern != null ? Pattern.compile(sqlToRegexLike(columnNamePattern)) : null;
 
-    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(connection, flightInfoTables,
+    return ArrowFlightJdbcFlightStreamResultSet.fromFlightInfo(
+        connection,
+        flightInfoTables,
         (originalRoot, transformedRoot) -> {
           int columnCounter = 0;
           if (transformedRoot == null) {
@@ -981,18 +1011,25 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
             final Schema currentSchema;
             try {
-              currentSchema = MessageSerializer.deserializeSchema(
-                  new ReadChannel(Channels.newChannel(
-                      new ByteArrayInputStream(schemaVector.get(i)))));
+              currentSchema =
+                  MessageSerializer.deserializeSchema(
+                      new ReadChannel(
+                          Channels.newChannel(new ByteArrayInputStream(schemaVector.get(i)))));
             } catch (final IOException e) {
               throw new IOException(
                   String.format("Failed to deserialize schema for table %s", tableName), e);
             }
             final List<Field> tableColumns = currentSchema.getFields();
 
-            columnCounter = setGetColumnsVectorSchemaRootFromFields(transformedRoot, columnCounter,
-                tableColumns,
-                catalogName, tableName, schemaName, columnNamePat);
+            columnCounter =
+                setGetColumnsVectorSchemaRootFromFields(
+                    transformedRoot,
+                    columnCounter,
+                    tableColumns,
+                    catalogName,
+                    tableName,
+                    schemaName,
+                    columnNamePat);
           }
 
           transformedRoot.setRowCount(columnCounter);
@@ -1002,12 +1039,14 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
         });
   }
 
-  private int setGetColumnsVectorSchemaRootFromFields(final VectorSchemaRoot currentRoot,
-                                                      int insertIndex,
-                                                      final List<Field> tableColumns,
-                                                      final Text catalogName,
-                                                      final Text tableName, final Text schemaName,
-                                                      final Pattern columnNamePattern) {
+  private int setGetColumnsVectorSchemaRootFromFields(
+      final VectorSchemaRoot currentRoot,
+      int insertIndex,
+      final List<Field> tableColumns,
+      final Text catalogName,
+      final Text tableName,
+      final Text schemaName,
+      final Pattern columnNamePattern) {
     int ordinalIndex = 1;
     final int tableColumnsSize = tableColumns.size();
 
@@ -1023,12 +1062,15 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
     final IntVector nullableVector = (IntVector) currentRoot.getVector("NULLABLE");
     final IntVector ordinalPositionVector = (IntVector) currentRoot.getVector("ORDINAL_POSITION");
     final VarCharVector isNullableVector = (VarCharVector) currentRoot.getVector("IS_NULLABLE");
-    final VarCharVector isAutoincrementVector = (VarCharVector) currentRoot.getVector("IS_AUTOINCREMENT");
-    final VarCharVector isGeneratedColumnVector = (VarCharVector) currentRoot.getVector("IS_GENERATEDCOLUMN");
+    final VarCharVector isAutoincrementVector =
+        (VarCharVector) currentRoot.getVector("IS_AUTOINCREMENT");
+    final VarCharVector isGeneratedColumnVector =
+        (VarCharVector) currentRoot.getVector("IS_GENERATEDCOLUMN");
 
     for (int i = 0; i < tableColumnsSize; i++, ordinalIndex++) {
       final Field field = tableColumns.get(i);
-      final FlightSqlColumnMetadata columnMetadata = new FlightSqlColumnMetadata(field.getMetadata());
+      final FlightSqlColumnMetadata columnMetadata =
+          new FlightSqlColumnMetadata(field.getMetadata());
       final String columnName = field.getName();
 
       if (columnNamePattern != null && !columnNamePattern.matcher(columnName).matches()) {
@@ -1053,13 +1095,15 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
       }
 
       dataTypeVector.setSafe(insertIndex, SqlTypes.getSqlTypeIdFromArrowType(fieldType));
-      byte[] typeName = columnMetadata.getTypeName() != null ?
-          columnMetadata.getTypeName().getBytes(CHARSET) :
-          SqlTypes.getSqlTypeNameFromArrowType(fieldType).getBytes(CHARSET);
+      byte[] typeName =
+          columnMetadata.getTypeName() != null
+              ? columnMetadata.getTypeName().getBytes(CHARSET)
+              : SqlTypes.getSqlTypeNameFromArrowType(fieldType).getBytes(CHARSET);
       typeNameVector.setSafe(insertIndex, typeName);
 
       // We aren't setting COLUMN_SIZE for ROWID SQL Types, as there's no such Arrow type.
-      // We aren't setting COLUMN_SIZE nor DECIMAL_DIGITS for Float/Double as their precision and scale are variable.
+      // We aren't setting COLUMN_SIZE nor DECIMAL_DIGITS for Float/Double as their precision and
+      // scale are variable.
       if (fieldType instanceof ArrowType.Decimal) {
         numPrecRadixVector.setSafe(insertIndex, BASE10_RADIX);
       } else if (fieldType instanceof ArrowType.Int) {
@@ -1152,7 +1196,8 @@ public class ArrowDatabaseMetadata extends AvaticaDatabaseMetaData {
 
   static Integer getColumnSize(final ArrowType fieldType) {
     // We aren't setting COLUMN_SIZE for ROWID SQL Types, as there's no such Arrow type.
-    // We aren't setting COLUMN_SIZE nor DECIMAL_DIGITS for Float/Double as their precision and scale are variable.
+    // We aren't setting COLUMN_SIZE nor DECIMAL_DIGITS for Float/Double as their precision and
+    // scale are variable.
     if (fieldType instanceof ArrowType.Decimal) {
       final ArrowType.Decimal thisDecimal = (ArrowType.Decimal) fieldType;
       return thisDecimal.getPrecision();

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
@@ -14,16 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.replaceSemiColons;
 
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl;
 import org.apache.arrow.flight.FlightClient;
@@ -33,11 +32,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.AvaticaFactory;
 
-import io.netty.util.concurrent.DefaultThreadFactory;
-
-/**
- * Connection to the Arrow Flight server.
- */
+/** Connection to the Arrow Flight server. */
 public final class ArrowFlightConnection extends AvaticaConnection {
 
   private final BufferAllocator allocator;
@@ -48,19 +43,22 @@ public final class ArrowFlightConnection extends AvaticaConnection {
   /**
    * Creates a new {@link ArrowFlightConnection}.
    *
-   * @param driver        the {@link ArrowFlightJdbcDriver} to use.
-   * @param factory       the {@link AvaticaFactory} to use.
-   * @param url           the URL to use.
-   * @param properties    the {@link Properties} to use.
-   * @param config        the {@link ArrowFlightConnectionConfigImpl} to use.
-   * @param allocator     the {@link BufferAllocator} to use.
+   * @param driver the {@link ArrowFlightJdbcDriver} to use.
+   * @param factory the {@link AvaticaFactory} to use.
+   * @param url the URL to use.
+   * @param properties the {@link Properties} to use.
+   * @param config the {@link ArrowFlightConnectionConfigImpl} to use.
+   * @param allocator the {@link BufferAllocator} to use.
    * @param clientHandler the {@link ArrowFlightSqlClientHandler} to use.
    */
-  private ArrowFlightConnection(final ArrowFlightJdbcDriver driver, final AvaticaFactory factory,
-                                final String url, final Properties properties,
-                                final ArrowFlightConnectionConfigImpl config,
-                                final BufferAllocator allocator,
-                                final ArrowFlightSqlClientHandler clientHandler) {
+  private ArrowFlightConnection(
+      final ArrowFlightJdbcDriver driver,
+      final AvaticaFactory factory,
+      final String url,
+      final Properties properties,
+      final ArrowFlightConnectionConfigImpl config,
+      final BufferAllocator allocator,
+      final ArrowFlightSqlClientHandler clientHandler) {
     super(driver, factory, url, properties);
     this.config = Preconditions.checkNotNull(config, "Config cannot be null.");
     this.allocator = Preconditions.checkNotNull(allocator, "Allocator cannot be null.");
@@ -70,28 +68,31 @@ public final class ArrowFlightConnection extends AvaticaConnection {
   /**
    * Creates a new {@link ArrowFlightConnection} to a {@link FlightClient}.
    *
-   * @param driver     the {@link ArrowFlightJdbcDriver} to use.
-   * @param factory    the {@link AvaticaFactory} to use.
-   * @param url        the URL to establish the connection to.
+   * @param driver the {@link ArrowFlightJdbcDriver} to use.
+   * @param factory the {@link AvaticaFactory} to use.
+   * @param url the URL to establish the connection to.
    * @param properties the {@link Properties} to use for this session.
-   * @param allocator  the {@link BufferAllocator} to use.
+   * @param allocator the {@link BufferAllocator} to use.
    * @return a new {@link ArrowFlightConnection}.
    * @throws SQLException on error.
    */
-  static ArrowFlightConnection createNewConnection(final ArrowFlightJdbcDriver driver,
-                                                   final AvaticaFactory factory,
-                                                   String url, final Properties properties,
-                                                   final BufferAllocator allocator)
+  static ArrowFlightConnection createNewConnection(
+      final ArrowFlightJdbcDriver driver,
+      final AvaticaFactory factory,
+      String url,
+      final Properties properties,
+      final BufferAllocator allocator)
       throws SQLException {
     url = replaceSemiColons(url);
     final ArrowFlightConnectionConfigImpl config = new ArrowFlightConnectionConfigImpl(properties);
     final ArrowFlightSqlClientHandler clientHandler = createNewClientHandler(config, allocator);
-    return new ArrowFlightConnection(driver, factory, url, properties, config, allocator, clientHandler);
+    return new ArrowFlightConnection(
+        driver, factory, url, properties, config, allocator, clientHandler);
   }
 
   private static ArrowFlightSqlClientHandler createNewClientHandler(
-      final ArrowFlightConnectionConfigImpl config,
-      final BufferAllocator allocator) throws SQLException {
+      final ArrowFlightConnectionConfigImpl config, final BufferAllocator allocator)
+      throws SQLException {
     try {
       return new ArrowFlightSqlClientHandler.Builder()
           .withHost(config.getHost())
@@ -154,10 +155,11 @@ public final class ArrowFlightConnection extends AvaticaConnection {
    * @return the {@link #executorService}.
    */
   synchronized ExecutorService getExecutorService() {
-    return executorService = executorService == null ?
-        Executors.newFixedThreadPool(config.threadPoolSize(),
-            new DefaultThreadFactory(getClass().getSimpleName())) :
-        executorService;
+    return executorService =
+        executorService == null
+            ? Executors.newFixedThreadPool(
+                config.threadPoolSize(), new DefaultThreadFactory(getClass().getSimpleName()))
+            : executorService;
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightInfoStatement.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightInfoStatement.java
@@ -14,17 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import org.apache.arrow.flight.FlightInfo;
 
-/**
- * A {@link Statement} that deals with {@link FlightInfo}.
- */
+/** A {@link Statement} that deals with {@link FlightInfo}. */
 public interface ArrowFlightInfoStatement extends Statement {
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArray.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArray.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.Array;
@@ -23,7 +22,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Arrays;
 import java.util.Map;
-
 import org.apache.arrow.driver.jdbc.accessor.impl.complex.AbstractArrowFlightJdbcListVectorAccessor;
 import org.apache.arrow.driver.jdbc.utils.SqlTypes;
 import org.apache.arrow.memory.util.LargeMemoryUtil;
@@ -46,9 +44,10 @@ public class ArrowFlightJdbcArray implements Array {
   private final long valuesCount;
 
   /**
-   * Instantiate an {@link Array} backed up by given {@link FieldVector}, limited by a start offset and values count.
+   * Instantiate an {@link Array} backed up by given {@link FieldVector}, limited by a start offset
+   * and values count.
    *
-   * @param dataVector  underlying FieldVector, containing the Array items.
+   * @param dataVector underlying FieldVector, containing the Array items.
    * @param startOffset offset from FieldVector pointing to this Array's first value.
    * @param valuesCount how many items this Array contains.
    */
@@ -111,8 +110,8 @@ public class ArrowFlightJdbcArray implements Array {
     }
 
     checkBoundaries(index, count);
-    return getArrayNoBoundCheck(this.dataVector,
-        LargeMemoryUtil.checkedCastToInt(this.startOffset + index), count);
+    return getArrayNoBoundCheck(
+        this.dataVector, LargeMemoryUtil.checkedCastToInt(this.startOffset + index), count);
   }
 
   @Override
@@ -134,12 +133,11 @@ public class ArrowFlightJdbcArray implements Array {
     return getResultSet(index, count, null);
   }
 
-  private static ResultSet getResultSetNoBoundariesCheck(ValueVector dataVector, long start,
-                                                         long count)
-      throws SQLException {
+  private static ResultSet getResultSetNoBoundariesCheck(
+      ValueVector dataVector, long start, long count) throws SQLException {
     TransferPair transferPair = dataVector.getTransferPair(dataVector.getAllocator());
-    transferPair.splitAndTransfer(LargeMemoryUtil.checkedCastToInt(start),
-        LargeMemoryUtil.checkedCastToInt(count));
+    transferPair.splitAndTransfer(
+        LargeMemoryUtil.checkedCastToInt(start), LargeMemoryUtil.checkedCastToInt(count));
     FieldVector vectorSlice = (FieldVector) transferPair.getTo();
 
     VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.of(vectorSlice);
@@ -154,14 +152,12 @@ public class ArrowFlightJdbcArray implements Array {
     }
 
     checkBoundaries(index, count);
-    return getResultSetNoBoundariesCheck(this.dataVector,
-        LargeMemoryUtil.checkedCastToInt(this.startOffset + index), count);
+    return getResultSetNoBoundariesCheck(
+        this.dataVector, LargeMemoryUtil.checkedCastToInt(this.startOffset + index), count);
   }
 
   @Override
-  public void free() {
-
-  }
+  public void free() {}
 
   @Override
   public String toString() {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionPoolDataSource.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionPoolDataSource.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.SQLException;
@@ -23,17 +22,13 @@ import java.util.Properties;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.PooledConnection;
-
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl;
 
-/**
- * {@link ConnectionPoolDataSource} implementation for Arrow Flight JDBC Driver.
- */
+/** {@link ConnectionPoolDataSource} implementation for Arrow Flight JDBC Driver. */
 public class ArrowFlightJdbcConnectionPoolDataSource extends ArrowFlightJdbcDataSource
     implements ConnectionPoolDataSource, ConnectionEventListener, AutoCloseable {
   private final Map<Properties, Queue<ArrowFlightJdbcPooledConnection>> pool =
@@ -43,10 +38,10 @@ public class ArrowFlightJdbcConnectionPoolDataSource extends ArrowFlightJdbcData
    * Instantiates a new DataSource.
    *
    * @param properties the properties
-   * @param config     the config.
+   * @param config the config.
    */
-  protected ArrowFlightJdbcConnectionPoolDataSource(final Properties properties,
-                                                    final ArrowFlightConnectionConfigImpl config) {
+  protected ArrowFlightJdbcConnectionPoolDataSource(
+      final Properties properties, final ArrowFlightConnectionConfigImpl config) {
     super(properties, config);
   }
 
@@ -58,8 +53,8 @@ public class ArrowFlightJdbcConnectionPoolDataSource extends ArrowFlightJdbcData
    */
   public static ArrowFlightJdbcConnectionPoolDataSource createNewDataSource(
       final Properties properties) {
-    return new ArrowFlightJdbcConnectionPoolDataSource(properties,
-        new ArrowFlightConnectionConfigImpl(properties));
+    return new ArrowFlightJdbcConnectionPoolDataSource(
+        properties, new ArrowFlightConnectionConfigImpl(properties));
   }
 
   @Override
@@ -84,8 +79,7 @@ public class ArrowFlightJdbcConnectionPoolDataSource extends ArrowFlightJdbcData
   }
 
   private ArrowFlightJdbcPooledConnection createPooledConnection(
-      final ArrowFlightConnectionConfigImpl config)
-      throws SQLException {
+      final ArrowFlightConnectionConfigImpl config) throws SQLException {
     ArrowFlightJdbcPooledConnection pooledConnection =
         new ArrowFlightJdbcPooledConnection(getConnection(config.getUser(), config.getPassword()));
     pooledConnection.addConnectionEventListener(this);
@@ -102,9 +96,7 @@ public class ArrowFlightJdbcConnectionPoolDataSource extends ArrowFlightJdbcData
   }
 
   @Override
-  public void connectionErrorOccurred(ConnectionEvent connectionEvent) {
-
-  }
+  public void connectionErrorOccurred(ConnectionEvent connectionEvent) {}
 
   @Override
   public void close() throws Exception {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcCursor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcCursor.java
@@ -14,16 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
-
 
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
@@ -34,9 +31,7 @@ import org.apache.calcite.avatica.util.ArrayImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Arrow Flight Jdbc's Cursor class.
- */
+/** Arrow Flight Jdbc's Cursor class. */
 public class ArrowFlightJdbcCursor extends AbstractCursor {
 
   private static final Logger LOGGER;
@@ -54,18 +49,20 @@ public class ArrowFlightJdbcCursor extends AbstractCursor {
   }
 
   @Override
-  public List<Accessor> createAccessors(List<ColumnMetaData> columns,
-                                        Calendar localCalendar,
-                                        ArrayImpl.Factory factory) {
+  public List<Accessor> createAccessors(
+      List<ColumnMetaData> columns, Calendar localCalendar, ArrayImpl.Factory factory) {
     final List<FieldVector> fieldVectors = root.getFieldVectors();
 
-    return IntStream.range(0, fieldVectors.size()).mapToObj(root::getVector)
+    return IntStream.range(0, fieldVectors.size())
+        .mapToObj(root::getVector)
         .map(this::createAccessor)
         .collect(Collectors.toCollection(() -> new ArrayList<>(fieldVectors.size())));
   }
 
   private Accessor createAccessor(FieldVector vector) {
-    return ArrowFlightJdbcAccessorFactory.createAccessor(vector, this::getCurrentRow,
+    return ArrowFlightJdbcAccessorFactory.createAccessor(
+        vector,
+        this::getCurrentRow,
         (boolean wasNull) -> {
           // AbstractCursor creates a boolean array of length 1 to hold the wasNull value
           this.wasNull[0] = wasNull;
@@ -73,8 +70,9 @@ public class ArrowFlightJdbcCursor extends AbstractCursor {
   }
 
   /**
-   * ArrowFlightJdbcAccessors do not use {@link AbstractCursor.Getter}, as it would box primitive types and cause
-   * performance issues. Each Accessor implementation works directly on Arrow Vectors.
+   * ArrowFlightJdbcAccessors do not use {@link AbstractCursor.Getter}, as it would box primitive
+   * types and cause performance issues. Each Accessor implementation works directly on Arrow
+   * Vectors.
    */
   @Override
   protected Getter createGetter(int column) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDataSource.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDataSource.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
@@ -24,25 +23,19 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
-
 import javax.sql.DataSource;
-
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl;
 import org.apache.arrow.util.Preconditions;
 
-/**
- * {@link DataSource} implementation for Arrow Flight JDBC Driver.
- */
+/** {@link DataSource} implementation for Arrow Flight JDBC Driver. */
 public class ArrowFlightJdbcDataSource implements DataSource {
   private final Properties properties;
   private final ArrowFlightConnectionConfigImpl config;
   private PrintWriter logWriter;
 
-  /**
-   * Instantiates a new DataSource.
-   */
-  protected ArrowFlightJdbcDataSource(final Properties properties,
-                                      final ArrowFlightConnectionConfigImpl config) {
+  /** Instantiates a new DataSource. */
+  protected ArrowFlightJdbcDataSource(
+      final Properties properties, final ArrowFlightConnectionConfigImpl config) {
     this.properties = Preconditions.checkNotNull(properties);
     this.config = Preconditions.checkNotNull(config);
   }
@@ -57,8 +50,8 @@ public class ArrowFlightJdbcDataSource implements DataSource {
   }
 
   /**
-   * Gets a copy of the {@link #properties} for this {@link ArrowFlightJdbcDataSource} with
-   * the provided {@code username} and {@code password}.
+   * Gets a copy of the {@link #properties} for this {@link ArrowFlightJdbcDataSource} with the
+   * provided {@code username} and {@code password}.
    *
    * @return the {@link Properties} for this data source.
    */
@@ -81,8 +74,8 @@ public class ArrowFlightJdbcDataSource implements DataSource {
    * @return a new data source.
    */
   public static ArrowFlightJdbcDataSource createNewDataSource(final Properties properties) {
-    return new ArrowFlightJdbcDataSource(properties,
-        new ArrowFlightConnectionConfigImpl(properties));
+    return new ArrowFlightJdbcDataSource(
+        properties, new ArrowFlightConnectionConfigImpl(properties));
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.replaceSemiColons;
@@ -32,7 +31,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Logger;
-
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
 import org.apache.arrow.driver.jdbc.utils.UrlParser;
 import org.apache.arrow.flight.FlightRuntimeException;
@@ -44,14 +42,12 @@ import org.apache.calcite.avatica.DriverVersion;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.UnregisteredDriver;
 
-
-/**
- * JDBC driver for querying data from an Apache Arrow Flight server.
- */
+/** JDBC driver for querying data from an Apache Arrow Flight server. */
 public class ArrowFlightJdbcDriver extends UnregisteredDriver {
   private static final String CONNECT_STRING_PREFIX = "jdbc:arrow-flight-sql://";
   private static final String CONNECT_STRING_PREFIX_DEPRECATED = "jdbc:arrow-flight://";
-  private static final String CONNECTION_STRING_EXPECTED = "jdbc:arrow-flight-sql://[host][:port][?param1=value&...]";
+  private static final String CONNECTION_STRING_EXPECTED =
+      "jdbc:arrow-flight-sql://[host][:port][?param1=value&...]";
   private static DriverVersion version;
 
   static {
@@ -92,11 +88,7 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
 
     try {
       return ArrowFlightConnection.createNewConnection(
-          this,
-          factory,
-          url,
-          lowerCasePropertyKeys(properties),
-          new RootAllocator(Long.MAX_VALUE));
+          this, factory, url, lowerCasePropertyKeys(properties), new RootAllocator(Long.MAX_VALUE));
     } catch (final FlightRuntimeException e) {
       throw new SQLException("Failed to connect.", e);
     }
@@ -111,11 +103,14 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
   @SuppressWarnings("StringSplitter")
   protected DriverVersion createDriverVersion() {
     if (version == null) {
-      final InputStream flightProperties = this.getClass().getResourceAsStream("/properties/flight.properties");
+      final InputStream flightProperties =
+          this.getClass().getResourceAsStream("/properties/flight.properties");
       if (flightProperties == null) {
-        throw new RuntimeException("Flight Properties not found. Ensure the JAR was built properly.");
+        throw new RuntimeException(
+            "Flight Properties not found. Ensure the JAR was built properly.");
       }
-      try (final Reader reader = new BufferedReader(new InputStreamReader(flightProperties, StandardCharsets.UTF_8))) {
+      try (final Reader reader =
+          new BufferedReader(new InputStreamReader(flightProperties, StandardCharsets.UTF_8))) {
         final Properties properties = new Properties();
         properties.load(reader);
 
@@ -127,22 +122,24 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
         final int parentMinorVersion = Integer.parseInt(pVersion[1]);
 
         final String childName = properties.getProperty("org.apache.arrow.flight.jdbc-driver.name");
-        final String childVersion = properties.getProperty("org.apache.arrow.flight.jdbc-driver.version");
+        final String childVersion =
+            properties.getProperty("org.apache.arrow.flight.jdbc-driver.version");
         final String[] cVersion = childVersion.split("\\.");
 
         final int childMajorVersion = Integer.parseInt(cVersion[0]);
         final int childMinorVersion = Integer.parseInt(cVersion[1]);
 
-        version = new DriverVersion(
-            childName,
-            childVersion,
-            parentName,
-            parentVersion,
-            true,
-            childMajorVersion,
-            childMinorVersion,
-            parentMajorVersion,
-            parentMinorVersion);
+        version =
+            new DriverVersion(
+                childName,
+                childVersion,
+                parentName,
+                parentVersion,
+                true,
+                childMajorVersion,
+                childMinorVersion,
+                parentMajorVersion,
+                parentMinorVersion);
       } catch (final IOException e) {
         throw new RuntimeException("Failed to load driver version.", e);
       }
@@ -164,15 +161,16 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
   @Override
   public boolean acceptsURL(final String url) {
     Preconditions.checkNotNull(url);
-    return url.startsWith(CONNECT_STRING_PREFIX) || url.startsWith(CONNECT_STRING_PREFIX_DEPRECATED);
+    return url.startsWith(CONNECT_STRING_PREFIX)
+        || url.startsWith(CONNECT_STRING_PREFIX_DEPRECATED);
   }
 
   /**
-   * Parses the provided url based on the format this driver accepts, retrieving
-   * arguments after the {@link #CONNECT_STRING_PREFIX}.
-   * <p>
-   * This method gets the args if the provided URL follows this pattern:
-   * {@code jdbc:arrow-flight-sql://<host>:<port>[/?key1=val1&key2=val2&(...)]}
+   * Parses the provided url based on the format this driver accepts, retrieving arguments after the
+   * {@link #CONNECT_STRING_PREFIX}.
+   *
+   * <p>This method gets the args if the provided URL follows this pattern: {@code
+   * jdbc:arrow-flight-sql://<host>:<port>[/?key1=val1&key2=val2&(...)]}
    *
    * <table border="1">
    *    <tr>
@@ -218,8 +216,7 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
    * @throws SQLException If an error occurs while trying to parse the URL.
    */
   @VisibleForTesting // ArrowFlightJdbcDriverTest
-  Optional<Map<Object, Object>> getUrlsArgs(String url)
-      throws SQLException {
+  Optional<Map<Object, Object>> getUrlsArgs(String url) throws SQLException {
 
     /*
      *
@@ -238,8 +235,9 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
     url = replaceSemiColons(url);
 
     if (!url.startsWith("jdbc:")) {
-      throw new SQLException("Connection string must start with 'jdbc:'. Expected format: " +
-          CONNECTION_STRING_EXPECTED);
+      throw new SQLException(
+          "Connection string must start with 'jdbc:'. Expected format: "
+              + CONNECTION_STRING_EXPECTED);
     }
 
     // It's necessary to use a string without "jdbc:" at the beginning to be parsed as a valid URL.
@@ -253,15 +251,17 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
       throw new SQLException("Malformed/invalid URL!", e);
     }
 
-    if (!Objects.equals(uri.getScheme(), "arrow-flight") &&
-        !Objects.equals(uri.getScheme(), "arrow-flight-sql")) {
+    if (!Objects.equals(uri.getScheme(), "arrow-flight")
+        && !Objects.equals(uri.getScheme(), "arrow-flight-sql")) {
       return Optional.empty();
     }
 
     if (uri.getHost() == null) {
-      throw new SQLException("URL must have a host. Expected format: " + CONNECTION_STRING_EXPECTED);
+      throw new SQLException(
+          "URL must have a host. Expected format: " + CONNECTION_STRING_EXPECTED);
     } else if (uri.getPort() < 0) {
-      throw new SQLException("URL must have a port. Expected format: " + CONNECTION_STRING_EXPECTED);
+      throw new SQLException(
+          "URL must have a port. Expected format: " + CONNECTION_STRING_EXPECTED);
     }
     resultMap.put(ArrowFlightConnectionProperty.HOST.camelName(), uri.getHost()); // host
     resultMap.put(ArrowFlightConnectionProperty.PORT.camelName(), uri.getPort()); // port

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactory.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactory.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.TimeZone;
-
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.calcite.avatica.AvaticaConnection;
@@ -33,9 +31,7 @@ import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.QueryState;
 import org.apache.calcite.avatica.UnregisteredDriver;
 
-/**
- * Factory for the Arrow Flight JDBC Driver.
- */
+/** Factory for the Arrow Flight JDBC Driver. */
 public class ArrowFlightJdbcFactory implements AvaticaFactory {
   private final int major;
   private final int minor;
@@ -51,16 +47,14 @@ public class ArrowFlightJdbcFactory implements AvaticaFactory {
   }
 
   @Override
-  public AvaticaConnection newConnection(final UnregisteredDriver driver,
-                                         final AvaticaFactory factory,
-                                         final String url,
-                                         final Properties info) throws SQLException {
+  public AvaticaConnection newConnection(
+      final UnregisteredDriver driver,
+      final AvaticaFactory factory,
+      final String url,
+      final Properties info)
+      throws SQLException {
     return ArrowFlightConnection.createNewConnection(
-        (ArrowFlightJdbcDriver) driver,
-        factory,
-        url,
-        info,
-        new RootAllocator(Long.MAX_VALUE));
+        (ArrowFlightJdbcDriver) driver, factory, url, info, new RootAllocator(Long.MAX_VALUE));
   }
 
   @Override
@@ -70,8 +64,12 @@ public class ArrowFlightJdbcFactory implements AvaticaFactory {
       final int resultType,
       final int resultSetConcurrency,
       final int resultSetHoldability) {
-    return new ArrowFlightStatement((ArrowFlightConnection) connection,
-        handle, resultType, resultSetConcurrency, resultSetHoldability);
+    return new ArrowFlightStatement(
+        (ArrowFlightConnection) connection,
+        handle,
+        resultType,
+        resultSetConcurrency,
+        resultSetHoldability);
   }
 
   @Override
@@ -81,27 +79,34 @@ public class ArrowFlightJdbcFactory implements AvaticaFactory {
       final Meta.Signature signature,
       final int resultType,
       final int resultSetConcurrency,
-      final int resultSetHoldability) throws SQLException {
+      final int resultSetHoldability)
+      throws SQLException {
     final ArrowFlightConnection flightConnection = (ArrowFlightConnection) connection;
     ArrowFlightSqlClientHandler.PreparedStatement preparedStatement =
         flightConnection.getMeta().getPreparedStatement(statementHandle);
 
     return ArrowFlightPreparedStatement.newPreparedStatement(
-        flightConnection, preparedStatement, statementHandle,
-        signature, resultType, resultSetConcurrency, resultSetHoldability);
+        flightConnection,
+        preparedStatement,
+        statementHandle,
+        signature,
+        resultType,
+        resultSetConcurrency,
+        resultSetHoldability);
   }
 
   @Override
-  public ArrowFlightJdbcVectorSchemaRootResultSet newResultSet(final AvaticaStatement statement,
-                                                               final QueryState state,
-                                                               final Meta.Signature signature,
-                                                               final TimeZone timeZone,
-                                                               final Meta.Frame frame)
+  public ArrowFlightJdbcVectorSchemaRootResultSet newResultSet(
+      final AvaticaStatement statement,
+      final QueryState state,
+      final Meta.Signature signature,
+      final TimeZone timeZone,
+      final Meta.Frame frame)
       throws SQLException {
     final ResultSetMetaData metaData = newResultSetMetaData(statement, signature);
 
-    return new ArrowFlightJdbcFlightStreamResultSet(statement, state, signature, metaData, timeZone,
-        frame);
+    return new ArrowFlightJdbcFlightStreamResultSet(
+        statement, state, signature, metaData, timeZone, frame);
   }
 
   @Override
@@ -111,10 +116,8 @@ public class ArrowFlightJdbcFactory implements AvaticaFactory {
 
   @Override
   public ResultSetMetaData newResultSetMetaData(
-      final AvaticaStatement avaticaStatement,
-      final Meta.Signature signature) {
-    return new AvaticaResultSetMetaData(avaticaStatement,
-        null, signature);
+      final AvaticaStatement avaticaStatement, final Meta.Signature signature) {
+    return new AvaticaResultSetMetaData(avaticaStatement, null, signature);
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFlightStreamResultSet.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.apache.arrow.driver.jdbc.utils.FlightEndpointDataQueue.createNewQueue;
@@ -25,7 +24,6 @@ import java.sql.SQLException;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.arrow.driver.jdbc.client.CloseableEndpointStreamPair;
 import org.apache.arrow.driver.jdbc.utils.FlightEndpointDataQueue;
 import org.apache.arrow.driver.jdbc.utils.VectorSchemaRootTransformer;
@@ -41,8 +39,8 @@ import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.QueryState;
 
 /**
- * {@link ResultSet} implementation for Arrow Flight used to access the results of multiple {@link FlightStream}
- * objects.
+ * {@link ResultSet} implementation for Arrow Flight used to access the results of multiple {@link
+ * FlightStream} objects.
  */
 public final class ArrowFlightJdbcFlightStreamResultSet
     extends ArrowFlightJdbcVectorSchemaRootResultSet {
@@ -57,49 +55,50 @@ public final class ArrowFlightJdbcFlightStreamResultSet
 
   private Schema schema;
 
-  /**
-   * Public constructor used by ArrowFlightJdbcFactory.
-   */
-  ArrowFlightJdbcFlightStreamResultSet(final AvaticaStatement statement,
-                                       final QueryState state,
-                                       final Meta.Signature signature,
-                                       final ResultSetMetaData resultSetMetaData,
-                                       final TimeZone timeZone,
-                                       final Meta.Frame firstFrame) throws SQLException {
+  /** Public constructor used by ArrowFlightJdbcFactory. */
+  ArrowFlightJdbcFlightStreamResultSet(
+      final AvaticaStatement statement,
+      final QueryState state,
+      final Meta.Signature signature,
+      final ResultSetMetaData resultSetMetaData,
+      final TimeZone timeZone,
+      final Meta.Frame firstFrame)
+      throws SQLException {
     super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
     this.connection = (ArrowFlightConnection) statement.connection;
     this.flightInfo = ((ArrowFlightInfoStatement) statement).executeFlightInfoQuery();
   }
 
-  /**
-   * Private constructor for fromFlightInfo.
-   */
-  private ArrowFlightJdbcFlightStreamResultSet(final ArrowFlightConnection connection,
-                                               final QueryState state,
-                                               final Meta.Signature signature,
-                                               final ResultSetMetaData resultSetMetaData,
-                                               final TimeZone timeZone,
-                                               final Meta.Frame firstFrame,
-                                               final FlightInfo flightInfo
-  ) throws SQLException {
+  /** Private constructor for fromFlightInfo. */
+  private ArrowFlightJdbcFlightStreamResultSet(
+      final ArrowFlightConnection connection,
+      final QueryState state,
+      final Meta.Signature signature,
+      final ResultSetMetaData resultSetMetaData,
+      final TimeZone timeZone,
+      final Meta.Frame firstFrame,
+      final FlightInfo flightInfo)
+      throws SQLException {
     super(null, state, signature, resultSetMetaData, timeZone, firstFrame);
     this.connection = connection;
     this.flightInfo = flightInfo;
   }
 
   /**
-   * Create a {@link ResultSet} which pulls data from given {@link FlightInfo}. This is used to fetch result sets
-   * from DatabaseMetadata calls and skips the Avatica factory.
+   * Create a {@link ResultSet} which pulls data from given {@link FlightInfo}. This is used to
+   * fetch result sets from DatabaseMetadata calls and skips the Avatica factory.
    *
-   * @param connection  The connection linked to the returned ResultSet.
-   * @param flightInfo  The FlightInfo from which data will be iterated by the returned ResultSet.
-   * @param transformer Optional transformer for processing VectorSchemaRoot before access from ResultSet
+   * @param connection The connection linked to the returned ResultSet.
+   * @param flightInfo The FlightInfo from which data will be iterated by the returned ResultSet.
+   * @param transformer Optional transformer for processing VectorSchemaRoot before access from
+   *     ResultSet
    * @return A ResultSet which pulls data from given FlightInfo.
    */
   static ArrowFlightJdbcFlightStreamResultSet fromFlightInfo(
       final ArrowFlightConnection connection,
       final FlightInfo flightInfo,
-      final VectorSchemaRootTransformer transformer) throws SQLException {
+      final VectorSchemaRootTransformer transformer)
+      throws SQLException {
     // Similar to how org.apache.calcite.avatica.util.ArrayFactoryImpl does
 
     final TimeZone timeZone = TimeZone.getDefault();
@@ -110,8 +109,8 @@ public final class ArrowFlightJdbcFlightStreamResultSet
     final AvaticaResultSetMetaData resultSetMetaData =
         new AvaticaResultSetMetaData(null, null, signature);
     final ArrowFlightJdbcFlightStreamResultSet resultSet =
-        new ArrowFlightJdbcFlightStreamResultSet(connection, state, signature, resultSetMetaData,
-            timeZone, null, flightInfo);
+        new ArrowFlightJdbcFlightStreamResultSet(
+            connection, state, signature, resultSetMetaData, timeZone, null, flightInfo);
 
     resultSet.transformer = transformer;
 
@@ -167,9 +166,7 @@ public final class ArrowFlightJdbcFlightStreamResultSet
     populateData(currentVectorSchemaRoot, schema);
   }
 
-  /**
-   * Expose appMetadata associated with the underlying FlightInfo for this ResultSet.
-   */
+  /** Expose appMetadata associated with the underlying FlightInfo for this ResultSet. */
   public byte[] getAppMetadata() {
     return flightInfo.getAppMetadata();
   }
@@ -253,11 +250,13 @@ public final class ArrowFlightJdbcFlightStreamResultSet
     }
   }
 
-  private CloseableEndpointStreamPair getNextEndpointStream(final boolean canTimeout) throws SQLException {
+  private CloseableEndpointStreamPair getNextEndpointStream(final boolean canTimeout)
+      throws SQLException {
     if (canTimeout) {
       final int statementTimeout = statement != null ? statement.getQueryTimeout() : 0;
-      return statementTimeout != 0 ?
-          flightEndpointDataQueue.next(statementTimeout, TimeUnit.SECONDS) : flightEndpointDataQueue.next();
+      return statementTimeout != 0
+          ? flightEndpointDataQueue.next(statementTimeout, TimeUnit.SECONDS)
+          : flightEndpointDataQueue.next();
     } else {
       return flightEndpointDataQueue.next();
     }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcPooledConnection.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcPooledConnection.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.Connection;
@@ -23,17 +22,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
 import javax.sql.PooledConnection;
 import javax.sql.StatementEventListener;
-
 import org.apache.arrow.driver.jdbc.utils.ConnectionWrapper;
 
-/**
- * {@link PooledConnection} implementation for Arrow Flight JDBC Driver.
- */
+/** {@link PooledConnection} implementation for Arrow Flight JDBC Driver. */
 public class ArrowFlightJdbcPooledConnection implements PooledConnection {
 
   private final ArrowFlightConnection connection;

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcTime.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcTime.java
@@ -14,24 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY;
 
+import com.google.common.collect.ImmutableList;
 import java.sql.Time;
 import java.time.LocalTime;
 import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.arrow.util.VisibleForTesting;
 
-import com.google.common.collect.ImmutableList;
-
 /**
- * Wrapper class for Time objects to include the milliseconds part in ISO 8601 format in this#toString.
+ * Wrapper class for Time objects to include the milliseconds part in ISO 8601 format in
+ * this#toString.
  */
 public class ArrowFlightJdbcTime extends Time {
   private static final List<String> LEADING_ZEROES = ImmutableList.of("", "0", "00");
@@ -54,7 +52,8 @@ public class ArrowFlightJdbcTime extends Time {
 
   @VisibleForTesting
   ArrowFlightJdbcTime(final LocalTime time) {
-    // Although the constructor is deprecated, this is the exact same code as Time#valueOf(LocalTime)
+    // Although the constructor is deprecated, this is the exact same code as
+    // Time#valueOf(LocalTime)
     super(time.getHour(), time.getMinute(), time.getSecond());
     millisReprValue = time.get(ChronoField.MILLI_OF_SECOND);
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcVectorSchemaRootResultSet.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.ResultSet;
@@ -25,7 +24,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
-
 import org.apache.arrow.driver.jdbc.utils.ConvertUtils;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -41,19 +39,20 @@ import org.apache.calcite.avatica.QueryState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * {@link ResultSet} implementation used to access a {@link VectorSchemaRoot}.
- */
+/** {@link ResultSet} implementation used to access a {@link VectorSchemaRoot}. */
 public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ArrowFlightJdbcVectorSchemaRootResultSet.class);
   VectorSchemaRoot vectorSchemaRoot;
 
-  ArrowFlightJdbcVectorSchemaRootResultSet(final AvaticaStatement statement, final QueryState state,
-                                           final Signature signature,
-                                           final ResultSetMetaData resultSetMetaData,
-                                           final TimeZone timeZone, final Frame firstFrame)
+  ArrowFlightJdbcVectorSchemaRootResultSet(
+      final AvaticaStatement statement,
+      final QueryState state,
+      final Signature signature,
+      final ResultSetMetaData resultSetMetaData,
+      final TimeZone timeZone,
+      final Frame firstFrame)
       throws SQLException {
     super(statement, state, signature, resultSetMetaData, timeZone, firstFrame);
   }
@@ -65,8 +64,7 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
    * @return a ResultSet which accesses the given VectorSchemaRoot
    */
   public static ArrowFlightJdbcVectorSchemaRootResultSet fromVectorSchemaRoot(
-      final VectorSchemaRoot vectorSchemaRoot)
-      throws SQLException {
+      final VectorSchemaRoot vectorSchemaRoot) throws SQLException {
     // Similar to how org.apache.calcite.avatica.util.ArrayFactoryImpl does
 
     final TimeZone timeZone = TimeZone.getDefault();
@@ -76,10 +74,9 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
 
     final AvaticaResultSetMetaData resultSetMetaData =
         new AvaticaResultSetMetaData(null, null, signature);
-    final ArrowFlightJdbcVectorSchemaRootResultSet
-        resultSet =
-        new ArrowFlightJdbcVectorSchemaRootResultSet(null, state, signature, resultSetMetaData,
-            timeZone, null);
+    final ArrowFlightJdbcVectorSchemaRootResultSet resultSet =
+        new ArrowFlightJdbcVectorSchemaRootResultSet(
+            null, state, signature, resultSetMetaData, timeZone, null);
 
     resultSet.populateData(vectorSchemaRoot);
     return resultSet;
@@ -96,7 +93,8 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
 
   void populateData(final VectorSchemaRoot vectorSchemaRoot, final Schema schema) {
     Schema currentSchema = schema == null ? vectorSchemaRoot.getSchema() : schema;
-    final List<ColumnMetaData> columns = ConvertUtils.convertArrowFieldsToColumnMetaDataList(currentSchema.getFields());
+    final List<ColumnMetaData> columns =
+        ConvertUtils.convertArrowFieldsToColumnMetaDataList(currentSchema.getFields());
     signature.columns.clear();
     signature.columns.addAll(columns);
 
@@ -138,9 +136,11 @@ public class ArrowFlightJdbcVectorSchemaRootResultSet extends AvaticaResultSet {
       }
     }
     exceptions.parallelStream().forEach(e -> LOGGER.error(e.getMessage(), e));
-    exceptions.stream().findAny().ifPresent(e -> {
-      throw new RuntimeException(e);
-    });
+    exceptions.stream()
+        .findAny()
+        .ifPresent(
+            e -> {
+              throw new RuntimeException(e);
+            });
   }
-
 }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightMetaImpl.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightMetaImpl.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.Connection;
@@ -25,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler.PreparedStatement;
 import org.apache.arrow.driver.jdbc.utils.AvaticaParameterBinder;
 import org.apache.arrow.driver.jdbc.utils.ConvertUtils;
@@ -39,14 +37,13 @@ import org.apache.calcite.avatica.NoSuchStatementException;
 import org.apache.calcite.avatica.QueryState;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * Metadata handler for Arrow Flight.
- */
+/** Metadata handler for Arrow Flight. */
 public class ArrowFlightMetaImpl extends MetaImpl {
   private final Map<StatementHandleKey, PreparedStatement> statementHandlePreparedStatementMap;
 
   /**
    * Constructs a {@link MetaImpl} object specific for Arrow Flight.
+   *
    * @param connection A {@link AvaticaConnection}.
    */
   public ArrowFlightMetaImpl(final AvaticaConnection connection) {
@@ -55,14 +52,16 @@ public class ArrowFlightMetaImpl extends MetaImpl {
     setDefaultConnectionProperties();
   }
 
-  /**
-   * Construct a signature.
-   */
+  /** Construct a signature. */
   static Signature newSignature(final String sql, Schema resultSetSchema, Schema parameterSchema) {
-    List<ColumnMetaData> columnMetaData = resultSetSchema == null ?
-            new ArrayList<>() : ConvertUtils.convertArrowFieldsToColumnMetaDataList(resultSetSchema.getFields());
-    List<AvaticaParameter> parameters = parameterSchema == null ?
-            new ArrayList<>() : ConvertUtils.convertArrowFieldsToAvaticaParameters(parameterSchema.getFields());
+    List<ColumnMetaData> columnMetaData =
+        resultSetSchema == null
+            ? new ArrayList<>()
+            : ConvertUtils.convertArrowFieldsToColumnMetaDataList(resultSetSchema.getFields());
+    List<AvaticaParameter> parameters =
+        parameterSchema == null
+            ? new ArrayList<>()
+            : ConvertUtils.convertArrowFieldsToAvaticaParameters(parameterSchema.getFields());
 
     return new Signature(
         columnMetaData,
@@ -70,15 +69,15 @@ public class ArrowFlightMetaImpl extends MetaImpl {
         parameters,
         Collections.emptyMap(),
         null, // unnecessary, as SQL requests use ArrowFlightJdbcCursor
-        StatementType.SELECT
-    );
+        StatementType.SELECT);
   }
 
   @Override
   public void closeStatement(final StatementHandle statementHandle) {
     PreparedStatement preparedStatement =
         statementHandlePreparedStatementMap.remove(new StatementHandleKey(statementHandle));
-    // Testing if the prepared statement was created because the statement can be not created until this moment
+    // Testing if the prepared statement was created because the statement can be not created until
+    // this moment
     if (preparedStatement != null) {
       preparedStatement.close();
     }
@@ -90,54 +89,64 @@ public class ArrowFlightMetaImpl extends MetaImpl {
   }
 
   @Override
-  public ExecuteResult execute(final StatementHandle statementHandle,
-                               final List<TypedValue> typedValues, final long maxRowCount) {
-    Preconditions.checkArgument(connection.id.equals(statementHandle.connectionId),
-            "Connection IDs are not consistent");
+  public ExecuteResult execute(
+      final StatementHandle statementHandle,
+      final List<TypedValue> typedValues,
+      final long maxRowCount) {
+    Preconditions.checkArgument(
+        connection.id.equals(statementHandle.connectionId), "Connection IDs are not consistent");
     PreparedStatement preparedStatement = getPreparedStatement(statementHandle);
 
     if (preparedStatement == null) {
       throw new IllegalStateException("Prepared statement not found: " + statementHandle);
     }
 
-
-    new AvaticaParameterBinder(preparedStatement, ((ArrowFlightConnection) connection).getBufferAllocator())
-            .bind(typedValues);
+    new AvaticaParameterBinder(
+            preparedStatement, ((ArrowFlightConnection) connection).getBufferAllocator())
+        .bind(typedValues);
 
     if (statementHandle.signature == null) {
       // Update query
       long updatedCount = preparedStatement.executeUpdate();
-      return new ExecuteResult(Collections.singletonList(MetaResultSet.count(statementHandle.connectionId,
-              statementHandle.id, updatedCount)));
+      return new ExecuteResult(
+          Collections.singletonList(
+              MetaResultSet.count(statementHandle.connectionId, statementHandle.id, updatedCount)));
     } else {
       // TODO Why is maxRowCount ignored?
       return new ExecuteResult(
-              Collections.singletonList(MetaResultSet.create(
-                      statementHandle.connectionId, statementHandle.id,
-                      true, statementHandle.signature, null)));
+          Collections.singletonList(
+              MetaResultSet.create(
+                  statementHandle.connectionId,
+                  statementHandle.id,
+                  true,
+                  statementHandle.signature,
+                  null)));
     }
   }
 
   @Override
-  public ExecuteResult execute(final StatementHandle statementHandle,
-                               final List<TypedValue> typedValues, final int maxRowsInFirstFrame) {
+  public ExecuteResult execute(
+      final StatementHandle statementHandle,
+      final List<TypedValue> typedValues,
+      final int maxRowsInFirstFrame) {
     return execute(statementHandle, typedValues, (long) maxRowsInFirstFrame);
   }
 
   @Override
-  public ExecuteBatchResult executeBatch(final StatementHandle statementHandle,
-                                         final List<List<TypedValue>> parameterValuesList)
+  public ExecuteBatchResult executeBatch(
+      final StatementHandle statementHandle, final List<List<TypedValue>> parameterValuesList)
       throws IllegalStateException {
-    Preconditions.checkArgument(connection.id.equals(statementHandle.connectionId),
-            "Connection IDs are not consistent");
+    Preconditions.checkArgument(
+        connection.id.equals(statementHandle.connectionId), "Connection IDs are not consistent");
     PreparedStatement preparedStatement = getPreparedStatement(statementHandle);
 
     if (preparedStatement == null) {
       throw new IllegalStateException("Prepared statement not found: " + statementHandle);
     }
 
-    final AvaticaParameterBinder binder = new AvaticaParameterBinder(preparedStatement,
-            ((ArrowFlightConnection) connection).getBufferAllocator());
+    final AvaticaParameterBinder binder =
+        new AvaticaParameterBinder(
+            preparedStatement, ((ArrowFlightConnection) connection).getBufferAllocator());
     for (int i = 0; i < parameterValuesList.size(); i++) {
       binder.bind(parameterValuesList.get(i), i);
     }
@@ -148,49 +157,53 @@ public class ArrowFlightMetaImpl extends MetaImpl {
   }
 
   @Override
-  public Frame fetch(final StatementHandle statementHandle, final long offset,
-                     final int fetchMaxRowCount) {
+  public Frame fetch(
+      final StatementHandle statementHandle, final long offset, final int fetchMaxRowCount) {
     /*
      * ArrowFlightMetaImpl does not use frames.
      * Instead, we have accessors that contain a VectorSchemaRoot with
      * the results.
      */
     throw AvaticaConnection.HELPER.wrap(
-        String.format("%s does not use frames.", this),
-        AvaticaConnection.HELPER.unsupported());
+        String.format("%s does not use frames.", this), AvaticaConnection.HELPER.unsupported());
   }
 
   private PreparedStatement prepareForHandle(final String query, StatementHandle handle) {
     final PreparedStatement preparedStatement =
         ((ArrowFlightConnection) connection).getClientHandler().prepare(query);
-    handle.signature = newSignature(query, preparedStatement.getDataSetSchema(),
-            preparedStatement.getParameterSchema());
+    handle.signature =
+        newSignature(
+            query, preparedStatement.getDataSetSchema(), preparedStatement.getParameterSchema());
     statementHandlePreparedStatementMap.put(new StatementHandleKey(handle), preparedStatement);
     return preparedStatement;
   }
 
   @Override
-  public StatementHandle prepare(final ConnectionHandle connectionHandle,
-                                 final String query, final long maxRowCount) {
+  public StatementHandle prepare(
+      final ConnectionHandle connectionHandle, final String query, final long maxRowCount) {
     final StatementHandle handle = super.createStatement(connectionHandle);
     prepareForHandle(query, handle);
     return handle;
   }
 
   @Override
-  public ExecuteResult prepareAndExecute(final StatementHandle statementHandle,
-                                         final String query, final long maxRowCount,
-                                         final PrepareCallback prepareCallback)
+  public ExecuteResult prepareAndExecute(
+      final StatementHandle statementHandle,
+      final String query,
+      final long maxRowCount,
+      final PrepareCallback prepareCallback)
       throws NoSuchStatementException {
     return prepareAndExecute(
         statementHandle, query, maxRowCount, -1 /* Not used */, prepareCallback);
   }
 
   @Override
-  public ExecuteResult prepareAndExecute(final StatementHandle handle,
-                                         final String query, final long maxRowCount,
-                                         final int maxRowsInFirstFrame,
-                                         final PrepareCallback callback)
+  public ExecuteResult prepareAndExecute(
+      final StatementHandle handle,
+      final String query,
+      final long maxRowCount,
+      final int maxRowsInFirstFrame,
+      final PrepareCallback callback)
       throws NoSuchStatementException {
     try {
       PreparedStatement preparedStatement = prepareForHandle(query, handle);
@@ -203,11 +216,12 @@ public class ArrowFlightMetaImpl extends MetaImpl {
         callback.assign(handle.signature, null, updateCount);
       }
       callback.execute();
-      final MetaResultSet metaResultSet = MetaResultSet.create(handle.connectionId, handle.id,
-          false, handle.signature, null);
+      final MetaResultSet metaResultSet =
+          MetaResultSet.create(handle.connectionId, handle.id, false, handle.signature, null);
       return new ExecuteResult(Collections.singletonList(metaResultSet));
     } catch (SQLTimeoutException e) {
-      // So far AvaticaStatement(executeInternal) only handles NoSuchStatement and Runtime Exceptions.
+      // So far AvaticaStatement(executeInternal) only handles NoSuchStatement and Runtime
+      // Exceptions.
       throw new RuntimeException(e);
     } catch (SQLException e) {
       throw new NoSuchStatementException(handle);
@@ -228,8 +242,8 @@ public class ArrowFlightMetaImpl extends MetaImpl {
   }
 
   @Override
-  public boolean syncResults(final StatementHandle statementHandle,
-                             final QueryState queryState, final long offset)
+  public boolean syncResults(
+      final StatementHandle statementHandle, final QueryState queryState, final long offset)
       throws NoSuchStatementException {
     // TODO Fill this stub.
     return false;
@@ -237,7 +251,8 @@ public class ArrowFlightMetaImpl extends MetaImpl {
 
   void setDefaultConnectionProperties() {
     // TODO Double-check this.
-    connProps.setDirty(false)
+    connProps
+        .setDirty(false)
         .setAutoCommit(true)
         .setReadOnly(true)
         .setCatalog(null)
@@ -249,7 +264,8 @@ public class ArrowFlightMetaImpl extends MetaImpl {
     return statementHandlePreparedStatementMap.get(new StatementHandleKey(statementHandle));
   }
 
-  // Helper used to look up prepared statement instances later. Avatica doesn't give us the signature in
+  // Helper used to look up prepared statement instances later. Avatica doesn't give us the
+  // signature in
   // an UPDATE code path so we can't directly use StatementHandle as a map key.
   private static final class StatementHandleKey {
     public final String connectionId;

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatement.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.util.Preconditions;
@@ -27,36 +25,42 @@ import org.apache.calcite.avatica.AvaticaPreparedStatement;
 import org.apache.calcite.avatica.Meta.Signature;
 import org.apache.calcite.avatica.Meta.StatementHandle;
 
-
-/**
- * Arrow Flight JBCS's implementation {@link PreparedStatement}.
- */
+/** Arrow Flight JBCS's implementation {@link PreparedStatement}. */
 public class ArrowFlightPreparedStatement extends AvaticaPreparedStatement
     implements ArrowFlightInfoStatement {
 
   private final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement;
 
-  private ArrowFlightPreparedStatement(final ArrowFlightConnection connection,
-                                       final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement,
-                                       final StatementHandle handle,
-                                       final Signature signature, final int resultSetType,
-                                       final int resultSetConcurrency,
-                                       final int resultSetHoldability)
+  private ArrowFlightPreparedStatement(
+      final ArrowFlightConnection connection,
+      final ArrowFlightSqlClientHandler.PreparedStatement preparedStatement,
+      final StatementHandle handle,
+      final Signature signature,
+      final int resultSetType,
+      final int resultSetConcurrency,
+      final int resultSetHoldability)
       throws SQLException {
     super(connection, handle, signature, resultSetType, resultSetConcurrency, resultSetHoldability);
     this.preparedStatement = Preconditions.checkNotNull(preparedStatement);
   }
 
-  static ArrowFlightPreparedStatement newPreparedStatement(final ArrowFlightConnection connection,
+  static ArrowFlightPreparedStatement newPreparedStatement(
+      final ArrowFlightConnection connection,
       final ArrowFlightSqlClientHandler.PreparedStatement preparedStmt,
       final StatementHandle statementHandle,
       final Signature signature,
       final int resultSetType,
       final int resultSetConcurrency,
-      final int resultSetHoldability) throws SQLException {
+      final int resultSetHoldability)
+      throws SQLException {
     return new ArrowFlightPreparedStatement(
-        connection, preparedStmt, statementHandle,
-        signature, resultSetType, resultSetConcurrency, resultSetHoldability);
+        connection,
+        preparedStmt,
+        statementHandle,
+        signature,
+        resultSetType,
+        resultSetConcurrency,
+        resultSetHoldability);
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightStatement.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightStatement.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.SQLException;
-
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler.PreparedStatement;
 import org.apache.arrow.driver.jdbc.utils.ConvertUtils;
 import org.apache.arrow.flight.FlightInfo;
@@ -27,14 +25,15 @@ import org.apache.calcite.avatica.AvaticaStatement;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.Meta.StatementHandle;
 
-/**
- * A SQL statement for querying data from an Arrow Flight server.
- */
+/** A SQL statement for querying data from an Arrow Flight server. */
 public class ArrowFlightStatement extends AvaticaStatement implements ArrowFlightInfoStatement {
 
-  ArrowFlightStatement(final ArrowFlightConnection connection,
-                       final StatementHandle handle, final int resultSetType,
-                       final int resultSetConcurrency, final int resultSetHoldability) {
+  ArrowFlightStatement(
+      final ArrowFlightConnection connection,
+      final StatementHandle handle,
+      final int resultSetType,
+      final int resultSetConcurrency,
+      final int resultSetHoldability) {
     super(connection, handle, resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 
@@ -45,14 +44,16 @@ public class ArrowFlightStatement extends AvaticaStatement implements ArrowFligh
 
   @Override
   public FlightInfo executeFlightInfoQuery() throws SQLException {
-    final PreparedStatement preparedStatement = getConnection().getMeta().getPreparedStatement(handle);
+    final PreparedStatement preparedStatement =
+        getConnection().getMeta().getPreparedStatement(handle);
     final Meta.Signature signature = getSignature();
     if (signature == null) {
       return null;
     }
 
     final Schema resultSetSchema = preparedStatement.getDataSetSchema();
-    signature.columns.addAll(ConvertUtils.convertArrowFieldsToColumnMetaDataList(resultSetSchema.getFields()));
+    signature.columns.addAll(
+        ConvertUtils.convertArrowFieldsToColumnMetaDataList(resultSetSchema.getFields()));
     setSignature(signature);
 
     return preparedStatement.executeQuery();

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor;
 
 import static org.apache.calcite.avatica.util.Cursor.Accessor;
@@ -38,9 +37,7 @@ import java.util.Calendar;
 import java.util.Map;
 import java.util.function.IntSupplier;
 
-/**
- * Base Jdbc Accessor.
- */
+/** Base Jdbc Accessor. */
 public abstract class ArrowFlightJdbcAccessor implements Accessor {
   private final IntSupplier currentRowSupplier;
 
@@ -48,8 +45,9 @@ public abstract class ArrowFlightJdbcAccessor implements Accessor {
   protected boolean wasNull;
   protected ArrowFlightJdbcAccessorFactory.WasNullConsumer wasNullConsumer;
 
-  protected ArrowFlightJdbcAccessor(final IntSupplier currentRowSupplier,
-                                    ArrowFlightJdbcAccessorFactory.WasNullConsumer wasNullConsumer) {
+  protected ArrowFlightJdbcAccessor(
+      final IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer wasNullConsumer) {
     this.currentRowSupplier = currentRowSupplier;
     this.wasNullConsumer = wasNullConsumer;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactory.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactory.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor;
 
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.impl.ArrowFlightJdbcNullVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.binary.ArrowFlightJdbcBinaryVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorAccessor;
@@ -78,139 +76,135 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
 
-/**
- * Factory to instantiate the accessors.
- */
+/** Factory to instantiate the accessors. */
 public class ArrowFlightJdbcAccessorFactory {
 
   /**
    * Create an accessor according to its type.
    *
-   * @param vector        an instance of an arrow vector.
+   * @param vector an instance of an arrow vector.
    * @param getCurrentRow a supplier to check which row is being accessed.
    * @return an instance of one of the accessors.
    */
-  public static ArrowFlightJdbcAccessor createAccessor(ValueVector vector,
-                                                       IntSupplier getCurrentRow,
-                                                       WasNullConsumer setCursorWasNull) {
+  public static ArrowFlightJdbcAccessor createAccessor(
+      ValueVector vector, IntSupplier getCurrentRow, WasNullConsumer setCursorWasNull) {
     if (vector instanceof UInt1Vector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((UInt1Vector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (UInt1Vector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof UInt2Vector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((UInt2Vector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (UInt2Vector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof UInt4Vector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((UInt4Vector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (UInt4Vector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof UInt8Vector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((UInt8Vector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (UInt8Vector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof TinyIntVector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((TinyIntVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (TinyIntVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof SmallIntVector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((SmallIntVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (SmallIntVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof IntVector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((IntVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (IntVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof BigIntVector) {
-      return new ArrowFlightJdbcBaseIntVectorAccessor((BigIntVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBaseIntVectorAccessor(
+          (BigIntVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof Float4Vector) {
-      return new ArrowFlightJdbcFloat4VectorAccessor((Float4Vector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcFloat4VectorAccessor(
+          (Float4Vector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof Float8Vector) {
-      return new ArrowFlightJdbcFloat8VectorAccessor((Float8Vector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcFloat8VectorAccessor(
+          (Float8Vector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof BitVector) {
-      return new ArrowFlightJdbcBitVectorAccessor((BitVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBitVectorAccessor(
+          (BitVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof DecimalVector) {
-      return new ArrowFlightJdbcDecimalVectorAccessor((DecimalVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcDecimalVectorAccessor(
+          (DecimalVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof Decimal256Vector) {
-      return new ArrowFlightJdbcDecimalVectorAccessor((Decimal256Vector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcDecimalVectorAccessor(
+          (Decimal256Vector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof VarBinaryVector) {
-      return new ArrowFlightJdbcBinaryVectorAccessor((VarBinaryVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBinaryVectorAccessor(
+          (VarBinaryVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof LargeVarBinaryVector) {
-      return new ArrowFlightJdbcBinaryVectorAccessor((LargeVarBinaryVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBinaryVectorAccessor(
+          (LargeVarBinaryVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof FixedSizeBinaryVector) {
-      return new ArrowFlightJdbcBinaryVectorAccessor((FixedSizeBinaryVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcBinaryVectorAccessor(
+          (FixedSizeBinaryVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof TimeStampVector) {
-      return new ArrowFlightJdbcTimeStampVectorAccessor((TimeStampVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcTimeStampVectorAccessor(
+          (TimeStampVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof TimeNanoVector) {
-      return new ArrowFlightJdbcTimeVectorAccessor((TimeNanoVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcTimeVectorAccessor(
+          (TimeNanoVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof TimeMicroVector) {
-      return new ArrowFlightJdbcTimeVectorAccessor((TimeMicroVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcTimeVectorAccessor(
+          (TimeMicroVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof TimeMilliVector) {
-      return new ArrowFlightJdbcTimeVectorAccessor((TimeMilliVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcTimeVectorAccessor(
+          (TimeMilliVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof TimeSecVector) {
-      return new ArrowFlightJdbcTimeVectorAccessor((TimeSecVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcTimeVectorAccessor(
+          (TimeSecVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof DateDayVector) {
-      return new ArrowFlightJdbcDateVectorAccessor(((DateDayVector) vector), getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcDateVectorAccessor(
+          ((DateDayVector) vector), getCurrentRow, setCursorWasNull);
     } else if (vector instanceof DateMilliVector) {
-      return new ArrowFlightJdbcDateVectorAccessor(((DateMilliVector) vector), getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcDateVectorAccessor(
+          ((DateMilliVector) vector), getCurrentRow, setCursorWasNull);
     } else if (vector instanceof VarCharVector) {
-      return new ArrowFlightJdbcVarCharVectorAccessor((VarCharVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcVarCharVectorAccessor(
+          (VarCharVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof LargeVarCharVector) {
-      return new ArrowFlightJdbcVarCharVectorAccessor((LargeVarCharVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcVarCharVectorAccessor(
+          (LargeVarCharVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof DurationVector) {
-      return new ArrowFlightJdbcDurationVectorAccessor((DurationVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcDurationVectorAccessor(
+          (DurationVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof IntervalDayVector) {
-      return new ArrowFlightJdbcIntervalVectorAccessor(((IntervalDayVector) vector), getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcIntervalVectorAccessor(
+          ((IntervalDayVector) vector), getCurrentRow, setCursorWasNull);
     } else if (vector instanceof IntervalYearVector) {
-      return new ArrowFlightJdbcIntervalVectorAccessor(((IntervalYearVector) vector), getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcIntervalVectorAccessor(
+          ((IntervalYearVector) vector), getCurrentRow, setCursorWasNull);
     } else if (vector instanceof IntervalMonthDayNanoVector) {
-      return new ArrowFlightJdbcIntervalVectorAccessor(((IntervalMonthDayNanoVector) vector), getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcIntervalVectorAccessor(
+          ((IntervalMonthDayNanoVector) vector), getCurrentRow, setCursorWasNull);
     } else if (vector instanceof StructVector) {
-      return new ArrowFlightJdbcStructVectorAccessor((StructVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcStructVectorAccessor(
+          (StructVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof MapVector) {
-      return new ArrowFlightJdbcMapVectorAccessor((MapVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcMapVectorAccessor(
+          (MapVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof ListVector) {
-      return new ArrowFlightJdbcListVectorAccessor((ListVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcListVectorAccessor(
+          (ListVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof LargeListVector) {
-      return new ArrowFlightJdbcLargeListVectorAccessor((LargeListVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcLargeListVectorAccessor(
+          (LargeListVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof FixedSizeListVector) {
-      return new ArrowFlightJdbcFixedSizeListVectorAccessor((FixedSizeListVector) vector,
-          getCurrentRow, setCursorWasNull);
+      return new ArrowFlightJdbcFixedSizeListVectorAccessor(
+          (FixedSizeListVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof UnionVector) {
-      return new ArrowFlightJdbcUnionVectorAccessor((UnionVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcUnionVectorAccessor(
+          (UnionVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof DenseUnionVector) {
-      return new ArrowFlightJdbcDenseUnionVectorAccessor((DenseUnionVector) vector, getCurrentRow,
-          setCursorWasNull);
+      return new ArrowFlightJdbcDenseUnionVectorAccessor(
+          (DenseUnionVector) vector, getCurrentRow, setCursorWasNull);
     } else if (vector instanceof NullVector || vector == null) {
       return new ArrowFlightJdbcNullVectorAccessor(setCursorWasNull);
     }
 
-    throw new UnsupportedOperationException("Unsupported vector type: " + vector.getClass().getName());
+    throw new UnsupportedOperationException(
+        "Unsupported vector type: " + vector.getClass().getName());
   }
 
-  /**
-   * Functional interface used to propagate that the value accessed was null or not.
-   */
+  /** Functional interface used to propagate that the value accessed was null or not. */
   @FunctionalInterface
   public interface WasNullConsumer {
     void setWasNull(boolean wasNull);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/ArrowFlightJdbcNullVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/ArrowFlightJdbcNullVectorAccessor.java
@@ -14,16 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl;
 
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.NullVector;
 
-/**
- * Accessor for the Arrow type {@link NullVector}.
- */
+/** Accessor for the Arrow type {@link NullVector}. */
 public class ArrowFlightJdbcNullVectorAccessor extends ArrowFlightJdbcAccessor {
   public ArrowFlightJdbcNullVectorAccessor(
       ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.binary;
 
 import java.io.ByteArrayInputStream;
@@ -23,7 +22,6 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
@@ -31,8 +29,8 @@ import org.apache.arrow.vector.LargeVarBinaryVector;
 import org.apache.arrow.vector.VarBinaryVector;
 
 /**
- * Accessor for the Arrow types: {@link FixedSizeBinaryVector}, {@link VarBinaryVector}
- * and {@link LargeVarBinaryVector}.
+ * Accessor for the Arrow types: {@link FixedSizeBinaryVector}, {@link VarBinaryVector} and {@link
+ * LargeVarBinaryVector}.
  */
 public class ArrowFlightJdbcBinaryVectorAccessor extends ArrowFlightJdbcAccessor {
 
@@ -42,26 +40,31 @@ public class ArrowFlightJdbcBinaryVectorAccessor extends ArrowFlightJdbcAccessor
 
   private final ByteArrayGetter getter;
 
-  public ArrowFlightJdbcBinaryVectorAccessor(FixedSizeBinaryVector vector,
-                                             IntSupplier currentRowSupplier,
-                                             ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBinaryVectorAccessor(
+      FixedSizeBinaryVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector::get, currentRowSupplier, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBinaryVectorAccessor(VarBinaryVector vector, IntSupplier currentRowSupplier,
-                                             ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBinaryVectorAccessor(
+      VarBinaryVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector::get, currentRowSupplier, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBinaryVectorAccessor(LargeVarBinaryVector vector,
-                                             IntSupplier currentRowSupplier,
-                                             ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBinaryVectorAccessor(
+      LargeVarBinaryVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector::get, currentRowSupplier, setCursorWasNull);
   }
 
-  private ArrowFlightJdbcBinaryVectorAccessor(ByteArrayGetter getter,
-                                              IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  private ArrowFlightJdbcBinaryVectorAccessor(
+      ByteArrayGetter getter,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.getter = getter;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorGetter.Getter;
@@ -29,7 +28,6 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.DateTimeUtils;
@@ -37,9 +35,7 @@ import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.ValueVector;
 
-/**
- * Accessor for the Arrow types: {@link DateDayVector} and {@link DateMilliVector}.
- */
+/** Accessor for the Arrow types: {@link DateDayVector} and {@link DateMilliVector}. */
 public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final Getter getter;
@@ -49,12 +45,14 @@ public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link DateDayVector}.
    *
-   * @param vector             an instance of a DateDayVector.
+   * @param vector an instance of a DateDayVector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcDateVectorAccessor(DateDayVector vector, IntSupplier currentRowSupplier,
-                                           ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcDateVectorAccessor(
+      DateDayVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new Holder();
     this.getter = createGetter(vector);
@@ -64,11 +62,13 @@ public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link DateMilliVector}.
    *
-   * @param vector             an instance of a DateMilliVector.
+   * @param vector an instance of a DateMilliVector.
    * @param currentRowSupplier the supplier to track the lines.
    */
-  public ArrowFlightJdbcDateVectorAccessor(DateMilliVector vector, IntSupplier currentRowSupplier,
-                                           ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcDateVectorAccessor(
+      DateMilliVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new Holder();
     this.getter = createGetter(vector);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorGetter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorGetter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import org.apache.arrow.vector.DateDayVector;
@@ -22,9 +21,7 @@ import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.holders.NullableDateDayHolder;
 import org.apache.arrow.vector.holders.NullableDateMilliHolder;
 
-/**
- * Auxiliary class used to unify data access on TimeStampVectors.
- */
+/** Auxiliary class used to unify data access on TimeStampVectors. */
 final class ArrowFlightJdbcDateVectorGetter {
 
   private ArrowFlightJdbcDateVectorGetter() {
@@ -32,16 +29,15 @@ final class ArrowFlightJdbcDateVectorGetter {
   }
 
   /**
-   * Auxiliary class meant to unify Date*Vector#get implementations with different classes of ValueHolders.
+   * Auxiliary class meant to unify Date*Vector#get implementations with different classes of
+   * ValueHolders.
    */
   static class Holder {
     int isSet; // Tells if value is set; 0 = not set, 1 = set
     long value; // Holds actual value in its respective timeunit
   }
 
-  /**
-   * Functional interface used to unify Date*Vector#get implementations.
-   */
+  /** Functional interface used to unify Date*Vector#get implementations. */
   @FunctionalInterface
   interface Getter {
     void get(int index, Holder holder);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDurationVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDurationVectorAccessor.java
@@ -14,26 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import java.time.Duration;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.DurationVector;
 
-/**
- * Accessor for the Arrow type {@link DurationVector}.
- */
+/** Accessor for the Arrow type {@link DurationVector}. */
 public class ArrowFlightJdbcDurationVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final DurationVector vector;
 
-  public ArrowFlightJdbcDurationVectorAccessor(DurationVector vector,
-                                               IntSupplier currentRowSupplier,
-                                               ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcDurationVectorAccessor(
+      DurationVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.utils.IntervalStringUtils.formatIntervalDay;
@@ -25,7 +24,6 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Period;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.BaseFixedWidthVector;
@@ -37,9 +35,7 @@ import org.apache.arrow.vector.holders.NullableIntervalDayHolder;
 import org.apache.arrow.vector.holders.NullableIntervalMonthDayNanoHolder;
 import org.apache.arrow.vector.holders.NullableIntervalYearHolder;
 
-/**
- * Accessor for the Arrow type {@link IntervalDayVector}.
- */
+/** Accessor for the Arrow type {@link IntervalDayVector}. */
 public class ArrowFlightJdbcIntervalVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final BaseFixedWidthVector vector;
@@ -49,82 +45,89 @@ public class ArrowFlightJdbcIntervalVectorAccessor extends ArrowFlightJdbcAccess
   /**
    * Instantiate an accessor for a {@link IntervalDayVector}.
    *
-   * @param vector             an instance of a IntervalDayVector.
+   * @param vector an instance of a IntervalDayVector.
    * @param currentRowSupplier the supplier to track the rows.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcIntervalVectorAccessor(IntervalDayVector vector,
-                                               IntSupplier currentRowSupplier,
-                                               ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcIntervalVectorAccessor(
+      IntervalDayVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
-    stringGetter = (index) -> {
-      final NullableIntervalDayHolder holder = new NullableIntervalDayHolder();
-      vector.get(index, holder);
-      if (holder.isSet == 0) {
-        return null;
-      } else {
-        final int days = holder.days;
-        final int millis = holder.milliseconds;
-        return formatIntervalDay(Duration.ofDays(days).plusMillis(millis));
-      }
-    };
+    stringGetter =
+        (index) -> {
+          final NullableIntervalDayHolder holder = new NullableIntervalDayHolder();
+          vector.get(index, holder);
+          if (holder.isSet == 0) {
+            return null;
+          } else {
+            final int days = holder.days;
+            final int millis = holder.milliseconds;
+            return formatIntervalDay(Duration.ofDays(days).plusMillis(millis));
+          }
+        };
     objectClass = java.time.Duration.class;
   }
 
   /**
    * Instantiate an accessor for a {@link IntervalYearVector}.
    *
-   * @param vector             an instance of a IntervalYearVector.
+   * @param vector an instance of a IntervalYearVector.
    * @param currentRowSupplier the supplier to track the rows.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcIntervalVectorAccessor(IntervalYearVector vector,
-                                               IntSupplier currentRowSupplier,
-                                               ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcIntervalVectorAccessor(
+      IntervalYearVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
-    stringGetter = (index) -> {
-      final NullableIntervalYearHolder holder = new NullableIntervalYearHolder();
-      vector.get(index, holder);
-      if (holder.isSet == 0) {
-        return null;
-      } else {
-        final int interval = holder.value;
-        final int years = (interval / yearsToMonths);
-        final int months = (interval % yearsToMonths);
-        return formatIntervalYear(Period.ofYears(years).plusMonths(months));
-      }
-    };
+    stringGetter =
+        (index) -> {
+          final NullableIntervalYearHolder holder = new NullableIntervalYearHolder();
+          vector.get(index, holder);
+          if (holder.isSet == 0) {
+            return null;
+          } else {
+            final int interval = holder.value;
+            final int years = (interval / yearsToMonths);
+            final int months = (interval % yearsToMonths);
+            return formatIntervalYear(Period.ofYears(years).plusMonths(months));
+          }
+        };
     objectClass = java.time.Period.class;
   }
 
   /**
    * Instantiate an accessor for a {@link IntervalMonthDayNanoVector}.
    *
-   * @param vector             an instance of a IntervalMonthDayNanoVector.
+   * @param vector an instance of a IntervalMonthDayNanoVector.
    * @param currentRowSupplier the supplier to track the rows.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcIntervalVectorAccessor(IntervalMonthDayNanoVector vector,
-                                               IntSupplier currentRowSupplier,
-                                               ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcIntervalVectorAccessor(
+      IntervalMonthDayNanoVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
-    stringGetter = (index) -> {
-      final NullableIntervalMonthDayNanoHolder holder = new NullableIntervalMonthDayNanoHolder();
-      vector.get(index, holder);
-      if (holder.isSet == 0) {
-        return null;
-      } else {
-        final int months = holder.months;
-        final int days = holder.days;
-        final long nanos = holder.nanoseconds;
-        final Period period = Period.ofMonths(months).plusDays(days);
-        final Duration duration = Duration.ofNanos(nanos);
-        return new PeriodDuration(period, duration).toISO8601IntervalString();
-      }
-    };
+    stringGetter =
+        (index) -> {
+          final NullableIntervalMonthDayNanoHolder holder =
+              new NullableIntervalMonthDayNanoHolder();
+          vector.get(index, holder);
+          if (holder.isSet == 0) {
+            return null;
+          } else {
+            final int months = holder.months;
+            final int days = holder.days;
+            final long nanos = holder.nanoseconds;
+            final Period period = Period.ofMonths(months).plusDays(days);
+            final Duration duration = Duration.ofNanos(nanos);
+            return new PeriodDuration(period, duration).toISO8601IntervalString();
+          }
+        };
     objectClass = PeriodDuration.class;
   }
 
@@ -149,9 +152,7 @@ public class ArrowFlightJdbcIntervalVectorAccessor extends ArrowFlightJdbcAccess
     return object;
   }
 
-  /**
-   * Functional interface used to unify Interval*Vector#getAsStringBuilder implementations.
-   */
+  /** Functional interface used to unify Interval*Vector#getAsStringBuilder implementations. */
   @FunctionalInterface
   interface StringGetter {
     String get(int index);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Getter;
@@ -30,16 +29,13 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.util.DateUtility;
 
-/**
- * Accessor for the Arrow types extending from {@link TimeStampVector}.
- */
+/** Accessor for the Arrow types extending from {@link TimeStampVector}. */
 public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final TimeZone timeZone;
@@ -48,19 +44,16 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
   private final LongToLocalDateTime longToLocalDateTime;
   private final Holder holder;
 
-  /**
-   * Functional interface used to convert a number (in any time resolution) to LocalDateTime.
-   */
+  /** Functional interface used to convert a number (in any time resolution) to LocalDateTime. */
   interface LongToLocalDateTime {
     LocalDateTime fromLong(long value);
   }
 
-  /**
-   * Instantiate a ArrowFlightJdbcTimeStampVectorAccessor for given vector.
-   */
-  public ArrowFlightJdbcTimeStampVectorAccessor(TimeStampVector vector,
-                                                IntSupplier currentRowSupplier,
-                                                ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  /** Instantiate a ArrowFlightJdbcTimeStampVectorAccessor for given vector. */
+  public ArrowFlightJdbcTimeStampVectorAccessor(
+      TimeStampVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new Holder();
     this.getter = createGetter(vector);
@@ -95,8 +88,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     if (calendar != null) {
       TimeZone timeZone = calendar.getTimeZone();
       long millis = this.timeUnit.toMillis(value);
-      localDateTime = localDateTime
-          .minus(timeZone.getOffset(millis) - this.timeZone.getOffset(millis), ChronoUnit.MILLIS);
+      localDateTime =
+          localDateTime.minus(
+              timeZone.getOffset(millis) - this.timeZone.getOffset(millis), ChronoUnit.MILLIS);
     }
     return localDateTime;
   }
@@ -149,8 +143,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     }
   }
 
-  protected static LongToLocalDateTime getLongToLocalDateTimeForVector(TimeStampVector vector,
-                                                                       TimeZone timeZone) {
+  protected static LongToLocalDateTime getLongToLocalDateTimeForVector(
+      TimeStampVector vector, TimeZone timeZone) {
     String timeZoneID = timeZone.getID();
 
     ArrowType.Timestamp arrowType =
@@ -164,8 +158,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
       case MILLISECOND:
         return milliseconds -> DateUtility.getLocalDateTimeFromEpochMilli(milliseconds, timeZoneID);
       case SECOND:
-        return seconds -> DateUtility.getLocalDateTimeFromEpochMilli(
-            TimeUnit.SECONDS.toMillis(seconds), timeZoneID);
+        return seconds ->
+            DateUtility.getLocalDateTimeFromEpochMilli(
+                TimeUnit.SECONDS.toMillis(seconds), timeZoneID);
       default:
         throw new UnsupportedOperationException("Invalid Arrow time unit");
     }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorGetter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorGetter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import org.apache.arrow.vector.TimeStampMicroTZVector;
@@ -35,9 +34,7 @@ import org.apache.arrow.vector.holders.NullableTimeStampNanoTZHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampSecHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampSecTZHolder;
 
-/**
- * Auxiliary class used to unify data access on TimeStampVectors.
- */
+/** Auxiliary class used to unify data access on TimeStampVectors. */
 final class ArrowFlightJdbcTimeStampVectorGetter {
 
   private ArrowFlightJdbcTimeStampVectorGetter() {
@@ -45,16 +42,15 @@ final class ArrowFlightJdbcTimeStampVectorGetter {
   }
 
   /**
-   * Auxiliary class meant to unify TimeStamp*Vector#get implementations with different classes of ValueHolders.
+   * Auxiliary class meant to unify TimeStamp*Vector#get implementations with different classes of
+   * ValueHolders.
    */
   static class Holder {
     int isSet; // Tells if value is set; 0 = not set, 1 = set
     long value; // Holds actual value in its respective timeunit
   }
 
-  /**
-   * Functional interface used to unify TimeStamp*Vector#get implementations.
-   */
+  /** Functional interface used to unify TimeStamp*Vector#get implementations. */
   @FunctionalInterface
   interface Getter {
     void get(int index, Holder holder);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeVectorGetter.Getter;
@@ -26,7 +25,6 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.ArrowFlightJdbcTime;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -38,8 +36,8 @@ import org.apache.arrow.vector.TimeSecVector;
 import org.apache.arrow.vector.ValueVector;
 
 /**
- * Accessor for the Arrow types: {@link TimeNanoVector}, {@link TimeMicroVector}, {@link TimeMilliVector}
- * and {@link TimeSecVector}.
+ * Accessor for the Arrow types: {@link TimeNanoVector}, {@link TimeMicroVector}, {@link
+ * TimeMilliVector} and {@link TimeSecVector}.
  */
 public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
 
@@ -50,12 +48,14 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeNanoVector}.
    *
-   * @param vector             an instance of a TimeNanoVector.
+   * @param vector an instance of a TimeNanoVector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcTimeVectorAccessor(TimeNanoVector vector, IntSupplier currentRowSupplier,
-                                           ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcTimeVectorAccessor(
+      TimeNanoVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new Holder();
     this.getter = createGetter(vector);
@@ -65,12 +65,14 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeMicroVector}.
    *
-   * @param vector             an instance of a TimeMicroVector.
+   * @param vector an instance of a TimeMicroVector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcTimeVectorAccessor(TimeMicroVector vector, IntSupplier currentRowSupplier,
-                                           ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcTimeVectorAccessor(
+      TimeMicroVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new Holder();
     this.getter = createGetter(vector);
@@ -80,11 +82,13 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeMilliVector}.
    *
-   * @param vector             an instance of a TimeMilliVector.
+   * @param vector an instance of a TimeMilliVector.
    * @param currentRowSupplier the supplier to track the lines.
    */
-  public ArrowFlightJdbcTimeVectorAccessor(TimeMilliVector vector, IntSupplier currentRowSupplier,
-                                           ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcTimeVectorAccessor(
+      TimeMilliVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new Holder();
     this.getter = createGetter(vector);
@@ -94,11 +98,13 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Instantiate an accessor for a {@link TimeSecVector}.
    *
-   * @param vector             an instance of a TimeSecVector.
+   * @param vector an instance of a TimeSecVector.
    * @param currentRowSupplier the supplier to track the lines.
    */
-  public ArrowFlightJdbcTimeVectorAccessor(TimeSecVector vector, IntSupplier currentRowSupplier,
-                                           ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcTimeVectorAccessor(
+      TimeSecVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new Holder();
     this.getter = createGetter(vector);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorGetter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorGetter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import org.apache.arrow.vector.TimeMicroVector;
@@ -26,9 +25,7 @@ import org.apache.arrow.vector.holders.NullableTimeMilliHolder;
 import org.apache.arrow.vector.holders.NullableTimeNanoHolder;
 import org.apache.arrow.vector.holders.NullableTimeSecHolder;
 
-/**
- * Auxiliary class used to unify data access on Time*Vectors.
- */
+/** Auxiliary class used to unify data access on Time*Vectors. */
 final class ArrowFlightJdbcTimeVectorGetter {
 
   private ArrowFlightJdbcTimeVectorGetter() {
@@ -36,16 +33,15 @@ final class ArrowFlightJdbcTimeVectorGetter {
   }
 
   /**
-   * Auxiliary class meant to unify TimeStamp*Vector#get implementations with different classes of ValueHolders.
+   * Auxiliary class meant to unify TimeStamp*Vector#get implementations with different classes of
+   * ValueHolders.
    */
   static class Holder {
     int isSet; // Tells if value is set; 0 = not set, 1 = set
     long value; // Holds actual value in its respective timeunit
   }
 
-  /**
-   * Functional interface used to unify TimeStamp*Vector#get implementations.
-   */
+  /** Functional interface used to unify TimeStamp*Vector#get implementations. */
   @FunctionalInterface
   interface Getter {
     void get(int index, Holder holder);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListVectorAccessor.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.sql.Array;
 import java.util.List;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.ArrowFlightJdbcArray;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
@@ -30,12 +28,14 @@ import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 
 /**
- * Base Accessor for the Arrow types {@link ListVector}, {@link LargeListVector} and {@link FixedSizeListVector}.
+ * Base Accessor for the Arrow types {@link ListVector}, {@link LargeListVector} and {@link
+ * FixedSizeListVector}.
  */
 public abstract class AbstractArrowFlightJdbcListVectorAccessor extends ArrowFlightJdbcAccessor {
 
-  protected AbstractArrowFlightJdbcListVectorAccessor(IntSupplier currentRowSupplier,
-                                                      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  protected AbstractArrowFlightJdbcListVectorAccessor(
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
   }
 
@@ -70,4 +70,3 @@ public abstract class AbstractArrowFlightJdbcListVectorAccessor extends ArrowFli
     return new ArrowFlightJdbcArray(dataVector, startOffset, valuesCount);
   }
 }
-

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.io.InputStream;
@@ -35,7 +34,6 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.accessor.impl.ArrowFlightJdbcNullVectorAccessor;
@@ -43,22 +41,20 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.UnionVector;
 
-/**
- * Base accessor for {@link UnionVector} and {@link DenseUnionVector}.
- */
+/** Base accessor for {@link UnionVector} and {@link DenseUnionVector}. */
 public abstract class AbstractArrowFlightJdbcUnionVectorAccessor extends ArrowFlightJdbcAccessor {
 
   /**
-   * Array of accessors for each type contained in UnionVector.
-   * Index corresponds to UnionVector and DenseUnionVector typeIds which are both limited to 128.
+   * Array of accessors for each type contained in UnionVector. Index corresponds to UnionVector and
+   * DenseUnionVector typeIds which are both limited to 128.
    */
   private final ArrowFlightJdbcAccessor[] accessors = new ArrowFlightJdbcAccessor[128];
 
   private final ArrowFlightJdbcNullVectorAccessor nullAccessor =
-      new ArrowFlightJdbcNullVectorAccessor((boolean wasNull) -> {
-      });
+      new ArrowFlightJdbcNullVectorAccessor((boolean wasNull) -> {});
 
-  protected AbstractArrowFlightJdbcUnionVectorAccessor(IntSupplier currentRowSupplier,
+  protected AbstractArrowFlightJdbcUnionVectorAccessor(
+      IntSupplier currentRowSupplier,
       ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessor.java
@@ -14,19 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 
-/**
- * Accessor for the Arrow type {@link DenseUnionVector}.
- */
+/** Accessor for the Arrow type {@link DenseUnionVector}. */
 public class ArrowFlightJdbcDenseUnionVectorAccessor
     extends AbstractArrowFlightJdbcUnionVectorAccessor {
 
@@ -35,22 +31,22 @@ public class ArrowFlightJdbcDenseUnionVectorAccessor
   /**
    * Instantiate an accessor for a {@link DenseUnionVector}.
    *
-   * @param vector             an instance of a DenseUnionVector.
+   * @param vector an instance of a DenseUnionVector.
    * @param currentRowSupplier the supplier to track the rows.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcDenseUnionVectorAccessor(DenseUnionVector vector,
-                                                 IntSupplier currentRowSupplier,
-                                                 ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcDenseUnionVectorAccessor(
+      DenseUnionVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }
 
   @Override
   protected ArrowFlightJdbcAccessor createAccessorForVector(ValueVector vector) {
-    return ArrowFlightJdbcAccessorFactory.createAccessor(vector,
-        () -> this.vector.getOffset(this.getCurrentRow()), (boolean wasNull) -> {
-        });
+    return ArrowFlightJdbcAccessorFactory.createAccessor(
+        vector, () -> this.vector.getOffset(this.getCurrentRow()), (boolean wasNull) -> {});
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcFixedSizeListVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcFixedSizeListVectorAccessor.java
@@ -14,27 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.util.List;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 
-/**
- * Accessor for the Arrow type {@link FixedSizeListVector}.
- */
+/** Accessor for the Arrow type {@link FixedSizeListVector}. */
 public class ArrowFlightJdbcFixedSizeListVectorAccessor
     extends AbstractArrowFlightJdbcListVectorAccessor {
 
   private final FixedSizeListVector vector;
 
-  public ArrowFlightJdbcFixedSizeListVectorAccessor(FixedSizeListVector vector,
-                                                    IntSupplier currentRowSupplier,
-                                                    ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcFixedSizeListVectorAccessor(
+      FixedSizeListVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcLargeListVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcLargeListVectorAccessor.java
@@ -14,27 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.util.List;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.LargeListVector;
 
-/**
- * Accessor for the Arrow type {@link LargeListVector}.
- */
+/** Accessor for the Arrow type {@link LargeListVector}. */
 public class ArrowFlightJdbcLargeListVectorAccessor
     extends AbstractArrowFlightJdbcListVectorAccessor {
 
   private final LargeListVector vector;
 
-  public ArrowFlightJdbcLargeListVectorAccessor(LargeListVector vector,
-                                                IntSupplier currentRowSupplier,
-                                                ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcLargeListVectorAccessor(
+      LargeListVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcListVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcListVectorAccessor.java
@@ -14,26 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.util.List;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
 import org.apache.arrow.vector.complex.ListVector;
 
-/**
- * Accessor for the Arrow type {@link ListVector}.
- */
+/** Accessor for the Arrow type {@link ListVector}. */
 public class ArrowFlightJdbcListVectorAccessor extends AbstractArrowFlightJdbcListVectorAccessor {
 
   private final ListVector vector;
 
-  public ArrowFlightJdbcListVectorAccessor(ListVector vector, IntSupplier currentRowSupplier,
-                                           ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcListVectorAccessor(
+      ListVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }
@@ -45,7 +43,8 @@ public class ArrowFlightJdbcListVectorAccessor extends AbstractArrowFlightJdbcLi
 
   @Override
   protected long getEndOffset(int index) {
-    return vector.getOffsetBuffer()
+    return vector
+        .getOffsetBuffer()
         .getInt((long) (index + 1) * BaseRepeatedValueVector.OFFSET_WIDTH);
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessor.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.util.Map;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
@@ -27,15 +25,15 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.impl.UnionMapReader;
 import org.apache.arrow.vector.util.JsonStringHashMap;
 
-/**
- * Accessor for the Arrow type {@link MapVector}.
- */
+/** Accessor for the Arrow type {@link MapVector}. */
 public class ArrowFlightJdbcMapVectorAccessor extends AbstractArrowFlightJdbcListVectorAccessor {
 
   private final MapVector vector;
 
-  public ArrowFlightJdbcMapVectorAccessor(MapVector vector, IntSupplier currentRowSupplier,
-                                          ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcMapVectorAccessor(
+      MapVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }
@@ -76,7 +74,8 @@ public class ArrowFlightJdbcMapVectorAccessor extends AbstractArrowFlightJdbcLis
 
   @Override
   protected long getEndOffset(int index) {
-    return vector.getOffsetBuffer()
+    return vector
+        .getOffsetBuffer()
         .getInt((long) (index + 1) * BaseRepeatedValueVector.OFFSET_WIDTH);
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcStructVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcStructVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.sql.Struct;
@@ -22,21 +21,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.calcite.avatica.util.StructImpl;
 
-/**
- * Accessor for the Arrow type {@link StructVector}.
- */
+/** Accessor for the Arrow type {@link StructVector}. */
 public class ArrowFlightJdbcStructVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final StructVector vector;
 
-  public ArrowFlightJdbcStructVectorAccessor(StructVector vector, IntSupplier currentRowSupplier,
-                                             ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcStructVectorAccessor(
+      StructVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }
@@ -65,10 +63,10 @@ public class ArrowFlightJdbcStructVectorAccessor extends ArrowFlightJdbcAccessor
       return null;
     }
 
-    List<Object> attributes = vector.getChildrenFromFields()
-        .stream()
-        .map(vector -> vector.getObject(currentRow))
-        .collect(Collectors.toList());
+    List<Object> attributes =
+        vector.getChildrenFromFields().stream()
+            .map(vector -> vector.getObject(currentRow))
+            .collect(Collectors.toList());
 
     return new StructImpl(attributes);
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessor.java
@@ -14,19 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.UnionVector;
 
-/**
- * Accessor for the Arrow type {@link UnionVector}.
- */
+/** Accessor for the Arrow type {@link UnionVector}. */
 public class ArrowFlightJdbcUnionVectorAccessor extends AbstractArrowFlightJdbcUnionVectorAccessor {
 
   private final UnionVector vector;
@@ -34,21 +30,22 @@ public class ArrowFlightJdbcUnionVectorAccessor extends AbstractArrowFlightJdbcU
   /**
    * Instantiate an accessor for a {@link UnionVector}.
    *
-   * @param vector             an instance of a UnionVector.
+   * @param vector an instance of a UnionVector.
    * @param currentRowSupplier the supplier to track the rows.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcUnionVectorAccessor(UnionVector vector, IntSupplier currentRowSupplier,
-                                            ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcUnionVectorAccessor(
+      UnionVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
   }
 
   @Override
   protected ArrowFlightJdbcAccessor createAccessorForVector(ValueVector vector) {
-    return ArrowFlightJdbcAccessorFactory.createAccessor(vector, this::getCurrentRow,
-        (boolean wasNull) -> {
-        });
+    return ArrowFlightJdbcAccessorFactory.createAccessor(
+        vector, this::getCurrentRow, (boolean wasNull) -> {});
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBaseIntVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBaseIntVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import static org.apache.arrow.driver.jdbc.accessor.impl.numeric.ArrowFlightJdbcNumericGetter.Getter;
@@ -23,7 +22,6 @@ import static org.apache.arrow.driver.jdbc.accessor.impl.numeric.ArrowFlightJdbc
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.accessor.impl.numeric.ArrowFlightJdbcNumericGetter.NumericHolder;
@@ -49,48 +47,66 @@ public class ArrowFlightJdbcBaseIntVectorAccessor extends ArrowFlightJdbcAccesso
   private final Getter getter;
   private final NumericHolder holder;
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(UInt1Vector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      UInt1Vector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, true, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(UInt2Vector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      UInt2Vector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, true, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(UInt4Vector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      UInt4Vector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, true, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(UInt8Vector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      UInt8Vector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, true, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(TinyIntVector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      TinyIntVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, false, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(SmallIntVector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      SmallIntVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, false, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(IntVector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      IntVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, false, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessor(BigIntVector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBaseIntVectorAccessor(
+      BigIntVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector, currentRowSupplier, false, setCursorWasNull);
   }
 
-  private ArrowFlightJdbcBaseIntVectorAccessor(BaseIntVector vector, IntSupplier currentRowSupplier,
-                                               boolean isUnsigned,
+  private ArrowFlightJdbcBaseIntVectorAccessor(
+      BaseIntVector vector,
+      IntSupplier currentRowSupplier,
+      boolean isUnsigned,
       ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.type = vector.getMinorType();

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBitVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBitVectorAccessor.java
@@ -14,20 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import java.math.BigDecimal;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.holders.NullableBitHolder;
 
-/**
- * Accessor for the arrow {@link BitVector}.
- */
+/** Accessor for the arrow {@link BitVector}. */
 public class ArrowFlightJdbcBitVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final BitVector vector;
@@ -36,12 +32,14 @@ public class ArrowFlightJdbcBitVectorAccessor extends ArrowFlightJdbcAccessor {
   /**
    * Constructor for the BitVectorAccessor.
    *
-   * @param vector             an instance of a {@link BitVector}.
+   * @param vector an instance of a {@link BitVector}.
    * @param currentRowSupplier a supplier to check which row is being accessed.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcBitVectorAccessor(BitVector vector, IntSupplier currentRowSupplier,
-                                          ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcBitVectorAccessor(
+      BitVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.vector = vector;
     this.holder = new NullableBitHolder();

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessor.java
@@ -14,42 +14,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.Decimal256Vector;
 import org.apache.arrow.vector.DecimalVector;
 
-/**
- * Accessor for {@link DecimalVector} and {@link Decimal256Vector}.
- */
+/** Accessor for {@link DecimalVector} and {@link Decimal256Vector}. */
 public class ArrowFlightJdbcDecimalVectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final Getter getter;
 
-  /**
-   * Functional interface used to unify Decimal*Vector#getObject implementations.
-   */
+  /** Functional interface used to unify Decimal*Vector#getObject implementations. */
   @FunctionalInterface
   interface Getter {
     BigDecimal getObject(int index);
   }
 
-  public ArrowFlightJdbcDecimalVectorAccessor(DecimalVector vector, IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcDecimalVectorAccessor(
+      DecimalVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.getter = vector::getObject;
   }
 
-  public ArrowFlightJdbcDecimalVectorAccessor(Decimal256Vector vector,
-                                              IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcDecimalVectorAccessor(
+      Decimal256Vector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.getter = vector::getObject;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat4VectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat4VectorAccessor.java
@@ -14,22 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
 
-/**
- * Accessor for the Float4Vector.
- */
+/** Accessor for the Float4Vector. */
 public class ArrowFlightJdbcFloat4VectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final Float4Vector vector;
@@ -38,13 +34,14 @@ public class ArrowFlightJdbcFloat4VectorAccessor extends ArrowFlightJdbcAccessor
   /**
    * Instantiate a accessor for the {@link Float4Vector}.
    *
-   * @param vector             an instance of a Float4Vector.
+   * @param vector an instance of a Float4Vector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcFloat4VectorAccessor(Float4Vector vector,
-                                             IntSupplier currentRowSupplier,
-                                             ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcFloat4VectorAccessor(
+      Float4Vector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new NullableFloat4Holder();
     this.vector = vector;

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat8VectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat8VectorAccessor.java
@@ -14,22 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.holders.NullableFloat8Holder;
 
-/**
- * Accessor for the Float8Vector.
- */
+/** Accessor for the Float8Vector. */
 public class ArrowFlightJdbcFloat8VectorAccessor extends ArrowFlightJdbcAccessor {
 
   private final Float8Vector vector;
@@ -38,13 +34,14 @@ public class ArrowFlightJdbcFloat8VectorAccessor extends ArrowFlightJdbcAccessor
   /**
    * Instantiate a accessor for the {@link Float8Vector}.
    *
-   * @param vector             an instance of a Float8Vector.
+   * @param vector an instance of a Float8Vector.
    * @param currentRowSupplier the supplier to track the lines.
-   * @param setCursorWasNull   the consumer to set if value was null.
+   * @param setCursorWasNull the consumer to set if value was null.
    */
-  public ArrowFlightJdbcFloat8VectorAccessor(Float8Vector vector,
-                                             IntSupplier currentRowSupplier,
-                                             ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcFloat8VectorAccessor(
+      Float8Vector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.holder = new NullableFloat8Holder();
     this.vector = vector;

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcNumericGetter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcNumericGetter.java
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import org.apache.arrow.vector.BaseIntVector;
@@ -36,29 +34,22 @@ import org.apache.arrow.vector.holders.NullableUInt2Holder;
 import org.apache.arrow.vector.holders.NullableUInt4Holder;
 import org.apache.arrow.vector.holders.NullableUInt8Holder;
 
-/**
- * A custom getter for values from the {@link BaseIntVector}.
- */
+/** A custom getter for values from the {@link BaseIntVector}. */
 class ArrowFlightJdbcNumericGetter {
-  /**
-   * A holder for values from the {@link BaseIntVector}.
-   */
+  /** A holder for values from the {@link BaseIntVector}. */
   static class NumericHolder {
     int isSet; // Tells if value is set; 0 = not set, 1 = set
     long value; // Holds actual value
   }
 
-  /**
-   * Functional interface for a getter to baseInt values.
-   */
+  /** Functional interface for a getter to baseInt values. */
   @FunctionalInterface
   interface Getter {
     void get(int index, NumericHolder holder);
   }
 
   /**
-   * Main class that will check the type of the vector to create
-   * a specific getter.
+   * Main class that will check the type of the vector to create a specific getter.
    *
    * @param vector an instance of the {@link BaseIntVector}
    * @return a getter.

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.text;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -31,7 +30,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.DateTimeUtils;
@@ -39,14 +37,10 @@ import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.util.Text;
 
-/**
- * Accessor for the Arrow types: {@link VarCharVector} and {@link LargeVarCharVector}.
- */
+/** Accessor for the Arrow types: {@link VarCharVector} and {@link LargeVarCharVector}. */
 public class ArrowFlightJdbcVarCharVectorAccessor extends ArrowFlightJdbcAccessor {
 
-  /**
-   * Functional interface to help integrating VarCharVector and LargeVarCharVector.
-   */
+  /** Functional interface to help integrating VarCharVector and LargeVarCharVector. */
   @FunctionalInterface
   interface Getter {
     byte[] get(int index);
@@ -54,21 +48,24 @@ public class ArrowFlightJdbcVarCharVectorAccessor extends ArrowFlightJdbcAccesso
 
   private final Getter getter;
 
-  public ArrowFlightJdbcVarCharVectorAccessor(VarCharVector vector,
-                                              IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcVarCharVectorAccessor(
+      VarCharVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector::get, currentRowSupplier, setCursorWasNull);
   }
 
-  public ArrowFlightJdbcVarCharVectorAccessor(LargeVarCharVector vector,
-                                              IntSupplier currentRowSupplier,
-                                              ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  public ArrowFlightJdbcVarCharVectorAccessor(
+      LargeVarCharVector vector,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     this(vector::get, currentRowSupplier, setCursorWasNull);
   }
 
-  ArrowFlightJdbcVarCharVectorAccessor(Getter getter,
-                                       IntSupplier currentRowSupplier,
-                                       ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
+  ArrowFlightJdbcVarCharVectorAccessor(
+      Getter getter,
+      IntSupplier currentRowSupplier,
+      ArrowFlightJdbcAccessorFactory.WasNullConsumer setCursorWasNull) {
     super(currentRowSupplier, setCursorWasNull);
     this.getter = getter;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/CloseableEndpointStreamPair.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/CloseableEndpointStreamPair.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.client;
 
 import org.apache.arrow.flight.FlightStream;
@@ -22,9 +21,7 @@ import org.apache.arrow.flight.sql.FlightSqlClient;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.util.Preconditions;
 
-/**
- * Represents a connection to a {@link org.apache.arrow.flight.FlightEndpoint}.
- */
+/** Represents a connection to a {@link org.apache.arrow.flight.FlightEndpoint}. */
 public class CloseableEndpointStreamPair implements AutoCloseable {
 
   private final FlightStream stream;

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtils.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.client.utils;
 
 import java.io.ByteArrayInputStream;
@@ -36,7 +35,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
-
 import org.apache.arrow.flight.CallOption;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.auth2.BasicAuthCredentialWriter;
@@ -46,9 +44,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.util.VisibleForTesting;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 
-/**
- * Utils for {@link FlightClientHandler} authentication.
- */
+/** Utils for {@link FlightClientHandler} authentication. */
 public final class ClientAuthenticationUtils {
 
   private ClientAuthenticationUtils() {
@@ -58,14 +54,15 @@ public final class ClientAuthenticationUtils {
   /**
    * Gets the {@link CredentialCallOption} for the provided authentication info.
    *
-   * @param client      the client.
-   * @param credential  the credential as CallOptions.
-   * @param options     the {@link CallOption}s to use.
+   * @param client the client.
+   * @param credential the credential as CallOptions.
+   * @param options the {@link CallOption}s to use.
    * @return the credential call option.
    */
-  public static CredentialCallOption getAuthenticate(final FlightClient client,
-                                                     final CredentialCallOption credential,
-                                                     final CallOption... options) {
+  public static CredentialCallOption getAuthenticate(
+      final FlightClient client,
+      final CredentialCallOption credential,
+      final CallOption... options) {
 
     final List<CallOption> theseOptions = new ArrayList<>();
     theseOptions.add(credential);
@@ -78,27 +75,32 @@ public final class ClientAuthenticationUtils {
   /**
    * Gets the {@link CredentialCallOption} for the provided authentication info.
    *
-   * @param client   the client.
+   * @param client the client.
    * @param username the username.
    * @param password the password.
-   * @param factory  the {@link ClientIncomingAuthHeaderMiddleware.Factory} to use.
-   * @param options  the {@link CallOption}s to use.
+   * @param factory the {@link ClientIncomingAuthHeaderMiddleware.Factory} to use.
+   * @param options the {@link CallOption}s to use.
    * @return the credential call option.
    */
-  public static CredentialCallOption getAuthenticate(final FlightClient client,
-                                                     final String username, final String password,
-                                                     final ClientIncomingAuthHeaderMiddleware.Factory factory,
-                                                     final CallOption... options) {
+  public static CredentialCallOption getAuthenticate(
+      final FlightClient client,
+      final String username,
+      final String password,
+      final ClientIncomingAuthHeaderMiddleware.Factory factory,
+      final CallOption... options) {
 
-    return getAuthenticate(client,
+    return getAuthenticate(
+        client,
         new CredentialCallOption(new BasicAuthCredentialWriter(username, password)),
-        factory, options);
+        factory,
+        options);
   }
 
-  private static CredentialCallOption getAuthenticate(final FlightClient client,
-                                                      final CredentialCallOption token,
-                                                      final ClientIncomingAuthHeaderMiddleware.Factory factory,
-                                                      final CallOption... options) {
+  private static CredentialCallOption getAuthenticate(
+      final FlightClient client,
+      final CredentialCallOption token,
+      final ClientIncomingAuthHeaderMiddleware.Factory factory,
+      final CallOption... options) {
     final List<CallOption> theseOptions = new ArrayList<>();
     theseOptions.add(token);
     theseOptions.addAll(Arrays.asList(options));
@@ -148,17 +150,16 @@ public final class ClientAuthenticationUtils {
   }
 
   /**
-   * It gets the trusted certificate based on the operating system and loads all the certificate into a
-   * {@link InputStream}.
+   * It gets the trusted certificate based on the operating system and loads all the certificate
+   * into a {@link InputStream}.
    *
    * @return An input stream with all the certificates.
-   *
-   * @throws KeyStoreException        if a key store could not be loaded.
-   * @throws CertificateException     if a certificate could not be found.
-   * @throws IOException              if it fails reading the file.
+   * @throws KeyStoreException if a key store could not be loaded.
+   * @throws CertificateException if a certificate could not be found.
+   * @throws IOException if it fails reading the file.
    */
-  public static InputStream getCertificateInputStreamFromSystem(String password) throws KeyStoreException,
-      CertificateException, IOException, NoSuchAlgorithmException {
+  public static InputStream getCertificateInputStreamFromSystem(String password)
+      throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
 
     List<KeyStore> keyStoreList = new ArrayList<>();
     if (isWindows()) {
@@ -201,36 +202,33 @@ public final class ClientAuthenticationUtils {
   static InputStream getCertificatesInputStream(Collection<KeyStore> keyStores)
       throws IOException, KeyStoreException {
     try (final StringWriter writer = new StringWriter();
-         final JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
+        final JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
 
       for (KeyStore keyStore : keyStores) {
         getCertificatesInputStream(keyStore, pemWriter);
       }
 
-      return new ByteArrayInputStream(
-        writer.toString().getBytes(StandardCharsets.UTF_8));
+      return new ByteArrayInputStream(writer.toString().getBytes(StandardCharsets.UTF_8));
     }
   }
 
   /**
-   * Generates an {@link InputStream} that contains certificates for a private
-   * key.
+   * Generates an {@link InputStream} that contains certificates for a private key.
    *
    * @param keyStorePath The path of the KeyStore.
    * @param keyStorePass The password of the KeyStore.
    * @return a new {code InputStream} containing the certificates.
    * @throws GeneralSecurityException on error.
-   * @throws IOException              on error.
+   * @throws IOException on error.
    */
-  public static InputStream getCertificateStream(final String keyStorePath,
-                                                 final String keyStorePass)
+  public static InputStream getCertificateStream(
+      final String keyStorePath, final String keyStorePass)
       throws GeneralSecurityException, IOException {
     Preconditions.checkNotNull(keyStorePath, "KeyStore path cannot be null!");
     Preconditions.checkNotNull(keyStorePass, "KeyStorePass cannot be null!");
     final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
 
-    try (final InputStream keyStoreStream = Files
-        .newInputStream(Paths.get(keyStorePath))) {
+    try (final InputStream keyStoreStream = Files.newInputStream(Paths.get(keyStorePath))) {
       keyStore.load(keyStoreStream, keyStorePass.toCharArray());
     }
 
@@ -238,54 +236,51 @@ public final class ClientAuthenticationUtils {
   }
 
   /**
-   * Generates an {@link InputStream} that contains certificates for path-based
-   * TLS Root Certificates.
+   * Generates an {@link InputStream} that contains certificates for path-based TLS Root
+   * Certificates.
    *
    * @param tlsRootsCertificatesPath The path of the TLS Root Certificates.
    * @return a new {code InputStream} containing the certificates.
    * @throws GeneralSecurityException on error.
-   * @throws IOException              on error.
+   * @throws IOException on error.
    */
   public static InputStream getTlsRootCertificatesStream(final String tlsRootsCertificatesPath)
-          throws GeneralSecurityException, IOException {
-    Preconditions.checkNotNull(tlsRootsCertificatesPath, "TLS Root certificates path cannot be null!");
+      throws GeneralSecurityException, IOException {
+    Preconditions.checkNotNull(
+        tlsRootsCertificatesPath, "TLS Root certificates path cannot be null!");
 
-    return Files
-      .newInputStream(Paths.get(tlsRootsCertificatesPath));
+    return Files.newInputStream(Paths.get(tlsRootsCertificatesPath));
   }
 
   /**
-   * Generates an {@link InputStream} that contains certificates for a path-based
-   * mTLS Client Certificate.
+   * Generates an {@link InputStream} that contains certificates for a path-based mTLS Client
+   * Certificate.
    *
    * @param clientCertificatePath The path of the mTLS Client Certificate.
    * @return a new {code InputStream} containing the certificates.
    * @throws GeneralSecurityException on error.
-   * @throws IOException              on error.
+   * @throws IOException on error.
    */
   public static InputStream getClientCertificateStream(final String clientCertificatePath)
       throws GeneralSecurityException, IOException {
     Preconditions.checkNotNull(clientCertificatePath, "Client certificate path cannot be null!");
 
-    return Files
-      .newInputStream(Paths.get(clientCertificatePath));
+    return Files.newInputStream(Paths.get(clientCertificatePath));
   }
 
   /**
-   * Generates an {@link InputStream} that contains certificates for a path-based
-   * mTLS Client Key.
+   * Generates an {@link InputStream} that contains certificates for a path-based mTLS Client Key.
    *
    * @param clientKeyPath The path of the mTLS Client Key.
    * @return a new {code InputStream} containing the certificates.
    * @throws GeneralSecurityException on error.
-   * @throws IOException              on error.
+   * @throws IOException on error.
    */
   public static InputStream getClientKeyStream(final String clientKeyPath)
-          throws GeneralSecurityException, IOException {
+      throws GeneralSecurityException, IOException {
     Preconditions.checkNotNull(clientKeyPath, "Client key path cannot be null!");
 
-    return Files
-      .newInputStream(Paths.get(clientKeyPath));
+    return Files.newInputStream(Paths.get(clientKeyPath));
   }
 
   private static InputStream getSingleCertificateInputStream(KeyStore keyStore)
@@ -302,16 +297,14 @@ public final class ClientAuthenticationUtils {
     throw new CertificateException("Keystore did not have a certificate.");
   }
 
-  private static InputStream toInputStream(final Certificate certificate)
-      throws IOException {
+  private static InputStream toInputStream(final Certificate certificate) throws IOException {
 
     try (final StringWriter writer = new StringWriter();
-         final JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
+        final JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
 
       pemWriter.writeObject(certificate);
       pemWriter.flush();
-      return new ByteArrayInputStream(
-          writer.toString().getBytes(StandardCharsets.UTF_8));
+      return new ByteArrayInputStream(writer.toString().getBytes(StandardCharsets.UTF_8));
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/AvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/AvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter;
 
 import org.apache.arrow.vector.FieldVector;

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BaseAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BaseAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.driver.jdbc.converter.AvaticaParameterConverter;
@@ -34,7 +33,8 @@ abstract class BaseAvaticaParameterConverter implements AvaticaParameterConverte
     final ArrowType arrowType = field.getType();
     final String typeName = arrowType.toString();
     final int precision = 0; // Would have to know about the actual number
-    final int scale = 0; // According to https://www.postgresql.org/docs/current/datatype-numeric.html
+    final int scale =
+        0; // According to https://www.postgresql.org/docs/current/datatype-numeric.html
     final int jdbcType = SqlTypes.getSqlTypeIdFromArrowType(arrowType);
     final String className = SqlType.valueOf(jdbcType).clazz.getCanonicalName();
     return new AvaticaParameter(signed, precision, scale, jdbcType, typeName, className, name);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BinaryAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BinaryAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -24,13 +23,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Binary Arrow types.
- */
+/** AvaticaParameterConverter for Binary Arrow types. */
 public class BinaryAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public BinaryAvaticaParameterConverter(ArrowType.Binary type) {
-  }
+  public BinaryAvaticaParameterConverter(ArrowType.Binary type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BinaryViewAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BinaryViewAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -26,9 +25,7 @@ import org.apache.calcite.avatica.remote.TypedValue;
 /** AvaticaParameterConverter for BinaryView Arrow types. */
 public class BinaryViewAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public BinaryViewAvaticaParameterConverter(ArrowType.BinaryView type) {
-
-  }
+  public BinaryViewAvaticaParameterConverter(ArrowType.BinaryView type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BoolAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/BoolAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.BitVector;
@@ -24,13 +23,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Bool Arrow types.
- */
+/** AvaticaParameterConverter for Bool Arrow types. */
 public class BoolAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public BoolAvaticaParameterConverter(ArrowType.Bool type) {
-  }
+  public BoolAvaticaParameterConverter(ArrowType.Bool type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/DateAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/DateAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.DateDayVector;
@@ -25,13 +24,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Date Arrow types.
- */
+/** AvaticaParameterConverter for Date Arrow types. */
 public class DateAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public DateAvaticaParameterConverter(ArrowType.Date type) {
-  }
+  public DateAvaticaParameterConverter(ArrowType.Date type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/DecimalAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/DecimalAvaticaParameterConverter.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import java.math.BigDecimal;
-
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -26,13 +24,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Decimal Arrow types.
- */
+/** AvaticaParameterConverter for Decimal Arrow types. */
 public class DecimalAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public DecimalAvaticaParameterConverter(ArrowType.Decimal type) {
-  }
+  public DecimalAvaticaParameterConverter(ArrowType.Decimal type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/DurationAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/DurationAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -23,13 +22,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Duration Arrow types.
- */
+/** AvaticaParameterConverter for Duration Arrow types. */
 public class DurationAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public DurationAvaticaParameterConverter(ArrowType.Duration type) {
-  }
+  public DurationAvaticaParameterConverter(ArrowType.Duration type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FixedSizeBinaryAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FixedSizeBinaryAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -24,13 +23,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for FixedSizeBinary Arrow types.
- */
+/** AvaticaParameterConverter for FixedSizeBinary Arrow types. */
 public class FixedSizeBinaryAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public FixedSizeBinaryAvaticaParameterConverter(ArrowType.FixedSizeBinary type) {
-  }
+  public FixedSizeBinaryAvaticaParameterConverter(ArrowType.FixedSizeBinary type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FixedSizeListAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FixedSizeListAvaticaParameterConverter.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import java.util.List;
-
 import org.apache.arrow.driver.jdbc.utils.AvaticaParameterBinder;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
@@ -27,13 +25,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for FixedSizeList Arrow types.
- */
+/** AvaticaParameterConverter for FixedSizeList Arrow types. */
 public class FixedSizeListAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public FixedSizeListAvaticaParameterConverter(ArrowType.FixedSizeList type) {
-  }
+  public FixedSizeListAvaticaParameterConverter(ArrowType.FixedSizeList type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {
@@ -47,9 +42,11 @@ public class FixedSizeListAvaticaParameterConverter extends BaseAvaticaParameter
 
       if (arraySize != maxArraySize) {
         if (!childVector.getField().isNullable()) {
-          throw new UnsupportedOperationException("Each array must contain " + maxArraySize + " elements");
+          throw new UnsupportedOperationException(
+              "Each array must contain " + maxArraySize + " elements");
         } else if (arraySize > maxArraySize) {
-          throw new UnsupportedOperationException("Each array must contain at most " + maxArraySize + " elements");
+          throw new UnsupportedOperationException(
+              "Each array must contain at most " + maxArraySize + " elements");
         }
       }
 
@@ -64,9 +61,12 @@ public class FixedSizeListAvaticaParameterConverter extends BaseAvaticaParameter
             throw new UnsupportedOperationException("Can't set null on non-nullable child list");
           }
         } else {
-          childVector.getField().getType().accept(
+          childVector
+              .getField()
+              .getType()
+              .accept(
                   new AvaticaParameterBinder.BinderVisitor(
-                          childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
+                      childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
         }
       }
       listVector.setValueCount(index + 1);

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FloatingPointAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/FloatingPointAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -25,13 +24,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for FloatingPoint Arrow types.
- */
+/** AvaticaParameterConverter for FloatingPoint Arrow types. */
 public class FloatingPointAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public FloatingPointAvaticaParameterConverter(ArrowType.FloatingPoint type) {
-  }
+  public FloatingPointAvaticaParameterConverter(ArrowType.FloatingPoint type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/IntAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/IntAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.BigIntVector;
@@ -31,9 +30,7 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Int Arrow types.
- */
+/** AvaticaParameterConverter for Int Arrow types. */
 public class IntAvaticaParameterConverter extends BaseAvaticaParameterConverter {
   private final ArrowType.Int type;
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/IntervalAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/IntervalAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -23,13 +22,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Interval Arrow types.
- */
+/** AvaticaParameterConverter for Interval Arrow types. */
 public class IntervalAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public IntervalAvaticaParameterConverter(ArrowType.Interval type) {
-  }
+  public IntervalAvaticaParameterConverter(ArrowType.Interval type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeBinaryAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeBinaryAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -24,13 +23,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for LargeBinary Arrow types.
- */
+/** AvaticaParameterConverter for LargeBinary Arrow types. */
 public class LargeBinaryAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public LargeBinaryAvaticaParameterConverter(ArrowType.LargeBinary type) {
-  }
+  public LargeBinaryAvaticaParameterConverter(ArrowType.LargeBinary type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeListAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeListAvaticaParameterConverter.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import java.util.List;
-
 import org.apache.arrow.driver.jdbc.utils.AvaticaParameterBinder;
 import org.apache.arrow.memory.util.LargeMemoryUtil;
 import org.apache.arrow.vector.FieldVector;
@@ -28,13 +26,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for LargeList Arrow types.
- */
+/** AvaticaParameterConverter for LargeList Arrow types. */
 public class LargeListAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public LargeListAvaticaParameterConverter(ArrowType.LargeList type) {
-  }
+  public LargeListAvaticaParameterConverter(ArrowType.LargeList type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {
@@ -55,9 +50,12 @@ public class LargeListAvaticaParameterConverter extends BaseAvaticaParameterConv
             throw new UnsupportedOperationException("Can't set null on non-nullable child list");
           }
         } else {
-          childVector.getField().getType().accept(
+          childVector
+              .getField()
+              .getType()
+              .accept(
                   new AvaticaParameterBinder.BinderVisitor(
-                          childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
+                      childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
         }
       }
       listVector.endValue(index, values.size());

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeUtf8AvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/LargeUtf8AvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -25,13 +24,10 @@ import org.apache.arrow.vector.util.Text;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for LargeUtf8 Arrow types.
- */
+/** AvaticaParameterConverter for LargeUtf8 Arrow types. */
 public class LargeUtf8AvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public LargeUtf8AvaticaParameterConverter(ArrowType.LargeUtf8 type) {
-  }
+  public LargeUtf8AvaticaParameterConverter(ArrowType.LargeUtf8 type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/ListAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/ListAvaticaParameterConverter.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import java.util.List;
-
 import org.apache.arrow.driver.jdbc.utils.AvaticaParameterBinder;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -27,13 +25,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for List Arrow types.
- */
+/** AvaticaParameterConverter for List Arrow types. */
 public class ListAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public ListAvaticaParameterConverter(ArrowType.List type) {
-  }
+  public ListAvaticaParameterConverter(ArrowType.List type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {
@@ -54,9 +49,12 @@ public class ListAvaticaParameterConverter extends BaseAvaticaParameterConverter
             throw new UnsupportedOperationException("Can't set null on non-nullable child list");
           }
         } else {
-          childVector.getField().getType().accept(
+          childVector
+              .getField()
+              .getType()
+              .accept(
                   new AvaticaParameterBinder.BinderVisitor(
-                          childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
+                      childVector, TypedValue.ofSerial(typedValue.componentType, val), childIndex));
         }
       }
       listVector.endValue(index, values.size());

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/MapAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/MapAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -23,13 +22,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Map Arrow types.
- */
+/** AvaticaParameterConverter for Map Arrow types. */
 public class MapAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public MapAvaticaParameterConverter(ArrowType.Map type) {
-  }
+  public MapAvaticaParameterConverter(ArrowType.Map type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/NullAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/NullAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -24,19 +23,18 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Null Arrow types.
- */
+/** AvaticaParameterConverter for Null Arrow types. */
 public class NullAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public NullAvaticaParameterConverter(ArrowType.Null type) {
-  }
+  public NullAvaticaParameterConverter(ArrowType.Null type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {
     Object value = typedValue.toLocal();
     if (vector instanceof NullVector) {
-      if (value != null) { throw new RuntimeException("Can't set non-null value on NullVector"); }
+      if (value != null) {
+        throw new RuntimeException("Can't set non-null value on NullVector");
+      }
       vector.setNull(index);
     }
     return false;

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/StructAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/StructAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -23,13 +22,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Struct Arrow types.
- */
+/** AvaticaParameterConverter for Struct Arrow types. */
 public class StructAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public StructAvaticaParameterConverter(ArrowType.Struct type) {
-  }
+  public StructAvaticaParameterConverter(ArrowType.Struct type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimeAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimeAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -27,13 +26,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Time Arrow types.
- */
+/** AvaticaParameterConverter for Time Arrow types. */
 public class TimeAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public TimeAvaticaParameterConverter(ArrowType.Time type) {
-  }
+  public TimeAvaticaParameterConverter(ArrowType.Time type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/TimestampAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -31,13 +30,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Timestamp Arrow types.
- */
+/** AvaticaParameterConverter for Timestamp Arrow types. */
 public class TimestampAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public TimestampAvaticaParameterConverter(ArrowType.Timestamp type) {
-  }
+  public TimestampAvaticaParameterConverter(ArrowType.Timestamp type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/UnionAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/UnionAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -23,13 +22,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Union Arrow types.
- */
+/** AvaticaParameterConverter for Union Arrow types. */
 public class UnionAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public UnionAvaticaParameterConverter(ArrowType.Union type) {
-  }
+  public UnionAvaticaParameterConverter(ArrowType.Union type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/Utf8AvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/Utf8AvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -25,13 +24,10 @@ import org.apache.arrow.vector.util.Text;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Utf8 Arrow types.
- */
+/** AvaticaParameterConverter for Utf8 Arrow types. */
 public class Utf8AvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public Utf8AvaticaParameterConverter(ArrowType.Utf8 type) {
-  }
+  public Utf8AvaticaParameterConverter(ArrowType.Utf8 type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/Utf8ViewAvaticaParameterConverter.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/converter/impl/Utf8ViewAvaticaParameterConverter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.converter.impl;
 
 import org.apache.arrow.vector.FieldVector;
@@ -23,13 +22,10 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.remote.TypedValue;
 
-/**
- * AvaticaParameterConverter for Utf8View Arrow types.
- */
+/** AvaticaParameterConverter for Utf8View Arrow types. */
 public class Utf8ViewAvaticaParameterConverter extends BaseAvaticaParameterConverter {
 
-  public Utf8ViewAvaticaParameterConverter(ArrowType.Utf8View type) {
-  }
+  public Utf8ViewAvaticaParameterConverter(ArrowType.Utf8View type) {}
 
   @Override
   public boolean bindParameter(FieldVector vector, TypedValue typedValue, int index) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.ArrowFlightConnection;
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallOption;
@@ -33,10 +31,7 @@ import org.apache.calcite.avatica.ConnectionConfig;
 import org.apache.calcite.avatica.ConnectionConfigImpl;
 import org.apache.calcite.avatica.ConnectionProperty;
 
-
-/**
- * A {@link ConnectionConfig} for the {@link ArrowFlightConnection}.
- */
+/** A {@link ConnectionConfig} for the {@link ArrowFlightConnection}. */
 public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl {
   public ArrowFlightConnectionConfigImpl(final Properties properties) {
     super(properties);
@@ -77,7 +72,6 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
   public String getPassword() {
     return ArrowFlightConnectionProperty.PASSWORD.getString(properties);
   }
-
 
   public String getToken() {
     return ArrowFlightConnectionProperty.TOKEN.getString(properties);
@@ -145,16 +139,16 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
   }
 
   /**
-   * Indicates if sub-connections created for stream retrieval
-   * should reuse cookies from the main connection.
+   * Indicates if sub-connections created for stream retrieval should reuse cookies from the main
+   * connection.
    */
   public boolean retainCookies() {
     return ArrowFlightConnectionProperty.RETAIN_COOKIES.getBoolean(properties);
   }
 
   /**
-   * Indicates if sub-connections created for stream retrieval
-   * should reuse bearer tokens created from the main connection.
+   * Indicates if sub-connections created for stream retrieval should reuse bearer tokens created
+   * from the main connection.
    */
   public boolean retainAuth() {
     return ArrowFlightConnectionProperty.RETAIN_AUTH.getBoolean(properties);
@@ -184,16 +178,15 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
         (key, val) -> {
           // For built-in properties before adding new headers
           if (Arrays.stream(builtInProperties)
-              .noneMatch(builtInProperty -> builtInProperty.camelName.equalsIgnoreCase(key.toString()))) {
+              .noneMatch(
+                  builtInProperty -> builtInProperty.camelName.equalsIgnoreCase(key.toString()))) {
             headers.put(key.toString(), val.toString());
           }
         });
     return headers;
   }
 
-  /**
-   * Custom {@link ConnectionProperty} for the {@link ArrowFlightConnectionConfigImpl}.
-   */
+  /** Custom {@link ConnectionProperty} for the {@link ArrowFlightConnectionConfigImpl}. */
   public enum ArrowFlightConnectionProperty implements ConnectionProperty {
     HOST("host", null, Type.STRING, true),
     PORT("port", null, Type.NUMBER, true),
@@ -217,8 +210,11 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
     private final Type type;
     private final boolean required;
 
-    ArrowFlightConnectionProperty(final String camelName, final Object defaultValue,
-                                  final Type type, final boolean required) {
+    ArrowFlightConnectionProperty(
+        final String camelName,
+        final Object defaultValue,
+        final Type type,
+        final boolean required) {
       this.camelName = Preconditions.checkNotNull(camelName);
       this.defaultValue = defaultValue;
       this.type = Preconditions.checkNotNull(type);
@@ -239,7 +235,8 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
       }
       if (required) {
         if (value == null) {
-          throw new IllegalStateException(String.format("Required property not provided: <%s>.", this));
+          throw new IllegalStateException(
+              String.format("Required property not provided: <%s>.", this));
         }
         return value;
       } else {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ConnectionWrapper.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ConnectionWrapper.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -37,7 +36,6 @@ import java.sql.Struct;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
-
 import org.apache.arrow.driver.jdbc.ArrowFlightJdbcPooledConnection;
 
 /**
@@ -162,15 +160,15 @@ public class ConnectionWrapper implements Connection {
   }
 
   @Override
-  public PreparedStatement prepareStatement(final String sqlQuery, final int resultSetTypeId,
-                                            final int resultSetConcurrencyId)
+  public PreparedStatement prepareStatement(
+      final String sqlQuery, final int resultSetTypeId, final int resultSetConcurrencyId)
       throws SQLException {
     return realConnection.prepareStatement(sqlQuery, resultSetTypeId, resultSetConcurrencyId);
   }
 
   @Override
-  public CallableStatement prepareCall(final String query, final int resultSetTypeId,
-                                       final int resultSetConcurrencyId)
+  public CallableStatement prepareCall(
+      final String query, final int resultSetTypeId, final int resultSetConcurrencyId)
       throws SQLException {
     return realConnection.prepareCall(query, resultSetTypeId, resultSetConcurrencyId);
   }
@@ -216,29 +214,33 @@ public class ConnectionWrapper implements Connection {
   }
 
   @Override
-  public Statement createStatement(final int resultSetType,
-                                   final int resultSetConcurrency,
-                                   final int resultSetHoldability) throws SQLException {
-    return realConnection.createStatement(resultSetType, resultSetConcurrency,
-        resultSetHoldability);
+  public Statement createStatement(
+      final int resultSetType, final int resultSetConcurrency, final int resultSetHoldability)
+      throws SQLException {
+    return realConnection.createStatement(
+        resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 
   @Override
-  public PreparedStatement prepareStatement(final String sqlQuery,
-                                            final int resultSetType,
-                                            final int resultSetConcurrency,
-                                            final int resultSetHoldability) throws SQLException {
-    return realConnection.prepareStatement(sqlQuery, resultSetType, resultSetConcurrency,
-        resultSetHoldability);
+  public PreparedStatement prepareStatement(
+      final String sqlQuery,
+      final int resultSetType,
+      final int resultSetConcurrency,
+      final int resultSetHoldability)
+      throws SQLException {
+    return realConnection.prepareStatement(
+        sqlQuery, resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 
   @Override
-  public CallableStatement prepareCall(final String sqlQuery,
-                                       final int resultSetType,
-                                       final int resultSetConcurrency,
-                                       final int resultSetHoldability) throws SQLException {
-    return realConnection.prepareCall(sqlQuery, resultSetType, resultSetConcurrency,
-        resultSetHoldability);
+  public CallableStatement prepareCall(
+      final String sqlQuery,
+      final int resultSetType,
+      final int resultSetConcurrency,
+      final int resultSetHoldability)
+      throws SQLException {
+    return realConnection.prepareCall(
+        sqlQuery, resultSetType, resultSetConcurrency, resultSetHoldability);
   }
 
   @Override
@@ -311,8 +313,7 @@ public class ConnectionWrapper implements Connection {
   }
 
   @Override
-  public Struct createStruct(final String typeName, final Object[] attributes)
-      throws SQLException {
+  public Struct createStruct(final String typeName, final Object[] attributes) throws SQLException {
     return realConnection.createStruct(typeName, attributes);
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ConvertUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ConvertUtils.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.arrow.driver.jdbc.converter.impl.BinaryAvaticaParameterConverter;
 import org.apache.arrow.driver.jdbc.converter.impl.BinaryViewAvaticaParameterConverter;
 import org.apache.arrow.driver.jdbc.converter.impl.BoolAvaticaParameterConverter;
@@ -52,13 +50,10 @@ import org.apache.calcite.avatica.AvaticaParameter;
 import org.apache.calcite.avatica.ColumnMetaData;
 import org.apache.calcite.avatica.proto.Common;
 
-/**
- * Convert objects between Arrow and Avatica.
- */
+/** Convert objects between Arrow and Avatica. */
 public final class ConvertUtils {
 
-  private ConvertUtils() {
-  }
+  private ConvertUtils() {}
 
   /**
    * Convert Fields To Column MetaData List functions.
@@ -66,36 +61,42 @@ public final class ConvertUtils {
    * @param fields list of {@link Field}.
    * @return list of {@link ColumnMetaData}.
    */
-  public static List<ColumnMetaData> convertArrowFieldsToColumnMetaDataList(final List<Field> fields) {
-    return Stream.iterate(0, Math::incrementExact).limit(fields.size())
-        .map(index -> {
-          final Field field = fields.get(index);
-          final ArrowType fieldType = field.getType();
+  public static List<ColumnMetaData> convertArrowFieldsToColumnMetaDataList(
+      final List<Field> fields) {
+    return Stream.iterate(0, Math::incrementExact)
+        .limit(fields.size())
+        .map(
+            index -> {
+              final Field field = fields.get(index);
+              final ArrowType fieldType = field.getType();
 
-          final Common.ColumnMetaData.Builder builder = Common.ColumnMetaData.newBuilder()
-              .setOrdinal(index)
-              .setColumnName(field.getName())
-              .setLabel(field.getName());
+              final Common.ColumnMetaData.Builder builder =
+                  Common.ColumnMetaData.newBuilder()
+                      .setOrdinal(index)
+                      .setColumnName(field.getName())
+                      .setLabel(field.getName());
 
-          setOnColumnMetaDataBuilder(builder, field.getMetadata());
+              setOnColumnMetaDataBuilder(builder, field.getMetadata());
 
-          builder.setType(Common.AvaticaType.newBuilder()
-              .setId(SqlTypes.getSqlTypeIdFromArrowType(fieldType))
-              .setName(SqlTypes.getSqlTypeNameFromArrowType(fieldType))
-              .build());
+              builder.setType(
+                  Common.AvaticaType.newBuilder()
+                      .setId(SqlTypes.getSqlTypeIdFromArrowType(fieldType))
+                      .setName(SqlTypes.getSqlTypeNameFromArrowType(fieldType))
+                      .build());
 
-          return ColumnMetaData.fromProto(builder.build());
-        }).collect(Collectors.toList());
+              return ColumnMetaData.fromProto(builder.build());
+            })
+        .collect(Collectors.toList());
   }
 
   /**
    * Set on Column MetaData Builder.
    *
-   * @param builder     {@link Common.ColumnMetaData.Builder}
+   * @param builder {@link Common.ColumnMetaData.Builder}
    * @param metadataMap {@link Map}
    */
-  public static void setOnColumnMetaDataBuilder(final Common.ColumnMetaData.Builder builder,
-                                                final Map<String, String> metadataMap) {
+  public static void setOnColumnMetaDataBuilder(
+      final Common.ColumnMetaData.Builder builder, final Map<String, String> metadataMap) {
     final FlightSqlColumnMetadata columnMetadata = new FlightSqlColumnMetadata(metadataMap);
     final String catalogName = columnMetadata.getCatalogName();
     if (catalogName != null) {
@@ -143,10 +144,11 @@ public final class ConvertUtils {
    * @param fields list of {@link Field}.
    * @return list of {@link AvaticaParameter}.
    */
-  public static List<AvaticaParameter> convertArrowFieldsToAvaticaParameters(final List<Field> fields) {
+  public static List<AvaticaParameter> convertArrowFieldsToAvaticaParameters(
+      final List<Field> fields) {
     return fields.stream()
-            .map(field -> field.getType().accept(new ConverterVisitor(field)))
-            .collect(Collectors.toList());
+        .map(field -> field.getType().accept(new ConverterVisitor(field)))
+        .collect(Collectors.toList());
   }
 
   private static class ConverterVisitor implements ArrowType.ArrowTypeVisitor<AvaticaParameter> {
@@ -169,25 +171,21 @@ public final class ConvertUtils {
     @Override
     public AvaticaParameter visit(ArrowType.List type) {
       return new ListAvaticaParameterConverter(type).createParameter(field);
-
     }
 
     @Override
     public AvaticaParameter visit(ArrowType.LargeList type) {
       return new LargeListAvaticaParameterConverter(type).createParameter(field);
-
     }
 
     @Override
     public AvaticaParameter visit(ArrowType.FixedSizeList type) {
       return new FixedSizeListAvaticaParameterConverter(type).createParameter(field);
-
     }
 
     @Override
     public AvaticaParameter visit(ArrowType.Union type) {
       return new UnionAvaticaParameterConverter(type).createParameter(field);
-
     }
 
     @Override
@@ -277,8 +275,8 @@ public final class ConvertUtils {
 
     @Override
     public AvaticaParameter visit(ArrowType.ListView type) {
-      throw new UnsupportedOperationException("AvaticaParameter not yet supported for type " + type);
+      throw new UnsupportedOperationException(
+          "AvaticaParameter not yet supported for type " + type);
     }
   }
-
 }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY;
@@ -27,17 +26,13 @@ import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Datetime utility functions.
- */
+/** Datetime utility functions. */
 public class DateTimeUtils {
   private DateTimeUtils() {
     // Prevent instantiation.
   }
 
-  /**
-   * Subtracts given Calendar's TimeZone offset from epoch milliseconds.
-   */
+  /** Subtracts given Calendar's TimeZone offset from epoch milliseconds. */
   public static long applyCalendarOffset(long milliseconds, Calendar calendar) {
     if (calendar == null) {
       calendar = Calendar.getInstance();
@@ -52,7 +47,6 @@ public class DateTimeUtils {
 
     return milliseconds;
   }
-
 
   /**
    * Converts Epoch millis to a {@link Timestamp} object.
@@ -70,7 +64,6 @@ public class DateTimeUtils {
     return Timestamp.valueOf(
         LocalDateTime.of(
             LocalDate.ofEpochDay(millisWithCalendar / MILLIS_PER_DAY),
-            LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(milliseconds % MILLIS_PER_DAY)))
-    );
+            LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(milliseconds % MILLIS_PER_DAY))));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/IntervalStringUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/IntervalStringUtils.java
@@ -14,29 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.time.Duration;
 import java.time.Period;
-
 import org.apache.arrow.vector.util.DateUtility;
 
 /**
- * Utility class to format periods similar to Oracle's representation
- * of "INTERVAL * to *" data type.
+ * Utility class to format periods similar to Oracle's representation of "INTERVAL * to *" data
+ * type.
  */
 public final class IntervalStringUtils {
 
-  /**
-   * Constructor Method of class.
-   */
-  private IntervalStringUtils( ) {
-  }
+  /** Constructor Method of class. */
+  private IntervalStringUtils() {}
 
   /**
-   * Formats a period similar to Oracle INTERVAL YEAR TO MONTH data type<br>.
-   * For example, the string "+21-02" defines an interval of 21 years and 2 months.
+   * Formats a period similar to Oracle INTERVAL YEAR TO MONTH data type<br>
+   * . For example, the string "+21-02" defines an interval of 21 years and 2 months.
    */
   public static String formatIntervalYear(final Period p) {
     long months = p.toTotalMonths();
@@ -52,9 +47,9 @@ public final class IntervalStringUtils {
   }
 
   /**
-   * Formats a period similar to Oracle INTERVAL DAY TO SECOND data type.<br>.
-   * For example, the string "-001 18:25:16.766" defines an interval of
-   * - 1 day 18 hours 25 minutes 16 seconds and 766 milliseconds.
+   * Formats a period similar to Oracle INTERVAL DAY TO SECOND data type.<br>
+   * . For example, the string "-001 18:25:16.766" defines an interval of - 1 day 18 hours 25
+   * minutes 16 seconds and 766 milliseconds.
    */
   public static String formatIntervalDay(final Duration d) {
     long millis = d.toMillis();
@@ -77,6 +72,7 @@ public final class IntervalStringUtils {
     final int seconds = (int) (millis / DateUtility.secondsToMillis);
     millis = millis % DateUtility.secondsToMillis;
 
-    return String.format("%c%03d %02d:%02d:%02d.%03d", neg ? '-' : '+', days, hours, minutes, seconds, millis);
+    return String.format(
+        "%c%03d %02d:%02d:%02d.%03d", neg ? '-' : '+', days, hours, minutes, seconds, millis);
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/SqlTypes.java
@@ -14,19 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
-/**
- * SQL Types utility functions.
- */
+/** SQL Types utility functions. */
 public class SqlTypes {
   private static final Map<Integer, String> typeIdToName = new HashMap<>();
 
@@ -83,7 +79,6 @@ public class SqlTypes {
     final int typeId = getSqlTypeIdFromArrowType(arrowType);
     return typeIdToName.get(typeId);
   }
-
 
   /**
    * Convert given {@link ArrowType} to its corresponding SQL type ID.

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/UrlParser.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/UrlParser.java
@@ -14,20 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
-/**
- * URL Parser for extracting key values from a connection string.
- */
 
+/** URL Parser for extracting key values from a connection string. */
 public final class UrlParser {
-  private UrlParser() {
-  }
+  private UrlParser() {}
 
   /**
    * Parse URL key value parameters.
@@ -45,8 +41,10 @@ public final class UrlParser {
 
       for (String keyValue : keyValues) {
         try {
-          int separatorKey = keyValue.indexOf("="); // Find the first equal sign to split key and value.
-          if (separatorKey != -1) { // Avoid crashes when not finding an equal sign in the property value.
+          int separatorKey =
+              keyValue.indexOf("="); // Find the first equal sign to split key and value.
+          if (separatorKey
+              != -1) { // Avoid crashes when not finding an equal sign in the property value.
             String key = keyValue.substring(0, separatorKey);
             key = URLDecoder.decode(key, "UTF-8");
             String value = "";

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadataTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowDatabaseMetadataTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static com.google.protobuf.ByteString.copyFrom;
@@ -33,6 +32,9 @@ import static org.apache.arrow.flight.sql.impl.FlightSql.SqlSupportsConvert.SQL_
 import static org.apache.arrow.flight.sql.impl.FlightSql.SqlSupportsConvert.SQL_CONVERT_INTEGER_VALUE;
 import static org.hamcrest.CoreMatchers.is;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Message;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -45,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.driver.jdbc.utils.ResultSetTestUtils;
 import org.apache.arrow.driver.jdbc.utils.ThrowableAssertionUtils;
@@ -84,25 +85,22 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.Message;
-
-/**
- * Class containing the tests from the {@link ArrowDatabaseMetadata}.
- */
+/** Class containing the tests from the {@link ArrowDatabaseMetadata}. */
 @SuppressWarnings("DoubleBraceInitialization")
 public class ArrowDatabaseMetadataTest {
   public static final boolean EXPECTED_MAX_ROW_SIZE_INCLUDES_BLOBS = false;
   private static final MockFlightSqlProducer FLIGHT_SQL_PRODUCER = new MockFlightSqlProducer();
   private static final MockFlightSqlProducer FLIGHT_SQL_PRODUCER_EMPTY_SQLINFO =
       new MockFlightSqlProducer();
+
   @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE = FlightServerTestRule
-      .createStandardTestRule(FLIGHT_SQL_PRODUCER);
+  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE =
+      FlightServerTestRule.createStandardTestRule(FLIGHT_SQL_PRODUCER);
+
   @ClassRule
   public static final FlightServerTestRule FLIGHT_SERVER_EMPTY_SQLINFO_TEST_RULE =
       FlightServerTestRule.createStandardTestRule(FLIGHT_SQL_PRODUCER_EMPTY_SQLINFO);
+
   private static final int ROW_COUNT = 10;
   private static final List<List<Object>> EXPECTED_GET_CATALOGS_RESULTS =
       range(0, ROW_COUNT)
@@ -118,61 +116,85 @@ public class ArrowDatabaseMetadataTest {
           .collect(toList());
   private static final List<List<Object>> EXPECTED_GET_TABLES_RESULTS =
       range(0, ROW_COUNT)
-          .mapToObj(i -> new Object[] {
-              format("catalog_name #%d", i),
-              format("db_schema_name #%d", i),
-              format("table_name #%d", i),
-              format("table_type #%d", i),
-              // TODO Add these fields to FlightSQL, as it's currently not possible to fetch them.
-              null, null, null, null, null, null})
+          .mapToObj(
+              i ->
+                  new Object[] {
+                    format("catalog_name #%d", i),
+                    format("db_schema_name #%d", i),
+                    format("table_name #%d", i),
+                    format("table_type #%d", i),
+                    // TODO Add these fields to FlightSQL, as it's currently not possible to fetch
+                    // them.
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                  })
           .map(Arrays::asList)
           .collect(toList());
   private static final List<List<Object>> EXPECTED_GET_SCHEMAS_RESULTS =
       range(0, ROW_COUNT)
-          .mapToObj(i -> new Object[] {
-              format("db_schema_name #%d", i),
-              format("catalog_name #%d", i)})
+          .mapToObj(
+              i -> new Object[] {format("db_schema_name #%d", i), format("catalog_name #%d", i)})
           .map(Arrays::asList)
           .collect(toList());
   private static final List<List<Object>> EXPECTED_GET_EXPORTED_AND_IMPORTED_KEYS_RESULTS =
       range(0, ROW_COUNT)
-          .mapToObj(i -> new Object[] {
-              format("pk_catalog_name #%d", i),
-              format("pk_db_schema_name #%d", i),
-              format("pk_table_name #%d", i),
-              format("pk_column_name #%d", i),
-              format("fk_catalog_name #%d", i),
-              format("fk_db_schema_name #%d", i),
-              format("fk_table_name #%d", i),
-              format("fk_column_name #%d", i),
-              i,
-              format("fk_key_name #%d", i),
-              format("pk_key_name #%d", i),
-              (byte) i,
-              (byte) i,
-              // TODO Add this field to FlightSQL, as it's currently not possible to fetch it.
-              null})
+          .mapToObj(
+              i ->
+                  new Object[] {
+                    format("pk_catalog_name #%d", i),
+                    format("pk_db_schema_name #%d", i),
+                    format("pk_table_name #%d", i),
+                    format("pk_column_name #%d", i),
+                    format("fk_catalog_name #%d", i),
+                    format("fk_db_schema_name #%d", i),
+                    format("fk_table_name #%d", i),
+                    format("fk_column_name #%d", i),
+                    i,
+                    format("fk_key_name #%d", i),
+                    format("pk_key_name #%d", i),
+                    (byte) i,
+                    (byte) i,
+                    // TODO Add this field to FlightSQL, as it's currently not possible to fetch it.
+                    null
+                  })
           .map(Arrays::asList)
           .collect(toList());
   private static final List<List<Object>> EXPECTED_CROSS_REFERENCE_RESULTS =
       EXPECTED_GET_EXPORTED_AND_IMPORTED_KEYS_RESULTS;
   private static final List<List<Object>> EXPECTED_PRIMARY_KEYS_RESULTS =
       range(0, ROW_COUNT)
-          .mapToObj(i -> new Object[] {
-              format("catalog_name #%d", i),
-              format("db_schema_name #%d", i),
-              format("table_name #%d", i),
-              format("column_name #%d", i),
-              i,
-              format("key_name #%d", i)})
+          .mapToObj(
+              i ->
+                  new Object[] {
+                    format("catalog_name #%d", i),
+                    format("db_schema_name #%d", i),
+                    format("table_name #%d", i),
+                    format("column_name #%d", i),
+                    i,
+                    format("key_name #%d", i)
+                  })
           .map(Arrays::asList)
           .collect(toList());
-  private static final List<String> FIELDS_GET_IMPORTED_EXPORTED_KEYS = ImmutableList.of(
-      "PKTABLE_CAT", "PKTABLE_SCHEM", "PKTABLE_NAME",
-      "PKCOLUMN_NAME", "FKTABLE_CAT", "FKTABLE_SCHEM",
-      "FKTABLE_NAME", "FKCOLUMN_NAME", "KEY_SEQ",
-      "FK_NAME", "PK_NAME", "UPDATE_RULE", "DELETE_RULE",
-      "DEFERRABILITY");
+  private static final List<String> FIELDS_GET_IMPORTED_EXPORTED_KEYS =
+      ImmutableList.of(
+          "PKTABLE_CAT",
+          "PKTABLE_SCHEM",
+          "PKTABLE_NAME",
+          "PKCOLUMN_NAME",
+          "FKTABLE_CAT",
+          "FKTABLE_SCHEM",
+          "FKTABLE_NAME",
+          "FKCOLUMN_NAME",
+          "KEY_SEQ",
+          "FK_NAME",
+          "PK_NAME",
+          "UPDATE_RULE",
+          "DELETE_RULE",
+          "DEFERRABILITY");
   private static final List<String> FIELDS_GET_CROSS_REFERENCE = FIELDS_GET_IMPORTED_EXPORTED_KEYS;
   private static final String TARGET_TABLE = "TARGET_TABLE";
   private static final String TARGET_FOREIGN_TABLE = "FOREIGN_TABLE";
@@ -234,8 +256,8 @@ public class ArrowDatabaseMetadataTest {
   private static final boolean EXPECTED_SUBQUERIES_IN_EXISTS = false;
   private static final boolean EXPECTED_SUBQUERIES_IN_INS = false;
   private static final boolean EXPECTED_SUBQUERIES_IN_QUANTIFIEDS = false;
-  private static final SqlSupportedSubqueries[] EXPECTED_SUPPORTED_SUBQUERIES = new SqlSupportedSubqueries[]
-      {SqlSupportedSubqueries.SQL_SUBQUERIES_IN_COMPARISONS};
+  private static final SqlSupportedSubqueries[] EXPECTED_SUPPORTED_SUBQUERIES =
+      new SqlSupportedSubqueries[] {SqlSupportedSubqueries.SQL_SUBQUERIES_IN_COMPARISONS};
   private static final boolean EXPECTED_CORRELATED_SUBQUERIES_SUPPORTED = true;
   private static final boolean EXPECTED_SUPPORTS_UNION = true;
   private static final boolean EXPECTED_SUPPORTS_UNION_ALL = true;
@@ -282,30 +304,41 @@ public class ArrowDatabaseMetadataTest {
     List<Integer> expectedGetColumnsColumnSize = Arrays.asList(5, 29, 10);
     List<Integer> expectedGetColumnsDecimalDigits = Arrays.asList(2, 9, 0);
     List<String> expectedGetColumnsIsNullable = Arrays.asList("YES", "YES", "NO");
-    EXPECTED_GET_COLUMNS_RESULTS = range(0, ROW_COUNT * 3)
-        .mapToObj(i -> new Object[] {
-            format("catalog_name #%d", i / 3),
-            format("db_schema_name #%d", i / 3),
-            format("table_name%d", i / 3),
-            format("column_%d", (i % 3) + 1),
-            expectedGetColumnsDataTypes.get(i % 3),
-            expectedGetColumnsTypeName.get(i % 3),
-            expectedGetColumnsColumnSize.get(i % 3),
-            null,
-            expectedGetColumnsDecimalDigits.get(i % 3),
-            expectedGetColumnsRadix.get(i % 3),
-            !Objects.equals(expectedGetColumnsIsNullable.get(i % 3), "NO") ? 1 : 0,
-            null, null, null, null, null,
-            (i % 3) + 1,
-            expectedGetColumnsIsNullable.get(i % 3),
-            null, null, null, null,
-            "", ""})
-        .map(Arrays::asList)
-        .collect(toList());
+    EXPECTED_GET_COLUMNS_RESULTS =
+        range(0, ROW_COUNT * 3)
+            .mapToObj(
+                i ->
+                    new Object[] {
+                      format("catalog_name #%d", i / 3),
+                      format("db_schema_name #%d", i / 3),
+                      format("table_name%d", i / 3),
+                      format("column_%d", (i % 3) + 1),
+                      expectedGetColumnsDataTypes.get(i % 3),
+                      expectedGetColumnsTypeName.get(i % 3),
+                      expectedGetColumnsColumnSize.get(i % 3),
+                      null,
+                      expectedGetColumnsDecimalDigits.get(i % 3),
+                      expectedGetColumnsRadix.get(i % 3),
+                      !Objects.equals(expectedGetColumnsIsNullable.get(i % 3), "NO") ? 1 : 0,
+                      null,
+                      null,
+                      null,
+                      null,
+                      null,
+                      (i % 3) + 1,
+                      expectedGetColumnsIsNullable.get(i % 3),
+                      null,
+                      null,
+                      null,
+                      null,
+                      "",
+                      ""
+                    })
+            .map(Arrays::asList)
+            .collect(toList());
   }
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
   public final ResultSetTestUtils resultSetTestUtils = new ResultSetTestUtils(collector);
 
   @BeforeClass
@@ -313,140 +346,149 @@ public class ArrowDatabaseMetadataTest {
     connection = FLIGHT_SERVER_TEST_RULE.getConnection(false);
 
     final Message commandGetCatalogs = CommandGetCatalogs.getDefaultInstance();
-    final Consumer<ServerStreamListener> commandGetCatalogsResultProducer = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_CATALOGS_SCHEMA,
-               allocator)) {
-        final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
-        range(0, ROW_COUNT).forEach(
-            i -> catalogName.setSafe(i, new Text(format("catalog #%d", i))));
-        root.setRowCount(ROW_COUNT);
-        listener.start(root);
-        listener.putNext();
-      } catch (final Throwable throwable) {
-        listener.error(throwable);
-      } finally {
-        listener.completed();
-      }
-    };
+    final Consumer<ServerStreamListener> commandGetCatalogsResultProducer =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator();
+              final VectorSchemaRoot root =
+                  VectorSchemaRoot.create(Schemas.GET_CATALOGS_SCHEMA, allocator)) {
+            final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
+            range(0, ROW_COUNT)
+                .forEach(i -> catalogName.setSafe(i, new Text(format("catalog #%d", i))));
+            root.setRowCount(ROW_COUNT);
+            listener.start(root);
+            listener.putNext();
+          } catch (final Throwable throwable) {
+            listener.error(throwable);
+          } finally {
+            listener.completed();
+          }
+        };
     FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetCatalogs, commandGetCatalogsResultProducer);
 
     final Message commandGetTableTypes = CommandGetTableTypes.getDefaultInstance();
-    final Consumer<ServerStreamListener> commandGetTableTypesResultProducer = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_TABLE_TYPES_SCHEMA,
-               allocator)) {
-        final VarCharVector tableType = (VarCharVector) root.getVector("table_type");
-        range(0, ROW_COUNT).forEach(
-            i -> tableType.setSafe(i, new Text(format("table_type #%d", i))));
-        root.setRowCount(ROW_COUNT);
-        listener.start(root);
-        listener.putNext();
-      } catch (final Throwable throwable) {
-        listener.error(throwable);
-      } finally {
-        listener.completed();
-      }
-    };
+    final Consumer<ServerStreamListener> commandGetTableTypesResultProducer =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator();
+              final VectorSchemaRoot root =
+                  VectorSchemaRoot.create(Schemas.GET_TABLE_TYPES_SCHEMA, allocator)) {
+            final VarCharVector tableType = (VarCharVector) root.getVector("table_type");
+            range(0, ROW_COUNT)
+                .forEach(i -> tableType.setSafe(i, new Text(format("table_type #%d", i))));
+            root.setRowCount(ROW_COUNT);
+            listener.start(root);
+            listener.putNext();
+          } catch (final Throwable throwable) {
+            listener.error(throwable);
+          } finally {
+            listener.completed();
+          }
+        };
     FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetTableTypes, commandGetTableTypesResultProducer);
 
     final Message commandGetTables = CommandGetTables.getDefaultInstance();
-    final Consumer<ServerStreamListener> commandGetTablesResultProducer = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(
-               Schemas.GET_TABLES_SCHEMA_NO_SCHEMA, allocator)) {
-        final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
-        final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
-        final VarCharVector tableName = (VarCharVector) root.getVector("table_name");
-        final VarCharVector tableType = (VarCharVector) root.getVector("table_type");
-        range(0, ROW_COUNT)
-            .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
-            .peek(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))))
-            .peek(i -> tableName.setSafe(i, new Text(format("table_name #%d", i))))
-            .forEach(i -> tableType.setSafe(i, new Text(format("table_type #%d", i))));
-        root.setRowCount(ROW_COUNT);
-        listener.start(root);
-        listener.putNext();
-      } catch (final Throwable throwable) {
-        listener.error(throwable);
-      } finally {
-        listener.completed();
-      }
-    };
+    final Consumer<ServerStreamListener> commandGetTablesResultProducer =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator();
+              final VectorSchemaRoot root =
+                  VectorSchemaRoot.create(Schemas.GET_TABLES_SCHEMA_NO_SCHEMA, allocator)) {
+            final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
+            final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
+            final VarCharVector tableName = (VarCharVector) root.getVector("table_name");
+            final VarCharVector tableType = (VarCharVector) root.getVector("table_type");
+            range(0, ROW_COUNT)
+                .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
+                .peek(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))))
+                .peek(i -> tableName.setSafe(i, new Text(format("table_name #%d", i))))
+                .forEach(i -> tableType.setSafe(i, new Text(format("table_type #%d", i))));
+            root.setRowCount(ROW_COUNT);
+            listener.start(root);
+            listener.putNext();
+          } catch (final Throwable throwable) {
+            listener.error(throwable);
+          } finally {
+            listener.completed();
+          }
+        };
     FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetTables, commandGetTablesResultProducer);
 
-    final Message commandGetTablesWithSchema = CommandGetTables.newBuilder()
-        .setIncludeSchema(true)
-        .build();
-    final Consumer<ServerStreamListener> commandGetTablesWithSchemaResultProducer = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_TABLES_SCHEMA,
-               allocator)) {
-        final byte[] filledTableSchemaBytes =
-            copyFrom(
-                serializeSchema(new Schema(Arrays.asList(
-                    Field.nullable("column_1", ArrowType.Decimal.createDecimal(5, 2, 128)),
-                    Field.nullable("column_2", new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC")),
-                    Field.notNullable("column_3", Types.MinorType.INT.getType())))))
-                .toByteArray();
-        final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
-        final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
-        final VarCharVector tableName = (VarCharVector) root.getVector("table_name");
-        final VarCharVector tableType = (VarCharVector) root.getVector("table_type");
-        final VarBinaryVector tableSchema = (VarBinaryVector) root.getVector("table_schema");
-        range(0, ROW_COUNT)
-            .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
-            .peek(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))))
-            .peek(i -> tableName.setSafe(i, new Text(format("table_name%d", i))))
-            .peek(i -> tableType.setSafe(i, new Text(format("table_type #%d", i))))
-            .forEach(i -> tableSchema.setSafe(i, filledTableSchemaBytes));
-        root.setRowCount(ROW_COUNT);
-        listener.start(root);
-        listener.putNext();
-      } catch (final Throwable throwable) {
-        listener.error(throwable);
-      } finally {
-        listener.completed();
-      }
-    };
-    FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetTablesWithSchema,
-        commandGetTablesWithSchemaResultProducer);
+    final Message commandGetTablesWithSchema =
+        CommandGetTables.newBuilder().setIncludeSchema(true).build();
+    final Consumer<ServerStreamListener> commandGetTablesWithSchemaResultProducer =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator();
+              final VectorSchemaRoot root =
+                  VectorSchemaRoot.create(Schemas.GET_TABLES_SCHEMA, allocator)) {
+            final byte[] filledTableSchemaBytes =
+                copyFrom(
+                        serializeSchema(
+                            new Schema(
+                                Arrays.asList(
+                                    Field.nullable(
+                                        "column_1", ArrowType.Decimal.createDecimal(5, 2, 128)),
+                                    Field.nullable(
+                                        "column_2",
+                                        new ArrowType.Timestamp(TimeUnit.NANOSECOND, "UTC")),
+                                    Field.notNullable("column_3", Types.MinorType.INT.getType())))))
+                    .toByteArray();
+            final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
+            final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
+            final VarCharVector tableName = (VarCharVector) root.getVector("table_name");
+            final VarCharVector tableType = (VarCharVector) root.getVector("table_type");
+            final VarBinaryVector tableSchema = (VarBinaryVector) root.getVector("table_schema");
+            range(0, ROW_COUNT)
+                .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
+                .peek(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))))
+                .peek(i -> tableName.setSafe(i, new Text(format("table_name%d", i))))
+                .peek(i -> tableType.setSafe(i, new Text(format("table_type #%d", i))))
+                .forEach(i -> tableSchema.setSafe(i, filledTableSchemaBytes));
+            root.setRowCount(ROW_COUNT);
+            listener.start(root);
+            listener.putNext();
+          } catch (final Throwable throwable) {
+            listener.error(throwable);
+          } finally {
+            listener.completed();
+          }
+        };
+    FLIGHT_SQL_PRODUCER.addCatalogQuery(
+        commandGetTablesWithSchema, commandGetTablesWithSchemaResultProducer);
 
     final Message commandGetDbSchemas = CommandGetDbSchemas.getDefaultInstance();
-    final Consumer<ServerStreamListener> commandGetSchemasResultProducer = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_SCHEMAS_SCHEMA,
-               allocator)) {
-        final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
-        final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
-        range(0, ROW_COUNT)
-            .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
-            .forEach(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))));
-        root.setRowCount(ROW_COUNT);
-        listener.start(root);
-        listener.putNext();
-      } catch (final Throwable throwable) {
-        listener.error(throwable);
-      } finally {
-        listener.completed();
-      }
-    };
+    final Consumer<ServerStreamListener> commandGetSchemasResultProducer =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator();
+              final VectorSchemaRoot root =
+                  VectorSchemaRoot.create(Schemas.GET_SCHEMAS_SCHEMA, allocator)) {
+            final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
+            final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
+            range(0, ROW_COUNT)
+                .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
+                .forEach(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))));
+            root.setRowCount(ROW_COUNT);
+            listener.start(root);
+            listener.putNext();
+          } catch (final Throwable throwable) {
+            listener.error(throwable);
+          } finally {
+            listener.completed();
+          }
+        };
     FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetDbSchemas, commandGetSchemasResultProducer);
 
     final Message commandGetExportedKeys =
         CommandGetExportedKeys.newBuilder().setTable(TARGET_TABLE).build();
     final Message commandGetImportedKeys =
         CommandGetImportedKeys.newBuilder().setTable(TARGET_TABLE).build();
-    final Message commandGetCrossReference = CommandGetCrossReference.newBuilder()
-        .setPkTable(TARGET_TABLE)
-        .setFkTable(TARGET_FOREIGN_TABLE)
-        .build();
+    final Message commandGetCrossReference =
+        CommandGetCrossReference.newBuilder()
+            .setPkTable(TARGET_TABLE)
+            .setFkTable(TARGET_FOREIGN_TABLE)
+            .build();
     final Consumer<ServerStreamListener> commandGetExportedAndImportedKeysResultProducer =
         listener -> {
           try (final BufferAllocator allocator = new RootAllocator();
-               final VectorSchemaRoot root = VectorSchemaRoot.create(
-                   Schemas.GET_IMPORTED_KEYS_SCHEMA,
-                   allocator)) {
+              final VectorSchemaRoot root =
+                  VectorSchemaRoot.create(Schemas.GET_IMPORTED_KEYS_SCHEMA, allocator)) {
             final VarCharVector pkCatalogName = (VarCharVector) root.getVector("pk_catalog_name");
             final VarCharVector pkSchemaName = (VarCharVector) root.getVector("pk_db_schema_name");
             final VarCharVector pkTableName = (VarCharVector) root.getVector("pk_table_name");
@@ -483,44 +525,46 @@ public class ArrowDatabaseMetadataTest {
             listener.completed();
           }
         };
-    FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetExportedKeys,
-        commandGetExportedAndImportedKeysResultProducer);
-    FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetImportedKeys,
-        commandGetExportedAndImportedKeysResultProducer);
-    FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetCrossReference,
-        commandGetExportedAndImportedKeysResultProducer);
+    FLIGHT_SQL_PRODUCER.addCatalogQuery(
+        commandGetExportedKeys, commandGetExportedAndImportedKeysResultProducer);
+    FLIGHT_SQL_PRODUCER.addCatalogQuery(
+        commandGetImportedKeys, commandGetExportedAndImportedKeysResultProducer);
+    FLIGHT_SQL_PRODUCER.addCatalogQuery(
+        commandGetCrossReference, commandGetExportedAndImportedKeysResultProducer);
 
     final Message commandGetPrimaryKeys =
         CommandGetPrimaryKeys.newBuilder().setTable(TARGET_TABLE).build();
-    final Consumer<ServerStreamListener> commandGetPrimaryKeysResultProducer = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator();
-           final VectorSchemaRoot root = VectorSchemaRoot.create(Schemas.GET_PRIMARY_KEYS_SCHEMA,
-               allocator)) {
-        final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
-        final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
-        final VarCharVector tableName = (VarCharVector) root.getVector("table_name");
-        final VarCharVector columnName = (VarCharVector) root.getVector("column_name");
-        final IntVector keySequence = (IntVector) root.getVector("key_sequence");
-        final VarCharVector keyName = (VarCharVector) root.getVector("key_name");
-        range(0, ROW_COUNT)
-            .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
-            .peek(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))))
-            .peek(i -> tableName.setSafe(i, new Text(format("table_name #%d", i))))
-            .peek(i -> columnName.setSafe(i, new Text(format("column_name #%d", i))))
-            .peek(i -> keySequence.setSafe(i, i))
-            .forEach(i -> keyName.setSafe(i, new Text(format("key_name #%d", i))));
-        root.setRowCount(ROW_COUNT);
-        listener.start(root);
-        listener.putNext();
-      } catch (final Throwable throwable) {
-        listener.error(throwable);
-      } finally {
-        listener.completed();
-      }
-    };
+    final Consumer<ServerStreamListener> commandGetPrimaryKeysResultProducer =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator();
+              final VectorSchemaRoot root =
+                  VectorSchemaRoot.create(Schemas.GET_PRIMARY_KEYS_SCHEMA, allocator)) {
+            final VarCharVector catalogName = (VarCharVector) root.getVector("catalog_name");
+            final VarCharVector schemaName = (VarCharVector) root.getVector("db_schema_name");
+            final VarCharVector tableName = (VarCharVector) root.getVector("table_name");
+            final VarCharVector columnName = (VarCharVector) root.getVector("column_name");
+            final IntVector keySequence = (IntVector) root.getVector("key_sequence");
+            final VarCharVector keyName = (VarCharVector) root.getVector("key_name");
+            range(0, ROW_COUNT)
+                .peek(i -> catalogName.setSafe(i, new Text(format("catalog_name #%d", i))))
+                .peek(i -> schemaName.setSafe(i, new Text(format("db_schema_name #%d", i))))
+                .peek(i -> tableName.setSafe(i, new Text(format("table_name #%d", i))))
+                .peek(i -> columnName.setSafe(i, new Text(format("column_name #%d", i))))
+                .peek(i -> keySequence.setSafe(i, i))
+                .forEach(i -> keyName.setSafe(i, new Text(format("key_name #%d", i))));
+            root.setRowCount(ROW_COUNT);
+            listener.start(root);
+            listener.putNext();
+          } catch (final Throwable throwable) {
+            listener.error(throwable);
+          } finally {
+            listener.completed();
+          }
+        };
     FLIGHT_SQL_PRODUCER.addCatalogQuery(commandGetPrimaryKeys, commandGetPrimaryKeysResultProducer);
 
-    FLIGHT_SQL_PRODUCER.getSqlInfoBuilder()
+    FLIGHT_SQL_PRODUCER
+        .getSqlInfoBuilder()
         .withSqlOuterJoinSupportLevel(FlightSql.SqlOuterJoinsSupportLevel.SQL_FULL_OUTER_JOINS)
         .withFlightSqlServerName(EXPECTED_DATABASE_PRODUCT_NAME)
         .withFlightSqlServerVersion(EXPECTED_DATABASE_PRODUCT_VERSION)
@@ -535,8 +579,10 @@ public class ArrowDatabaseMetadataTest {
         .withSqlExtraNameCharacters(EXPECTED_EXTRA_NAME_CHARACTERS)
         .withSqlSupportsColumnAliasing(EXPECTED_SUPPORTS_COLUMN_ALIASING)
         .withSqlNullPlusNullIsNull(EXPECTED_NULL_PLUS_NULL_IS_NULL)
-        .withSqlSupportsConvert(ImmutableMap.of(SQL_CONVERT_BIT_VALUE,
-            Arrays.asList(SQL_CONVERT_INTEGER_VALUE, SQL_CONVERT_BIGINT_VALUE)))
+        .withSqlSupportsConvert(
+            ImmutableMap.of(
+                SQL_CONVERT_BIT_VALUE,
+                Arrays.asList(SQL_CONVERT_INTEGER_VALUE, SQL_CONVERT_BIGINT_VALUE)))
         .withSqlSupportsTableCorrelationNames(EXPECTED_SUPPORTS_TABLE_CORRELATION_NAMES)
         .withSqlSupportsDifferentTableCorrelationNames(
             EXPECTED_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES)
@@ -545,9 +591,11 @@ public class ArrowDatabaseMetadataTest {
         .withSqlSupportedGroupBy(FlightSql.SqlSupportedGroupBy.SQL_GROUP_BY_UNRELATED)
         .withSqlSupportsLikeEscapeClause(EXPECTED_SUPPORTS_LIKE_ESCAPE_CLAUSE)
         .withSqlSupportsNonNullableColumns(EXPECTED_NON_NULLABLE_COLUMNS)
-        .withSqlSupportedGrammar(FlightSql.SupportedSqlGrammar.SQL_CORE_GRAMMAR,
+        .withSqlSupportedGrammar(
+            FlightSql.SupportedSqlGrammar.SQL_CORE_GRAMMAR,
             FlightSql.SupportedSqlGrammar.SQL_MINIMUM_GRAMMAR)
-        .withSqlAnsi92SupportedLevel(FlightSql.SupportedAnsi92SqlGrammarLevel.ANSI92_ENTRY_SQL,
+        .withSqlAnsi92SupportedLevel(
+            FlightSql.SupportedAnsi92SqlGrammarLevel.ANSI92_ENTRY_SQL,
             FlightSql.SupportedAnsi92SqlGrammarLevel.ANSI92_INTERMEDIATE_SQL)
         .withSqlSupportsIntegrityEnhancementFacility(
             EXPECTED_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY)
@@ -612,7 +660,6 @@ public class ArrowDatabaseMetadataTest {
     AutoCloseables.close(connection, FLIGHT_SQL_PRODUCER, FLIGHT_SQL_PRODUCER_EMPTY_SQLINFO);
   }
 
-
   @Test
   public void testGetCatalogsCanBeAccessedByIndices() throws SQLException {
     try (final ResultSet resultSet = connection.getMetaData().getCatalogs()) {
@@ -623,8 +670,8 @@ public class ArrowDatabaseMetadataTest {
   @Test
   public void testGetCatalogsCanBeAccessedByNames() throws SQLException {
     try (final ResultSet resultSet = connection.getMetaData().getCatalogs()) {
-      resultSetTestUtils.testData(resultSet, singletonList("TABLE_CAT"),
-          EXPECTED_GET_CATALOGS_RESULTS);
+      resultSetTestUtils.testData(
+          resultSet, singletonList("TABLE_CAT"), EXPECTED_GET_CATALOGS_RESULTS);
     }
   }
 
@@ -638,8 +685,8 @@ public class ArrowDatabaseMetadataTest {
   @Test
   public void testTableTypesCanBeAccessedByNames() throws SQLException {
     try (final ResultSet resultSet = connection.getMetaData().getTableTypes()) {
-      resultSetTestUtils.testData(resultSet, singletonList("TABLE_TYPE"),
-          EXPECTED_GET_TABLE_TYPES_RESULTS);
+      resultSetTestUtils.testData(
+          resultSet, singletonList("TABLE_TYPE"), EXPECTED_GET_TABLE_TYPES_RESULTS);
     }
   }
 
@@ -666,8 +713,7 @@ public class ArrowDatabaseMetadataTest {
               "TYPE_NAME",
               "SELF_REFERENCING_COL_NAME",
               "REF_GENERATION"),
-          EXPECTED_GET_TABLES_RESULTS
-      );
+          EXPECTED_GET_TABLES_RESULTS);
     }
   }
 
@@ -681,59 +727,67 @@ public class ArrowDatabaseMetadataTest {
   @Test
   public void testGetSchemasCanBeAccessedByNames() throws SQLException {
     try (final ResultSet resultSet = connection.getMetaData().getSchemas()) {
-      resultSetTestUtils.testData(resultSet, ImmutableList.of("TABLE_SCHEM", "TABLE_CATALOG"),
+      resultSetTestUtils.testData(
+          resultSet,
+          ImmutableList.of("TABLE_SCHEM", "TABLE_CATALOG"),
           EXPECTED_GET_SCHEMAS_RESULTS);
     }
   }
 
   @Test
   public void testGetExportedKeysCanBeAccessedByIndices() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData()
-        .getExportedKeys(null, null, TARGET_TABLE)) {
+    try (final ResultSet resultSet =
+        connection.getMetaData().getExportedKeys(null, null, TARGET_TABLE)) {
       resultSetTestUtils.testData(resultSet, EXPECTED_GET_EXPORTED_AND_IMPORTED_KEYS_RESULTS);
     }
   }
 
   @Test
   public void testGetExportedKeysCanBeAccessedByNames() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData()
-        .getExportedKeys(null, null, TARGET_TABLE)) {
+    try (final ResultSet resultSet =
+        connection.getMetaData().getExportedKeys(null, null, TARGET_TABLE)) {
       resultSetTestUtils.testData(
-          resultSet, FIELDS_GET_IMPORTED_EXPORTED_KEYS,
+          resultSet,
+          FIELDS_GET_IMPORTED_EXPORTED_KEYS,
           EXPECTED_GET_EXPORTED_AND_IMPORTED_KEYS_RESULTS);
     }
   }
 
   @Test
   public void testGetImportedKeysCanBeAccessedByIndices() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData()
-        .getImportedKeys(null, null, TARGET_TABLE)) {
+    try (final ResultSet resultSet =
+        connection.getMetaData().getImportedKeys(null, null, TARGET_TABLE)) {
       resultSetTestUtils.testData(resultSet, EXPECTED_GET_EXPORTED_AND_IMPORTED_KEYS_RESULTS);
     }
   }
 
   @Test
   public void testGetImportedKeysCanBeAccessedByNames() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData()
-        .getImportedKeys(null, null, TARGET_TABLE)) {
+    try (final ResultSet resultSet =
+        connection.getMetaData().getImportedKeys(null, null, TARGET_TABLE)) {
       resultSetTestUtils.testData(
-          resultSet, FIELDS_GET_IMPORTED_EXPORTED_KEYS,
+          resultSet,
+          FIELDS_GET_IMPORTED_EXPORTED_KEYS,
           EXPECTED_GET_EXPORTED_AND_IMPORTED_KEYS_RESULTS);
     }
   }
 
   @Test
   public void testGetCrossReferenceCanBeAccessedByIndices() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData().getCrossReference(null, null,
-        TARGET_TABLE, null, null, TARGET_FOREIGN_TABLE)) {
+    try (final ResultSet resultSet =
+        connection
+            .getMetaData()
+            .getCrossReference(null, null, TARGET_TABLE, null, null, TARGET_FOREIGN_TABLE)) {
       resultSetTestUtils.testData(resultSet, EXPECTED_CROSS_REFERENCE_RESULTS);
     }
   }
 
   @Test
   public void testGetGetCrossReferenceCanBeAccessedByNames() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData().getCrossReference(null, null,
-        TARGET_TABLE, null, null, TARGET_FOREIGN_TABLE)) {
+    try (final ResultSet resultSet =
+        connection
+            .getMetaData()
+            .getCrossReference(null, null, TARGET_TABLE, null, null, TARGET_FOREIGN_TABLE)) {
       resultSetTestUtils.testData(
           resultSet, FIELDS_GET_CROSS_REFERENCE, EXPECTED_CROSS_REFERENCE_RESULTS);
     }
@@ -741,27 +795,21 @@ public class ArrowDatabaseMetadataTest {
 
   @Test
   public void testPrimaryKeysCanBeAccessedByIndices() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData()
-        .getPrimaryKeys(null, null, TARGET_TABLE)) {
+    try (final ResultSet resultSet =
+        connection.getMetaData().getPrimaryKeys(null, null, TARGET_TABLE)) {
       resultSetTestUtils.testData(resultSet, EXPECTED_PRIMARY_KEYS_RESULTS);
     }
   }
 
   @Test
   public void testPrimaryKeysCanBeAccessedByNames() throws SQLException {
-    try (final ResultSet resultSet = connection.getMetaData()
-        .getPrimaryKeys(null, null, TARGET_TABLE)) {
+    try (final ResultSet resultSet =
+        connection.getMetaData().getPrimaryKeys(null, null, TARGET_TABLE)) {
       resultSetTestUtils.testData(
           resultSet,
           ImmutableList.of(
-              "TABLE_CAT",
-              "TABLE_SCHEM",
-              "TABLE_NAME",
-              "COLUMN_NAME",
-              "KEY_SEQ",
-              "PK_NAME"),
-          EXPECTED_PRIMARY_KEYS_RESULTS
-      );
+              "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "KEY_SEQ", "PK_NAME"),
+          EXPECTED_PRIMARY_KEYS_RESULTS);
     }
   }
 
@@ -774,14 +822,13 @@ public class ArrowDatabaseMetadataTest {
 
   @Test
   public void testGetColumnsCanByIndicesFilteringColumnNames() throws SQLException {
-    try (
-        final ResultSet resultSet = connection.getMetaData()
-            .getColumns(null, null, null, "column_1")) {
-      resultSetTestUtils.testData(resultSet, EXPECTED_GET_COLUMNS_RESULTS
-          .stream()
-          .filter(insideList -> Objects.equals(insideList.get(3), "column_1"))
-          .collect(toList())
-      );
+    try (final ResultSet resultSet =
+        connection.getMetaData().getColumns(null, null, null, "column_1")) {
+      resultSetTestUtils.testData(
+          resultSet,
+          EXPECTED_GET_COLUMNS_RESULTS.stream()
+              .filter(insideList -> Objects.equals(insideList.get(3), "column_1"))
+              .collect(toList()));
     }
   }
 
@@ -789,8 +836,8 @@ public class ArrowDatabaseMetadataTest {
   public void testGetSqlInfo() throws SQLException {
     final DatabaseMetaData metaData = connection.getMetaData();
     collector.checkThat(metaData.getDatabaseProductName(), is(EXPECTED_DATABASE_PRODUCT_NAME));
-    collector.checkThat(metaData.getDatabaseProductVersion(),
-        is(EXPECTED_DATABASE_PRODUCT_VERSION));
+    collector.checkThat(
+        metaData.getDatabaseProductVersion(), is(EXPECTED_DATABASE_PRODUCT_VERSION));
     collector.checkThat(metaData.getIdentifierQuoteString(), is(EXPECTED_IDENTIFIER_QUOTE_STRING));
     collector.checkThat(metaData.isReadOnly(), is(EXPECTED_IS_READ_ONLY));
     collector.checkThat(metaData.getSQLKeywords(), is(EXPECTED_SQL_KEYWORDS));
@@ -803,29 +850,29 @@ public class ArrowDatabaseMetadataTest {
     collector.checkThat(metaData.supportsConvert(), is(EXPECTED_SQL_SUPPORTS_CONVERT));
     collector.checkThat(metaData.supportsConvert(BIT, INTEGER), is(EXPECTED_SQL_SUPPORTS_CONVERT));
     collector.checkThat(metaData.supportsConvert(BIT, BIGINT), is(EXPECTED_SQL_SUPPORTS_CONVERT));
-    collector.checkThat(metaData.supportsConvert(BIGINT, INTEGER),
-        is(EXPECTED_INVALID_SQL_SUPPORTS_CONVERT));
-    collector.checkThat(metaData.supportsConvert(JAVA_OBJECT, INTEGER),
-        is(EXPECTED_INVALID_SQL_SUPPORTS_CONVERT));
-    collector.checkThat(metaData.supportsTableCorrelationNames(),
-        is(EXPECTED_SUPPORTS_TABLE_CORRELATION_NAMES));
-    collector.checkThat(metaData.supportsExpressionsInOrderBy(),
-        is(EXPECTED_EXPRESSIONS_IN_ORDER_BY));
-    collector.checkThat(metaData.supportsOrderByUnrelated(),
-        is(EXPECTED_SUPPORTS_ORDER_BY_UNRELATED));
+    collector.checkThat(
+        metaData.supportsConvert(BIGINT, INTEGER), is(EXPECTED_INVALID_SQL_SUPPORTS_CONVERT));
+    collector.checkThat(
+        metaData.supportsConvert(JAVA_OBJECT, INTEGER), is(EXPECTED_INVALID_SQL_SUPPORTS_CONVERT));
+    collector.checkThat(
+        metaData.supportsTableCorrelationNames(), is(EXPECTED_SUPPORTS_TABLE_CORRELATION_NAMES));
+    collector.checkThat(
+        metaData.supportsExpressionsInOrderBy(), is(EXPECTED_EXPRESSIONS_IN_ORDER_BY));
+    collector.checkThat(
+        metaData.supportsOrderByUnrelated(), is(EXPECTED_SUPPORTS_ORDER_BY_UNRELATED));
     collector.checkThat(metaData.supportsGroupBy(), is(EXPECTED_SUPPORTS_GROUP_BY));
-    collector.checkThat(metaData.supportsGroupByUnrelated(),
-        is(EXPECTED_SUPPORTS_GROUP_BY_UNRELATED));
-    collector.checkThat(metaData.supportsLikeEscapeClause(),
-        is(EXPECTED_SUPPORTS_LIKE_ESCAPE_CLAUSE));
+    collector.checkThat(
+        metaData.supportsGroupByUnrelated(), is(EXPECTED_SUPPORTS_GROUP_BY_UNRELATED));
+    collector.checkThat(
+        metaData.supportsLikeEscapeClause(), is(EXPECTED_SUPPORTS_LIKE_ESCAPE_CLAUSE));
     collector.checkThat(metaData.supportsNonNullableColumns(), is(EXPECTED_NON_NULLABLE_COLUMNS));
     collector.checkThat(metaData.supportsMinimumSQLGrammar(), is(EXPECTED_MINIMUM_SQL_GRAMMAR));
     collector.checkThat(metaData.supportsCoreSQLGrammar(), is(EXPECTED_CORE_SQL_GRAMMAR));
     collector.checkThat(metaData.supportsExtendedSQLGrammar(), is(EXPECTED_EXTEND_SQL_GRAMMAR));
-    collector.checkThat(metaData.supportsANSI92EntryLevelSQL(),
-        is(EXPECTED_ANSI92_ENTRY_LEVEL_SQL));
-    collector.checkThat(metaData.supportsANSI92IntermediateSQL(),
-        is(EXPECTED_ANSI92_INTERMEDIATE_SQL));
+    collector.checkThat(
+        metaData.supportsANSI92EntryLevelSQL(), is(EXPECTED_ANSI92_ENTRY_LEVEL_SQL));
+    collector.checkThat(
+        metaData.supportsANSI92IntermediateSQL(), is(EXPECTED_ANSI92_INTERMEDIATE_SQL));
     collector.checkThat(metaData.supportsANSI92FullSQL(), is(EXPECTED_ANSI92_FULL_SQL));
     collector.checkThat(metaData.supportsOuterJoins(), is(EXPECTED_SUPPORTS_OUTER_JOINS));
     collector.checkThat(metaData.supportsFullOuterJoins(), is(EXPECTED_SUPPORTS_FULL_OUTER_JOINS));
@@ -834,32 +881,33 @@ public class ArrowDatabaseMetadataTest {
     collector.checkThat(metaData.getProcedureTerm(), is(EXPECTED_PROCEDURE_TERM));
     collector.checkThat(metaData.getCatalogTerm(), is(EXPECTED_CATALOG_TERM));
     collector.checkThat(metaData.isCatalogAtStart(), is(EXPECTED_CATALOG_AT_START));
-    collector.checkThat(metaData.supportsSchemasInProcedureCalls(),
-        is(EXPECTED_SCHEMAS_IN_PROCEDURE_CALLS));
-    collector.checkThat(metaData.supportsSchemasInIndexDefinitions(),
-        is(EXPECTED_SCHEMAS_IN_INDEX_DEFINITIONS));
-    collector.checkThat(metaData.supportsCatalogsInIndexDefinitions(),
-        is(EXPECTED_CATALOGS_IN_INDEX_DEFINITIONS));
+    collector.checkThat(
+        metaData.supportsSchemasInProcedureCalls(), is(EXPECTED_SCHEMAS_IN_PROCEDURE_CALLS));
+    collector.checkThat(
+        metaData.supportsSchemasInIndexDefinitions(), is(EXPECTED_SCHEMAS_IN_INDEX_DEFINITIONS));
+    collector.checkThat(
+        metaData.supportsCatalogsInIndexDefinitions(), is(EXPECTED_CATALOGS_IN_INDEX_DEFINITIONS));
     collector.checkThat(metaData.supportsPositionedDelete(), is(EXPECTED_POSITIONED_DELETE));
     collector.checkThat(metaData.supportsPositionedUpdate(), is(EXPECTED_POSITIONED_UPDATE));
-    collector.checkThat(metaData.supportsResultSetType(ResultSet.TYPE_FORWARD_ONLY),
+    collector.checkThat(
+        metaData.supportsResultSetType(ResultSet.TYPE_FORWARD_ONLY),
         is(EXPECTED_TYPE_FORWARD_ONLY));
-    collector.checkThat(metaData.supportsSelectForUpdate(),
-        is(EXPECTED_SELECT_FOR_UPDATE_SUPPORTED));
-    collector.checkThat(metaData.supportsStoredProcedures(),
-        is(EXPECTED_STORED_PROCEDURES_SUPPORTED));
-    collector.checkThat(metaData.supportsSubqueriesInComparisons(),
-        is(EXPECTED_SUBQUERIES_IN_COMPARISON));
+    collector.checkThat(
+        metaData.supportsSelectForUpdate(), is(EXPECTED_SELECT_FOR_UPDATE_SUPPORTED));
+    collector.checkThat(
+        metaData.supportsStoredProcedures(), is(EXPECTED_STORED_PROCEDURES_SUPPORTED));
+    collector.checkThat(
+        metaData.supportsSubqueriesInComparisons(), is(EXPECTED_SUBQUERIES_IN_COMPARISON));
     collector.checkThat(metaData.supportsSubqueriesInExists(), is(EXPECTED_SUBQUERIES_IN_EXISTS));
     collector.checkThat(metaData.supportsSubqueriesInIns(), is(EXPECTED_SUBQUERIES_IN_INS));
-    collector.checkThat(metaData.supportsSubqueriesInQuantifieds(),
-        is(EXPECTED_SUBQUERIES_IN_QUANTIFIEDS));
-    collector.checkThat(metaData.supportsCorrelatedSubqueries(),
-        is(EXPECTED_CORRELATED_SUBQUERIES_SUPPORTED));
+    collector.checkThat(
+        metaData.supportsSubqueriesInQuantifieds(), is(EXPECTED_SUBQUERIES_IN_QUANTIFIEDS));
+    collector.checkThat(
+        metaData.supportsCorrelatedSubqueries(), is(EXPECTED_CORRELATED_SUBQUERIES_SUPPORTED));
     collector.checkThat(metaData.supportsUnion(), is(EXPECTED_SUPPORTS_UNION));
     collector.checkThat(metaData.supportsUnionAll(), is(EXPECTED_SUPPORTS_UNION_ALL));
-    collector.checkThat(metaData.getMaxBinaryLiteralLength(),
-        is(EXPECTED_MAX_BINARY_LITERAL_LENGTH));
+    collector.checkThat(
+        metaData.getMaxBinaryLiteralLength(), is(EXPECTED_MAX_BINARY_LITERAL_LENGTH));
     collector.checkThat(metaData.getMaxCharLiteralLength(), is(EXPECTED_MAX_CHAR_LITERAL_LENGTH));
     collector.checkThat(metaData.getMaxColumnsInGroupBy(), is(EXPECTED_MAX_COLUMNS_IN_GROUP_BY));
     collector.checkThat(metaData.getMaxColumnsInIndex(), is(EXPECTED_MAX_COLUMNS_IN_INDEX));
@@ -869,35 +917,40 @@ public class ArrowDatabaseMetadataTest {
     collector.checkThat(metaData.getMaxCursorNameLength(), is(EXPECTED_MAX_CURSOR_NAME_LENGTH));
     collector.checkThat(metaData.getMaxIndexLength(), is(EXPECTED_MAX_INDEX_LENGTH));
     collector.checkThat(metaData.getMaxSchemaNameLength(), is(EXPECTED_SCHEMA_NAME_LENGTH));
-    collector.checkThat(metaData.getMaxProcedureNameLength(),
-        is(EXPECTED_MAX_PROCEDURE_NAME_LENGTH));
+    collector.checkThat(
+        metaData.getMaxProcedureNameLength(), is(EXPECTED_MAX_PROCEDURE_NAME_LENGTH));
     collector.checkThat(metaData.getMaxCatalogNameLength(), is(EXPECTED_MAX_CATALOG_NAME_LENGTH));
     collector.checkThat(metaData.getMaxRowSize(), is(EXPECTED_MAX_ROW_SIZE));
-    collector.checkThat(metaData.doesMaxRowSizeIncludeBlobs(),
-        is(EXPECTED_MAX_ROW_SIZE_INCLUDES_BLOBS));
+    collector.checkThat(
+        metaData.doesMaxRowSizeIncludeBlobs(), is(EXPECTED_MAX_ROW_SIZE_INCLUDES_BLOBS));
     collector.checkThat(metaData.getMaxStatementLength(), is(EXPECTED_MAX_STATEMENT_LENGTH));
     collector.checkThat(metaData.getMaxStatements(), is(EXPECTED_MAX_STATEMENTS));
     collector.checkThat(metaData.getMaxTableNameLength(), is(EXPECTED_MAX_TABLE_NAME_LENGTH));
     collector.checkThat(metaData.getMaxTablesInSelect(), is(EXPECTED_MAX_TABLES_IN_SELECT));
     collector.checkThat(metaData.getMaxUserNameLength(), is(EXPECTED_MAX_USERNAME_LENGTH));
-    collector.checkThat(metaData.getDefaultTransactionIsolation(),
-        is(EXPECTED_DEFAULT_TRANSACTION_ISOLATION));
+    collector.checkThat(
+        metaData.getDefaultTransactionIsolation(), is(EXPECTED_DEFAULT_TRANSACTION_ISOLATION));
     collector.checkThat(metaData.supportsTransactions(), is(EXPECTED_TRANSACTIONS_SUPPORTED));
     collector.checkThat(metaData.supportsBatchUpdates(), is(EXPECTED_BATCH_UPDATES_SUPPORTED));
     collector.checkThat(metaData.supportsSavepoints(), is(EXPECTED_SAVEPOINTS_SUPPORTED));
-    collector.checkThat(metaData.supportsNamedParameters(),
-        is(EXPECTED_NAMED_PARAMETERS_SUPPORTED));
+    collector.checkThat(
+        metaData.supportsNamedParameters(), is(EXPECTED_NAMED_PARAMETERS_SUPPORTED));
     collector.checkThat(metaData.locatorsUpdateCopy(), is(EXPECTED_LOCATORS_UPDATE_COPY));
 
-    collector.checkThat(metaData.supportsResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE),
+    collector.checkThat(
+        metaData.supportsResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE),
         is(EXPECTED_TYPE_SCROLL_INSENSITIVE));
-    collector.checkThat(metaData.supportsResultSetType(ResultSet.TYPE_SCROLL_SENSITIVE),
+    collector.checkThat(
+        metaData.supportsResultSetType(ResultSet.TYPE_SCROLL_SENSITIVE),
         is(EXPECTED_TYPE_SCROLL_SENSITIVE));
-    collector.checkThat(metaData.supportsSchemasInPrivilegeDefinitions(),
+    collector.checkThat(
+        metaData.supportsSchemasInPrivilegeDefinitions(),
         is(EXPECTED_SCHEMAS_IN_PRIVILEGE_DEFINITIONS));
-    collector.checkThat(metaData.supportsCatalogsInPrivilegeDefinitions(),
+    collector.checkThat(
+        metaData.supportsCatalogsInPrivilegeDefinitions(),
         is(EXPECTED_CATALOGS_IN_PRIVILEGE_DEFINITIONS));
-    collector.checkThat(metaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_NONE),
+    collector.checkThat(
+        metaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_NONE),
         is(EXPECTED_TRANSACTION_NONE));
     collector.checkThat(
         metaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_READ_COMMITTED),
@@ -911,27 +964,35 @@ public class ArrowDatabaseMetadataTest {
     collector.checkThat(
         metaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_SERIALIZABLE),
         is(EXPECTED_TRANSACTION_SERIALIZABLE));
-    collector.checkThat(metaData.dataDefinitionCausesTransactionCommit(),
+    collector.checkThat(
+        metaData.dataDefinitionCausesTransactionCommit(),
         is(EXPECTED_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT));
-    collector.checkThat(metaData.dataDefinitionIgnoredInTransactions(),
+    collector.checkThat(
+        metaData.dataDefinitionIgnoredInTransactions(),
         is(EXPECTED_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED));
-    collector.checkThat(metaData.supportsStoredFunctionsUsingCallSyntax(),
+    collector.checkThat(
+        metaData.supportsStoredFunctionsUsingCallSyntax(),
         is(EXPECTED_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED));
-    collector.checkThat(metaData.supportsIntegrityEnhancementFacility(),
+    collector.checkThat(
+        metaData.supportsIntegrityEnhancementFacility(),
         is(EXPECTED_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY));
-    collector.checkThat(metaData.supportsDifferentTableCorrelationNames(),
+    collector.checkThat(
+        metaData.supportsDifferentTableCorrelationNames(),
         is(EXPECTED_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES));
 
-    ThrowableAssertionUtils.simpleAssertThrowableClass(SQLException.class,
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        SQLException.class,
         () -> metaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_SERIALIZABLE + 1));
-    ThrowableAssertionUtils.simpleAssertThrowableClass(SQLException.class,
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        SQLException.class,
         () -> metaData.supportsResultSetType(ResultSet.HOLD_CURSORS_OVER_COMMIT));
   }
 
   @Test
   public void testGetColumnsCanBeAccessedByNames() throws SQLException {
     try (final ResultSet resultSet = connection.getMetaData().getColumns(null, null, null, null)) {
-      resultSetTestUtils.testData(resultSet,
+      resultSetTestUtils.testData(
+          resultSet,
           ImmutableList.of(
               "TABLE_CAT",
               "TABLE_SCHEM",
@@ -957,8 +1018,7 @@ public class ArrowDatabaseMetadataTest {
               "SOURCE_DATA_TYPE",
               "IS_AUTOINCREMENT",
               "IS_GENERATEDCOLUMN"),
-          EXPECTED_GET_COLUMNS_RESULTS
-      );
+          EXPECTED_GET_COLUMNS_RESULTS);
     }
   }
 
@@ -966,27 +1026,28 @@ public class ArrowDatabaseMetadataTest {
   public void testGetProcedures() throws SQLException {
     try (final ResultSet resultSet = connection.getMetaData().getProcedures(null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetProceduresSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "PROCEDURE_CAT");
-          put(2, "PROCEDURE_SCHEM");
-          put(3, "PROCEDURE_NAME");
-          put(4, "FUTURE_USE1");
-          put(5, "FUTURE_USE2");
-          put(6, "FUTURE_USE3");
-          put(7, "REMARKS");
-          put(8, "PROCEDURE_TYPE");
-          put(9, "SPECIFIC_NAME");
-        }
-      };
+      final Map<Integer, String> expectedGetProceduresSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "PROCEDURE_CAT");
+              put(2, "PROCEDURE_SCHEM");
+              put(3, "PROCEDURE_NAME");
+              put(4, "FUTURE_USE1");
+              put(5, "FUTURE_USE2");
+              put(6, "FUTURE_USE3");
+              put(7, "REMARKS");
+              put(8, "PROCEDURE_TYPE");
+              put(9, "SPECIFIC_NAME");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetProceduresSchema);
     }
   }
 
   @Test
   public void testGetProcedureColumns() throws SQLException {
-    try (ResultSet resultSet = connection.getMetaData()
-        .getProcedureColumns(null, null, null, null)) {
+    try (ResultSet resultSet =
+        connection.getMetaData().getProcedureColumns(null, null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
       final Map<Integer, String> expectedGetProcedureColumnsSchema =
           new HashMap<Integer, String>() {
@@ -1019,8 +1080,8 @@ public class ArrowDatabaseMetadataTest {
 
   @Test
   public void testGetColumnPrivileges() throws SQLException {
-    try (ResultSet resultSet = connection.getMetaData()
-        .getColumnPrivileges(null, null, null, null)) {
+    try (ResultSet resultSet =
+        connection.getMetaData().getColumnPrivileges(null, null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
       final Map<Integer, String> expectedGetColumnPrivilegesSchema =
           new HashMap<Integer, String>() {
@@ -1043,25 +1104,26 @@ public class ArrowDatabaseMetadataTest {
   public void testGetTablePrivileges() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getTablePrivileges(null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetTablePrivilegesSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TABLE_CAT");
-          put(2, "TABLE_SCHEM");
-          put(3, "TABLE_NAME");
-          put(4, "GRANTOR");
-          put(5, "GRANTEE");
-          put(6, "PRIVILEGE");
-          put(7, "IS_GRANTABLE");
-        }
-      };
+      final Map<Integer, String> expectedGetTablePrivilegesSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TABLE_CAT");
+              put(2, "TABLE_SCHEM");
+              put(3, "TABLE_NAME");
+              put(4, "GRANTOR");
+              put(5, "GRANTEE");
+              put(6, "PRIVILEGE");
+              put(7, "IS_GRANTABLE");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetTablePrivilegesSchema);
     }
   }
 
   @Test
   public void testGetBestRowIdentifier() throws SQLException {
-    try (ResultSet resultSet = connection.getMetaData()
-        .getBestRowIdentifier(null, null, null, 0, true)) {
+    try (ResultSet resultSet =
+        connection.getMetaData().getBestRowIdentifier(null, null, null, 0, true)) {
       // Maps ordinal index to column name according to JDBC documentation
       final Map<Integer, String> expectedGetBestRowIdentifierSchema =
           new HashMap<Integer, String>() {
@@ -1084,18 +1146,19 @@ public class ArrowDatabaseMetadataTest {
   public void testGetVersionColumns() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getVersionColumns(null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetVersionColumnsSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "SCOPE");
-          put(2, "COLUMN_NAME");
-          put(3, "DATA_TYPE");
-          put(4, "TYPE_NAME");
-          put(5, "COLUMN_SIZE");
-          put(6, "BUFFER_LENGTH");
-          put(7, "DECIMAL_DIGITS");
-          put(8, "PSEUDO_COLUMN");
-        }
-      };
+      final Map<Integer, String> expectedGetVersionColumnsSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "SCOPE");
+              put(2, "COLUMN_NAME");
+              put(3, "DATA_TYPE");
+              put(4, "TYPE_NAME");
+              put(5, "COLUMN_SIZE");
+              put(6, "BUFFER_LENGTH");
+              put(7, "DECIMAL_DIGITS");
+              put(8, "PSEUDO_COLUMN");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetVersionColumnsSchema);
     }
   }
@@ -1104,54 +1167,56 @@ public class ArrowDatabaseMetadataTest {
   public void testGetTypeInfo() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getTypeInfo()) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetTypeInfoSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TYPE_NAME");
-          put(2, "DATA_TYPE");
-          put(3, "PRECISION");
-          put(4, "LITERAL_PREFIX");
-          put(5, "LITERAL_SUFFIX");
-          put(6, "CREATE_PARAMS");
-          put(7, "NULLABLE");
-          put(8, "CASE_SENSITIVE");
-          put(9, "SEARCHABLE");
-          put(10, "UNSIGNED_ATTRIBUTE");
-          put(11, "FIXED_PREC_SCALE");
-          put(12, "AUTO_INCREMENT");
-          put(13, "LOCAL_TYPE_NAME");
-          put(14, "MINIMUM_SCALE");
-          put(15, "MAXIMUM_SCALE");
-          put(16, "SQL_DATA_TYPE");
-          put(17, "SQL_DATETIME_SUB");
-          put(18, "NUM_PREC_RADIX");
-        }
-      };
+      final Map<Integer, String> expectedGetTypeInfoSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TYPE_NAME");
+              put(2, "DATA_TYPE");
+              put(3, "PRECISION");
+              put(4, "LITERAL_PREFIX");
+              put(5, "LITERAL_SUFFIX");
+              put(6, "CREATE_PARAMS");
+              put(7, "NULLABLE");
+              put(8, "CASE_SENSITIVE");
+              put(9, "SEARCHABLE");
+              put(10, "UNSIGNED_ATTRIBUTE");
+              put(11, "FIXED_PREC_SCALE");
+              put(12, "AUTO_INCREMENT");
+              put(13, "LOCAL_TYPE_NAME");
+              put(14, "MINIMUM_SCALE");
+              put(15, "MAXIMUM_SCALE");
+              put(16, "SQL_DATA_TYPE");
+              put(17, "SQL_DATETIME_SUB");
+              put(18, "NUM_PREC_RADIX");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetTypeInfoSchema);
     }
   }
 
   @Test
   public void testGetIndexInfo() throws SQLException {
-    try (ResultSet resultSet = connection.getMetaData()
-        .getIndexInfo(null, null, null, false, true)) {
+    try (ResultSet resultSet =
+        connection.getMetaData().getIndexInfo(null, null, null, false, true)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetIndexInfoSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TABLE_CAT");
-          put(2, "TABLE_SCHEM");
-          put(3, "TABLE_NAME");
-          put(4, "NON_UNIQUE");
-          put(5, "INDEX_QUALIFIER");
-          put(6, "INDEX_NAME");
-          put(7, "TYPE");
-          put(8, "ORDINAL_POSITION");
-          put(9, "COLUMN_NAME");
-          put(10, "ASC_OR_DESC");
-          put(11, "CARDINALITY");
-          put(12, "PAGES");
-          put(13, "FILTER_CONDITION");
-        }
-      };
+      final Map<Integer, String> expectedGetIndexInfoSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TABLE_CAT");
+              put(2, "TABLE_SCHEM");
+              put(3, "TABLE_NAME");
+              put(4, "NON_UNIQUE");
+              put(5, "INDEX_QUALIFIER");
+              put(6, "INDEX_NAME");
+              put(7, "TYPE");
+              put(8, "ORDINAL_POSITION");
+              put(9, "COLUMN_NAME");
+              put(10, "ASC_OR_DESC");
+              put(11, "CARDINALITY");
+              put(12, "PAGES");
+              put(13, "FILTER_CONDITION");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetIndexInfoSchema);
     }
   }
@@ -1160,17 +1225,18 @@ public class ArrowDatabaseMetadataTest {
   public void testGetUDTs() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getUDTs(null, null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetUDTsSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TYPE_CAT");
-          put(2, "TYPE_SCHEM");
-          put(3, "TYPE_NAME");
-          put(4, "CLASS_NAME");
-          put(5, "DATA_TYPE");
-          put(6, "REMARKS");
-          put(7, "BASE_TYPE");
-        }
-      };
+      final Map<Integer, String> expectedGetUDTsSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TYPE_CAT");
+              put(2, "TYPE_SCHEM");
+              put(3, "TYPE_NAME");
+              put(4, "CLASS_NAME");
+              put(5, "DATA_TYPE");
+              put(6, "REMARKS");
+              put(7, "BASE_TYPE");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetUDTsSchema);
     }
   }
@@ -1179,16 +1245,17 @@ public class ArrowDatabaseMetadataTest {
   public void testGetSuperTypes() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getSuperTypes(null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetSuperTypesSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TYPE_CAT");
-          put(2, "TYPE_SCHEM");
-          put(3, "TYPE_NAME");
-          put(4, "SUPERTYPE_CAT");
-          put(5, "SUPERTYPE_SCHEM");
-          put(6, "SUPERTYPE_NAME");
-        }
-      };
+      final Map<Integer, String> expectedGetSuperTypesSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TYPE_CAT");
+              put(2, "TYPE_SCHEM");
+              put(3, "TYPE_NAME");
+              put(4, "SUPERTYPE_CAT");
+              put(5, "SUPERTYPE_SCHEM");
+              put(6, "SUPERTYPE_NAME");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetSuperTypesSchema);
     }
   }
@@ -1197,14 +1264,15 @@ public class ArrowDatabaseMetadataTest {
   public void testGetSuperTables() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getSuperTables(null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetSuperTablesSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TABLE_CAT");
-          put(2, "TABLE_SCHEM");
-          put(3, "TABLE_NAME");
-          put(4, "SUPERTABLE_NAME");
-        }
-      };
+      final Map<Integer, String> expectedGetSuperTablesSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TABLE_CAT");
+              put(2, "TABLE_SCHEM");
+              put(3, "TABLE_NAME");
+              put(4, "SUPERTABLE_NAME");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetSuperTablesSchema);
     }
   }
@@ -1213,31 +1281,32 @@ public class ArrowDatabaseMetadataTest {
   public void testGetAttributes() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getAttributes(null, null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetAttributesSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TYPE_CAT");
-          put(2, "TYPE_SCHEM");
-          put(3, "TYPE_NAME");
-          put(4, "ATTR_NAME");
-          put(5, "DATA_TYPE");
-          put(6, "ATTR_TYPE_NAME");
-          put(7, "ATTR_SIZE");
-          put(8, "DECIMAL_DIGITS");
-          put(9, "NUM_PREC_RADIX");
-          put(10, "NULLABLE");
-          put(11, "REMARKS");
-          put(12, "ATTR_DEF");
-          put(13, "SQL_DATA_TYPE");
-          put(14, "SQL_DATETIME_SUB");
-          put(15, "CHAR_OCTET_LENGTH");
-          put(16, "ORDINAL_POSITION");
-          put(17, "IS_NULLABLE");
-          put(18, "SCOPE_CATALOG");
-          put(19, "SCOPE_SCHEMA");
-          put(20, "SCOPE_TABLE");
-          put(21, "SOURCE_DATA_TYPE");
-        }
-      };
+      final Map<Integer, String> expectedGetAttributesSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TYPE_CAT");
+              put(2, "TYPE_SCHEM");
+              put(3, "TYPE_NAME");
+              put(4, "ATTR_NAME");
+              put(5, "DATA_TYPE");
+              put(6, "ATTR_TYPE_NAME");
+              put(7, "ATTR_SIZE");
+              put(8, "DECIMAL_DIGITS");
+              put(9, "NUM_PREC_RADIX");
+              put(10, "NULLABLE");
+              put(11, "REMARKS");
+              put(12, "ATTR_DEF");
+              put(13, "SQL_DATA_TYPE");
+              put(14, "SQL_DATETIME_SUB");
+              put(15, "CHAR_OCTET_LENGTH");
+              put(16, "ORDINAL_POSITION");
+              put(17, "IS_NULLABLE");
+              put(18, "SCOPE_CATALOG");
+              put(19, "SCOPE_SCHEMA");
+              put(20, "SCOPE_TABLE");
+              put(21, "SOURCE_DATA_TYPE");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetAttributesSchema);
     }
   }
@@ -1263,46 +1332,48 @@ public class ArrowDatabaseMetadataTest {
   public void testGetFunctions() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getFunctions(null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetFunctionsSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "FUNCTION_CAT");
-          put(2, "FUNCTION_SCHEM");
-          put(3, "FUNCTION_NAME");
-          put(4, "REMARKS");
-          put(5, "FUNCTION_TYPE");
-          put(6, "SPECIFIC_NAME");
-        }
-      };
+      final Map<Integer, String> expectedGetFunctionsSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "FUNCTION_CAT");
+              put(2, "FUNCTION_SCHEM");
+              put(3, "FUNCTION_NAME");
+              put(4, "REMARKS");
+              put(5, "FUNCTION_TYPE");
+              put(6, "SPECIFIC_NAME");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetFunctionsSchema);
     }
   }
 
   @Test
   public void testGetFunctionColumns() throws SQLException {
-    try (
-        ResultSet resultSet = connection.getMetaData().getFunctionColumns(null, null, null, null)) {
+    try (ResultSet resultSet =
+        connection.getMetaData().getFunctionColumns(null, null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetFunctionColumnsSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "FUNCTION_CAT");
-          put(2, "FUNCTION_SCHEM");
-          put(3, "FUNCTION_NAME");
-          put(4, "COLUMN_NAME");
-          put(5, "COLUMN_TYPE");
-          put(6, "DATA_TYPE");
-          put(7, "TYPE_NAME");
-          put(8, "PRECISION");
-          put(9, "LENGTH");
-          put(10, "SCALE");
-          put(11, "RADIX");
-          put(12, "NULLABLE");
-          put(13, "REMARKS");
-          put(14, "CHAR_OCTET_LENGTH");
-          put(15, "ORDINAL_POSITION");
-          put(16, "IS_NULLABLE");
-          put(17, "SPECIFIC_NAME");
-        }
-      };
+      final Map<Integer, String> expectedGetFunctionColumnsSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "FUNCTION_CAT");
+              put(2, "FUNCTION_SCHEM");
+              put(3, "FUNCTION_NAME");
+              put(4, "COLUMN_NAME");
+              put(5, "COLUMN_TYPE");
+              put(6, "DATA_TYPE");
+              put(7, "TYPE_NAME");
+              put(8, "PRECISION");
+              put(9, "LENGTH");
+              put(10, "SCALE");
+              put(11, "RADIX");
+              put(12, "NULLABLE");
+              put(13, "REMARKS");
+              put(14, "CHAR_OCTET_LENGTH");
+              put(15, "ORDINAL_POSITION");
+              put(16, "IS_NULLABLE");
+              put(17, "SPECIFIC_NAME");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetFunctionColumnsSchema);
     }
   }
@@ -1311,28 +1382,29 @@ public class ArrowDatabaseMetadataTest {
   public void testGetPseudoColumns() throws SQLException {
     try (ResultSet resultSet = connection.getMetaData().getPseudoColumns(null, null, null, null)) {
       // Maps ordinal index to column name according to JDBC documentation
-      final Map<Integer, String> expectedGetPseudoColumnsSchema = new HashMap<Integer, String>() {
-        {
-          put(1, "TABLE_CAT");
-          put(2, "TABLE_SCHEM");
-          put(3, "TABLE_NAME");
-          put(4, "COLUMN_NAME");
-          put(5, "DATA_TYPE");
-          put(6, "COLUMN_SIZE");
-          put(7, "DECIMAL_DIGITS");
-          put(8, "NUM_PREC_RADIX");
-          put(9, "COLUMN_USAGE");
-          put(10, "REMARKS");
-          put(11, "CHAR_OCTET_LENGTH");
-          put(12, "IS_NULLABLE");
-        }
-      };
+      final Map<Integer, String> expectedGetPseudoColumnsSchema =
+          new HashMap<Integer, String>() {
+            {
+              put(1, "TABLE_CAT");
+              put(2, "TABLE_SCHEM");
+              put(3, "TABLE_NAME");
+              put(4, "COLUMN_NAME");
+              put(5, "DATA_TYPE");
+              put(6, "COLUMN_SIZE");
+              put(7, "DECIMAL_DIGITS");
+              put(8, "NUM_PREC_RADIX");
+              put(9, "COLUMN_USAGE");
+              put(10, "REMARKS");
+              put(11, "CHAR_OCTET_LENGTH");
+              put(12, "IS_NULLABLE");
+            }
+          };
       testEmptyResultSet(resultSet, expectedGetPseudoColumnsSchema);
     }
   }
 
-  private void testEmptyResultSet(final ResultSet resultSet,
-                                  final Map<Integer, String> expectedResultSetSchema)
+  private void testEmptyResultSet(
+      final ResultSet resultSet, final Map<Integer, String> expectedResultSetSchema)
       throws SQLException {
     Assert.assertFalse(resultSet.next());
     final ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -1343,76 +1415,102 @@ public class ArrowDatabaseMetadataTest {
 
   @Test
   public void testGetColumnSize() {
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_BYTE),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_BYTE),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Int(Byte.SIZE, true)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_SHORT),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_SHORT),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Int(Short.SIZE, true)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_INT),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_INT),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Int(Integer.SIZE, true)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_LONG),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_LONG),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Int(Long.SIZE, true)));
 
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_VARCHAR_AND_BINARY),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_VARCHAR_AND_BINARY),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Utf8()));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_VARCHAR_AND_BINARY),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_VARCHAR_AND_BINARY),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Binary()));
 
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_SECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_SECONDS),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Timestamp(TimeUnit.SECOND, null)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_MILLISECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_MILLISECONDS),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_MICROSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_MICROSECONDS),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_NANOSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIMESTAMP_NANOSECONDS),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Timestamp(TimeUnit.NANOSECOND, null)));
 
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Time(TimeUnit.SECOND, Integer.SIZE)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME_MILLISECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME_MILLISECONDS),
         ArrowDatabaseMetadata.getColumnSize(
             new ArrowType.Time(TimeUnit.MILLISECOND, Integer.SIZE)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME_MICROSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME_MICROSECONDS),
         ArrowDatabaseMetadata.getColumnSize(
             new ArrowType.Time(TimeUnit.MICROSECOND, Integer.SIZE)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME_NANOSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_TIME_NANOSECONDS),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Time(TimeUnit.NANOSECOND, Integer.SIZE)));
 
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_DATE),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.COLUMN_SIZE_DATE),
         ArrowDatabaseMetadata.getColumnSize(new ArrowType.Date(DateUnit.DAY)));
 
-    Assert.assertNull(ArrowDatabaseMetadata.getColumnSize(new ArrowType.FloatingPoint(
-        FloatingPointPrecision.DOUBLE)));
+    Assert.assertNull(
+        ArrowDatabaseMetadata.getColumnSize(
+            new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)));
   }
 
   @Test
   public void testGetDecimalDigits() {
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
         ArrowDatabaseMetadata.getDecimalDigits(new ArrowType.Int(Byte.SIZE, true)));
 
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
         ArrowDatabaseMetadata.getDecimalDigits(new ArrowType.Timestamp(TimeUnit.SECOND, null)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MILLISECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MILLISECONDS),
         ArrowDatabaseMetadata.getDecimalDigits(
             new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MICROSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MICROSECONDS),
         ArrowDatabaseMetadata.getDecimalDigits(
             new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_NANOSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_NANOSECONDS),
         ArrowDatabaseMetadata.getDecimalDigits(new ArrowType.Timestamp(TimeUnit.NANOSECOND, null)));
 
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
         ArrowDatabaseMetadata.getDecimalDigits(new ArrowType.Time(TimeUnit.SECOND, Integer.SIZE)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MILLISECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MILLISECONDS),
         ArrowDatabaseMetadata.getDecimalDigits(
             new ArrowType.Time(TimeUnit.MILLISECOND, Integer.SIZE)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MICROSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_MICROSECONDS),
         ArrowDatabaseMetadata.getDecimalDigits(
             new ArrowType.Time(TimeUnit.MICROSECOND, Integer.SIZE)));
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_NANOSECONDS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.DECIMAL_DIGITS_TIME_NANOSECONDS),
         ArrowDatabaseMetadata.getDecimalDigits(
             new ArrowType.Time(TimeUnit.NANOSECOND, Integer.SIZE)));
 
-    Assert.assertEquals(Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
+    Assert.assertEquals(
+        Integer.valueOf(ArrowDatabaseMetadata.NO_DECIMAL_DIGITS),
         ArrowDatabaseMetadata.getDecimalDigits(new ArrowType.Date(DateUnit.DAY)));
 
     Assert.assertNull(ArrowDatabaseMetadata.getDecimalDigits(new ArrowType.Utf8()));
@@ -1428,7 +1526,8 @@ public class ArrowDatabaseMetadataTest {
 
   @Test
   public void testEmptySqlInfo() throws Exception {
-    try (final Connection testConnection = FLIGHT_SERVER_EMPTY_SQLINFO_TEST_RULE.getConnection(false)) {
+    try (final Connection testConnection =
+        FLIGHT_SERVER_EMPTY_SQLINFO_TEST_RULE.getConnection(false)) {
       final DatabaseMetaData metaData = testConnection.getMetaData();
       collector.checkThat(metaData.getSQLKeywords(), is(""));
       collector.checkThat(metaData.getNumericFunctions(), is(""));

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArrayTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcArrayTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.ResultSet;
@@ -23,7 +22,6 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.HashMap;
-
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.util.JsonStringArrayList;
@@ -38,8 +36,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ArrowFlightJdbcArrayTest {
 
-  @Rule
-  public RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
+  @Rule public RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
   IntVector dataVector;
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionCookieTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionCookieTest.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import org.apache.arrow.driver.jdbc.utils.CoreMockedSqlProducers;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -30,8 +28,7 @@ import org.junit.rules.ErrorCollector;
 
 public class ArrowFlightJdbcConnectionCookieTest {
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   @ClassRule
   public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE =
@@ -40,7 +37,7 @@ public class ArrowFlightJdbcConnectionCookieTest {
   @Test
   public void testCookies() throws SQLException {
     try (Connection connection = FLIGHT_SERVER_TEST_RULE.getConnection(false);
-         Statement statement = connection.createStatement()) {
+        Statement statement = connection.createStatement()) {
 
       // Expect client didn't receive cookies before any operation
       Assert.assertNull(FLIGHT_SERVER_TEST_RULE.getMiddlewareCookieFactory().getCookie());
@@ -51,4 +48,3 @@ public class ArrowFlightJdbcConnectionCookieTest {
     }
   }
 }
-

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionPoolDataSourceTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcConnectionPoolDataSourceTest.java
@@ -14,13 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.Connection;
-
 import javax.sql.PooledConnection;
-
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.utils.ConnectionWrapper;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
@@ -31,8 +28,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 public class ArrowFlightJdbcConnectionPoolDataSourceTest {
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
 
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
 
@@ -43,10 +39,11 @@ public class ArrowFlightJdbcConnectionPoolDataSourceTest {
             .user("user2", "pass2")
             .build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(authentication)
-        .producer(PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(authentication)
+            .producer(PRODUCER)
+            .build();
   }
 
   private ArrowFlightJdbcConnectionPoolDataSource dataSource;
@@ -107,7 +104,8 @@ public class ArrowFlightJdbcConnectionPoolDataSourceTest {
 
     Assert.assertSame(pooledConnection, pooledConnection2);
     Assert.assertNotSame(connection, connection2);
-    Assert.assertSame(connection.unwrap(ArrowFlightConnection.class),
+    Assert.assertSame(
+        connection.unwrap(ArrowFlightConnection.class),
         connection2.unwrap(ArrowFlightConnection.class));
   }
 
@@ -129,7 +127,8 @@ public class ArrowFlightJdbcConnectionPoolDataSourceTest {
 
     Assert.assertNotSame(pooledConnection, pooledConnection2);
     Assert.assertNotSame(connection, connection2);
-    Assert.assertNotSame(connection.unwrap(ArrowFlightConnection.class),
+    Assert.assertNotSame(
+        connection.unwrap(ArrowFlightConnection.class),
         connection2.unwrap(ArrowFlightConnection.class));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcCursorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcCursorTest.java
@@ -14,15 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BitVector;
@@ -55,11 +54,7 @@ import org.apache.calcite.avatica.util.Cursor;
 import org.junit.After;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-
-/**
- * Tests for {@link ArrowFlightJdbcCursor}.
- */
+/** Tests for {@link ArrowFlightJdbcCursor}. */
 public class ArrowFlightJdbcCursorTest {
 
   ArrowFlightJdbcCursor cursor;
@@ -88,44 +83,42 @@ public class ArrowFlightJdbcCursorTest {
 
   @Test
   public void testDurationVectorNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("Duration",
-        new ArrowType.Duration(TimeUnit.MILLISECOND), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot("Duration", new ArrowType.Duration(TimeUnit.MILLISECOND), null);
     ((DurationVector) root.getVector("Duration")).setNull(0);
     testCursorWasNull(root);
   }
 
   @Test
   public void testDateInternalNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("Interval",
-        new ArrowType.Interval(IntervalUnit.DAY_TIME), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot("Interval", new ArrowType.Interval(IntervalUnit.DAY_TIME), null);
     ((IntervalDayVector) root.getVector("Interval")).setNull(0);
     testCursorWasNull(root);
   }
 
   @Test
   public void testTimeStampVectorNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("TimeStamp",
-        new ArrowType.Timestamp(TimeUnit.MILLISECOND, null), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot("TimeStamp", new ArrowType.Timestamp(TimeUnit.MILLISECOND, null), null);
     ((TimeStampMilliVector) root.getVector("TimeStamp")).setNull(0);
     testCursorWasNull(root);
   }
 
   @Test
   public void testTimeVectorNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("Time",
-        new ArrowType.Time(TimeUnit.MILLISECOND, 32), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot("Time", new ArrowType.Time(TimeUnit.MILLISECOND, 32), null);
     ((TimeMilliVector) root.getVector("Time")).setNull(0);
     testCursorWasNull(root);
-
   }
 
   @Test
   public void testFixedSizeListVectorNullTrue() throws SQLException {
     List<Field> fieldList = new ArrayList<>();
-    fieldList.add(new Field("Null", new FieldType(true, new ArrowType.Null(), null),
-        null));
-    final VectorSchemaRoot root = getVectorSchemaRoot("FixedSizeList",
-        new ArrowType.FixedSizeList(10), fieldList);
+    fieldList.add(new Field("Null", new FieldType(true, new ArrowType.Null(), null), null));
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot("FixedSizeList", new ArrowType.FixedSizeList(10), fieldList);
     ((FixedSizeListVector) root.getVector("FixedSizeList")).setNull(0);
     testCursorWasNull(root);
   }
@@ -133,8 +126,7 @@ public class ArrowFlightJdbcCursorTest {
   @Test
   public void testLargeListVectorNullTrue() throws SQLException {
     List<Field> fieldList = new ArrayList<>();
-    fieldList.add(new Field("Null", new FieldType(true, new ArrowType.Null(), null),
-        null));
+    fieldList.add(new Field("Null", new FieldType(true, new ArrowType.Null(), null), null));
     final VectorSchemaRoot root =
         getVectorSchemaRoot("LargeList", new ArrowType.LargeList(), fieldList);
     ((LargeListVector) root.getVector("LargeList")).setNull(0);
@@ -144,8 +136,7 @@ public class ArrowFlightJdbcCursorTest {
   @Test
   public void testListVectorNullTrue() throws SQLException {
     List<Field> fieldList = new ArrayList<>();
-    fieldList.add(new Field("Null", new FieldType(true, new ArrowType.Null(), null),
-        null));
+    fieldList.add(new Field("Null", new FieldType(true, new ArrowType.Null(), null), null));
     final VectorSchemaRoot root = getVectorSchemaRoot("List", new ArrowType.List(), fieldList);
     ((ListVector) root.getVector("List")).setNull(0);
     testCursorWasNull(root);
@@ -154,13 +145,11 @@ public class ArrowFlightJdbcCursorTest {
   @Test
   public void testMapVectorNullTrue() throws SQLException {
     List<Field> structChildren = new ArrayList<>();
-    structChildren.add(new Field("Key", new FieldType(false, new ArrowType.Utf8(), null),
-        null));
-    structChildren.add(new Field("Value", new FieldType(false, new ArrowType.Utf8(), null),
-        null));
+    structChildren.add(new Field("Key", new FieldType(false, new ArrowType.Utf8(), null), null));
+    structChildren.add(new Field("Value", new FieldType(false, new ArrowType.Utf8(), null), null));
     List<Field> fieldList = new ArrayList<>();
-    fieldList.add(new Field("Struct", new FieldType(false, new ArrowType.Struct(), null),
-        structChildren));
+    fieldList.add(
+        new Field("Struct", new FieldType(false, new ArrowType.Struct(), null), structChildren));
     final VectorSchemaRoot root = getVectorSchemaRoot("Map", new ArrowType.Map(false), fieldList);
     ((MapVector) root.getVector("Map")).setNull(0);
     testCursorWasNull(root);
@@ -175,8 +164,8 @@ public class ArrowFlightJdbcCursorTest {
 
   @Test
   public void testBaseIntVectorNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("BaseInt",
-        new ArrowType.Int(32, false), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot("BaseInt", new ArrowType.Int(32, false), null);
     ((UInt4Vector) root.getVector("BaseInt")).setNull(0);
     testCursorWasNull(root);
   }
@@ -190,24 +179,26 @@ public class ArrowFlightJdbcCursorTest {
 
   @Test
   public void testDecimalVectorNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("Decimal",
-        new ArrowType.Decimal(2, 2, 128), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot("Decimal", new ArrowType.Decimal(2, 2, 128), null);
     ((DecimalVector) root.getVector("Decimal")).setNull(0);
     testCursorWasNull(root);
   }
 
   @Test
   public void testFloat4VectorNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("Float4",
-        new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot(
+            "Float4", new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE), null);
     ((Float4Vector) root.getVector("Float4")).setNull(0);
     testCursorWasNull(root);
   }
 
   @Test
   public void testFloat8VectorNullTrue() throws SQLException {
-    final VectorSchemaRoot root = getVectorSchemaRoot("Float8",
-        new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE), null);
+    final VectorSchemaRoot root =
+        getVectorSchemaRoot(
+            "Float8", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE), null);
     ((Float8Vector) root.getVector("Float8")).setNull(0);
     testCursorWasNull(root);
   }
@@ -225,14 +216,11 @@ public class ArrowFlightJdbcCursorTest {
     testCursorWasNull(root);
   }
 
-  private VectorSchemaRoot getVectorSchemaRoot(String name, ArrowType arrowType,
-                                               List<Field> children) {
-    final Schema schema = new Schema(ImmutableList.of(
-        new Field(
-            name,
-            new FieldType(true, arrowType,
-                null),
-            children)));
+  private VectorSchemaRoot getVectorSchemaRoot(
+      String name, ArrowType arrowType, List<Field> children) {
+    final Schema schema =
+        new Schema(
+            ImmutableList.of(new Field(name, new FieldType(true, arrowType, null), children)));
     allocator = new RootAllocator(Long.MAX_VALUE);
     final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
     root.allocateNew();

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriverTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriverTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,7 +29,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
@@ -42,24 +40,24 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-/**
- * Tests for {@link ArrowFlightJdbcDriver}.
- */
+/** Tests for {@link ArrowFlightJdbcDriver}. */
 public class ArrowFlightJdbcDriverTest {
 
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
 
   static {
     UserPasswordAuthentication authentication =
-        new UserPasswordAuthentication.Builder().user("user1", "pass1").user("user2", "pass2")
+        new UserPasswordAuthentication.Builder()
+            .user("user1", "pass1")
+            .user("user2", "pass2")
             .build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(authentication)
-        .producer(PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(authentication)
+            .producer(PRODUCER)
+            .build();
   }
 
   private BufferAllocator allocator;
@@ -79,34 +77,36 @@ public class ArrowFlightJdbcDriverTest {
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} is registered in the
-   * {@link DriverManager}.
+   * Tests whether the {@link ArrowFlightJdbcDriver} is registered in the {@link DriverManager}.
    *
    * @throws SQLException If an error occurs. (This is not supposed to happen.)
    */
   @Test
   public void testDriverIsRegisteredInDriverManager() throws Exception {
-    assertTrue(DriverManager.getDriver("jdbc:arrow-flight://localhost:32010") instanceof
-        ArrowFlightJdbcDriver);
-    assertTrue(DriverManager.getDriver("jdbc:arrow-flight-sql://localhost:32010") instanceof
-        ArrowFlightJdbcDriver);
+    assertTrue(
+        DriverManager.getDriver("jdbc:arrow-flight://localhost:32010")
+            instanceof ArrowFlightJdbcDriver);
+    assertTrue(
+        DriverManager.getDriver("jdbc:arrow-flight-sql://localhost:32010")
+            instanceof ArrowFlightJdbcDriver);
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} returns null when provided with an
-   * unsupported URL prefix.
+   * Tests whether the {@link ArrowFlightJdbcDriver} returns null when provided with an unsupported
+   * URL prefix.
    */
   @Test
   public void testShouldDeclineUrlWithUnsupportedPrefix() throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
 
-    assertNull(driver.connect("jdbc:mysql://localhost:32010",
-        dataSource.getProperties("flight", "flight123")));
+    assertNull(
+        driver.connect(
+            "jdbc:mysql://localhost:32010", dataSource.getProperties("flight", "flight123")));
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} can establish a successful
-   * connection to the Arrow Flight client.
+   * Tests whether the {@link ArrowFlightJdbcDriver} can establish a successful connection to the
+   * Arrow Flight client.
    *
    * @throws Exception If the connection fails to be established.
    */
@@ -116,19 +116,27 @@ public class ArrowFlightJdbcDriverTest {
     final Driver driver = new ArrowFlightJdbcDriver();
 
     try (Connection connection =
-             driver.connect("jdbc:arrow-flight://" +
-                     dataSource.getConfig().getHost() + ":" +
-                     dataSource.getConfig().getPort() + "?" +
-                     "useEncryption=false",
-                 dataSource.getProperties(dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
+        driver.connect(
+            "jdbc:arrow-flight://"
+                + dataSource.getConfig().getHost()
+                + ":"
+                + dataSource.getConfig().getPort()
+                + "?"
+                + "useEncryption=false",
+            dataSource.getProperties(
+                dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
       assertTrue(connection.isValid(300));
     }
     try (Connection connection =
-             driver.connect("jdbc:arrow-flight-sql://" +
-                     dataSource.getConfig().getHost() + ":" +
-                     dataSource.getConfig().getPort() + "?" +
-                     "useEncryption=false",
-                 dataSource.getProperties(dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
+        driver.connect(
+            "jdbc:arrow-flight-sql://"
+                + dataSource.getConfig().getHost()
+                + ":"
+                + dataSource.getConfig().getPort()
+                + "?"
+                + "useEncryption=false",
+            dataSource.getProperties(
+                dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
       assertTrue(connection.isValid(300));
     }
   }
@@ -139,19 +147,27 @@ public class ArrowFlightJdbcDriverTest {
     final Driver driver = new ArrowFlightJdbcDriver();
 
     try (Connection connection =
-             driver.connect("jdbc:arrow-flight://" +
-                     dataSource.getConfig().getHost() + ":" +
-                     dataSource.getConfig().getPort() + "?" +
-                     "UseEncryptIon=false",
-                 dataSource.getProperties(dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
+        driver.connect(
+            "jdbc:arrow-flight://"
+                + dataSource.getConfig().getHost()
+                + ":"
+                + dataSource.getConfig().getPort()
+                + "?"
+                + "UseEncryptIon=false",
+            dataSource.getProperties(
+                dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
       assertTrue(connection.isValid(300));
     }
     try (Connection connection =
-             driver.connect("jdbc:arrow-flight-sql://" +
-                     dataSource.getConfig().getHost() + ":" +
-                     dataSource.getConfig().getPort() + "?" +
-                     "UseEncryptIon=false",
-                 dataSource.getProperties(dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
+        driver.connect(
+            "jdbc:arrow-flight-sql://"
+                + dataSource.getConfig().getHost()
+                + ":"
+                + dataSource.getConfig().getPort()
+                + "?"
+                + "UseEncryptIon=false",
+            dataSource.getProperties(
+                dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()))) {
       assertTrue(connection.isValid(300));
     }
   }
@@ -161,26 +177,32 @@ public class ArrowFlightJdbcDriverTest {
     // Get the Arrow Flight JDBC driver by providing a property object with insensitive case keys.
     final Driver driver = new ArrowFlightJdbcDriver();
     Properties properties =
-        dataSource.getProperties(dataSource.getConfig().getUser(), dataSource.getConfig().getPassword());
+        dataSource.getProperties(
+            dataSource.getConfig().getUser(), dataSource.getConfig().getPassword());
     properties.put("UseEncryptIon", "false");
 
     try (Connection connection =
-             driver.connect("jdbc:arrow-flight://" +
-                 dataSource.getConfig().getHost() + ":" +
-                 dataSource.getConfig().getPort(), properties)) {
+        driver.connect(
+            "jdbc:arrow-flight://"
+                + dataSource.getConfig().getHost()
+                + ":"
+                + dataSource.getConfig().getPort(),
+            properties)) {
       assertTrue(connection.isValid(300));
     }
     try (Connection connection =
-             driver.connect("jdbc:arrow-flight-sql://" +
-                 dataSource.getConfig().getHost() + ":" +
-                 dataSource.getConfig().getPort(), properties)) {
+        driver.connect(
+            "jdbc:arrow-flight-sql://"
+                + dataSource.getConfig().getHost()
+                + ":"
+                + dataSource.getConfig().getPort(),
+            properties)) {
       assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Tests whether an exception is thrown upon attempting to connect to a
-   * malformed URI.
+   * Tests whether an exception is thrown upon attempting to connect to a malformed URI.
    *
    * @throws SQLException If an error occurs.
    */
@@ -193,8 +215,7 @@ public class ArrowFlightJdbcDriverTest {
   }
 
   /**
-   * Tests whether an exception is thrown upon attempting to connect to a
-   * malformed URI.
+   * Tests whether an exception is thrown upon attempting to connect to a malformed URI.
    *
    * @throws SQLException If an error occurs.
    */
@@ -203,60 +224,72 @@ public class ArrowFlightJdbcDriverTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     final String malformedUri = "localhost:32010";
 
-    driver.connect(malformedUri, dataSource.getProperties(dataSource.getConfig().getUser(),
-        dataSource.getConfig().getPassword()));
+    driver.connect(
+        malformedUri,
+        dataSource.getProperties(
+            dataSource.getConfig().getUser(), dataSource.getConfig().getPassword()));
   }
 
-  /**
-   * Tests whether an exception is thrown upon attempting to connect to a
-   * malformed URI.
-   */
+  /** Tests whether an exception is thrown upon attempting to connect to a malformed URI. */
   @Test
   public void testShouldThrowExceptionWhenAttemptingToConnectToUrlNoPort() {
     final Driver driver = new ArrowFlightJdbcDriver();
-    SQLException e = assertThrows(SQLException.class, () -> {
-      Properties properties = dataSource.getProperties(dataSource.getConfig().getUser(),
-          dataSource.getConfig().getPassword());
-      Connection conn = driver.connect("jdbc:arrow-flight://localhost", properties);
-      conn.close();
-    });
+    SQLException e =
+        assertThrows(
+            SQLException.class,
+            () -> {
+              Properties properties =
+                  dataSource.getProperties(
+                      dataSource.getConfig().getUser(), dataSource.getConfig().getPassword());
+              Connection conn = driver.connect("jdbc:arrow-flight://localhost", properties);
+              conn.close();
+            });
     assertTrue(e.getMessage().contains("URL must have a port"));
-    e = assertThrows(SQLException.class, () -> {
-      Properties properties = dataSource.getProperties(dataSource.getConfig().getUser(),
-          dataSource.getConfig().getPassword());
-      Connection conn = driver.connect("jdbc:arrow-flight-sql://localhost", properties);
-      conn.close();
-    });
+    e =
+        assertThrows(
+            SQLException.class,
+            () -> {
+              Properties properties =
+                  dataSource.getProperties(
+                      dataSource.getConfig().getUser(), dataSource.getConfig().getPassword());
+              Connection conn = driver.connect("jdbc:arrow-flight-sql://localhost", properties);
+              conn.close();
+            });
     assertTrue(e.getMessage().contains("URL must have a port"));
   }
 
-  /**
-   * Tests whether an exception is thrown upon attempting to connect to a
-   * malformed URI.
-   */
+  /** Tests whether an exception is thrown upon attempting to connect to a malformed URI. */
   @Test
   public void testShouldThrowExceptionWhenAttemptingToConnectToUrlNoHost() {
     final Driver driver = new ArrowFlightJdbcDriver();
-    SQLException e = assertThrows(SQLException.class, () -> {
-      Properties properties = dataSource.getProperties(dataSource.getConfig().getUser(),
-          dataSource.getConfig().getPassword());
-      Connection conn = driver.connect("jdbc:arrow-flight://32010:localhost", properties);
-      conn.close();
-    });
+    SQLException e =
+        assertThrows(
+            SQLException.class,
+            () -> {
+              Properties properties =
+                  dataSource.getProperties(
+                      dataSource.getConfig().getUser(), dataSource.getConfig().getPassword());
+              Connection conn = driver.connect("jdbc:arrow-flight://32010:localhost", properties);
+              conn.close();
+            });
     assertTrue(e.getMessage().contains("URL must have a host"));
 
-    e = assertThrows(SQLException.class, () -> {
-      Properties properties = dataSource.getProperties(dataSource.getConfig().getUser(),
-          dataSource.getConfig().getPassword());
-      Connection conn = driver.connect("jdbc:arrow-flight-sql://32010:localhost", properties);
-      conn.close();
-    });
+    e =
+        assertThrows(
+            SQLException.class,
+            () -> {
+              Properties properties =
+                  dataSource.getProperties(
+                      dataSource.getConfig().getUser(), dataSource.getConfig().getPassword());
+              Connection conn =
+                  driver.connect("jdbc:arrow-flight-sql://32010:localhost", properties);
+              conn.close();
+            });
     assertTrue(e.getMessage().contains("URL must have a host"));
   }
 
   /**
-   * Tests whether {@link ArrowFlightJdbcDriver#getUrlsArgs} returns the
-   * correct URL parameters.
+   * Tests whether {@link ArrowFlightJdbcDriver#getUrlsArgs} returns the correct URL parameters.
    *
    * @throws Exception If an error occurs.
    */
@@ -264,9 +297,10 @@ public class ArrowFlightJdbcDriverTest {
   public void testDriverUrlParsingMechanismShouldReturnTheDesiredArgsFromUrl() throws Exception {
     final ArrowFlightJdbcDriver driver = new ArrowFlightJdbcDriver();
 
-    final Map<Object, Object> parsedArgs = driver.getUrlsArgs(
-        "jdbc:arrow-flight-sql://localhost:2222/?key1=value1&key2=value2&a=b")
-        .orElseThrow(() -> new RuntimeException("URL was rejected"));
+    final Map<Object, Object> parsedArgs =
+        driver
+            .getUrlsArgs("jdbc:arrow-flight-sql://localhost:2222/?key1=value1&key2=value2&a=b")
+            .orElseThrow(() -> new RuntimeException("URL was rejected"));
 
     // Check size == the amount of args provided (scheme not included)
     assertEquals(5, parsedArgs.size());
@@ -284,11 +318,13 @@ public class ArrowFlightJdbcDriverTest {
   }
 
   @Test
-  public void testDriverUrlParsingMechanismShouldReturnTheDesiredArgsFromUrlWithSemicolon() throws Exception {
+  public void testDriverUrlParsingMechanismShouldReturnTheDesiredArgsFromUrlWithSemicolon()
+      throws Exception {
     final ArrowFlightJdbcDriver driver = new ArrowFlightJdbcDriver();
-    final Map<Object, Object> parsedArgs = driver.getUrlsArgs(
-        "jdbc:arrow-flight-sql://localhost:2222/;key1=value1;key2=value2;a=b")
-        .orElseThrow(() -> new RuntimeException("URL was rejected"));
+    final Map<Object, Object> parsedArgs =
+        driver
+            .getUrlsArgs("jdbc:arrow-flight-sql://localhost:2222/;key1=value1;key2=value2;a=b")
+            .orElseThrow(() -> new RuntimeException("URL was rejected"));
 
     // Check size == the amount of args provided (scheme not included)
     assertEquals(5, parsedArgs.size());
@@ -306,11 +342,13 @@ public class ArrowFlightJdbcDriverTest {
   }
 
   @Test
-  public void testDriverUrlParsingMechanismShouldReturnTheDesiredArgsFromUrlWithOneSemicolon() throws Exception {
+  public void testDriverUrlParsingMechanismShouldReturnTheDesiredArgsFromUrlWithOneSemicolon()
+      throws Exception {
     final ArrowFlightJdbcDriver driver = new ArrowFlightJdbcDriver();
-    final Map<Object, Object> parsedArgs = driver.getUrlsArgs(
-        "jdbc:arrow-flight-sql://localhost:2222/;key1=value1")
-        .orElseThrow(() -> new RuntimeException("URL was rejected"));
+    final Map<Object, Object> parsedArgs =
+        driver
+            .getUrlsArgs("jdbc:arrow-flight-sql://localhost:2222/;key1=value1")
+            .orElseThrow(() -> new RuntimeException("URL was rejected"));
 
     // Check size == the amount of args provided (scheme not included)
     assertEquals(3, parsedArgs.size());
@@ -326,22 +364,25 @@ public class ArrowFlightJdbcDriverTest {
   }
 
   @Test
-  public void testDriverUrlParsingMechanismShouldReturnEmptyOptionalForUnknownScheme() throws SQLException {
+  public void testDriverUrlParsingMechanismShouldReturnEmptyOptionalForUnknownScheme()
+      throws SQLException {
     final ArrowFlightJdbcDriver driver = new ArrowFlightJdbcDriver();
     assertFalse(driver.getUrlsArgs("jdbc:malformed-url-flight://localhost:2222").isPresent());
   }
 
   /**
-   * Tests whether {@code ArrowFlightJdbcDriverTest#getUrlsArgs} returns the
-   * correct URL parameters when the host is an IP Address.
+   * Tests whether {@code ArrowFlightJdbcDriverTest#getUrlsArgs} returns the correct URL parameters
+   * when the host is an IP Address.
    *
    * @throws Exception If an error occurs.
    */
   @Test
   public void testDriverUrlParsingMechanismShouldWorkWithIPAddress() throws Exception {
     final ArrowFlightJdbcDriver driver = new ArrowFlightJdbcDriver();
-    final Map<Object, Object> parsedArgs = driver.getUrlsArgs("jdbc:arrow-flight-sql://0.0.0.0:2222")
-        .orElseThrow(() -> new RuntimeException("URL was rejected"));
+    final Map<Object, Object> parsedArgs =
+        driver
+            .getUrlsArgs("jdbc:arrow-flight-sql://0.0.0.0:2222")
+            .orElseThrow(() -> new RuntimeException("URL was rejected"));
 
     // Check size == the amount of args provided (scheme not included)
     assertEquals(2, parsedArgs.size());
@@ -354,8 +395,9 @@ public class ArrowFlightJdbcDriverTest {
   }
 
   /**
-   * Tests whether {@code ArrowFlightJdbcDriverTest#getUrlsArgs} escape especial characters and returns the
-   * correct URL parameters when the especial character '&' is embedded in the query parameters values.
+   * Tests whether {@code ArrowFlightJdbcDriverTest#getUrlsArgs} escape especial characters and
+   * returns the correct URL parameters when the especial character '&' is embedded in the query
+   * parameters values.
    *
    * @throws Exception If an error occurs.
    */
@@ -363,9 +405,11 @@ public class ArrowFlightJdbcDriverTest {
   public void testDriverUrlParsingMechanismShouldWorkWithEmbeddedEspecialCharacter()
       throws Exception {
     final ArrowFlightJdbcDriver driver = new ArrowFlightJdbcDriver();
-    final Map<Object, Object> parsedArgs = driver.getUrlsArgs(
-        "jdbc:arrow-flight-sql://0.0.0.0:2222?test1=test1value&test2%26continue=test2value&test3=test3value")
-        .orElseThrow(() -> new RuntimeException("URL was rejected"));
+    final Map<Object, Object> parsedArgs =
+        driver
+            .getUrlsArgs(
+                "jdbc:arrow-flight-sql://0.0.0.0:2222?test1=test1value&test2%26continue=test2value&test3=test3value")
+            .orElseThrow(() -> new RuntimeException("URL was rejected"));
 
     // Check size == the amount of args provided (scheme not included)
     assertEquals(5, parsedArgs.size());

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactoryTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcFactoryTest.java
@@ -14,13 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
+import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
@@ -33,26 +32,24 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableMap;
-
-/**
- * Tests for {@link ArrowFlightJdbcDriver}.
- */
+/** Tests for {@link ArrowFlightJdbcDriver}. */
 public class ArrowFlightJdbcFactoryTest {
 
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
 
   static {
     UserPasswordAuthentication authentication =
-        new UserPasswordAuthentication.Builder().user("user1", "pass1").user("user2", "pass2")
+        new UserPasswordAuthentication.Builder()
+            .user("user1", "pass1")
+            .user("user2", "pass2")
             .build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(authentication)
-        .producer(PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(authentication)
+            .producer(PRODUCER)
+            .build();
   }
 
   private BufferAllocator allocator;
@@ -77,13 +74,21 @@ public class ArrowFlightJdbcFactoryTest {
     ArrowFlightJdbcFactory factory = constructor.newInstance();
 
     final Properties properties = new Properties();
-    properties.putAll(ImmutableMap.of(
-        ArrowFlightConnectionProperty.HOST.camelName(), "localhost",
-        ArrowFlightConnectionProperty.PORT.camelName(), 32010,
-        ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false));
+    properties.putAll(
+        ImmutableMap.of(
+            ArrowFlightConnectionProperty.HOST.camelName(),
+            "localhost",
+            ArrowFlightConnectionProperty.PORT.camelName(),
+            32010,
+            ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(),
+            false));
 
-    try (Connection connection = factory.newConnection(driver, constructor.newInstance(),
-        "jdbc:arrow-flight-sql://localhost:32010", properties)) {
+    try (Connection connection =
+        factory.newConnection(
+            driver,
+            constructor.newInstance(),
+            "jdbc:arrow-flight-sql://localhost:32010",
+            properties)) {
       assert connection.isValid(300);
     }
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcTimeTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcTimeTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.hamcrest.CoreMatchers.endsWith;
@@ -22,15 +21,13 @@ import static org.hamcrest.CoreMatchers.is;
 
 import java.time.LocalTime;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
 public class ArrowFlightJdbcTimeTest {
 
-  @ClassRule
-  public static final ErrorCollector collector = new ErrorCollector();
+  @ClassRule public static final ErrorCollector collector = new ErrorCollector();
   final int hour = 5;
   final int minute = 6;
   final int second = 7;
@@ -38,7 +35,8 @@ public class ArrowFlightJdbcTimeTest {
   @Test
   public void testPrintingMillisNoLeadingZeroes() {
     // testing the regular case where the precision of the millisecond is 3
-    LocalTime dateTime = LocalTime.of(hour, minute, second, (int) TimeUnit.MILLISECONDS.toNanos(999));
+    LocalTime dateTime =
+        LocalTime.of(hour, minute, second, (int) TimeUnit.MILLISECONDS.toNanos(999));
     ArrowFlightJdbcTime time = new ArrowFlightJdbcTime(dateTime);
     collector.checkThat(time.toString(), endsWith(".999"));
     collector.checkThat(time.getHours(), is(hour));
@@ -49,7 +47,8 @@ public class ArrowFlightJdbcTimeTest {
   @Test
   public void testPrintingMillisOneLeadingZeroes() {
     // test case where one leading zero needs to be added
-    LocalTime dateTime = LocalTime.of(hour, minute, second, (int) TimeUnit.MILLISECONDS.toNanos(99));
+    LocalTime dateTime =
+        LocalTime.of(hour, minute, second, (int) TimeUnit.MILLISECONDS.toNanos(99));
     ArrowFlightJdbcTime time = new ArrowFlightJdbcTime(dateTime);
     collector.checkThat(time.toString(), endsWith(".099"));
     collector.checkThat(time.getHours(), is(hour));

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightPreparedStatementTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -28,7 +27,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.arrow.driver.jdbc.utils.CoreMockedSqlProducers;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.flight.sql.FlightSqlUtils;
@@ -54,14 +52,14 @@ import org.junit.rules.ErrorCollector;
 public class ArrowFlightPreparedStatementTest {
 
   public static final MockFlightSqlProducer PRODUCER = CoreMockedSqlProducers.getLegacyProducer();
+
   @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE = FlightServerTestRule
-      .createStandardTestRule(PRODUCER);
+  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE =
+      FlightServerTestRule.createStandardTestRule(PRODUCER);
 
   private static Connection connection;
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   @BeforeClass
   public static void setup() throws SQLException {
@@ -82,7 +80,7 @@ public class ArrowFlightPreparedStatementTest {
   public void testSimpleQueryNoParameterBinding() throws SQLException {
     final String query = CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD;
     try (final PreparedStatement preparedStatement = connection.prepareStatement(query);
-         final ResultSet resultSet = preparedStatement.executeQuery()) {
+        final ResultSet resultSet = preparedStatement.executeQuery()) {
       CoreMockedSqlProducers.assertLegacyRegularSqlResultSet(resultSet, collector);
     }
   }
@@ -90,20 +88,26 @@ public class ArrowFlightPreparedStatementTest {
   @Test
   public void testQueryWithParameterBinding() throws SQLException {
     final String query = "Fake query with parameters";
-    final Schema schema = new Schema(Collections.singletonList(Field.nullable("", Types.MinorType.INT.getType())));
-    final Schema parameterSchema = new Schema(Arrays.asList(
-            Field.nullable("", ArrowType.Utf8.INSTANCE),
-            new Field("", FieldType.nullable(ArrowType.List.INSTANCE),
+    final Schema schema =
+        new Schema(Collections.singletonList(Field.nullable("", Types.MinorType.INT.getType())));
+    final Schema parameterSchema =
+        new Schema(
+            Arrays.asList(
+                Field.nullable("", ArrowType.Utf8.INSTANCE),
+                new Field(
+                    "",
+                    FieldType.nullable(ArrowType.List.INSTANCE),
                     Collections.singletonList(Field.nullable("", Types.MinorType.INT.getType())))));
-    final List<List<Object>> expected = Collections.singletonList(Arrays.asList(
-                    new Text("foo"),
-                    new Integer[]{1, 2, null}));
+    final List<List<Object>> expected =
+        Collections.singletonList(Arrays.asList(new Text("foo"), new Integer[] {1, 2, null}));
 
-    PRODUCER.addSelectQuery(query, schema,
-            Collections.singletonList(listener -> {
+    PRODUCER.addSelectQuery(
+        query,
+        schema,
+        Collections.singletonList(
+            listener -> {
               try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-                   final VectorSchemaRoot root = VectorSchemaRoot.create(schema,
-                           allocator)) {
+                  final VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
                 ((IntVector) root.getVector(0)).setSafe(0, 10);
                 root.setRowCount(1);
                 listener.start(root);
@@ -119,7 +123,8 @@ public class ArrowFlightPreparedStatementTest {
 
     try (final PreparedStatement preparedStatement = connection.prepareStatement(query)) {
       preparedStatement.setString(1, "foo");
-      preparedStatement.setArray(2, connection.createArrayOf("INTEGER", new Integer[]{1, 2, null}));
+      preparedStatement.setArray(
+          2, connection.createArrayOf("INTEGER", new Integer[] {1, 2, null}));
 
       try (final ResultSet resultSet = preparedStatement.executeQuery()) {
         resultSet.next();
@@ -128,15 +133,20 @@ public class ArrowFlightPreparedStatementTest {
     }
   }
 
-
   @Test
   @Ignore("https://github.com/apache/arrow/issues/34741: flaky test")
   public void testPreparedStatementExecutionOnce() throws SQLException {
-    final PreparedStatement statement = connection.prepareStatement(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD);
-    // Expect that there is one entry in the map -- {prepared statement action type, invocation count}.
+    final PreparedStatement statement =
+        connection.prepareStatement(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD);
+    // Expect that there is one entry in the map -- {prepared statement action type, invocation
+    // count}.
     assertEquals(PRODUCER.getActionTypeCounter().size(), 1);
     // Expect that the prepared statement was executed exactly once.
-    assertEquals(PRODUCER.getActionTypeCounter().get(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType()), 1);
+    assertEquals(
+        PRODUCER
+            .getActionTypeCounter()
+            .get(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType()),
+        1);
     statement.close();
   }
 
@@ -157,7 +167,7 @@ public class ArrowFlightPreparedStatementTest {
   @Test
   public void testUpdateQuery() throws SQLException {
     String query = "Fake update";
-    PRODUCER.addUpdateQuery(query, /*updatedRows*/42);
+    PRODUCER.addUpdateQuery(query, /*updatedRows*/ 42);
     try (final PreparedStatement stmt = connection.prepareStatement(query)) {
       int updated = stmt.executeUpdate();
       assertEquals(42, updated);
@@ -167,10 +177,12 @@ public class ArrowFlightPreparedStatementTest {
   @Test
   public void testUpdateQueryWithParameters() throws SQLException {
     String query = "Fake update with parameters";
-    PRODUCER.addUpdateQuery(query, /*updatedRows*/42);
-    PRODUCER.addExpectedParameters(query,
+    PRODUCER.addUpdateQuery(query, /*updatedRows*/ 42);
+    PRODUCER.addExpectedParameters(
+        query,
         new Schema(Collections.singletonList(Field.nullable("", ArrowType.Utf8.INSTANCE))),
-        Collections.singletonList(Collections.singletonList(new Text("foo".getBytes(StandardCharsets.UTF_8)))));
+        Collections.singletonList(
+            Collections.singletonList(new Text("foo".getBytes(StandardCharsets.UTF_8)))));
     try (final PreparedStatement stmt = connection.prepareStatement(query)) {
       // TODO: make sure this is validated on the server too
       stmt.setString(1, "foo");
@@ -182,29 +194,29 @@ public class ArrowFlightPreparedStatementTest {
   @Test
   public void testUpdateQueryWithBatchedParameters() throws SQLException {
     String query = "Fake update with batched parameters";
-    Schema parameterSchema = new Schema(Arrays.asList(
-            Field.nullable("", ArrowType.Utf8.INSTANCE),
-            new Field("", FieldType.nullable(ArrowType.List.INSTANCE),
+    Schema parameterSchema =
+        new Schema(
+            Arrays.asList(
+                Field.nullable("", ArrowType.Utf8.INSTANCE),
+                new Field(
+                    "",
+                    FieldType.nullable(ArrowType.List.INSTANCE),
                     Collections.singletonList(Field.nullable("", Types.MinorType.INT.getType())))));
-    List<List<Object>> expected = Arrays.asList(
-            Arrays.asList(
-                    new Text("foo"),
-                    new Integer[]{1, 2, null}),
-            Arrays.asList(
-                    new Text("bar"),
-                    new Integer[]{0, -1, 100000})
-            );
+    List<List<Object>> expected =
+        Arrays.asList(
+            Arrays.asList(new Text("foo"), new Integer[] {1, 2, null}),
+            Arrays.asList(new Text("bar"), new Integer[] {0, -1, 100000}));
 
-    PRODUCER.addUpdateQuery(query, /*updatedRows*/42);
+    PRODUCER.addUpdateQuery(query, /*updatedRows*/ 42);
     PRODUCER.addExpectedParameters(query, parameterSchema, expected);
 
     try (final PreparedStatement stmt = connection.prepareStatement(query)) {
       // TODO: make sure this is validated on the server too
       stmt.setString(1, "foo");
-      stmt.setArray(2, connection.createArrayOf("INTEGER", new Integer[]{1, 2, null}));
+      stmt.setArray(2, connection.createArrayOf("INTEGER", new Integer[] {1, 2, null}));
       stmt.addBatch();
       stmt.setString(1, "bar");
-      stmt.setArray(2, connection.createArrayOf("INTEGER", new Integer[]{0, -1, 100000}));
+      stmt.setArray(2, connection.createArrayOf("INTEGER", new Integer[] {0, -1, 100000}));
       stmt.addBatch();
       int[] updated = stmt.executeBatch();
       assertEquals(42, updated[0]);

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightStatementExecuteTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightStatementExecuteTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -32,7 +31,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -52,9 +50,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
-/**
- * Tests for {@link ArrowFlightStatement#execute}.
- */
+/** Tests for {@link ArrowFlightStatement#execute}. */
 public class ArrowFlightStatementExecuteTest {
   private static final String SAMPLE_QUERY_CMD = "SELECT * FROM this_test";
   private static final int SAMPLE_QUERY_ROWS = Byte.MAX_VALUE;
@@ -68,11 +64,12 @@ public class ArrowFlightStatementExecuteTest {
       "UPDATE this_large_table SET this_large_field = that_large_field FROM this_large_test WHERE this_large_condition";
   private static final long SAMPLE_LARGE_UPDATE_COUNT = Long.MAX_VALUE;
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
-  @ClassRule
-  public static final FlightServerTestRule SERVER_TEST_RULE = FlightServerTestRule.createStandardTestRule(PRODUCER);
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @ClassRule
+  public static final FlightServerTestRule SERVER_TEST_RULE =
+      FlightServerTestRule.createStandardTestRule(PRODUCER);
+
+  @Rule public final ErrorCollector collector = new ErrorCollector();
   private Connection connection;
   private Statement statement;
 
@@ -81,22 +78,24 @@ public class ArrowFlightStatementExecuteTest {
     PRODUCER.addSelectQuery(
         SAMPLE_QUERY_CMD,
         SAMPLE_QUERY_SCHEMA,
-        Collections.singletonList(listener -> {
-          try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-               final VectorSchemaRoot root = VectorSchemaRoot.create(SAMPLE_QUERY_SCHEMA,
-                   allocator)) {
-            final UInt1Vector vector = (UInt1Vector) root.getVector(VECTOR_NAME);
-            IntStream.range(0, SAMPLE_QUERY_ROWS).forEach(index -> vector.setSafe(index, index));
-            vector.setValueCount(SAMPLE_QUERY_ROWS);
-            root.setRowCount(SAMPLE_QUERY_ROWS);
-            listener.start(root);
-            listener.putNext();
-          } catch (final Throwable throwable) {
-            listener.error(throwable);
-          } finally {
-            listener.completed();
-          }
-        }));
+        Collections.singletonList(
+            listener -> {
+              try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                  final VectorSchemaRoot root =
+                      VectorSchemaRoot.create(SAMPLE_QUERY_SCHEMA, allocator)) {
+                final UInt1Vector vector = (UInt1Vector) root.getVector(VECTOR_NAME);
+                IntStream.range(0, SAMPLE_QUERY_ROWS)
+                    .forEach(index -> vector.setSafe(index, index));
+                vector.setValueCount(SAMPLE_QUERY_ROWS);
+                root.setRowCount(SAMPLE_QUERY_ROWS);
+                listener.start(root);
+                listener.putNext();
+              } catch (final Throwable throwable) {
+                listener.error(throwable);
+              } finally {
+                listener.completed();
+              }
+            }));
     PRODUCER.addUpdateQuery(SAMPLE_UPDATE_QUERY, SAMPLE_UPDATE_COUNT);
     PRODUCER.addUpdateQuery(SAMPLE_LARGE_UPDATE_QUERY, SAMPLE_LARGE_UPDATE_COUNT);
   }
@@ -119,10 +118,11 @@ public class ArrowFlightStatementExecuteTest {
 
   @Test
   public void testExecuteShouldRunSelectQuery() throws SQLException {
-    collector.checkThat(statement.execute(SAMPLE_QUERY_CMD),
-        is(true)); // Means this is a SELECT query.
+    collector.checkThat(
+        statement.execute(SAMPLE_QUERY_CMD), is(true)); // Means this is a SELECT query.
     final Set<Byte> numbers =
-        IntStream.range(0, SAMPLE_QUERY_ROWS).boxed()
+        IntStream.range(0, SAMPLE_QUERY_ROWS)
+            .boxed()
             .map(Integer::byteValue)
             .collect(Collectors.toCollection(HashSet::new));
     try (final ResultSet resultSet = statement.getResultSet()) {
@@ -142,8 +142,8 @@ public class ArrowFlightStatementExecuteTest {
 
   @Test
   public void testExecuteShouldRunUpdateQueryForSmallUpdate() throws SQLException {
-    collector.checkThat(statement.execute(SAMPLE_UPDATE_QUERY),
-        is(false)); // Means this is an UPDATE query.
+    collector.checkThat(
+        statement.execute(SAMPLE_UPDATE_QUERY), is(false)); // Means this is an UPDATE query.
     collector.checkThat(
         (long) statement.getUpdateCount(),
         is(allOf(equalTo(statement.getLargeUpdateCount()), equalTo(SAMPLE_UPDATE_COUNT))));
@@ -158,8 +158,10 @@ public class ArrowFlightStatementExecuteTest {
     collector.checkThat(updateCountLarge, is(equalTo(SAMPLE_LARGE_UPDATE_COUNT)));
     collector.checkThat(
         updateCountSmall,
-        is(allOf(equalTo((long) AvaticaUtils.toSaturatedInt(updateCountLarge)),
-            not(equalTo(updateCountLarge)))));
+        is(
+            allOf(
+                equalTo((long) AvaticaUtils.toSaturatedInt(updateCountLarge)),
+                not(equalTo(updateCountLarge)))));
     collector.checkThat(statement.getResultSet(), is(nullValue()));
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightStatementExecuteUpdateTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightStatementExecuteUpdateTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static java.lang.String.format;
@@ -29,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.Collections;
-
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -48,9 +46,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
-/**
- * Tests for {@link ArrowFlightStatement#executeUpdate}.
- */
+/** Tests for {@link ArrowFlightStatement#executeUpdate}. */
 public class ArrowFlightStatementExecuteUpdateTest {
   private static final String UPDATE_SAMPLE_QUERY =
       "UPDATE sample_table SET sample_col = sample_val WHERE sample_condition";
@@ -63,11 +59,12 @@ public class ArrowFlightStatementExecuteUpdateTest {
       new Schema(
           Collections.singletonList(Field.nullable("placeholder", MinorType.VARCHAR.getType())));
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
-  @ClassRule
-  public static final FlightServerTestRule SERVER_TEST_RULE = FlightServerTestRule.createStandardTestRule(PRODUCER);
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @ClassRule
+  public static final FlightServerTestRule SERVER_TEST_RULE =
+      FlightServerTestRule.createStandardTestRule(PRODUCER);
+
+  @Rule public final ErrorCollector collector = new ErrorCollector();
   public Connection connection;
   public Statement statement;
 
@@ -78,18 +75,19 @@ public class ArrowFlightStatementExecuteUpdateTest {
     PRODUCER.addSelectQuery(
         REGULAR_QUERY_SAMPLE,
         REGULAR_QUERY_SCHEMA,
-        Collections.singletonList(listener -> {
-          try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-               final VectorSchemaRoot root = VectorSchemaRoot.create(REGULAR_QUERY_SCHEMA,
-                   allocator)) {
-            listener.start(root);
-            listener.putNext();
-          } catch (final Throwable throwable) {
-            listener.error(throwable);
-          } finally {
-            listener.completed();
-          }
-        }));
+        Collections.singletonList(
+            listener -> {
+              try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                  final VectorSchemaRoot root =
+                      VectorSchemaRoot.create(REGULAR_QUERY_SCHEMA, allocator)) {
+                listener.start(root);
+                listener.putNext();
+              } catch (final Throwable throwable) {
+                listener.error(throwable);
+              } finally {
+                listener.completed();
+              }
+            }));
   }
 
   @Before
@@ -111,8 +109,8 @@ public class ArrowFlightStatementExecuteUpdateTest {
   @Test
   public void testExecuteUpdateShouldReturnNumColsAffectedForNumRowsFittingInt()
       throws SQLException {
-    collector.checkThat(statement.executeUpdate(UPDATE_SAMPLE_QUERY),
-        is(UPDATE_SAMPLE_QUERY_AFFECTED_COLS));
+    collector.checkThat(
+        statement.executeUpdate(UPDATE_SAMPLE_QUERY), is(UPDATE_SAMPLE_QUERY_AFFECTED_COLS));
   }
 
   @Test
@@ -122,10 +120,13 @@ public class ArrowFlightStatementExecuteUpdateTest {
     final long expectedRowCountRaw = LARGE_UPDATE_SAMPLE_QUERY_AFFECTED_COLS;
     collector.checkThat(
         result,
-        is(allOf(
-            not(equalTo(expectedRowCountRaw)),
-            equalTo((long) AvaticaUtils.toSaturatedInt(
-                expectedRowCountRaw))))); // Because of long-to-integer overflow.
+        is(
+            allOf(
+                not(equalTo(expectedRowCountRaw)),
+                equalTo(
+                    (long)
+                        AvaticaUtils.toSaturatedInt(
+                            expectedRowCountRaw))))); // Because of long-to-integer overflow.
   }
 
   @Test
@@ -161,10 +162,10 @@ public class ArrowFlightStatementExecuteUpdateTest {
 
   @Test
   public void testExecuteShouldExecuteUpdateQueryAutomatically() throws SQLException {
-    collector.checkThat(statement.execute(UPDATE_SAMPLE_QUERY),
-        is(false)); // Meaning there was an update query.
-    collector.checkThat(statement.execute(REGULAR_QUERY_SAMPLE),
-        is(true)); // Meaning there was a select query.
+    collector.checkThat(
+        statement.execute(UPDATE_SAMPLE_QUERY), is(false)); // Meaning there was an update query.
+    collector.checkThat(
+        statement.execute(REGULAR_QUERY_SAMPLE), is(true)); // Meaning there was a select query.
   }
 
   @Test

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionMutualTlsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionMutualTlsTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.Assert.assertNotNull;
@@ -27,7 +26,6 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
@@ -42,13 +40,10 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-/**
- * Tests encrypted connections.
- */
+/** Tests encrypted connections. */
 public class ConnectionMutualTlsTest {
 
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
   private static final String tlsRootCertsPath;
   private static final String clientMTlsCertPath;
   private static final String badClientMTlsCertPath;
@@ -59,15 +54,15 @@ public class ConnectionMutualTlsTest {
   private static final String passTest = "pass1";
 
   static {
-    final FlightSqlTestCertificates.CertKeyPair
-        certKey = FlightSqlTestCertificates.exampleTlsCerts().get(0);
+    final FlightSqlTestCertificates.CertKeyPair certKey =
+        FlightSqlTestCertificates.exampleTlsCerts().get(0);
 
     tlsRootCertsPath = certKey.cert.getPath();
 
     final File serverMTlsCACert = FlightSqlTestCertificates.exampleCACert();
 
-    final FlightSqlTestCertificates.CertKeyPair
-        clientMTlsCertKey = FlightSqlTestCertificates.exampleTlsCerts().get(1);
+    final FlightSqlTestCertificates.CertKeyPair clientMTlsCertKey =
+        FlightSqlTestCertificates.exampleTlsCerts().get(1);
 
     clientMTlsCertPath = clientMTlsCertKey.cert.getPath();
     clientMTlsKeyPath = clientMTlsCertKey.key.getPath();
@@ -75,16 +70,16 @@ public class ConnectionMutualTlsTest {
     badClientMTlsCertPath = clientMTlsCertPath + ".bad";
     badClientMTlsKeyPath = clientMTlsKeyPath + ".bad";
 
-    UserPasswordAuthentication authentication = new UserPasswordAuthentication.Builder()
-            .user(userTest, passTest)
-            .build();
+    UserPasswordAuthentication authentication =
+        new UserPasswordAuthentication.Builder().user(userTest, passTest).build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(authentication)
-        .useEncryption(certKey.cert, certKey.key)
-        .useMTlsClientVerification(serverMTlsCACert)
-        .producer(PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(authentication)
+            .useEncryption(certKey.cert, certKey.key)
+            .useMTlsClientVerification(serverMTlsCACert)
+            .producer(PRODUCER)
+            .build();
   }
 
   private BufferAllocator allocator;
@@ -109,17 +104,17 @@ public class ConnectionMutualTlsTest {
   public void testGetEncryptedClientAuthenticated() throws Exception {
 
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-                 .withUsername(userTest)
-                 .withPassword(passTest)
-                 .withTlsRootCertificates(tlsRootCertsPath)
-                 .withClientCertificate(clientMTlsCertPath)
-                 .withClientKey(clientMTlsKeyPath)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withUsername(userTest)
+            .withPassword(passTest)
+            .withTlsRootCertificates(tlsRootCertsPath)
+            .withClientCertificate(clientMTlsCertPath)
+            .withClientKey(clientMTlsKeyPath)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       assertNotNull(client);
     }
   }
@@ -131,21 +126,24 @@ public class ConnectionMutualTlsTest {
   @Test
   public void testGetEncryptedClientWithBadMTlsCertPath() {
 
-    assertThrows(SQLException.class, () -> {
-      try (ArrowFlightSqlClientHandler handler = new ArrowFlightSqlClientHandler.Builder()
-          .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-          .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-          .withUsername(userTest)
-          .withPassword(passTest)
-          .withTlsRootCertificates(tlsRootCertsPath)
-          .withClientCertificate(badClientMTlsCertPath)
-          .withClientKey(clientMTlsKeyPath)
-          .withBufferAllocator(allocator)
-          .withEncryption(true)
-          .build()) {
-        Assert.fail();
-      }
-    });
+    assertThrows(
+        SQLException.class,
+        () -> {
+          try (ArrowFlightSqlClientHandler handler =
+              new ArrowFlightSqlClientHandler.Builder()
+                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+                  .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+                  .withUsername(userTest)
+                  .withPassword(passTest)
+                  .withTlsRootCertificates(tlsRootCertsPath)
+                  .withClientCertificate(badClientMTlsCertPath)
+                  .withClientKey(clientMTlsKeyPath)
+                  .withBufferAllocator(allocator)
+                  .withEncryption(true)
+                  .build()) {
+            Assert.fail();
+          }
+        });
   }
 
   /**
@@ -155,21 +153,24 @@ public class ConnectionMutualTlsTest {
   @Test
   public void testGetEncryptedClientWithBadMTlsKeyPath() {
 
-    assertThrows(SQLException.class, () -> {
-      try (ArrowFlightSqlClientHandler handler = new ArrowFlightSqlClientHandler.Builder()
-          .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-          .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-          .withUsername(userTest)
-          .withPassword(passTest)
-          .withTlsRootCertificates(tlsRootCertsPath)
-          .withClientCertificate(clientMTlsCertPath)
-          .withClientKey(badClientMTlsKeyPath)
-          .withBufferAllocator(allocator)
-          .withEncryption(true)
-          .build()) {
-        Assert.fail();
-      }
-    });
+    assertThrows(
+        SQLException.class,
+        () -> {
+          try (ArrowFlightSqlClientHandler handler =
+              new ArrowFlightSqlClientHandler.Builder()
+                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+                  .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+                  .withUsername(userTest)
+                  .withPassword(passTest)
+                  .withTlsRootCertificates(tlsRootCertsPath)
+                  .withClientCertificate(clientMTlsCertPath)
+                  .withClientKey(badClientMTlsKeyPath)
+                  .withBufferAllocator(allocator)
+                  .withEncryption(true)
+                  .build()) {
+            Assert.fail();
+          }
+        });
   }
 
   /**
@@ -180,21 +181,21 @@ public class ConnectionMutualTlsTest {
   @Test
   public void testGetNonAuthenticatedEncryptedClientNoAuth() throws Exception {
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withTlsRootCertificates(tlsRootCertsPath)
-                 .withClientCertificate(clientMTlsCertPath)
-                 .withClientKey(clientMTlsKeyPath)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withTlsRootCertificates(tlsRootCertsPath)
+            .withClientCertificate(clientMTlsCertPath)
+            .withClientKey(clientMTlsKeyPath)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       assertNotNull(client);
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when the
-   * provided valid credentials and a valid TLS Root Certs path.
+   * Check if an encrypted connection can be established successfully when the provided valid
+   * credentials and a valid TLS Root Certs path.
    *
    * @throws Exception on error.
    */
@@ -203,18 +204,14 @@ public class ConnectionMutualTlsTest {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
-    properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
-        tlsRootCertsPath);
-    properties.put(ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(),
-        clientMTlsCertPath);
-    properties.put(ArrowFlightConnectionProperty.CLIENT_KEY.camelName(),
-        clientMTlsKeyPath);
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
+    properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
+    properties.put(
+        ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
+    properties.put(ArrowFlightConnectionProperty.CLIENT_KEY.camelName(), clientMTlsKeyPath);
 
     final ArrowFlightJdbcDataSource dataSource =
         ArrowFlightJdbcDataSource.createNewDataSource(properties);
@@ -224,8 +221,8 @@ public class ConnectionMutualTlsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when not
-   * providing authentication.
+   * Check if an encrypted connection can be established successfully when not providing
+   * authentication.
    *
    * @throws Exception on error.
    */
@@ -233,22 +230,26 @@ public class ConnectionMutualTlsTest {
   public void testGetNonAuthenticatedEncryptedConnection() throws Exception {
     final Properties properties = new Properties();
 
-    properties.put(ArrowFlightConnectionProperty.HOST.camelName(), FLIGHT_SERVER_TEST_RULE.getHost());
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(
+        ArrowFlightConnectionProperty.HOST.camelName(), FLIGHT_SERVER_TEST_RULE.getHost());
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), true);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
-    properties.put(ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
+    properties.put(
+        ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
     properties.put(ArrowFlightConnectionProperty.CLIENT_KEY.camelName(), clientMTlsKeyPath);
 
-    final ArrowFlightJdbcDataSource dataSource = ArrowFlightJdbcDataSource.createNewDataSource(properties);
+    final ArrowFlightJdbcDataSource dataSource =
+        ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
       Assert.assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through
-   * the DriverManager using just a connection url.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using just a connection url.
    *
    * @throws Exception on error.
    */
@@ -257,9 +258,10 @@ public class ConnectionMutualTlsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    final String jdbcUrl = String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
-                    "&useEncryption=true&%s=%s&%s=%s&%s=%s",
+    final String jdbcUrl =
+        String.format(
+            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s"
+                + "&useEncryption=true&%s=%s&%s=%s&%s=%s",
             FLIGHT_SERVER_TEST_RULE.getPort(),
             userTest,
             passTest,
@@ -276,14 +278,15 @@ public class ConnectionMutualTlsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with String K-V pairs.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with String K-V pairs.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -291,14 +294,15 @@ public class ConnectionMutualTlsTest {
 
     properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
-    properties.setProperty(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "true");
-    properties.setProperty(ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
     properties.setProperty(ArrowFlightConnectionProperty.CLIENT_KEY.camelName(), clientMTlsKeyPath);
 
-    final String jdbcUrl = String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort());
+    final String jdbcUrl =
+        String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort());
 
     try (Connection connection = DriverManager.getConnection(jdbcUrl, properties)) {
       Assert.assertTrue(connection.isValid(0));
@@ -306,8 +310,8 @@ public class ConnectionMutualTlsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with Object K-V pairs.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with Object K-V pairs.
    *
    * @throws Exception on error.
    */
@@ -323,12 +327,12 @@ public class ConnectionMutualTlsTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), true);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
-    properties.put(ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
+    properties.put(
+        ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
     properties.put(ArrowFlightConnectionProperty.CLIENT_KEY.camelName(), clientMTlsKeyPath);
 
-    final String jdbcUrl = String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort());
+    final String jdbcUrl =
+        String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort());
 
     try (Connection connection = DriverManager.getConnection(jdbcUrl, properties)) {
       Assert.assertTrue(connection.isValid(0));
@@ -336,8 +340,8 @@ public class ConnectionMutualTlsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * just a connection url and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using just a connection url and using 0 and 1 as ssl values.
    *
    * @throws Exception on error.
    */
@@ -347,9 +351,10 @@ public class ConnectionMutualTlsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    final String jdbcUrl = String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
-                    "&useEncryption=1&useSystemTrustStore=0&%s=%s&%s=%s&%s=%s",
+    final String jdbcUrl =
+        String.format(
+            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s"
+                + "&useEncryption=1&useSystemTrustStore=0&%s=%s&%s=%s&%s=%s",
             FLIGHT_SERVER_TEST_RULE.getPort(),
             userTest,
             passTest,
@@ -366,14 +371,16 @@ public class ConnectionMutualTlsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with String K-V pairs and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with String K-V pairs and using 0 and 1 as
+   * ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -381,12 +388,15 @@ public class ConnectionMutualTlsTest {
 
     properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
-    properties.setProperty(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "1");
-    properties.setProperty(ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
     properties.setProperty(ArrowFlightConnectionProperty.CLIENT_KEY.camelName(), clientMTlsKeyPath);
 
-    final String jdbcUrl = String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort());
+    final String jdbcUrl =
+        String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort());
 
     try (Connection connection = DriverManager.getConnection(jdbcUrl, properties)) {
       Assert.assertTrue(connection.isValid(0));
@@ -394,14 +404,16 @@ public class ConnectionMutualTlsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with Object K-V pairs and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1 as
+   * ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -411,11 +423,12 @@ public class ConnectionMutualTlsTest {
     properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), 1);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
-    properties.put(ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
+    properties.put(
+        ArrowFlightConnectionProperty.CLIENT_CERTIFICATE.camelName(), clientMTlsCertPath);
     properties.put(ArrowFlightConnectionProperty.CLIENT_KEY.camelName(), clientMTlsKeyPath);
 
-    final String jdbcUrl = String.format("jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort());
+    final String jdbcUrl =
+        String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort());
 
     try (Connection connection = DriverManager.getConnection(jdbcUrl, properties)) {
       Assert.assertTrue(connection.isValid(0));

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.Assert.assertNotNull;
@@ -28,7 +27,6 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
@@ -42,27 +40,23 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-/**
- * Tests for {@link Connection}.
- */
+/** Tests for {@link Connection}. */
 public class ConnectionTest {
 
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
   private static final String userTest = "user1";
   private static final String passTest = "pass1";
 
   static {
     UserPasswordAuthentication authentication =
-        new UserPasswordAuthentication.Builder()
-            .user(userTest, passTest)
-            .build();
+        new UserPasswordAuthentication.Builder().user(userTest, passTest).build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(authentication)
-        .producer(PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(authentication)
+            .producer(PRODUCER)
+            .build();
   }
 
   private BufferAllocator allocator;
@@ -79,8 +73,8 @@ public class ConnectionTest {
   }
 
   /**
-   * Checks if an unencrypted connection can be established successfully when
-   * the provided valid credentials.
+   * Checks if an unencrypted connection can be established successfully when the provided valid
+   * credentials.
    *
    * @throws SQLException on error.
    */
@@ -90,58 +84,64 @@ public class ConnectionTest {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" +
-            FLIGHT_SERVER_TEST_RULE.getPort(), properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            "jdbc:arrow-flight-sql://"
+                + FLIGHT_SERVER_TEST_RULE.getHost()
+                + ":"
+                + FLIGHT_SERVER_TEST_RULE.getPort(),
+            properties)) {
       Assert.assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Checks if a token is provided it takes precedence over username/pass. In this case,
-   * the connection should fail if a token is passed in.
+   * Checks if a token is provided it takes precedence over username/pass. In this case, the
+   * connection should fail if a token is passed in.
    */
   @Test
   public void testTokenOverridesUsernameAndPasswordAuth() {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.TOKEN.camelName(), "token");
     properties.put("useEncryption", false);
 
-    SQLException e = assertThrows(SQLException.class, () -> {
-      try (Connection conn = DriverManager.getConnection(
-          "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" + FLIGHT_SERVER_TEST_RULE.getPort(),
-          properties)) {
-        Assert.fail();
-      }
-    });
+    SQLException e =
+        assertThrows(
+            SQLException.class,
+            () -> {
+              try (Connection conn =
+                  DriverManager.getConnection(
+                      "jdbc:arrow-flight-sql://"
+                          + FLIGHT_SERVER_TEST_RULE.getHost()
+                          + ":"
+                          + FLIGHT_SERVER_TEST_RULE.getPort(),
+                      properties)) {
+                Assert.fail();
+              }
+            });
     assertTrue(e.getMessage().contains("UNAUTHENTICATED"));
   }
 
-
   /**
-   * Checks if the exception SQLException is thrown when trying to establish a connection without a host.
+   * Checks if the exception SQLException is thrown when trying to establish a connection without a
+   * host.
    *
    * @throws SQLException on error.
    */
   @Test(expected = SQLException.class)
-  public void testUnencryptedConnectionWithEmptyHost()
-      throws Exception {
+  public void testUnencryptedConnectionWithEmptyHost() throws Exception {
     final Properties properties = new Properties();
 
     properties.put("user", userTest);
@@ -159,43 +159,38 @@ public class ConnectionTest {
    * @throws URISyntaxException on error.
    */
   @Test
-  public void testGetBasicClientAuthenticatedShouldOpenConnection()
-      throws Exception {
+  public void testGetBasicClientAuthenticatedShouldOpenConnection() throws Exception {
 
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-                 .withEncryption(false)
-                 .withUsername(userTest)
-                 .withPassword(passTest)
-                 .withBufferAllocator(allocator)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withEncryption(false)
+            .withUsername(userTest)
+            .withPassword(passTest)
+            .withBufferAllocator(allocator)
+            .build()) {
 
       assertNotNull(client);
     }
   }
 
   /**
-   * Checks if the exception IllegalArgumentException is thrown when trying to establish an  unencrypted
-   * connection providing with an invalid port.
+   * Checks if the exception IllegalArgumentException is thrown when trying to establish an
+   * unencrypted connection providing with an invalid port.
    *
    * @throws SQLException on error.
    */
   @Test(expected = SQLException.class)
-  public void testUnencryptedConnectionProvidingInvalidPort()
-      throws Exception {
+  public void testUnencryptedConnectionProvidingInvalidPort() throws Exception {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
-    properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(),
-        false);
-    final String invalidUrl = "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() +
-        ":" + 65537;
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
+    properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
+    final String invalidUrl =
+        "jdbc:arrow-flight-sql://" + FLIGHT_SERVER_TEST_RULE.getHost() + ":" + 65537;
 
     try (Connection conn = DriverManager.getConnection(invalidUrl, properties)) {
       fail("Expected SQLException");
@@ -211,18 +206,18 @@ public class ConnectionTest {
   public void testGetBasicClientNoAuthShouldOpenConnection() throws Exception {
 
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withBufferAllocator(allocator)
-                 .withEncryption(false)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withBufferAllocator(allocator)
+            .withEncryption(false)
+            .build()) {
       assertNotNull(client);
     }
   }
 
   /**
-   * Checks if an unencrypted connection can be established successfully when
-   * not providing credentials.
+   * Checks if an unencrypted connection can be established successfully when not providing
+   * credentials.
    *
    * @throws SQLException on error.
    */
@@ -231,19 +226,17 @@ public class ConnectionTest {
       throws Exception {
     final Properties properties = new Properties();
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(),
-        false);
-    try (Connection connection = DriverManager
-        .getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
+    try (Connection connection =
+        DriverManager.getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
       Assert.assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Check if an unencrypted connection throws an exception when provided with
-   * invalid credentials.
+   * Check if an unencrypted connection throws an exception when provided with invalid credentials.
    *
    * @throws SQLException The exception expected to be thrown.
    */
@@ -254,17 +247,14 @@ public class ConnectionTest {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        "invalidUser");
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(),
-        false);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        "invalidPassword");
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), "invalidUser");
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), "invalidPassword");
 
-    try (Connection ignored = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost:32010",
-        properties)) {
+    try (Connection ignored =
+        DriverManager.getConnection("jdbc:arrow-flight-sql://localhost:32010", properties)) {
       Assert.fail();
     }
   }
@@ -280,12 +270,11 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=false",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=false",
+                FLIGHT_SERVER_TEST_RULE.getPort(), userTest, passTest))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
@@ -297,24 +286,23 @@ public class ConnectionTest {
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyFalseCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyFalseCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
     Properties properties = new Properties();
 
-    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "false");
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
@@ -332,17 +320,15 @@ public class ConnectionTest {
     DriverManager.registerDriver(driver);
 
     Properties properties = new Properties();
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
@@ -359,70 +345,67 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=0",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=0",
+                FLIGHT_SERVER_TEST_RULE.getPort(), userTest, passTest))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
    * Check if an non-encrypted connection can be established successfully when connecting through
-   * the DriverManager using a connection url and properties with String K-V pairs and using
-   * 0 and 1 as ssl values.
+   * the DriverManager using a connection url and properties with String K-V pairs and using 0 and 1
+   * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
     Properties properties = new Properties();
 
-    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "0");
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
    * Check if an non-encrypted connection can be established successfully when connecting through
-   * the DriverManager using a connection url and properties with Object K-V pairs and using
-   * 0 and 1 as ssl values.
+   * the DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1
+   * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyFalseIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
     Properties properties = new Properties();
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), 0);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
@@ -439,73 +422,69 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&threadPoolSize=1&useEncryption=%s",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest,
-            false))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&threadPoolSize=1&useEncryption=%s",
+                FLIGHT_SERVER_TEST_RULE.getPort(), userTest, passTest, false))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
    * Check if an non-encrypted connection can be established successfully when connecting through
-   * the DriverManager using a connection url and properties with String K-V pairs and using
-   * 0 and 1 as ssl values.
+   * the DriverManager using a connection url and properties with String K-V pairs and using 0 and 1
+   * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
     Properties properties = new Properties();
 
-    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.setProperty(ArrowFlightConnectionProperty.THREAD_POOL_SIZE.camelName(), "1");
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
    * Check if an non-encrypted connection can be established successfully when connecting through
-   * the DriverManager using a connection url and properties with Object K-V pairs and using
-   * 0 and 1 as ssl values.
+   * the DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1
+   * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testThreadPoolSizeConnectionPropertyCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
     Properties properties = new Properties();
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.THREAD_POOL_SIZE.camelName(), 1);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
@@ -522,71 +501,67 @@ public class ConnectionTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=%s",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest,
-            false))) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s&useEncryption=%s",
+                FLIGHT_SERVER_TEST_RULE.getPort(), userTest, passTest, false))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
    * Check if an non-encrypted connection can be established successfully when connecting through
-   * the DriverManager using a connection url and properties with String K-V pairs and using
-   * 0 and 1 as ssl values.
+   * the DriverManager using a connection url and properties with String K-V pairs and using 0 and 1
+   * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
     Properties properties = new Properties();
 
-    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
    * Check if an non-encrypted connection can be established successfully when connecting through
-   * the DriverManager using a connection url and properties with Object K-V pairs and using
-   * 0 and 1 as ssl values.
+   * the DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1
+   * as ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testPasswordConnectionPropertyIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
     Properties properties = new Properties();
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put("useEncryption", false);
 
-    try (Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsRootCertsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsRootCertsTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.Assert.assertNotNull;
@@ -26,7 +25,6 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
@@ -41,14 +39,10 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-
-/**
- * Tests encrypted connections.
- */
+/** Tests encrypted connections. */
 public class ConnectionTlsRootCertsTest {
 
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
   private static final String tlsRootCertsPath;
   private static final String badTlsRootCertsPath;
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
@@ -56,22 +50,22 @@ public class ConnectionTlsRootCertsTest {
   private static final String passTest = "pass1";
 
   static {
-    final FlightSqlTestCertificates.CertKeyPair
-        certKey = FlightSqlTestCertificates.exampleTlsCerts().get(0);
+    final FlightSqlTestCertificates.CertKeyPair certKey =
+        FlightSqlTestCertificates.exampleTlsCerts().get(0);
 
     tlsRootCertsPath = certKey.cert.getPath();
 
     badTlsRootCertsPath = certKey.cert.getPath() + ".bad";
 
-    UserPasswordAuthentication authentication = new UserPasswordAuthentication.Builder()
-            .user(userTest, passTest)
-            .build();
+    UserPasswordAuthentication authentication =
+        new UserPasswordAuthentication.Builder().user(userTest, passTest).build();
 
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(authentication)
-        .useEncryption(certKey.cert, certKey.key)
-        .producer(PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(authentication)
+            .useEncryption(certKey.cert, certKey.key)
+            .producer(PRODUCER)
+            .build();
   }
 
   private BufferAllocator allocator;
@@ -96,35 +90,38 @@ public class ConnectionTlsRootCertsTest {
   public void testGetEncryptedClientAuthenticated() throws Exception {
 
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-                 .withUsername(userTest)
-                 .withPassword(passTest)
-                 .withTlsRootCertificates(tlsRootCertsPath)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withUsername(userTest)
+            .withPassword(passTest)
+            .withTlsRootCertificates(tlsRootCertsPath)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       assertNotNull(client);
     }
   }
 
   /**
-   * Try to instantiate an encrypted FlightClient providing a bad TLS Root Certs Path. It's expected to
-   * receive the SQLException.
+   * Try to instantiate an encrypted FlightClient providing a bad TLS Root Certs Path. It's expected
+   * to receive the SQLException.
    */
   @Test
   public void testGetEncryptedClientWithNoCertificateOnKeyStore() {
-    assertThrows(SQLException.class, () -> {
-      try (ArrowFlightSqlClientHandler handler = new ArrowFlightSqlClientHandler.Builder()
-          .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-          .withTlsRootCertificates(badTlsRootCertsPath)
-          .withBufferAllocator(allocator)
-          .withEncryption(true)
-          .build()) {
-        Assert.fail();
-      }
-    });
+    assertThrows(
+        SQLException.class,
+        () -> {
+          try (ArrowFlightSqlClientHandler handler =
+              new ArrowFlightSqlClientHandler.Builder()
+                  .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+                  .withTlsRootCertificates(badTlsRootCertsPath)
+                  .withBufferAllocator(allocator)
+                  .withEncryption(true)
+                  .build()) {
+            Assert.fail();
+          }
+        });
   }
 
   /**
@@ -135,19 +132,19 @@ public class ConnectionTlsRootCertsTest {
   @Test
   public void testGetNonAuthenticatedEncryptedClientNoAuth() throws Exception {
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withTlsRootCertificates(tlsRootCertsPath)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withTlsRootCertificates(tlsRootCertsPath)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       assertNotNull(client);
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when the
-   * provided valid credentials and a valid TLS Root Certs path.
+   * Check if an encrypted connection can be established successfully when the provided valid
+   * credentials and a valid TLS Root Certs path.
    *
    * @throws Exception on error.
    */
@@ -156,14 +153,11 @@ public class ConnectionTlsRootCertsTest {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
-    properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
-        tlsRootCertsPath);
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
+    properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
 
     final ArrowFlightJdbcDataSource dataSource =
         ArrowFlightJdbcDataSource.createNewDataSource(properties);
@@ -173,8 +167,8 @@ public class ConnectionTlsRootCertsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when not
-   * providing authentication.
+   * Check if an encrypted connection can be established successfully when not providing
+   * authentication.
    *
    * @throws Exception on error.
    */
@@ -182,20 +176,23 @@ public class ConnectionTlsRootCertsTest {
   public void testGetNonAuthenticatedEncryptedConnection() throws Exception {
     final Properties properties = new Properties();
 
-    properties.put(ArrowFlightConnectionProperty.HOST.camelName(), FLIGHT_SERVER_TEST_RULE.getHost());
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(
+        ArrowFlightConnectionProperty.HOST.camelName(), FLIGHT_SERVER_TEST_RULE.getHost());
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), true);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
 
-    final ArrowFlightJdbcDataSource dataSource = ArrowFlightJdbcDataSource.createNewDataSource(properties);
+    final ArrowFlightJdbcDataSource dataSource =
+        ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
       Assert.assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through
-   * the DriverManager using just a connection url.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using just a connection url.
    *
    * @throws Exception on error.
    */
@@ -204,28 +201,30 @@ public class ConnectionTlsRootCertsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
-                "&useEncryption=true&%s=%s",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest,
-            ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
-            URLEncoder.encode(tlsRootCertsPath, "UTF-8")))) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s"
+                    + "&useEncryption=true&%s=%s",
+                FLIGHT_SERVER_TEST_RULE.getPort(),
+                userTest,
+                passTest,
+                ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
+                URLEncoder.encode(tlsRootCertsPath, "UTF-8")))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with String K-V pairs.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with String K-V pairs.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -233,21 +232,22 @@ public class ConnectionTlsRootCertsTest {
 
     properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
-    properties.setProperty(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "true");
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with Object K-V pairs.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with Object K-V pairs.
    *
    * @throws Exception on error.
    */
@@ -264,18 +264,18 @@ public class ConnectionTlsRootCertsTest {
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), true);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * just a connection url and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using just a connection url and using 0 and 1 as ssl values.
    *
    * @throws Exception on error.
    */
@@ -285,28 +285,31 @@ public class ConnectionTlsRootCertsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
-                "&useEncryption=1&useSystemTrustStore=0&%s=%s",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest,
-            ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
-            URLEncoder.encode(tlsRootCertsPath, "UTF-8")))) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s"
+                    + "&useEncryption=1&useSystemTrustStore=0&%s=%s",
+                FLIGHT_SERVER_TEST_RULE.getPort(),
+                userTest,
+                passTest,
+                ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(),
+                URLEncoder.encode(tlsRootCertsPath, "UTF-8")))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with String K-V pairs and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with String K-V pairs and using 0 and 1 as
+   * ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -314,25 +317,30 @@ public class ConnectionTlsRootCertsTest {
 
     properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
-    properties.setProperty(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "1");
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with Object K-V pairs and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1 as
+   * ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -343,10 +351,11 @@ public class ConnectionTlsRootCertsTest {
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), 1);
     properties.put(ArrowFlightConnectionProperty.TLS_ROOT_CERTS.camelName(), tlsRootCertsPath);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format("jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ConnectionTlsTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.Assert.assertNotNull;
@@ -26,7 +25,6 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.client.ArrowFlightSqlClientHandler;
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
@@ -42,30 +40,27 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-/**
- * Tests encrypted connections.
- */
+/** Tests encrypted connections. */
 public class ConnectionTlsTest {
 
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
   private static final MockFlightSqlProducer PRODUCER = new MockFlightSqlProducer();
   private static final String userTest = "user1";
   private static final String passTest = "pass1";
 
   static {
-    final FlightSqlTestCertificates.CertKeyPair
-        certKey = FlightSqlTestCertificates.exampleTlsCerts().get(0);
+    final FlightSqlTestCertificates.CertKeyPair certKey =
+        FlightSqlTestCertificates.exampleTlsCerts().get(0);
 
-    UserPasswordAuthentication authentication = new UserPasswordAuthentication.Builder()
-            .user(userTest, passTest)
+    UserPasswordAuthentication authentication =
+        new UserPasswordAuthentication.Builder().user(userTest, passTest).build();
+
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(authentication)
+            .useEncryption(certKey.cert, certKey.key)
+            .producer(PRODUCER)
             .build();
-
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(authentication)
-        .useEncryption(certKey.cert, certKey.key)
-        .producer(PRODUCER)
-        .build();
   }
 
   private String trustStorePath;
@@ -75,10 +70,14 @@ public class ConnectionTlsTest {
 
   @Before
   public void setUp() throws Exception {
-    trustStorePath = Paths.get(
-        Preconditions.checkNotNull(getClass().getResource("/keys/keyStore.jks")).toURI()).toString();
-    noCertificateKeyStorePath = Paths.get(
-        Preconditions.checkNotNull(getClass().getResource("/keys/noCertificate.jks")).toURI()).toString();
+    trustStorePath =
+        Paths.get(Preconditions.checkNotNull(getClass().getResource("/keys/keyStore.jks")).toURI())
+            .toString();
+    noCertificateKeyStorePath =
+        Paths.get(
+                Preconditions.checkNotNull(getClass().getResource("/keys/noCertificate.jks"))
+                    .toURI())
+            .toString();
     allocator = new RootAllocator(Long.MAX_VALUE);
   }
 
@@ -97,15 +96,15 @@ public class ConnectionTlsTest {
   public void testGetEncryptedClientAuthenticatedWithDisableCertVerification() throws Exception {
 
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-                 .withUsername(userTest)
-                 .withPassword(passTest)
-                 .withDisableCertificateVerification(true)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withUsername(userTest)
+            .withPassword(passTest)
+            .withDisableCertificateVerification(true)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       assertNotNull(client);
     }
   }
@@ -119,24 +118,24 @@ public class ConnectionTlsTest {
   public void testGetEncryptedClientAuthenticated() throws Exception {
 
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-                 .withSystemTrustStore(false)
-                 .withUsername(userTest)
-                 .withPassword(passTest)
-                 .withTrustStorePath(trustStorePath)
-                 .withTrustStorePassword(trustStorePass)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withSystemTrustStore(false)
+            .withUsername(userTest)
+            .withPassword(passTest)
+            .withTrustStorePath(trustStorePath)
+            .withTrustStorePassword(trustStorePass)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       assertNotNull(client);
     }
   }
 
   /**
-   * Try to instantiate an encrypted FlightClient providing a keystore without certificate. It's expected to
-   * receive the SQLException.
+   * Try to instantiate an encrypted FlightClient providing a keystore without certificate. It's
+   * expected to receive the SQLException.
    *
    * @throws Exception on error.
    */
@@ -145,14 +144,14 @@ public class ConnectionTlsTest {
     final String noCertificateKeyStorePassword = "flight1";
 
     try (ArrowFlightSqlClientHandler ignored =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withTrustStorePath(noCertificateKeyStorePath)
-                 .withTrustStorePassword(noCertificateKeyStorePassword)
-                 .withSystemTrustStore(false)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withTrustStorePath(noCertificateKeyStorePath)
+            .withTrustStorePassword(noCertificateKeyStorePassword)
+            .withSystemTrustStore(false)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       Assert.fail();
     }
   }
@@ -165,14 +164,14 @@ public class ConnectionTlsTest {
   @Test
   public void testGetNonAuthenticatedEncryptedClientNoAuth() throws Exception {
     try (ArrowFlightSqlClientHandler client =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withSystemTrustStore(false)
-                 .withTrustStorePath(trustStorePath)
-                 .withTrustStorePassword(trustStorePass)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withSystemTrustStore(false)
+            .withTrustStorePath(trustStorePath)
+            .withTrustStorePassword(trustStorePass)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       assertNotNull(client);
     }
   }
@@ -188,21 +187,21 @@ public class ConnectionTlsTest {
     String keyStoreBadPassword = "badPassword";
 
     try (ArrowFlightSqlClientHandler ignored =
-             new ArrowFlightSqlClientHandler.Builder()
-                 .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-                 .withSystemTrustStore(false)
-                 .withTrustStorePath(trustStorePath)
-                 .withTrustStorePassword(keyStoreBadPassword)
-                 .withBufferAllocator(allocator)
-                 .withEncryption(true)
-                 .build()) {
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withSystemTrustStore(false)
+            .withTrustStorePath(trustStorePath)
+            .withTrustStorePassword(keyStoreBadPassword)
+            .withBufferAllocator(allocator)
+            .withEncryption(true)
+            .build()) {
       Assert.fail();
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when the
-   * provided valid credentials and a valid Keystore.
+   * Check if an encrypted connection can be established successfully when the provided valid
+   * credentials and a valid Keystore.
    *
    * @throws Exception on error.
    */
@@ -211,12 +210,10 @@ public class ConnectionTlsTest {
     final Properties properties = new Properties();
 
     properties.put(ArrowFlightConnectionProperty.HOST.camelName(), "localhost");
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
     properties.put(ArrowFlightConnectionProperty.USE_SYSTEM_TRUST_STORE.camelName(), false);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
@@ -229,8 +226,8 @@ public class ConnectionTlsTest {
   }
 
   /**
-   * Check if the SQLException is thrown when trying to establish an encrypted connection
-   * providing valid credentials but invalid password to the Keystore.
+   * Check if the SQLException is thrown when trying to establish an encrypted connection providing
+   * valid credentials but invalid password to the Keystore.
    *
    * @throws SQLException on error.
    */
@@ -238,14 +235,12 @@ public class ConnectionTlsTest {
   public void testGetAuthenticatedEncryptedConnectionWithKeyStoreBadPassword() throws Exception {
     final Properties properties = new Properties();
 
-    properties.put(ArrowFlightConnectionProperty.HOST.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getHost());
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(),
-        FLIGHT_SERVER_TEST_RULE.getPort());
-    properties.put(ArrowFlightConnectionProperty.USER.camelName(),
-        userTest);
-    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(),
-        passTest);
+    properties.put(
+        ArrowFlightConnectionProperty.HOST.camelName(), FLIGHT_SERVER_TEST_RULE.getHost());
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(ArrowFlightConnectionProperty.USER.camelName(), userTest);
+    properties.put(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), true);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), "badpassword");
@@ -258,7 +253,8 @@ public class ConnectionTlsTest {
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when not providing authentication.
+   * Check if an encrypted connection can be established successfully when not providing
+   * authentication.
    *
    * @throws Exception on error.
    */
@@ -266,22 +262,25 @@ public class ConnectionTlsTest {
   public void testGetNonAuthenticatedEncryptedConnection() throws Exception {
     final Properties properties = new Properties();
 
-    properties.put(ArrowFlightConnectionProperty.HOST.camelName(), FLIGHT_SERVER_TEST_RULE.getHost());
-    properties.put(ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
+    properties.put(
+        ArrowFlightConnectionProperty.HOST.camelName(), FLIGHT_SERVER_TEST_RULE.getHost());
+    properties.put(
+        ArrowFlightConnectionProperty.PORT.camelName(), FLIGHT_SERVER_TEST_RULE.getPort());
     properties.put(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), true);
     properties.put(ArrowFlightConnectionProperty.USE_SYSTEM_TRUST_STORE.camelName(), false);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
 
-    final ArrowFlightJdbcDataSource dataSource = ArrowFlightJdbcDataSource.createNewDataSource(properties);
+    final ArrowFlightJdbcDataSource dataSource =
+        ArrowFlightJdbcDataSource.createNewDataSource(properties);
     try (final Connection connection = dataSource.getConnection()) {
       Assert.assertTrue(connection.isValid(300));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * just a connection url.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using just a connection url.
    *
    * @throws Exception on error.
    */
@@ -290,30 +289,32 @@ public class ConnectionTlsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
-                "&useEncryption=true&useSystemTrustStore=false&%s=%s&%s=%s",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest,
-            ArrowFlightConnectionProperty.TRUST_STORE.camelName(),
-            URLEncoder.encode(trustStorePath, "UTF-8"),
-            ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(),
-            URLEncoder.encode(trustStorePass, "UTF-8")))) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s"
+                    + "&useEncryption=true&useSystemTrustStore=false&%s=%s&%s=%s",
+                FLIGHT_SERVER_TEST_RULE.getPort(),
+                userTest,
+                passTest,
+                ArrowFlightConnectionProperty.TRUST_STORE.camelName(),
+                URLEncoder.encode(trustStorePath, "UTF-8"),
+                ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(),
+                URLEncoder.encode(trustStorePass, "UTF-8")))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with String K-V pairs.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with String K-V pairs.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -322,22 +323,24 @@ public class ConnectionTlsTest {
     properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.setProperty(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
-    properties.setProperty(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "true");
-    properties.setProperty(ArrowFlightConnectionProperty.USE_SYSTEM_TRUST_STORE.camelName(), "false");
+    properties.setProperty(
+        ArrowFlightConnectionProperty.USE_SYSTEM_TRUST_STORE.camelName(), "false");
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with Object K-V pairs.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with Object K-V pairs.
    *
    * @throws Exception on error.
    */
@@ -356,18 +359,18 @@ public class ConnectionTlsTest {
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * just a connection url and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using just a connection url and using 0 and 1 as ssl values.
    *
    * @throws Exception on error.
    */
@@ -377,30 +380,33 @@ public class ConnectionTlsTest {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format(
-            "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s" +
-                "&useEncryption=1&useSystemTrustStore=0&%s=%s&%s=%s",
-            FLIGHT_SERVER_TEST_RULE.getPort(),
-            userTest,
-            passTest,
-            ArrowFlightConnectionProperty.TRUST_STORE.camelName(),
-            URLEncoder.encode(trustStorePath, "UTF-8"),
-            ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(),
-            URLEncoder.encode(trustStorePass, "UTF-8")))) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s?user=%s&password=%s"
+                    + "&useEncryption=1&useSystemTrustStore=0&%s=%s&%s=%s",
+                FLIGHT_SERVER_TEST_RULE.getPort(),
+                userTest,
+                passTest,
+                ArrowFlightConnectionProperty.TRUST_STORE.camelName(),
+                URLEncoder.encode(trustStorePath, "UTF-8"),
+                ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(),
+                URLEncoder.encode(trustStorePass, "UTF-8")))) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with String K-V pairs and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with String K-V pairs and using 0 and 1 as
+   * ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingSetPropertyWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -409,26 +415,31 @@ public class ConnectionTlsTest {
     properties.setProperty(ArrowFlightConnectionProperty.USER.camelName(), userTest);
     properties.setProperty(ArrowFlightConnectionProperty.PASSWORD.camelName(), passTest);
     properties.setProperty(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
-    properties.setProperty(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
+    properties.setProperty(
+        ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
     properties.setProperty(ArrowFlightConnectionProperty.USE_ENCRYPTION.camelName(), "1");
     properties.setProperty(ArrowFlightConnectionProperty.USE_SYSTEM_TRUST_STORE.camelName(), "0");
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format("jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }
 
   /**
-   * Check if an encrypted connection can be established successfully when connecting through the DriverManager using
-   * a connection url and properties with Object K-V pairs and using 0 and 1 as ssl values.
+   * Check if an encrypted connection can be established successfully when connecting through the
+   * DriverManager using a connection url and properties with Object K-V pairs and using 0 and 1 as
+   * ssl values.
    *
    * @throws Exception on error.
    */
   @Test
-  public void testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
-      throws Exception {
+  public void
+      testTLSConnectionPropertyTrueIntegerCorrectCastUrlAndPropertiesUsingPutWithDriverManager()
+          throws Exception {
     final Driver driver = new ArrowFlightJdbcDriver();
     DriverManager.registerDriver(driver);
 
@@ -441,10 +452,11 @@ public class ConnectionTlsTest {
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE.camelName(), trustStorePath);
     properties.put(ArrowFlightConnectionProperty.TRUST_STORE_PASSWORD.camelName(), trustStorePass);
 
-    try (final Connection connection = DriverManager.getConnection(
-        String.format("jdbc:arrow-flight-sql://localhost:%s",
-            FLIGHT_SERVER_TEST_RULE.getPort()),
-        properties)) {
+    try (final Connection connection =
+        DriverManager.getConnection(
+            String.format(
+                "jdbc:arrow-flight-sql://localhost:%s", FLIGHT_SERVER_TEST_RULE.getPort()),
+            properties)) {
       Assert.assertTrue(connection.isValid(0));
     }
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/FlightServerTestRule.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/FlightServerTestRule.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.apache.arrow.driver.jdbc.utils.FlightSqlTestCertificates.CertKeyPair;
@@ -27,7 +26,6 @@ import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.authentication.Authentication;
 import org.apache.arrow.driver.jdbc.authentication.TokenAuthentication;
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
@@ -51,8 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Utility class for unit tests that need to instantiate a {@link FlightServer}
- * and interact with it.
+ * Utility class for unit tests that need to instantiate a {@link FlightServer} and interact with
+ * it.
  */
 public class FlightServerTestRule implements TestRule, AutoCloseable {
   public static final String DEFAULT_USER = "flight-test-user";
@@ -70,13 +68,14 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
 
   private final MiddlewareCookie.Factory middlewareCookieFactory = new MiddlewareCookie.Factory();
 
-  private FlightServerTestRule(final Properties properties,
-                               final ArrowFlightConnectionConfigImpl config,
-                               final BufferAllocator allocator,
-                               final FlightSqlProducer producer,
-                               final Authentication authentication,
-                               final CertKeyPair certKeyPair,
-                               final File mTlsCACert) {
+  private FlightServerTestRule(
+      final Properties properties,
+      final ArrowFlightConnectionConfigImpl config,
+      final BufferAllocator allocator,
+      final FlightSqlProducer producer,
+      final Authentication authentication,
+      final CertKeyPair certKeyPair,
+      final File mTlsCACert) {
     this.properties = Preconditions.checkNotNull(properties);
     this.config = Preconditions.checkNotNull(config);
     this.allocator = Preconditions.checkNotNull(allocator);
@@ -94,14 +93,9 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
    */
   public static FlightServerTestRule createStandardTestRule(final FlightSqlProducer producer) {
     UserPasswordAuthentication authentication =
-        new UserPasswordAuthentication.Builder()
-            .user(DEFAULT_USER, DEFAULT_PASSWORD)
-            .build();
+        new UserPasswordAuthentication.Builder().user(DEFAULT_USER, DEFAULT_PASSWORD).build();
 
-    return new Builder()
-        .authentication(authentication)
-        .producer(producer)
-        .build();
+    return new Builder().authentication(authentication).producer(producer).build();
   }
 
   ArrowFlightJdbcDataSource createDataSource() {
@@ -112,7 +106,8 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
     return ArrowFlightJdbcConnectionPoolDataSource.createNewDataSource(properties);
   }
 
-  public ArrowFlightJdbcConnectionPoolDataSource createConnectionPoolDataSource(boolean useEncryption) {
+  public ArrowFlightJdbcConnectionPoolDataSource createConnectionPoolDataSource(
+      boolean useEncryption) {
     setUseEncryption(useEncryption);
     return ArrowFlightJdbcConnectionPoolDataSource.createNewDataSource(properties);
   }
@@ -142,9 +137,10 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
   }
 
   private FlightServer initiateServer(Location location) throws IOException {
-    FlightServer.Builder builder = FlightServer.builder(allocator, location, producer)
-        .headerAuthenticator(authentication.authenticate())
-        .middleware(FlightServerMiddleware.Key.of("KEY"), middlewareCookieFactory);
+    FlightServer.Builder builder =
+        FlightServer.builder(allocator, location, producer)
+            .headerAuthenticator(authentication.authenticate())
+            .middleware(FlightServerMiddleware.Key.of("KEY"), middlewareCookieFactory);
     if (certKeyPair != null) {
       builder.useTls(certKeyPair.cert, certKeyPair.key);
     }
@@ -170,12 +166,13 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
     };
   }
 
-  private FlightServer getStartServer(CheckedFunction<Location, FlightServer> newServerFromLocation,
-                                      int retries)
+  private FlightServer getStartServer(
+      CheckedFunction<Location, FlightServer> newServerFromLocation, int retries)
       throws IOException {
     final Deque<ReflectiveOperationException> exceptions = new ArrayDeque<>();
     for (; retries > 0; retries--) {
-      final FlightServer server = newServerFromLocation.apply(Location.forGrpcInsecure("localhost", 0));
+      final FlightServer server =
+          newServerFromLocation.apply(Location.forGrpcInsecure("localhost", 0));
       try {
         Method start = server.getClass().getMethod("start");
         start.setAccessible(true);
@@ -213,9 +210,7 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
     AutoCloseables.close(allocator);
   }
 
-  /**
-   * Builder for {@link FlightServerTestRule}.
-   */
+  /** Builder for {@link FlightServerTestRule}. */
   public static final class Builder {
     private final Properties properties;
     private FlightSqlProducer producer;
@@ -240,9 +235,8 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
     }
 
     /**
-     * Sets the type of the authentication that will be used in the server rules.
-     * There are two types of authentication: {@link UserPasswordAuthentication} and
-     * {@link TokenAuthentication}.
+     * Sets the type of the authentication that will be used in the server rules. There are two
+     * types of authentication: {@link UserPasswordAuthentication} and {@link TokenAuthentication}.
      *
      * @param authentication the type of authentication.
      * @return the Builder.
@@ -256,7 +250,7 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
      * Enable TLS on the server.
      *
      * @param certChain The certificate chain to use.
-     * @param key       The private key to use.
+     * @param key The private key to use.
      * @return the Builder.
      */
     public Builder useEncryption(final File certChain, final File key) {
@@ -282,14 +276,20 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
      */
     public FlightServerTestRule build() {
       authentication.populateProperties(properties);
-      return new FlightServerTestRule(properties, new ArrowFlightConnectionConfigImpl(properties),
-          new RootAllocator(Long.MAX_VALUE), producer, authentication, certKeyPair, mTlsCACert);
+      return new FlightServerTestRule(
+          properties,
+          new ArrowFlightConnectionConfigImpl(properties),
+          new RootAllocator(Long.MAX_VALUE),
+          producer,
+          authentication,
+          certKeyPair,
+          mTlsCACert);
     }
   }
 
   /**
-   * A middleware to handle with the cookies in the server. It is used to test if cookies are
-   * being sent properly.
+   * A middleware to handle with the cookies in the server. It is used to test if cookies are being
+   * sent properly.
    */
   static class MiddlewareCookie implements FlightServerMiddleware {
 
@@ -307,26 +307,20 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
     }
 
     @Override
-    public void onCallCompleted(CallStatus callStatus) {
-
-    }
+    public void onCallCompleted(CallStatus callStatus) {}
 
     @Override
-    public void onCallErrored(Throwable throwable) {
+    public void onCallErrored(Throwable throwable) {}
 
-    }
-
-    /**
-     * A factory for the MiddlewareCookie.
-     */
+    /** A factory for the MiddlewareCookie. */
     static class Factory implements FlightServerMiddleware.Factory<MiddlewareCookie> {
 
       private boolean receivedCookieHeader = false;
       private String cookie;
 
       @Override
-      public MiddlewareCookie onCallStarted(CallInfo callInfo, CallHeaders callHeaders,
-                                            RequestContext requestContext) {
+      public MiddlewareCookie onCallStarted(
+          CallInfo callInfo, CallHeaders callHeaders, RequestContext requestContext) {
         cookie = callHeaders.get("Cookie");
         receivedCookieHeader = null != cookie;
         return new MiddlewareCookie(this);
@@ -337,5 +331,4 @@ public class FlightServerTestRule implements TestRule, AutoCloseable {
       }
     }
   }
-
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetMetadataTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetMetadataTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -26,7 +25,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-
 import org.apache.arrow.driver.jdbc.utils.CoreMockedSqlProducers;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
@@ -42,20 +40,19 @@ public class ResultSetMetadataTest {
 
   private static Connection connection;
 
-  @Rule
-  public ErrorCollector collector = new ErrorCollector();
+  @Rule public ErrorCollector collector = new ErrorCollector();
 
   @ClassRule
-  public static final FlightServerTestRule SERVER_TEST_RULE = FlightServerTestRule
-      .createStandardTestRule(CoreMockedSqlProducers.getLegacyProducer());
+  public static final FlightServerTestRule SERVER_TEST_RULE =
+      FlightServerTestRule.createStandardTestRule(CoreMockedSqlProducers.getLegacyProducer());
 
   @BeforeClass
   public static void setup() throws SQLException {
     connection = SERVER_TEST_RULE.getConnection(false);
 
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_METADATA_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_METADATA_SQL_CMD)) {
       metadata = resultSet.getMetaData();
     }
   }
@@ -65,9 +62,7 @@ public class ResultSetMetadataTest {
     connection.close();
   }
 
-  /**
-   * Test if {@link ResultSetMetaData} object is not null.
-   */
+  /** Test if {@link ResultSetMetaData} object is not null. */
   @Test
   public void testShouldGetResultSetMetadata() {
     collector.checkThat(metadata, CoreMatchers.is(notNullValue()));
@@ -86,7 +81,7 @@ public class ResultSetMetadataTest {
   }
 
   /**
-   * Test if {@link ResultSetMetaData#getColumnTypeName(int)}  returns the correct type name for each
+   * Test if {@link ResultSetMetaData#getColumnTypeName(int)} returns the correct type name for each
    * column.
    *
    * @throws SQLException in case of error.
@@ -103,7 +98,8 @@ public class ResultSetMetadataTest {
   }
 
   /**
-   * Test if {@link ResultSetMetaData#getColumnTypeName(int)} passing an column index that does not exist.
+   * Test if {@link ResultSetMetaData#getColumnTypeName(int)} passing an column index that does not
+   * exist.
    *
    * @throws SQLException in case of error.
    */
@@ -130,9 +126,9 @@ public class ResultSetMetadataTest {
     collector.checkThat(thirdColumn, equalTo("float2"));
   }
 
-
   /**
-   * Test {@link ResultSetMetaData#getColumnTypeName(int)} passing an column index that does not exist.
+   * Test {@link ResultSetMetaData#getColumnTypeName(int)} passing an column index that does not
+   * exist.
    *
    * @throws SQLException in case of error.
    */
@@ -223,7 +219,8 @@ public class ResultSetMetadataTest {
   }
 
   /**
-   * Test if {@link ResultSetMetaData#getColumnTypeName(int)} passing an column index that does not exist.
+   * Test if {@link ResultSetMetaData#getColumnTypeName(int)} passing an column index that does not
+   * exist.
    *
    * @throws SQLException in case of error.
    */

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static java.lang.String.format;
@@ -30,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableSet;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-
 import org.apache.arrow.driver.jdbc.utils.CoreMockedSqlProducers;
 import org.apache.arrow.driver.jdbc.utils.FallbackFlightSqlProducer;
 import org.apache.arrow.driver.jdbc.utils.PartitionedFlightSqlProducer;
@@ -72,17 +71,16 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.rules.ErrorCollector;
 
-import com.google.common.collect.ImmutableSet;
-
 public class ResultSetTest {
   private static final Random RANDOM = new Random(10);
+
   @ClassRule
-  public static final FlightServerTestRule SERVER_TEST_RULE = FlightServerTestRule
-      .createStandardTestRule(CoreMockedSqlProducers.getLegacyProducer());
+  public static final FlightServerTestRule SERVER_TEST_RULE =
+      FlightServerTestRule.createStandardTestRule(CoreMockedSqlProducers.getLegacyProducer());
+
   private static Connection connection;
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   @BeforeClass
   public static void setup() throws SQLException {
@@ -109,8 +107,8 @@ public class ResultSetTest {
   @Test
   public void testShouldRunSelectQuery() throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
       CoreMockedSqlProducers.assertLegacyRegularSqlResultSet(resultSet, collector);
     }
   }
@@ -118,8 +116,8 @@ public class ResultSetTest {
   @Test
   public void testShouldExecuteQueryNotBlockIfClosedBeforeEnd() throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
 
       for (int i = 0; i < 7500; i++) {
         assertTrue(resultSet.next());
@@ -128,16 +126,16 @@ public class ResultSetTest {
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} query only returns only the
-   * amount of value set by {@link org.apache.calcite.avatica.AvaticaStatement#setMaxRows(int)}.
+   * Tests whether the {@link ArrowFlightJdbcDriver} query only returns only the amount of value set
+   * by {@link org.apache.calcite.avatica.AvaticaStatement#setMaxRows(int)}.
    *
    * @throws Exception If the connection fails to be established.
    */
   @Test
   public void testShouldRunSelectQuerySettingMaxRowLimit() throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
 
       final int maxRowsLimit = 3;
       statement.setMaxRows(maxRowsLimit);
@@ -158,8 +156,7 @@ public class ResultSetTest {
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} fails upon attempting
-   * to run an invalid query.
+   * Tests whether the {@link ArrowFlightJdbcDriver} fails upon attempting to run an invalid query.
    *
    * @throws Exception If the connection fails to be established.
    */
@@ -167,22 +164,22 @@ public class ResultSetTest {
   public void testShouldThrowExceptionUponAttemptingToExecuteAnInvalidSelectQuery()
       throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet result = statement.executeQuery("SELECT * FROM SHOULD-FAIL")) {
+        ResultSet result = statement.executeQuery("SELECT * FROM SHOULD-FAIL")) {
       fail();
     }
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} query only returns only the
-   * amount of value set by {@link org.apache.calcite.avatica.AvaticaStatement#setLargeMaxRows(long)} (int)}.
+   * Tests whether the {@link ArrowFlightJdbcDriver} query only returns only the amount of value set
+   * by {@link org.apache.calcite.avatica.AvaticaStatement#setLargeMaxRows(long)} (int)}.
    *
    * @throws Exception If the connection fails to be established.
    */
   @Test
   public void testShouldRunSelectQuerySettingLargeMaxRowLimit() throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
       final long maxRowsLimit = 3;
       statement.setLargeMaxRows(maxRowsLimit);
 
@@ -206,8 +203,8 @@ public class ResultSetTest {
       throws SQLException {
     final Set<Integer> counts = new HashSet<>();
     try (final Statement statement = connection.createStatement();
-         final ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        final ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
       while (resultSet.next()) {
         counts.add(resultSet.getMetaData().getColumnCount());
       }
@@ -224,7 +221,8 @@ public class ResultSetTest {
   @Test
   public void testShouldCloseStatementWhenIsCloseOnCompletion() throws Exception {
     try (Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
 
       statement.closeOnCompletion();
 
@@ -235,15 +233,17 @@ public class ResultSetTest {
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} close the statement after complete ResultSet with max rows limit
-   * when call {@link org.apache.calcite.avatica.AvaticaStatement#closeOnCompletion()}.
+   * Tests whether the {@link ArrowFlightJdbcDriver} close the statement after complete ResultSet
+   * with max rows limit when call {@link
+   * org.apache.calcite.avatica.AvaticaStatement#closeOnCompletion()}.
    *
    * @throws Exception If the connection fails to be established.
    */
   @Test
   public void testShouldCloseStatementWhenIsCloseOnCompletionWithMaxRowsLimit() throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
 
       final long maxRowsLimit = 3;
       statement.setLargeMaxRows(maxRowsLimit);
@@ -256,8 +256,9 @@ public class ResultSetTest {
   }
 
   /**
-   * Tests whether the {@link ArrowFlightJdbcDriver} not close the statement after complete ResultSet with max rows
-   * limit when call {@link org.apache.calcite.avatica.AvaticaStatement#closeOnCompletion()}.
+   * Tests whether the {@link ArrowFlightJdbcDriver} not close the statement after complete
+   * ResultSet with max rows limit when call {@link
+   * org.apache.calcite.avatica.AvaticaStatement#closeOnCompletion()}.
    *
    * @throws Exception If the connection fails to be established.
    */
@@ -265,8 +266,8 @@ public class ResultSetTest {
   public void testShouldNotCloseStatementWhenIsNotCloseOnCompletionWithMaxRowsLimit()
       throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
 
       final long maxRowsLimit = 3;
       statement.setLargeMaxRows(maxRowsLimit);
@@ -281,8 +282,8 @@ public class ResultSetTest {
   @Test
   public void testShouldCancelQueryUponCancelAfterQueryingResultSet() throws SQLException {
     try (final Statement statement = connection.createStatement();
-         final ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+        final ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
       final int column = RANDOM.nextInt(resultSet.getMetaData().getColumnCount()) + 1;
       collector.checkThat(resultSet.isClosed(), is(false));
       collector.checkThat(resultSet.next(), is(true));
@@ -301,20 +302,22 @@ public class ResultSetTest {
     try (final Statement statement = connection.createStatement()) {
       final CountDownLatch latch = new CountDownLatch(1);
       final Set<Exception> exceptions = synchronizedSet(new HashSet<>(1));
-      final Thread thread = new Thread(() -> {
-        try (final ResultSet resultSet = statement.executeQuery(
-            CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
-          final int cachedColumnCount = resultSet.getMetaData().getColumnCount();
-          Thread.sleep(300);
-          while (resultSet.next()) {
-            resultSet.getObject(RANDOM.nextInt(cachedColumnCount) + 1);
-          }
-        } catch (final SQLException | InterruptedException e) {
-          exceptions.add(e);
-        } finally {
-          latch.countDown();
-        }
-      });
+      final Thread thread =
+          new Thread(
+              () -> {
+                try (final ResultSet resultSet =
+                    statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+                  final int cachedColumnCount = resultSet.getMetaData().getColumnCount();
+                  Thread.sleep(300);
+                  while (resultSet.next()) {
+                    resultSet.getObject(RANDOM.nextInt(cachedColumnCount) + 1);
+                  }
+                } catch (final SQLException | InterruptedException e) {
+                  exceptions.add(e);
+                } finally {
+                  latch.countDown();
+                }
+              });
       thread.setName("Test Case: interrupt query execution before first retrieval");
       thread.start();
       statement.cancel();
@@ -331,18 +334,21 @@ public class ResultSetTest {
   }
 
   @Test
-  public void testShouldInterruptFlightStreamsIfQueryIsCancelledMidProcessingForTimeConsumingQueries()
-      throws SQLException, InterruptedException {
+  public void
+      testShouldInterruptFlightStreamsIfQueryIsCancelledMidProcessingForTimeConsumingQueries()
+          throws SQLException, InterruptedException {
     final String query = CoreMockedSqlProducers.LEGACY_CANCELLATION_SQL_CMD;
     try (final Statement statement = connection.createStatement()) {
       final Set<Exception> exceptions = synchronizedSet(new HashSet<>(1));
-      final Thread thread = new Thread(() -> {
-        try (final ResultSet ignored = statement.executeQuery(query)) {
-          fail();
-        } catch (final SQLException e) {
-          exceptions.add(e);
-        }
-      });
+      final Thread thread =
+          new Thread(
+              () -> {
+                try (final ResultSet ignored = statement.executeQuery(query)) {
+                  fail();
+                } catch (final SQLException e) {
+                  exceptions.add(e);
+                }
+              });
       thread.setName("Test Case: interrupt query execution mid-process");
       thread.setPriority(Thread.MAX_PRIORITY);
       thread.start();
@@ -356,8 +362,10 @@ public class ResultSetTest {
               .reduce(StringBuilder::append)
               .orElseThrow(IllegalStateException::new)
               .toString(),
-          anyOf(is(format("Error while executing SQL \"%s\": Query canceled", query)),
-              allOf(containsString(format("Error while executing SQL \"%s\"", query)),
+          anyOf(
+              is(format("Error while executing SQL \"%s\": Query canceled", query)),
+              allOf(
+                  containsString(format("Error while executing SQL \"%s\"", query)),
                   anyOf(containsString("CANCELLED"), containsString("Cancelling")))));
     }
   }
@@ -375,14 +383,11 @@ public class ResultSetTest {
       } catch (final Exception e) {
         exceptions.add(e);
       }
-      final Throwable comparisonCause = exceptions.stream()
-          .findFirst()
-          .orElseThrow(RuntimeException::new)
-          .getCause()
-          .getCause();
-      collector.checkThat(comparisonCause,
-          is(instanceOf(SQLTimeoutException.class)));
-      collector.checkThat(comparisonCause.getMessage(),
+      final Throwable comparisonCause =
+          exceptions.stream().findFirst().orElseThrow(RuntimeException::new).getCause().getCause();
+      collector.checkThat(comparisonCause, is(instanceOf(SQLTimeoutException.class)));
+      collector.checkThat(
+          comparisonCause.getMessage(),
           is(format("Query timed out after %d %s", timeoutValue, timeoutUnit)));
     }
   }
@@ -402,8 +407,9 @@ public class ResultSetTest {
   @Test
   public void testPartitionedFlightServer() throws Exception {
     // Arrange
-    final Schema schema = new Schema(
-        Arrays.asList(Field.nullablePrimitive("int_column", new ArrowType.Int(32, true))));
+    final Schema schema =
+        new Schema(
+            Arrays.asList(Field.nullablePrimitive("int_column", new ArrowType.Int(32, true))));
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
         VectorSchemaRoot firstPartition = VectorSchemaRoot.create(schema, allocator);
         VectorSchemaRoot secondPartition = VectorSchemaRoot.create(schema, allocator)) {
@@ -413,48 +419,55 @@ public class ResultSetTest {
       ((IntVector) secondPartition.getVector(0)).set(0, 2);
 
       // Construct the data-only nodes first.
-      FlightProducer firstProducer = new PartitionedFlightSqlProducer.DataOnlyFlightSqlProducer(
-          new Ticket("first".getBytes(StandardCharsets.UTF_8)), firstPartition);
-      FlightProducer secondProducer = new PartitionedFlightSqlProducer.DataOnlyFlightSqlProducer(
-          new Ticket("second".getBytes(StandardCharsets.UTF_8)), secondPartition);
+      FlightProducer firstProducer =
+          new PartitionedFlightSqlProducer.DataOnlyFlightSqlProducer(
+              new Ticket("first".getBytes(StandardCharsets.UTF_8)), firstPartition);
+      FlightProducer secondProducer =
+          new PartitionedFlightSqlProducer.DataOnlyFlightSqlProducer(
+              new Ticket("second".getBytes(StandardCharsets.UTF_8)), secondPartition);
 
-      final FlightServer.Builder firstBuilder = FlightServer.builder(
-          allocator, forGrpcInsecure("localhost", 0), firstProducer);
+      final FlightServer.Builder firstBuilder =
+          FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), firstProducer);
 
-      final FlightServer.Builder secondBuilder = FlightServer.builder(
-          allocator, forGrpcInsecure("localhost", 0), secondProducer);
+      final FlightServer.Builder secondBuilder =
+          FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), secondProducer);
 
       // Run the data-only nodes so that we can get the Locations they are running at.
       try (FlightServer firstServer = firstBuilder.build();
-           FlightServer secondServer = secondBuilder.build()) {
+          FlightServer secondServer = secondBuilder.build()) {
         firstServer.start();
         secondServer.start();
         final FlightEndpoint firstEndpoint =
-            new FlightEndpoint(new Ticket("first".getBytes(StandardCharsets.UTF_8)), firstServer.getLocation());
+            new FlightEndpoint(
+                new Ticket("first".getBytes(StandardCharsets.UTF_8)), firstServer.getLocation());
 
         final FlightEndpoint secondEndpoint =
-            new FlightEndpoint(new Ticket("second".getBytes(StandardCharsets.UTF_8)), secondServer.getLocation());
+            new FlightEndpoint(
+                new Ticket("second".getBytes(StandardCharsets.UTF_8)), secondServer.getLocation());
 
         // Finally start the root node.
-        try (final PartitionedFlightSqlProducer rootProducer = new PartitionedFlightSqlProducer(
-            schema, firstEndpoint, secondEndpoint);
-             FlightServer rootServer = FlightServer.builder(
-                 allocator, forGrpcInsecure("localhost", 0), rootProducer)
-                 .build()
-                 .start();
-             Connection newConnection = DriverManager.getConnection(String.format(
-                 "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
-                 rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
-             Statement newStatement = newConnection.createStatement();
-             // Act
-             ResultSet result = newStatement.executeQuery("Select partitioned_data")) {
+        try (final PartitionedFlightSqlProducer rootProducer =
+                new PartitionedFlightSqlProducer(schema, firstEndpoint, secondEndpoint);
+            FlightServer rootServer =
+                FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), rootProducer)
+                    .build()
+                    .start();
+            Connection newConnection =
+                DriverManager.getConnection(
+                    String.format(
+                        "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
+                        rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
+            Statement newStatement = newConnection.createStatement();
+            // Act
+            ResultSet result = newStatement.executeQuery("Select partitioned_data")) {
           List<Integer> resultData = new ArrayList<>();
           while (result.next()) {
             resultData.add(result.getInt(1));
           }
 
           // Assert
-          assertEquals(firstPartition.getRowCount() + secondPartition.getRowCount(), resultData.size());
+          assertEquals(
+              firstPartition.getRowCount() + secondPartition.getRowCount(), resultData.size());
           assertTrue(resultData.contains(((IntVector) firstPartition.getVector(0)).get(0)));
           assertTrue(resultData.contains(((IntVector) secondPartition.getVector(0)).get(0)));
         }
@@ -464,29 +477,36 @@ public class ResultSetTest {
 
   @Test
   public void testPartitionedFlightServerIgnoreFailure() throws Exception {
-    final Schema schema = new Schema(
-            Collections.singletonList(Field.nullablePrimitive("int_column", new ArrowType.Int(32, true))));
+    final Schema schema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullablePrimitive("int_column", new ArrowType.Int(32, true))));
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
       final FlightEndpoint firstEndpoint =
-              new FlightEndpoint(new Ticket("first".getBytes(StandardCharsets.UTF_8)),
-                      Location.forGrpcInsecure("127.0.0.2", 1234),
-                      Location.forGrpcInsecure("127.0.0.3", 1234));
+          new FlightEndpoint(
+              new Ticket("first".getBytes(StandardCharsets.UTF_8)),
+              Location.forGrpcInsecure("127.0.0.2", 1234),
+              Location.forGrpcInsecure("127.0.0.3", 1234));
 
-      try (final PartitionedFlightSqlProducer rootProducer = new PartitionedFlightSqlProducer(
-              schema, firstEndpoint);
-           FlightServer rootServer = FlightServer.builder(
-                           allocator, forGrpcInsecure("localhost", 0), rootProducer)
-                   .build()
-                   .start();
-           Connection newConnection = DriverManager.getConnection(String.format(
-                   "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
-                   rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
-           Statement newStatement = newConnection.createStatement()) {
-        final SQLException e = Assertions.assertThrows(SQLException.class, () -> {
-          ResultSet result = newStatement.executeQuery("Select partitioned_data");
-          while (result.next()) {
-          }
-        });
+      try (final PartitionedFlightSqlProducer rootProducer =
+              new PartitionedFlightSqlProducer(schema, firstEndpoint);
+          FlightServer rootServer =
+              FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), rootProducer)
+                  .build()
+                  .start();
+          Connection newConnection =
+              DriverManager.getConnection(
+                  String.format(
+                      "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
+                      rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
+          Statement newStatement = newConnection.createStatement()) {
+        final SQLException e =
+            Assertions.assertThrows(
+                SQLException.class,
+                () -> {
+                  ResultSet result = newStatement.executeQuery("Select partitioned_data");
+                  while (result.next()) {}
+                });
         final Throwable cause = e.getCause();
         Assertions.assertTrue(cause instanceof FlightRuntimeException);
         final FlightRuntimeException fre = (FlightRuntimeException) cause;
@@ -498,41 +518,48 @@ public class ResultSetTest {
   @Test
   public void testPartitionedFlightServerAllFailure() throws Exception {
     // Arrange
-    final Schema schema = new Schema(
-            Collections.singletonList(Field.nullablePrimitive("int_column", new ArrowType.Int(32, true))));
+    final Schema schema =
+        new Schema(
+            Collections.singletonList(
+                Field.nullablePrimitive("int_column", new ArrowType.Int(32, true))));
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         VectorSchemaRoot firstPartition = VectorSchemaRoot.create(schema, allocator)) {
+        VectorSchemaRoot firstPartition = VectorSchemaRoot.create(schema, allocator)) {
       firstPartition.setRowCount(1);
       ((IntVector) firstPartition.getVector(0)).set(0, 1);
 
       // Construct the data-only nodes first.
-      FlightProducer firstProducer = new PartitionedFlightSqlProducer.DataOnlyFlightSqlProducer(
+      FlightProducer firstProducer =
+          new PartitionedFlightSqlProducer.DataOnlyFlightSqlProducer(
               new Ticket("first".getBytes(StandardCharsets.UTF_8)), firstPartition);
 
-      final FlightServer.Builder firstBuilder = FlightServer.builder(
-              allocator, forGrpcInsecure("localhost", 0), firstProducer);
+      final FlightServer.Builder firstBuilder =
+          FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), firstProducer);
 
       // Run the data-only nodes so that we can get the Locations they are running at.
       try (FlightServer firstServer = firstBuilder.build()) {
         firstServer.start();
         final Location badLocation = Location.forGrpcInsecure("127.0.0.2", 1234);
         final FlightEndpoint firstEndpoint =
-                new FlightEndpoint(new Ticket("first".getBytes(StandardCharsets.UTF_8)),
-                        badLocation, firstServer.getLocation());
+            new FlightEndpoint(
+                new Ticket("first".getBytes(StandardCharsets.UTF_8)),
+                badLocation,
+                firstServer.getLocation());
 
         // Finally start the root node.
-        try (final PartitionedFlightSqlProducer rootProducer = new PartitionedFlightSqlProducer(
-                schema, firstEndpoint);
-             FlightServer rootServer = FlightServer.builder(
-                             allocator, forGrpcInsecure("localhost", 0), rootProducer)
-                     .build()
-                     .start();
-             Connection newConnection = DriverManager.getConnection(String.format(
-                     "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
-                     rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
-             Statement newStatement = newConnection.createStatement();
-             // Act
-             ResultSet result = newStatement.executeQuery("Select partitioned_data")) {
+        try (final PartitionedFlightSqlProducer rootProducer =
+                new PartitionedFlightSqlProducer(schema, firstEndpoint);
+            FlightServer rootServer =
+                FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), rootProducer)
+                    .build()
+                    .start();
+            Connection newConnection =
+                DriverManager.getConnection(
+                    String.format(
+                        "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
+                        rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
+            Statement newStatement = newConnection.createStatement();
+            // Act
+            ResultSet result = newStatement.executeQuery("Select partitioned_data")) {
           List<Integer> resultData = new ArrayList<>();
           while (result.next()) {
             resultData.add(result.getInt(1));
@@ -548,23 +575,27 @@ public class ResultSetTest {
 
   @Test
   public void testFallbackFlightServer() throws Exception {
-    final Schema schema = new Schema(
+    final Schema schema =
+        new Schema(
             Collections.singletonList(Field.nullable("int_column", Types.MinorType.INT.getType())));
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         VectorSchemaRoot resultData = VectorSchemaRoot.create(schema, allocator)) {
+        VectorSchemaRoot resultData = VectorSchemaRoot.create(schema, allocator)) {
       resultData.setRowCount(1);
       ((IntVector) resultData.getVector(0)).set(0, 1);
 
-      try (final FallbackFlightSqlProducer rootProducer = new FallbackFlightSqlProducer(resultData);
-           FlightServer rootServer = FlightServer.builder(
-                           allocator, forGrpcInsecure("localhost", 0), rootProducer)
-                   .build()
-                   .start();
-           Connection newConnection = DriverManager.getConnection(String.format(
-                   "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
-                   rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
-           Statement newStatement = newConnection.createStatement();
-           ResultSet result = newStatement.executeQuery("fallback")) {
+      try (final FallbackFlightSqlProducer rootProducer =
+              new FallbackFlightSqlProducer(resultData);
+          FlightServer rootServer =
+              FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), rootProducer)
+                  .build()
+                  .start();
+          Connection newConnection =
+              DriverManager.getConnection(
+                  String.format(
+                      "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
+                      rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
+          Statement newStatement = newConnection.createStatement();
+          ResultSet result = newStatement.executeQuery("fallback")) {
         List<Integer> actualData = new ArrayList<>();
         while (result.next()) {
           actualData.add(result.getInt(1));
@@ -579,23 +610,27 @@ public class ResultSetTest {
 
   @Test
   public void testFallbackSecondFlightServer() throws Exception {
-    final Schema schema = new Schema(
+    final Schema schema =
+        new Schema(
             Collections.singletonList(Field.nullable("int_column", Types.MinorType.INT.getType())));
     try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-         VectorSchemaRoot resultData = VectorSchemaRoot.create(schema, allocator)) {
+        VectorSchemaRoot resultData = VectorSchemaRoot.create(schema, allocator)) {
       resultData.setRowCount(1);
       ((IntVector) resultData.getVector(0)).set(0, 1);
 
-      try (final FallbackFlightSqlProducer rootProducer = new FallbackFlightSqlProducer(resultData);
-           FlightServer rootServer = FlightServer.builder(
-                           allocator, forGrpcInsecure("localhost", 0), rootProducer)
-                   .build()
-                   .start();
-           Connection newConnection = DriverManager.getConnection(String.format(
-                   "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
-                   rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
-           Statement newStatement = newConnection.createStatement();
-           ResultSet result = newStatement.executeQuery("fallback with error")) {
+      try (final FallbackFlightSqlProducer rootProducer =
+              new FallbackFlightSqlProducer(resultData);
+          FlightServer rootServer =
+              FlightServer.builder(allocator, forGrpcInsecure("localhost", 0), rootProducer)
+                  .build()
+                  .start();
+          Connection newConnection =
+              DriverManager.getConnection(
+                  String.format(
+                      "jdbc:arrow-flight-sql://%s:%d/?useEncryption=false",
+                      rootServer.getLocation().getUri().getHost(), rootServer.getPort()));
+          Statement newStatement = newConnection.createStatement();
+          ResultSet result = newStatement.executeQuery("fallback with error")) {
         List<Integer> actualData = new ArrayList<>();
         while (result.next()) {
           actualData.add(result.getInt(1));
@@ -611,8 +646,8 @@ public class ResultSetTest {
   @Test
   public void testShouldRunSelectQueryWithEmptyVectorsEmbedded() throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_WITH_EMPTY_SQL_CMD)) {
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_WITH_EMPTY_SQL_CMD)) {
       long rowCount = 0;
       while (resultSet.next()) {
         ++rowCount;
@@ -624,10 +659,11 @@ public class ResultSetTest {
   @Test
   public void testResultSetAppMetadata() throws Exception {
     try (Statement statement = connection.createStatement();
-         ResultSet resultSet = statement.executeQuery(
-             CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
-      assertArrayEquals(((ArrowFlightJdbcFlightStreamResultSet) resultSet).getAppMetadata(),
-              "foo".getBytes(StandardCharsets.UTF_8));
+        ResultSet resultSet =
+            statement.executeQuery(CoreMockedSqlProducers.LEGACY_REGULAR_SQL_CMD)) {
+      assertArrayEquals(
+          ((ArrowFlightJdbcFlightStreamResultSet) resultSet).getAppMetadata(),
+          "foo".getBytes(StandardCharsets.UTF_8));
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TokenAuthenticationTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/TokenAuthenticationTest.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-
 import org.apache.arrow.driver.jdbc.authentication.TokenAuthentication;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.util.AutoCloseables;
@@ -31,16 +29,14 @@ import org.junit.Test;
 public class TokenAuthenticationTest {
   private static final MockFlightSqlProducer FLIGHT_SQL_PRODUCER = new MockFlightSqlProducer();
 
-  @ClassRule
-  public static FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @ClassRule public static FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
 
   static {
-    FLIGHT_SERVER_TEST_RULE = new FlightServerTestRule.Builder()
-        .authentication(new TokenAuthentication.Builder()
-            .token("1234")
-            .build())
-        .producer(FLIGHT_SQL_PRODUCER)
-        .build();
+    FLIGHT_SERVER_TEST_RULE =
+        new FlightServerTestRule.Builder()
+            .authentication(new TokenAuthentication.Builder().token("1234").build())
+            .producer(FLIGHT_SQL_PRODUCER)
+            .build();
   }
 
   @AfterClass

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactoryTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorFactoryTest.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor;
 
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.impl.binary.ArrowFlightJdbcBinaryVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDurationVectorAccessor;
@@ -67,9 +65,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForUInt1Vector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createUInt1Vector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -79,9 +76,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForUInt2Vector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createUInt2Vector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -91,9 +87,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForUInt4Vector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createUInt4Vector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -103,9 +98,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForUInt8Vector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createUInt8Vector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -115,9 +109,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForTinyIntVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createTinyIntVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -127,9 +120,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForSmallIntVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createSmallIntVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -139,9 +131,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForIntVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createIntVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -151,9 +142,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForBigIntVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createBigIntVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBaseIntVectorAccessor);
     }
@@ -163,9 +153,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForFloat4Vector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createFloat4Vector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcFloat4VectorAccessor);
     }
@@ -175,9 +164,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForFloat8Vector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createFloat8Vector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcFloat8VectorAccessor);
     }
@@ -187,9 +175,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForBitVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createBitVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBitVectorAccessor);
     }
@@ -199,9 +186,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForDecimalVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createDecimalVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcDecimalVectorAccessor);
     }
@@ -211,9 +197,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForDecimal256Vector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createDecimal256Vector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcDecimalVectorAccessor);
     }
@@ -223,9 +208,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForVarBinaryVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createVarBinaryVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBinaryVectorAccessor);
     }
@@ -235,9 +219,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForLargeVarBinaryVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createLargeVarBinaryVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBinaryVectorAccessor);
     }
@@ -247,9 +230,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForFixedSizeBinaryVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createFixedSizeBinaryVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcBinaryVectorAccessor);
     }
@@ -259,9 +241,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForTimeStampVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createTimeStampMilliVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcTimeStampVectorAccessor);
     }
@@ -271,9 +252,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForTimeNanoVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createTimeNanoVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -283,9 +263,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForTimeMicroVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createTimeMicroVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -295,9 +274,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForTimeMilliVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createTimeMilliVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -307,9 +285,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForTimeSecVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createTimeSecVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcTimeVectorAccessor);
     }
@@ -319,9 +296,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForDateDayVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createDateDayVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcDateVectorAccessor);
     }
@@ -331,9 +307,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForDateMilliVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createDateMilliVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcDateVectorAccessor);
     }
@@ -341,12 +316,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForVarCharVector() {
-    try (
-        ValueVector valueVector = new VarCharVector("", rootAllocatorTestRule.getRootAllocator())) {
+    try (ValueVector valueVector =
+        new VarCharVector("", rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcVarCharVectorAccessor);
     }
@@ -354,12 +328,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForLargeVarCharVector() {
-    try (ValueVector valueVector = new LargeVarCharVector("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (ValueVector valueVector =
+        new LargeVarCharVector("", rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcVarCharVectorAccessor);
     }
@@ -368,13 +341,13 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   @Test
   public void createAccessorForDurationVector() {
     try (ValueVector valueVector =
-             new DurationVector("",
-                 new FieldType(true, new ArrowType.Duration(TimeUnit.MILLISECOND), null),
-                 rootAllocatorTestRule.getRootAllocator())) {
+        new DurationVector(
+            "",
+            new FieldType(true, new ArrowType.Duration(TimeUnit.MILLISECOND), null),
+            rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcDurationVectorAccessor);
     }
@@ -382,12 +355,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForIntervalDayVector() {
-    try (ValueVector valueVector = new IntervalDayVector("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (ValueVector valueVector =
+        new IntervalDayVector("", rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcIntervalVectorAccessor);
     }
@@ -395,12 +367,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForIntervalYearVector() {
-    try (ValueVector valueVector = new IntervalYearVector("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (ValueVector valueVector =
+        new IntervalYearVector("", rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcIntervalVectorAccessor);
     }
@@ -408,12 +379,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForIntervalMonthDayNanoVector() {
-    try (ValueVector valueVector = new IntervalMonthDayNanoVector("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (ValueVector valueVector =
+        new IntervalMonthDayNanoVector("", rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcIntervalVectorAccessor);
     }
@@ -421,12 +391,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForUnionVector() {
-    try (ValueVector valueVector = new UnionVector("", rootAllocatorTestRule.getRootAllocator(),
-        null, null)) {
+    try (ValueVector valueVector =
+        new UnionVector("", rootAllocatorTestRule.getRootAllocator(), null, null)) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcUnionVectorAccessor);
     }
@@ -434,13 +403,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForDenseUnionVector() {
-    try (
-        ValueVector valueVector = new DenseUnionVector("", rootAllocatorTestRule.getRootAllocator(),
-            null, null)) {
+    try (ValueVector valueVector =
+        new DenseUnionVector("", rootAllocatorTestRule.getRootAllocator(), null, null)) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcDenseUnionVectorAccessor);
     }
@@ -448,12 +415,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForStructVector() {
-    try (ValueVector valueVector = StructVector.empty("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (ValueVector valueVector =
+        StructVector.empty("", rootAllocatorTestRule.getRootAllocator())) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcStructVectorAccessor);
     }
@@ -463,9 +429,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForListVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createListVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcListVectorAccessor);
     }
@@ -475,9 +440,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForLargeListVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createLargeListVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcLargeListVectorAccessor);
     }
@@ -487,9 +451,8 @@ public class ArrowFlightJdbcAccessorFactoryTest {
   public void createAccessorForFixedSizeListVector() {
     try (ValueVector valueVector = rootAllocatorTestRule.createFixedSizeListVector()) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcFixedSizeListVectorAccessor);
     }
@@ -497,12 +460,11 @@ public class ArrowFlightJdbcAccessorFactoryTest {
 
   @Test
   public void createAccessorForMapVector() {
-    try (ValueVector valueVector = MapVector.empty("", rootAllocatorTestRule.getRootAllocator(),
-        true)) {
+    try (ValueVector valueVector =
+        MapVector.empty("", rootAllocatorTestRule.getRootAllocator(), true)) {
       ArrowFlightJdbcAccessor accessor =
-          ArrowFlightJdbcAccessorFactory.createAccessor(valueVector, GET_CURRENT_ROW,
-              (boolean wasNull) -> {
-              });
+          ArrowFlightJdbcAccessorFactory.createAccessor(
+              valueVector, GET_CURRENT_ROW, (boolean wasNull) -> {});
 
       Assert.assertTrue(accessor instanceof ArrowFlightJdbcMapVectorAccessor);
     }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor;
 
 import static org.mockito.Mockito.verify;
@@ -25,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,8 +36,7 @@ public class ArrowFlightJdbcAccessorTest {
   static class MockedArrowFlightJdbcAccessor extends ArrowFlightJdbcAccessor {
 
     protected MockedArrowFlightJdbcAccessor() {
-      super(() -> 0, (boolean wasNull) -> {
-      });
+      super(() -> 0, (boolean wasNull) -> {});
     }
 
     @Override
@@ -48,8 +45,7 @@ public class ArrowFlightJdbcAccessorTest {
     }
   }
 
-  @Mock
-  MockedArrowFlightJdbcAccessor accessor;
+  @Mock MockedArrowFlightJdbcAccessor accessor;
 
   @Test
   public void testShouldGetObjectWithByteClassReturnGetByte() throws SQLException {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/ArrowFlightJdbcNullVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/ArrowFlightJdbcNullVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl;
 
 import org.junit.Assert;
@@ -23,8 +22,7 @@ import org.junit.Test;
 public class ArrowFlightJdbcNullVectorAccessorTest {
 
   ArrowFlightJdbcNullVectorAccessor accessor =
-      new ArrowFlightJdbcNullVectorAccessor((boolean wasNull) -> {
-      });
+      new ArrowFlightJdbcNullVectorAccessor((boolean wasNull) -> {});
 
   @Test
   public void testShouldWasNullReturnTrue() {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.binary;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -26,7 +25,6 @@ import java.io.Reader;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -51,47 +49,53 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private ValueVector vector;
   private final Supplier<ValueVector> vectorSupplier;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcBinaryVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer = (boolean wasNull) -> {
-        };
-        if (vector instanceof VarBinaryVector) {
-          return new ArrowFlightJdbcBinaryVectorAccessor(((VarBinaryVector) vector), getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof LargeVarBinaryVector) {
-          return new ArrowFlightJdbcBinaryVectorAccessor(((LargeVarBinaryVector) vector),
-              getCurrentRow, noOpWasNullConsumer);
-        } else if (vector instanceof FixedSizeBinaryVector) {
-          return new ArrowFlightJdbcBinaryVectorAccessor(((FixedSizeBinaryVector) vector),
-              getCurrentRow, noOpWasNullConsumer);
-        }
-        return null;
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer =
+                (boolean wasNull) -> {};
+            if (vector instanceof VarBinaryVector) {
+              return new ArrowFlightJdbcBinaryVectorAccessor(
+                  ((VarBinaryVector) vector), getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof LargeVarBinaryVector) {
+              return new ArrowFlightJdbcBinaryVectorAccessor(
+                  ((LargeVarBinaryVector) vector), getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof FixedSizeBinaryVector) {
+              return new ArrowFlightJdbcBinaryVectorAccessor(
+                  ((FixedSizeBinaryVector) vector), getCurrentRow, noOpWasNullConsumer);
+            }
+            return null;
+          };
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcBinaryVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createVarBinaryVector(),
-            "VarBinaryVector"},
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createLargeVarBinaryVector(),
-            "LargeVarBinaryVector"},
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createFixedSizeBinaryVector(),
-            "FixedSizeBinaryVector"},
-    });
+    return Arrays.asList(
+        new Object[][] {
+          {
+            (Supplier<ValueVector>) () -> rootAllocatorTestRule.createVarBinaryVector(),
+            "VarBinaryVector"
+          },
+          {
+            (Supplier<ValueVector>) () -> rootAllocatorTestRule.createLargeVarBinaryVector(),
+            "LargeVarBinaryVector"
+          },
+          {
+            (Supplier<ValueVector>) () -> rootAllocatorTestRule.createFixedSizeBinaryVector(),
+            "FixedSizeBinaryVector"
+          },
+        });
   }
 
-  public ArrowFlightJdbcBinaryVectorAccessorTest(Supplier<ValueVector> vectorSupplier,
-                                                 String vectorType) {
+  public ArrowFlightJdbcBinaryVectorAccessorTest(
+      Supplier<ValueVector> vectorSupplier, String vectorType) {
     this.vectorSupplier = vectorSupplier;
   }
 
@@ -107,7 +111,9 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
 
   @Test
   public void testShouldGetStringReturnExpectedString() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBinaryVectorAccessor::getString,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBinaryVectorAccessor::getString,
         (accessor) -> is(new String(accessor.getBytes(), UTF_8)));
   }
 
@@ -116,14 +122,15 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
     vector.reset();
     vector.setValueCount(5);
 
-    accessorIterator
-        .assertAccessorGetter(vector, ArrowFlightJdbcBinaryVectorAccessor::getString,
-            CoreMatchers.nullValue());
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcBinaryVectorAccessor::getString, CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetBytesReturnExpectedByteArray() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBinaryVectorAccessor::getBytes,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBinaryVectorAccessor::getBytes,
         (accessor, currentRow) -> {
           if (vector instanceof VarBinaryVector) {
             return is(((VarBinaryVector) vector).get(currentRow));
@@ -148,7 +155,9 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
 
   @Test
   public void testShouldGetObjectReturnAsGetBytes() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBinaryVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBinaryVectorAccessor::getObject,
         (accessor) -> is(accessor.getBytes()));
   }
 
@@ -164,12 +173,14 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
 
   @Test
   public void testShouldGetUnicodeStreamReturnCorrectInputStream() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      InputStream inputStream = accessor.getUnicodeStream();
-      String actualString = IOUtils.toString(inputStream, UTF_8);
-      collector.checkThat(accessor.wasNull(), is(false));
-      collector.checkThat(actualString, is(accessor.getString()));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          InputStream inputStream = accessor.getUnicodeStream();
+          String actualString = IOUtils.toString(inputStream, UTF_8);
+          collector.checkThat(accessor.wasNull(), is(false));
+          collector.checkThat(actualString, is(accessor.getString()));
+        });
   }
 
   @Test
@@ -184,12 +195,14 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
 
   @Test
   public void testShouldGetAsciiStreamReturnCorrectInputStream() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      InputStream inputStream = accessor.getAsciiStream();
-      String actualString = IOUtils.toString(inputStream, US_ASCII);
-      collector.checkThat(accessor.wasNull(), is(false));
-      collector.checkThat(actualString, is(accessor.getString()));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          InputStream inputStream = accessor.getAsciiStream();
+          String actualString = IOUtils.toString(inputStream, US_ASCII);
+          collector.checkThat(accessor.wasNull(), is(false));
+          collector.checkThat(actualString, is(accessor.getString()));
+        });
   }
 
   @Test
@@ -204,12 +217,14 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
 
   @Test
   public void testShouldGetBinaryStreamReturnCurrentInputStream() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      InputStream inputStream = accessor.getBinaryStream();
-      String actualString = IOUtils.toString(inputStream, UTF_8);
-      collector.checkThat(accessor.wasNull(), is(false));
-      collector.checkThat(actualString, is(accessor.getString()));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          InputStream inputStream = accessor.getBinaryStream();
+          String actualString = IOUtils.toString(inputStream, UTF_8);
+          collector.checkThat(accessor.wasNull(), is(false));
+          collector.checkThat(actualString, is(accessor.getString()));
+        });
   }
 
   @Test
@@ -224,12 +239,14 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
 
   @Test
   public void testShouldGetCharacterStreamReturnCorrectReader() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      Reader characterStream = accessor.getCharacterStream();
-      String actualString = IOUtils.toString(characterStream);
-      collector.checkThat(accessor.wasNull(), is(false));
-      collector.checkThat(actualString, is(accessor.getString()));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          Reader characterStream = accessor.getCharacterStream();
+          String actualString = IOUtils.toString(characterStream);
+          collector.checkThat(accessor.wasNull(), is(false));
+          collector.checkThat(actualString, is(accessor.getString()));
+        });
   }
 
   @Test

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorAccessor.getTimeUnitForVector;
@@ -31,7 +30,6 @@ import java.util.Collection;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.impl.text.ArrowFlightJdbcVarCharVectorAccessor;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -58,42 +56,44 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private BaseFixedWidthVector vector;
   private final Supplier<BaseFixedWidthVector> vectorSupplier;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcDateVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        if (vector instanceof DateDayVector) {
-          return new ArrowFlightJdbcDateVectorAccessor((DateDayVector) vector, getCurrentRow,
-              (boolean wasNull) -> {
-              });
-        } else if (vector instanceof DateMilliVector) {
-          return new ArrowFlightJdbcDateVectorAccessor((DateMilliVector) vector, getCurrentRow,
-              (boolean wasNull) -> {
-              });
-        }
-        return null;
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            if (vector instanceof DateDayVector) {
+              return new ArrowFlightJdbcDateVectorAccessor(
+                  (DateDayVector) vector, getCurrentRow, (boolean wasNull) -> {});
+            } else if (vector instanceof DateMilliVector) {
+              return new ArrowFlightJdbcDateVectorAccessor(
+                  (DateMilliVector) vector, getCurrentRow, (boolean wasNull) -> {});
+            }
+            return null;
+          };
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcDateVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<DateDayVector>) () -> rootAllocatorTestRule.createDateDayVector(),
-            "DateDayVector"},
-        {(Supplier<DateMilliVector>) () -> rootAllocatorTestRule.createDateMilliVector(),
-            "DateMilliVector"},
-    });
+    return Arrays.asList(
+        new Object[][] {
+          {
+            (Supplier<DateDayVector>) () -> rootAllocatorTestRule.createDateDayVector(),
+            "DateDayVector"
+          },
+          {
+            (Supplier<DateMilliVector>) () -> rootAllocatorTestRule.createDateMilliVector(),
+            "DateMilliVector"
+          },
+        });
   }
 
-  public ArrowFlightJdbcDateVectorAccessorTest(Supplier<BaseFixedWidthVector> vectorSupplier,
-                                               String vectorType) {
+  public ArrowFlightJdbcDateVectorAccessorTest(
+      Supplier<BaseFixedWidthVector> vectorSupplier, String vectorType) {
     this.vectorSupplier = vectorSupplier;
   }
 
@@ -109,13 +109,17 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
 
   @Test
   public void testShouldGetTimestampReturnValidTimestampWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getTimestamp(null),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getTimestamp(null),
         (accessor, currentRow) -> is(getTimestampForVector(currentRow)));
   }
 
   @Test
   public void testShouldGetObjectWithDateClassReturnValidDateWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getObject(Date.class),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getObject(Date.class),
         (accessor, currentRow) -> is(new Date(getTimestampForVector(currentRow).getTime())));
   }
 
@@ -124,15 +128,17 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_VANCOUVER);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
-      final Timestamp result = accessor.getTimestamp(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
+          final Timestamp result = accessor.getTimestamp(calendar);
 
-      long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
+          long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
-    });
+          collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+          collector.checkThat(accessor.wasNull(), is(false));
+        });
   }
 
   @Test
@@ -145,7 +151,9 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
 
   @Test
   public void testShouldGetDateReturnValidDateWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getDate(null),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getDate(null),
         (accessor, currentRow) -> is(new Date(getTimestampForVector(currentRow).getTime())));
   }
 
@@ -154,15 +162,17 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_VANCOUVER);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Date resultWithoutCalendar = accessor.getDate(null);
-      final Date result = accessor.getDate(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Date resultWithoutCalendar = accessor.getDate(null);
+          final Date result = accessor.getDate(calendar);
 
-      long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
+          long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
-    });
+          collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+          collector.checkThat(accessor.wasNull(), is(false));
+        });
   }
 
   @Test
@@ -190,9 +200,8 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator
-        .assertAccessorGetter(vector, ArrowFlightJdbcDateVectorAccessor::getObjectClass,
-            equalTo(Date.class));
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcDateVectorAccessor::getObjectClass, equalTo(Date.class));
   }
 
   @Test
@@ -208,47 +217,51 @@ public class ArrowFlightJdbcDateVectorAccessorTest {
 
   @Test
   public void testValidateGetStringTimeZoneConsistency() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final TimeZone defaultTz = TimeZone.getDefault();
-      try {
-        final String string = accessor.getString(); // Should always be UTC as no calendar is provided
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final TimeZone defaultTz = TimeZone.getDefault();
+          try {
+            final String string =
+                accessor.getString(); // Should always be UTC as no calendar is provided
 
-        // Validate with UTC
-        Date date = accessor.getDate(null);
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-        collector.checkThat(date.toString(), is(string));
+            // Validate with UTC
+            Date date = accessor.getDate(null);
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+            collector.checkThat(date.toString(), is(string));
 
-        // Validate with different TZ
-        TimeZone.setDefault(TimeZone.getTimeZone(AMERICA_VANCOUVER));
-        collector.checkThat(date.toString(), not(string));
+            // Validate with different TZ
+            TimeZone.setDefault(TimeZone.getTimeZone(AMERICA_VANCOUVER));
+            collector.checkThat(date.toString(), not(string));
 
-        collector.checkThat(accessor.wasNull(), is(false));
-      } finally {
-        // Set default Tz back
-        TimeZone.setDefault(defaultTz);
-      }
-    });
+            collector.checkThat(accessor.wasNull(), is(false));
+          } finally {
+            // Set default Tz back
+            TimeZone.setDefault(defaultTz);
+          }
+        });
   }
 
   private void assertGetStringIsConsistentWithVarCharAccessor(Calendar calendar) throws Exception {
-    try (VarCharVector varCharVector = new VarCharVector("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (VarCharVector varCharVector =
+        new VarCharVector("", rootAllocatorTestRule.getRootAllocator())) {
       varCharVector.allocateNew(1);
       ArrowFlightJdbcVarCharVectorAccessor varCharVectorAccessor =
-          new ArrowFlightJdbcVarCharVectorAccessor(varCharVector, () -> 0, (boolean wasNull) -> {
+          new ArrowFlightJdbcVarCharVectorAccessor(varCharVector, () -> 0, (boolean wasNull) -> {});
+
+      accessorIterator.iterate(
+          vector,
+          (accessor, currentRow) -> {
+            final String string = accessor.getString();
+            varCharVector.set(0, new Text(string));
+            varCharVector.setValueCount(1);
+
+            Date dateFromVarChar = varCharVectorAccessor.getDate(calendar);
+            Date date = accessor.getDate(calendar);
+
+            collector.checkThat(date, is(dateFromVarChar));
+            collector.checkThat(accessor.wasNull(), is(false));
           });
-
-      accessorIterator.iterate(vector, (accessor, currentRow) -> {
-        final String string = accessor.getString();
-        varCharVector.set(0, new Text(string));
-        varCharVector.setValueCount(1);
-
-        Date dateFromVarChar = varCharVectorAccessor.getDate(calendar);
-        Date date = accessor.getDate(calendar);
-
-        collector.checkThat(date, is(dateFromVarChar));
-        collector.checkThat(accessor.wasNull(), is(false));
-      });
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDurationVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDurationVectorAccessorTest.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.time.Duration;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -41,20 +39,18 @@ public class ArrowFlightJdbcDurationVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private DurationVector vector;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcDurationVectorAccessor>
       accessorSupplier =
-          (vector, getCurrentRow) -> new ArrowFlightJdbcDurationVectorAccessor((DurationVector) vector,
-              getCurrentRow, (boolean wasNull) -> {
-          });
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcDurationVectorAccessor(
+                  (DurationVector) vector, getCurrentRow, (boolean wasNull) -> {});
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcDurationVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Before
   public void setup() {
@@ -75,7 +71,9 @@ public class ArrowFlightJdbcDurationVectorAccessorTest {
 
   @Test
   public void getObject() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDurationVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDurationVectorAccessor::getObject,
         (accessor, currentRow) -> is(Duration.ofDays(currentRow + 1)));
   }
 
@@ -86,13 +84,17 @@ public class ArrowFlightJdbcDurationVectorAccessorTest {
       vector.setNull(i);
     }
 
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDurationVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDurationVectorAccessor::getObject,
         (accessor, currentRow) -> equalTo(null));
   }
 
   @Test
   public void getString() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcAccessor::getString,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcAccessor::getString,
         (accessor, currentRow) -> is(Duration.ofDays(currentRow + 1).toString()));
   }
 
@@ -103,13 +105,15 @@ public class ArrowFlightJdbcDurationVectorAccessorTest {
       vector.setNull(i);
     }
 
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcAccessor::getString,
-        (accessor, currentRow) -> equalTo(null));
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcAccessor::getString, (accessor, currentRow) -> equalTo(null));
   }
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcAccessor::getObjectClass,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcAccessor::getObjectClass,
         (accessor, currentRow) -> equalTo(Duration.class));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcIntervalVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.utils.IntervalStringUtils.formatIntervalDay;
@@ -28,7 +27,6 @@ import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -53,73 +51,86 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private final Supplier<ValueVector> vectorSupplier;
   private ValueVector vector;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcIntervalVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer = (boolean wasNull) -> {
-        };
-        if (vector instanceof IntervalDayVector) {
-          return new ArrowFlightJdbcIntervalVectorAccessor((IntervalDayVector) vector,
-              getCurrentRow, noOpWasNullConsumer);
-        } else if (vector instanceof IntervalYearVector) {
-          return new ArrowFlightJdbcIntervalVectorAccessor((IntervalYearVector) vector,
-              getCurrentRow, noOpWasNullConsumer);
-        } else if (vector instanceof IntervalMonthDayNanoVector) {
-          return new ArrowFlightJdbcIntervalVectorAccessor((IntervalMonthDayNanoVector) vector,
-                  getCurrentRow, noOpWasNullConsumer);
-        }
-        return null;
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer =
+                (boolean wasNull) -> {};
+            if (vector instanceof IntervalDayVector) {
+              return new ArrowFlightJdbcIntervalVectorAccessor(
+                  (IntervalDayVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof IntervalYearVector) {
+              return new ArrowFlightJdbcIntervalVectorAccessor(
+                  (IntervalYearVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof IntervalMonthDayNanoVector) {
+              return new ArrowFlightJdbcIntervalVectorAccessor(
+                  (IntervalMonthDayNanoVector) vector, getCurrentRow, noOpWasNullConsumer);
+            }
+            return null;
+          };
 
   final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcIntervalVectorAccessor> accessorIterator =
       new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<ValueVector>) () -> {
-          IntervalDayVector vector =
-              new IntervalDayVector("", rootAllocatorTestRule.getRootAllocator());
+    return Arrays.asList(
+        new Object[][] {
+          {
+            (Supplier<ValueVector>)
+                () -> {
+                  IntervalDayVector vector =
+                      new IntervalDayVector("", rootAllocatorTestRule.getRootAllocator());
 
-          int valueCount = 10;
-          vector.setValueCount(valueCount);
-          for (int i = 0; i < valueCount; i++) {
-            vector.set(i, i + 1, (i + 1) * 1000);
-          }
-          return vector;
-        }, "IntervalDayVector"},
-        {(Supplier<ValueVector>) () -> {
-          IntervalYearVector vector =
-              new IntervalYearVector("", rootAllocatorTestRule.getRootAllocator());
+                  int valueCount = 10;
+                  vector.setValueCount(valueCount);
+                  for (int i = 0; i < valueCount; i++) {
+                    vector.set(i, i + 1, (i + 1) * 1000);
+                  }
+                  return vector;
+                },
+            "IntervalDayVector"
+          },
+          {
+            (Supplier<ValueVector>)
+                () -> {
+                  IntervalYearVector vector =
+                      new IntervalYearVector("", rootAllocatorTestRule.getRootAllocator());
 
-          int valueCount = 10;
-          vector.setValueCount(valueCount);
-          for (int i = 0; i < valueCount; i++) {
-            vector.set(i, i + 1);
-          }
-          return vector;
-        }, "IntervalYearVector"},
-        {(Supplier<ValueVector>) () -> {
-          IntervalMonthDayNanoVector vector =
-                  new IntervalMonthDayNanoVector("", rootAllocatorTestRule.getRootAllocator());
+                  int valueCount = 10;
+                  vector.setValueCount(valueCount);
+                  for (int i = 0; i < valueCount; i++) {
+                    vector.set(i, i + 1);
+                  }
+                  return vector;
+                },
+            "IntervalYearVector"
+          },
+          {
+            (Supplier<ValueVector>)
+                () -> {
+                  IntervalMonthDayNanoVector vector =
+                      new IntervalMonthDayNanoVector("", rootAllocatorTestRule.getRootAllocator());
 
-          int valueCount = 10;
-          vector.setValueCount(valueCount);
-          for (int i = 0; i < valueCount; i++) {
-            vector.set(i, i + 1, (i + 1) * 10, (i + 1) * 100);
-          }
-          return vector;
-        }, "IntervalMonthDayNanoVector"},
-    });
+                  int valueCount = 10;
+                  vector.setValueCount(valueCount);
+                  for (int i = 0; i < valueCount; i++) {
+                    vector.set(i, i + 1, (i + 1) * 10, (i + 1) * 100);
+                  }
+                  return vector;
+                },
+            "IntervalMonthDayNanoVector"
+          },
+        });
   }
 
-  public ArrowFlightJdbcIntervalVectorAccessorTest(Supplier<ValueVector> vectorSupplier,
-                                                   String vectorType) {
+  public ArrowFlightJdbcIntervalVectorAccessorTest(
+      Supplier<ValueVector> vectorSupplier, String vectorType) {
     this.vectorSupplier = vectorSupplier;
   }
 
@@ -135,21 +146,27 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
 
   @Test
   public void testShouldGetObjectReturnValidObject() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcIntervalVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcIntervalVectorAccessor::getObject,
         (accessor, currentRow) -> is(getExpectedObject(vector, currentRow)));
   }
 
   @Test
   public void testShouldGetObjectPassingObjectClassAsParameterReturnValidObject() throws Exception {
     Class<?> objectClass = getExpectedObjectClassForVector(vector);
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getObject(objectClass),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getObject(objectClass),
         (accessor, currentRow) -> is(getExpectedObject(vector, currentRow)));
   }
 
   @Test
   public void testShouldGetObjectReturnNull() throws Exception {
     setAllNullOnVector(vector);
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcIntervalVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcIntervalVectorAccessor::getObject,
         (accessor, currentRow) -> equalTo(null));
   }
 
@@ -165,15 +182,19 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
       String iso8601IntervalString = ((PeriodDuration) object).toISO8601IntervalString();
       String[] periodAndDuration = iso8601IntervalString.split("T");
       if (periodAndDuration.length == 1) {
-        // If there is no 'T', then either Period or Duration is zero, and the other one will successfully parse it
+        // If there is no 'T', then either Period or Duration is zero, and the other one will
+        // successfully parse it
         String periodOrDuration = periodAndDuration[0];
         try {
-          return new PeriodDuration(Period.parse(periodOrDuration), Duration.ZERO).toISO8601IntervalString();
+          return new PeriodDuration(Period.parse(periodOrDuration), Duration.ZERO)
+              .toISO8601IntervalString();
         } catch (DateTimeParseException e) {
-          return new PeriodDuration(Period.ZERO, Duration.parse(periodOrDuration)).toISO8601IntervalString();
+          return new PeriodDuration(Period.ZERO, Duration.parse(periodOrDuration))
+              .toISO8601IntervalString();
         }
       } else {
-        // If there is a 'T', both Period and Duration are non-zero, and we just need to prepend the 'PT' to the
+        // If there is a 'T', both Period and Duration are non-zero, and we just need to prepend the
+        // 'PT' to the
         // duration for both to parse successfully
         Period parse = Period.parse(periodAndDuration[0]);
         Duration duration = Duration.parse("PT" + periodAndDuration[1]);
@@ -184,7 +205,7 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
   }
 
   @Test
-  public void testShouldGetIntervalYear( ) {
+  public void testShouldGetIntervalYear() {
     Assert.assertEquals("-002-00", formatIntervalYear(Period.parse("P-2Y")));
     Assert.assertEquals("-001-01", formatIntervalYear(Period.parse("P-1Y-1M")));
     Assert.assertEquals("-001-02", formatIntervalYear(Period.parse("P-1Y-2M")));
@@ -200,22 +221,30 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
   }
 
   @Test
-  public void testShouldGetIntervalDay( ) {
+  public void testShouldGetIntervalDay() {
     Assert.assertEquals("-001 00:00:00.000", formatIntervalDay(Duration.parse("PT-24H")));
     Assert.assertEquals("+001 00:00:00.000", formatIntervalDay(Duration.parse("PT+24H")));
     Assert.assertEquals("-000 01:00:00.000", formatIntervalDay(Duration.parse("PT-1H")));
-    // "JDK-8054978: java.time.Duration.parse() fails for negative duration with 0 seconds and nanos" not fixed on JDK8
-    //Assert.assertEquals("-000 01:00:00.001", formatIntervalDay(Duration.parse("PT-1H-0M-00.001S")));
-    Assert.assertEquals("-000 01:00:00.001", formatIntervalDay(Duration.ofHours(-1).minusMillis(1)));
+    // "JDK-8054978: java.time.Duration.parse() fails for negative duration with 0 seconds and
+    // nanos" not fixed on JDK8
+    // Assert.assertEquals("-000 01:00:00.001",
+    // formatIntervalDay(Duration.parse("PT-1H-0M-00.001S")));
+    Assert.assertEquals(
+        "-000 01:00:00.001", formatIntervalDay(Duration.ofHours(-1).minusMillis(1)));
     Assert.assertEquals("-000 01:01:01.000", formatIntervalDay(Duration.parse("PT-1H-1M-1S")));
     Assert.assertEquals("-000 02:02:02.002", formatIntervalDay(Duration.parse("PT-2H-2M-02.002S")));
-    Assert.assertEquals("-000 23:59:59.999", formatIntervalDay(Duration.parse("PT-23H-59M-59.999S")));
-    // "JDK-8054978: java.time.Duration.parse() fails for negative duration with 0 seconds and nanos" not fixed on JDK8
-    //Assert.assertEquals("-000 11:59:00.100", formatIntervalDay(Duration.parse("PT-11H-59M-00.100S")));
-    Assert.assertEquals("-000 11:59:00.100", 
+    Assert.assertEquals(
+        "-000 23:59:59.999", formatIntervalDay(Duration.parse("PT-23H-59M-59.999S")));
+    // "JDK-8054978: java.time.Duration.parse() fails for negative duration with 0 seconds and
+    // nanos" not fixed on JDK8
+    // Assert.assertEquals("-000 11:59:00.100",
+    // formatIntervalDay(Duration.parse("PT-11H-59M-00.100S")));
+    Assert.assertEquals(
+        "-000 11:59:00.100",
         formatIntervalDay(Duration.ofHours(-11).minusMinutes(59).minusMillis(100)));
     Assert.assertEquals("-000 05:02:03.000", formatIntervalDay(Duration.parse("PT-5H-2M-3S")));
-    Assert.assertEquals("-000 22:22:22.222", formatIntervalDay(Duration.parse("PT-22H-22M-22.222S")));
+    Assert.assertEquals(
+        "-000 22:22:22.222", formatIntervalDay(Duration.parse("PT-22H-22M-22.222S")));
     Assert.assertEquals("+000 01:00:00.000", formatIntervalDay(Duration.parse("PT+1H")));
     Assert.assertEquals("+000 01:00:00.001", formatIntervalDay(Duration.parse("PT+1H0M00.001S")));
     Assert.assertEquals("+000 01:01:01.000", formatIntervalDay(Duration.parse("PT+1H1M1S")));
@@ -228,29 +257,32 @@ public class ArrowFlightJdbcIntervalVectorAccessorTest {
 
   @Test
   public void testIntervalDayWithJodaPeriodObject() {
-    Assert.assertEquals("+1567 00:00:00.000",
-        formatIntervalDay(Duration.ofDays(1567)));
-    Assert.assertEquals("-1567 00:00:00.000",
-        formatIntervalDay(Duration.ofDays(-1567)));
+    Assert.assertEquals("+1567 00:00:00.000", formatIntervalDay(Duration.ofDays(1567)));
+    Assert.assertEquals("-1567 00:00:00.000", formatIntervalDay(Duration.ofDays(-1567)));
   }
 
   @Test
   public void testShouldGetStringReturnCorrectString() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcIntervalVectorAccessor::getString,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcIntervalVectorAccessor::getString,
         (accessor, currentRow) -> is(getStringOnVector(vector, currentRow)));
   }
 
   @Test
   public void testShouldGetStringReturnNull() throws Exception {
     setAllNullOnVector(vector);
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcIntervalVectorAccessor::getString,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcIntervalVectorAccessor::getString,
         (accessor, currentRow) -> equalTo(null));
   }
 
   @Test
   public void testShouldGetObjectClassReturnCorrectClass() throws Exception {
     Class<?> expectedObjectClass = getExpectedObjectClassForVector(vector);
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         ArrowFlightJdbcIntervalVectorAccessor::getObjectClass,
         (accessor, currentRow) -> equalTo(expectedObjectClass));
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorAccessor.getTimeUnitForVector;
@@ -32,7 +31,6 @@ import java.util.Collection;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.impl.text.ArrowFlightJdbcVarCharVectorAccessor;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -64,8 +62,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
   private final String timeZone;
 
   private TimeStampVector vector;
@@ -73,81 +70,114 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcTimeStampVectorAccessor>
       accessorSupplier =
-          (vector, getCurrentRow) -> new ArrowFlightJdbcTimeStampVectorAccessor(
-              (TimeStampVector) vector, getCurrentRow, (boolean wasNull) -> {
-          });
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcTimeStampVectorAccessor(
+                  (TimeStampVector) vector, getCurrentRow, (boolean wasNull) -> {});
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcTimeStampVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1} - TimeZone: {2}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampNanoVector(),
+    return Arrays.asList(
+        new Object[][] {
+          {
+            (Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampNanoVector(),
             "TimeStampNanoVector",
-            null},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampNanoTZVector("UTC"),
+            null
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampNanoTZVector("UTC"),
             "TimeStampNanoTZVector",
-            "UTC"},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampNanoTZVector(
-            AMERICA_VANCOUVER),
+            "UTC"
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampNanoTZVector(AMERICA_VANCOUVER),
             "TimeStampNanoTZVector",
-            AMERICA_VANCOUVER},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampNanoTZVector(
-            ASIA_BANGKOK),
+            AMERICA_VANCOUVER
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampNanoTZVector(ASIA_BANGKOK),
             "TimeStampNanoTZVector",
-            ASIA_BANGKOK},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMicroVector(),
+            ASIA_BANGKOK
+          },
+          {
+            (Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMicroVector(),
             "TimeStampMicroVector",
-            null},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMicroTZVector(
-            "UTC"),
+            null
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampMicroTZVector("UTC"),
             "TimeStampMicroTZVector",
-            "UTC"},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMicroTZVector(
-            AMERICA_VANCOUVER),
+            "UTC"
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampMicroTZVector(AMERICA_VANCOUVER),
             "TimeStampMicroTZVector",
-            AMERICA_VANCOUVER},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMicroTZVector(
-            ASIA_BANGKOK),
+            AMERICA_VANCOUVER
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampMicroTZVector(ASIA_BANGKOK),
             "TimeStampMicroTZVector",
-            ASIA_BANGKOK},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMilliVector(),
+            ASIA_BANGKOK
+          },
+          {
+            (Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMilliVector(),
             "TimeStampMilliVector",
-            null},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMilliTZVector(
-            "UTC"),
+            null
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampMilliTZVector("UTC"),
             "TimeStampMilliTZVector",
-            "UTC"},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMilliTZVector(
-            AMERICA_VANCOUVER),
+            "UTC"
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampMilliTZVector(AMERICA_VANCOUVER),
             "TimeStampMilliTZVector",
-            AMERICA_VANCOUVER},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampMilliTZVector(
-            ASIA_BANGKOK),
+            AMERICA_VANCOUVER
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampMilliTZVector(ASIA_BANGKOK),
             "TimeStampMilliTZVector",
-            ASIA_BANGKOK},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampSecVector(),
+            ASIA_BANGKOK
+          },
+          {
+            (Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampSecVector(),
             "TimeStampSecVector",
-            null},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampSecTZVector("UTC"),
+            null
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampSecTZVector("UTC"),
             "TimeStampSecTZVector",
-            "UTC"},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampSecTZVector(
-            AMERICA_VANCOUVER),
+            "UTC"
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampSecTZVector(AMERICA_VANCOUVER),
             "TimeStampSecTZVector",
-            AMERICA_VANCOUVER},
-        {(Supplier<TimeStampVector>) () -> rootAllocatorTestRule.createTimeStampSecTZVector(
-            ASIA_BANGKOK),
+            AMERICA_VANCOUVER
+          },
+          {
+            (Supplier<TimeStampVector>)
+                () -> rootAllocatorTestRule.createTimeStampSecTZVector(ASIA_BANGKOK),
             "TimeStampSecTZVector",
-            ASIA_BANGKOK}
-    });
+            ASIA_BANGKOK
+          }
+        });
   }
 
-  public ArrowFlightJdbcTimeStampVectorAccessorTest(Supplier<TimeStampVector> vectorSupplier,
-                                                    String vectorType,
-                                                    String timeZone) {
+  public ArrowFlightJdbcTimeStampVectorAccessorTest(
+      Supplier<TimeStampVector> vectorSupplier, String vectorType, String timeZone) {
     this.vectorSupplier = vectorSupplier;
     this.timeZone = timeZone;
   }
@@ -164,7 +194,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
   @Test
   public void testShouldGetTimestampReturnValidTimestampWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getTimestamp(null),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getTimestamp(null),
         (accessor, currentRow) -> is(getTimestampForVector(currentRow)));
   }
 
@@ -175,16 +207,19 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
-      final Timestamp result = accessor.getTimestamp(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
+          final Timestamp result = accessor.getTimestamp(calendar);
 
-      long offset = (long) timeZone.getOffset(resultWithoutCalendar.getTime()) -
-          timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          long offset =
+              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
-    });
+          collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+          collector.checkThat(accessor.wasNull(), is(false));
+        });
   }
 
   @Test
@@ -197,7 +232,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
   @Test
   public void testShouldGetDateReturnValidDateWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getDate(null),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getDate(null),
         (accessor, currentRow) -> is(new Date(getTimestampForVector(currentRow).getTime())));
   }
 
@@ -208,16 +245,19 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Date resultWithoutCalendar = accessor.getDate(null);
-      final Date result = accessor.getDate(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Date resultWithoutCalendar = accessor.getDate(null);
+          final Date result = accessor.getDate(calendar);
 
-      long offset = (long) timeZone.getOffset(resultWithoutCalendar.getTime()) -
-          timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          long offset =
+              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
-    });
+          collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+          collector.checkThat(accessor.wasNull(), is(false));
+        });
   }
 
   @Test
@@ -230,7 +270,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
   @Test
   public void testShouldGetTimeReturnValidTimeWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getTime(null),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getTime(null),
         (accessor, currentRow) -> is(new Time(getTimestampForVector(currentRow).getTime())));
   }
 
@@ -241,16 +283,19 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
     TimeZone timeZoneForVector = getTimeZoneForVector(vector);
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Time resultWithoutCalendar = accessor.getTime(null);
-      final Time result = accessor.getTime(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Time resultWithoutCalendar = accessor.getTime(null);
+          final Time result = accessor.getTime(calendar);
 
-      long offset = (long) timeZone.getOffset(resultWithoutCalendar.getTime()) -
-          timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
+          long offset =
+              (long) timeZone.getOffset(resultWithoutCalendar.getTime())
+                  - timeZoneForVector.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
-    });
+          collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+          collector.checkThat(accessor.wasNull(), is(false));
+        });
   }
 
   @Test
@@ -278,9 +323,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
-        ArrowFlightJdbcTimeStampVectorAccessor::getObjectClass,
-        equalTo(Timestamp.class));
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcTimeStampVectorAccessor::getObjectClass, equalTo(Timestamp.class));
   }
 
   @Test
@@ -292,31 +336,34 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
   public void testShouldGetStringBeConsistentWithVarCharAccessorWithCalendar() throws Exception {
     // Ignore for TimeStamp vectors with TZ, as VarChar accessor won't consider their TZ
     Assume.assumeTrue(
-        vector instanceof TimeStampNanoVector || vector instanceof TimeStampMicroVector ||
-            vector instanceof TimeStampMilliVector || vector instanceof TimeStampSecVector);
+        vector instanceof TimeStampNanoVector
+            || vector instanceof TimeStampMicroVector
+            || vector instanceof TimeStampMilliVector
+            || vector instanceof TimeStampSecVector);
     Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(AMERICA_VANCOUVER));
     assertGetStringIsConsistentWithVarCharAccessor(calendar);
   }
 
   private void assertGetStringIsConsistentWithVarCharAccessor(Calendar calendar) throws Exception {
-    try (VarCharVector varCharVector = new VarCharVector("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (VarCharVector varCharVector =
+        new VarCharVector("", rootAllocatorTestRule.getRootAllocator())) {
       varCharVector.allocateNew(1);
       ArrowFlightJdbcVarCharVectorAccessor varCharVectorAccessor =
-          new ArrowFlightJdbcVarCharVectorAccessor(varCharVector, () -> 0, (boolean wasNull) -> {
+          new ArrowFlightJdbcVarCharVectorAccessor(varCharVector, () -> 0, (boolean wasNull) -> {});
+
+      accessorIterator.iterate(
+          vector,
+          (accessor, currentRow) -> {
+            final String string = accessor.getString();
+            varCharVector.set(0, new Text(string));
+            varCharVector.setValueCount(1);
+
+            Timestamp timestampFromVarChar = varCharVectorAccessor.getTimestamp(calendar);
+            Timestamp timestamp = accessor.getTimestamp(calendar);
+
+            collector.checkThat(timestamp, is(timestampFromVarChar));
+            collector.checkThat(accessor.wasNull(), is(false));
           });
-
-      accessorIterator.iterate(vector, (accessor, currentRow) -> {
-        final String string = accessor.getString();
-        varCharVector.set(0, new Text(string));
-        varCharVector.setValueCount(1);
-
-        Timestamp timestampFromVarChar = varCharVectorAccessor.getTimestamp(calendar);
-        Timestamp timestamp = accessor.getTimestamp(calendar);
-
-        collector.checkThat(timestamp, is(timestampFromVarChar));
-        collector.checkThat(accessor.wasNull(), is(false));
-      });
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeVectorAccessor.getTimeUnitForVector;
@@ -31,7 +30,6 @@ import java.util.Collection;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.accessor.impl.text.ArrowFlightJdbcVarCharVectorAccessor;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
@@ -61,52 +59,60 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private BaseFixedWidthVector vector;
   private final Supplier<BaseFixedWidthVector> vectorSupplier;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcTimeVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer = (boolean wasNull) -> {
-        };
-        if (vector instanceof TimeNanoVector) {
-          return new ArrowFlightJdbcTimeVectorAccessor((TimeNanoVector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof TimeMicroVector) {
-          return new ArrowFlightJdbcTimeVectorAccessor((TimeMicroVector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof TimeMilliVector) {
-          return new ArrowFlightJdbcTimeVectorAccessor((TimeMilliVector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof TimeSecVector) {
-          return new ArrowFlightJdbcTimeVectorAccessor((TimeSecVector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        }
-        return null;
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer =
+                (boolean wasNull) -> {};
+            if (vector instanceof TimeNanoVector) {
+              return new ArrowFlightJdbcTimeVectorAccessor(
+                  (TimeNanoVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof TimeMicroVector) {
+              return new ArrowFlightJdbcTimeVectorAccessor(
+                  (TimeMicroVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof TimeMilliVector) {
+              return new ArrowFlightJdbcTimeVectorAccessor(
+                  (TimeMilliVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof TimeSecVector) {
+              return new ArrowFlightJdbcTimeVectorAccessor(
+                  (TimeSecVector) vector, getCurrentRow, noOpWasNullConsumer);
+            }
+            return null;
+          };
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcTimeVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<TimeNanoVector>) () -> rootAllocatorTestRule.createTimeNanoVector(),
-            "TimeNanoVector"},
-        {(Supplier<TimeMicroVector>) () -> rootAllocatorTestRule.createTimeMicroVector(),
-            "TimeMicroVector"},
-        {(Supplier<TimeMilliVector>) () -> rootAllocatorTestRule.createTimeMilliVector(),
-            "TimeMilliVector"},
-        {(Supplier<TimeSecVector>) () -> rootAllocatorTestRule.createTimeSecVector(),
-            "TimeSecVector"}
-    });
+    return Arrays.asList(
+        new Object[][] {
+          {
+            (Supplier<TimeNanoVector>) () -> rootAllocatorTestRule.createTimeNanoVector(),
+            "TimeNanoVector"
+          },
+          {
+            (Supplier<TimeMicroVector>) () -> rootAllocatorTestRule.createTimeMicroVector(),
+            "TimeMicroVector"
+          },
+          {
+            (Supplier<TimeMilliVector>) () -> rootAllocatorTestRule.createTimeMilliVector(),
+            "TimeMilliVector"
+          },
+          {
+            (Supplier<TimeSecVector>) () -> rootAllocatorTestRule.createTimeSecVector(),
+            "TimeSecVector"
+          }
+        });
   }
 
-  public ArrowFlightJdbcTimeVectorAccessorTest(Supplier<BaseFixedWidthVector> vectorSupplier,
-                                               String vectorType) {
+  public ArrowFlightJdbcTimeVectorAccessorTest(
+      Supplier<BaseFixedWidthVector> vectorSupplier, String vectorType) {
     this.vectorSupplier = vectorSupplier;
   }
 
@@ -122,7 +128,9 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
 
   @Test
   public void testShouldGetTimestampReturnValidTimestampWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getTimestamp(null),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getTimestamp(null),
         (accessor, currentRow) -> is(getTimestampForVector(currentRow)));
   }
 
@@ -131,15 +139,17 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_VANCOUVER);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
-      final Timestamp result = accessor.getTimestamp(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
+          final Timestamp result = accessor.getTimestamp(calendar);
 
-      long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
+          long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
-    });
+          collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+          collector.checkThat(accessor.wasNull(), is(false));
+        });
   }
 
   @Test
@@ -152,7 +162,9 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
 
   @Test
   public void testShouldGetTimeReturnValidTimeWithoutCalendar() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, accessor -> accessor.getTime(null),
+    accessorIterator.assertAccessorGetter(
+        vector,
+        accessor -> accessor.getTime(null),
         (accessor, currentRow) -> {
           Timestamp expectedTimestamp = getTimestampForVector(currentRow);
           return is(new Time(expectedTimestamp.getTime()));
@@ -164,15 +176,17 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_VANCOUVER);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Time resultWithoutCalendar = accessor.getTime(null);
-      final Time result = accessor.getTime(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Time resultWithoutCalendar = accessor.getTime(null);
+          final Time result = accessor.getTime(calendar);
 
-      long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
+          long offset = timeZone.getOffset(resultWithoutCalendar.getTime());
 
-      collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
-      collector.checkThat(accessor.wasNull(), is(false));
-    });
+          collector.checkThat(resultWithoutCalendar.getTime() - result.getTime(), is(offset));
+          collector.checkThat(accessor.wasNull(), is(false));
+        });
   }
 
   @Test
@@ -200,8 +214,8 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcTimeVectorAccessor::getObjectClass,
-        equalTo(Time.class));
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcTimeVectorAccessor::getObjectClass, equalTo(Time.class));
   }
 
   @Test
@@ -217,47 +231,51 @@ public class ArrowFlightJdbcTimeVectorAccessorTest {
 
   @Test
   public void testValidateGetStringTimeZoneConsistency() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final TimeZone defaultTz = TimeZone.getDefault();
-      try {
-        final String string = accessor.getString(); // Should always be UTC as no calendar is provided
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final TimeZone defaultTz = TimeZone.getDefault();
+          try {
+            final String string =
+                accessor.getString(); // Should always be UTC as no calendar is provided
 
-        // Validate with UTC
-        Time time = accessor.getTime(null);
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-        collector.checkThat(time.toString(), is(string));
+            // Validate with UTC
+            Time time = accessor.getTime(null);
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+            collector.checkThat(time.toString(), is(string));
 
-        // Validate with different TZ
-        TimeZone.setDefault(TimeZone.getTimeZone(AMERICA_VANCOUVER));
-        collector.checkThat(time.toString(), not(string));
+            // Validate with different TZ
+            TimeZone.setDefault(TimeZone.getTimeZone(AMERICA_VANCOUVER));
+            collector.checkThat(time.toString(), not(string));
 
-        collector.checkThat(accessor.wasNull(), is(false));
-      } finally {
-        // Set default Tz back
-        TimeZone.setDefault(defaultTz);
-      }
-    });
+            collector.checkThat(accessor.wasNull(), is(false));
+          } finally {
+            // Set default Tz back
+            TimeZone.setDefault(defaultTz);
+          }
+        });
   }
 
   private void assertGetStringIsConsistentWithVarCharAccessor(Calendar calendar) throws Exception {
-    try (VarCharVector varCharVector = new VarCharVector("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (VarCharVector varCharVector =
+        new VarCharVector("", rootAllocatorTestRule.getRootAllocator())) {
       varCharVector.allocateNew(1);
       ArrowFlightJdbcVarCharVectorAccessor varCharVectorAccessor =
-          new ArrowFlightJdbcVarCharVectorAccessor(varCharVector, () -> 0, (boolean wasNull) -> {
+          new ArrowFlightJdbcVarCharVectorAccessor(varCharVector, () -> 0, (boolean wasNull) -> {});
+
+      accessorIterator.iterate(
+          vector,
+          (accessor, currentRow) -> {
+            final String string = accessor.getString();
+            varCharVector.set(0, new Text(string));
+            varCharVector.setValueCount(1);
+
+            Time timeFromVarChar = varCharVectorAccessor.getTime(calendar);
+            Time time = accessor.getTime(calendar);
+
+            collector.checkThat(time, is(timeFromVarChar));
+            collector.checkThat(accessor.wasNull(), is(false));
           });
-
-      accessorIterator.iterate(vector, (accessor, currentRow) -> {
-        final String string = accessor.getString();
-        varCharVector.set(0, new Text(string));
-        varCharVector.setValueCount(1);
-
-        Time timeFromVarChar = varCharVectorAccessor.getTime(calendar);
-        Time time = accessor.getTime(calendar);
-
-        collector.checkThat(time, is(timeFromVarChar));
-        collector.checkThat(accessor.wasNull(), is(false));
-      });
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcListAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -25,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -49,46 +47,50 @@ public class AbstractArrowFlightJdbcListAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private final Supplier<ValueVector> vectorSupplier;
   private ValueVector vector;
 
   private final AccessorTestUtils.AccessorSupplier<AbstractArrowFlightJdbcListVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer = (boolean wasNull) -> {
-        };
-        if (vector instanceof ListVector) {
-          return new ArrowFlightJdbcListVectorAccessor((ListVector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof LargeListVector) {
-          return new ArrowFlightJdbcLargeListVectorAccessor((LargeListVector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof FixedSizeListVector) {
-          return new ArrowFlightJdbcFixedSizeListVectorAccessor((FixedSizeListVector) vector,
-              getCurrentRow, noOpWasNullConsumer);
-        }
-        return null;
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer =
+                (boolean wasNull) -> {};
+            if (vector instanceof ListVector) {
+              return new ArrowFlightJdbcListVectorAccessor(
+                  (ListVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof LargeListVector) {
+              return new ArrowFlightJdbcLargeListVectorAccessor(
+                  (LargeListVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof FixedSizeListVector) {
+              return new ArrowFlightJdbcFixedSizeListVectorAccessor(
+                  (FixedSizeListVector) vector, getCurrentRow, noOpWasNullConsumer);
+            }
+            return null;
+          };
 
   final AccessorTestUtils.AccessorIterator<AbstractArrowFlightJdbcListVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createListVector(), "ListVector"},
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createLargeListVector(),
-            "LargeListVector"},
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createFixedSizeListVector(),
-            "FixedSizeListVector"},
-    });
+    return Arrays.asList(
+        new Object[][] {
+          {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createListVector(), "ListVector"},
+          {
+            (Supplier<ValueVector>) () -> rootAllocatorTestRule.createLargeListVector(),
+            "LargeListVector"
+          },
+          {
+            (Supplier<ValueVector>) () -> rootAllocatorTestRule.createFixedSizeListVector(),
+            "FixedSizeListVector"
+          },
+        });
   }
 
-  public AbstractArrowFlightJdbcListAccessorTest(Supplier<ValueVector> vectorSupplier,
-                                                 String vectorType) {
+  public AbstractArrowFlightJdbcListAccessorTest(
+      Supplier<ValueVector> vectorSupplier, String vectorType) {
     this.vectorSupplier = vectorSupplier;
   }
 
@@ -104,17 +106,19 @@ public class AbstractArrowFlightJdbcListAccessorTest {
 
   @Test
   public void testShouldGetObjectClassReturnCorrectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         AbstractArrowFlightJdbcListVectorAccessor::getObjectClass,
         (accessor, currentRow) -> equalTo(List.class));
   }
 
   @Test
   public void testShouldGetObjectReturnValidList() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         AbstractArrowFlightJdbcListVectorAccessor::getObject,
-        (accessor, currentRow) -> equalTo(
-            Arrays.asList(0, currentRow, currentRow * 2, currentRow * 3, currentRow * 4)));
+        (accessor, currentRow) ->
+            equalTo(Arrays.asList(0, currentRow, currentRow * 2, currentRow * 3, currentRow * 4)));
   }
 
   @Test
@@ -123,22 +127,27 @@ public class AbstractArrowFlightJdbcListAccessorTest {
     vector.allocateNewSafe();
     vector.setValueCount(5);
 
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         AbstractArrowFlightJdbcListVectorAccessor::getObject,
         (accessor, currentRow) -> CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetArrayReturnValidArray() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      Array array = accessor.getArray();
-      assert array != null;
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          Array array = accessor.getArray();
+          assert array != null;
 
-      Object[] arrayObject = (Object[]) array.getArray();
+          Object[] arrayObject = (Object[]) array.getArray();
 
-      collector.checkThat(arrayObject, equalTo(
-          new Object[] {0, currentRow, currentRow * 2, currentRow * 3, currentRow * 4}));
-    });
+          collector.checkThat(
+              arrayObject,
+              equalTo(
+                  new Object[] {0, currentRow, currentRow * 2, currentRow * 3, currentRow * 4}));
+        });
   }
 
   @Test
@@ -147,39 +156,42 @@ public class AbstractArrowFlightJdbcListAccessorTest {
     vector.allocateNewSafe();
     vector.setValueCount(5);
 
-    accessorIterator.assertAccessorGetter(vector,
-        AbstractArrowFlightJdbcListVectorAccessor::getArray,
-        CoreMatchers.nullValue());
+    accessorIterator.assertAccessorGetter(
+        vector, AbstractArrowFlightJdbcListVectorAccessor::getArray, CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetArrayReturnValidArrayPassingOffsets() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      Array array = accessor.getArray();
-      assert array != null;
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          Array array = accessor.getArray();
+          assert array != null;
 
-      Object[] arrayObject = (Object[]) array.getArray(1, 3);
+          Object[] arrayObject = (Object[]) array.getArray(1, 3);
 
-      collector.checkThat(arrayObject, equalTo(
-          new Object[] {currentRow, currentRow * 2, currentRow * 3}));
-    });
+          collector.checkThat(
+              arrayObject, equalTo(new Object[] {currentRow, currentRow * 2, currentRow * 3}));
+        });
   }
 
   @Test
   public void testShouldGetArrayGetResultSetReturnValidResultSet() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      Array array = accessor.getArray();
-      assert array != null;
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          Array array = accessor.getArray();
+          assert array != null;
 
-      try (ResultSet rs = array.getResultSet()) {
-        int count = 0;
-        while (rs.next()) {
-          final int value = rs.getInt(1);
-          collector.checkThat(value, equalTo(currentRow * count));
-          count++;
-        }
-        collector.checkThat(count, equalTo(5));
-      }
-    });
+          try (ResultSet rs = array.getResultSet()) {
+            int count = 0;
+            while (rs.next()) {
+              final int value = rs.getInt(1);
+              collector.checkThat(value, equalTo(currentRow * count));
+              count++;
+            }
+            collector.checkThat(count, equalTo(5));
+          }
+        });
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import static org.mockito.Mockito.mock;
@@ -24,7 +23,6 @@ import static org.mockito.Mockito.when;
 import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.Map;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.ArrowFlightJdbcNullVectorAccessor;
 import org.apache.arrow.vector.NullVector;
@@ -39,10 +37,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractArrowFlightJdbcUnionVectorAccessorTest {
 
-  @Mock
-  ArrowFlightJdbcAccessor innerAccessor;
-  @Spy
-  AbstractArrowFlightJdbcUnionVectorAccessorMock accessor;
+  @Mock ArrowFlightJdbcAccessor innerAccessor;
+  @Spy AbstractArrowFlightJdbcUnionVectorAccessorMock accessor;
 
   @Before
   public void setup() {
@@ -242,14 +238,12 @@ public class AbstractArrowFlightJdbcUnionVectorAccessorTest {
   private static class AbstractArrowFlightJdbcUnionVectorAccessorMock
       extends AbstractArrowFlightJdbcUnionVectorAccessor {
     protected AbstractArrowFlightJdbcUnionVectorAccessorMock() {
-      super(() -> 0, (boolean wasNull) -> {
-      });
+      super(() -> 0, (boolean wasNull) -> {});
     }
 
     @Override
     protected ArrowFlightJdbcAccessor createAccessorForVector(ValueVector vector) {
-      return new ArrowFlightJdbcNullVectorAccessor((boolean wasNull) -> {
-      });
+      return new ArrowFlightJdbcNullVectorAccessor((boolean wasNull) -> {});
     }
 
     @Override

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcDenseUnionVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -23,7 +22,6 @@ import static org.hamcrest.CoreMatchers.is;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.complex.DenseUnionVector;
@@ -44,21 +42,22 @@ public class ArrowFlightJdbcDenseUnionVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private DenseUnionVector vector;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcDenseUnionVectorAccessor>
       accessorSupplier =
-          (vector, getCurrentRow) -> new ArrowFlightJdbcDenseUnionVectorAccessor(
-              (DenseUnionVector) vector, getCurrentRow, (boolean wasNull) -> {
-            //No Operation
-          });
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcDenseUnionVectorAccessor(
+                  (DenseUnionVector) vector,
+                  getCurrentRow,
+                  (boolean wasNull) -> {
+                    // No Operation
+                  });
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcDenseUnionVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Before
   public void setup() throws Exception {
@@ -106,12 +105,8 @@ public class ArrowFlightJdbcDenseUnionVectorAccessorTest {
   @Test
   public void getObject() throws Exception {
     List<Object> result = accessorIterator.toList(vector);
-    List<Object> expected = Arrays.asList(
-        Long.MAX_VALUE,
-        Math.PI,
-        new Timestamp(1625702400000L),
-        null,
-        null);
+    List<Object> expected =
+        Arrays.asList(Long.MAX_VALUE, Math.PI, new Timestamp(1625702400000L), null, null);
 
     collector.checkThat(result, is(expected));
   }
@@ -120,7 +115,7 @@ public class ArrowFlightJdbcDenseUnionVectorAccessorTest {
   public void getObjectForNull() throws Exception {
     vector.reset();
     vector.setValueCount(5);
-    accessorIterator.assertAccessorGetter(vector,
-        AbstractArrowFlightJdbcUnionVectorAccessor::getObject, equalTo(null));
+    accessorIterator.assertAccessorGetter(
+        vector, AbstractArrowFlightJdbcUnionVectorAccessor::getObject, equalTo(null));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcMapVectorAccessorTest.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Map;
-
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.complex.MapVector;
@@ -40,8 +38,7 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private MapVector vector;
 
@@ -105,8 +102,8 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
   public void testShouldGetObjectReturnValidMap() {
     AccessorTestUtils.Cursor cursor = new AccessorTestUtils.Cursor(vector.getValueCount());
     ArrowFlightJdbcMapVectorAccessor accessor =
-        new ArrowFlightJdbcMapVectorAccessor(vector, cursor::getCurrentRow, (boolean wasNull) -> {
-        });
+        new ArrowFlightJdbcMapVectorAccessor(
+            vector, cursor::getCurrentRow, (boolean wasNull) -> {});
 
     Map<Object, Object> expected = new JsonStringHashMap<>();
     expected.put(1, 11);
@@ -135,8 +132,7 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
   public void testShouldGetObjectReturnNull() {
     vector.setNull(0);
     ArrowFlightJdbcMapVectorAccessor accessor =
-        new ArrowFlightJdbcMapVectorAccessor(vector, () -> 0, (boolean wasNull) -> {
-        });
+        new ArrowFlightJdbcMapVectorAccessor(vector, () -> 0, (boolean wasNull) -> {});
 
     Assert.assertNull(accessor.getObject());
     Assert.assertTrue(accessor.wasNull());
@@ -146,8 +142,8 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
   public void testShouldGetArrayReturnValidArray() throws SQLException {
     AccessorTestUtils.Cursor cursor = new AccessorTestUtils.Cursor(vector.getValueCount());
     ArrowFlightJdbcMapVectorAccessor accessor =
-        new ArrowFlightJdbcMapVectorAccessor(vector, cursor::getCurrentRow, (boolean wasNull) -> {
-        });
+        new ArrowFlightJdbcMapVectorAccessor(
+            vector, cursor::getCurrentRow, (boolean wasNull) -> {});
 
     Array array = accessor.getArray();
     Assert.assertNotNull(array);
@@ -212,8 +208,7 @@ public class ArrowFlightJdbcMapVectorAccessorTest {
     ((StructVector) vector.getDataVector()).setNull(0);
 
     ArrowFlightJdbcMapVectorAccessor accessor =
-        new ArrowFlightJdbcMapVectorAccessor(vector, () -> 0, (boolean wasNull) -> {
-        });
+        new ArrowFlightJdbcMapVectorAccessor(vector, () -> 0, (boolean wasNull) -> {});
 
     Assert.assertNull(accessor.getArray());
     Assert.assertTrue(accessor.wasNull());

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcStructVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcStructVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -24,7 +23,6 @@ import java.sql.SQLException;
 import java.sql.Struct;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.Float8Vector;
@@ -52,20 +50,18 @@ public class ArrowFlightJdbcStructVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private StructVector vector;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcStructVectorAccessor>
       accessorSupplier =
-          (vector, getCurrentRow) -> new ArrowFlightJdbcStructVectorAccessor((StructVector) vector,
-              getCurrentRow, (boolean wasNull) -> {
-          });
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcStructVectorAccessor(
+                  (StructVector) vector, getCurrentRow, (boolean wasNull) -> {});
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcStructVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Before
   public void setUp() throws Exception {
@@ -78,8 +74,8 @@ public class ArrowFlightJdbcStructVectorAccessorTest {
     IntVector intVector =
         vector.addOrGet("int", FieldType.nullable(Types.MinorType.INT.getType()), IntVector.class);
     Float8Vector float8Vector =
-        vector.addOrGet("float8", FieldType.nullable(Types.MinorType.FLOAT8.getType()),
-            Float8Vector.class);
+        vector.addOrGet(
+            "float8", FieldType.nullable(Types.MinorType.FLOAT8.getType()), Float8Vector.class);
 
     intVector.setSafe(0, 100);
     float8Vector.setSafe(0, 100.05);
@@ -98,14 +94,17 @@ public class ArrowFlightJdbcStructVectorAccessorTest {
 
   @Test
   public void testShouldGetObjectClassReturnMapClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         ArrowFlightJdbcStructVectorAccessor::getObjectClass,
         (accessor, currentRow) -> equalTo(Map.class));
   }
 
   @Test
   public void testShouldGetObjectReturnValidMap() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcStructVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcStructVectorAccessor::getObject,
         (accessor, currentRow) -> {
           Map<String, Object> expected = new HashMap<>();
           expected.put("int", 100 * (currentRow + 1));
@@ -119,37 +118,40 @@ public class ArrowFlightJdbcStructVectorAccessorTest {
   public void testShouldGetObjectReturnNull() throws Exception {
     vector.setNull(0);
     vector.setNull(1);
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcStructVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcStructVectorAccessor::getObject,
         (accessor, currentRow) -> nullValue());
   }
 
   @Test
   public void testShouldGetStructReturnValidStruct() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      Struct struct = accessor.getStruct();
-      assert struct != null;
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          Struct struct = accessor.getStruct();
+          assert struct != null;
 
-      Object[] expected = new Object[] {
-          100 * (currentRow + 1),
-          100.05 * (currentRow + 1)
-      };
+          Object[] expected = new Object[] {100 * (currentRow + 1), 100.05 * (currentRow + 1)};
 
-      collector.checkThat(struct.getAttributes(), equalTo(expected));
-    });
+          collector.checkThat(struct.getAttributes(), equalTo(expected));
+        });
   }
 
   @Test
   public void testShouldGetStructReturnNull() throws Exception {
     vector.setNull(0);
     vector.setNull(1);
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcStructVectorAccessor::getStruct,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcStructVectorAccessor::getStruct,
         (accessor, currentRow) -> nullValue());
   }
 
   @Test
   public void testShouldGetObjectWorkWithNestedComplexData() throws SQLException {
-    try (StructVector rootVector = StructVector.empty("",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (StructVector rootVector =
+        StructVector.empty("", rootAllocatorTestRule.getRootAllocator())) {
       StructVector structVector = rootVector.addOrGetStruct("struct");
 
       FieldType intFieldType = FieldType.nullable(Types.MinorType.INT.getType());
@@ -199,8 +201,7 @@ public class ArrowFlightJdbcStructVectorAccessorTest {
       expected.put("union", true);
 
       ArrowFlightJdbcStructVectorAccessor accessor =
-          new ArrowFlightJdbcStructVectorAccessor(rootVector, () -> 0, (boolean wasNull) -> {
-          });
+          new ArrowFlightJdbcStructVectorAccessor(rootVector, () -> 0, (boolean wasNull) -> {});
 
       Assert.assertEquals(expected, accessor.getObject());
       Assert.assertEquals(expected.toString(), accessor.getString());

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/ArrowFlightJdbcUnionVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -23,7 +22,6 @@ import static org.hamcrest.CoreMatchers.is;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -43,20 +41,18 @@ public class ArrowFlightJdbcUnionVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private UnionVector vector;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcUnionVectorAccessor>
       accessorSupplier =
-          (vector, getCurrentRow) -> new ArrowFlightJdbcUnionVectorAccessor((UnionVector) vector,
-              getCurrentRow, (boolean wasNull) -> {
-          });
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcUnionVectorAccessor(
+                  (UnionVector) vector, getCurrentRow, (boolean wasNull) -> {});
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcUnionVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Before
   public void setup() {
@@ -96,12 +92,8 @@ public class ArrowFlightJdbcUnionVectorAccessorTest {
   @Test
   public void getObject() throws Exception {
     List<Object> result = accessorIterator.toList(vector);
-    List<Object> expected = Arrays.asList(
-        Long.MAX_VALUE,
-        Math.PI,
-        new Timestamp(1625702400000L),
-        null,
-        null);
+    List<Object> expected =
+        Arrays.asList(Long.MAX_VALUE, Math.PI, new Timestamp(1625702400000L), null, null);
 
     collector.checkThat(result, is(expected));
   }
@@ -111,8 +103,7 @@ public class ArrowFlightJdbcUnionVectorAccessorTest {
     vector.reset();
     vector.setValueCount(5);
 
-    accessorIterator.assertAccessorGetter(vector,
-        AbstractArrowFlightJdbcUnionVectorAccessor::getObject,
-        equalTo(null));
+    accessorIterator.assertAccessorGetter(
+        vector, AbstractArrowFlightJdbcUnionVectorAccessor::getObject, equalTo(null));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBaseIntVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBaseIntVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -22,7 +21,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -44,75 +42,87 @@ import org.junit.rules.ErrorCollector;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-
 @RunWith(Parameterized.class)
 public class ArrowFlightJdbcBaseIntVectorAccessorTest {
 
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private BaseIntVector vector;
   private final Supplier<BaseIntVector> vectorSupplier;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcBaseIntVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer = (boolean wasNull) -> {
-        };
-        if (vector instanceof UInt1Vector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((UInt1Vector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof UInt2Vector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((UInt2Vector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else {
-          if (vector instanceof UInt4Vector) {
-            return new ArrowFlightJdbcBaseIntVectorAccessor((UInt4Vector) vector, getCurrentRow,
-                noOpWasNullConsumer);
-          } else if (vector instanceof UInt8Vector) {
-            return new ArrowFlightJdbcBaseIntVectorAccessor((UInt8Vector) vector, getCurrentRow,
-                noOpWasNullConsumer);
-          } else if (vector instanceof TinyIntVector) {
-            return new ArrowFlightJdbcBaseIntVectorAccessor((TinyIntVector) vector, getCurrentRow,
-                noOpWasNullConsumer);
-          } else if (vector instanceof SmallIntVector) {
-            return new ArrowFlightJdbcBaseIntVectorAccessor((SmallIntVector) vector, getCurrentRow,
-                noOpWasNullConsumer);
-          } else if (vector instanceof IntVector) {
-            return new ArrowFlightJdbcBaseIntVectorAccessor((IntVector) vector, getCurrentRow,
-                noOpWasNullConsumer);
-          } else if (vector instanceof BigIntVector) {
-            return new ArrowFlightJdbcBaseIntVectorAccessor((BigIntVector) vector, getCurrentRow,
-                noOpWasNullConsumer);
-          }
-        }
-        throw new UnsupportedOperationException();
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer =
+                (boolean wasNull) -> {};
+            if (vector instanceof UInt1Vector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (UInt1Vector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof UInt2Vector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (UInt2Vector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else {
+              if (vector instanceof UInt4Vector) {
+                return new ArrowFlightJdbcBaseIntVectorAccessor(
+                    (UInt4Vector) vector, getCurrentRow, noOpWasNullConsumer);
+              } else if (vector instanceof UInt8Vector) {
+                return new ArrowFlightJdbcBaseIntVectorAccessor(
+                    (UInt8Vector) vector, getCurrentRow, noOpWasNullConsumer);
+              } else if (vector instanceof TinyIntVector) {
+                return new ArrowFlightJdbcBaseIntVectorAccessor(
+                    (TinyIntVector) vector, getCurrentRow, noOpWasNullConsumer);
+              } else if (vector instanceof SmallIntVector) {
+                return new ArrowFlightJdbcBaseIntVectorAccessor(
+                    (SmallIntVector) vector, getCurrentRow, noOpWasNullConsumer);
+              } else if (vector instanceof IntVector) {
+                return new ArrowFlightJdbcBaseIntVectorAccessor(
+                    (IntVector) vector, getCurrentRow, noOpWasNullConsumer);
+              } else if (vector instanceof BigIntVector) {
+                return new ArrowFlightJdbcBaseIntVectorAccessor(
+                    (BigIntVector) vector, getCurrentRow, noOpWasNullConsumer);
+              }
+            }
+            throw new UnsupportedOperationException();
+          };
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcBaseIntVectorAccessor>
       accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createIntVector(), "IntVector"},
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createSmallIntVector(),
-            "SmallIntVector"},
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createTinyIntVector(),
-            "TinyIntVector"},
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createBigIntVector(),
-            "BigIntVector"},
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt1Vector(), "UInt1Vector"},
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt2Vector(), "UInt2Vector"},
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt4Vector(), "UInt4Vector"},
-        {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt8Vector(), "UInt8Vector"}
-    });
+    return Arrays.asList(
+        new Object[][] {
+          {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createIntVector(), "IntVector"},
+          {
+            (Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createSmallIntVector(),
+            "SmallIntVector"
+          },
+          {
+            (Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createTinyIntVector(),
+            "TinyIntVector"
+          },
+          {
+            (Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createBigIntVector(),
+            "BigIntVector"
+          },
+          {
+            (Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt1Vector(), "UInt1Vector"
+          },
+          {
+            (Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt2Vector(), "UInt2Vector"
+          },
+          {
+            (Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt4Vector(), "UInt4Vector"
+          },
+          {(Supplier<BaseIntVector>) () -> rootAllocatorTestRule.createUInt8Vector(), "UInt8Vector"}
+        });
   }
 
-  public ArrowFlightJdbcBaseIntVectorAccessorTest(Supplier<BaseIntVector> vectorSupplier,
-                                                  String vectorType) {
+  public ArrowFlightJdbcBaseIntVectorAccessorTest(
+      Supplier<BaseIntVector> vectorSupplier, String vectorType) {
     this.vectorSupplier = vectorSupplier;
   }
 
@@ -128,44 +138,55 @@ public class ArrowFlightJdbcBaseIntVectorAccessorTest {
 
   @Test
   public void testShouldConvertToByteMethodFromBaseIntVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBaseIntVectorAccessor::getByte,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getByte,
         (accessor, currentRow) -> equalTo((byte) accessor.getLong()));
   }
 
   @Test
   public void testShouldConvertToShortMethodFromBaseIntVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBaseIntVectorAccessor::getShort,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getShort,
         (accessor, currentRow) -> equalTo((short) accessor.getLong()));
   }
 
   @Test
   public void testShouldConvertToIntegerMethodFromBaseIntVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBaseIntVectorAccessor::getInt,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getInt,
         (accessor, currentRow) -> equalTo((int) accessor.getLong()));
   }
 
   @Test
   public void testShouldConvertToFloatMethodFromBaseIntVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBaseIntVectorAccessor::getFloat,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getFloat,
         (accessor, currentRow) -> equalTo((float) accessor.getLong()));
   }
 
   @Test
   public void testShouldConvertToDoubleMethodFromBaseIntVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBaseIntVectorAccessor::getDouble,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getDouble,
         (accessor, currentRow) -> equalTo((double) accessor.getLong()));
   }
 
   @Test
   public void testShouldConvertToBooleanMethodFromBaseIntVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBaseIntVectorAccessor::getBoolean,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getBoolean,
         (accessor, currentRow) -> equalTo(accessor.getLong() != 0L));
   }
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getObjectClass,
-        equalTo(Long.class));
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcBaseIntVectorAccessor::getObjectClass, equalTo(Long.class));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBaseIntVectorAccessorUnitTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBaseIntVectorAccessorUnitTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -44,8 +43,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ArrowFlightJdbcBaseIntVectorAccessorUnitTest {
 
-  @ClassRule
-  public static RootAllocatorTestRule rule = new RootAllocatorTestRule();
+  @ClassRule public static RootAllocatorTestRule rule = new RootAllocatorTestRule();
   private static UInt4Vector int4Vector;
   private static UInt8Vector int8Vector;
   private static IntVector intVectorWithNull;
@@ -53,40 +51,40 @@ public class ArrowFlightJdbcBaseIntVectorAccessorUnitTest {
   private static SmallIntVector smallIntVector;
   private static IntVector intVector;
   private static BigIntVector bigIntVector;
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcBaseIntVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer = (boolean wasNull) -> {
-        };
-        if (vector instanceof UInt1Vector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((UInt1Vector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        } else if (vector instanceof UInt2Vector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((UInt2Vector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        } else if (vector instanceof UInt4Vector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((UInt4Vector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        } else if (vector instanceof UInt8Vector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((UInt8Vector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        } else if (vector instanceof TinyIntVector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((TinyIntVector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        } else if (vector instanceof SmallIntVector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((SmallIntVector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        } else if (vector instanceof IntVector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((IntVector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        } else if (vector instanceof BigIntVector) {
-          return new ArrowFlightJdbcBaseIntVectorAccessor((BigIntVector) vector, getCurrentRow,
-            noOpWasNullConsumer);
-        }
-        return null;
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer =
+                (boolean wasNull) -> {};
+            if (vector instanceof UInt1Vector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (UInt1Vector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof UInt2Vector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (UInt2Vector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof UInt4Vector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (UInt4Vector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof UInt8Vector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (UInt8Vector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof TinyIntVector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (TinyIntVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof SmallIntVector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (SmallIntVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof IntVector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (IntVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof BigIntVector) {
+              return new ArrowFlightJdbcBaseIntVectorAccessor(
+                  (BigIntVector) vector, getCurrentRow, noOpWasNullConsumer);
+            }
+            return null;
+          };
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcBaseIntVectorAccessor>
       accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
@@ -124,90 +122,108 @@ public class ArrowFlightJdbcBaseIntVectorAccessorUnitTest {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    AutoCloseables.close(bigIntVector, intVector, smallIntVector, tinyIntVector, int4Vector,
-        int8Vector, intVectorWithNull, rule);
+    AutoCloseables.close(
+        bigIntVector,
+        intVector,
+        smallIntVector,
+        tinyIntVector,
+        int4Vector,
+        int8Vector,
+        intVectorWithNull,
+        rule);
   }
 
   @Test
   public void testShouldGetStringFromUnsignedValue() throws Exception {
-    accessorIterator.assertAccessorGetter(int8Vector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getString, equalTo("18446744073709551615"));
+    accessorIterator.assertAccessorGetter(
+        int8Vector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getString,
+        equalTo("18446744073709551615"));
   }
 
   @Test
   public void testShouldGetBytesFromIntVectorThrowsSqlException() throws Exception {
-    accessorIterator.assertAccessorGetterThrowingException(intVector, ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
+    accessorIterator.assertAccessorGetterThrowingException(
+        intVector, ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
   }
 
   @Test
   public void testShouldGetStringFromIntVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(intVectorWithNull,
-        ArrowFlightJdbcBaseIntVectorAccessor::getString, CoreMatchers.nullValue());
-  }
-
-  @Test
-  public void testShouldGetObjectFromInt() throws Exception {
-    accessorIterator.assertAccessorGetter(intVector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo(0xAABBCCDD));
-  }
-
-  @Test
-  public void testShouldGetObjectFromTinyInt() throws Exception {
-    accessorIterator.assertAccessorGetter(tinyIntVector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo((byte) 0xAA));
-  }
-
-  @Test
-  public void testShouldGetObjectFromSmallInt() throws Exception {
-    accessorIterator.assertAccessorGetter(smallIntVector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo((short) 0xAABB));
-  }
-
-  @Test
-  public void testShouldGetObjectFromBigInt() throws Exception {
-    accessorIterator.assertAccessorGetter(bigIntVector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo(0xAABBCCDDEEFFAABBL));
-  }
-
-  @Test
-  public void testShouldGetObjectFromUnsignedInt() throws Exception {
-    accessorIterator.assertAccessorGetter(int4Vector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo(0x80000001));
-  }
-
-  @Test
-  public void testShouldGetObjectFromIntVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(intVectorWithNull,
-        ArrowFlightJdbcBaseIntVectorAccessor::getObject, CoreMatchers.nullValue());
-  }
-
-  @Test
-  public void testShouldGetBigDecimalFromIntVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(intVectorWithNull,
-        ArrowFlightJdbcBaseIntVectorAccessor::getBigDecimal, CoreMatchers.nullValue());
-  }
-
-  @Test
-  public void testShouldGetBigDecimalWithScaleFromIntVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(intVectorWithNull, accessor -> accessor.getBigDecimal(2),
+    accessorIterator.assertAccessorGetter(
+        intVectorWithNull,
+        ArrowFlightJdbcBaseIntVectorAccessor::getString,
         CoreMatchers.nullValue());
   }
 
   @Test
+  public void testShouldGetObjectFromInt() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        intVector, ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo(0xAABBCCDD));
+  }
+
+  @Test
+  public void testShouldGetObjectFromTinyInt() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        tinyIntVector, ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo((byte) 0xAA));
+  }
+
+  @Test
+  public void testShouldGetObjectFromSmallInt() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        smallIntVector, ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo((short) 0xAABB));
+  }
+
+  @Test
+  public void testShouldGetObjectFromBigInt() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        bigIntVector,
+        ArrowFlightJdbcBaseIntVectorAccessor::getObject,
+        equalTo(0xAABBCCDDEEFFAABBL));
+  }
+
+  @Test
+  public void testShouldGetObjectFromUnsignedInt() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        int4Vector, ArrowFlightJdbcBaseIntVectorAccessor::getObject, equalTo(0x80000001));
+  }
+
+  @Test
+  public void testShouldGetObjectFromIntVectorWithNull() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        intVectorWithNull,
+        ArrowFlightJdbcBaseIntVectorAccessor::getObject,
+        CoreMatchers.nullValue());
+  }
+
+  @Test
+  public void testShouldGetBigDecimalFromIntVectorWithNull() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        intVectorWithNull,
+        ArrowFlightJdbcBaseIntVectorAccessor::getBigDecimal,
+        CoreMatchers.nullValue());
+  }
+
+  @Test
+  public void testShouldGetBigDecimalWithScaleFromIntVectorWithNull() throws Exception {
+    accessorIterator.assertAccessorGetter(
+        intVectorWithNull, accessor -> accessor.getBigDecimal(2), CoreMatchers.nullValue());
+  }
+
+  @Test
   public void testShouldGetBytesFromSmallVectorThrowsSqlException() throws Exception {
-    accessorIterator.assertAccessorGetterThrowingException(smallIntVector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
+    accessorIterator.assertAccessorGetterThrowingException(
+        smallIntVector, ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
   }
 
   @Test
   public void testShouldGetBytesFromTinyIntVectorThrowsSqlException() throws Exception {
-    accessorIterator.assertAccessorGetterThrowingException(tinyIntVector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
+    accessorIterator.assertAccessorGetterThrowingException(
+        tinyIntVector, ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
   }
 
   @Test
   public void testShouldGetBytesFromBigIntVectorThrowsSqlException() throws Exception {
-    accessorIterator.assertAccessorGetterThrowingException(bigIntVector,
-        ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
+    accessorIterator.assertAccessorGetterThrowingException(
+        bigIntVector, ArrowFlightJdbcBaseIntVectorAccessor::getBytes);
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBitVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcBitVectorAccessorTest.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.math.BigDecimal;
-
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils.AccessorIterator;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils.CheckedFunction;
@@ -38,14 +36,13 @@ public class ArrowFlightJdbcBitVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcBitVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> new ArrowFlightJdbcBitVectorAccessor((BitVector) vector,
-          getCurrentRow, (boolean wasNull) -> {
-      });
-  private final AccessorIterator<ArrowFlightJdbcBitVectorAccessor>
-      accessorIterator =
+      accessorSupplier =
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcBitVectorAccessor(
+                  (BitVector) vector, getCurrentRow, (boolean wasNull) -> {});
+  private final AccessorIterator<ArrowFlightJdbcBitVectorAccessor> accessorIterator =
       new AccessorIterator<>(collector, accessorSupplier);
   private BitVector vector;
   private BitVector vectorWithNull;
@@ -64,12 +61,16 @@ public class ArrowFlightJdbcBitVectorAccessorTest {
     this.vectorWithNull.close();
   }
 
-  private <T> void iterate(final CheckedFunction<ArrowFlightJdbcBitVectorAccessor, T> function,
-                           final T result,
-                           final T resultIfFalse, final BitVector vector) throws Exception {
-    accessorIterator.assertAccessorGetter(vector, function,
-        (accessor, currentRow) -> is(arrayToAssert[currentRow] ? result : resultIfFalse)
-    );
+  private <T> void iterate(
+      final CheckedFunction<ArrowFlightJdbcBitVectorAccessor, T> function,
+      final T result,
+      final T resultIfFalse,
+      final BitVector vector)
+      throws Exception {
+    accessorIterator.assertAccessorGetter(
+        vector,
+        function,
+        (accessor, currentRow) -> is(arrayToAssert[currentRow] ? result : resultIfFalse));
   }
 
   @Test
@@ -90,66 +91,57 @@ public class ArrowFlightJdbcBitVectorAccessorTest {
   @Test
   public void testShouldGetIntMethodFromBitVector() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getInt, 1, 0, vector);
-
   }
 
   @Test
   public void testShouldGetLongMethodFromBitVector() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getLong, (long) 1, (long) 0, vector);
-
   }
 
   @Test
   public void testShouldGetFloatMethodFromBitVector() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getFloat, (float) 1, (float) 0, vector);
-
   }
 
   @Test
   public void testShouldGetDoubleMethodFromBitVector() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getDouble, (double) 1, (double) 0, vector);
-
   }
 
   @Test
   public void testShouldGetBigDecimalMethodFromBitVector() throws Exception {
-    iterate(ArrowFlightJdbcBitVectorAccessor::getBigDecimal, BigDecimal.ONE, BigDecimal.ZERO,
-        vector);
+    iterate(
+        ArrowFlightJdbcBitVectorAccessor::getBigDecimal, BigDecimal.ONE, BigDecimal.ZERO, vector);
   }
 
   @Test
   public void testShouldGetBigDecimalMethodFromBitVectorFromNull() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getBigDecimal, null, null, vectorWithNull);
-
   }
 
   @Test
   public void testShouldGetObjectMethodFromBitVector() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getObject, true, false, vector);
-
   }
 
   @Test
   public void testShouldGetObjectMethodFromBitVectorFromNull() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getObject, null, null, vectorWithNull);
-
   }
 
   @Test
   public void testShouldGetStringMethodFromBitVector() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getString, "true", "false", vector);
-
   }
 
   @Test
   public void testShouldGetStringMethodFromBitVectorFromNull() throws Exception {
     iterate(ArrowFlightJdbcBitVectorAccessor::getString, null, null, vectorWithNull);
-
   }
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBitVectorAccessor::getObjectClass,
-        equalTo(Boolean.class));
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcBitVectorAccessor::getObjectClass, equalTo(Boolean.class));
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -24,7 +23,6 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessorFactory;
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
@@ -47,43 +45,47 @@ public class ArrowFlightJdbcDecimalVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   private final Supplier<ValueVector> vectorSupplier;
   private ValueVector vector;
   private ValueVector vectorWithNull;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcDecimalVectorAccessor>
-      accessorSupplier = (vector, getCurrentRow) -> {
-        ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer = (boolean wasNull) -> {
-        };
-        if (vector instanceof DecimalVector) {
-          return new ArrowFlightJdbcDecimalVectorAccessor((DecimalVector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        } else if (vector instanceof Decimal256Vector) {
-          return new ArrowFlightJdbcDecimalVectorAccessor((Decimal256Vector) vector, getCurrentRow,
-              noOpWasNullConsumer);
-        }
-        return null;
-      };
+      accessorSupplier =
+          (vector, getCurrentRow) -> {
+            ArrowFlightJdbcAccessorFactory.WasNullConsumer noOpWasNullConsumer =
+                (boolean wasNull) -> {};
+            if (vector instanceof DecimalVector) {
+              return new ArrowFlightJdbcDecimalVectorAccessor(
+                  (DecimalVector) vector, getCurrentRow, noOpWasNullConsumer);
+            } else if (vector instanceof Decimal256Vector) {
+              return new ArrowFlightJdbcDecimalVectorAccessor(
+                  (Decimal256Vector) vector, getCurrentRow, noOpWasNullConsumer);
+            }
+            return null;
+          };
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcDecimalVectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createDecimalVector(),
-            "DecimalVector"},
-        {(Supplier<ValueVector>) () -> rootAllocatorTestRule.createDecimal256Vector(),
-            "Decimal256Vector"},
-    });
+    return Arrays.asList(
+        new Object[][] {
+          {
+            (Supplier<ValueVector>) () -> rootAllocatorTestRule.createDecimalVector(),
+            "DecimalVector"
+          },
+          {
+            (Supplier<ValueVector>) () -> rootAllocatorTestRule.createDecimal256Vector(),
+            "Decimal256Vector"
+          },
+        });
   }
 
-  public ArrowFlightJdbcDecimalVectorAccessorTest(Supplier<ValueVector> vectorSupplier,
-                                                  String vectorType) {
+  public ArrowFlightJdbcDecimalVectorAccessorTest(
+      Supplier<ValueVector> vectorSupplier, String vectorType) {
     this.vectorSupplier = vectorSupplier;
   }
 
@@ -104,145 +106,177 @@ public class ArrowFlightJdbcDecimalVectorAccessorTest {
 
   @Test
   public void testShouldGetBigDecimalFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         ArrowFlightJdbcDecimalVectorAccessor::getBigDecimal,
         (accessor, currentRow) -> CoreMatchers.notNullValue());
   }
 
   @Test
   public void testShouldGetDoubleMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getDouble,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getDouble,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal().doubleValue()));
   }
 
   @Test
   public void testShouldGetFloatMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getFloat,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getFloat,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal().floatValue()));
   }
 
   @Test
   public void testShouldGetLongMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getLong,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getLong,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal().longValue()));
   }
 
   @Test
   public void testShouldGetIntMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getInt,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getInt,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal().intValue()));
   }
 
   @Test
   public void testShouldGetShortMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getShort,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getShort,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal().shortValue()));
   }
 
   @Test
   public void testShouldGetByteMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getByte,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getByte,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal().byteValue()));
   }
 
   @Test
   public void testShouldGetStringMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getString,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getString,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal().toString()));
   }
 
   @Test
   public void testShouldGetBooleanMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getBoolean,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getBoolean,
         (accessor, currentRow) -> equalTo(!accessor.getBigDecimal().equals(BigDecimal.ZERO)));
   }
 
   @Test
   public void testShouldGetObjectMethodFromDecimalVector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcDecimalVectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcDecimalVectorAccessor::getObject,
         (accessor, currentRow) -> equalTo(accessor.getBigDecimal()));
   }
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         ArrowFlightJdbcDecimalVectorAccessor::getObjectClass,
         (accessor, currentRow) -> equalTo(BigDecimal.class));
   }
 
   @Test
   public void testShouldGetBigDecimalMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getBigDecimal,
         (accessor, currentRow) -> CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetObjectMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getObject,
         (accessor, currentRow) -> CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetStringMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getString,
         (accessor, currentRow) -> CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetByteMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getByte,
         (accessor, currentRow) -> is((byte) 0));
   }
 
   @Test
   public void testShouldGetShortMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getShort,
         (accessor, currentRow) -> is((short) 0));
   }
 
   @Test
   public void testShouldGetIntMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getInt,
         (accessor, currentRow) -> is(0));
   }
 
   @Test
   public void testShouldGetLongMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getLong,
         (accessor, currentRow) -> is((long) 0));
   }
 
   @Test
   public void testShouldGetFloatMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getFloat,
         (accessor, currentRow) -> is(0.0f));
   }
 
   @Test
   public void testShouldGetDoubleMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getDouble,
         (accessor, currentRow) -> is(0.0D));
   }
 
   @Test
   public void testShouldGetBooleanMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcDecimalVectorAccessor::getBoolean,
         (accessor, currentRow) -> is(false));
   }
 
   @Test
   public void testShouldGetBigDecimalWithScaleMethodFromDecimalVectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull, accessor -> accessor.getBigDecimal(2),
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
+        accessor -> accessor.getBigDecimal(2),
         (accessor, currentRow) -> CoreMatchers.nullValue());
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat4VectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat4VectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -23,7 +22,6 @@ import static org.hamcrest.CoreMatchers.is;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
-
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.Float4Vector;
@@ -41,23 +39,20 @@ public class ArrowFlightJdbcFloat4VectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
-  @Rule
-  public ExpectedException exceptionCollector = ExpectedException.none();
+  @Rule public ExpectedException exceptionCollector = ExpectedException.none();
 
   private Float4Vector vector;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcFloat4VectorAccessor>
       accessorSupplier =
-          (vector, getCurrentRow) -> new ArrowFlightJdbcFloat4VectorAccessor((Float4Vector) vector,
-              getCurrentRow, (boolean wasNull) -> {
-          });
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcFloat4VectorAccessor(
+                  (Float4Vector) vector, getCurrentRow, (boolean wasNull) -> {});
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcFloat4VectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Before
   public void setup() {
@@ -71,55 +66,61 @@ public class ArrowFlightJdbcFloat4VectorAccessorTest {
 
   @Test
   public void testShouldGetFloatMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getFloat,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getFloat,
         (accessor, currentRow) -> is(vector.get(currentRow)));
   }
 
   @Test
   public void testShouldGetObjectMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getObject,
         (accessor) -> is(accessor.getFloat()));
   }
 
   @Test
   public void testShouldGetStringMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getString,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getString,
         accessor -> is(Float.toString(accessor.getFloat())));
   }
 
   @Test
   public void testShouldGetStringMethodFromFloat4VectorWithNull() throws Exception {
-    try (final Float4Vector float4Vector = new Float4Vector("ID",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (final Float4Vector float4Vector =
+        new Float4Vector("ID", rootAllocatorTestRule.getRootAllocator())) {
       float4Vector.setNull(0);
       float4Vector.setValueCount(1);
 
-      accessorIterator.assertAccessorGetter(float4Vector,
-          ArrowFlightJdbcFloat4VectorAccessor::getString,
-          CoreMatchers.nullValue());
+      accessorIterator.assertAccessorGetter(
+          float4Vector, ArrowFlightJdbcFloat4VectorAccessor::getString, CoreMatchers.nullValue());
     }
   }
 
   @Test
   public void testShouldGetFloatMethodFromFloat4VectorWithNull() throws Exception {
-    try (final Float4Vector float4Vector = new Float4Vector("ID",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (final Float4Vector float4Vector =
+        new Float4Vector("ID", rootAllocatorTestRule.getRootAllocator())) {
       float4Vector.setNull(0);
       float4Vector.setValueCount(1);
 
-      accessorIterator.assertAccessorGetter(float4Vector,
-          ArrowFlightJdbcFloat4VectorAccessor::getFloat, is(0.0f));
+      accessorIterator.assertAccessorGetter(
+          float4Vector, ArrowFlightJdbcFloat4VectorAccessor::getFloat, is(0.0f));
     }
   }
 
   @Test
   public void testShouldGetBigDecimalMethodFromFloat4VectorWithNull() throws Exception {
-    try (final Float4Vector float4Vector = new Float4Vector("ID",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (final Float4Vector float4Vector =
+        new Float4Vector("ID", rootAllocatorTestRule.getRootAllocator())) {
       float4Vector.setNull(0);
       float4Vector.setValueCount(1);
 
-      accessorIterator.assertAccessorGetter(float4Vector,
+      accessorIterator.assertAccessorGetter(
+          float4Vector,
           ArrowFlightJdbcFloat4VectorAccessor::getBigDecimal,
           CoreMatchers.nullValue());
     }
@@ -127,79 +128,96 @@ public class ArrowFlightJdbcFloat4VectorAccessorTest {
 
   @Test
   public void testShouldGetObjectMethodFromFloat4VectorWithNull() throws Exception {
-    try (final Float4Vector float4Vector = new Float4Vector("ID",
-        rootAllocatorTestRule.getRootAllocator())) {
+    try (final Float4Vector float4Vector =
+        new Float4Vector("ID", rootAllocatorTestRule.getRootAllocator())) {
       float4Vector.setNull(0);
       float4Vector.setValueCount(1);
 
-      accessorIterator.assertAccessorGetter(float4Vector,
-          ArrowFlightJdbcFloat4VectorAccessor::getObject,
-          CoreMatchers.nullValue());
+      accessorIterator.assertAccessorGetter(
+          float4Vector, ArrowFlightJdbcFloat4VectorAccessor::getObject, CoreMatchers.nullValue());
     }
   }
 
   @Test
   public void testShouldGetBooleanMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getBoolean,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getBoolean,
         accessor -> is(accessor.getFloat() != 0.0f));
   }
 
   @Test
   public void testShouldGetByteMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getByte,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getByte,
         accessor -> is((byte) accessor.getFloat()));
   }
 
   @Test
   public void testShouldGetShortMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getShort,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getShort,
         accessor -> is((short) accessor.getFloat()));
   }
 
   @Test
   public void testShouldGetIntMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getInt,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getInt,
         accessor -> is((int) accessor.getFloat()));
   }
 
   @Test
   public void testShouldGetLongMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getLong,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getLong,
         accessor -> is((long) accessor.getFloat()));
   }
 
   @Test
   public void testShouldGetDoubleMethodFromFloat4Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat4VectorAccessor::getDouble,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat4VectorAccessor::getDouble,
         accessor -> is((double) accessor.getFloat()));
   }
 
   @Test
   public void testShouldGetBigDecimalMethodFromFloat4Vector() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      float value = accessor.getFloat();
-      if (Float.isInfinite(value) || Float.isNaN(value)) {
-        exceptionCollector.expect(SQLException.class);
-      }
-      collector.checkThat(accessor.getBigDecimal(), is(BigDecimal.valueOf(value)));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          float value = accessor.getFloat();
+          if (Float.isInfinite(value) || Float.isNaN(value)) {
+            exceptionCollector.expect(SQLException.class);
+          }
+          collector.checkThat(accessor.getBigDecimal(), is(BigDecimal.valueOf(value)));
+        });
   }
 
   @Test
   public void testShouldGetBigDecimalWithScaleMethodFromFloat4Vector() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      float value = accessor.getFloat();
-      if (Float.isInfinite(value) || Float.isNaN(value)) {
-        exceptionCollector.expect(SQLException.class);
-      }
-      collector.checkThat(accessor.getBigDecimal(9),
-          is(BigDecimal.valueOf(value).setScale(9, RoundingMode.HALF_UP)));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          float value = accessor.getFloat();
+          if (Float.isInfinite(value) || Float.isNaN(value)) {
+            exceptionCollector.expect(SQLException.class);
+          }
+          collector.checkThat(
+              accessor.getBigDecimal(9),
+              is(BigDecimal.valueOf(value).setScale(9, RoundingMode.HALF_UP)));
+        });
   }
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator.assertAccessorGetter(vector,
+    accessorIterator.assertAccessorGetter(
+        vector,
         ArrowFlightJdbcFloat4VectorAccessor::getObjectClass,
         accessor -> equalTo(Float.class));
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat8VectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcFloat8VectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.numeric;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -23,7 +22,6 @@ import static org.hamcrest.CoreMatchers.is;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.sql.SQLException;
-
 import org.apache.arrow.driver.jdbc.utils.AccessorTestUtils;
 import org.apache.arrow.driver.jdbc.utils.RootAllocatorTestRule;
 import org.apache.arrow.vector.Float8Vector;
@@ -41,25 +39,21 @@ public class ArrowFlightJdbcFloat8VectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
-  @Rule
-  public ExpectedException exceptionCollector = ExpectedException.none();
-
+  @Rule public ExpectedException exceptionCollector = ExpectedException.none();
 
   private Float8Vector vector;
   private Float8Vector vectorWithNull;
 
   private final AccessorTestUtils.AccessorSupplier<ArrowFlightJdbcFloat8VectorAccessor>
       accessorSupplier =
-          (vector, getCurrentRow) -> new ArrowFlightJdbcFloat8VectorAccessor((Float8Vector) vector,
-              getCurrentRow, (boolean wasNull) -> {
-          });
+          (vector, getCurrentRow) ->
+              new ArrowFlightJdbcFloat8VectorAccessor(
+                  (Float8Vector) vector, getCurrentRow, (boolean wasNull) -> {});
 
   private final AccessorTestUtils.AccessorIterator<ArrowFlightJdbcFloat8VectorAccessor>
-      accessorIterator =
-      new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
+      accessorIterator = new AccessorTestUtils.AccessorIterator<>(collector, accessorSupplier);
 
   @Before
   public void setup() {
@@ -75,113 +69,133 @@ public class ArrowFlightJdbcFloat8VectorAccessorTest {
 
   @Test
   public void testShouldGetDoubleMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getDouble,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getDouble,
         (accessor, currentRow) -> is(vector.getValueAsDouble(currentRow)));
   }
 
   @Test
   public void testShouldGetObjectMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getObject,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getObject,
         (accessor) -> is(accessor.getDouble()));
   }
 
   @Test
   public void testShouldGetStringMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getString,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getString,
         (accessor) -> is(Double.toString(accessor.getDouble())));
   }
 
   @Test
   public void testShouldGetBooleanMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getBoolean,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getBoolean,
         (accessor) -> is(accessor.getDouble() != 0.0));
   }
 
   @Test
   public void testShouldGetByteMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getByte,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getByte,
         (accessor) -> is((byte) accessor.getDouble()));
   }
 
   @Test
   public void testShouldGetShortMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getShort,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getShort,
         (accessor) -> is((short) accessor.getDouble()));
   }
 
   @Test
   public void testShouldGetIntMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getInt,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getInt,
         (accessor) -> is((int) accessor.getDouble()));
   }
 
   @Test
   public void testShouldGetLongMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getLong,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getLong,
         (accessor) -> is((long) accessor.getDouble()));
   }
 
   @Test
   public void testShouldGetFloatMethodFromFloat8Vector() throws Exception {
-    accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getFloat,
+    accessorIterator.assertAccessorGetter(
+        vector,
+        ArrowFlightJdbcFloat8VectorAccessor::getFloat,
         (accessor) -> is((float) accessor.getDouble()));
   }
 
   @Test
   public void testShouldGetBigDecimalMethodFromFloat8Vector() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      double value = accessor.getDouble();
-      if (Double.isInfinite(value) || Double.isNaN(value)) {
-        exceptionCollector.expect(SQLException.class);
-      }
-      collector.checkThat(accessor.getBigDecimal(), is(BigDecimal.valueOf(value)));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          double value = accessor.getDouble();
+          if (Double.isInfinite(value) || Double.isNaN(value)) {
+            exceptionCollector.expect(SQLException.class);
+          }
+          collector.checkThat(accessor.getBigDecimal(), is(BigDecimal.valueOf(value)));
+        });
   }
 
   @Test
   public void testShouldGetObjectClass() throws Exception {
-    accessorIterator
-        .assertAccessorGetter(vector, ArrowFlightJdbcFloat8VectorAccessor::getObjectClass,
-            equalTo(Double.class));
+    accessorIterator.assertAccessorGetter(
+        vector, ArrowFlightJdbcFloat8VectorAccessor::getObjectClass, equalTo(Double.class));
   }
 
   @Test
   public void testShouldGetStringMethodFromFloat8VectorWithNull() throws Exception {
-    accessorIterator
-        .assertAccessorGetter(vectorWithNull, ArrowFlightJdbcFloat8VectorAccessor::getString,
-            CoreMatchers.nullValue());
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull, ArrowFlightJdbcFloat8VectorAccessor::getString, CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetFloatMethodFromFloat8VectorWithNull() throws Exception {
-    accessorIterator
-        .assertAccessorGetter(vectorWithNull, ArrowFlightJdbcFloat8VectorAccessor::getFloat,
-            is(0.0f));
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull, ArrowFlightJdbcFloat8VectorAccessor::getFloat, is(0.0f));
   }
 
   @Test
   public void testShouldGetBigDecimalMethodFromFloat8VectorWithNull() throws Exception {
-    accessorIterator.assertAccessorGetter(vectorWithNull,
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull,
         ArrowFlightJdbcFloat8VectorAccessor::getBigDecimal,
         CoreMatchers.nullValue());
   }
 
   @Test
   public void testShouldGetBigDecimalWithScaleMethodFromFloat4Vector() throws Exception {
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      double value = accessor.getDouble();
-      if (Double.isInfinite(value) || Double.isNaN(value)) {
-        exceptionCollector.expect(SQLException.class);
-      }
-      collector.checkThat(accessor.getBigDecimal(9),
-          is(BigDecimal.valueOf(value).setScale(9, RoundingMode.HALF_UP)));
-    });
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          double value = accessor.getDouble();
+          if (Double.isInfinite(value) || Double.isNaN(value)) {
+            exceptionCollector.expect(SQLException.class);
+          }
+          collector.checkThat(
+              accessor.getBigDecimal(9),
+              is(BigDecimal.valueOf(value).setScale(9, RoundingMode.HALF_UP)));
+        });
   }
 
   @Test
   public void testShouldGetObjectMethodFromFloat8VectorWithNull() throws Exception {
-    accessorIterator
-        .assertAccessorGetter(vectorWithNull, ArrowFlightJdbcFloat8VectorAccessor::getObject,
-            CoreMatchers.nullValue());
+    accessorIterator.assertAccessorGetter(
+        vectorWithNull, ArrowFlightJdbcFloat8VectorAccessor::getObject, CoreMatchers.nullValue());
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.accessor.impl.text;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -36,7 +35,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.function.IntSupplier;
-
 import org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeVectorAccessor;
@@ -57,7 +55,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-
 @RunWith(MockitoJUnitRunner.class)
 public class ArrowFlightJdbcVarCharVectorAccessorTest {
 
@@ -69,21 +66,18 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
   @ClassRule
   public static RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
 
-  @Mock
-  private ArrowFlightJdbcVarCharVectorAccessor.Getter getter;
+  @Mock private ArrowFlightJdbcVarCharVectorAccessor.Getter getter;
 
-  @Rule
-  public ErrorCollector collector = new ErrorCollector();
+  @Rule public ErrorCollector collector = new ErrorCollector();
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void setUp() {
     IntSupplier currentRowSupplier = () -> 0;
     accessor =
-        new ArrowFlightJdbcVarCharVectorAccessor(getter, currentRowSupplier, (boolean wasNull) -> {
-        });
+        new ArrowFlightJdbcVarCharVectorAccessor(
+            getter, currentRowSupplier, (boolean wasNull) -> {});
   }
 
   @Test
@@ -313,7 +307,8 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
   }
 
   @Test
-  public void testShouldBigDecimalWithParametersThrowsExceptionForNonNumericValue() throws Exception {
+  public void testShouldBigDecimalWithParametersThrowsExceptionForNonNumericValue()
+      throws Exception {
     Text value = new Text("Invalid value for BigDecimal.");
     when(getter.get(0)).thenReturn(value.copyBytes());
 
@@ -501,8 +496,8 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     Calendar calendar = Calendar.getInstance();
     calendar.setTime(result);
 
-    collector.checkThat(dateTimeFormat.format(calendar.getTime()),
-        equalTo("2021-07-02T00:00:00.000Z"));
+    collector.checkThat(
+        dateTimeFormat.format(calendar.getTime()), equalTo("2021-07-02T00:00:00.000Z"));
   }
 
   @Test
@@ -516,8 +511,8 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
     calendar.setTime(result);
 
-    collector.checkThat(dateTimeFormat.format(calendar.getTime()),
-        equalTo("2021-07-02T03:00:00.000Z"));
+    collector.checkThat(
+        dateTimeFormat.format(calendar.getTime()), equalTo("2021-07-02T03:00:00.000Z"));
   }
 
   @Test
@@ -575,8 +570,8 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     Calendar calendar = Calendar.getInstance();
     calendar.setTime(result);
 
-    collector.checkThat(dateTimeFormat.format(calendar.getTime()),
-        equalTo("2021-07-02T02:30:00.000Z"));
+    collector.checkThat(
+        dateTimeFormat.format(calendar.getTime()), equalTo("2021-07-02T02:30:00.000Z"));
   }
 
   @Test
@@ -590,8 +585,8 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/UTC"));
     calendar.setTime(result);
 
-    collector.checkThat(dateTimeFormat.format(calendar.getTime()),
-        equalTo("2021-07-02T05:30:00.000Z"));
+    collector.checkThat(
+        dateTimeFormat.format(calendar.getTime()), equalTo("2021-07-02T05:30:00.000Z"));
   }
 
   private void assertGetBoolean(Text value, boolean expectedResult) throws SQLException {
@@ -602,7 +597,8 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
 
   private void assertGetBooleanForSQLException(Text value) {
     when(getter.get(0)).thenReturn(value == null ? null : value.copyBytes());
-    ThrowableAssertionUtils.simpleAssertThrowableClass(SQLException.class, () -> accessor.getBoolean());
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        SQLException.class, () -> accessor.getBoolean());
   }
 
   @Test
@@ -649,8 +645,7 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     try (final InputStream result = accessor.getUnicodeStream()) {
       byte[] resultBytes = toByteArray(result);
 
-      collector.checkThat(new String(resultBytes, UTF_8),
-          equalTo(value.toString()));
+      collector.checkThat(new String(resultBytes, UTF_8), equalTo(value.toString()));
     }
   }
 
@@ -683,9 +678,8 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
   public void testShouldGetTimeStampBeConsistentWithTimeStampAccessor() throws Exception {
     try (TimeStampVector timeStampVector = rootAllocatorTestRule.createTimeStampMilliVector()) {
       ArrowFlightJdbcTimeStampVectorAccessor timeStampVectorAccessor =
-          new ArrowFlightJdbcTimeStampVectorAccessor(timeStampVector, () -> 0,
-              (boolean wasNull) -> {
-              });
+          new ArrowFlightJdbcTimeStampVectorAccessor(
+              timeStampVector, () -> 0, (boolean wasNull) -> {});
 
       Text value = new Text(timeStampVectorAccessor.getString());
       when(getter.get(0)).thenReturn(value.copyBytes());
@@ -699,8 +693,7 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
   public void testShouldGetTimeBeConsistentWithTimeAccessor() throws Exception {
     try (TimeMilliVector timeVector = rootAllocatorTestRule.createTimeMilliVector()) {
       ArrowFlightJdbcTimeVectorAccessor timeVectorAccessor =
-          new ArrowFlightJdbcTimeVectorAccessor(timeVector, () -> 0, (boolean wasNull) -> {
-          });
+          new ArrowFlightJdbcTimeVectorAccessor(timeVector, () -> 0, (boolean wasNull) -> {});
 
       Text value = new Text(timeVectorAccessor.getString());
       when(getter.get(0)).thenReturn(value.copyBytes());
@@ -714,8 +707,7 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
   public void testShouldGetDateBeConsistentWithDateAccessor() throws Exception {
     try (DateMilliVector dateVector = rootAllocatorTestRule.createDateMilliVector()) {
       ArrowFlightJdbcDateVectorAccessor dateVectorAccessor =
-          new ArrowFlightJdbcDateVectorAccessor(dateVector, () -> 0, (boolean wasNull) -> {
-          });
+          new ArrowFlightJdbcDateVectorAccessor(dateVector, () -> 0, (boolean wasNull) -> {});
 
       Text value = new Text(dateVectorAccessor.getString());
       when(getter.get(0)).thenReturn(value.copyBytes());

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/authentication/Authentication.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/authentication/Authentication.java
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.authentication;
 
 import java.util.Properties;
-
 import org.apache.arrow.flight.auth2.CallHeaderAuthenticator;
 
 public interface Authentication {
@@ -31,6 +29,7 @@ public interface Authentication {
 
   /**
    * Uses the validCredentials variable and populate the Properties object.
+   *
    * @param properties the Properties object that will be populated.
    */
   void populateProperties(Properties properties);

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/authentication/TokenAuthentication.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/authentication/TokenAuthentication.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.authentication;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl;
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallStatus;
@@ -40,7 +38,9 @@ public class TokenAuthentication implements Authentication {
       public AuthResult authenticate(CallHeaders incomingHeaders) {
         String authorization = incomingHeaders.get("authorization");
         if (!validCredentials.contains(authorization)) {
-          throw CallStatus.UNAUTHENTICATED.withDescription("Invalid credentials.").toRuntimeException();
+          throw CallStatus.UNAUTHENTICATED
+              .withDescription("Invalid credentials.")
+              .toRuntimeException();
         }
         return new AuthResult() {
           @Override
@@ -54,8 +54,11 @@ public class TokenAuthentication implements Authentication {
 
   @Override
   public void populateProperties(Properties properties) {
-    this.validCredentials.forEach(value -> properties.put(
-        ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.TOKEN.camelName(), value));
+    this.validCredentials.forEach(
+        value ->
+            properties.put(
+                ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.TOKEN.camelName(),
+                value));
   }
 
   public static final class Builder {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/authentication/UserPasswordAuthentication.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/authentication/UserPasswordAuthentication.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.authentication;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.auth2.BasicCallHeaderAuthenticator;
@@ -42,20 +40,28 @@ public class UserPasswordAuthentication implements Authentication {
   @Override
   public CallHeaderAuthenticator authenticate() {
     return new GeneratedBearerTokenAuthenticator(
-        new BasicCallHeaderAuthenticator((username, password) -> {
-          if (validCredentials.containsKey(username) && getCredentials(username).equals(password)) {
-            return () -> username;
-          }
-          throw CallStatus.UNAUTHENTICATED.withDescription("Invalid credentials.").toRuntimeException();
-        }));
+        new BasicCallHeaderAuthenticator(
+            (username, password) -> {
+              if (validCredentials.containsKey(username)
+                  && getCredentials(username).equals(password)) {
+                return () -> username;
+              }
+              throw CallStatus.UNAUTHENTICATED
+                  .withDescription("Invalid credentials.")
+                  .toRuntimeException();
+            }));
   }
 
   @Override
   public void populateProperties(Properties properties) {
-    validCredentials.forEach((key, value) -> {
-      properties.put(ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.USER.camelName(), key);
-      properties.put(ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.PASSWORD.camelName(), value);
-    });
+    validCredentials.forEach(
+        (key, value) -> {
+          properties.put(
+              ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.USER.camelName(), key);
+          properties.put(
+              ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty.PASSWORD.camelName(),
+              value);
+        });
   }
 
   public static class Builder {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandlerBuilderTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.client;
 
 import static org.junit.Assert.assertFalse;
@@ -32,13 +31,11 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-/**
- * Test the behavior of ArrowFlightSqlClientHandler.Builder
- */
+/** Test the behavior of ArrowFlightSqlClientHandler.Builder */
 public class ArrowFlightSqlClientHandlerBuilderTest {
   @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE = FlightServerTestRule
-      .createStandardTestRule(CoreMockedSqlProducers.getLegacyProducer());
+  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE =
+      FlightServerTestRule.createStandardTestRule(CoreMockedSqlProducers.getLegacyProducer());
 
   private static BufferAllocator allocator;
 
@@ -55,19 +52,21 @@ public class ArrowFlightSqlClientHandlerBuilderTest {
   @Test
   public void testRetainCookiesOnAuthOff() throws Exception {
     // Arrange
-    final ArrowFlightSqlClientHandler.Builder rootBuilder = new ArrowFlightSqlClientHandler.Builder()
-        .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-        .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-        .withBufferAllocator(allocator)
-        .withUsername(FlightServerTestRule.DEFAULT_USER)
-        .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
-        .withEncryption(false)
-        .withRetainCookies(true)
-        .withRetainAuth(false);
+    final ArrowFlightSqlClientHandler.Builder rootBuilder =
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withBufferAllocator(allocator)
+            .withUsername(FlightServerTestRule.DEFAULT_USER)
+            .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
+            .withEncryption(false)
+            .withRetainCookies(true)
+            .withRetainAuth(false);
 
     try (ArrowFlightSqlClientHandler rootHandler = rootBuilder.build()) {
       // Act
-      final ArrowFlightSqlClientHandler.Builder testBuilder = new ArrowFlightSqlClientHandler.Builder(rootBuilder);
+      final ArrowFlightSqlClientHandler.Builder testBuilder =
+          new ArrowFlightSqlClientHandler.Builder(rootBuilder);
 
       // Assert
       assertSame(rootBuilder.cookieFactory, testBuilder.cookieFactory);
@@ -78,19 +77,21 @@ public class ArrowFlightSqlClientHandlerBuilderTest {
   @Test
   public void testRetainCookiesOffAuthOff() throws Exception {
     // Arrange
-    final ArrowFlightSqlClientHandler.Builder rootBuilder = new ArrowFlightSqlClientHandler.Builder()
-        .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-        .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-        .withBufferAllocator(allocator)
-        .withUsername(FlightServerTestRule.DEFAULT_USER)
-        .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
-        .withEncryption(false)
-        .withRetainCookies(false)
-        .withRetainAuth(false);
+    final ArrowFlightSqlClientHandler.Builder rootBuilder =
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withBufferAllocator(allocator)
+            .withUsername(FlightServerTestRule.DEFAULT_USER)
+            .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
+            .withEncryption(false)
+            .withRetainCookies(false)
+            .withRetainAuth(false);
 
     try (ArrowFlightSqlClientHandler rootHandler = rootBuilder.build()) {
       // Act
-      final ArrowFlightSqlClientHandler.Builder testBuilder = new ArrowFlightSqlClientHandler.Builder(rootBuilder);
+      final ArrowFlightSqlClientHandler.Builder testBuilder =
+          new ArrowFlightSqlClientHandler.Builder(rootBuilder);
 
       // Assert
       assertNotSame(rootBuilder.cookieFactory, testBuilder.cookieFactory);
@@ -101,19 +102,21 @@ public class ArrowFlightSqlClientHandlerBuilderTest {
   @Test
   public void testRetainCookiesOnAuthOn() throws Exception {
     // Arrange
-    final ArrowFlightSqlClientHandler.Builder rootBuilder = new ArrowFlightSqlClientHandler.Builder()
-        .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
-        .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
-        .withBufferAllocator(allocator)
-        .withUsername(FlightServerTestRule.DEFAULT_USER)
-        .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
-        .withEncryption(false)
-        .withRetainCookies(true)
-        .withRetainAuth(true);
+    final ArrowFlightSqlClientHandler.Builder rootBuilder =
+        new ArrowFlightSqlClientHandler.Builder()
+            .withHost(FLIGHT_SERVER_TEST_RULE.getHost())
+            .withPort(FLIGHT_SERVER_TEST_RULE.getPort())
+            .withBufferAllocator(allocator)
+            .withUsername(FlightServerTestRule.DEFAULT_USER)
+            .withPassword(FlightServerTestRule.DEFAULT_PASSWORD)
+            .withEncryption(false)
+            .withRetainCookies(true)
+            .withRetainAuth(true);
 
     try (ArrowFlightSqlClientHandler rootHandler = rootBuilder.build()) {
       // Act
-      final ArrowFlightSqlClientHandler.Builder testBuilder = new ArrowFlightSqlClientHandler.Builder(rootBuilder);
+      final ArrowFlightSqlClientHandler.Builder testBuilder =
+          new ArrowFlightSqlClientHandler.Builder(rootBuilder);
 
       // Assert
       assertSame(rootBuilder.cookieFactory, testBuilder.cookieFactory);

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/client/utils/ClientAuthenticationUtilsTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.client.utils;
 
 import static org.mockito.Mockito.mock;
@@ -30,7 +29,6 @@ import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
-
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,8 +40,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClientAuthenticationUtilsTest {
-  @Mock
-  KeyStore keyStoreMock;
+  @Mock KeyStore keyStoreMock;
 
   @Test
   public void testGetCertificatesInputStream() throws IOException, KeyStoreException {
@@ -61,29 +58,27 @@ public class ClientAuthenticationUtilsTest {
   }
 
   @Test
-  public void testGetKeyStoreInstance() throws IOException,
-      KeyStoreException, CertificateException, NoSuchAlgorithmException {
+  public void testGetKeyStoreInstance()
+      throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     try (MockedStatic<KeyStore> keyStoreMockedStatic = Mockito.mockStatic(KeyStore.class)) {
       keyStoreMockedStatic
           .when(() -> ClientAuthenticationUtils.getKeyStoreInstance(Mockito.any()))
           .thenReturn(keyStoreMock);
 
       KeyStore receiveKeyStore = ClientAuthenticationUtils.getKeyStoreInstance("test1");
-      Mockito
-          .verify(keyStoreMock)
-          .load(null, null);
+      Mockito.verify(keyStoreMock).load(null, null);
 
       Assert.assertEquals(receiveKeyStore, keyStoreMock);
     }
   }
 
   @Test
-  public void testGetDefaultKeyStoreInstancePassword() throws IOException,
-          KeyStoreException, CertificateException, NoSuchAlgorithmException {
+  public void testGetDefaultKeyStoreInstancePassword()
+      throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     try (MockedStatic<KeyStore> keyStoreMockedStatic = Mockito.mockStatic(KeyStore.class)) {
 
       keyStoreMockedStatic
-         .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit"))
+          .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit"))
           .thenReturn(keyStoreMock);
       KeyStore receiveKeyStore = ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit");
       Assert.assertEquals(receiveKeyStore, keyStoreMock);
@@ -91,8 +86,8 @@ public class ClientAuthenticationUtilsTest {
   }
 
   @Test
-  public void testGetDefaultKeyStoreInstanceNoPassword() throws IOException,
-          KeyStoreException, CertificateException, NoSuchAlgorithmException {
+  public void testGetDefaultKeyStoreInstanceNoPassword()
+      throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     try (MockedStatic<KeyStore> keyStoreMockedStatic = Mockito.mockStatic(KeyStore.class)) {
 
       keyStoreMockedStatic
@@ -103,44 +98,44 @@ public class ClientAuthenticationUtilsTest {
     }
   }
 
-
   @Test
-  public void testGetCertificateInputStreamFromMacSystem() throws IOException,
-      KeyStoreException, CertificateException, NoSuchAlgorithmException {
+  public void testGetCertificateInputStreamFromMacSystem()
+      throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     InputStream mock = mock(InputStream.class);
 
     try (MockedStatic<KeyStore> keyStoreMockedStatic = createKeyStoreStaticMock();
-         MockedStatic<ClientAuthenticationUtils>
-             clientAuthenticationUtilsMockedStatic = createClientAuthenticationUtilsStaticMock()) {
+        MockedStatic<ClientAuthenticationUtils> clientAuthenticationUtilsMockedStatic =
+            createClientAuthenticationUtilsStaticMock()) {
 
       setOperatingSystemMock(clientAuthenticationUtilsMockedStatic, false, true);
-      keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
-          .getKeyStoreInstance("KeychainStore"))
+      keyStoreMockedStatic
+          .when(() -> ClientAuthenticationUtils.getKeyStoreInstance("KeychainStore"))
           .thenReturn(keyStoreMock);
-      keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
-          .getDefaultKeyStoreInstance("changeit"))
+      keyStoreMockedStatic
+          .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance("changeit"))
           .thenReturn(keyStoreMock);
       clientAuthenticationUtilsMockedStatic
           .when(ClientAuthenticationUtils::getKeystoreInputStream)
           .thenCallRealMethod();
       keyStoreMockedStatic.when(KeyStore::getDefaultType).thenCallRealMethod();
-      keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
-          .getCertificatesInputStream(Mockito.any()))
+      keyStoreMockedStatic
+          .when(() -> ClientAuthenticationUtils.getCertificatesInputStream(Mockito.any()))
           .thenReturn(mock);
 
-      InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");
+      InputStream inputStream =
+          ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");
       Assert.assertEquals(inputStream, mock);
     }
   }
 
   @Test
-  public void testGetCertificateInputStreamFromWindowsSystem() throws IOException,
-      KeyStoreException, CertificateException, NoSuchAlgorithmException {
+  public void testGetCertificateInputStreamFromWindowsSystem()
+      throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     InputStream mock = mock(InputStream.class);
 
     try (MockedStatic<KeyStore> keyStoreMockedStatic = createKeyStoreStaticMock();
-        MockedStatic<ClientAuthenticationUtils>
-            clientAuthenticationUtilsMockedStatic = createClientAuthenticationUtilsStaticMock()) {
+        MockedStatic<ClientAuthenticationUtils> clientAuthenticationUtilsMockedStatic =
+            createClientAuthenticationUtilsStaticMock()) {
 
       setOperatingSystemMock(clientAuthenticationUtilsMockedStatic, true, false);
       keyStoreMockedStatic
@@ -153,67 +148,74 @@ public class ClientAuthenticationUtilsTest {
           .when(() -> ClientAuthenticationUtils.getCertificatesInputStream(Mockito.any()))
           .thenReturn(mock);
 
-      InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("test");
+      InputStream inputStream =
+          ClientAuthenticationUtils.getCertificateInputStreamFromSystem("test");
       Assert.assertEquals(inputStream, mock);
     }
   }
 
   @Test
-  public void testGetCertificateInputStreamFromLinuxSystem() throws IOException,
-      KeyStoreException, CertificateException, NoSuchAlgorithmException {
+  public void testGetCertificateInputStreamFromLinuxSystem()
+      throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     InputStream mock = mock(InputStream.class);
 
-    try (
-        MockedStatic<KeyStore> keyStoreMockedStatic = createKeyStoreStaticMock();
-        MockedStatic<ClientAuthenticationUtils>
-            clientAuthenticationUtilsMockedStatic = createClientAuthenticationUtilsStaticMock()) {
+    try (MockedStatic<KeyStore> keyStoreMockedStatic = createKeyStoreStaticMock();
+        MockedStatic<ClientAuthenticationUtils> clientAuthenticationUtilsMockedStatic =
+            createClientAuthenticationUtilsStaticMock()) {
 
       setOperatingSystemMock(clientAuthenticationUtilsMockedStatic, false, false);
-      keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
-          .getCertificatesInputStream(Mockito.any()))
+      keyStoreMockedStatic
+          .when(() -> ClientAuthenticationUtils.getCertificatesInputStream(Mockito.any()))
           .thenReturn(mock);
-      keyStoreMockedStatic.when(() -> ClientAuthenticationUtils
-          .getDefaultKeyStoreInstance(Mockito.any()))
+      keyStoreMockedStatic
+          .when(() -> ClientAuthenticationUtils.getDefaultKeyStoreInstance(Mockito.any()))
           .thenReturn(keyStoreMock);
       clientAuthenticationUtilsMockedStatic
           .when(ClientAuthenticationUtils::getKeystoreInputStream)
           .thenCallRealMethod();
       keyStoreMockedStatic.when(KeyStore::getDefaultType).thenCallRealMethod();
 
-      InputStream inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");
+      InputStream inputStream =
+          ClientAuthenticationUtils.getCertificateInputStreamFromSystem("changeit");
       Assert.assertEquals(inputStream, mock);
       inputStream = ClientAuthenticationUtils.getCertificateInputStreamFromSystem(null);
       Assert.assertEquals(inputStream, mock);
     }
   }
 
-
   private MockedStatic<KeyStore> createKeyStoreStaticMock() {
-    return Mockito.mockStatic(KeyStore.class, invocationOnMock -> {
+    return Mockito.mockStatic(
+        KeyStore.class,
+        invocationOnMock -> {
           Method method = invocationOnMock.getMethod();
           if (method.getName().equals("getInstance")) {
             return invocationOnMock.callRealMethod();
           }
           return method.invoke(invocationOnMock.getMock(), invocationOnMock.getArguments());
-        }
-    );
+        });
   }
 
   private MockedStatic<ClientAuthenticationUtils> createClientAuthenticationUtilsStaticMock() {
-    return Mockito.mockStatic(ClientAuthenticationUtils.class , invocationOnMock -> {
-      Method method = invocationOnMock.getMethod();
-      if (method.getName().equals("getCertificateInputStreamFromSystem")) {
-        return invocationOnMock.callRealMethod();
-      }
-      return method.invoke(invocationOnMock.getMock(), invocationOnMock.getArguments());
-    });
+    return Mockito.mockStatic(
+        ClientAuthenticationUtils.class,
+        invocationOnMock -> {
+          Method method = invocationOnMock.getMethod();
+          if (method.getName().equals("getCertificateInputStreamFromSystem")) {
+            return invocationOnMock.callRealMethod();
+          }
+          return method.invoke(invocationOnMock.getMock(), invocationOnMock.getArguments());
+        });
   }
 
-  private void setOperatingSystemMock(MockedStatic<ClientAuthenticationUtils> clientAuthenticationUtilsMockedStatic,
-                                      boolean isWindows, boolean isMac) {
+  private void setOperatingSystemMock(
+      MockedStatic<ClientAuthenticationUtils> clientAuthenticationUtilsMockedStatic,
+      boolean isWindows,
+      boolean isMac) {
     clientAuthenticationUtilsMockedStatic.when(ClientAuthenticationUtils::isMac).thenReturn(isMac);
     Assert.assertEquals(ClientAuthenticationUtils.isMac(), isMac);
-    clientAuthenticationUtilsMockedStatic.when(ClientAuthenticationUtils::isWindows).thenReturn(isWindows);
+    clientAuthenticationUtilsMockedStatic
+        .when(ClientAuthenticationUtils::isWindows)
+        .thenReturn(isWindows);
     Assert.assertEquals(ClientAuthenticationUtils.isWindows(), isWindows);
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/AccessorTestUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/AccessorTestUtils.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -26,7 +25,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntSupplier;
 import java.util.function.Supplier;
-
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.vector.ValueVector;
 import org.hamcrest.Matcher;
@@ -106,35 +104,43 @@ public class AccessorTestUtils {
       return result;
     }
 
-    public <R> void assertAccessorGetter(ValueVector vector, CheckedFunction<T, R> getter,
-                                         MatcherGetter<T, R> matcherGetter) throws Exception {
-      iterate(vector, (accessor, currentRow) -> {
-        R object = getter.apply(accessor);
-        boolean wasNull = accessor.wasNull();
-
-        collector.checkThat(object, matcherGetter.get(accessor, currentRow));
-        collector.checkThat(wasNull, is(accessor.getObject() == null));
-      });
-    }
-
-    public <R> void assertAccessorGetterThrowingException(ValueVector vector, CheckedFunction<T, R> getter)
+    public <R> void assertAccessorGetter(
+        ValueVector vector, CheckedFunction<T, R> getter, MatcherGetter<T, R> matcherGetter)
         throws Exception {
-      iterate(vector, (accessor, currentRow) ->
-          ThrowableAssertionUtils.simpleAssertThrowableClass(SQLException.class, () -> getter.apply(accessor)));
+      iterate(
+          vector,
+          (accessor, currentRow) -> {
+            R object = getter.apply(accessor);
+            boolean wasNull = accessor.wasNull();
+
+            collector.checkThat(object, matcherGetter.get(accessor, currentRow));
+            collector.checkThat(wasNull, is(accessor.getObject() == null));
+          });
     }
 
-    public <R> void assertAccessorGetter(ValueVector vector, CheckedFunction<T, R> getter,
-                                         Function<T, Matcher<R>> matcherGetter) throws Exception {
+    public <R> void assertAccessorGetterThrowingException(
+        ValueVector vector, CheckedFunction<T, R> getter) throws Exception {
+      iterate(
+          vector,
+          (accessor, currentRow) ->
+              ThrowableAssertionUtils.simpleAssertThrowableClass(
+                  SQLException.class, () -> getter.apply(accessor)));
+    }
+
+    public <R> void assertAccessorGetter(
+        ValueVector vector, CheckedFunction<T, R> getter, Function<T, Matcher<R>> matcherGetter)
+        throws Exception {
       assertAccessorGetter(vector, getter, (accessor, currentRow) -> matcherGetter.apply(accessor));
     }
 
-    public <R> void assertAccessorGetter(ValueVector vector, CheckedFunction<T, R> getter,
-                                         Supplier<Matcher<R>> matcherGetter) throws Exception {
+    public <R> void assertAccessorGetter(
+        ValueVector vector, CheckedFunction<T, R> getter, Supplier<Matcher<R>> matcherGetter)
+        throws Exception {
       assertAccessorGetter(vector, getter, (accessor, currentRow) -> matcherGetter.get());
     }
 
-    public <R> void assertAccessorGetter(ValueVector vector, CheckedFunction<T, R> getter,
-                                         Matcher<R> matcher) throws Exception {
+    public <R> void assertAccessorGetter(
+        ValueVector vector, CheckedFunction<T, R> getter, Matcher<R> matcher) throws Exception {
       assertAccessorGetter(vector, getter, (accessor, currentRow) -> matcher);
     }
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImplTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImplTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static java.lang.Runtime.getRuntime;
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 import java.util.function.Function;
-
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,11 +48,9 @@ public final class ArrowFlightConnectionConfigImplTest {
   private final Properties properties = new Properties();
   private ArrowFlightConnectionConfigImpl arrowFlightConnectionConfig;
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
-  @Parameter
-  public ArrowFlightConnectionProperty property;
+  @Parameter public ArrowFlightConnectionProperty property;
 
   @Parameter(value = 1)
   public Object value;
@@ -70,27 +66,47 @@ public final class ArrowFlightConnectionConfigImplTest {
 
   @Test
   public void testGetProperty() {
-    collector.checkThat(arrowFlightConnectionConfigFunction.apply(arrowFlightConnectionConfig),
-        is(value));
+    collector.checkThat(
+        arrowFlightConnectionConfigFunction.apply(arrowFlightConnectionConfig), is(value));
   }
 
   @Parameters(name = "<{0}> as <{1}>")
   public static List<Object[]> provideParameters() {
-    return asList(new Object[][] {
-        {HOST, "host",
-            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::getHost},
-        {PORT,
+    return asList(
+        new Object[][] {
+          {
+            HOST,
+            "host",
+            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::getHost
+          },
+          {
+            PORT,
             RANDOM.nextInt(Short.toUnsignedInt(Short.MAX_VALUE)),
-            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::getPort},
-        {USER, "user",
-            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::getUser},
-        {PASSWORD, "password",
-            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::getPassword},
-        {USE_ENCRYPTION, RANDOM.nextBoolean(),
-            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::useEncryption},
-        {THREAD_POOL_SIZE,
+            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::getPort
+          },
+          {
+            USER,
+            "user",
+            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::getUser
+          },
+          {
+            PASSWORD,
+            "password",
+            (Function<ArrowFlightConnectionConfigImpl, ?>)
+                ArrowFlightConnectionConfigImpl::getPassword
+          },
+          {
+            USE_ENCRYPTION,
+            RANDOM.nextBoolean(),
+            (Function<ArrowFlightConnectionConfigImpl, ?>)
+                ArrowFlightConnectionConfigImpl::useEncryption
+          },
+          {
+            THREAD_POOL_SIZE,
             RANDOM.nextInt(getRuntime().availableProcessors()),
-            (Function<ArrowFlightConnectionConfigImpl, ?>) ArrowFlightConnectionConfigImpl::threadPoolSize},
-    });
+            (Function<ArrowFlightConnectionConfigImpl, ?>)
+                ArrowFlightConnectionConfigImpl::threadPoolSize
+          },
+        });
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionPropertyTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionPropertyTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.apache.arrow.util.AutoCloseables.close;
@@ -23,7 +22,6 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
 import org.junit.After;
 import org.junit.Assert;
@@ -39,13 +37,11 @@ import org.mockito.Mock;
 @RunWith(Parameterized.class)
 public final class ArrowFlightConnectionPropertyTest {
 
-  @Mock
-  public Properties properties;
+  @Mock public Properties properties;
 
   private AutoCloseable mockitoResource;
 
-  @Parameter
-  public ArrowFlightConnectionProperty arrowFlightConnectionProperty;
+  @Parameter public ArrowFlightConnectionProperty arrowFlightConnectionProperty;
 
   @Before
   public void setUp() {
@@ -59,21 +55,22 @@ public final class ArrowFlightConnectionPropertyTest {
 
   @Test
   public void testWrapIsUnsupported() {
-    ThrowableAssertionUtils.simpleAssertThrowableClass(UnsupportedOperationException.class,
-        () -> arrowFlightConnectionProperty.wrap(properties));
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        UnsupportedOperationException.class, () -> arrowFlightConnectionProperty.wrap(properties));
   }
 
   @Test
   public void testRequiredPropertyThrows() {
     Assume.assumeTrue(arrowFlightConnectionProperty.required());
-    ThrowableAssertionUtils.simpleAssertThrowableClass(IllegalStateException.class,
-        () -> arrowFlightConnectionProperty.get(new Properties()));
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        IllegalStateException.class, () -> arrowFlightConnectionProperty.get(new Properties()));
   }
 
   @Test
   public void testOptionalPropertyReturnsDefault() {
     Assume.assumeTrue(!arrowFlightConnectionProperty.required());
-    Assert.assertEquals(arrowFlightConnectionProperty.defaultValue(),
+    Assert.assertEquals(
+        arrowFlightConnectionProperty.defaultValue(),
         arrowFlightConnectionProperty.get(new Properties()));
   }
 
@@ -82,7 +79,8 @@ public final class ArrowFlightConnectionPropertyTest {
     final ArrowFlightConnectionProperty[] arrowFlightConnectionProperties =
         ArrowFlightConnectionProperty.values();
     final List<Object[]> parameters = new ArrayList<>(arrowFlightConnectionProperties.length);
-    for (final ArrowFlightConnectionProperty arrowFlightConnectionProperty : arrowFlightConnectionProperties) {
+    for (final ArrowFlightConnectionProperty arrowFlightConnectionProperty :
+        arrowFlightConnectionProperties) {
       parameters.add(new Object[] {arrowFlightConnectionProperty});
     }
     return parameters;

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ConnectionWrapperTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ConnectionWrapperTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static java.lang.String.format;
@@ -35,7 +34,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Random;
-
 import org.apache.arrow.driver.jdbc.ArrowFlightConnection;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.calcite.avatica.AvaticaConnection;
@@ -66,11 +64,9 @@ public final class ConnectionWrapperTest {
   private static final Random RANDOM = new Random(Long.MAX_VALUE);
   private static final int TIMEOUT = RANDOM.nextInt(Integer.MAX_VALUE);
 
-  @Mock
-  public AvaticaConnection underlyingConnection;
+  @Mock public AvaticaConnection underlyingConnection;
   private ConnectionWrapper connectionWrapper;
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
+  @Rule public final ErrorCollector collector = new ErrorCollector();
 
   @Before
   public void setUp() {
@@ -93,10 +89,10 @@ public final class ConnectionWrapperTest {
     collector.checkThat(
         collector.checkSucceeds(() -> connectionWrapper.unwrap(AvaticaConnection.class)),
         is(sameInstance(underlyingConnection)));
-    ThrowableAssertionUtils.simpleAssertThrowableClass(ClassCastException.class,
-        () -> connectionWrapper.unwrap(ArrowFlightConnection.class));
-    ThrowableAssertionUtils.simpleAssertThrowableClass(ClassCastException.class,
-        () -> connectionWrapper.unwrap(ConnectionWrapper.class));
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        ClassCastException.class, () -> connectionWrapper.unwrap(ArrowFlightConnection.class));
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        ClassCastException.class, () -> connectionWrapper.unwrap(ConnectionWrapper.class));
   }
 
   @Test
@@ -106,14 +102,16 @@ public final class ConnectionWrapperTest {
         connectionWrapper.createStatement(),
         is(sameInstance(verify(underlyingConnection, times(1)).createStatement())));
     collector.checkThat(
-        connectionWrapper.createStatement(RESULT_SET_TYPE, RESULT_SET_CONCURRENCY,
-            RESULT_SET_HOLDABILITY),
-        is(verify(underlyingConnection, times(1))
-            .createStatement(RESULT_SET_TYPE, RESULT_SET_CONCURRENCY, RESULT_SET_HOLDABILITY)));
+        connectionWrapper.createStatement(
+            RESULT_SET_TYPE, RESULT_SET_CONCURRENCY, RESULT_SET_HOLDABILITY),
+        is(
+            verify(underlyingConnection, times(1))
+                .createStatement(RESULT_SET_TYPE, RESULT_SET_CONCURRENCY, RESULT_SET_HOLDABILITY)));
     collector.checkThat(
         connectionWrapper.createStatement(RESULT_SET_TYPE, RESULT_SET_CONCURRENCY),
-        is(verify(underlyingConnection, times(1))
-            .createStatement(RESULT_SET_TYPE, RESULT_SET_CONCURRENCY)));
+        is(
+            verify(underlyingConnection, times(1))
+                .createStatement(RESULT_SET_TYPE, RESULT_SET_CONCURRENCY)));
   }
 
   @Test
@@ -121,49 +119,62 @@ public final class ConnectionWrapperTest {
       throws SQLException {
     collector.checkThat(
         connectionWrapper.prepareStatement(PLACEHOLDER_QUERY),
-        is(sameInstance(
-            verify(underlyingConnection, times(1)).prepareStatement(PLACEHOLDER_QUERY))));
+        is(
+            sameInstance(
+                verify(underlyingConnection, times(1)).prepareStatement(PLACEHOLDER_QUERY))));
     collector.checkThat(
         connectionWrapper.prepareStatement(PLACEHOLDER_QUERY, COLUMN_INDICES),
-        is(allOf(sameInstance(verify(underlyingConnection, times(1))
-                .prepareStatement(PLACEHOLDER_QUERY, COLUMN_INDICES)),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(
+                    verify(underlyingConnection, times(1))
+                        .prepareStatement(PLACEHOLDER_QUERY, COLUMN_INDICES)),
+                nullValue())));
     collector.checkThat(
         connectionWrapper.prepareStatement(PLACEHOLDER_QUERY, COLUMN_NAMES),
-        is(allOf(sameInstance(verify(underlyingConnection, times(1))
-                .prepareStatement(PLACEHOLDER_QUERY, COLUMN_NAMES)),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(
+                    verify(underlyingConnection, times(1))
+                        .prepareStatement(PLACEHOLDER_QUERY, COLUMN_NAMES)),
+                nullValue())));
     collector.checkThat(
-        connectionWrapper.prepareStatement(PLACEHOLDER_QUERY, RESULT_SET_TYPE,
-            RESULT_SET_CONCURRENCY),
-        is(allOf(sameInstance(verify(underlyingConnection, times(1))
-                .prepareStatement(PLACEHOLDER_QUERY, RESULT_SET_TYPE, RESULT_SET_CONCURRENCY)),
-            nullValue())));
+        connectionWrapper.prepareStatement(
+            PLACEHOLDER_QUERY, RESULT_SET_TYPE, RESULT_SET_CONCURRENCY),
+        is(
+            allOf(
+                sameInstance(
+                    verify(underlyingConnection, times(1))
+                        .prepareStatement(
+                            PLACEHOLDER_QUERY, RESULT_SET_TYPE, RESULT_SET_CONCURRENCY)),
+                nullValue())));
     collector.checkThat(
         connectionWrapper.prepareStatement(PLACEHOLDER_QUERY, GENERATED_KEYS),
-        is(allOf(sameInstance(verify(underlyingConnection, times(1))
-                .prepareStatement(PLACEHOLDER_QUERY, GENERATED_KEYS)),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(
+                    verify(underlyingConnection, times(1))
+                        .prepareStatement(PLACEHOLDER_QUERY, GENERATED_KEYS)),
+                nullValue())));
   }
 
   @Test
   public void testPrepareCallShouldPrepareCallFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.prepareCall(PLACEHOLDER_QUERY),
-        is(sameInstance(
-            verify(underlyingConnection, times(1)).prepareCall(PLACEHOLDER_QUERY))));
+        is(sameInstance(verify(underlyingConnection, times(1)).prepareCall(PLACEHOLDER_QUERY))));
     collector.checkThat(
         connectionWrapper.prepareCall(PLACEHOLDER_QUERY, RESULT_SET_TYPE, RESULT_SET_CONCURRENCY),
-        is(verify(underlyingConnection, times(1))
-            .prepareCall(PLACEHOLDER_QUERY, RESULT_SET_TYPE, RESULT_SET_CONCURRENCY)));
+        is(
+            verify(underlyingConnection, times(1))
+                .prepareCall(PLACEHOLDER_QUERY, RESULT_SET_TYPE, RESULT_SET_CONCURRENCY)));
   }
 
   @Test
   public void testNativeSqlShouldGetNativeSqlFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.nativeSQL(PLACEHOLDER_QUERY),
-        is(sameInstance(
-            verify(underlyingConnection, times(1)).nativeSQL(PLACEHOLDER_QUERY))));
+        is(sameInstance(verify(underlyingConnection, times(1)).nativeSQL(PLACEHOLDER_QUERY))));
   }
 
   @Test
@@ -221,8 +232,8 @@ public final class ConnectionWrapperTest {
 
   @Test
   public void testSetIsReadOnlyShouldGetStatusFromUnderlyingConnection() throws SQLException {
-    collector.checkThat(connectionWrapper.isReadOnly(),
-        is(verify(underlyingConnection).isReadOnly()));
+    collector.checkThat(
+        connectionWrapper.isReadOnly(), is(verify(underlyingConnection).isReadOnly()));
   }
 
   @Test
@@ -257,9 +268,7 @@ public final class ConnectionWrapperTest {
   public void getWarningShouldGetWarningsFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.getWarnings(),
-        is(allOf(
-            sameInstance(verify(underlyingConnection, times(1)).getWarnings()),
-            nullValue())));
+        is(allOf(sameInstance(verify(underlyingConnection, times(1)).getWarnings()), nullValue())));
   }
 
   @Test
@@ -272,8 +281,7 @@ public final class ConnectionWrapperTest {
   public void getTypeMapShouldGetTypeMapFromUnderlyingConnection() throws SQLException {
     when(underlyingConnection.getTypeMap()).thenReturn(null);
     collector.checkThat(
-        connectionWrapper.getTypeMap(),
-        is(verify(underlyingConnection, times(1)).getTypeMap()));
+        connectionWrapper.getTypeMap(), is(verify(underlyingConnection, times(1)).getTypeMap()));
   }
 
   @Test
@@ -299,13 +307,12 @@ public final class ConnectionWrapperTest {
   public void testSetSavepointShouldSetSavepointInUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.setSavepoint(),
-        is(allOf(
-            sameInstance(verify(underlyingConnection, times(1)).setSavepoint()),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(verify(underlyingConnection, times(1)).setSavepoint()), nullValue())));
     collector.checkThat(
         connectionWrapper.setSavepoint(SAVEPOINT_NAME),
-        is(sameInstance(
-            verify(underlyingConnection, times(1)).setSavepoint(SAVEPOINT_NAME))));
+        is(sameInstance(verify(underlyingConnection, times(1)).setSavepoint(SAVEPOINT_NAME))));
   }
 
   @Test
@@ -325,32 +332,30 @@ public final class ConnectionWrapperTest {
   public void testCreateClobShouldCreateClobFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.createClob(),
-        is(allOf(sameInstance(
-            verify(underlyingConnection, times(1)).createClob()), nullValue())));
+        is(allOf(sameInstance(verify(underlyingConnection, times(1)).createClob()), nullValue())));
   }
 
   @Test
   public void testCreateBlobShouldCreateBlobFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.createBlob(),
-        is(allOf(sameInstance(
-            verify(underlyingConnection, times(1)).createBlob()), nullValue())));
+        is(allOf(sameInstance(verify(underlyingConnection, times(1)).createBlob()), nullValue())));
   }
 
   @Test
   public void testCreateNClobShouldCreateNClobFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.createNClob(),
-        is(allOf(sameInstance(
-            verify(underlyingConnection, times(1)).createNClob()), nullValue())));
+        is(allOf(sameInstance(verify(underlyingConnection, times(1)).createNClob()), nullValue())));
   }
 
   @Test
   public void testCreateSQLXMLShouldCreateSQLXMLFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.createSQLXML(),
-        is(allOf(sameInstance(
-            verify(underlyingConnection, times(1)).createSQLXML()), nullValue())));
+        is(
+            allOf(
+                sameInstance(verify(underlyingConnection, times(1)).createSQLXML()), nullValue())));
   }
 
   @Test
@@ -371,16 +376,16 @@ public final class ConnectionWrapperTest {
   public void testGetClientInfoShouldGetClientInfoFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.getClientInfo(CLIENT_INFO),
-        is(allOf(
-            sameInstance(
-                verify(underlyingConnection, times(1)).getClientInfo(CLIENT_INFO)),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(verify(underlyingConnection, times(1)).getClientInfo(CLIENT_INFO)),
+                nullValue())));
     collector.checkThat(
         connectionWrapper.getClientInfo(),
-        is(allOf(
-            sameInstance(
-                verify(underlyingConnection, times(1)).getClientInfo()),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(verify(underlyingConnection, times(1)).getClientInfo()),
+                nullValue())));
   }
 
   @Test
@@ -388,10 +393,11 @@ public final class ConnectionWrapperTest {
     final Object[] elements = range(0, 100).boxed().toArray();
     collector.checkThat(
         connectionWrapper.createArrayOf(TYPE_NAME, elements),
-        is(allOf(
-            sameInstance(
-                verify(underlyingConnection, times(1)).createArrayOf(TYPE_NAME, elements)),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(
+                    verify(underlyingConnection, times(1)).createArrayOf(TYPE_NAME, elements)),
+                nullValue())));
   }
 
   @Test
@@ -399,10 +405,11 @@ public final class ConnectionWrapperTest {
     final Object[] attributes = range(0, 120).boxed().toArray();
     collector.checkThat(
         connectionWrapper.createStruct(TYPE_NAME, attributes),
-        is(allOf(
-            sameInstance(
-                verify(underlyingConnection, times(1)).createStruct(TYPE_NAME, attributes)),
-            nullValue())));
+        is(
+            allOf(
+                sameInstance(
+                    verify(underlyingConnection, times(1)).createStruct(TYPE_NAME, attributes)),
+                nullValue())));
   }
 
   @Test
@@ -415,9 +422,7 @@ public final class ConnectionWrapperTest {
   public void testGetSchemaShouldGetSchemaFromUnderlyingConnection() throws SQLException {
     collector.checkThat(
         connectionWrapper.getSchema(),
-        is(allOf(
-            sameInstance(verify(underlyingConnection, times(1)).getSchema()),
-            nullValue())));
+        is(allOf(sameInstance(verify(underlyingConnection, times(1)).getSchema()), nullValue())));
   }
 
   @Test

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ConvertUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ConvertUtilsTest.java
@@ -14,13 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-
 import org.apache.arrow.flight.sql.FlightSqlColumnMetadata;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -31,28 +30,26 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
-import com.google.common.collect.ImmutableList;
-
 public class ConvertUtilsTest {
 
-  @Rule
-  public ErrorCollector collector = new ErrorCollector();
+  @Rule public ErrorCollector collector = new ErrorCollector();
 
   @Test
   public void testShouldSetOnColumnMetaDataBuilder() {
 
     final Common.ColumnMetaData.Builder builder = Common.ColumnMetaData.newBuilder();
-    final FlightSqlColumnMetadata expectedColumnMetaData = new FlightSqlColumnMetadata.Builder()
-        .catalogName("catalog1")
-        .schemaName("schema1")
-        .tableName("table1")
-        .isAutoIncrement(true)
-        .isCaseSensitive(true)
-        .isReadOnly(true)
-        .isSearchable(true)
-        .precision(20)
-        .scale(10)
-        .build();
+    final FlightSqlColumnMetadata expectedColumnMetaData =
+        new FlightSqlColumnMetadata.Builder()
+            .catalogName("catalog1")
+            .schemaName("schema1")
+            .tableName("table1")
+            .isAutoIncrement(true)
+            .isCaseSensitive(true)
+            .isReadOnly(true)
+            .isSearchable(true)
+            .precision(20)
+            .scale(10)
+            .build();
     ConvertUtils.setOnColumnMetaDataBuilder(builder, expectedColumnMetaData.getMetadataMap());
     assertBuilder(builder, expectedColumnMetaData);
   }
@@ -60,57 +57,77 @@ public class ConvertUtilsTest {
   @Test
   public void testShouldConvertArrowFieldsToColumnMetaDataList() {
 
-    final List<Field> listField = ImmutableList.of(
-        new Field("col1",
-            new FieldType(true, ArrowType.Utf8.INSTANCE, null,
-                new FlightSqlColumnMetadata.Builder()
-                    .catalogName("catalog1")
-                    .schemaName("schema1")
-                    .tableName("table1")
-                    .build().getMetadataMap()
-            ), null));
+    final List<Field> listField =
+        ImmutableList.of(
+            new Field(
+                "col1",
+                new FieldType(
+                    true,
+                    ArrowType.Utf8.INSTANCE,
+                    null,
+                    new FlightSqlColumnMetadata.Builder()
+                        .catalogName("catalog1")
+                        .schemaName("schema1")
+                        .tableName("table1")
+                        .build()
+                        .getMetadataMap()),
+                null));
 
-    final List<ColumnMetaData> expectedColumnMetaData = ImmutableList.of(
-        ColumnMetaData.fromProto(
-            Common.ColumnMetaData.newBuilder()
-                .setCatalogName("catalog1")
-                .setSchemaName("schema1")
-                .setTableName("table1")
-                .build()));
+    final List<ColumnMetaData> expectedColumnMetaData =
+        ImmutableList.of(
+            ColumnMetaData.fromProto(
+                Common.ColumnMetaData.newBuilder()
+                    .setCatalogName("catalog1")
+                    .setSchemaName("schema1")
+                    .setTableName("table1")
+                    .build()));
 
-    final List<ColumnMetaData> actualColumnMetaData = ConvertUtils.convertArrowFieldsToColumnMetaDataList(listField);
+    final List<ColumnMetaData> actualColumnMetaData =
+        ConvertUtils.convertArrowFieldsToColumnMetaDataList(listField);
     assertColumnMetaData(expectedColumnMetaData, actualColumnMetaData);
   }
 
-  private void assertColumnMetaData(final List<ColumnMetaData> expected, final List<ColumnMetaData> actual) {
+  private void assertColumnMetaData(
+      final List<ColumnMetaData> expected, final List<ColumnMetaData> actual) {
     collector.checkThat(expected.size(), equalTo(actual.size()));
     int size = expected.size();
     for (int i = 0; i < size; i++) {
       final ColumnMetaData expectedColumnMetaData = expected.get(i);
       final ColumnMetaData actualColumnMetaData = actual.get(i);
-      collector.checkThat(expectedColumnMetaData.catalogName, equalTo(actualColumnMetaData.catalogName));
-      collector.checkThat(expectedColumnMetaData.schemaName, equalTo(actualColumnMetaData.schemaName));
-      collector.checkThat(expectedColumnMetaData.tableName, equalTo(actualColumnMetaData.tableName));
+      collector.checkThat(
+          expectedColumnMetaData.catalogName, equalTo(actualColumnMetaData.catalogName));
+      collector.checkThat(
+          expectedColumnMetaData.schemaName, equalTo(actualColumnMetaData.schemaName));
+      collector.checkThat(
+          expectedColumnMetaData.tableName, equalTo(actualColumnMetaData.tableName));
       collector.checkThat(expectedColumnMetaData.readOnly, equalTo(actualColumnMetaData.readOnly));
-      collector.checkThat(expectedColumnMetaData.autoIncrement, equalTo(actualColumnMetaData.autoIncrement));
-      collector.checkThat(expectedColumnMetaData.precision, equalTo(actualColumnMetaData.precision));
+      collector.checkThat(
+          expectedColumnMetaData.autoIncrement, equalTo(actualColumnMetaData.autoIncrement));
+      collector.checkThat(
+          expectedColumnMetaData.precision, equalTo(actualColumnMetaData.precision));
       collector.checkThat(expectedColumnMetaData.scale, equalTo(actualColumnMetaData.scale));
-      collector.checkThat(expectedColumnMetaData.caseSensitive, equalTo(actualColumnMetaData.caseSensitive));
-      collector.checkThat(expectedColumnMetaData.searchable, equalTo(actualColumnMetaData.searchable));
+      collector.checkThat(
+          expectedColumnMetaData.caseSensitive, equalTo(actualColumnMetaData.caseSensitive));
+      collector.checkThat(
+          expectedColumnMetaData.searchable, equalTo(actualColumnMetaData.searchable));
     }
   }
 
-  private void assertBuilder(final Common.ColumnMetaData.Builder builder,
-                             final FlightSqlColumnMetadata flightSqlColumnMetaData) {
+  private void assertBuilder(
+      final Common.ColumnMetaData.Builder builder,
+      final FlightSqlColumnMetadata flightSqlColumnMetaData) {
 
     final Integer precision = flightSqlColumnMetaData.getPrecision();
     final Integer scale = flightSqlColumnMetaData.getScale();
 
-    collector.checkThat(flightSqlColumnMetaData.getCatalogName(), equalTo(builder.getCatalogName()));
+    collector.checkThat(
+        flightSqlColumnMetaData.getCatalogName(), equalTo(builder.getCatalogName()));
     collector.checkThat(flightSqlColumnMetaData.getSchemaName(), equalTo(builder.getSchemaName()));
     collector.checkThat(flightSqlColumnMetaData.getTableName(), equalTo(builder.getTableName()));
-    collector.checkThat(flightSqlColumnMetaData.isAutoIncrement(), equalTo(builder.getAutoIncrement()));
-    collector.checkThat(flightSqlColumnMetaData.isCaseSensitive(), equalTo(builder.getCaseSensitive()));
+    collector.checkThat(
+        flightSqlColumnMetaData.isAutoIncrement(), equalTo(builder.getAutoIncrement()));
+    collector.checkThat(
+        flightSqlColumnMetaData.isCaseSensitive(), equalTo(builder.getCaseSensitive()));
     collector.checkThat(flightSqlColumnMetaData.isSearchable(), equalTo(builder.getSearchable()));
     collector.checkThat(flightSqlColumnMetaData.isReadOnly(), equalTo(builder.getReadOnly()));
     collector.checkThat(precision == null ? 0 : precision, equalTo(builder.getPrecision()));

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/CoreMockedSqlProducers.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/CoreMockedSqlProducers.java
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
+import com.google.common.collect.ImmutableList;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
-
 import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import org.apache.arrow.flight.sql.FlightSqlColumnMetadata;
 import org.apache.arrow.memory.BufferAllocator;
@@ -53,11 +52,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.Text;
 import org.junit.rules.ErrorCollector;
 
-import com.google.common.collect.ImmutableList;
-
-/**
- * Standard {@link MockFlightSqlProducer} instances for tests.
- */
+/** Standard {@link MockFlightSqlProducer} instances for tests. */
 // TODO Remove this once all tests are refactor to use only the queries they need.
 public final class CoreMockedSqlProducers {
 
@@ -86,210 +81,216 @@ public final class CoreMockedSqlProducers {
   }
 
   private static void addQueryWithEmbeddedEmptyRoot(final MockFlightSqlProducer producer) {
-    final Schema querySchema = new Schema(ImmutableList.of(
-        new Field(
-            "ID",
-            new FieldType(true, new ArrowType.Int(64, true),
-                null),
-            null)
-    ));
+    final Schema querySchema =
+        new Schema(
+            ImmutableList.of(
+                new Field("ID", new FieldType(true, new ArrowType.Int(64, true), null), null)));
 
     final List<Consumer<ServerStreamListener>> resultProducers = new ArrayList<>();
-    Consumer<ServerStreamListener> dataRoot = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-           final VectorSchemaRoot root = VectorSchemaRoot.create(querySchema, allocator)) {
-        root.allocateNew();
-        root.setRowCount(0);
-        listener.start(root);
-        listener.putNext(); // empty root
-        ((BigIntVector) root.getVector("ID")).setSafe(0, 100L);
-        root.setRowCount(1);
-        listener.putNext(); // data root
-        root.clear();
-        root.setRowCount(0);
-        listener.putNext(); // empty root
-        ((BigIntVector) root.getVector("ID")).setSafe(0, 100L);
-        root.setRowCount(1);
-        listener.putNext(); // data root
-      } finally {
-        listener.completed();
-      }
-    };
+    Consumer<ServerStreamListener> dataRoot =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+              final VectorSchemaRoot root = VectorSchemaRoot.create(querySchema, allocator)) {
+            root.allocateNew();
+            root.setRowCount(0);
+            listener.start(root);
+            listener.putNext(); // empty root
+            ((BigIntVector) root.getVector("ID")).setSafe(0, 100L);
+            root.setRowCount(1);
+            listener.putNext(); // data root
+            root.clear();
+            root.setRowCount(0);
+            listener.putNext(); // empty root
+            ((BigIntVector) root.getVector("ID")).setSafe(0, 100L);
+            root.setRowCount(1);
+            listener.putNext(); // data root
+          } finally {
+            listener.completed();
+          }
+        };
     resultProducers.add(dataRoot);
     producer.addSelectQuery(LEGACY_REGULAR_WITH_EMPTY_SQL_CMD, querySchema, resultProducers);
   }
 
   private static void addLegacyRegularSqlCmdSupport(final MockFlightSqlProducer producer) {
-    final Schema querySchema = new Schema(ImmutableList.of(
-        new Field(
-            "ID",
-            new FieldType(true, new ArrowType.Int(64, true),
-                null),
-            null),
-        new Field(
-            "Name",
-            new FieldType(true, new ArrowType.Utf8(), null),
-            null),
-        new Field(
-            "Age",
-            new FieldType(true, new ArrowType.Int(32, false),
-                null),
-            null),
-        new Field(
-            "Salary",
-            new FieldType(true, new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE),
-                null),
-            null),
-        new Field(
-            "Hire Date",
-            new FieldType(true, new ArrowType.Date(DateUnit.DAY), null),
-            null),
-        new Field(
-            "Last Sale",
-            new FieldType(true, new ArrowType.Timestamp(TimeUnit.MILLISECOND, null),
-                null),
-            null)
-    ));
+    final Schema querySchema =
+        new Schema(
+            ImmutableList.of(
+                new Field("ID", new FieldType(true, new ArrowType.Int(64, true), null), null),
+                new Field("Name", new FieldType(true, new ArrowType.Utf8(), null), null),
+                new Field("Age", new FieldType(true, new ArrowType.Int(32, false), null), null),
+                new Field(
+                    "Salary",
+                    new FieldType(
+                        true, new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE), null),
+                    null),
+                new Field(
+                    "Hire Date", new FieldType(true, new ArrowType.Date(DateUnit.DAY), null), null),
+                new Field(
+                    "Last Sale",
+                    new FieldType(true, new ArrowType.Timestamp(TimeUnit.MILLISECOND, null), null),
+                    null)));
     final List<Consumer<ServerStreamListener>> resultProducers = new ArrayList<>();
-    IntStream.range(0, 10).forEach(page -> {
-      resultProducers.add(listener -> {
-        final int rowsPerPage = 5000;
-        try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-             final VectorSchemaRoot root = VectorSchemaRoot.create(querySchema, allocator)) {
-          root.allocateNew();
-          listener.start(root);
-          int batchSize = 500;
-          int indexOnBatch = 0;
-          int resultsOffset = page * rowsPerPage;
-          for (int i = 0; i < rowsPerPage; i++) {
-            ((BigIntVector) root.getVector("ID"))
-                .setSafe(indexOnBatch, (long) Integer.MAX_VALUE + 1 + i + resultsOffset);
-            ((VarCharVector) root.getVector("Name"))
-                .setSafe(indexOnBatch, new Text("Test Name #" + (resultsOffset + i)));
-            ((UInt4Vector) root.getVector("Age"))
-                .setSafe(indexOnBatch, (int) Short.MAX_VALUE + 1 + i + resultsOffset);
-            ((Float8Vector) root.getVector("Salary"))
-                .setSafe(indexOnBatch,
-                    Math.scalb((double) (i + resultsOffset) / 2, i + resultsOffset));
-            ((DateDayVector) root.getVector("Hire Date"))
-                .setSafe(indexOnBatch, i + resultsOffset);
-            ((TimeStampMilliVector) root.getVector("Last Sale"))
-                .setSafe(indexOnBatch, Long.MAX_VALUE - i - resultsOffset);
-            indexOnBatch++;
-            if (indexOnBatch == batchSize) {
-              root.setRowCount(indexOnBatch);
-              if (listener.isCancelled()) {
-                return;
-              }
-              listener.putNext();
-              root.allocateNew();
-              indexOnBatch = 0;
-            }
-          }
-          if (listener.isCancelled()) {
-            return;
-          }
-          root.setRowCount(indexOnBatch);
-          listener.putNext();
-        } finally {
-          listener.completed();
-        }
-      });
-    });
+    IntStream.range(0, 10)
+        .forEach(
+            page -> {
+              resultProducers.add(
+                  listener -> {
+                    final int rowsPerPage = 5000;
+                    try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+                        final VectorSchemaRoot root =
+                            VectorSchemaRoot.create(querySchema, allocator)) {
+                      root.allocateNew();
+                      listener.start(root);
+                      int batchSize = 500;
+                      int indexOnBatch = 0;
+                      int resultsOffset = page * rowsPerPage;
+                      for (int i = 0; i < rowsPerPage; i++) {
+                        ((BigIntVector) root.getVector("ID"))
+                            .setSafe(
+                                indexOnBatch, (long) Integer.MAX_VALUE + 1 + i + resultsOffset);
+                        ((VarCharVector) root.getVector("Name"))
+                            .setSafe(indexOnBatch, new Text("Test Name #" + (resultsOffset + i)));
+                        ((UInt4Vector) root.getVector("Age"))
+                            .setSafe(indexOnBatch, (int) Short.MAX_VALUE + 1 + i + resultsOffset);
+                        ((Float8Vector) root.getVector("Salary"))
+                            .setSafe(
+                                indexOnBatch,
+                                Math.scalb((double) (i + resultsOffset) / 2, i + resultsOffset));
+                        ((DateDayVector) root.getVector("Hire Date"))
+                            .setSafe(indexOnBatch, i + resultsOffset);
+                        ((TimeStampMilliVector) root.getVector("Last Sale"))
+                            .setSafe(indexOnBatch, Long.MAX_VALUE - i - resultsOffset);
+                        indexOnBatch++;
+                        if (indexOnBatch == batchSize) {
+                          root.setRowCount(indexOnBatch);
+                          if (listener.isCancelled()) {
+                            return;
+                          }
+                          listener.putNext();
+                          root.allocateNew();
+                          indexOnBatch = 0;
+                        }
+                      }
+                      if (listener.isCancelled()) {
+                        return;
+                      }
+                      root.setRowCount(indexOnBatch);
+                      listener.putNext();
+                    } finally {
+                      listener.completed();
+                    }
+                  });
+            });
     producer.addSelectQuery(LEGACY_REGULAR_SQL_CMD, querySchema, resultProducers);
   }
 
   private static void addLegacyMetadataSqlCmdSupport(final MockFlightSqlProducer producer) {
-    final Schema metadataSchema = new Schema(ImmutableList.of(
-        new Field(
-            "integer0",
-            new FieldType(true, new ArrowType.Int(64, true),
-                null, new FlightSqlColumnMetadata.Builder()
-                .catalogName("CATALOG_NAME_1")
-                .schemaName("SCHEMA_NAME_1")
-                .tableName("TABLE_NAME_1")
-                .typeName("TYPE_NAME_1")
-                .precision(10)
-                .scale(0)
-                .isAutoIncrement(true)
-                .isCaseSensitive(false)
-                .isReadOnly(true)
-                .isSearchable(true)
-                .build().getMetadataMap()),
-            null),
-        new Field(
-            "string1",
-            new FieldType(true, new ArrowType.Utf8(),
-                null, new FlightSqlColumnMetadata.Builder()
-                .catalogName("CATALOG_NAME_2")
-                .schemaName("SCHEMA_NAME_2")
-                .tableName("TABLE_NAME_2")
-                .typeName("TYPE_NAME_2")
-                .precision(65535)
-                .scale(0)
-                .isAutoIncrement(false)
-                .isCaseSensitive(true)
-                .isReadOnly(false)
-                .isSearchable(true)
-                .build().getMetadataMap()),
-            null),
-        new Field(
-            "float2",
-            new FieldType(true, new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
-                null, new FlightSqlColumnMetadata.Builder()
-                .catalogName("CATALOG_NAME_3")
-                .schemaName("SCHEMA_NAME_3")
-                .tableName("TABLE_NAME_3")
-                .typeName("TYPE_NAME_3")
-                .precision(15)
-                .scale(20)
-                .isAutoIncrement(false)
-                .isCaseSensitive(false)
-                .isReadOnly(false)
-                .isSearchable(true)
-                .build().getMetadataMap()),
-            null)));
-    final Consumer<ServerStreamListener> formula = listener -> {
-      try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-           final VectorSchemaRoot root = VectorSchemaRoot.create(metadataSchema, allocator)) {
-        root.allocateNew();
-        ((BigIntVector) root.getVector("integer0")).setSafe(0, 1);
-        ((VarCharVector) root.getVector("string1")).setSafe(0, new Text("teste"));
-        ((Float4Vector) root.getVector("float2")).setSafe(0, (float) 4.1);
-        root.setRowCount(1);
-        listener.start(root);
-        listener.putNext();
-      } finally {
-        listener.completed();
-      }
-    };
-    producer.addSelectQuery(LEGACY_METADATA_SQL_CMD, metadataSchema,
-        Collections.singletonList(formula));
+    final Schema metadataSchema =
+        new Schema(
+            ImmutableList.of(
+                new Field(
+                    "integer0",
+                    new FieldType(
+                        true,
+                        new ArrowType.Int(64, true),
+                        null,
+                        new FlightSqlColumnMetadata.Builder()
+                            .catalogName("CATALOG_NAME_1")
+                            .schemaName("SCHEMA_NAME_1")
+                            .tableName("TABLE_NAME_1")
+                            .typeName("TYPE_NAME_1")
+                            .precision(10)
+                            .scale(0)
+                            .isAutoIncrement(true)
+                            .isCaseSensitive(false)
+                            .isReadOnly(true)
+                            .isSearchable(true)
+                            .build()
+                            .getMetadataMap()),
+                    null),
+                new Field(
+                    "string1",
+                    new FieldType(
+                        true,
+                        new ArrowType.Utf8(),
+                        null,
+                        new FlightSqlColumnMetadata.Builder()
+                            .catalogName("CATALOG_NAME_2")
+                            .schemaName("SCHEMA_NAME_2")
+                            .tableName("TABLE_NAME_2")
+                            .typeName("TYPE_NAME_2")
+                            .precision(65535)
+                            .scale(0)
+                            .isAutoIncrement(false)
+                            .isCaseSensitive(true)
+                            .isReadOnly(false)
+                            .isSearchable(true)
+                            .build()
+                            .getMetadataMap()),
+                    null),
+                new Field(
+                    "float2",
+                    new FieldType(
+                        true,
+                        new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
+                        null,
+                        new FlightSqlColumnMetadata.Builder()
+                            .catalogName("CATALOG_NAME_3")
+                            .schemaName("SCHEMA_NAME_3")
+                            .tableName("TABLE_NAME_3")
+                            .typeName("TYPE_NAME_3")
+                            .precision(15)
+                            .scale(20)
+                            .isAutoIncrement(false)
+                            .isCaseSensitive(false)
+                            .isReadOnly(false)
+                            .isSearchable(true)
+                            .build()
+                            .getMetadataMap()),
+                    null)));
+    final Consumer<ServerStreamListener> formula =
+        listener -> {
+          try (final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+              final VectorSchemaRoot root = VectorSchemaRoot.create(metadataSchema, allocator)) {
+            root.allocateNew();
+            ((BigIntVector) root.getVector("integer0")).setSafe(0, 1);
+            ((VarCharVector) root.getVector("string1")).setSafe(0, new Text("teste"));
+            ((Float4Vector) root.getVector("float2")).setSafe(0, (float) 4.1);
+            root.setRowCount(1);
+            listener.start(root);
+            listener.putNext();
+          } finally {
+            listener.completed();
+          }
+        };
+    producer.addSelectQuery(
+        LEGACY_METADATA_SQL_CMD, metadataSchema, Collections.singletonList(formula));
   }
 
   private static void addLegacyCancellationSqlCmdSupport(final MockFlightSqlProducer producer) {
     producer.addSelectQuery(
         LEGACY_CANCELLATION_SQL_CMD,
-        new Schema(Collections.singletonList(new Field(
-            "integer0",
-            new FieldType(true, new ArrowType.Int(64, true), null),
-            null))),
-        Collections.singletonList(listener -> {
-          // Should keep hanging until canceled.
-        }));
+        new Schema(
+            Collections.singletonList(
+                new Field(
+                    "integer0", new FieldType(true, new ArrowType.Int(64, true), null), null))),
+        Collections.singletonList(
+            listener -> {
+              // Should keep hanging until canceled.
+            }));
   }
 
   /**
-   * Asserts that the values in the provided {@link ResultSet} are expected for the
-   * legacy {@link MockFlightSqlProducer}.
+   * Asserts that the values in the provided {@link ResultSet} are expected for the legacy {@link
+   * MockFlightSqlProducer}.
    *
    * @param resultSet the result set.
    * @param collector the {@link ErrorCollector} to use.
    * @throws SQLException on error.
    */
-  public static void assertLegacyRegularSqlResultSet(final ResultSet resultSet,
-                                                     final ErrorCollector collector)
-      throws SQLException {
+  public static void assertLegacyRegularSqlResultSet(
+      final ResultSet resultSet, final ErrorCollector collector) throws SQLException {
     final int expectedRowCount = 50_000;
 
     final long[] expectedIds = new long[expectedRowCount];

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -23,15 +22,13 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Calendar;
 import java.util.TimeZone;
-
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 
 public class DateTimeUtilsTest {
 
-  @ClassRule
-  public static final ErrorCollector collector = new ErrorCollector();
+  @ClassRule public static final ErrorCollector collector = new ErrorCollector();
   private final TimeZone defaultTimezone = TimeZone.getTimeZone("UTC");
   private final TimeZone alternateTimezone = TimeZone.getTimeZone("America/Vancouver");
   private final long positiveEpochMilli = 959817600000L; // 2000-06-01 00:00:00 UTC
@@ -48,7 +45,8 @@ public class DateTimeUtilsTest {
 
     try { // Trying to guarantee timezone returns to its original value
       final long expected = epochMillis + offset;
-      final long actual = DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(defaultTimezone));
+      final long actual =
+          DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(defaultTimezone));
 
       collector.checkThat(actual, is(expected));
     } finally {
@@ -68,8 +66,8 @@ public class DateTimeUtilsTest {
 
     try { // Trying to guarantee timezone returns to its original value
       final long expectedEpochMillis = epochMillis + offset;
-      final long actualEpochMillis = DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(
-          defaultTimezone));
+      final long actualEpochMillis =
+          DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(defaultTimezone));
 
       collector.checkThat(actualEpochMillis, is(expectedEpochMillis));
     } finally {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/FlightEndpointDataQueueTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/FlightEndpointDataQueueTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -22,7 +21,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.CompletionService;
-
 import org.apache.arrow.driver.jdbc.client.CloseableEndpointStreamPair;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,16 +30,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/**
- * Tests for {@link FlightEndpointDataQueue}.
- */
+/** Tests for {@link FlightEndpointDataQueue}. */
 @RunWith(MockitoJUnitRunner.class)
 public class FlightEndpointDataQueueTest {
 
-  @Rule
-  public final ErrorCollector collector = new ErrorCollector();
-  @Mock
-  private CompletionService<CloseableEndpointStreamPair> mockedService;
+  @Rule public final ErrorCollector collector = new ErrorCollector();
+  @Mock private CompletionService<CloseableEndpointStreamPair> mockedService;
   private FlightEndpointDataQueue queue;
 
   @Before
@@ -57,24 +51,27 @@ public class FlightEndpointDataQueueTest {
   @Test
   public void testNextShouldThrowExceptionUponClose() throws Exception {
     queue.close();
-    ThrowableAssertionUtils.simpleAssertThrowableClass(IllegalStateException.class, () -> queue.next());
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        IllegalStateException.class, () -> queue.next());
   }
 
   @Test
   public void testEnqueueShouldThrowExceptionUponClose() throws Exception {
     queue.close();
-    ThrowableAssertionUtils.simpleAssertThrowableClass(IllegalStateException.class,
-        () -> queue.enqueue(mock(CloseableEndpointStreamPair.class)));
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        IllegalStateException.class, () -> queue.enqueue(mock(CloseableEndpointStreamPair.class)));
   }
 
   @Test
   public void testCheckOpen() throws Exception {
-    collector.checkSucceeds(() -> {
-      queue.checkOpen();
-      return true;
-    });
+    collector.checkSucceeds(
+        () -> {
+          queue.checkOpen();
+          return true;
+        });
     queue.close();
-    ThrowableAssertionUtils.simpleAssertThrowableClass(IllegalStateException.class, () -> queue.checkOpen());
+    ThrowableAssertionUtils.simpleAssertThrowableClass(
+        IllegalStateException.class, () -> queue.checkOpen());
   }
 
   @Test

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/FlightSqlTestCertificates.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/FlightSqlTestCertificates.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.io.File;
@@ -24,9 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * Utility class for unit tests that need to reference the certificate params.
- */
+/** Utility class for unit tests that need to reference the certificate params. */
 public class FlightSqlTestCertificates {
 
   public static final String TEST_DATA_ENV_VAR = "ARROW_TEST_DATA";
@@ -37,9 +34,12 @@ public class FlightSqlTestCertificates {
     if (path == null) {
       path = System.getProperty(TEST_DATA_PROPERTY);
     }
-    return Paths.get(Objects.requireNonNull(path,
-        String.format("Could not find test data path. Set the environment variable %s or the JVM property %s.",
-            TEST_DATA_ENV_VAR, TEST_DATA_PROPERTY)));
+    return Paths.get(
+        Objects.requireNonNull(
+            path,
+            String.format(
+                "Could not find test data path. Set the environment variable %s or the JVM property %s.",
+                TEST_DATA_ENV_VAR, TEST_DATA_PROPERTY)));
   }
 
   /**
@@ -68,10 +68,9 @@ public class FlightSqlTestCertificates {
    */
   public static List<CertKeyPair> exampleTlsCerts() {
     final Path root = getFlightTestDataRoot();
-    return Arrays.asList(new CertKeyPair(root.resolve("cert0.pem")
-            .toFile(), root.resolve("cert0.pkcs1").toFile()),
-        new CertKeyPair(root.resolve("cert1.pem")
-            .toFile(), root.resolve("cert1.pkcs1").toFile()));
+    return Arrays.asList(
+        new CertKeyPair(root.resolve("cert0.pem").toFile(), root.resolve("cert0.pkcs1").toFile()),
+        new CertKeyPair(root.resolve("cert1.pem").toFile(), root.resolve("cert1.pkcs1").toFile()));
   }
 
   public static class CertKeyPair {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/PartitionedFlightSqlProducer.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/PartitionedFlightSqlProducer.java
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static com.google.protobuf.Any.pack;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
@@ -34,14 +34,9 @@ import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Message;
-
 public class PartitionedFlightSqlProducer extends BasicFlightSqlProducer {
 
-  /**
-   * A minimal FlightProducer intended to just serve data when given the correct Ticket.
-   */
+  /** A minimal FlightProducer intended to just serve data when given the correct Ticket. */
   public static class DataOnlyFlightSqlProducer extends NoOpFlightProducer {
     private final Ticket ticket;
     private final VectorSchemaRoot data;
@@ -54,7 +49,8 @@ public class PartitionedFlightSqlProducer extends BasicFlightSqlProducer {
     @Override
     public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
       if (!Arrays.equals(ticket.getBytes(), this.ticket.getBytes())) {
-        listener.error(CallStatus.INVALID_ARGUMENT.withDescription("Illegal ticket.").toRuntimeException());
+        listener.error(
+            CallStatus.INVALID_ARGUMENT.withDescription("Illegal ticket.").toRuntimeException());
         return;
       }
 
@@ -80,8 +76,10 @@ public class PartitionedFlightSqlProducer extends BasicFlightSqlProducer {
   }
 
   @Override
-  public void createPreparedStatement(FlightSql.ActionCreatePreparedStatementRequest request,
-                                      CallContext context, StreamListener<Result> listener) {
+  public void createPreparedStatement(
+      FlightSql.ActionCreatePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
     final FlightSql.ActionCreatePreparedStatementResult.Builder resultBuilder =
         FlightSql.ActionCreatePreparedStatementResult.newBuilder()
             .setPreparedStatementHandle(ByteString.EMPTY);
@@ -100,14 +98,18 @@ public class PartitionedFlightSqlProducer extends BasicFlightSqlProducer {
   }
 
   @Override
-  public FlightInfo getFlightInfoPreparedStatement(FlightSql.CommandPreparedStatementQuery command,
-                                                   CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPreparedStatement(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightDescriptor descriptor) {
     return FlightInfo.builder(schema, descriptor, endpoints).build();
   }
 
   @Override
-  public void closePreparedStatement(FlightSql.ActionClosePreparedStatementRequest request,
-                                     CallContext context, StreamListener<Result> listener) {
+  public void closePreparedStatement(
+      FlightSql.ActionClosePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
     listener.onCompleted();
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ResultSetTestUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ResultSetTestUtils.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static java.util.stream.IntStream.range;
@@ -25,34 +24,35 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-
 import org.apache.arrow.util.Preconditions;
 import org.junit.rules.ErrorCollector;
 
 /**
- * Utility class for testing that require asserting that the values in a {@link ResultSet} are expected.
+ * Utility class for testing that require asserting that the values in a {@link ResultSet} are
+ * expected.
  */
 public final class ResultSetTestUtils {
   private final ErrorCollector collector;
 
   public ResultSetTestUtils(final ErrorCollector collector) {
-    this.collector =
-        Preconditions.checkNotNull(collector, "Error collector cannot be null.");
+    this.collector = Preconditions.checkNotNull(collector, "Error collector cannot be null.");
   }
 
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
+   * @param resultSet the {@code ResultSet} to assert.
    * @param expectedResults the rows and columns representing the only values the {@code resultSet}
-   *                        is expected to have.
-   * @param collector       the {@link ErrorCollector} to use for asserting that the {@code resultSet}
-   *                        has the expected values.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   *     is expected to have.
+   * @param collector the {@link ErrorCollector} to use for asserting that the {@code resultSet} has
+   *     the expected values.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
-  public static <T> void testData(final ResultSet resultSet, final List<List<T>> expectedResults,
-                                  final ErrorCollector collector)
+  public static <T> void testData(
+      final ResultSet resultSet,
+      final List<List<T>> expectedResults,
+      final ErrorCollector collector)
       throws SQLException {
     testData(
         resultSet,
@@ -64,19 +64,21 @@ public final class ResultSetTestUtils {
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
-   * @param columnNames     the column names to fetch in the {@code ResultSet} for comparison.
+   * @param resultSet the {@code ResultSet} to assert.
+   * @param columnNames the column names to fetch in the {@code ResultSet} for comparison.
    * @param expectedResults the rows and columns representing the only values the {@code resultSet}
-   *                        is expected to have.
-   * @param collector       the {@link ErrorCollector} to use for asserting that the {@code resultSet}
-   *                        has the expected values.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   *     is expected to have.
+   * @param collector the {@link ErrorCollector} to use for asserting that the {@code resultSet} has
+   *     the expected values.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
   @SuppressWarnings("unchecked")
-  public static <T> void testData(final ResultSet resultSet, final List<String> columnNames,
-                                  final List<List<T>> expectedResults,
-                                  final ErrorCollector collector)
+  public static <T> void testData(
+      final ResultSet resultSet,
+      final List<String> columnNames,
+      final List<List<T>> expectedResults,
+      final ErrorCollector collector)
       throws SQLException {
     testData(
         resultSet,
@@ -98,19 +100,21 @@ public final class ResultSetTestUtils {
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
-   * @param columnIndices   the column indices to fetch in the {@code ResultSet} for comparison.
+   * @param resultSet the {@code ResultSet} to assert.
+   * @param columnIndices the column indices to fetch in the {@code ResultSet} for comparison.
    * @param expectedResults the rows and columns representing the only values the {@code resultSet}
-   *                        is expected to have.
-   * @param collector       the {@link ErrorCollector} to use for asserting that the {@code resultSet}
-   *                        has the expected values.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   *     is expected to have.
+   * @param collector the {@link ErrorCollector} to use for asserting that the {@code resultSet} has
+   *     the expected values.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
   @SuppressWarnings("unchecked")
-  public static <T> void testData(final ResultSet resultSet, final int[] columnIndices,
-                                  final List<List<T>> expectedResults,
-                                  final ErrorCollector collector)
+  public static <T> void testData(
+      final ResultSet resultSet,
+      final int[] columnIndices,
+      final List<List<T>> expectedResults,
+      final ErrorCollector collector)
       throws SQLException {
     testData(
         resultSet,
@@ -132,19 +136,20 @@ public final class ResultSetTestUtils {
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
-   * @param dataConsumer    the column indices to fetch in the {@code ResultSet} for comparison.
+   * @param resultSet the {@code ResultSet} to assert.
+   * @param dataConsumer the column indices to fetch in the {@code ResultSet} for comparison.
    * @param expectedResults the rows and columns representing the only values the {@code resultSet}
-   *                        is expected to have.
-   * @param collector       the {@link ErrorCollector} to use for asserting that the {@code resultSet}
-   *                        has the expected values.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   *     is expected to have.
+   * @param collector the {@link ErrorCollector} to use for asserting that the {@code resultSet} has
+   *     the expected values.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
-  public static <T> void testData(final ResultSet resultSet,
-                                  final Function<ResultSet, List<T>> dataConsumer,
-                                  final List<List<T>> expectedResults,
-                                  final ErrorCollector collector)
+  public static <T> void testData(
+      final ResultSet resultSet,
+      final Function<ResultSet, List<T>> dataConsumer,
+      final List<List<T>> expectedResults,
+      final ErrorCollector collector)
       throws SQLException {
     final List<List<T>> actualResults = new ArrayList<>();
     while (resultSet.next()) {
@@ -156,9 +161,10 @@ public final class ResultSetTestUtils {
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
-   * @param expectedResults the rows and columns representing the only values the {@code resultSet} is expected to have.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   * @param resultSet the {@code ResultSet} to assert.
+   * @param expectedResults the rows and columns representing the only values the {@code resultSet}
+   *     is expected to have.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
   public <T> void testData(final ResultSet resultSet, final List<List<T>> expectedResults)
@@ -169,45 +175,54 @@ public final class ResultSetTestUtils {
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
-   * @param columnNames     the column names to fetch in the {@code ResultSet} for comparison.
-   * @param expectedResults the rows and columns representing the only values the {@code resultSet} is expected to have.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   * @param resultSet the {@code ResultSet} to assert.
+   * @param columnNames the column names to fetch in the {@code ResultSet} for comparison.
+   * @param expectedResults the rows and columns representing the only values the {@code resultSet}
+   *     is expected to have.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
   @SuppressWarnings("unchecked")
-  public <T> void testData(final ResultSet resultSet, final List<String> columnNames,
-                           final List<List<T>> expectedResults) throws SQLException {
+  public <T> void testData(
+      final ResultSet resultSet,
+      final List<String> columnNames,
+      final List<List<T>> expectedResults)
+      throws SQLException {
     testData(resultSet, columnNames, expectedResults, collector);
   }
 
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
-   * @param columnIndices   the column indices to fetch in the {@code ResultSet} for comparison.
-   * @param expectedResults the rows and columns representing the only values the {@code resultSet} is expected to have.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   * @param resultSet the {@code ResultSet} to assert.
+   * @param columnIndices the column indices to fetch in the {@code ResultSet} for comparison.
+   * @param expectedResults the rows and columns representing the only values the {@code resultSet}
+   *     is expected to have.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
   @SuppressWarnings("unchecked")
-  public <T> void testData(final ResultSet resultSet, final int[] columnIndices,
-                           final List<List<T>> expectedResults) throws SQLException {
+  public <T> void testData(
+      final ResultSet resultSet, final int[] columnIndices, final List<List<T>> expectedResults)
+      throws SQLException {
     testData(resultSet, columnIndices, expectedResults, collector);
   }
 
   /**
    * Checks that the values (rows and columns) in the provided {@link ResultSet} are expected.
    *
-   * @param resultSet       the {@code ResultSet} to assert.
-   * @param dataConsumer    the column indices to fetch in the {@code ResultSet} for comparison.
-   * @param expectedResults the rows and columns representing the only values the {@code resultSet} is expected to have.
-   * @param <T>             the type to be found in the expected results for the {@code resultSet}.
+   * @param resultSet the {@code ResultSet} to assert.
+   * @param dataConsumer the column indices to fetch in the {@code ResultSet} for comparison.
+   * @param expectedResults the rows and columns representing the only values the {@code resultSet}
+   *     is expected to have.
+   * @param <T> the type to be found in the expected results for the {@code resultSet}.
    * @throws SQLException if querying the {@code ResultSet} fails at some point unexpectedly.
    */
-  public <T> void testData(final ResultSet resultSet,
-                           final Function<ResultSet, List<T>> dataConsumer,
-                           final List<List<T>> expectedResults) throws SQLException {
+  public <T> void testData(
+      final ResultSet resultSet,
+      final Function<ResultSet, List<T>> dataConsumer,
+      final List<List<T>> expectedResults)
+      throws SQLException {
     testData(resultSet, dataConsumer, expectedResults, collector);
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/RootAllocatorTestRule.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/RootAllocatorTestRule.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.math.BigDecimal;
@@ -22,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
@@ -103,31 +101,32 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    * @return Float8Vector
    */
   public Float8Vector createFloat8Vector() {
-    double[] doubleVectorValues = new double[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-        Integer.MIN_VALUE,
-        Integer.MAX_VALUE,
-        Long.MIN_VALUE,
-        Long.MAX_VALUE,
-        Float.MAX_VALUE,
-        -Float.MAX_VALUE,
-        Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY,
-        Float.MIN_VALUE,
-        -Float.MIN_VALUE,
-        Double.MAX_VALUE,
-        -Double.MAX_VALUE,
-        Double.NEGATIVE_INFINITY,
-        Double.POSITIVE_INFINITY,
-        Double.MIN_VALUE,
-        -Double.MIN_VALUE,
-    };
+    double[] doubleVectorValues =
+        new double[] {
+          0,
+          1,
+          -1,
+          Byte.MIN_VALUE,
+          Byte.MAX_VALUE,
+          Short.MIN_VALUE,
+          Short.MAX_VALUE,
+          Integer.MIN_VALUE,
+          Integer.MAX_VALUE,
+          Long.MIN_VALUE,
+          Long.MAX_VALUE,
+          Float.MAX_VALUE,
+          -Float.MAX_VALUE,
+          Float.NEGATIVE_INFINITY,
+          Float.POSITIVE_INFINITY,
+          Float.MIN_VALUE,
+          -Float.MIN_VALUE,
+          Double.MAX_VALUE,
+          -Double.MAX_VALUE,
+          Double.NEGATIVE_INFINITY,
+          Double.POSITIVE_INFINITY,
+          Double.MIN_VALUE,
+          -Double.MIN_VALUE,
+        };
 
     Float8Vector result = new Float8Vector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -158,25 +157,26 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public Float4Vector createFloat4Vector() {
 
-    float[] floatVectorValues = new float[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-        Integer.MIN_VALUE,
-        Integer.MAX_VALUE,
-        Long.MIN_VALUE,
-        Long.MAX_VALUE,
-        Float.MAX_VALUE,
-        -Float.MAX_VALUE,
-        Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY,
-        Float.MIN_VALUE,
-        -Float.MIN_VALUE,
-    };
+    float[] floatVectorValues =
+        new float[] {
+          0,
+          1,
+          -1,
+          Byte.MIN_VALUE,
+          Byte.MAX_VALUE,
+          Short.MIN_VALUE,
+          Short.MAX_VALUE,
+          Integer.MIN_VALUE,
+          Integer.MAX_VALUE,
+          Long.MIN_VALUE,
+          Long.MAX_VALUE,
+          Float.MAX_VALUE,
+          -Float.MAX_VALUE,
+          Float.NEGATIVE_INFINITY,
+          Float.POSITIVE_INFINITY,
+          Float.MIN_VALUE,
+          -Float.MIN_VALUE,
+        };
 
     Float4Vector result = new Float4Vector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -198,17 +198,18 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public IntVector createIntVector() {
 
-    int[] intVectorValues = new int[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-        Integer.MIN_VALUE,
-        Integer.MAX_VALUE,
-    };
+    int[] intVectorValues =
+        new int[] {
+          0,
+          1,
+          -1,
+          Byte.MIN_VALUE,
+          Byte.MAX_VALUE,
+          Short.MIN_VALUE,
+          Short.MAX_VALUE,
+          Integer.MIN_VALUE,
+          Integer.MAX_VALUE,
+        };
 
     IntVector result = new IntVector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -230,15 +231,10 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public SmallIntVector createSmallIntVector() {
 
-    short[] smallIntVectorValues = new short[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-    };
+    short[] smallIntVectorValues =
+        new short[] {
+          0, 1, -1, Byte.MIN_VALUE, Byte.MAX_VALUE, Short.MIN_VALUE, Short.MAX_VALUE,
+        };
 
     SmallIntVector result = new SmallIntVector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -260,13 +256,10 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public TinyIntVector createTinyIntVector() {
 
-    byte[] byteVectorValues = new byte[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-    };
+    byte[] byteVectorValues =
+        new byte[] {
+          0, 1, -1, Byte.MIN_VALUE, Byte.MAX_VALUE,
+        };
 
     TinyIntVector result = new TinyIntVector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -288,19 +281,20 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public BigIntVector createBigIntVector() {
 
-    long[] longVectorValues = new long[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-        Integer.MIN_VALUE,
-        Integer.MAX_VALUE,
-        Long.MIN_VALUE,
-        Long.MAX_VALUE,
-    };
+    long[] longVectorValues =
+        new long[] {
+          0,
+          1,
+          -1,
+          Byte.MIN_VALUE,
+          Byte.MAX_VALUE,
+          Short.MIN_VALUE,
+          Short.MAX_VALUE,
+          Integer.MIN_VALUE,
+          Integer.MAX_VALUE,
+          Long.MIN_VALUE,
+          Long.MAX_VALUE,
+        };
 
     BigIntVector result = new BigIntVector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -322,13 +316,10 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public UInt1Vector createUInt1Vector() {
 
-    short[] uInt1VectorValues = new short[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-    };
+    short[] uInt1VectorValues =
+        new short[] {
+          0, 1, -1, Byte.MIN_VALUE, Byte.MAX_VALUE,
+        };
 
     UInt1Vector result = new UInt1Vector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -350,15 +341,10 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public UInt2Vector createUInt2Vector() {
 
-    int[] uInt2VectorValues = new int[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-    };
+    int[] uInt2VectorValues =
+        new int[] {
+          0, 1, -1, Byte.MIN_VALUE, Byte.MAX_VALUE, Short.MIN_VALUE, Short.MAX_VALUE,
+        };
 
     UInt2Vector result = new UInt2Vector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -380,18 +366,18 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public UInt4Vector createUInt4Vector() {
 
-
-    int[] uInt4VectorValues = new int[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-        Integer.MIN_VALUE,
-        Integer.MAX_VALUE
-    };
+    int[] uInt4VectorValues =
+        new int[] {
+          0,
+          1,
+          -1,
+          Byte.MIN_VALUE,
+          Byte.MAX_VALUE,
+          Short.MIN_VALUE,
+          Short.MAX_VALUE,
+          Integer.MIN_VALUE,
+          Integer.MAX_VALUE
+        };
 
     UInt4Vector result = new UInt4Vector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -413,19 +399,20 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public UInt8Vector createUInt8Vector() {
 
-    long[] uInt8VectorValues = new long[] {
-        0,
-        1,
-        -1,
-        Byte.MIN_VALUE,
-        Byte.MAX_VALUE,
-        Short.MIN_VALUE,
-        Short.MAX_VALUE,
-        Integer.MIN_VALUE,
-        Integer.MAX_VALUE,
-        Long.MIN_VALUE,
-        Long.MAX_VALUE
-    };
+    long[] uInt8VectorValues =
+        new long[] {
+          0,
+          1,
+          -1,
+          Byte.MIN_VALUE,
+          Byte.MAX_VALUE,
+          Short.MIN_VALUE,
+          Short.MAX_VALUE,
+          Integer.MIN_VALUE,
+          Integer.MAX_VALUE,
+          Long.MIN_VALUE,
+          Long.MAX_VALUE
+        };
 
     UInt8Vector result = new UInt8Vector("", this.getRootAllocator());
     result.setValueCount(MAX_VALUE);
@@ -504,20 +491,21 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public DecimalVector createDecimalVector() {
 
-    BigDecimal[] bigDecimalValues = new BigDecimal[] {
-        new BigDecimal(0),
-        new BigDecimal(1),
-        new BigDecimal(-1),
-        new BigDecimal(Byte.MIN_VALUE),
-        new BigDecimal(Byte.MAX_VALUE),
-        new BigDecimal(-Short.MAX_VALUE),
-        new BigDecimal(Short.MIN_VALUE),
-        new BigDecimal(Integer.MIN_VALUE),
-        new BigDecimal(Integer.MAX_VALUE),
-        new BigDecimal(Long.MIN_VALUE),
-        new BigDecimal(-Long.MAX_VALUE),
-        new BigDecimal("170141183460469231731687303715884105727")
-    };
+    BigDecimal[] bigDecimalValues =
+        new BigDecimal[] {
+          new BigDecimal(0),
+          new BigDecimal(1),
+          new BigDecimal(-1),
+          new BigDecimal(Byte.MIN_VALUE),
+          new BigDecimal(Byte.MAX_VALUE),
+          new BigDecimal(-Short.MAX_VALUE),
+          new BigDecimal(Short.MIN_VALUE),
+          new BigDecimal(Integer.MIN_VALUE),
+          new BigDecimal(Integer.MAX_VALUE),
+          new BigDecimal(Long.MIN_VALUE),
+          new BigDecimal(-Long.MAX_VALUE),
+          new BigDecimal("170141183460469231731687303715884105727")
+        };
 
     DecimalVector result = new DecimalVector("ID", this.getRootAllocator(), 39, 0);
     result.setValueCount(MAX_VALUE);
@@ -539,30 +527,31 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
    */
   public Decimal256Vector createDecimal256Vector() {
 
-    BigDecimal[] bigDecimalValues = new BigDecimal[] {
-        new BigDecimal(0),
-        new BigDecimal(1),
-        new BigDecimal(-1),
-        new BigDecimal(Byte.MIN_VALUE),
-        new BigDecimal(Byte.MAX_VALUE),
-        new BigDecimal(-Short.MAX_VALUE),
-        new BigDecimal(Short.MIN_VALUE),
-        new BigDecimal(Integer.MIN_VALUE),
-        new BigDecimal(Integer.MAX_VALUE),
-        new BigDecimal(Long.MIN_VALUE),
-        new BigDecimal(-Long.MAX_VALUE),
-        new BigDecimal("170141183460469231731687303715884105727"),
-        new BigDecimal("17014118346046923173168234157303715884105727"),
-        new BigDecimal("1701411834604692317316823415265417303715884105727"),
-        new BigDecimal("-17014118346046923173168234152654115451237303715884105727"),
-        new BigDecimal("-17014118346046923173168234152654115451231545157303715884105727"),
-        new BigDecimal("1701411834604692315815656534152654115451231545157303715884105727"),
-        new BigDecimal("30560141183460469231581565634152654115451231545157303715884105727"),
-        new BigDecimal(
-            "57896044618658097711785492504343953926634992332820282019728792003956564819967"),
-        new BigDecimal(
-            "-56896044618658097711785492504343953926634992332820282019728792003956564819967")
-    };
+    BigDecimal[] bigDecimalValues =
+        new BigDecimal[] {
+          new BigDecimal(0),
+          new BigDecimal(1),
+          new BigDecimal(-1),
+          new BigDecimal(Byte.MIN_VALUE),
+          new BigDecimal(Byte.MAX_VALUE),
+          new BigDecimal(-Short.MAX_VALUE),
+          new BigDecimal(Short.MIN_VALUE),
+          new BigDecimal(Integer.MIN_VALUE),
+          new BigDecimal(Integer.MAX_VALUE),
+          new BigDecimal(Long.MIN_VALUE),
+          new BigDecimal(-Long.MAX_VALUE),
+          new BigDecimal("170141183460469231731687303715884105727"),
+          new BigDecimal("17014118346046923173168234157303715884105727"),
+          new BigDecimal("1701411834604692317316823415265417303715884105727"),
+          new BigDecimal("-17014118346046923173168234152654115451237303715884105727"),
+          new BigDecimal("-17014118346046923173168234152654115451231545157303715884105727"),
+          new BigDecimal("1701411834604692315815656534152654115451231545157303715884105727"),
+          new BigDecimal("30560141183460469231581565634152654115451231545157303715884105727"),
+          new BigDecimal(
+              "57896044618658097711785492504343953926634992332820282019728792003956564819967"),
+          new BigDecimal(
+              "-56896044618658097711785492504343953926634992332820282019728792003956564819967")
+        };
 
     Decimal256Vector result = new Decimal256Vector("ID", this.getRootAllocator(), 77, 0);
     result.setValueCount(MAX_VALUE);
@@ -764,13 +753,14 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
 
     IntStream range = IntStream.range(0, MAX_VALUE);
 
-    range.forEach(row -> {
-      writer.startList();
-      writer.setPosition(row);
-      IntStream.range(0, 5).map(j -> j * row).forEach(writer::writeInt);
-      writer.setValueCount(5);
-      writer.endList();
-    });
+    range.forEach(
+        row -> {
+          writer.startList();
+          writer.setPosition(row);
+          IntStream.range(0, 5).map(j -> j * row).forEach(writer::writeInt);
+          writer.setValueCount(5);
+          writer.endList();
+        });
 
     valueVector.setValueCount(MAX_VALUE);
 
@@ -785,13 +775,14 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
 
     IntStream range = IntStream.range(0, MAX_VALUE);
 
-    range.forEach(row -> {
-      writer.startList();
-      writer.setPosition(row);
-      IntStream.range(0, 5).map(j -> j * row).forEach(writer::writeInt);
-      writer.setValueCount(5);
-      writer.endList();
-    });
+    range.forEach(
+        row -> {
+          writer.startList();
+          writer.setPosition(row);
+          IntStream.range(0, 5).map(j -> j * row).forEach(writer::writeInt);
+          writer.setValueCount(5);
+          writer.endList();
+        });
 
     valueVector.setValueCount(MAX_VALUE);
 
@@ -806,13 +797,14 @@ public class RootAllocatorTestRule implements TestRule, AutoCloseable {
 
     IntStream range = IntStream.range(0, MAX_VALUE);
 
-    range.forEach(row -> {
-      writer.startList();
-      writer.setPosition(row);
-      IntStream.range(0, 5).map(j -> j * row).forEach(writer::writeInt);
-      writer.setValueCount(5);
-      writer.endList();
-    });
+    range.forEach(
+        row -> {
+          writer.startList();
+          writer.setPosition(row);
+          IntStream.range(0, 5).map(j -> j * row).forEach(writer::writeInt);
+          writer.setValueCount(5);
+          writer.endList();
+        });
 
     valueVector.setValueCount(MAX_VALUE);
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/SqlTypesTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/SqlTypesTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.apache.arrow.driver.jdbc.utils.SqlTypes.getSqlTypeIdFromArrowType;
@@ -22,7 +21,6 @@ import static org.apache.arrow.driver.jdbc.utils.SqlTypes.getSqlTypeNameFromArro
 import static org.junit.Assert.assertEquals;
 
 import java.sql.Types;
-
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.IntervalUnit;
@@ -48,17 +46,20 @@ public class SqlTypesTest {
     assertEquals(Types.LONGVARCHAR, getSqlTypeIdFromArrowType(new ArrowType.LargeUtf8()));
 
     assertEquals(Types.DATE, getSqlTypeIdFromArrowType(new ArrowType.Date(DateUnit.MILLISECOND)));
-    assertEquals(Types.TIME,
-        getSqlTypeIdFromArrowType(new ArrowType.Time(TimeUnit.MILLISECOND, 32)));
-    assertEquals(Types.TIMESTAMP,
+    assertEquals(
+        Types.TIME, getSqlTypeIdFromArrowType(new ArrowType.Time(TimeUnit.MILLISECOND, 32)));
+    assertEquals(
+        Types.TIMESTAMP,
         getSqlTypeIdFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "")));
 
     assertEquals(Types.BOOLEAN, getSqlTypeIdFromArrowType(new ArrowType.Bool()));
 
     assertEquals(Types.DECIMAL, getSqlTypeIdFromArrowType(new ArrowType.Decimal(0, 0, 64)));
-    assertEquals(Types.DOUBLE,
+    assertEquals(
+        Types.DOUBLE,
         getSqlTypeIdFromArrowType(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)));
-    assertEquals(Types.FLOAT,
+    assertEquals(
+        Types.FLOAT,
         getSqlTypeIdFromArrowType(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)));
 
     assertEquals(Types.ARRAY, getSqlTypeIdFromArrowType(new ArrowType.List()));
@@ -66,12 +67,13 @@ public class SqlTypesTest {
     assertEquals(Types.ARRAY, getSqlTypeIdFromArrowType(new ArrowType.FixedSizeList(10)));
 
     assertEquals(Types.JAVA_OBJECT, getSqlTypeIdFromArrowType(new ArrowType.Struct()));
-    assertEquals(Types.JAVA_OBJECT,
-        getSqlTypeIdFromArrowType(new ArrowType.Duration(TimeUnit.MILLISECOND)));
-    assertEquals(Types.JAVA_OBJECT,
+    assertEquals(
+        Types.JAVA_OBJECT, getSqlTypeIdFromArrowType(new ArrowType.Duration(TimeUnit.MILLISECOND)));
+    assertEquals(
+        Types.JAVA_OBJECT,
         getSqlTypeIdFromArrowType(new ArrowType.Interval(IntervalUnit.DAY_TIME)));
-    assertEquals(Types.JAVA_OBJECT,
-        getSqlTypeIdFromArrowType(new ArrowType.Union(UnionMode.Dense, null)));
+    assertEquals(
+        Types.JAVA_OBJECT, getSqlTypeIdFromArrowType(new ArrowType.Union(UnionMode.Dense, null)));
     assertEquals(Types.JAVA_OBJECT, getSqlTypeIdFromArrowType(new ArrowType.Map(true)));
 
     assertEquals(Types.NULL, getSqlTypeIdFromArrowType(new ArrowType.Null()));
@@ -93,15 +95,18 @@ public class SqlTypesTest {
 
     assertEquals("DATE", getSqlTypeNameFromArrowType(new ArrowType.Date(DateUnit.MILLISECOND)));
     assertEquals("TIME", getSqlTypeNameFromArrowType(new ArrowType.Time(TimeUnit.MILLISECOND, 32)));
-    assertEquals("TIMESTAMP",
+    assertEquals(
+        "TIMESTAMP",
         getSqlTypeNameFromArrowType(new ArrowType.Timestamp(TimeUnit.MILLISECOND, "")));
 
     assertEquals("BOOLEAN", getSqlTypeNameFromArrowType(new ArrowType.Bool()));
 
     assertEquals("DECIMAL", getSqlTypeNameFromArrowType(new ArrowType.Decimal(0, 0, 64)));
-    assertEquals("DOUBLE",
+    assertEquals(
+        "DOUBLE",
         getSqlTypeNameFromArrowType(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)));
-    assertEquals("FLOAT",
+    assertEquals(
+        "FLOAT",
         getSqlTypeNameFromArrowType(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)));
 
     assertEquals("ARRAY", getSqlTypeNameFromArrowType(new ArrowType.List()));
@@ -110,12 +115,12 @@ public class SqlTypesTest {
 
     assertEquals("JAVA_OBJECT", getSqlTypeNameFromArrowType(new ArrowType.Struct()));
 
-    assertEquals("JAVA_OBJECT",
-        getSqlTypeNameFromArrowType(new ArrowType.Duration(TimeUnit.MILLISECOND)));
-    assertEquals("JAVA_OBJECT",
-        getSqlTypeNameFromArrowType(new ArrowType.Interval(IntervalUnit.DAY_TIME)));
-    assertEquals("JAVA_OBJECT",
-        getSqlTypeNameFromArrowType(new ArrowType.Union(UnionMode.Dense, null)));
+    assertEquals(
+        "JAVA_OBJECT", getSqlTypeNameFromArrowType(new ArrowType.Duration(TimeUnit.MILLISECOND)));
+    assertEquals(
+        "JAVA_OBJECT", getSqlTypeNameFromArrowType(new ArrowType.Interval(IntervalUnit.DAY_TIME)));
+    assertEquals(
+        "JAVA_OBJECT", getSqlTypeNameFromArrowType(new ArrowType.Union(UnionMode.Dense, null)));
     assertEquals("JAVA_OBJECT", getSqlTypeNameFromArrowType(new ArrowType.Map(true)));
 
     assertEquals("NULL", getSqlTypeNameFromArrowType(new ArrowType.Null()));

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ThrowableAssertionUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/ThrowableAssertionUtils.java
@@ -14,16 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 /**
- * Utility class to avoid upgrading JUnit to version >= 4.13 and keep using code to assert a {@link Throwable}.
- * This should be removed as soon as we can use the proper assertThrows/checkThrows.
+ * Utility class to avoid upgrading JUnit to version >= 4.13 and keep using code to assert a {@link
+ * Throwable}. This should be removed as soon as we can use the proper assertThrows/checkThrows.
  */
 public class ThrowableAssertionUtils {
-  private ThrowableAssertionUtils() {
-  }
+  private ThrowableAssertionUtils() {}
 
   public static void simpleAssertThrowableClass(
       final Class<? extends Throwable> expectedThrowable, final ThrowingRunnable runnable) {
@@ -33,15 +31,17 @@ public class ThrowableAssertionUtils {
       if (expectedThrowable.isInstance(actualThrown)) {
         return;
       } else {
-        final String mismatchMessage = String.format("unexpected exception type thrown;\nexpected: %s\nactual: %s",
-            formatClass(expectedThrowable),
-            formatClass(actualThrown.getClass()));
+        final String mismatchMessage =
+            String.format(
+                "unexpected exception type thrown;\nexpected: %s\nactual: %s",
+                formatClass(expectedThrowable), formatClass(actualThrown.getClass()));
 
         throw new AssertionError(mismatchMessage, actualThrown);
       }
     }
-    final String notThrownMessage = String.format("expected %s to be thrown, but nothing was thrown",
-        formatClass(expectedThrowable));
+    final String notThrownMessage =
+        String.format(
+            "expected %s to be thrown, but nothing was thrown", formatClass(expectedThrowable));
     throw new AssertionError(notThrownMessage);
   }
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/UrlParserTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/UrlParserTest.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 class UrlParserTest {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/VectorSchemaRootTransformerTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/VectorSchemaRootTransformerTest.java
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc.utils;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
@@ -34,12 +33,9 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-
 public class VectorSchemaRootTransformerTest {
 
-  @Rule
-  public RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
+  @Rule public RootAllocatorTestRule rootAllocatorTestRule = new RootAllocatorTestRule();
   private final BufferAllocator rootAllocator = rootAllocatorTestRule.getRootAllocator();
 
   @Test
@@ -49,11 +45,10 @@ public class VectorSchemaRootTransformerTest {
     final VarBinaryVector field3 = rootAllocatorTestRule.createVarBinaryVector("FIELD_3");
 
     try (final VectorSchemaRoot originalRoot = VectorSchemaRoot.of(field1, field2, field3);
-         final VectorSchemaRoot clonedRoot = cloneVectorSchemaRoot(originalRoot)) {
+        final VectorSchemaRoot clonedRoot = cloneVectorSchemaRoot(originalRoot)) {
 
       final VectorSchemaRootTransformer.Builder builder =
-          new VectorSchemaRootTransformer.Builder(originalRoot.getSchema(),
-              rootAllocator);
+          new VectorSchemaRootTransformer.Builder(originalRoot.getSchema(), rootAllocator);
 
       builder.renameFieldVector("FIELD_3", "FIELD_3_RENAMED");
       builder.addEmptyField("EMPTY_FIELD", new ArrowType.Bool());
@@ -62,12 +57,13 @@ public class VectorSchemaRootTransformerTest {
 
       final VectorSchemaRootTransformer transformer = builder.build();
 
-      final Schema transformedSchema = new Schema(ImmutableList.of(
-          Field.nullable("FIELD_3_RENAMED", new ArrowType.Binary()),
-          Field.nullable("EMPTY_FIELD", new ArrowType.Bool()),
-          Field.nullable("FIELD_2_RENAMED", new ArrowType.Binary()),
-          Field.nullable("FIELD_1_RENAMED", new ArrowType.Binary())
-      ));
+      final Schema transformedSchema =
+          new Schema(
+              ImmutableList.of(
+                  Field.nullable("FIELD_3_RENAMED", new ArrowType.Binary()),
+                  Field.nullable("EMPTY_FIELD", new ArrowType.Bool()),
+                  Field.nullable("FIELD_2_RENAMED", new ArrowType.Binary()),
+                  Field.nullable("FIELD_1_RENAMED", new ArrowType.Binary())));
       try (final VectorSchemaRoot transformedRoot = createVectorSchemaRoot(transformedSchema)) {
         Assert.assertSame(transformedRoot, transformer.transform(clonedRoot, transformedRoot));
         Assert.assertEquals(transformedSchema, transformedRoot.getSchema());
@@ -75,12 +71,9 @@ public class VectorSchemaRootTransformerTest {
         final int rowCount = originalRoot.getRowCount();
         Assert.assertEquals(rowCount, transformedRoot.getRowCount());
 
-        final VarBinaryVector originalField1 =
-            (VarBinaryVector) originalRoot.getVector("FIELD_1");
-        final VarBinaryVector originalField2 =
-            (VarBinaryVector) originalRoot.getVector("FIELD_2");
-        final VarBinaryVector originalField3 =
-            (VarBinaryVector) originalRoot.getVector("FIELD_3");
+        final VarBinaryVector originalField1 = (VarBinaryVector) originalRoot.getVector("FIELD_1");
+        final VarBinaryVector originalField2 = (VarBinaryVector) originalRoot.getVector("FIELD_2");
+        final VarBinaryVector originalField3 = (VarBinaryVector) originalRoot.getVector("FIELD_3");
 
         final VarBinaryVector transformedField1 =
             (VarBinaryVector) transformedRoot.getVector("FIELD_1_RENAMED");
@@ -111,9 +104,10 @@ public class VectorSchemaRootTransformerTest {
   }
 
   private VectorSchemaRoot createVectorSchemaRoot(final Schema schema) {
-    final List<FieldVector> fieldVectors = schema.getFields().stream()
-        .map(field -> field.createVector(rootAllocator))
-        .collect(Collectors.toList());
+    final List<FieldVector> fieldVectors =
+        schema.getFields().stream()
+            .map(field -> field.createVector(rootAllocator))
+            .collect(Collectors.toList());
     return new VectorSchemaRoot(fieldVectors);
   }
 }

--- a/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ITDriverJarValidation.java
+++ b/java/flight/flight-sql-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/ITDriverJarValidation.java
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.driver.jdbc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
 import java.net.JarURLConnection;
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,33 +36,26 @@ import org.junit.rules.ErrorCollector;
 import org.junit.rules.TestRule;
 import org.junit.rules.Timeout;
 
-import com.google.common.collect.ImmutableSet;
-
 /**
  * Check the content of the JDBC driver jar
  *
- * After shading everything should be either under org.apache.arrow.driver.jdbc. package
+ * <p>After shading everything should be either under org.apache.arrow.driver.jdbc. package
  */
 public class ITDriverJarValidation {
   /**
-   * Use this property to provide path to the JDBC driver jar. Can be used to run the test from an IDE
+   * Use this property to provide path to the JDBC driver jar. Can be used to run the test from an
+   * IDE
    */
   public static final String JDBC_DRIVER_PATH_OVERRIDE =
       System.getProperty("arrow-flight-jdbc-driver.jar.override");
 
-  /**
-   * List of allowed prefixes a jar entry may match.
-   */
-  public static final Set<String> ALLOWED_PREFIXES = ImmutableSet.of(
-      "org/apache/arrow/driver/jdbc/",
-      "META-INF/");
+  /** List of allowed prefixes a jar entry may match. */
+  public static final Set<String> ALLOWED_PREFIXES =
+      ImmutableSet.of("org/apache/arrow/driver/jdbc/", "META-INF/");
 
-  /**
-   * List of allowed files a jar entry may match.
-   */
-  public static final Set<String> ALLOWED_FILES = ImmutableSet.of(
-      "arrow-git.properties",
-      "properties/flight.properties");
+  /** List of allowed files a jar entry may match. */
+  public static final Set<String> ALLOWED_FILES =
+      ImmutableSet.of("arrow-git.properties", "properties/flight.properties");
 
   // This method is designed to work with Maven failsafe plugin and expects the
   // JDBC driver jar to be present in the test classpath (instead of the individual classes)
@@ -74,28 +66,31 @@ public class ITDriverJarValidation {
     }
 
     // Check classpath to find the driver jar
-    URL driverClassURL = ITDriverJarValidation.class.getClassLoader()
-        .getResource("org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.class");
+    URL driverClassURL =
+        ITDriverJarValidation.class
+            .getClassLoader()
+            .getResource("org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.class");
 
     assertNotNull(driverClassURL, "Driver jar was not detected in the classpath");
-    assertEquals("Driver jar was not detected in the classpath", "jar", driverClassURL.getProtocol());
+    assertEquals(
+        "Driver jar was not detected in the classpath", "jar", driverClassURL.getProtocol());
 
     JarURLConnection connection = (JarURLConnection) driverClassURL.openConnection();
     return connection.getJarFile();
   }
 
   @ClassRule
-  public static final TestRule CLASS_TIMEOUT = Timeout.builder().withTimeout(2, TimeUnit.MINUTES).build();
+  public static final TestRule CLASS_TIMEOUT =
+      Timeout.builder().withTimeout(2, TimeUnit.MINUTES).build();
 
-  @Rule
-  public ErrorCollector collector = new ErrorCollector();
+  @Rule public ErrorCollector collector = new ErrorCollector();
 
   @Test
   public void validateShadedJar() throws IOException {
     // Validate the content of the jar to enforce all 3rd party dependencies have
     // been shaded
     try (JarFile jar = getJdbcJarFile()) {
-      for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements();) {
+      for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements(); ) {
         final JarEntry entry = entries.nextElement();
         if (entry.isDirectory()) {
           // Directories are ignored
@@ -113,11 +108,10 @@ public class ITDriverJarValidation {
 
   /**
    * Check if a jar entry is allowed.
-   * 
-   * <p>
-   * A jar entry is allowed if either it is part of the allowed files or it
-   * matches one of the allowed prefixes
-   * 
+   *
+   * <p>A jar entry is allowed if either it is part of the allowed files or it matches one of the
+   * allowed prefixes
+   *
    * @param name the jar entry name
    * @throws AssertionException if the entry is not allowed
    */

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/BasicFlightSqlProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/BasicFlightSqlProducer.java
@@ -14,51 +14,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
+import com.google.protobuf.Message;
 import java.util.List;
-
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import com.google.protobuf.Message;
-
-/**
- * A {@link FlightSqlProducer} that implements getting FlightInfo for each metadata request.
- */
+/** A {@link FlightSqlProducer} that implements getting FlightInfo for each metadata request. */
 public abstract class BasicFlightSqlProducer extends NoOpFlightSqlProducer {
 
   @Override
-  public FlightInfo getFlightInfoSqlInfo(FlightSql.CommandGetSqlInfo request, CallContext context,
-                                         FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSqlInfo(
+      FlightSql.CommandGetSqlInfo request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_SQL_INFO_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoTypeInfo(FlightSql.CommandGetXdbcTypeInfo request, CallContext context,
-                                          FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTypeInfo(
+      FlightSql.CommandGetXdbcTypeInfo request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_TYPE_INFO_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoCatalogs(FlightSql.CommandGetCatalogs request, CallContext context,
-                                          FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCatalogs(
+      FlightSql.CommandGetCatalogs request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_CATALOGS_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoSchemas(FlightSql.CommandGetDbSchemas request, CallContext context,
-                                         FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSchemas(
+      FlightSql.CommandGetDbSchemas request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_SCHEMAS_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoTables(FlightSql.CommandGetTables request, CallContext context,
-                                        FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTables(
+      FlightSql.CommandGetTables request, CallContext context, FlightDescriptor descriptor) {
     if (request.getIncludeSchema()) {
       return generateFlightInfo(request, descriptor, Schemas.GET_TABLES_SCHEMA);
     }
@@ -66,43 +61,46 @@ public abstract class BasicFlightSqlProducer extends NoOpFlightSqlProducer {
   }
 
   @Override
-  public FlightInfo getFlightInfoTableTypes(FlightSql.CommandGetTableTypes request, CallContext context,
-                                            FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTableTypes(
+      FlightSql.CommandGetTableTypes request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_TABLE_TYPES_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoPrimaryKeys(FlightSql.CommandGetPrimaryKeys request, CallContext context,
-                                             FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPrimaryKeys(
+      FlightSql.CommandGetPrimaryKeys request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_PRIMARY_KEYS_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoExportedKeys(FlightSql.CommandGetExportedKeys request, CallContext context,
-                                              FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoExportedKeys(
+      FlightSql.CommandGetExportedKeys request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_EXPORTED_KEYS_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoImportedKeys(FlightSql.CommandGetImportedKeys request, CallContext context,
-                                              FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoImportedKeys(
+      FlightSql.CommandGetImportedKeys request, CallContext context, FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_IMPORTED_KEYS_SCHEMA);
   }
 
   @Override
-  public FlightInfo getFlightInfoCrossReference(FlightSql.CommandGetCrossReference request, CallContext context,
-                                                FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCrossReference(
+      FlightSql.CommandGetCrossReference request,
+      CallContext context,
+      FlightDescriptor descriptor) {
     return generateFlightInfo(request, descriptor, Schemas.GET_CROSS_REFERENCE_SCHEMA);
   }
 
   /**
-   * Return a list of FlightEndpoints for the given request and FlightDescriptor. This method should validate that
-   * the request is supported by this FlightSqlProducer.
+   * Return a list of FlightEndpoints for the given request and FlightDescriptor. This method should
+   * validate that the request is supported by this FlightSqlProducer.
    */
-  protected abstract <T extends Message>
-        List<FlightEndpoint> determineEndpoints(T request, FlightDescriptor flightDescriptor, Schema schema);
+  protected abstract <T extends Message> List<FlightEndpoint> determineEndpoints(
+      T request, FlightDescriptor flightDescriptor, Schema schema);
 
-  protected <T extends Message> FlightInfo generateFlightInfo(T request, FlightDescriptor descriptor, Schema schema) {
+  protected <T extends Message> FlightInfo generateFlightInfo(
+      T request, FlightDescriptor descriptor, Schema schema) {
     final List<FlightEndpoint> endpoints = determineEndpoints(request, descriptor, schema);
     return new FlightInfo(schema, descriptor, endpoints, -1, -1);
   }

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CancelListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CancelListener.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
+import com.google.protobuf.Any;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.flight.Result;
 import org.apache.arrow.flight.sql.impl.FlightSql;
-
-import com.google.protobuf.Any;
 
 /** Typed StreamListener for cancelQuery. */
 @SuppressWarnings("deprecation")
@@ -34,9 +32,8 @@ class CancelListener implements FlightProducer.StreamListener<CancelResult> {
 
   @Override
   public void onNext(CancelResult val) {
-    FlightSql.ActionCancelQueryResult result = FlightSql.ActionCancelQueryResult.newBuilder()
-        .setResult(val.toProtocol())
-        .build();
+    FlightSql.ActionCancelQueryResult result =
+        FlightSql.ActionCancelQueryResult.newBuilder().setResult(val.toProtocol()).build();
     listener.onNext(new Result(Any.pack(result).toByteArray()));
   }
 

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CancelResult.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CancelResult.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.sql.impl.FlightSql;

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CancelStatusListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CancelStatusListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.CancelFlightInfoResult;

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CloseSessionResultListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/CloseSessionResultListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.CloseSessionResult;
@@ -22,7 +21,8 @@ import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.flight.Result;
 
 /** Typed StreamListener for closeSession. */
-public class CloseSessionResultListener implements FlightProducer.StreamListener<CloseSessionResult> {
+public class CloseSessionResultListener
+    implements FlightProducer.StreamListener<CloseSessionResult> {
   private final FlightProducer.StreamListener<Result> listener;
 
   CloseSessionResultListener(FlightProducer.StreamListener<Result> listener) {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightEndpointListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightEndpointListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.FlightEndpoint;

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlClient.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlClient.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import static org.apache.arrow.flight.sql.impl.FlightSql.ActionBeginSavepointRequest;
@@ -45,6 +44,9 @@ import static org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementUpdate;
 import static org.apache.arrow.flight.sql.impl.FlightSql.DoPutUpdateResult;
 import static org.apache.arrow.flight.sql.impl.FlightSql.SqlInfo;
 
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
@@ -55,7 +57,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-
 import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.CallOption;
 import org.apache.arrow.flight.CallStatus;
@@ -90,13 +91,7 @@ import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import com.google.protobuf.Any;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
-
-/**
- * Flight client with Flight SQL semantics.
- */
+/** Flight client with Flight SQL semantics. */
 public class FlightSqlClient implements AutoCloseable {
   private final FlightClient client;
 
@@ -107,7 +102,7 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Execute a query on the server.
    *
-   * @param query   The query to execute.
+   * @param query The query to execute.
    * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
@@ -123,12 +118,15 @@ public class FlightSqlClient implements AutoCloseable {
    * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
-  public FlightInfo execute(final String query, Transaction transaction, final CallOption... options) {
-    final CommandStatementQuery.Builder builder = CommandStatementQuery.newBuilder().setQuery(query);
+  public FlightInfo execute(
+      final String query, Transaction transaction, final CallOption... options) {
+    final CommandStatementQuery.Builder builder =
+        CommandStatementQuery.newBuilder().setQuery(query);
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -151,61 +149,67 @@ public class FlightSqlClient implements AutoCloseable {
    * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
-  public FlightInfo executeSubstrait(SubstraitPlan plan, Transaction transaction, CallOption... options) {
-    final CommandStatementSubstraitPlan.Builder builder = CommandStatementSubstraitPlan.newBuilder();
-    builder.getPlanBuilder().setPlan(ByteString.copyFrom(plan.getPlan())).setVersion(plan.getVersion());
+  public FlightInfo executeSubstrait(
+      SubstraitPlan plan, Transaction transaction, CallOption... options) {
+    final CommandStatementSubstraitPlan.Builder builder =
+        CommandStatementSubstraitPlan.newBuilder();
+    builder
+        .getPlanBuilder()
+        .setPlan(ByteString.copyFrom(plan.getPlan()))
+        .setVersion(plan.getVersion());
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
-  /**
-   * Get the schema of the result set of a query.
-   */
-  public SchemaResult getExecuteSchema(String query, Transaction transaction, CallOption... options) {
+  /** Get the schema of the result set of a query. */
+  public SchemaResult getExecuteSchema(
+      String query, Transaction transaction, CallOption... options) {
     final CommandStatementQuery.Builder builder = CommandStatementQuery.newBuilder();
     builder.setQuery(query);
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getSchema(descriptor, options);
   }
 
-  /**
-   * Get the schema of the result set of a query.
-   */
+  /** Get the schema of the result set of a query. */
   public SchemaResult getExecuteSchema(String query, CallOption... options) {
-    return getExecuteSchema(query, /*transaction*/null, options);
+    return getExecuteSchema(query, /*transaction*/ null, options);
   }
 
-  /**
-   * Get the schema of the result set of a Substrait plan.
-   */
-  public SchemaResult getExecuteSubstraitSchema(SubstraitPlan plan, Transaction transaction,
-                                                final CallOption... options) {
-    final CommandStatementSubstraitPlan.Builder builder = CommandStatementSubstraitPlan.newBuilder();
-    builder.getPlanBuilder().setPlan(ByteString.copyFrom(plan.getPlan())).setVersion(plan.getVersion());
+  /** Get the schema of the result set of a Substrait plan. */
+  public SchemaResult getExecuteSubstraitSchema(
+      SubstraitPlan plan, Transaction transaction, final CallOption... options) {
+    final CommandStatementSubstraitPlan.Builder builder =
+        CommandStatementSubstraitPlan.newBuilder();
+    builder
+        .getPlanBuilder()
+        .setPlan(ByteString.copyFrom(plan.getPlan()))
+        .setVersion(plan.getVersion());
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getSchema(descriptor, options);
   }
 
-  /**
-   * Get the schema of the result set of a Substrait plan.
-   */
-  public SchemaResult getExecuteSubstraitSchema(SubstraitPlan substraitPlan, final CallOption... options) {
-    return getExecuteSubstraitSchema(substraitPlan, /*transaction*/null, options);
+  /** Get the schema of the result set of a Substrait plan. */
+  public SchemaResult getExecuteSubstraitSchema(
+      SubstraitPlan substraitPlan, final CallOption... options) {
+    return getExecuteSubstraitSchema(substraitPlan, /*transaction*/ null, options);
   }
 
   /**
    * Execute an update query on the server.
    *
-   * @param query   The query to execute.
+   * @param query The query to execute.
    * @param options RPC-layer hints for this call.
    * @return the number of rows affected.
    */
@@ -216,24 +220,27 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Execute an update query on the server.
    *
-   * @param query   The query to execute.
+   * @param query The query to execute.
    * @param transaction The transaction that this query is part of.
    * @param options RPC-layer hints for this call.
    * @return the number of rows affected.
    */
-  public long executeUpdate(final String query, Transaction transaction, final CallOption... options) {
-    final CommandStatementUpdate.Builder builder = CommandStatementUpdate.newBuilder().setQuery(query);
+  public long executeUpdate(
+      final String query, Transaction transaction, final CallOption... options) {
+    final CommandStatementUpdate.Builder builder =
+        CommandStatementUpdate.newBuilder().setQuery(query);
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     try (final SyncPutListener putListener = new SyncPutListener()) {
       final FlightClient.ClientStreamListener listener =
           client.startPut(descriptor, VectorSchemaRoot.of(), putListener, options);
       try (final PutResult result = putListener.read()) {
-        final DoPutUpdateResult doPutUpdateResult = DoPutUpdateResult.parseFrom(
-            result.getApplicationMetadata().nioBuffer());
+        final DoPutUpdateResult doPutUpdateResult =
+            DoPutUpdateResult.parseFrom(result.getApplicationMetadata().nioBuffer());
         return doPutUpdateResult.getRecordCount();
       } finally {
         listener.getResult();
@@ -264,20 +271,26 @@ public class FlightSqlClient implements AutoCloseable {
    * @param options RPC-layer hints for this call.
    * @return the number of rows affected.
    */
-  public long executeSubstraitUpdate(SubstraitPlan plan, Transaction transaction, CallOption... options) {
-    final CommandStatementSubstraitPlan.Builder builder = CommandStatementSubstraitPlan.newBuilder();
-    builder.getPlanBuilder().setPlan(ByteString.copyFrom(plan.getPlan())).setVersion(plan.getVersion());
+  public long executeSubstraitUpdate(
+      SubstraitPlan plan, Transaction transaction, CallOption... options) {
+    final CommandStatementSubstraitPlan.Builder builder =
+        CommandStatementSubstraitPlan.newBuilder();
+    builder
+        .getPlanBuilder()
+        .setPlan(ByteString.copyFrom(plan.getPlan()))
+        .setVersion(plan.getVersion());
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     try (final SyncPutListener putListener = new SyncPutListener()) {
       final FlightClient.ClientStreamListener listener =
           client.startPut(descriptor, VectorSchemaRoot.of(), putListener, options);
       try (final PutResult result = putListener.read()) {
-        final DoPutUpdateResult doPutUpdateResult = DoPutUpdateResult.parseFrom(
-            result.getApplicationMetadata().nioBuffer());
+        final DoPutUpdateResult doPutUpdateResult =
+            DoPutUpdateResult.parseFrom(result.getApplicationMetadata().nioBuffer());
         return doPutUpdateResult.getRecordCount();
       } finally {
         listener.getResult();
@@ -297,7 +310,8 @@ public class FlightSqlClient implements AutoCloseable {
    */
   public FlightInfo getCatalogs(final CallOption... options) {
     final CommandGetCatalogs.Builder builder = CommandGetCatalogs.newBuilder();
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -315,12 +329,13 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Request a list of schemas.
    *
-   * @param catalog               The catalog.
+   * @param catalog The catalog.
    * @param dbSchemaFilterPattern The schema filter pattern.
-   * @param options               RPC-layer hints for this call.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
-  public FlightInfo getSchemas(final String catalog, final String dbSchemaFilterPattern, final CallOption... options) {
+  public FlightInfo getSchemas(
+      final String catalog, final String dbSchemaFilterPattern, final CallOption... options) {
     final CommandGetDbSchemas.Builder builder = CommandGetDbSchemas.newBuilder();
 
     if (catalog != null) {
@@ -331,7 +346,8 @@ public class FlightSqlClient implements AutoCloseable {
       builder.setDbSchemaFilterPattern(dbSchemaFilterPattern);
     }
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -350,7 +366,7 @@ public class FlightSqlClient implements AutoCloseable {
    * Get schema for a stream.
    *
    * @param descriptor The descriptor for the stream.
-   * @param options    RPC-layer hints for this call.
+   * @param options RPC-layer hints for this call.
    */
   public SchemaResult getSchema(FlightDescriptor descriptor, CallOption... options) {
     return client.getSchema(descriptor, options);
@@ -359,7 +375,7 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Retrieve a stream from the server.
    *
-   * @param ticket  The ticket granting access to the data stream.
+   * @param ticket The ticket granting access to the data stream.
    * @param options RPC-layer hints for this call.
    */
   public FlightStream getStream(Ticket ticket, CallOption... options) {
@@ -379,7 +395,7 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Request a set of Flight SQL metadata.
    *
-   * @param info    The set of metadata to retrieve. None to retrieve all metadata.
+   * @param info The set of metadata to retrieve. None to retrieve all metadata.
    * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
@@ -389,11 +405,10 @@ public class FlightSqlClient implements AutoCloseable {
   }
 
   /**
-   * Request a set of Flight SQL metadata.
-   * Use this method if you would like to retrieve custom metadata, where the custom metadata key values start
-   * from 10_000.
+   * Request a set of Flight SQL metadata. Use this method if you would like to retrieve custom
+   * metadata, where the custom metadata key values start from 10_000.
    *
-   * @param info    The set of metadata to retrieve. None to retrieve all metadata.
+   * @param info The set of metadata to retrieve. None to retrieve all metadata.
    * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
@@ -402,18 +417,18 @@ public class FlightSqlClient implements AutoCloseable {
   }
 
   /**
-   * Request a set of Flight SQL metadata.
-   * Use this method if you would like to retrieve custom metadata, where the custom metadata key values start
-   * from 10_000.
+   * Request a set of Flight SQL metadata. Use this method if you would like to retrieve custom
+   * metadata, where the custom metadata key values start from 10_000.
    *
-   * @param info    The set of metadata to retrieve. None to retrieve all metadata.
+   * @param info The set of metadata to retrieve. None to retrieve all metadata.
    * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
   public FlightInfo getSqlInfo(final Iterable<Integer> info, final CallOption... options) {
     final CommandGetSqlInfo.Builder builder = CommandGetSqlInfo.newBuilder();
     builder.addAllInfo(info);
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -429,11 +444,10 @@ public class FlightSqlClient implements AutoCloseable {
   }
 
   /**
-   * Request the information about the data types supported related to
-   * a filter data type.
+   * Request the information about the data types supported related to a filter data type.
    *
-   * @param dataType  the data type to be used as filter.
-   * @param options   RPC-layer hints for this call.
+   * @param dataType the data type to be used as filter.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
   public FlightInfo getXdbcTypeInfo(final int dataType, final CallOption... options) {
@@ -441,20 +455,22 @@ public class FlightSqlClient implements AutoCloseable {
 
     builder.setDataType(dataType);
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
   /**
    * Request the information about all the data types supported.
    *
-   * @param options   RPC-layer hints for this call.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
   public FlightInfo getXdbcTypeInfo(final CallOption... options) {
     final CommandGetXdbcTypeInfo.Builder builder = CommandGetXdbcTypeInfo.newBuilder();
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -472,17 +488,21 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Request a list of tables.
    *
-   * @param catalog               The catalog.
+   * @param catalog The catalog.
    * @param dbSchemaFilterPattern The schema filter pattern.
-   * @param tableFilterPattern    The table filter pattern.
-   * @param tableTypes            The table types to include.
-   * @param includeSchema         True to include the schema upon return, false to not include the schema.
-   * @param options               RPC-layer hints for this call.
+   * @param tableFilterPattern The table filter pattern.
+   * @param tableTypes The table types to include.
+   * @param includeSchema True to include the schema upon return, false to not include the schema.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
-  public FlightInfo getTables(final String catalog, final String dbSchemaFilterPattern,
-                              final String tableFilterPattern, final List<String> tableTypes,
-                              final boolean includeSchema, final CallOption... options) {
+  public FlightInfo getTables(
+      final String catalog,
+      final String dbSchemaFilterPattern,
+      final String tableFilterPattern,
+      final List<String> tableTypes,
+      final boolean includeSchema,
+      final CallOption... options) {
     final CommandGetTables.Builder builder = CommandGetTables.newBuilder();
 
     if (catalog != null) {
@@ -502,18 +522,21 @@ public class FlightSqlClient implements AutoCloseable {
     }
     builder.setIncludeSchema(includeSchema);
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
   /**
-   * Get the schema of {@link #getTables(String, String, String, List, boolean, CallOption...)} from the server.
+   * Get the schema of {@link #getTables(String, String, String, List, boolean, CallOption...)} from
+   * the server.
    *
-   * <p>Should be identical to {@link FlightSqlProducer.Schemas#GET_TABLES_SCHEMA} or
-   * {@link FlightSqlProducer.Schemas#GET_TABLES_SCHEMA_NO_SCHEMA}.
+   * <p>Should be identical to {@link FlightSqlProducer.Schemas#GET_TABLES_SCHEMA} or {@link
+   * FlightSqlProducer.Schemas#GET_TABLES_SCHEMA_NO_SCHEMA}.
    */
   public SchemaResult getTablesSchema(boolean includeSchema, final CallOption... options) {
-    final CommandGetTables command = CommandGetTables.newBuilder().setIncludeSchema(includeSchema).build();
+    final CommandGetTables command =
+        CommandGetTables.newBuilder().setIncludeSchema(includeSchema).build();
     final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(command).toByteArray());
     return client.getSchema(descriptor, options);
   }
@@ -521,8 +544,8 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Request the primary keys for a table.
    *
-   * @param tableRef  An object which hold info about catalog, dbSchema and table.
-   * @param options   RPC-layer hints for this call.
+   * @param tableRef An object which hold info about catalog, dbSchema and table.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
   public FlightInfo getPrimaryKeys(final TableRef tableRef, final CallOption... options) {
@@ -539,7 +562,8 @@ public class FlightSqlClient implements AutoCloseable {
     Objects.requireNonNull(tableRef.getTable());
     builder.setTable(tableRef.getTable());
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -555,10 +579,11 @@ public class FlightSqlClient implements AutoCloseable {
   }
 
   /**
-   * Retrieves a description about the foreign key columns that reference the primary key columns of the given table.
+   * Retrieves a description about the foreign key columns that reference the primary key columns of
+   * the given table.
    *
-   * @param tableRef  An object which hold info about catalog, dbSchema and table.
-   * @param options   RPC-layer hints for this call.
+   * @param tableRef An object which hold info about catalog, dbSchema and table.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
   public FlightInfo getExportedKeys(final TableRef tableRef, final CallOption... options) {
@@ -577,7 +602,8 @@ public class FlightSqlClient implements AutoCloseable {
     Objects.requireNonNull(tableRef.getTable());
     builder.setTable(tableRef.getTable());
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -595,12 +621,11 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Retrieves the foreign key columns for the given table.
    *
-   * @param tableRef  An object which hold info about catalog, dbSchema and table.
-   * @param options   RPC-layer hints for this call.
+   * @param tableRef An object which hold info about catalog, dbSchema and table.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
-  public FlightInfo getImportedKeys(final TableRef tableRef,
-                                    final CallOption... options) {
+  public FlightInfo getImportedKeys(final TableRef tableRef, final CallOption... options) {
     Objects.requireNonNull(tableRef.getTable(), "Table cannot be null.");
 
     final CommandGetImportedKeys.Builder builder = CommandGetImportedKeys.newBuilder();
@@ -616,7 +641,8 @@ public class FlightSqlClient implements AutoCloseable {
     Objects.requireNonNull(tableRef.getTable());
     builder.setTable(tableRef.getTable());
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -632,16 +658,18 @@ public class FlightSqlClient implements AutoCloseable {
   }
 
   /**
-   * Retrieves a description of the foreign key columns that reference the given table's
-   * primary key columns (the foreign keys exported by a table).
+   * Retrieves a description of the foreign key columns that reference the given table's primary key
+   * columns (the foreign keys exported by a table).
    *
-   * @param pkTableRef    An object which hold info about catalog, dbSchema and table from a primary table.
-   * @param fkTableRef    An object which hold info about catalog, dbSchema and table from a foreign table.
-   * @param options       RPC-layer hints for this call.
+   * @param pkTableRef An object which hold info about catalog, dbSchema and table from a primary
+   *     table.
+   * @param fkTableRef An object which hold info about catalog, dbSchema and table from a foreign
+   *     table.
+   * @param options RPC-layer hints for this call.
    * @return a FlightInfo object representing the stream(s) to fetch.
    */
-  public FlightInfo getCrossReference(final TableRef pkTableRef,
-                                      final TableRef fkTableRef, final CallOption... options) {
+  public FlightInfo getCrossReference(
+      final TableRef pkTableRef, final TableRef fkTableRef, final CallOption... options) {
     Objects.requireNonNull(pkTableRef.getTable(), "Parent Table cannot be null.");
     Objects.requireNonNull(fkTableRef.getTable(), "Foreign Table cannot be null.");
 
@@ -666,12 +694,14 @@ public class FlightSqlClient implements AutoCloseable {
     builder.setPkTable(pkTableRef.getTable());
     builder.setFkTable(fkTableRef.getTable());
 
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
   /**
-   * Get the schema of {@link #getCrossReference(TableRef, TableRef, CallOption...)} from the server.
+   * Get the schema of {@link #getCrossReference(TableRef, TableRef, CallOption...)} from the
+   * server.
    *
    * <p>Should be identical to {@link FlightSqlProducer.Schemas#GET_CROSS_REFERENCE_SCHEMA}.
    */
@@ -689,7 +719,8 @@ public class FlightSqlClient implements AutoCloseable {
    */
   public FlightInfo getTableTypes(final CallOption... options) {
     final CommandGetTableTypes.Builder builder = CommandGetTableTypes.newBuilder();
-    final FlightDescriptor descriptor = FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
+    final FlightDescriptor descriptor =
+        FlightDescriptor.command(Any.pack(builder.build()).toByteArray());
     return client.getInfo(descriptor, options);
   }
 
@@ -707,7 +738,7 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Create a prepared statement for a SQL query on the server.
    *
-   * @param query   The query to prepare.
+   * @param query The query to prepare.
    * @param options RPC-layer hints for this call.
    * @return The representation of the prepared statement which exists on the server.
    */
@@ -729,7 +760,8 @@ public class FlightSqlClient implements AutoCloseable {
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
-    return new PreparedStatement(client,
+    return new PreparedStatement(
+        client,
         new Action(
             FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType(),
             Any.pack(builder.build()).toByteArray()),
@@ -739,7 +771,7 @@ public class FlightSqlClient implements AutoCloseable {
   /**
    * Create a prepared statement for a Substrait plan on the server.
    *
-   * @param plan    The query to prepare.
+   * @param plan The query to prepare.
    * @param options RPC-layer hints for this call.
    * @return The representation of the prepared statement which exists on the server.
    */
@@ -755,14 +787,19 @@ public class FlightSqlClient implements AutoCloseable {
    * @param options RPC-layer hints for this call.
    * @return The representation of the prepared statement which exists on the server.
    */
-  public PreparedStatement prepare(SubstraitPlan plan, Transaction transaction, CallOption... options) {
+  public PreparedStatement prepare(
+      SubstraitPlan plan, Transaction transaction, CallOption... options) {
     ActionCreatePreparedSubstraitPlanRequest.Builder builder =
         ActionCreatePreparedSubstraitPlanRequest.newBuilder();
-    builder.getPlanBuilder().setPlan(ByteString.copyFrom(plan.getPlan())).setVersion(plan.getVersion());
+    builder
+        .getPlanBuilder()
+        .setPlan(ByteString.copyFrom(plan.getPlan()))
+        .setVersion(plan.getVersion());
     if (transaction != null) {
       builder.setTransactionId(ByteString.copyFrom(transaction.getTransactionId()));
     }
-    return new PreparedStatement(client,
+    return new PreparedStatement(
+        client,
         new Action(
             FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_SUBSTRAIT_PLAN.getType(),
             Any.pack(builder.build()).toByteArray()),
@@ -771,95 +808,114 @@ public class FlightSqlClient implements AutoCloseable {
 
   /** Begin a transaction. */
   public Transaction beginTransaction(CallOption... options) {
-    final Action action = new Action(
-        FlightSqlUtils.FLIGHT_SQL_BEGIN_TRANSACTION.getType(),
-        Any.pack(ActionBeginTransactionRequest.getDefaultInstance()).toByteArray());
+    final Action action =
+        new Action(
+            FlightSqlUtils.FLIGHT_SQL_BEGIN_TRANSACTION.getType(),
+            Any.pack(ActionBeginTransactionRequest.getDefaultInstance()).toByteArray());
     final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-    final ActionBeginTransactionResult result = FlightSqlUtils.unpackAndParseOrThrow(
-        preparedStatementResults.next().getBody(),
-        ActionBeginTransactionResult.class);
-    preparedStatementResults.forEachRemaining((ignored) -> { });
+    final ActionBeginTransactionResult result =
+        FlightSqlUtils.unpackAndParseOrThrow(
+            preparedStatementResults.next().getBody(), ActionBeginTransactionResult.class);
+    preparedStatementResults.forEachRemaining((ignored) -> {});
     if (result.getTransactionId().isEmpty()) {
-      throw CallStatus.INTERNAL.withDescription("Server returned an empty transaction ID").toRuntimeException();
+      throw CallStatus.INTERNAL
+          .withDescription("Server returned an empty transaction ID")
+          .toRuntimeException();
     }
     return new Transaction(result.getTransactionId().toByteArray());
   }
 
   /** Create a savepoint within a transaction. */
   public Savepoint beginSavepoint(Transaction transaction, String name, CallOption... options) {
-    Preconditions.checkArgument(transaction.getTransactionId().length != 0, "Transaction must be initialized");
-    ActionBeginSavepointRequest request = ActionBeginSavepointRequest.newBuilder()
-        .setTransactionId(ByteString.copyFrom(transaction.getTransactionId()))
-        .setName(name)
-        .build();
-    final Action action = new Action(
-        FlightSqlUtils.FLIGHT_SQL_BEGIN_SAVEPOINT.getType(),
-        Any.pack(request).toByteArray());
+    Preconditions.checkArgument(
+        transaction.getTransactionId().length != 0, "Transaction must be initialized");
+    ActionBeginSavepointRequest request =
+        ActionBeginSavepointRequest.newBuilder()
+            .setTransactionId(ByteString.copyFrom(transaction.getTransactionId()))
+            .setName(name)
+            .build();
+    final Action action =
+        new Action(
+            FlightSqlUtils.FLIGHT_SQL_BEGIN_SAVEPOINT.getType(), Any.pack(request).toByteArray());
     final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-    final ActionBeginSavepointResult result = FlightSqlUtils.unpackAndParseOrThrow(
-        preparedStatementResults.next().getBody(),
-        ActionBeginSavepointResult.class);
-    preparedStatementResults.forEachRemaining((ignored) -> { });
+    final ActionBeginSavepointResult result =
+        FlightSqlUtils.unpackAndParseOrThrow(
+            preparedStatementResults.next().getBody(), ActionBeginSavepointResult.class);
+    preparedStatementResults.forEachRemaining((ignored) -> {});
     if (result.getSavepointId().isEmpty()) {
-      throw CallStatus.INTERNAL.withDescription("Server returned an empty transaction ID").toRuntimeException();
+      throw CallStatus.INTERNAL
+          .withDescription("Server returned an empty transaction ID")
+          .toRuntimeException();
     }
     return new Savepoint(result.getSavepointId().toByteArray());
   }
 
   /** Commit a transaction. */
   public void commit(Transaction transaction, CallOption... options) {
-    Preconditions.checkArgument(transaction.getTransactionId().length != 0, "Transaction must be initialized");
-    ActionEndTransactionRequest request = ActionEndTransactionRequest.newBuilder()
-        .setTransactionId(ByteString.copyFrom(transaction.getTransactionId()))
-        .setActionValue(ActionEndTransactionRequest.EndTransaction.END_TRANSACTION_COMMIT.getNumber())
-        .build();
-    final Action action = new Action(
-        FlightSqlUtils.FLIGHT_SQL_END_TRANSACTION.getType(),
-        Any.pack(request).toByteArray());
+    Preconditions.checkArgument(
+        transaction.getTransactionId().length != 0, "Transaction must be initialized");
+    ActionEndTransactionRequest request =
+        ActionEndTransactionRequest.newBuilder()
+            .setTransactionId(ByteString.copyFrom(transaction.getTransactionId()))
+            .setActionValue(
+                ActionEndTransactionRequest.EndTransaction.END_TRANSACTION_COMMIT.getNumber())
+            .build();
+    final Action action =
+        new Action(
+            FlightSqlUtils.FLIGHT_SQL_END_TRANSACTION.getType(), Any.pack(request).toByteArray());
     final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-    preparedStatementResults.forEachRemaining((ignored) -> { });
+    preparedStatementResults.forEachRemaining((ignored) -> {});
   }
 
   /** Release a savepoint. */
   public void release(Savepoint savepoint, CallOption... options) {
-    Preconditions.checkArgument(savepoint.getSavepointId().length != 0, "Savepoint must be initialized");
-    ActionEndSavepointRequest request = ActionEndSavepointRequest.newBuilder()
-        .setSavepointId(ByteString.copyFrom(savepoint.getSavepointId()))
-        .setActionValue(ActionEndSavepointRequest.EndSavepoint.END_SAVEPOINT_RELEASE.getNumber())
-        .build();
-    final Action action = new Action(
-        FlightSqlUtils.FLIGHT_SQL_END_SAVEPOINT.getType(),
-        Any.pack(request).toByteArray());
+    Preconditions.checkArgument(
+        savepoint.getSavepointId().length != 0, "Savepoint must be initialized");
+    ActionEndSavepointRequest request =
+        ActionEndSavepointRequest.newBuilder()
+            .setSavepointId(ByteString.copyFrom(savepoint.getSavepointId()))
+            .setActionValue(
+                ActionEndSavepointRequest.EndSavepoint.END_SAVEPOINT_RELEASE.getNumber())
+            .build();
+    final Action action =
+        new Action(
+            FlightSqlUtils.FLIGHT_SQL_END_SAVEPOINT.getType(), Any.pack(request).toByteArray());
     final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-    preparedStatementResults.forEachRemaining((ignored) -> { });
+    preparedStatementResults.forEachRemaining((ignored) -> {});
   }
 
   /** Rollback a transaction. */
   public void rollback(Transaction transaction, CallOption... options) {
-    Preconditions.checkArgument(transaction.getTransactionId().length != 0, "Transaction must be initialized");
-    ActionEndTransactionRequest request = ActionEndTransactionRequest.newBuilder()
-        .setTransactionId(ByteString.copyFrom(transaction.getTransactionId()))
-        .setActionValue(ActionEndTransactionRequest.EndTransaction.END_TRANSACTION_ROLLBACK.getNumber())
-        .build();
-    final Action action = new Action(
-        FlightSqlUtils.FLIGHT_SQL_END_TRANSACTION.getType(),
-        Any.pack(request).toByteArray());
+    Preconditions.checkArgument(
+        transaction.getTransactionId().length != 0, "Transaction must be initialized");
+    ActionEndTransactionRequest request =
+        ActionEndTransactionRequest.newBuilder()
+            .setTransactionId(ByteString.copyFrom(transaction.getTransactionId()))
+            .setActionValue(
+                ActionEndTransactionRequest.EndTransaction.END_TRANSACTION_ROLLBACK.getNumber())
+            .build();
+    final Action action =
+        new Action(
+            FlightSqlUtils.FLIGHT_SQL_END_TRANSACTION.getType(), Any.pack(request).toByteArray());
     final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-    preparedStatementResults.forEachRemaining((ignored) -> { });
+    preparedStatementResults.forEachRemaining((ignored) -> {});
   }
 
   /** Rollback to a savepoint. */
   public void rollback(Savepoint savepoint, CallOption... options) {
-    Preconditions.checkArgument(savepoint.getSavepointId().length != 0, "Savepoint must be initialized");
-    ActionEndSavepointRequest request = ActionEndSavepointRequest.newBuilder()
-        .setSavepointId(ByteString.copyFrom(savepoint.getSavepointId()))
-        .setActionValue(ActionEndSavepointRequest.EndSavepoint.END_SAVEPOINT_RELEASE.getNumber())
-        .build();
-    final Action action = new Action(
-        FlightSqlUtils.FLIGHT_SQL_END_SAVEPOINT.getType(),
-        Any.pack(request).toByteArray());
+    Preconditions.checkArgument(
+        savepoint.getSavepointId().length != 0, "Savepoint must be initialized");
+    ActionEndSavepointRequest request =
+        ActionEndSavepointRequest.newBuilder()
+            .setSavepointId(ByteString.copyFrom(savepoint.getSavepointId()))
+            .setActionValue(
+                ActionEndSavepointRequest.EndSavepoint.END_SAVEPOINT_RELEASE.getNumber())
+            .build();
+    final Action action =
+        new Action(
+            FlightSqlUtils.FLIGHT_SQL_END_SAVEPOINT.getType(), Any.pack(request).toByteArray());
     final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-    preparedStatementResults.forEachRemaining((ignored) -> { });
+    preparedStatementResults.forEachRemaining((ignored) -> {});
   }
 
   /**
@@ -869,35 +925,36 @@ public class FlightSqlClient implements AutoCloseable {
    * @param options Call options.
    * @return The server response.
    */
-  public CancelFlightInfoResult cancelFlightInfo(CancelFlightInfoRequest request, CallOption... options) {
+  public CancelFlightInfoResult cancelFlightInfo(
+      CancelFlightInfoRequest request, CallOption... options) {
     return client.cancelFlightInfo(request, options);
   }
 
   /**
    * Explicitly cancel a running query.
-   * <p>
-   * This lets a single client explicitly cancel work, no matter how many clients
-   * are involved/whether the query is distributed or not, given server support.
-   * The transaction/statement is not rolled back; it is the application's job to
-   * commit or rollback as appropriate. This only indicates the client no longer
-   * wishes to read the remainder of the query results or continue submitting
-   * data.
+   *
+   * <p>This lets a single client explicitly cancel work, no matter how many clients are
+   * involved/whether the query is distributed or not, given server support. The
+   * transaction/statement is not rolled back; it is the application's job to commit or rollback as
+   * appropriate. This only indicates the client no longer wishes to read the remainder of the query
+   * results or continue submitting data.
    *
    * @deprecated Prefer {@link #cancelFlightInfo}.
    */
   @Deprecated
   public CancelResult cancelQuery(FlightInfo info, CallOption... options) {
-    ActionCancelQueryRequest request = ActionCancelQueryRequest.newBuilder()
-        .setInfo(ByteString.copyFrom(info.serialize()))
-        .build();
-    final Action action = new Action(
-        FlightSqlUtils.FLIGHT_SQL_CANCEL_QUERY.getType(),
-        Any.pack(request).toByteArray());
+    ActionCancelQueryRequest request =
+        ActionCancelQueryRequest.newBuilder()
+            .setInfo(ByteString.copyFrom(info.serialize()))
+            .build();
+    final Action action =
+        new Action(
+            FlightSqlUtils.FLIGHT_SQL_CANCEL_QUERY.getType(), Any.pack(request).toByteArray());
     final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-    final ActionCancelQueryResult result = FlightSqlUtils.unpackAndParseOrThrow(
-        preparedStatementResults.next().getBody(),
-        ActionCancelQueryResult.class);
-    preparedStatementResults.forEachRemaining((ignored) -> { });
+    final ActionCancelQueryResult result =
+        FlightSqlUtils.unpackAndParseOrThrow(
+            preparedStatementResults.next().getBody(), ActionCancelQueryResult.class);
+    preparedStatementResults.forEachRemaining((ignored) -> {});
     switch (result.getResult()) {
       case CANCEL_RESULT_UNSPECIFIED:
         return CancelResult.UNSPECIFIED;
@@ -909,7 +966,9 @@ public class FlightSqlClient implements AutoCloseable {
         return CancelResult.NOT_CANCELLABLE;
       case UNRECOGNIZED:
       default:
-        throw CallStatus.INTERNAL.withDescription("Unknown result: " + result.getResult()).toRuntimeException();
+        throw CallStatus.INTERNAL
+            .withDescription("Unknown result: " + result.getResult())
+            .toRuntimeException();
     }
   }
 
@@ -920,15 +979,18 @@ public class FlightSqlClient implements AutoCloseable {
    * @param options Call options.
    * @return The new endpoint with an updated expiration time.
    */
-  public FlightEndpoint renewFlightEndpoint(RenewFlightEndpointRequest request, CallOption... options) {
+  public FlightEndpoint renewFlightEndpoint(
+      RenewFlightEndpointRequest request, CallOption... options) {
     return client.renewFlightEndpoint(request, options);
   }
 
-  public SetSessionOptionsResult setSessionOptions(SetSessionOptionsRequest request, CallOption... options) {
+  public SetSessionOptionsResult setSessionOptions(
+      SetSessionOptionsRequest request, CallOption... options) {
     return client.setSessionOptions(request, options);
   }
 
-  public GetSessionOptionsResult getSessionOptions(GetSessionOptionsRequest request, CallOption... options) {
+  public GetSessionOptionsResult getSessionOptions(
+      GetSessionOptionsRequest request, CallOption... options) {
     return client.getSessionOptions(request, options);
   }
 
@@ -941,9 +1003,7 @@ public class FlightSqlClient implements AutoCloseable {
     AutoCloseables.close(client);
   }
 
-  /**
-   * Helper class to encapsulate Flight SQL prepared statement logic.
-   */
+  /** Helper class to encapsulate Flight SQL prepared statement logic. */
   public static class PreparedStatement implements AutoCloseable {
     private final FlightClient client;
     private final ActionCreatePreparedStatementResult preparedStatementResult;
@@ -956,18 +1016,18 @@ public class FlightSqlClient implements AutoCloseable {
       this.client = client;
 
       final Iterator<Result> preparedStatementResults = client.doAction(action, options);
-      preparedStatementResult = FlightSqlUtils.unpackAndParseOrThrow(
-          preparedStatementResults.next().getBody(),
-          ActionCreatePreparedStatementResult.class);
+      preparedStatementResult =
+          FlightSqlUtils.unpackAndParseOrThrow(
+              preparedStatementResults.next().getBody(), ActionCreatePreparedStatementResult.class);
       isClosed = false;
     }
 
     /**
-     * Set the {@link #parameterBindingRoot} containing the parameter binding from a {@link PreparedStatement}
-     * operation.
+     * Set the {@link #parameterBindingRoot} containing the parameter binding from a {@link
+     * PreparedStatement} operation.
      *
-     * @param parameterBindingRoot a {@code VectorSchemaRoot} object containing the values to be used in the
-     *                             {@code PreparedStatement} setters.
+     * @param parameterBindingRoot a {@code VectorSchemaRoot} object containing the values to be
+     *     used in the {@code PreparedStatement} setters.
      */
     public void setParameters(final VectorSchemaRoot parameterBindingRoot) {
       if (parameterBindingRoot == this.parameterBindingRoot) {
@@ -979,8 +1039,8 @@ public class FlightSqlClient implements AutoCloseable {
     }
 
     /**
-     * Closes the {@link #parameterBindingRoot}, which contains the parameter binding from
-     * a {@link PreparedStatement} operation, releasing its resources.
+     * Closes the {@link #parameterBindingRoot}, which contains the parameter binding from a {@link
+     * PreparedStatement} operation, releasing its resources.
      */
     public void clearParameters() {
       if (parameterBindingRoot != null) {
@@ -1014,27 +1074,28 @@ public class FlightSqlClient implements AutoCloseable {
       return parameterSchema;
     }
 
-    /**
-     * Get the schema of the result set (should be identical to {@link #getResultSetSchema()}).
-     */
+    /** Get the schema of the result set (should be identical to {@link #getResultSetSchema()}). */
     public SchemaResult fetchSchema(CallOption... options) {
       checkOpen();
 
-      final FlightDescriptor descriptor = FlightDescriptor
-          .command(Any.pack(CommandPreparedStatementQuery.newBuilder()
-                  .setPreparedStatementHandle(preparedStatementResult.getPreparedStatementHandle())
-                  .build())
-              .toByteArray());
+      final FlightDescriptor descriptor =
+          FlightDescriptor.command(
+              Any.pack(
+                      CommandPreparedStatementQuery.newBuilder()
+                          .setPreparedStatementHandle(
+                              preparedStatementResult.getPreparedStatementHandle())
+                          .build())
+                  .toByteArray());
       return client.getSchema(descriptor, options);
     }
 
     private Schema deserializeSchema(final ByteString bytes) {
       try {
-        return bytes.isEmpty() ?
-            new Schema(Collections.emptyList()) :
-            MessageSerializer.deserializeSchema(
-                new ReadChannel(Channels.newChannel(
-                    new ByteArrayInputStream(bytes.toByteArray()))));
+        return bytes.isEmpty()
+            ? new Schema(Collections.emptyList())
+            : MessageSerializer.deserializeSchema(
+                new ReadChannel(
+                    Channels.newChannel(new ByteArrayInputStream(bytes.toByteArray()))));
       } catch (final IOException e) {
         throw new RuntimeException("Failed to deserialize schema", e);
       }
@@ -1049,28 +1110,33 @@ public class FlightSqlClient implements AutoCloseable {
     public FlightInfo execute(final CallOption... options) {
       checkOpen();
 
-      FlightDescriptor descriptor = FlightDescriptor
-          .command(Any.pack(CommandPreparedStatementQuery.newBuilder()
-                  .setPreparedStatementHandle(preparedStatementResult.getPreparedStatementHandle())
-                  .build())
-              .toByteArray());
+      FlightDescriptor descriptor =
+          FlightDescriptor.command(
+              Any.pack(
+                      CommandPreparedStatementQuery.newBuilder()
+                          .setPreparedStatementHandle(
+                              preparedStatementResult.getPreparedStatementHandle())
+                          .build())
+                  .toByteArray());
 
       if (parameterBindingRoot != null && parameterBindingRoot.getRowCount() > 0) {
         try (final SyncPutListener putListener = putParameters(descriptor, options)) {
-          if (getParameterSchema().getFields().size() > 0 &&
-                  parameterBindingRoot != null &&
-                  parameterBindingRoot.getRowCount() > 0) {
+          if (getParameterSchema().getFields().size() > 0
+              && parameterBindingRoot != null
+              && parameterBindingRoot.getRowCount() > 0) {
             final PutResult read = putListener.read();
             if (read != null) {
               try (final ArrowBuf metadata = read.getApplicationMetadata()) {
                 final FlightSql.DoPutPreparedStatementResult doPutPreparedStatementResult =
-                        FlightSql.DoPutPreparedStatementResult.parseFrom(metadata.nioBuffer());
-                descriptor = FlightDescriptor
-                        .command(Any.pack(CommandPreparedStatementQuery.newBuilder()
-                                        .setPreparedStatementHandle(
-                                                doPutPreparedStatementResult.getPreparedStatementHandle())
-                                        .build())
-                                .toByteArray());
+                    FlightSql.DoPutPreparedStatementResult.parseFrom(metadata.nioBuffer());
+                descriptor =
+                    FlightDescriptor.command(
+                        Any.pack(
+                                CommandPreparedStatementQuery.newBuilder()
+                                    .setPreparedStatementHandle(
+                                        doPutPreparedStatementResult.getPreparedStatementHandle())
+                                    .build())
+                            .toByteArray());
               }
             }
           }
@@ -1088,7 +1154,7 @@ public class FlightSqlClient implements AutoCloseable {
       final SyncPutListener putListener = new SyncPutListener();
 
       FlightClient.ClientStreamListener listener =
-              client.startPut(descriptor, parameterBindingRoot, putListener, options);
+          client.startPut(descriptor, parameterBindingRoot, putListener, options);
 
       listener.putNext();
       listener.completed();
@@ -1114,11 +1180,14 @@ public class FlightSqlClient implements AutoCloseable {
      */
     public long executeUpdate(final CallOption... options) {
       checkOpen();
-      final FlightDescriptor descriptor = FlightDescriptor
-          .command(Any.pack(CommandPreparedStatementUpdate.newBuilder()
-                  .setPreparedStatementHandle(preparedStatementResult.getPreparedStatementHandle())
-                  .build())
-              .toByteArray());
+      final FlightDescriptor descriptor =
+          FlightDescriptor.command(
+              Any.pack(
+                      CommandPreparedStatementUpdate.newBuilder()
+                          .setPreparedStatementHandle(
+                              preparedStatementResult.getPreparedStatementHandle())
+                          .build())
+                  .toByteArray());
       setParameters(parameterBindingRoot == null ? VectorSchemaRoot.of() : parameterBindingRoot);
       SyncPutListener putListener = putParameters(descriptor, options);
 
@@ -1146,15 +1215,17 @@ public class FlightSqlClient implements AutoCloseable {
         return;
       }
       isClosed = true;
-      final Action action = new Action(
-          FlightSqlUtils.FLIGHT_SQL_CLOSE_PREPARED_STATEMENT.getType(),
-          Any.pack(ActionClosePreparedStatementRequest.newBuilder()
-                  .setPreparedStatementHandle(preparedStatementResult.getPreparedStatementHandle())
-                  .build())
-              .toByteArray());
+      final Action action =
+          new Action(
+              FlightSqlUtils.FLIGHT_SQL_CLOSE_PREPARED_STATEMENT.getType(),
+              Any.pack(
+                      ActionClosePreparedStatementRequest.newBuilder()
+                          .setPreparedStatementHandle(
+                              preparedStatementResult.getPreparedStatementHandle())
+                          .build())
+                  .toByteArray());
       final Iterator<Result> closePreparedStatementResults = client.doAction(action, options);
-      closePreparedStatementResults.forEachRemaining(result -> {
-      });
+      closePreparedStatementResults.forEachRemaining(result -> {});
       clearParameters();
     }
 
@@ -1243,10 +1314,13 @@ public class FlightSqlClient implements AutoCloseable {
 
     @Override
     public String toString() {
-      return "SubstraitPlan{" +
-          "plan=" + Arrays.toString(plan) +
-          ", version='" + version + '\'' +
-          '}';
+      return "SubstraitPlan{"
+          + "plan="
+          + Arrays.toString(plan)
+          + ", version='"
+          + version
+          + '\''
+          + '}';
     }
   }
 }

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlColumnMetadata.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlColumnMetadata.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import java.util.Collections;
@@ -24,14 +23,16 @@ import java.util.Map;
 /**
  * Metadata for a column in a Flight SQL query.
  *
- * This can be used with FlightSqlClient to access column's metadata contained in schemas returned
- * by GetTables and query execution as follows:
+ * <p>This can be used with FlightSqlClient to access column's metadata contained in schemas
+ * returned by GetTables and query execution as follows:
+ *
  * <pre>
  *   FlightSqlColumnMetadata metadata = new FlightSqlColumnMetadata(field.getMetadata());
  *   Integer precision = metadata.getPrecision();
  * </pre>
  *
  * FlightSqlProducer can use this to set metadata on a column in a schema as follows:
+ *
  * <pre>
  *   FlightSqlColumnMetadata metadata = new FlightSqlColumnMetadata.Builder()
  *         .precision(10)
@@ -58,15 +59,14 @@ public class FlightSqlColumnMetadata {
 
   private final Map<String, String> metadataMap;
 
-  /**
-   * Creates a new instance of FlightSqlColumnMetadata.
-   */
+  /** Creates a new instance of FlightSqlColumnMetadata. */
   public FlightSqlColumnMetadata(Map<String, String> metadataMap) {
     this.metadataMap = new HashMap<>(metadataMap);
   }
 
   /**
    * Returns the metadata map.
+   *
    * @return The metadata map.
    */
   public Map<String, String> getMetadataMap() {
@@ -75,6 +75,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns the catalog name.
+   *
    * @return The catalog name.
    */
   public String getCatalogName() {
@@ -83,6 +84,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns the schema name.
+   *
    * @return The schema name.
    */
   public String getSchemaName() {
@@ -91,6 +93,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns the table name.
+   *
    * @return The table name.
    */
   public String getTableName() {
@@ -99,6 +102,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns the type name.
+   *
    * @return The type name.
    */
   public String getTypeName() {
@@ -107,6 +111,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns the precision / column size.
+   *
    * @return The precision / column size.
    */
   public Integer getPrecision() {
@@ -120,6 +125,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns the scale / decimal digits.
+   *
    * @return The scale / decimal digits.
    */
   public Integer getScale() {
@@ -133,6 +139,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns if the column is auto incremented.
+   *
    * @return True if the column is auto incremented, false otherwise.
    */
   public Boolean isAutoIncrement() {
@@ -146,6 +153,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns if the column is case-sensitive.
+   *
    * @return True if the column is case-sensitive, false otherwise.
    */
   public Boolean isCaseSensitive() {
@@ -159,6 +167,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns if the column is read only.
+   *
    * @return True if the column is read only, false otherwise.
    */
   public Boolean isReadOnly() {
@@ -172,6 +181,7 @@ public class FlightSqlColumnMetadata {
 
   /**
    * Returns if the column is searchable.
+   *
    * @return True if the column is searchable, false otherwise.
    */
   public Boolean isSearchable() {
@@ -183,21 +193,18 @@ public class FlightSqlColumnMetadata {
     return stringToBoolean(value);
   }
 
-  /**
-   * Builder of FlightSqlColumnMetadata, used on FlightSqlProducer implementations.
-   */
+  /** Builder of FlightSqlColumnMetadata, used on FlightSqlProducer implementations. */
   public static class Builder {
     private final Map<String, String> metadataMap;
 
-    /**
-     * Creates a new instance of FlightSqlColumnMetadata.Builder.
-     */
+    /** Creates a new instance of FlightSqlColumnMetadata.Builder. */
     public Builder() {
       this.metadataMap = new HashMap<>();
     }
 
     /**
      * Sets the catalog name.
+     *
      * @param catalogName the catalog name.
      * @return This builder.
      */
@@ -208,6 +215,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets the schema name.
+     *
      * @param schemaName The schema name.
      * @return This builder.
      */
@@ -218,6 +226,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets the table name.
+     *
      * @param tableName The table name.
      * @return This builder.
      */
@@ -228,6 +237,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets the type name.
+     *
      * @param typeName The type name.
      * @return This builder.
      */
@@ -238,6 +248,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets the precision / column size.
+     *
      * @param precision The precision / column size.
      * @return This builder.
      */
@@ -248,6 +259,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets the scale / decimal digits.
+     *
      * @param scale The scale / decimal digits.
      * @return This builder.
      */
@@ -258,6 +270,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets if the column is auto incremented.
+     *
      * @param isAutoIncrement True if the column is auto incremented.
      * @return This builder.
      */
@@ -268,6 +281,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets if the column is case-sensitive.
+     *
      * @param isCaseSensitive If the column is case-sensitive.
      * @return This builder.
      */
@@ -278,6 +292,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets if the column is read only.
+     *
      * @param isReadOnly If the column is read only.
      * @return This builder.
      */
@@ -288,6 +303,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Sets if the column is searchable.
+     *
      * @param isSearchable If the column is searchable.
      * @return This builder.
      */
@@ -298,6 +314,7 @@ public class FlightSqlColumnMetadata {
 
     /**
      * Builds a new instance of FlightSqlColumnMetadata.
+     *
      * @return A new instance of FlightSqlColumnMetadata.
      */
     public FlightSqlColumnMetadata build() {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlProducer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import static java.util.Arrays.asList;
@@ -46,11 +45,13 @@ import static org.apache.arrow.vector.types.Types.MinorType.STRUCT;
 import static org.apache.arrow.vector.types.Types.MinorType.UINT4;
 import static org.apache.arrow.vector.types.Types.MinorType.VARCHAR;
 
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.List;
-
 import org.apache.arrow.flight.Action;
 import org.apache.arrow.flight.ActionType;
 import org.apache.arrow.flight.CallStatus;
@@ -94,20 +95,13 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 
-import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Any;
-import com.google.protobuf.InvalidProtocolBufferException;
-
-/**
- * API to Implement an Arrow Flight SQL producer.
- */
+/** API to Implement an Arrow Flight SQL producer. */
 public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   /**
-   * Depending on the provided command, method either:
-   * 1. Return information about a SQL query, or
+   * Depending on the provided command, method either: 1. Return information about a SQL query, or
    * 2. Return information about a prepared statement. In this case, parameters binding is allowed.
    *
-   * @param context    Per-call context.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return information about the given SQL query, or the given prepared statement.
    */
@@ -120,10 +114,14 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
           FlightSqlUtils.unpackOrThrow(command, CommandStatementQuery.class), context, descriptor);
     } else if (command.is(CommandStatementSubstraitPlan.class)) {
       return getFlightInfoSubstraitPlan(
-          FlightSqlUtils.unpackOrThrow(command, CommandStatementSubstraitPlan.class), context, descriptor);
+          FlightSqlUtils.unpackOrThrow(command, CommandStatementSubstraitPlan.class),
+          context,
+          descriptor);
     } else if (command.is(CommandPreparedStatementQuery.class)) {
       return getFlightInfoPreparedStatement(
-          FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class), context, descriptor);
+          FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class),
+          context,
+          descriptor);
     } else if (command.is(CommandGetCatalogs.class)) {
       return getFlightInfoCatalogs(
           FlightSqlUtils.unpackOrThrow(command, CommandGetCatalogs.class), context, descriptor);
@@ -150,7 +148,9 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
           FlightSqlUtils.unpackOrThrow(command, CommandGetImportedKeys.class), context, descriptor);
     } else if (command.is(CommandGetCrossReference.class)) {
       return getFlightInfoCrossReference(
-          FlightSqlUtils.unpackOrThrow(command, CommandGetCrossReference.class), context, descriptor);
+          FlightSqlUtils.unpackOrThrow(command, CommandGetCrossReference.class),
+          context,
+          descriptor);
     } else if (command.is(CommandGetXdbcTypeInfo.class)) {
       return getFlightInfoTypeInfo(
           FlightSqlUtils.unpackOrThrow(command, CommandGetXdbcTypeInfo.class), context, descriptor);
@@ -164,7 +164,7 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   /**
    * Returns the schema of the result produced by the SQL query.
    *
-   * @param context    Per-call context.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return the result set schema.
    */
@@ -177,10 +177,14 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
           FlightSqlUtils.unpackOrThrow(command, CommandStatementQuery.class), context, descriptor);
     } else if (command.is(CommandPreparedStatementQuery.class)) {
       return getSchemaPreparedStatement(
-          FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class), context, descriptor);
+          FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class),
+          context,
+          descriptor);
     } else if (command.is(CommandStatementSubstraitPlan.class)) {
       return getSchemaSubstraitPlan(
-          FlightSqlUtils.unpackOrThrow(command, CommandStatementSubstraitPlan.class), context, descriptor);
+          FlightSqlUtils.unpackOrThrow(command, CommandStatementSubstraitPlan.class),
+          context,
+          descriptor);
     } else if (command.is(CommandGetCatalogs.class)) {
       return new SchemaResult(Schemas.GET_CATALOGS_SCHEMA);
     } else if (command.is(CommandGetCrossReference.class)) {
@@ -212,12 +216,12 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   }
 
   /**
-   * Depending on the provided command, method either:
-   * 1. Return data for a stream produced by executing the provided SQL query, or
-   * 2. Return data for a prepared statement. In this case, parameters binding is allowed.
+   * Depending on the provided command, method either: 1. Return data for a stream produced by
+   * executing the provided SQL query, or 2. Return data for a prepared statement. In this case,
+   * parameters binding is allowed.
    *
-   * @param context  Per-call context.
-   * @param ticket   The application-defined ticket identifying this stream.
+   * @param context Per-call context.
+   * @param ticket The application-defined ticket identifying this stream.
    * @param listener An interface for sending data back to the client.
    */
   @Override
@@ -236,73 +240,94 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
           FlightSqlUtils.unpackOrThrow(command, TicketStatementQuery.class), context, listener);
     } else if (command.is(CommandPreparedStatementQuery.class)) {
       getStreamPreparedStatement(
-          FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class), context, listener);
+          FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class),
+          context,
+          listener);
     } else if (command.is(CommandGetCatalogs.class)) {
       getStreamCatalogs(context, listener);
     } else if (command.is(CommandGetDbSchemas.class)) {
-      getStreamSchemas(FlightSqlUtils.unpackOrThrow(command, CommandGetDbSchemas.class), context, listener);
+      getStreamSchemas(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetDbSchemas.class), context, listener);
     } else if (command.is(CommandGetTables.class)) {
-      getStreamTables(FlightSqlUtils.unpackOrThrow(command, CommandGetTables.class), context, listener);
+      getStreamTables(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetTables.class), context, listener);
     } else if (command.is(CommandGetTableTypes.class)) {
       getStreamTableTypes(context, listener);
     } else if (command.is(CommandGetSqlInfo.class)) {
-      getStreamSqlInfo(FlightSqlUtils.unpackOrThrow(command, CommandGetSqlInfo.class), context, listener);
+      getStreamSqlInfo(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetSqlInfo.class), context, listener);
     } else if (command.is(CommandGetPrimaryKeys.class)) {
-      getStreamPrimaryKeys(FlightSqlUtils.unpackOrThrow(command, CommandGetPrimaryKeys.class), context, listener);
+      getStreamPrimaryKeys(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetPrimaryKeys.class), context, listener);
     } else if (command.is(CommandGetExportedKeys.class)) {
-      getStreamExportedKeys(FlightSqlUtils.unpackOrThrow(command, CommandGetExportedKeys.class), context, listener);
+      getStreamExportedKeys(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetExportedKeys.class), context, listener);
     } else if (command.is(CommandGetImportedKeys.class)) {
-      getStreamImportedKeys(FlightSqlUtils.unpackOrThrow(command, CommandGetImportedKeys.class), context, listener);
+      getStreamImportedKeys(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetImportedKeys.class), context, listener);
     } else if (command.is(CommandGetCrossReference.class)) {
-      getStreamCrossReference(FlightSqlUtils.unpackOrThrow(command, CommandGetCrossReference.class), context, listener);
+      getStreamCrossReference(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetCrossReference.class), context, listener);
     } else if (command.is(CommandGetXdbcTypeInfo.class)) {
-      getStreamTypeInfo(FlightSqlUtils.unpackOrThrow(command, CommandGetXdbcTypeInfo.class), context, listener);
+      getStreamTypeInfo(
+          FlightSqlUtils.unpackOrThrow(command, CommandGetXdbcTypeInfo.class), context, listener);
     } else {
-      throw CallStatus.INVALID_ARGUMENT.withDescription("The defined request is invalid.").toRuntimeException();
+      throw CallStatus.INVALID_ARGUMENT
+          .withDescription("The defined request is invalid.")
+          .toRuntimeException();
     }
   }
 
   /**
-   * Depending on the provided command, method either:
-   * 1. Execute provided SQL query as an update statement, or
-   * 2. Execute provided update SQL query prepared statement. In this case, parameters binding
-   * is allowed, or
-   * 3. Binds parameters to the provided prepared statement.
+   * Depending on the provided command, method either: 1. Execute provided SQL query as an update
+   * statement, or 2. Execute provided update SQL query prepared statement. In this case, parameters
+   * binding is allowed, or 3. Binds parameters to the provided prepared statement.
    *
-   * @param context      Per-call context.
+   * @param context Per-call context.
    * @param flightStream The data stream being uploaded.
-   * @param ackStream    The data stream listener for update result acknowledgement.
+   * @param ackStream The data stream listener for update result acknowledgement.
    * @return a Runnable to process the stream.
    */
   @Override
-  default Runnable acceptPut(CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  default Runnable acceptPut(
+      CallContext context, FlightStream flightStream, StreamListener<PutResult> ackStream) {
     final Any command = FlightSqlUtils.parseOrThrow(flightStream.getDescriptor().getCommand());
 
     if (command.is(CommandStatementUpdate.class)) {
       return acceptPutStatement(
           FlightSqlUtils.unpackOrThrow(command, CommandStatementUpdate.class),
-          context, flightStream, ackStream);
+          context,
+          flightStream,
+          ackStream);
     } else if (command.is(CommandStatementSubstraitPlan.class)) {
       return acceptPutSubstraitPlan(
           FlightSqlUtils.unpackOrThrow(command, CommandStatementSubstraitPlan.class),
-          context, flightStream, ackStream);
+          context,
+          flightStream,
+          ackStream);
     } else if (command.is(CommandPreparedStatementUpdate.class)) {
       return acceptPutPreparedStatementUpdate(
           FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementUpdate.class),
-          context, flightStream, ackStream);
+          context,
+          flightStream,
+          ackStream);
     } else if (command.is(CommandPreparedStatementQuery.class)) {
       return acceptPutPreparedStatementQuery(
           FlightSqlUtils.unpackOrThrow(command, CommandPreparedStatementQuery.class),
-          context, flightStream, ackStream);
+          context,
+          flightStream,
+          ackStream);
     }
 
-    throw CallStatus.INVALID_ARGUMENT.withDescription("The defined request is invalid.").toRuntimeException();
+    throw CallStatus.INVALID_ARGUMENT
+        .withDescription("The defined request is invalid.")
+        .toRuntimeException();
   }
 
   /**
    * Lists all available Flight SQL actions.
    *
-   * @param context  Per-call context.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
   @Override
@@ -314,8 +339,8 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   /**
    * Performs the requested Flight SQL action.
    *
-   * @param context  Per-call context.
-   * @param action   Client-supplied parameters.
+   * @param context Per-call context.
+   * @param action Client-supplied parameters.
    * @param listener A stream of responses.
    */
   @Override
@@ -328,7 +353,8 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
       beginSavepoint(request, context, new ProtoListener<>(listener));
     } else if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_BEGIN_TRANSACTION.getType())) {
       final ActionBeginTransactionRequest request =
-          FlightSqlUtils.unpackAndParseOrThrow(action.getBody(), ActionBeginTransactionRequest.class);
+          FlightSqlUtils.unpackAndParseOrThrow(
+              action.getBody(), ActionBeginTransactionRequest.class);
       beginTransaction(request, context, new ProtoListener<>(listener));
     } else if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_CANCEL_QUERY.getType())) {
       //noinspection deprecation
@@ -338,24 +364,29 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
       try {
         info = FlightInfo.deserialize(request.getInfo().asReadOnlyByteBuffer());
       } catch (IOException | URISyntaxException e) {
-        listener.onError(CallStatus.INTERNAL
-            .withDescription("Could not unpack FlightInfo: " + e)
-            .withCause(e)
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INTERNAL
+                .withDescription("Could not unpack FlightInfo: " + e)
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
       cancelQuery(info, context, new CancelListener(listener));
     } else if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_STATEMENT.getType())) {
-      final ActionCreatePreparedStatementRequest request = FlightSqlUtils.unpackAndParseOrThrow(action.getBody(),
-          ActionCreatePreparedStatementRequest.class);
+      final ActionCreatePreparedStatementRequest request =
+          FlightSqlUtils.unpackAndParseOrThrow(
+              action.getBody(), ActionCreatePreparedStatementRequest.class);
       createPreparedStatement(request, context, listener);
-    } else if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_SUBSTRAIT_PLAN.getType())) {
+    } else if (actionType.equals(
+        FlightSqlUtils.FLIGHT_SQL_CREATE_PREPARED_SUBSTRAIT_PLAN.getType())) {
       final ActionCreatePreparedSubstraitPlanRequest request =
-          FlightSqlUtils.unpackAndParseOrThrow(action.getBody(), ActionCreatePreparedSubstraitPlanRequest.class);
+          FlightSqlUtils.unpackAndParseOrThrow(
+              action.getBody(), ActionCreatePreparedSubstraitPlanRequest.class);
       createPreparedSubstraitPlan(request, context, new ProtoListener<>(listener));
     } else if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_CLOSE_PREPARED_STATEMENT.getType())) {
       final ActionClosePreparedStatementRequest request =
-          FlightSqlUtils.unpackAndParseOrThrow(action.getBody(), ActionClosePreparedStatementRequest.class);
+          FlightSqlUtils.unpackAndParseOrThrow(
+              action.getBody(), ActionClosePreparedStatementRequest.class);
       closePreparedStatement(request, context, new NoResultListener(listener));
     } else if (actionType.equals(FlightSqlUtils.FLIGHT_SQL_END_SAVEPOINT.getType())) {
       ActionEndSavepointRequest request =
@@ -370,10 +401,11 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
       try {
         request = CancelFlightInfoRequest.deserialize(ByteBuffer.wrap(action.getBody()));
       } catch (IOException | URISyntaxException e) {
-        listener.onError(CallStatus.INTERNAL
-            .withDescription("Could not unpack FlightInfo: " + e)
-            .withCause(e)
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INTERNAL
+                .withDescription("Could not unpack FlightInfo: " + e)
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
       cancelFlightInfo(request, context, new CancelStatusListener(listener));
@@ -382,10 +414,11 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
       try {
         request = RenewFlightEndpointRequest.deserialize(ByteBuffer.wrap(action.getBody()));
       } catch (IOException | URISyntaxException e) {
-        listener.onError(CallStatus.INTERNAL
-            .withDescription("Could not unpack FlightInfo: " + e)
-            .withCause(e)
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INTERNAL
+                .withDescription("Could not unpack FlightInfo: " + e)
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
       renewFlightEndpoint(request, context, new FlightEndpointListener(listener));
@@ -394,10 +427,11 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
       try {
         request = SetSessionOptionsRequest.deserialize(ByteBuffer.wrap(action.getBody()));
       } catch (IOException e) {
-        listener.onError(CallStatus.INTERNAL
-            .withDescription("Could not unpack SetSessionOptionsRequest: " + e)
-            .withCause(e)
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INTERNAL
+                .withDescription("Could not unpack SetSessionOptionsRequest: " + e)
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
       setSessionOptions(request, context, new SetSessionOptionsResultListener(listener));
@@ -406,10 +440,11 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
       try {
         request = GetSessionOptionsRequest.deserialize(ByteBuffer.wrap(action.getBody()));
       } catch (IOException e) {
-        listener.onError(CallStatus.INTERNAL
-            .withDescription("Could not unpack GetSessionOptionsRequest: " + e)
-            .withCause(e)
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INTERNAL
+                .withDescription("Could not unpack GetSessionOptionsRequest: " + e)
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
       getSessionOptions(request, context, new GetSessionOptionsResultListener(listener));
@@ -418,10 +453,11 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
       try {
         request = CloseSessionRequest.deserialize(ByteBuffer.wrap(action.getBody()));
       } catch (IOException e) {
-        listener.onError(CallStatus.INTERNAL
-            .withDescription("Could not unpack CloseSessionRequest: " + e)
-            .withCause(e)
-            .toRuntimeException());
+        listener.onError(
+            CallStatus.INTERNAL
+                .withDescription("Could not unpack CloseSessionRequest: " + e)
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
       closeSession(request, context, new CloseSessionResultListener(listener));
@@ -435,24 +471,28 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   /**
    * Create a savepoint within a transaction.
    *
-   * @param request  The savepoint request.
-   * @param context  Per-call context.
+   * @param request The savepoint request.
+   * @param context Per-call context.
    * @param listener The newly created savepoint ID.
    */
-  default void beginSavepoint(ActionBeginSavepointRequest request, CallContext context,
-                              StreamListener<ActionBeginSavepointResult> listener) {
+  default void beginSavepoint(
+      ActionBeginSavepointRequest request,
+      CallContext context,
+      StreamListener<ActionBeginSavepointResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
   /**
    * Begin a transaction.
    *
-   * @param request  The transaction request.
-   * @param context  Per-call context.
+   * @param request The transaction request.
+   * @param context Per-call context.
    * @param listener The newly created transaction ID.
    */
-  default void beginTransaction(ActionBeginTransactionRequest request, CallContext context,
-                                StreamListener<ActionBeginTransactionResult> listener) {
+  default void beginTransaction(
+      ActionBeginTransactionRequest request,
+      CallContext context,
+      StreamListener<ActionBeginTransactionResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
@@ -463,67 +503,73 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
    * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  default void cancelFlightInfo(CancelFlightInfoRequest request, CallContext context,
-                                StreamListener<CancelStatus> listener) {
+  default void cancelFlightInfo(
+      CancelFlightInfoRequest request, CallContext context, StreamListener<CancelStatus> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
-
 
   /**
    * Explicitly cancel a query.
    *
-   * @param info     The FlightInfo of the query to cancel.
-   * @param context  Per-call context.
+   * @param info The FlightInfo of the query to cancel.
+   * @param context Per-call context.
    * @param listener Whether cancellation succeeded.
-   * @deprecated Prefer {@link #cancelFlightInfo(CancelFlightInfoRequest, CallContext, StreamListener)}.
+   * @deprecated Prefer {@link #cancelFlightInfo(CancelFlightInfoRequest, CallContext,
+   *     StreamListener)}.
    */
   @Deprecated
-  default void cancelQuery(FlightInfo info, CallContext context, StreamListener<CancelResult> listener) {
+  default void cancelQuery(
+      FlightInfo info, CallContext context, StreamListener<CancelResult> listener) {
     CancelFlightInfoRequest request = new CancelFlightInfoRequest(info);
-    cancelFlightInfo(request, context, new StreamListener<CancelStatus>() {
-      @Override
-      public void onNext(CancelStatus val) {
-        switch (val) {
-          case UNSPECIFIED:
-            listener.onNext(CancelResult.UNSPECIFIED);
-            break;
-          case CANCELLED:
-            listener.onNext(CancelResult.CANCELLED);
-            break;
-          case CANCELLING:
-            listener.onNext(CancelResult.CANCELLING);
-            break;
-          case NOT_CANCELLABLE:
-            listener.onNext(CancelResult.NOT_CANCELLABLE);
-            break;
-          default:
-            // XXX: CheckStyle requires a default clause which arguably makes the code worse.
-            throw new AssertionError("Unknown enum variant " + val);
-        }
-      }
+    cancelFlightInfo(
+        request,
+        context,
+        new StreamListener<CancelStatus>() {
+          @Override
+          public void onNext(CancelStatus val) {
+            switch (val) {
+              case UNSPECIFIED:
+                listener.onNext(CancelResult.UNSPECIFIED);
+                break;
+              case CANCELLED:
+                listener.onNext(CancelResult.CANCELLED);
+                break;
+              case CANCELLING:
+                listener.onNext(CancelResult.CANCELLING);
+                break;
+              case NOT_CANCELLABLE:
+                listener.onNext(CancelResult.NOT_CANCELLABLE);
+                break;
+              default:
+                // XXX: CheckStyle requires a default clause which arguably makes the code worse.
+                throw new AssertionError("Unknown enum variant " + val);
+            }
+          }
 
-      @Override
-      public void onError(Throwable t) {
-        listener.onError(t);
-      }
+          @Override
+          public void onError(Throwable t) {
+            listener.onError(t);
+          }
 
-      @Override
-      public void onCompleted() {
-        listener.onCompleted();
-      }
-    });
+          @Override
+          public void onCompleted() {
+            listener.onCompleted();
+          }
+        });
   }
 
   /**
    * Set server session options(s).
    *
-   * @param request The session options to set. For *DBC driver compatibility, servers
-   *                should support converting values from strings.
+   * @param request The session options to set. For *DBC driver compatibility, servers should
+   *     support converting values from strings.
    * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  default void setSessionOptions(SetSessionOptionsRequest request, CallContext context,
-                                StreamListener<SetSessionOptionsResult> listener) {
+  default void setSessionOptions(
+      SetSessionOptionsRequest request,
+      CallContext context,
+      StreamListener<SetSessionOptionsResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
@@ -534,8 +580,10 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
    * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  default void getSessionOptions(GetSessionOptionsRequest request, CallContext context,
-                                StreamListener<GetSessionOptionsResult> listener) {
+  default void getSessionOptions(
+      GetSessionOptionsRequest request,
+      CallContext context,
+      StreamListener<GetSessionOptionsResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
@@ -546,126 +594,134 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
    * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  default void closeSession(CloseSessionRequest request, CallContext context,
-                                StreamListener<CloseSessionResult> listener) {
+  default void closeSession(
+      CloseSessionRequest request,
+      CallContext context,
+      StreamListener<CloseSessionResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
   /**
-   * Creates a prepared statement on the server and returns a handle and metadata for in a
-   * {@link ActionCreatePreparedStatementResult} object in a {@link Result}
-   * object.
+   * Creates a prepared statement on the server and returns a handle and metadata for in a {@link
+   * ActionCreatePreparedStatementResult} object in a {@link Result} object.
    *
-   * @param request  The sql command to generate the prepared statement.
-   * @param context  Per-call context.
+   * @param request The sql command to generate the prepared statement.
+   * @param context Per-call context.
    * @param listener A stream of responses.
    */
-  void createPreparedStatement(ActionCreatePreparedStatementRequest request, CallContext context,
-                               StreamListener<Result> listener);
+  void createPreparedStatement(
+      ActionCreatePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener);
 
   /**
    * Pre-compile a Substrait plan.
-   * @param request  The plan.
-   * @param context  Per-call context.
+   *
+   * @param request The plan.
+   * @param context Per-call context.
    * @param listener The resulting prepared statement.
    */
-  default void createPreparedSubstraitPlan(ActionCreatePreparedSubstraitPlanRequest request, CallContext context,
-                                           StreamListener<ActionCreatePreparedStatementResult> listener) {
+  default void createPreparedSubstraitPlan(
+      ActionCreatePreparedSubstraitPlanRequest request,
+      CallContext context,
+      StreamListener<ActionCreatePreparedStatementResult> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
   /**
    * Closes a prepared statement on the server. No result is expected.
    *
-   * @param request  The sql command to generate the prepared statement.
-   * @param context  Per-call context.
+   * @param request The sql command to generate the prepared statement.
+   * @param context Per-call context.
    * @param listener A stream of responses.
    */
-  void closePreparedStatement(ActionClosePreparedStatementRequest request, CallContext context,
-                              StreamListener<Result> listener);
+  void closePreparedStatement(
+      ActionClosePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener);
 
   /**
    * Release or roll back to a savepoint.
    *
-   * @param request  The savepoint, and whether to release/rollback.
-   * @param context  Per-call context.
-   * @param listener Call {@link StreamListener#onCompleted()} or
-   *                 {@link StreamListener#onError(Throwable)} when done; do not send a result.
+   * @param request The savepoint, and whether to release/rollback.
+   * @param context Per-call context.
+   * @param listener Call {@link StreamListener#onCompleted()} or {@link
+   *     StreamListener#onError(Throwable)} when done; do not send a result.
    */
-  default void endSavepoint(ActionEndSavepointRequest request, CallContext context,
-                            StreamListener<Result> listener) {
+  default void endSavepoint(
+      ActionEndSavepointRequest request, CallContext context, StreamListener<Result> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
   /**
    * Commit or roll back to a transaction.
    *
-   * @param request  The transaction, and whether to release/rollback.
-   * @param context  Per-call context.
-   * @param listener Call {@link StreamListener#onCompleted()} or
-   *                 {@link StreamListener#onError(Throwable)} when done; do not send a result.
+   * @param request The transaction, and whether to release/rollback.
+   * @param context Per-call context.
+   * @param listener Call {@link StreamListener#onCompleted()} or {@link
+   *     StreamListener#onError(Throwable)} when done; do not send a result.
    */
-  default void endTransaction(ActionEndTransactionRequest request, CallContext context,
-                              StreamListener<Result> listener) {
+  default void endTransaction(
+      ActionEndTransactionRequest request, CallContext context, StreamListener<Result> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
   /**
    * Evaluate a SQL query.
    *
-   * @param command    The SQL query.
-   * @param context    Per-call context.
+   * @param command The SQL query.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoStatement(CommandStatementQuery command, CallContext context,
-                                    FlightDescriptor descriptor);
+  FlightInfo getFlightInfoStatement(
+      CommandStatementQuery command, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Evaluate a Substrait plan.
    *
-   * @param command    The Substrait plan.
-   * @param context    Per-call context.
+   * @param command The Substrait plan.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  default FlightInfo getFlightInfoSubstraitPlan(CommandStatementSubstraitPlan command, CallContext context,
-                                                FlightDescriptor descriptor) {
+  default FlightInfo getFlightInfoSubstraitPlan(
+      CommandStatementSubstraitPlan command, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.toRuntimeException();
   }
 
   /**
    * Gets information about a particular prepared statement data stream.
    *
-   * @param command    The prepared statement to generate the data stream.
-   * @param context    Per-call context.
+   * @param command The prepared statement to generate the data stream.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoPreparedStatement(CommandPreparedStatementQuery command,
-                                            CallContext context, FlightDescriptor descriptor);
+  FlightInfo getFlightInfoPreparedStatement(
+      CommandPreparedStatementQuery command, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Get the result schema for a SQL query.
    *
-   * @param command    The SQL query.
-   * @param context    Per-call context.
+   * @param command The SQL query.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return the schema of the result set.
    */
-  SchemaResult getSchemaStatement(CommandStatementQuery command, CallContext context,
-                                  FlightDescriptor descriptor);
+  SchemaResult getSchemaStatement(
+      CommandStatementQuery command, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Get the schema of the result set of a prepared statement.
    *
-   * @param command    The prepared statement handle.
-   * @param context    Per-call context.
+   * @param command The prepared statement handle.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return the schema of the result set.
    */
-  default SchemaResult getSchemaPreparedStatement(CommandPreparedStatementQuery command, CallContext context,
-                                  FlightDescriptor descriptor) {
+  default SchemaResult getSchemaPreparedStatement(
+      CommandPreparedStatementQuery command, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED
         .withDescription("GetSchema with CommandPreparedStatementQuery is not implemented")
         .toRuntimeException();
@@ -674,59 +730,67 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
   /**
    * Get the result schema for a Substrait plan.
    *
-   * @param command    The Substrait plan.
-   * @param context    Per-call context.
+   * @param command The Substrait plan.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Schema for the stream.
    */
-  default SchemaResult getSchemaSubstraitPlan(CommandStatementSubstraitPlan command, CallContext context,
-                                              FlightDescriptor descriptor) {
+  default SchemaResult getSchemaSubstraitPlan(
+      CommandStatementSubstraitPlan command, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.toRuntimeException();
   }
 
   /**
    * Returns data for a SQL query based data stream.
-   * @param ticket   Ticket message containing the statement handle.
-   * @param context  Per-call context.
+   *
+   * @param ticket Ticket message containing the statement handle.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamStatement(TicketStatementQuery ticket, CallContext context,
-                          ServerStreamListener listener);
+  void getStreamStatement(
+      TicketStatementQuery ticket, CallContext context, ServerStreamListener listener);
 
   /**
    * Returns data for a particular prepared statement query instance.
    *
-   * @param command  The prepared statement to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The prepared statement to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamPreparedStatement(CommandPreparedStatementQuery command, CallContext context,
-                                  ServerStreamListener listener);
+  void getStreamPreparedStatement(
+      CommandPreparedStatementQuery command, CallContext context, ServerStreamListener listener);
 
   /**
    * Accepts uploaded data for a particular SQL query based data stream.
+   *
    * <p>`PutResult`s must be in the form of a {@link DoPutUpdateResult}.
    *
-   * @param command      The sql command to generate the data stream.
-   * @param context      Per-call context.
+   * @param command The sql command to generate the data stream.
+   * @param context Per-call context.
    * @param flightStream The data stream being uploaded.
-   * @param ackStream    The result data stream.
+   * @param ackStream The result data stream.
    * @return A runnable to process the stream.
    */
-  Runnable acceptPutStatement(CommandStatementUpdate command, CallContext context,
-                              FlightStream flightStream, StreamListener<PutResult> ackStream);
+  Runnable acceptPutStatement(
+      CommandStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream);
 
   /**
    * Handle a Substrait plan with uploaded data.
    *
-   * @param command      The Substrait plan to evaluate.
-   * @param context      Per-call context.
+   * @param command The Substrait plan to evaluate.
+   * @param context Per-call context.
    * @param flightStream The data stream being uploaded.
-   * @param ackStream    The result data stream.
+   * @param ackStream The result data stream.
    * @return A runnable to process the stream.
    */
-  default Runnable acceptPutSubstraitPlan(CommandStatementSubstraitPlan command, CallContext context,
-                                          FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  default Runnable acceptPutSubstraitPlan(
+      CommandStatementSubstraitPlan command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     return () -> {
       ackStream.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
     };
@@ -734,239 +798,247 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
 
   /**
    * Accepts uploaded data for a particular prepared statement data stream.
+   *
    * <p>`PutResult`s must be in the form of a {@link DoPutUpdateResult}.
    *
-   * @param command      The prepared statement to generate the data stream.
-   * @param context      Per-call context.
+   * @param command The prepared statement to generate the data stream.
+   * @param context Per-call context.
    * @param flightStream The data stream being uploaded.
-   * @param ackStream    The result data stream.
+   * @param ackStream The result data stream.
    * @return A runnable to process the stream.
    */
-  Runnable acceptPutPreparedStatementUpdate(CommandPreparedStatementUpdate command,
-                                            CallContext context, FlightStream flightStream,
-                                            StreamListener<PutResult> ackStream);
+  Runnable acceptPutPreparedStatementUpdate(
+      CommandPreparedStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream);
 
   /**
    * Accepts uploaded parameter values for a particular prepared statement query.
    *
-   * @param command      The prepared statement the parameter values will bind to.
-   * @param context      Per-call context.
+   * @param command The prepared statement the parameter values will bind to.
+   * @param context Per-call context.
    * @param flightStream The data stream being uploaded.
-   * @param ackStream    The result data stream.
+   * @param ackStream The result data stream.
    * @return A runnable to process the stream.
    */
-  Runnable acceptPutPreparedStatementQuery(CommandPreparedStatementQuery command,
-                                           CallContext context, FlightStream flightStream,
-                                           StreamListener<PutResult> ackStream);
+  Runnable acceptPutPreparedStatementQuery(
+      CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream);
 
   /**
-   * Returns the SQL Info of the server by returning a
-   * {@link CommandGetSqlInfo} in a {@link Result}.
+   * Returns the SQL Info of the server by returning a {@link CommandGetSqlInfo} in a {@link
+   * Result}.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoSqlInfo(CommandGetSqlInfo request, CallContext context,
-                                  FlightDescriptor descriptor);
+  FlightInfo getFlightInfoSqlInfo(
+      CommandGetSqlInfo request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for SQL info based data stream.
    *
-   * @param command  The command to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The command to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamSqlInfo(CommandGetSqlInfo command, CallContext context, ServerStreamListener listener);
-
+  void getStreamSqlInfo(
+      CommandGetSqlInfo command, CallContext context, ServerStreamListener listener);
 
   /**
    * Returns a description of all the data types supported by source.
    *
-   * @param request     request filter parameters.
-   * @param descriptor  The descriptor identifying the data stream.
-   * @return  Metadata about the stream.
+   * @param request request filter parameters.
+   * @param descriptor The descriptor identifying the data stream.
+   * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoTypeInfo(CommandGetXdbcTypeInfo request, CallContext context,
-                                   FlightDescriptor descriptor);
+  FlightInfo getFlightInfoTypeInfo(
+      CommandGetXdbcTypeInfo request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for type info based data stream.
    *
-   * @param context  Per-call context.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamTypeInfo(CommandGetXdbcTypeInfo request, CallContext context, ServerStreamListener listener);
+  void getStreamTypeInfo(
+      CommandGetXdbcTypeInfo request, CallContext context, ServerStreamListener listener);
 
   /**
-   * Returns the available catalogs by returning a stream of
-   * {@link CommandGetCatalogs} objects in {@link Result} objects.
+   * Returns the available catalogs by returning a stream of {@link CommandGetCatalogs} objects in
+   * {@link Result} objects.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoCatalogs(CommandGetCatalogs request, CallContext context,
-                                   FlightDescriptor descriptor);
+  FlightInfo getFlightInfoCatalogs(
+      CommandGetCatalogs request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for catalogs based data stream.
    *
-   * @param context  Per-call context.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
   void getStreamCatalogs(CallContext context, ServerStreamListener listener);
 
   /**
-   * Returns the available schemas by returning a stream of
-   * {@link CommandGetDbSchemas} objects in {@link Result} objects.
+   * Returns the available schemas by returning a stream of {@link CommandGetDbSchemas} objects in
+   * {@link Result} objects.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoSchemas(CommandGetDbSchemas request, CallContext context,
-                                  FlightDescriptor descriptor);
+  FlightInfo getFlightInfoSchemas(
+      CommandGetDbSchemas request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for schemas based data stream.
    *
-   * @param command  The command to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The command to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamSchemas(CommandGetDbSchemas command, CallContext context, ServerStreamListener listener);
+  void getStreamSchemas(
+      CommandGetDbSchemas command, CallContext context, ServerStreamListener listener);
 
   /**
-   * Returns the available tables by returning a stream of
-   * {@link CommandGetTables} objects in {@link Result} objects.
+   * Returns the available tables by returning a stream of {@link CommandGetTables} objects in
+   * {@link Result} objects.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoTables(CommandGetTables request, CallContext context,
-                                 FlightDescriptor descriptor);
+  FlightInfo getFlightInfoTables(
+      CommandGetTables request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for tables based data stream.
    *
-   * @param command  The command to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The command to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamTables(CommandGetTables command, CallContext context, ServerStreamListener listener);
+  void getStreamTables(
+      CommandGetTables command, CallContext context, ServerStreamListener listener);
 
   /**
-   * Returns the available table types by returning a stream of
-   * {@link CommandGetTableTypes} objects in {@link Result} objects.
+   * Returns the available table types by returning a stream of {@link CommandGetTableTypes} objects
+   * in {@link Result} objects.
    *
-   * @param context    Per-call context.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoTableTypes(CommandGetTableTypes request, CallContext context,
-                                     FlightDescriptor descriptor);
+  FlightInfo getFlightInfoTableTypes(
+      CommandGetTableTypes request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for table types based data stream.
    *
-   * @param context  Per-call context.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
   void getStreamTableTypes(CallContext context, ServerStreamListener listener);
 
   /**
-   * Returns the available primary keys by returning a stream of
-   * {@link CommandGetPrimaryKeys} objects in {@link Result} objects.
+   * Returns the available primary keys by returning a stream of {@link CommandGetPrimaryKeys}
+   * objects in {@link Result} objects.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoPrimaryKeys(CommandGetPrimaryKeys request, CallContext context,
-                                      FlightDescriptor descriptor);
+  FlightInfo getFlightInfoPrimaryKeys(
+      CommandGetPrimaryKeys request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for primary keys based data stream.
    *
-   * @param command  The command to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The command to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamPrimaryKeys(CommandGetPrimaryKeys command, CallContext context,
-                            ServerStreamListener listener);
+  void getStreamPrimaryKeys(
+      CommandGetPrimaryKeys command, CallContext context, ServerStreamListener listener);
 
   /**
-   * Retrieves a description of the foreign key columns that reference the given table's primary key columns
-   * {@link CommandGetExportedKeys} objects in {@link Result} objects.
+   * Retrieves a description of the foreign key columns that reference the given table's primary key
+   * columns {@link CommandGetExportedKeys} objects in {@link Result} objects.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoExportedKeys(CommandGetExportedKeys request, CallContext context,
-                                       FlightDescriptor descriptor);
+  FlightInfo getFlightInfoExportedKeys(
+      CommandGetExportedKeys request, CallContext context, FlightDescriptor descriptor);
 
   /**
-   * Retrieves a description of the primary key columns that are referenced by given table's foreign key columns
-   * {@link CommandGetImportedKeys} objects in {@link Result} objects.
+   * Retrieves a description of the primary key columns that are referenced by given table's foreign
+   * key columns {@link CommandGetImportedKeys} objects in {@link Result} objects.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoImportedKeys(CommandGetImportedKeys request, CallContext context,
-                                       FlightDescriptor descriptor);
+  FlightInfo getFlightInfoImportedKeys(
+      CommandGetImportedKeys request, CallContext context, FlightDescriptor descriptor);
 
   /**
-   * Retrieve a description of the foreign key columns that reference the given table's primary key columns
-   * {@link CommandGetCrossReference} objects in {@link Result} objects.
+   * Retrieve a description of the foreign key columns that reference the given table's primary key
+   * columns {@link CommandGetCrossReference} objects in {@link Result} objects.
    *
-   * @param request    request filter parameters.
-   * @param context    Per-call context.
+   * @param request request filter parameters.
+   * @param context Per-call context.
    * @param descriptor The descriptor identifying the data stream.
    * @return Metadata about the stream.
    */
-  FlightInfo getFlightInfoCrossReference(CommandGetCrossReference request, CallContext context,
-                                         FlightDescriptor descriptor);
+  FlightInfo getFlightInfoCrossReference(
+      CommandGetCrossReference request, CallContext context, FlightDescriptor descriptor);
 
   /**
    * Returns data for foreign keys based data stream.
    *
-   * @param command  The command to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The command to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamExportedKeys(CommandGetExportedKeys command, CallContext context,
-                             ServerStreamListener listener);
+  void getStreamExportedKeys(
+      CommandGetExportedKeys command, CallContext context, ServerStreamListener listener);
 
   /**
    * Returns data for foreign keys based data stream.
    *
-   * @param command  The command to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The command to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamImportedKeys(CommandGetImportedKeys command, CallContext context,
-                             ServerStreamListener listener);
+  void getStreamImportedKeys(
+      CommandGetImportedKeys command, CallContext context, ServerStreamListener listener);
 
   /**
    * Returns data for cross reference based data stream.
    *
-   * @param command  The command to generate the data stream.
-   * @param context  Per-call context.
+   * @param command The command to generate the data stream.
+   * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  void getStreamCrossReference(CommandGetCrossReference command, CallContext context,
-                             ServerStreamListener listener);
+  void getStreamCrossReference(
+      CommandGetCrossReference command, CallContext context, ServerStreamListener listener);
 
   /**
    * Renew the duration of the given endpoint.
@@ -975,107 +1047,129 @@ public interface FlightSqlProducer extends FlightProducer, AutoCloseable {
    * @param context Per-call context.
    * @param listener An interface for sending data back to the client.
    */
-  default void renewFlightEndpoint(RenewFlightEndpointRequest request, CallContext context,
-                                   StreamListener<FlightEndpoint> listener) {
+  default void renewFlightEndpoint(
+      RenewFlightEndpointRequest request,
+      CallContext context,
+      StreamListener<FlightEndpoint> listener) {
     listener.onError(CallStatus.UNIMPLEMENTED.toRuntimeException());
   }
 
-  /**
-   * Default schema templates for the {@link FlightSqlProducer}.
-   */
+  /** Default schema templates for the {@link FlightSqlProducer}. */
   final class Schemas {
-    public static final Schema GET_TABLES_SCHEMA = new Schema(asList(
-        Field.nullable("catalog_name", VARCHAR.getType()),
-        Field.nullable("db_schema_name", VARCHAR.getType()),
-        Field.notNullable("table_name", VARCHAR.getType()),
-        Field.notNullable("table_type", VARCHAR.getType()),
-        Field.notNullable("table_schema", MinorType.VARBINARY.getType())));
-    public static final Schema GET_TABLES_SCHEMA_NO_SCHEMA = new Schema(asList(
-        Field.nullable("catalog_name", VARCHAR.getType()),
-        Field.nullable("db_schema_name", VARCHAR.getType()),
-        Field.notNullable("table_name", VARCHAR.getType()),
-        Field.notNullable("table_type", VARCHAR.getType())));
-    public static final Schema GET_CATALOGS_SCHEMA = new Schema(
-        singletonList(Field.notNullable("catalog_name", VARCHAR.getType())));
+    public static final Schema GET_TABLES_SCHEMA =
+        new Schema(
+            asList(
+                Field.nullable("catalog_name", VARCHAR.getType()),
+                Field.nullable("db_schema_name", VARCHAR.getType()),
+                Field.notNullable("table_name", VARCHAR.getType()),
+                Field.notNullable("table_type", VARCHAR.getType()),
+                Field.notNullable("table_schema", MinorType.VARBINARY.getType())));
+    public static final Schema GET_TABLES_SCHEMA_NO_SCHEMA =
+        new Schema(
+            asList(
+                Field.nullable("catalog_name", VARCHAR.getType()),
+                Field.nullable("db_schema_name", VARCHAR.getType()),
+                Field.notNullable("table_name", VARCHAR.getType()),
+                Field.notNullable("table_type", VARCHAR.getType())));
+    public static final Schema GET_CATALOGS_SCHEMA =
+        new Schema(singletonList(Field.notNullable("catalog_name", VARCHAR.getType())));
     public static final Schema GET_TABLE_TYPES_SCHEMA =
         new Schema(singletonList(Field.notNullable("table_type", VARCHAR.getType())));
     public static final Schema GET_SCHEMAS_SCHEMA =
-        new Schema(asList(
-            Field.nullable("catalog_name", VARCHAR.getType()),
-            Field.notNullable("db_schema_name", VARCHAR.getType())));
+        new Schema(
+            asList(
+                Field.nullable("catalog_name", VARCHAR.getType()),
+                Field.notNullable("db_schema_name", VARCHAR.getType())));
     private static final Schema GET_IMPORTED_EXPORTED_AND_CROSS_REFERENCE_KEYS_SCHEMA =
-        new Schema(asList(
-            Field.nullable("pk_catalog_name", VARCHAR.getType()),
-            Field.nullable("pk_db_schema_name", VARCHAR.getType()),
-            Field.notNullable("pk_table_name", VARCHAR.getType()),
-            Field.notNullable("pk_column_name", VARCHAR.getType()),
-            Field.nullable("fk_catalog_name", VARCHAR.getType()),
-            Field.nullable("fk_db_schema_name", VARCHAR.getType()),
-            Field.notNullable("fk_table_name", VARCHAR.getType()),
-            Field.notNullable("fk_column_name", VARCHAR.getType()),
-            Field.notNullable("key_sequence", INT.getType()),
-            Field.nullable("fk_key_name", VARCHAR.getType()),
-            Field.nullable("pk_key_name", VARCHAR.getType()),
-            Field.notNullable("update_rule", MinorType.UINT1.getType()),
-            Field.notNullable("delete_rule", MinorType.UINT1.getType())));
-    public static final Schema GET_IMPORTED_KEYS_SCHEMA = GET_IMPORTED_EXPORTED_AND_CROSS_REFERENCE_KEYS_SCHEMA;
-    public static final Schema GET_EXPORTED_KEYS_SCHEMA = GET_IMPORTED_EXPORTED_AND_CROSS_REFERENCE_KEYS_SCHEMA;
-    public static final Schema GET_CROSS_REFERENCE_SCHEMA = GET_IMPORTED_EXPORTED_AND_CROSS_REFERENCE_KEYS_SCHEMA;
-    private static final List<Field> GET_SQL_INFO_DENSE_UNION_SCHEMA_FIELDS = asList(
-        Field.notNullable("string_value", VARCHAR.getType()),
-        Field.notNullable("bool_value", BIT.getType()),
-        Field.notNullable("bigint_value", BIGINT.getType()),
-        Field.notNullable("int32_bitmask", INT.getType()),
-        new Field(
-            "string_list", FieldType.notNullable(LIST.getType()),
-            singletonList(Field.nullable("item", VARCHAR.getType()))),
-        new Field(
-            "int32_to_int32_list_map", FieldType.notNullable(new ArrowType.Map(false)),
-            singletonList(new Field(DATA_VECTOR_NAME, new FieldType(false, STRUCT.getType(), null),
-                ImmutableList.of(
-                    Field.notNullable(KEY_NAME, INT.getType()),
-                    new Field(
-                        VALUE_NAME, FieldType.nullable(LIST.getType()),
-                        singletonList(Field.nullable("item", INT.getType()))))))));
-    public static final Schema GET_SQL_INFO_SCHEMA =
-        new Schema(asList(
-            Field.notNullable("info_name", UINT4.getType()),
-            new Field("value",
-                FieldType.notNullable(
-                    new Union(UnionMode.Dense, range(0, GET_SQL_INFO_DENSE_UNION_SCHEMA_FIELDS.size()).toArray())),
-                GET_SQL_INFO_DENSE_UNION_SCHEMA_FIELDS)));
-    public static final Schema GET_TYPE_INFO_SCHEMA =
-        new Schema(asList(
-            Field.notNullable("type_name", VARCHAR.getType()),
-            Field.notNullable("data_type", INT.getType()),
-            Field.nullable("column_size", INT.getType()),
-            Field.nullable("literal_prefix", VARCHAR.getType()),
-            Field.nullable("literal_suffix", VARCHAR.getType()),
+        new Schema(
+            asList(
+                Field.nullable("pk_catalog_name", VARCHAR.getType()),
+                Field.nullable("pk_db_schema_name", VARCHAR.getType()),
+                Field.notNullable("pk_table_name", VARCHAR.getType()),
+                Field.notNullable("pk_column_name", VARCHAR.getType()),
+                Field.nullable("fk_catalog_name", VARCHAR.getType()),
+                Field.nullable("fk_db_schema_name", VARCHAR.getType()),
+                Field.notNullable("fk_table_name", VARCHAR.getType()),
+                Field.notNullable("fk_column_name", VARCHAR.getType()),
+                Field.notNullable("key_sequence", INT.getType()),
+                Field.nullable("fk_key_name", VARCHAR.getType()),
+                Field.nullable("pk_key_name", VARCHAR.getType()),
+                Field.notNullable("update_rule", MinorType.UINT1.getType()),
+                Field.notNullable("delete_rule", MinorType.UINT1.getType())));
+    public static final Schema GET_IMPORTED_KEYS_SCHEMA =
+        GET_IMPORTED_EXPORTED_AND_CROSS_REFERENCE_KEYS_SCHEMA;
+    public static final Schema GET_EXPORTED_KEYS_SCHEMA =
+        GET_IMPORTED_EXPORTED_AND_CROSS_REFERENCE_KEYS_SCHEMA;
+    public static final Schema GET_CROSS_REFERENCE_SCHEMA =
+        GET_IMPORTED_EXPORTED_AND_CROSS_REFERENCE_KEYS_SCHEMA;
+    private static final List<Field> GET_SQL_INFO_DENSE_UNION_SCHEMA_FIELDS =
+        asList(
+            Field.notNullable("string_value", VARCHAR.getType()),
+            Field.notNullable("bool_value", BIT.getType()),
+            Field.notNullable("bigint_value", BIGINT.getType()),
+            Field.notNullable("int32_bitmask", INT.getType()),
             new Field(
-                "create_params", FieldType.nullable(LIST.getType()),
-                singletonList(Field.notNullable("item", VARCHAR.getType()))),
-            Field.notNullable("nullable", INT.getType()),
-            Field.notNullable("case_sensitive", BIT.getType()),
-            Field.notNullable("searchable", INT.getType()),
-            Field.nullable("unsigned_attribute", BIT.getType()),
-            Field.notNullable("fixed_prec_scale", BIT.getType()),
-            Field.nullable("auto_increment", BIT.getType()),
-            Field.nullable("local_type_name", VARCHAR.getType()),
-            Field.nullable("minimum_scale", INT.getType()),
-            Field.nullable("maximum_scale", INT.getType()),
-            Field.notNullable("sql_data_type", INT.getType()),
-            Field.nullable("datetime_subcode", INT.getType()),
-            Field.nullable("num_prec_radix", INT.getType()),
-            Field.nullable("interval_precision", INT.getType())
-        ));
+                "string_list",
+                FieldType.notNullable(LIST.getType()),
+                singletonList(Field.nullable("item", VARCHAR.getType()))),
+            new Field(
+                "int32_to_int32_list_map",
+                FieldType.notNullable(new ArrowType.Map(false)),
+                singletonList(
+                    new Field(
+                        DATA_VECTOR_NAME,
+                        new FieldType(false, STRUCT.getType(), null),
+                        ImmutableList.of(
+                            Field.notNullable(KEY_NAME, INT.getType()),
+                            new Field(
+                                VALUE_NAME,
+                                FieldType.nullable(LIST.getType()),
+                                singletonList(Field.nullable("item", INT.getType()))))))));
+    public static final Schema GET_SQL_INFO_SCHEMA =
+        new Schema(
+            asList(
+                Field.notNullable("info_name", UINT4.getType()),
+                new Field(
+                    "value",
+                    FieldType.notNullable(
+                        new Union(
+                            UnionMode.Dense,
+                            range(0, GET_SQL_INFO_DENSE_UNION_SCHEMA_FIELDS.size()).toArray())),
+                    GET_SQL_INFO_DENSE_UNION_SCHEMA_FIELDS)));
+    public static final Schema GET_TYPE_INFO_SCHEMA =
+        new Schema(
+            asList(
+                Field.notNullable("type_name", VARCHAR.getType()),
+                Field.notNullable("data_type", INT.getType()),
+                Field.nullable("column_size", INT.getType()),
+                Field.nullable("literal_prefix", VARCHAR.getType()),
+                Field.nullable("literal_suffix", VARCHAR.getType()),
+                new Field(
+                    "create_params",
+                    FieldType.nullable(LIST.getType()),
+                    singletonList(Field.notNullable("item", VARCHAR.getType()))),
+                Field.notNullable("nullable", INT.getType()),
+                Field.notNullable("case_sensitive", BIT.getType()),
+                Field.notNullable("searchable", INT.getType()),
+                Field.nullable("unsigned_attribute", BIT.getType()),
+                Field.notNullable("fixed_prec_scale", BIT.getType()),
+                Field.nullable("auto_increment", BIT.getType()),
+                Field.nullable("local_type_name", VARCHAR.getType()),
+                Field.nullable("minimum_scale", INT.getType()),
+                Field.nullable("maximum_scale", INT.getType()),
+                Field.notNullable("sql_data_type", INT.getType()),
+                Field.nullable("datetime_subcode", INT.getType()),
+                Field.nullable("num_prec_radix", INT.getType()),
+                Field.nullable("interval_precision", INT.getType())));
     public static final Schema GET_PRIMARY_KEYS_SCHEMA =
-        new Schema(asList(
-            Field.nullable("catalog_name", VARCHAR.getType()),
-            Field.nullable("db_schema_name", VARCHAR.getType()),
-            Field.notNullable("table_name", VARCHAR.getType()),
-            Field.notNullable("column_name", VARCHAR.getType()),
-            Field.notNullable("key_sequence", INT.getType()),
-            Field.nullable("key_name", VARCHAR.getType())));
+        new Schema(
+            asList(
+                Field.nullable("catalog_name", VARCHAR.getType()),
+                Field.nullable("db_schema_name", VARCHAR.getType()),
+                Field.notNullable("table_name", VARCHAR.getType()),
+                Field.notNullable("column_name", VARCHAR.getType()),
+                Field.notNullable("key_sequence", INT.getType()),
+                Field.nullable("key_name", VARCHAR.getType())));
 
     private Schemas() {
       // Prevent instantiation.

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlUtils.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlUtils.java
@@ -14,72 +14,75 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
-
-import java.util.List;
-
-import org.apache.arrow.flight.ActionType;
-import org.apache.arrow.flight.CallStatus;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import java.util.List;
+import org.apache.arrow.flight.ActionType;
+import org.apache.arrow.flight.CallStatus;
 
-/**
- * Utilities to work with Flight SQL semantics.
- */
+/** Utilities to work with Flight SQL semantics. */
 public final class FlightSqlUtils {
 
   public static final ActionType FLIGHT_SQL_BEGIN_SAVEPOINT =
-      new ActionType("BeginSavepoint",
-          "Create a new savepoint.\n" +
-              "Request Message: ActionBeginSavepointRequest\n" +
-              "Response Message: ActionBeginSavepointResult");
+      new ActionType(
+          "BeginSavepoint",
+          "Create a new savepoint.\n"
+              + "Request Message: ActionBeginSavepointRequest\n"
+              + "Response Message: ActionBeginSavepointResult");
 
   public static final ActionType FLIGHT_SQL_BEGIN_TRANSACTION =
-      new ActionType("BeginTransaction",
-          "Start a new transaction.\n" +
-              "Request Message: ActionBeginTransactionRequest\n" +
-              "Response Message: ActionBeginTransactionResult");
-  public static final ActionType FLIGHT_SQL_CREATE_PREPARED_STATEMENT = new ActionType("CreatePreparedStatement",
-      "Creates a reusable prepared statement resource on the server. \n" +
-          "Request Message: ActionCreatePreparedStatementRequest\n" +
-          "Response Message: ActionCreatePreparedStatementResult");
+      new ActionType(
+          "BeginTransaction",
+          "Start a new transaction.\n"
+              + "Request Message: ActionBeginTransactionRequest\n"
+              + "Response Message: ActionBeginTransactionResult");
+  public static final ActionType FLIGHT_SQL_CREATE_PREPARED_STATEMENT =
+      new ActionType(
+          "CreatePreparedStatement",
+          "Creates a reusable prepared statement resource on the server. \n"
+              + "Request Message: ActionCreatePreparedStatementRequest\n"
+              + "Response Message: ActionCreatePreparedStatementResult");
 
-  public static final ActionType FLIGHT_SQL_CLOSE_PREPARED_STATEMENT = new ActionType("ClosePreparedStatement",
-      "Closes a reusable prepared statement resource on the server. \n" +
-          "Request Message: ActionClosePreparedStatementRequest\n" +
-          "Response Message: N/A");
+  public static final ActionType FLIGHT_SQL_CLOSE_PREPARED_STATEMENT =
+      new ActionType(
+          "ClosePreparedStatement",
+          "Closes a reusable prepared statement resource on the server. \n"
+              + "Request Message: ActionClosePreparedStatementRequest\n"
+              + "Response Message: N/A");
 
   public static final ActionType FLIGHT_SQL_CREATE_PREPARED_SUBSTRAIT_PLAN =
-      new ActionType("CreatePreparedSubstraitPlan",
-          "Creates a reusable prepared statement resource on the server.\n" +
-              "Request Message: ActionCreatePreparedSubstraitPlanRequest\n" +
-              "Response Message: ActionCreatePreparedStatementResult");
+      new ActionType(
+          "CreatePreparedSubstraitPlan",
+          "Creates a reusable prepared statement resource on the server.\n"
+              + "Request Message: ActionCreatePreparedSubstraitPlanRequest\n"
+              + "Response Message: ActionCreatePreparedStatementResult");
 
   public static final ActionType FLIGHT_SQL_CANCEL_QUERY =
-      new ActionType("CancelQuery",
-          "Explicitly cancel a running query.\n" +
-              "Request Message: ActionCancelQueryRequest\n" +
-              "Response Message: ActionCancelQueryResult");
+      new ActionType(
+          "CancelQuery",
+          "Explicitly cancel a running query.\n"
+              + "Request Message: ActionCancelQueryRequest\n"
+              + "Response Message: ActionCancelQueryResult");
 
   public static final ActionType FLIGHT_SQL_END_SAVEPOINT =
-      new ActionType("EndSavepoint",
-          "End a savepoint.\n" +
-              "Request Message: ActionEndSavepointRequest\n" +
-              "Response Message: N/A");
+      new ActionType(
+          "EndSavepoint",
+          "End a savepoint.\n"
+              + "Request Message: ActionEndSavepointRequest\n"
+              + "Response Message: N/A");
   public static final ActionType FLIGHT_SQL_END_TRANSACTION =
-      new ActionType("EndTransaction",
-          "End a transaction.\n" +
-              "Request Message: ActionEndTransactionRequest\n" +
-              "Response Message: N/A");
+      new ActionType(
+          "EndTransaction",
+          "End a transaction.\n"
+              + "Request Message: ActionEndTransactionRequest\n"
+              + "Response Message: N/A");
 
-  public static final List<ActionType> FLIGHT_SQL_ACTIONS = ImmutableList.of(
-      FLIGHT_SQL_CREATE_PREPARED_STATEMENT,
-      FLIGHT_SQL_CLOSE_PREPARED_STATEMENT
-  );
+  public static final List<ActionType> FLIGHT_SQL_ACTIONS =
+      ImmutableList.of(FLIGHT_SQL_CREATE_PREPARED_STATEMENT, FLIGHT_SQL_CLOSE_PREPARED_STATEMENT);
 
   /**
    * Helper to parse {@link com.google.protobuf.Any} objects to the specific protobuf object.
@@ -102,8 +105,8 @@ public final class FlightSqlUtils {
    * Helper to unpack {@link com.google.protobuf.Any} objects to the specific protobuf object.
    *
    * @param source the parsed Source value.
-   * @param as     the class to unpack as.
-   * @param <T>    the class to unpack as.
+   * @param as the class to unpack as.
+   * @param <T> the class to unpack as.
    * @return the materialized protobuf object.
    */
   public static <T extends Message> T unpackOrThrow(Any source, Class<T> as) {
@@ -118,11 +121,12 @@ public final class FlightSqlUtils {
   }
 
   /**
-   * Helper to parse and unpack {@link com.google.protobuf.Any} objects to the specific protobuf object.
+   * Helper to parse and unpack {@link com.google.protobuf.Any} objects to the specific protobuf
+   * object.
    *
    * @param source the raw bytes source value.
-   * @param as     the class to unpack as.
-   * @param <T>    the class to unpack as.
+   * @param as the class to unpack as.
+   * @param <T> the class to unpack as.
    * @return the materialized protobuf object.
    */
   public static <T extends Message> T unpackAndParseOrThrow(byte[] source, Class<T> as) {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/GetSessionOptionsResultListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/GetSessionOptionsResultListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.FlightProducer;
@@ -22,7 +21,8 @@ import org.apache.arrow.flight.GetSessionOptionsResult;
 import org.apache.arrow.flight.Result;
 
 /** Typed StreamListener for getSessionOptions. */
-public class GetSessionOptionsResultListener implements FlightProducer.StreamListener<GetSessionOptionsResult> {
+public class GetSessionOptionsResultListener
+    implements FlightProducer.StreamListener<GetSessionOptionsResult> {
   private final FlightProducer.StreamListener<Result> listener;
 
   GetSessionOptionsResultListener(FlightProducer.StreamListener<Result> listener) {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/NoOpFlightSqlProducer.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/NoOpFlightSqlProducer.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.CallStatus;
@@ -27,195 +26,233 @@ import org.apache.arrow.flight.Result;
 import org.apache.arrow.flight.SchemaResult;
 import org.apache.arrow.flight.sql.impl.FlightSql;
 
-/**
- * A {@link FlightSqlProducer} that throws on all FlightSql-specific operations.
- */
+/** A {@link FlightSqlProducer} that throws on all FlightSql-specific operations. */
 public class NoOpFlightSqlProducer implements FlightSqlProducer {
   @Override
-  public void createPreparedStatement(FlightSql.ActionCreatePreparedStatementRequest request,
-                                      CallContext context, StreamListener<Result> listener) {
-    listener.onError(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void createPreparedStatement(
+      FlightSql.ActionCreatePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
+    listener.onError(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public void closePreparedStatement(FlightSql.ActionClosePreparedStatementRequest request,
-                                     CallContext context, StreamListener<Result> listener) {
-    listener.onError(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void closePreparedStatement(
+      FlightSql.ActionClosePreparedStatementRequest request,
+      CallContext context,
+      StreamListener<Result> listener) {
+    listener.onError(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoStatement(FlightSql.CommandStatementQuery command,
-                                           CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoStatement(
+      FlightSql.CommandStatementQuery command, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public FlightInfo getFlightInfoPreparedStatement(FlightSql.CommandPreparedStatementQuery command,
-                                                   CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPreparedStatement(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public SchemaResult getSchemaStatement(FlightSql.CommandStatementQuery command,
-                                         CallContext context, FlightDescriptor descriptor) {
+  public SchemaResult getSchemaStatement(
+      FlightSql.CommandStatementQuery command, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void getStreamStatement(FlightSql.TicketStatementQuery ticket,
-                                 CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamStatement(
+      FlightSql.TicketStatementQuery ticket, CallContext context, ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public void getStreamPreparedStatement(FlightSql.CommandPreparedStatementQuery command,
-                                         CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamPreparedStatement(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public Runnable acceptPutStatement(FlightSql.CommandStatementUpdate command, CallContext context,
-                                     FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutStatement(
+      FlightSql.CommandStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public Runnable acceptPutPreparedStatementUpdate(FlightSql.CommandPreparedStatementUpdate command,
-                                                   CallContext context, FlightStream flightStream,
-                                                   StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutPreparedStatementUpdate(
+      FlightSql.CommandPreparedStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public Runnable acceptPutPreparedStatementQuery(FlightSql.CommandPreparedStatementQuery command, CallContext context,
-                                                  FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutPreparedStatementQuery(
+      FlightSql.CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public FlightInfo getFlightInfoSqlInfo(FlightSql.CommandGetSqlInfo request, CallContext context,
-                                         FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSqlInfo(
+      FlightSql.CommandGetSqlInfo request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void getStreamSqlInfo(FlightSql.CommandGetSqlInfo command, CallContext context,
-                               ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamSqlInfo(
+      FlightSql.CommandGetSqlInfo command, CallContext context, ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoTypeInfo(FlightSql.CommandGetXdbcTypeInfo request,
-                                          CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTypeInfo(
+      FlightSql.CommandGetXdbcTypeInfo request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void getStreamTypeInfo(FlightSql.CommandGetXdbcTypeInfo request,
-                                CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamTypeInfo(
+      FlightSql.CommandGetXdbcTypeInfo request,
+      CallContext context,
+      ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoCatalogs(FlightSql.CommandGetCatalogs request,
-                                          CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCatalogs(
+      FlightSql.CommandGetCatalogs request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
   public void getStreamCatalogs(CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoSchemas(FlightSql.CommandGetDbSchemas request,
-                                         CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSchemas(
+      FlightSql.CommandGetDbSchemas request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void getStreamSchemas(FlightSql.CommandGetDbSchemas command,
-                               CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamSchemas(
+      FlightSql.CommandGetDbSchemas command, CallContext context, ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoTables(FlightSql.CommandGetTables request,
-                                        CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTables(
+      FlightSql.CommandGetTables request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void getStreamTables(FlightSql.CommandGetTables command, CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamTables(
+      FlightSql.CommandGetTables command, CallContext context, ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoTableTypes(FlightSql.CommandGetTableTypes request, CallContext context,
-                                            FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTableTypes(
+      FlightSql.CommandGetTableTypes request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
   public void getStreamTableTypes(CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoPrimaryKeys(FlightSql.CommandGetPrimaryKeys request,
-                                             CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPrimaryKeys(
+      FlightSql.CommandGetPrimaryKeys request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void getStreamPrimaryKeys(FlightSql.CommandGetPrimaryKeys command,
-                                   CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamPrimaryKeys(
+      FlightSql.CommandGetPrimaryKeys command, CallContext context, ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public FlightInfo getFlightInfoExportedKeys(FlightSql.CommandGetExportedKeys request,
-                                              CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoExportedKeys(
+      FlightSql.CommandGetExportedKeys request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public FlightInfo getFlightInfoImportedKeys(FlightSql.CommandGetImportedKeys request,
-                                              CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoImportedKeys(
+      FlightSql.CommandGetImportedKeys request, CallContext context, FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public FlightInfo getFlightInfoCrossReference(FlightSql.CommandGetCrossReference request,
-                                                CallContext context, FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCrossReference(
+      FlightSql.CommandGetCrossReference request,
+      CallContext context,
+      FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 
   @Override
-  public void getStreamExportedKeys(FlightSql.CommandGetExportedKeys command,
-                                    CallContext context, ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamExportedKeys(
+      FlightSql.CommandGetExportedKeys command,
+      CallContext context,
+      ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public void getStreamImportedKeys(FlightSql.CommandGetImportedKeys command, CallContext context,
-                                    ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamImportedKeys(
+      FlightSql.CommandGetImportedKeys command,
+      CallContext context,
+      ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public void getStreamCrossReference(FlightSql.CommandGetCrossReference command, CallContext context,
-                                      ServerStreamListener listener) {
-    listener.error(CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
+  public void getStreamCrossReference(
+      FlightSql.CommandGetCrossReference command,
+      CallContext context,
+      ServerStreamListener listener) {
+    listener.error(
+        CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException());
   }
 
   @Override
-  public void close() throws Exception {
-
-  }
+  public void close() throws Exception {}
 
   @Override
-  public void listFlights(CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
+  public void listFlights(
+      CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
     throw CallStatus.UNIMPLEMENTED.withDescription("Not implemented.").toRuntimeException();
   }
 }

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/NoResultListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/NoResultListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.FlightProducer;

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/ProtoListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/ProtoListener.java
@@ -14,14 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
-
-import org.apache.arrow.flight.FlightProducer;
-import org.apache.arrow.flight.Result;
 
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
+import org.apache.arrow.flight.FlightProducer;
+import org.apache.arrow.flight.Result;
 
 /**
  * A StreamListener that accepts a particular type.

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SetSessionOptionsResultListener.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SetSessionOptionsResultListener.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import org.apache.arrow.flight.FlightProducer;
@@ -22,7 +21,8 @@ import org.apache.arrow.flight.Result;
 import org.apache.arrow.flight.SetSessionOptionsResult;
 
 /** Typed StreamListener for setSessionOptions. */
-public class SetSessionOptionsResultListener implements FlightProducer.StreamListener<SetSessionOptionsResult> {
+public class SetSessionOptionsResultListener
+    implements FlightProducer.StreamListener<SetSessionOptionsResult> {
   private final FlightProducer.StreamListener<Result> listener;
 
   SetSessionOptionsResultListener(FlightProducer.StreamListener<Result> listener) {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SqlInfoBuilder.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/SqlInfoBuilder.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql;
 
 import static java.util.stream.IntStream.range;
@@ -22,6 +21,7 @@ import static org.apache.arrow.flight.FlightProducer.ServerStreamListener;
 import static org.apache.arrow.flight.sql.impl.FlightSql.SqlSupportedTransaction;
 import static org.apache.arrow.flight.sql.util.SqlInfoOptionsUtils.createBitmaskFromEnums;
 
+import com.google.protobuf.ProtocolMessageEnum;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.ObjIntConsumer;
-
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlInfo;
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlNullOrdering;
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlOuterJoinsSupportLevel;
@@ -59,24 +58,24 @@ import org.apache.arrow.vector.holders.NullableBitHolder;
 import org.apache.arrow.vector.holders.NullableIntHolder;
 import org.apache.arrow.vector.holders.NullableVarCharHolder;
 
-import com.google.protobuf.ProtocolMessageEnum;
-
 /**
- * Auxiliary class meant to facilitate the implementation of {@link FlightSqlProducer#getStreamSqlInfo}.
- * <p>
- * Usage requires the user to add the required SqlInfo values using the {@code with*} methods
- * like {@link SqlInfoBuilder#withFlightSqlServerName(String)}, and request it back
- * through the {@link SqlInfoBuilder#send(List, ServerStreamListener)} method.
+ * Auxiliary class meant to facilitate the implementation of {@link
+ * FlightSqlProducer#getStreamSqlInfo}.
+ *
+ * <p>Usage requires the user to add the required SqlInfo values using the {@code with*} methods
+ * like {@link SqlInfoBuilder#withFlightSqlServerName(String)}, and request it back through the
+ * {@link SqlInfoBuilder#send(List, ServerStreamListener)} method.
  */
 @SuppressWarnings({"unused"})
 public class SqlInfoBuilder {
   private final Map<Integer, ObjIntConsumer<VectorSchemaRoot>> providers = new HashMap<>();
 
   /**
-   * Gets a {@link NullableVarCharHolder} from the provided {@code string} using the provided {@code buf}.
+   * Gets a {@link NullableVarCharHolder} from the provided {@code string} using the provided {@code
+   * buf}.
    *
    * @param string the {@link StandardCharsets#UTF_8}-encoded text input to store onto the holder.
-   * @param buf    the {@link ArrowBuf} from which to create the new holder.
+   * @param buf the {@link ArrowBuf} from which to create the new holder.
    * @return a new {@link NullableVarCharHolder} with the provided input data {@code string}.
    */
   public static NullableVarCharHolder getHolderForUtf8(final String string, final ArrowBuf buf) {
@@ -292,7 +291,8 @@ public class SqlInfoBuilder {
   /**
    * Sets a value for {@link SqlInfo#SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES} in the builder.
    *
-   * @param value the value for {@link SqlInfo#SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES} to be set.
+   * @param value the value for {@link SqlInfo#SQL_SUPPORTS_DIFFERENT_TABLE_CORRELATION_NAMES} to be
+   *     set.
    * @return the SqlInfoBuilder itself.
    */
   public SqlInfoBuilder withSqlSupportsDifferentTableCorrelationNames(final boolean value) {
@@ -342,7 +342,8 @@ public class SqlInfoBuilder {
   /**
    * Sets a value for {@link SqlInfo#SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY} in the builder.
    *
-   * @param value the value for {@link SqlInfo#SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY} to be set.
+   * @param value the value for {@link SqlInfo#SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY} to be
+   *     set.
    * @return the SqlInfoBuilder itself.
    */
   public SqlInfoBuilder withSqlSupportsIntegrityEnhancementFacility(final boolean value) {
@@ -412,23 +413,23 @@ public class SqlInfoBuilder {
   /**
    * Sets a value for {@link SqlInfo#SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT} in the builder.
    *
-   * @param value the value for {@link SqlInfo#SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT} to be set.
+   * @param value the value for {@link SqlInfo#SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT} to be
+   *     set.
    * @return the SqlInfoBuilder itself.
    */
   public SqlInfoBuilder withSqlDataDefinitionCausesTransactionCommit(final boolean value) {
-    return withBooleanProvider(SqlInfo.SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT_VALUE,
-        value);
+    return withBooleanProvider(SqlInfo.SQL_DATA_DEFINITION_CAUSES_TRANSACTION_COMMIT_VALUE, value);
   }
 
   /**
    * Sets a value for {@link SqlInfo#SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED} in the builder.
    *
-   * @param value the value for {@link SqlInfo#SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED} to be set.
+   * @param value the value for {@link SqlInfo#SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED} to be
+   *     set.
    * @return the SqlInfoBuilder itself.
    */
   public SqlInfoBuilder withSqlDataDefinitionsInTransactionsIgnored(final boolean value) {
-    return withBooleanProvider(SqlInfo.SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED_VALUE,
-        value);
+    return withBooleanProvider(SqlInfo.SQL_DATA_DEFINITIONS_IN_TRANSACTIONS_IGNORED_VALUE, value);
   }
 
   /**
@@ -472,14 +473,16 @@ public class SqlInfoBuilder {
   }
 
   /**
-   * Sets a value for {@link SqlInfo#SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED} in the builder.
+   * Sets a value for {@link SqlInfo#SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED} in the
+   * builder.
    *
-   * @param value the value for {@link SqlInfo#SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED} to be set.
+   * @param value the value for {@link SqlInfo#SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED} to
+   *     be set.
    * @return the SqlInfoBuilder itself.
    */
   public SqlInfoBuilder withSqlStoredFunctionsUsingCallSyntaxSupported(final boolean value) {
-    return withBooleanProvider(SqlInfo.SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED_VALUE,
-        value);
+    return withBooleanProvider(
+        SqlInfo.SQL_STORED_FUNCTIONS_USING_CALL_SYNTAX_SUPPORTED_VALUE, value);
   }
 
   /**
@@ -758,7 +761,8 @@ public class SqlInfoBuilder {
    * @param values the value for {@link SqlInfo#SQL_ANSI92_SUPPORTED_LEVEL} to be set.
    * @return the SqlInfoBuilder itself.
    */
-  public SqlInfoBuilder withSqlAnsi92SupportedLevel(final SupportedAnsi92SqlGrammarLevel... values) {
+  public SqlInfoBuilder withSqlAnsi92SupportedLevel(
+      final SupportedAnsi92SqlGrammarLevel... values) {
     return withEnumProvider(SqlInfo.SQL_ANSI92_SUPPORTED_LEVEL_VALUE, values);
   }
 
@@ -778,7 +782,8 @@ public class SqlInfoBuilder {
    * @param values the value for {@link SqlInfo#SQL_CATALOGS_SUPPORTED_ACTIONS} to be set.
    * @return the SqlInfoBuilder itself.
    */
-  public SqlInfoBuilder withSqlCatalogsSupportedActions(final SqlSupportedElementActions... values) {
+  public SqlInfoBuilder withSqlCatalogsSupportedActions(
+      final SqlSupportedElementActions... values) {
     return withEnumProvider(SqlInfo.SQL_CATALOGS_SUPPORTED_ACTIONS_VALUE, values);
   }
 
@@ -788,7 +793,8 @@ public class SqlInfoBuilder {
    * @param values the value for {@link SqlInfo#SQL_SUPPORTED_POSITIONED_COMMANDS} to be set.
    * @return the SqlInfoBuilder itself.
    */
-  public SqlInfoBuilder withSqlSupportedPositionedCommands(final SqlSupportedPositionedCommands... values) {
+  public SqlInfoBuilder withSqlSupportedPositionedCommands(
+      final SqlSupportedPositionedCommands... values) {
     return withEnumProvider(SqlInfo.SQL_SUPPORTED_POSITIONED_COMMANDS_VALUE, values);
   }
 
@@ -825,10 +831,12 @@ public class SqlInfoBuilder {
   /**
    * Sets a value for {@link SqlInfo#SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS} in the builder.
    *
-   * @param values the values for {@link SqlInfo#SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS} to be set.
+   * @param values the values for {@link SqlInfo#SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS} to be
+   *     set.
    * @return the SqlInfoBuilder itself.
    */
-  public SqlInfoBuilder withSqlSupportedTransactionsIsolationLevels(final SqlTransactionIsolationLevel... values) {
+  public SqlInfoBuilder withSqlSupportedTransactionsIsolationLevels(
+      final SqlTransactionIsolationLevel... values) {
     return withEnumProvider(SqlInfo.SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS_VALUE, values);
   }
 
@@ -839,8 +847,7 @@ public class SqlInfoBuilder {
    * @return the SqlInfoBuilder itself.
    */
   public SqlInfoBuilder withSqlSupportedResultSetTypes(final SqlSupportedResultSetType... values) {
-    return withEnumProvider(SqlInfo.SQL_SUPPORTED_RESULT_SET_TYPES_VALUE, values
-    );
+    return withEnumProvider(SqlInfo.SQL_SUPPORTED_RESULT_SET_TYPES_VALUE, values);
   }
 
   /**
@@ -921,8 +928,7 @@ public class SqlInfoBuilder {
     return this;
   }
 
-  private SqlInfoBuilder withBooleanProvider(final int sqlInfo,
-                                             final boolean value) {
+  private SqlInfoBuilder withBooleanProvider(final int sqlInfo, final boolean value) {
     addProvider(sqlInfo, (root, index) -> setDataForBooleanField(root, index, sqlInfo, value));
     return this;
   }
@@ -932,14 +938,13 @@ public class SqlInfoBuilder {
     return this;
   }
 
-  private SqlInfoBuilder withStringArrayProvider(final int sqlInfo,
-                                                 final String[] value) {
+  private SqlInfoBuilder withStringArrayProvider(final int sqlInfo, final String[] value) {
     addProvider(sqlInfo, (root, index) -> setDataVarCharListField(root, index, sqlInfo, value));
     return this;
   }
 
-  private SqlInfoBuilder withIntToIntListMapProvider(final int sqlInfo,
-                                                     final Map<Integer, List<Integer>> value) {
+  private SqlInfoBuilder withIntToIntListMapProvider(
+      final int sqlInfo, final Map<Integer, List<Integer>> value) {
     addProvider(sqlInfo, (root, index) -> setIntToIntListMapField(root, index, sqlInfo, value));
     return this;
   }
@@ -947,7 +952,7 @@ public class SqlInfoBuilder {
   /**
    * Send the requested information to given ServerStreamListener.
    *
-   * @param infos    List of SqlInfo to be sent.
+   * @param infos List of SqlInfo to be sent.
    * @param listener ServerStreamListener to send data to.
    */
   public void send(List<Integer> infos, final ServerStreamListener listener) {
@@ -955,9 +960,8 @@ public class SqlInfoBuilder {
       infos = new ArrayList<>(providers.keySet());
     }
     try (final BufferAllocator allocator = new RootAllocator();
-         final VectorSchemaRoot root = VectorSchemaRoot.create(
-             FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA,
-             allocator)) {
+        final VectorSchemaRoot root =
+            VectorSchemaRoot.create(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA, allocator)) {
       final int rows = infos.size();
       for (int i = 0; i < rows; i++) {
         providers.get(infos.get(i)).accept(root, i);
@@ -977,8 +981,11 @@ public class SqlInfoBuilder {
     infoName.setSafe(index, info);
   }
 
-  private void setValues(final VectorSchemaRoot root, final int index, final byte typeId,
-                         final Consumer<DenseUnionVector> dataSetter) {
+  private void setValues(
+      final VectorSchemaRoot root,
+      final int index,
+      final byte typeId,
+      final Consumer<DenseUnionVector> dataSetter) {
     final DenseUnionVector values = (DenseUnionVector) root.getVector("value");
     values.setTypeId(index, typeId);
     dataSetter.accept(values);
@@ -991,23 +998,24 @@ public class SqlInfoBuilder {
    */
   private void onCreateArrowBuf(final Consumer<ArrowBuf> executor) {
     try (final BufferAllocator allocator = new RootAllocator();
-         final ArrowBuf buf = allocator.buffer(1024)) {
+        final ArrowBuf buf = allocator.buffer(1024)) {
       executor.accept(buf);
     }
   }
 
-  private void setDataForUtf8Field(final VectorSchemaRoot root, final int index,
-                                   final int sqlInfo, final String value) {
+  private void setDataForUtf8Field(
+      final VectorSchemaRoot root, final int index, final int sqlInfo, final String value) {
     setInfoName(root, index, sqlInfo);
-    onCreateArrowBuf(buf -> {
-      final Consumer<DenseUnionVector> producer =
-          values -> values.setSafe(index, getHolderForUtf8(value, buf));
-      setValues(root, index, (byte) 0, producer);
-    });
+    onCreateArrowBuf(
+        buf -> {
+          final Consumer<DenseUnionVector> producer =
+              values -> values.setSafe(index, getHolderForUtf8(value, buf));
+          setValues(root, index, (byte) 0, producer);
+        });
   }
 
-  private void setDataForIntField(final VectorSchemaRoot root, final int index,
-                                  final int sqlInfo, final int value) {
+  private void setDataForIntField(
+      final VectorSchemaRoot root, final int index, final int sqlInfo, final int value) {
     setInfoName(root, index, sqlInfo);
     final NullableIntHolder dataHolder = new NullableIntHolder();
     dataHolder.isSet = 1;
@@ -1015,8 +1023,8 @@ public class SqlInfoBuilder {
     setValues(root, index, (byte) 3, values -> values.setSafe(index, dataHolder));
   }
 
-  private void setDataForBigIntField(final VectorSchemaRoot root, final int index,
-                                     final int sqlInfo, final long value) {
+  private void setDataForBigIntField(
+      final VectorSchemaRoot root, final int index, final int sqlInfo, final long value) {
     setInfoName(root, index, sqlInfo);
     final NullableBigIntHolder dataHolder = new NullableBigIntHolder();
     dataHolder.isSet = 1;
@@ -1024,8 +1032,8 @@ public class SqlInfoBuilder {
     setValues(root, index, (byte) 2, values -> values.setSafe(index, dataHolder));
   }
 
-  private void setDataForBooleanField(final VectorSchemaRoot root, final int index,
-                                      final int sqlInfo, final boolean value) {
+  private void setDataForBooleanField(
+      final VectorSchemaRoot root, final int index, final int sqlInfo, final boolean value) {
     setInfoName(root, index, sqlInfo);
     final NullableBitHolder dataHolder = new NullableBitHolder();
     dataHolder.isSet = 1;
@@ -1033,9 +1041,8 @@ public class SqlInfoBuilder {
     setValues(root, index, (byte) 1, values -> values.setSafe(index, dataHolder));
   }
 
-  private void setDataVarCharListField(final VectorSchemaRoot root, final int index,
-                                       final int sqlInfo,
-                                       final String[] values) {
+  private void setDataVarCharListField(
+      final VectorSchemaRoot root, final int index, final int sqlInfo, final String[] values) {
     final DenseUnionVector denseUnion = (DenseUnionVector) root.getVector("value");
     final ListVector listVector = denseUnion.getList((byte) 4);
     final int listIndex = listVector.getValueCount();
@@ -1049,11 +1056,14 @@ public class SqlInfoBuilder {
     writer.startList();
     final int length = values.length;
     range(0, length)
-        .forEach(i -> onCreateArrowBuf(buf -> {
-          final byte[] bytes = values[i].getBytes(StandardCharsets.UTF_8);
-          buf.setBytes(0, bytes);
-          writer.writeVarChar(0, bytes.length, buf);
-        }));
+        .forEach(
+            i ->
+                onCreateArrowBuf(
+                    buf -> {
+                      final byte[] bytes = values[i].getBytes(StandardCharsets.UTF_8);
+                      buf.setBytes(0, bytes);
+                      writer.writeVarChar(0, bytes.length, buf);
+                    }));
     writer.endList();
     writer.setValueCount(listVectorValueCount);
 
@@ -1062,9 +1072,11 @@ public class SqlInfoBuilder {
     setInfoName(root, index, sqlInfo);
   }
 
-  private void setIntToIntListMapField(final VectorSchemaRoot root, final int index,
-                                       final int sqlInfo,
-                                       final Map<Integer, List<Integer>> values) {
+  private void setIntToIntListMapField(
+      final VectorSchemaRoot root,
+      final int index,
+      final int sqlInfo,
+      final Map<Integer, List<Integer>> values) {
     final DenseUnionVector denseUnion = (DenseUnionVector) root.getVector("value");
     final MapVector mapVector = denseUnion.getMap((byte) 5);
     final int mapIndex = mapVector.getValueCount();
@@ -1074,17 +1086,18 @@ public class SqlInfoBuilder {
     final UnionMapWriter mapWriter = mapVector.getWriter();
     mapWriter.setPosition(mapIndex);
     mapWriter.startMap();
-    values.forEach((key, value) -> {
-      mapWriter.startEntry();
-      mapWriter.key().integer().writeInt(key);
-      final BaseWriter.ListWriter listWriter = mapWriter.value().list();
-      listWriter.startList();
-      for (final int v : value) {
-        listWriter.integer().writeInt(v);
-      }
-      listWriter.endList();
-      mapWriter.endEntry();
-    });
+    values.forEach(
+        (key, value) -> {
+          mapWriter.startEntry();
+          mapWriter.key().integer().writeInt(key);
+          final BaseWriter.ListWriter listWriter = mapWriter.value().list();
+          listWriter.startList();
+          for (final int v : value) {
+            listWriter.integer().writeInt(v);
+          }
+          listWriter.endList();
+          mapWriter.endEntry();
+        });
     mapWriter.endMap();
     mapWriter.setValueCount(mapIndex + 1);
 

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/example/FlightSqlClientDemoApp.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/example/FlightSqlClientDemoApp.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.example;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.arrow.flight.CallOption;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightInfo;
@@ -37,9 +35,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-/**
- * Flight SQL Client Demo CLI Application.
- */
+/** Flight SQL Client Demo CLI Application. */
 public class FlightSqlClientDemoApp implements AutoCloseable {
   public final List<CallOption> callOptions = new ArrayList<>();
   public final BufferAllocator allocator;
@@ -67,7 +63,8 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
 
     try {
       cmd = parser.parse(options, args);
-      try (final FlightSqlClientDemoApp thisApp = new FlightSqlClientDemoApp(new RootAllocator(Integer.MAX_VALUE))) {
+      try (final FlightSqlClientDemoApp thisApp =
+          new FlightSqlClientDemoApp(new RootAllocator(Integer.MAX_VALUE))) {
         thisApp.executeApp(cmd);
       }
 
@@ -79,8 +76,8 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
   }
 
   /**
-   * Gets the current {@link CallOption} as an array; usually used as an
-   * argument in {@link FlightSqlClient} methods.
+   * Gets the current {@link CallOption} as an array; usually used as an argument in {@link
+   * FlightSqlClient} methods.
    *
    * @return current {@link CallOption} array.
    */
@@ -89,12 +86,12 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
   }
 
   /**
-   * Calls {@link FlightSqlClientDemoApp#createFlightSqlClient(String, int)}
-   * in order to create a {@link FlightSqlClient} to be used in future calls,
-   * and then calls {@link FlightSqlClientDemoApp#executeCommand(CommandLine)}
-   * to execute the command parsed at execution.
+   * Calls {@link FlightSqlClientDemoApp#createFlightSqlClient(String, int)} in order to create a
+   * {@link FlightSqlClient} to be used in future calls, and then calls {@link
+   * FlightSqlClientDemoApp#executeCommand(CommandLine)} to execute the command parsed at execution.
    *
-   * @param cmd parsed {@link CommandLine}; often the result of {@link DefaultParser#parse(Options, String[])}.
+   * @param cmd parsed {@link CommandLine}; often the result of {@link DefaultParser#parse(Options,
+   *     String[])}.
    */
   public void executeApp(final CommandLine cmd) throws Exception {
     final String host = cmd.getOptionValue("host").trim();
@@ -107,29 +104,22 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
   /**
    * Parses the "{@code command}" CLI argument and redirects to the appropriate method.
    *
-   * @param cmd parsed {@link CommandLine}; often the result of
-   *            {@link DefaultParser#parse(Options, String[])}.
+   * @param cmd parsed {@link CommandLine}; often the result of {@link DefaultParser#parse(Options,
+   *     String[])}.
    */
   public void executeCommand(CommandLine cmd) throws Exception {
     switch (cmd.getOptionValue("command").trim()) {
       case "Execute":
-        exampleExecute(
-            cmd.getOptionValue("query")
-        );
+        exampleExecute(cmd.getOptionValue("query"));
         break;
       case "ExecuteUpdate":
-        exampleExecuteUpdate(
-            cmd.getOptionValue("query")
-        );
+        exampleExecuteUpdate(cmd.getOptionValue("query"));
         break;
       case "GetCatalogs":
         exampleGetCatalogs();
         break;
       case "GetSchemas":
-        exampleGetSchemas(
-            cmd.getOptionValue("catalog"),
-            cmd.getOptionValue("schema")
-        );
+        exampleGetSchemas(cmd.getOptionValue("catalog"), cmd.getOptionValue("schema"));
         break;
       case "GetTableTypes":
         exampleGetTableTypes();
@@ -138,41 +128,38 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
         exampleGetTables(
             cmd.getOptionValue("catalog"),
             cmd.getOptionValue("schema"),
-            cmd.getOptionValue("table")
-        );
+            cmd.getOptionValue("table"));
         break;
       case "GetExportedKeys":
         exampleGetExportedKeys(
             cmd.getOptionValue("catalog"),
             cmd.getOptionValue("schema"),
-            cmd.getOptionValue("table")
-        );
+            cmd.getOptionValue("table"));
         break;
       case "GetImportedKeys":
         exampleGetImportedKeys(
             cmd.getOptionValue("catalog"),
             cmd.getOptionValue("schema"),
-            cmd.getOptionValue("table")
-        );
+            cmd.getOptionValue("table"));
         break;
       case "GetPrimaryKeys":
         exampleGetPrimaryKeys(
             cmd.getOptionValue("catalog"),
             cmd.getOptionValue("schema"),
-            cmd.getOptionValue("table")
-        );
+            cmd.getOptionValue("table"));
         break;
       default:
-        System.out.println("Command used is not valid! Please use one of: \n" +
-            "[\"ExecuteUpdate\",\n" +
-            "\"Execute\",\n" +
-            "\"GetCatalogs\",\n" +
-            "\"GetSchemas\",\n" +
-            "\"GetTableTypes\",\n" +
-            "\"GetTables\",\n" +
-            "\"GetExportedKeys\",\n" +
-            "\"GetImportedKeys\",\n" +
-            "\"GetPrimaryKeys\"]");
+        System.out.println(
+            "Command used is not valid! Please use one of: \n"
+                + "[\"ExecuteUpdate\",\n"
+                + "\"Execute\",\n"
+                + "\"GetCatalogs\",\n"
+                + "\"GetSchemas\",\n"
+                + "\"GetTableTypes\",\n"
+                + "\"GetTables\",\n"
+                + "\"GetExportedKeys\",\n"
+                + "\"GetImportedKeys\",\n"
+                + "\"GetPrimaryKeys\"]");
     }
   }
 
@@ -192,7 +179,8 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
   }
 
   private void exampleExecuteUpdate(final String query) {
-    System.out.println("Updated: " + flightSqlClient.executeUpdate(query, getCallOptions()) + "rows.");
+    System.out.println(
+        "Updated: " + flightSqlClient.executeUpdate(query, getCallOptions()) + "rows.");
   }
 
   private void exampleGetCatalogs() throws Exception {
@@ -207,22 +195,29 @@ public class FlightSqlClientDemoApp implements AutoCloseable {
     printFlightInfoResults(flightSqlClient.getTableTypes(getCallOptions()));
   }
 
-  private void exampleGetTables(final String catalog, final String schema, final String table) throws Exception {
+  private void exampleGetTables(final String catalog, final String schema, final String table)
+      throws Exception {
     // For now, this won't filter by table types.
-    printFlightInfoResults(flightSqlClient.getTables(
-        catalog, schema, table, null, false, getCallOptions()));
+    printFlightInfoResults(
+        flightSqlClient.getTables(catalog, schema, table, null, false, getCallOptions()));
   }
 
-  private void exampleGetExportedKeys(final String catalog, final String schema, final String table) throws Exception {
-    printFlightInfoResults(flightSqlClient.getExportedKeys(TableRef.of(catalog, schema, table), getCallOptions()));
+  private void exampleGetExportedKeys(final String catalog, final String schema, final String table)
+      throws Exception {
+    printFlightInfoResults(
+        flightSqlClient.getExportedKeys(TableRef.of(catalog, schema, table), getCallOptions()));
   }
 
-  private void exampleGetImportedKeys(final String catalog, final String schema, final String table) throws Exception {
-    printFlightInfoResults(flightSqlClient.getImportedKeys(TableRef.of(catalog, schema, table), getCallOptions()));
+  private void exampleGetImportedKeys(final String catalog, final String schema, final String table)
+      throws Exception {
+    printFlightInfoResults(
+        flightSqlClient.getImportedKeys(TableRef.of(catalog, schema, table), getCallOptions()));
   }
 
-  private void exampleGetPrimaryKeys(final String catalog, final String schema, final String table) throws Exception {
-    printFlightInfoResults(flightSqlClient.getPrimaryKeys(TableRef.of(catalog, schema, table), getCallOptions()));
+  private void exampleGetPrimaryKeys(final String catalog, final String schema, final String table)
+      throws Exception {
+    printFlightInfoResults(
+        flightSqlClient.getPrimaryKeys(TableRef.of(catalog, schema, table), getCallOptions()));
   }
 
   private void printFlightInfoResults(final FlightInfo flightInfo) throws Exception {

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/util/SqlInfoOptionsUtils.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/util/SqlInfoOptionsUtils.java
@@ -14,34 +14,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.util;
 
+import com.google.protobuf.ProtocolMessageEnum;
 import java.util.Arrays;
 import java.util.Collection;
-
 import org.apache.arrow.flight.sql.FlightSqlClient;
 import org.apache.arrow.flight.sql.impl.FlightSql.SqlInfo;
 
-import com.google.protobuf.ProtocolMessageEnum;
-
-/**
- * Utility class for {@link SqlInfo} and {@link FlightSqlClient#getSqlInfo} option parsing.
- */
+/** Utility class for {@link SqlInfo} and {@link FlightSqlClient#getSqlInfo} option parsing. */
 public final class SqlInfoOptionsUtils {
   private SqlInfoOptionsUtils() {
     // Prevent instantiation.
   }
 
   /**
-   * Returns whether the provided {@code bitmask} points to the provided {@link ProtocolMessageEnum} by comparing
-   * {@link ProtocolMessageEnum#getNumber} with the respective bit index of the {@code bitmask}.
+   * Returns whether the provided {@code bitmask} points to the provided {@link ProtocolMessageEnum}
+   * by comparing {@link ProtocolMessageEnum#getNumber} with the respective bit index of the {@code
+   * bitmask}.
    *
    * @param enumInstance the protobuf message enum to use.
-   * @param bitmask      the bitmask response from {@link FlightSqlClient#getSqlInfo}.
+   * @param bitmask the bitmask response from {@link FlightSqlClient#getSqlInfo}.
    * @return whether the provided {@code bitmask} points to the specified {@code enumInstance}.
    */
-  public static boolean doesBitmaskTranslateToEnum(final ProtocolMessageEnum enumInstance, final long bitmask) {
+  public static boolean doesBitmaskTranslateToEnum(
+      final ProtocolMessageEnum enumInstance, final long bitmask) {
     return ((bitmask >> enumInstance.getNumber()) & 1) == 1;
   }
 

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/util/TableRef.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/util/TableRef.java
@@ -14,13 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.util;
 
-/**
- * A helper class to reference a table to be passed to the flight
- * sql client.
- */
+/** A helper class to reference a table to be passed to the flight sql client. */
 public class TableRef {
   private final String catalog;
   private final String dbSchema;
@@ -28,9 +24,10 @@ public class TableRef {
 
   /**
    * The complete constructor for the TableRef class.
-   * @param catalog   the catalog from a table.
-   * @param dbSchema  the database schema from a table.
-   * @param table     the table name from a table.
+   *
+   * @param catalog the catalog from a table.
+   * @param dbSchema the database schema from a table.
+   * @param table the table name from a table.
    */
   public TableRef(String catalog, String dbSchema, String table) {
     this.catalog = catalog;
@@ -40,10 +37,11 @@ public class TableRef {
 
   /**
    * A static initializer of the TableRef with all the arguments.
-   * @param catalog   the catalog from a table.
-   * @param dbSchema  the database schema from a table.
-   * @param table     the table name from a table.
-   * @return  A TableRef object.
+   *
+   * @param catalog the catalog from a table.
+   * @param dbSchema the database schema from a table.
+   * @param table the table name from a table.
+   * @return A TableRef object.
    */
   public static TableRef of(String catalog, String dbSchema, String table) {
     return new TableRef(catalog, dbSchema, table);
@@ -51,7 +49,8 @@ public class TableRef {
 
   /**
    * Retrieve the catalog from the object.
-   * @return  the catalog.
+   *
+   * @return the catalog.
    */
   public String getCatalog() {
     return catalog;
@@ -59,7 +58,8 @@ public class TableRef {
 
   /**
    * Retrieves the db schema from the object.
-   * @return  the dbSchema
+   *
+   * @return the dbSchema
    */
   public String getDbSchema() {
     return dbSchema;
@@ -67,10 +67,10 @@ public class TableRef {
 
   /**
    * Retrieves the table from the object.
-   * @return  the table.
+   *
+   * @return the table.
    */
   public String getTable() {
     return table;
   }
 }
-

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/DoPutPreparedStatementResultPOJO.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/DoPutPreparedStatementResultPOJO.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.example;
 
 import java.io.Serializable;

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlExample.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.example;
 
 import static com.google.common.base.Strings.emptyToNull;
@@ -37,6 +36,15 @@ import static org.apache.arrow.flight.sql.impl.FlightSql.TicketStatementQuery;
 import static org.apache.arrow.util.Preconditions.checkState;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import com.google.protobuf.ProtocolStringList;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -75,7 +83,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
 import org.apache.arrow.adapter.jdbc.ArrowVectorIterator;
 import org.apache.arrow.adapter.jdbc.JdbcFieldInfo;
 import org.apache.arrow.adapter.jdbc.JdbcParameterBinder;
@@ -141,19 +148,9 @@ import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.slf4j.Logger;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Message;
-import com.google.protobuf.ProtocolStringList;
-
 /**
- * Example {@link FlightSqlProducer} implementation showing an Apache Derby backed Flight SQL server that generally
- * supports all current features of Flight SQL.
+ * Example {@link FlightSqlProducer} implementation showing an Apache Derby backed Flight SQL server
+ * that generally supports all current features of Flight SQL.
  */
 public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   private static final Logger LOGGER = getLogger(FlightSqlExample.class);
@@ -165,7 +162,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   private final Location location;
   protected final PoolingDataSource<PoolableConnection> dataSource;
   protected final BufferAllocator rootAllocator = new RootAllocator();
-  private final Cache<ByteString, StatementContext<PreparedStatement>> preparedStatementLoadingCache;
+  private final Cache<ByteString, StatementContext<PreparedStatement>>
+      preparedStatementLoadingCache;
   private final Cache<ByteString, StatementContext<Statement>> statementLoadingCache;
   private final SqlInfoBuilder sqlInfoBuilder;
 
@@ -174,7 +172,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     final FlightSqlExample example = new FlightSqlExample(location, DB_NAME);
     Location listenLocation = Location.forGrpcInsecure("0.0.0.0", 55555);
     try (final BufferAllocator allocator = new RootAllocator();
-         final FlightServer server = FlightServer.builder(allocator, listenLocation, example).build()) {
+        final FlightServer server =
+            FlightServer.builder(allocator, listenLocation, example).build()) {
       server.start();
       server.awaitTermination();
     }
@@ -190,7 +189,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
         new DriverManagerConnectionFactory(databaseUri, new Properties());
     final PoolableConnectionFactory poolableConnectionFactory =
         new PoolableConnectionFactory(connectionFactory, null);
-    final ObjectPool<PoolableConnection> connectionPool = new GenericObjectPool<>(poolableConnectionFactory);
+    final ObjectPool<PoolableConnection> connectionPool =
+        new GenericObjectPool<>(poolableConnectionFactory);
 
     poolableConnectionFactory.setPool(connectionPool);
     // PoolingDataSource takes ownership of `connectionPool`
@@ -216,7 +216,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     try (final Connection connection = dataSource.getConnection()) {
       final DatabaseMetaData metaData = connection.getMetaData();
 
-      sqlInfoBuilder.withFlightSqlServerName(metaData.getDatabaseProductName())
+      sqlInfoBuilder
+          .withFlightSqlServerName(metaData.getDatabaseProductName())
           .withFlightSqlServerVersion(metaData.getDatabaseProductVersion())
           .withFlightSqlServerArrowVersion(metaData.getDriverVersion())
           .withFlightSqlServerReadOnly(metaData.isReadOnly())
@@ -225,29 +226,30 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
           .withFlightSqlServerTransaction(SqlSupportedTransaction.SQL_SUPPORTED_TRANSACTION_NONE)
           .withSqlIdentifierQuoteChar(metaData.getIdentifierQuoteString())
           .withSqlDdlCatalog(metaData.supportsCatalogsInDataManipulation())
-          .withSqlDdlSchema( metaData.supportsSchemasInDataManipulation())
-          .withSqlDdlTable( metaData.allTablesAreSelectable())
-          .withSqlIdentifierCase(metaData.storesMixedCaseIdentifiers() ?
-              SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_CASE_INSENSITIVE :
-              metaData.storesUpperCaseIdentifiers() ?
-                  SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UPPERCASE :
-                  metaData.storesLowerCaseIdentifiers() ?
-                      SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_LOWERCASE :
-                      SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UNKNOWN)
-          .withSqlQuotedIdentifierCase(metaData.storesMixedCaseQuotedIdentifiers() ?
-              SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_CASE_INSENSITIVE :
-              metaData.storesUpperCaseQuotedIdentifiers() ?
-                  SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UPPERCASE :
-                  metaData.storesLowerCaseQuotedIdentifiers() ?
-                      SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_LOWERCASE :
-                      SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UNKNOWN)
+          .withSqlDdlSchema(metaData.supportsSchemasInDataManipulation())
+          .withSqlDdlTable(metaData.allTablesAreSelectable())
+          .withSqlIdentifierCase(
+              metaData.storesMixedCaseIdentifiers()
+                  ? SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_CASE_INSENSITIVE
+                  : metaData.storesUpperCaseIdentifiers()
+                      ? SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UPPERCASE
+                      : metaData.storesLowerCaseIdentifiers()
+                          ? SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_LOWERCASE
+                          : SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UNKNOWN)
+          .withSqlQuotedIdentifierCase(
+              metaData.storesMixedCaseQuotedIdentifiers()
+                  ? SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_CASE_INSENSITIVE
+                  : metaData.storesUpperCaseQuotedIdentifiers()
+                      ? SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UPPERCASE
+                      : metaData.storesLowerCaseQuotedIdentifiers()
+                          ? SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_LOWERCASE
+                          : SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UNKNOWN)
           .withSqlAllTablesAreSelectable(true)
           .withSqlNullOrdering(SqlNullOrdering.SQL_NULLS_SORTED_AT_END)
           .withSqlMaxColumnsInTable(42);
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
-
   }
 
   public static boolean removeDerbyDatabaseIfExists(final String dbName) {
@@ -263,8 +265,12 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
        * If for whatever reason the resulting `Stream<Boolean>` is empty, throw an `IOException`;
        * this not expected.
        */
-      wasSuccess = walk.sorted(Comparator.reverseOrder()).map(Path::toFile).map(File::delete)
-              .reduce(Boolean::logicalAnd).orElseThrow(IOException::new);
+      wasSuccess =
+          walk.sorted(Comparator.reverseOrder())
+              .map(Path::toFile)
+              .map(File::delete)
+              .reduce(Boolean::logicalAnd)
+              .orElseThrow(IOException::new);
     } catch (IOException e) {
       /*
        * The only acceptable scenario for an `IOException` to be thrown here is if
@@ -280,26 +286,30 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   private static boolean populateDerbyDatabase(final String dbName) {
-    try (final Connection connection = DriverManager.getConnection("jdbc:derby:target/" + dbName + ";create=true");
-         Statement statement = connection.createStatement()) {
+    try (final Connection connection =
+            DriverManager.getConnection("jdbc:derby:target/" + dbName + ";create=true");
+        Statement statement = connection.createStatement()) {
 
       dropTable(statement, "intTable");
       dropTable(statement, "foreignTable");
-      statement.execute("CREATE TABLE foreignTable (" +
-          "id INT not null primary key GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), " +
-          "foreignName varchar(100), " +
-          "value int)");
-      statement.execute("CREATE TABLE intTable (" +
-          "id INT not null primary key GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), " +
-          "keyName varchar(100), " +
-          "value int, " +
-          "foreignId int references foreignTable(id))");
+      statement.execute(
+          "CREATE TABLE foreignTable ("
+              + "id INT not null primary key GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), "
+              + "foreignName varchar(100), "
+              + "value int)");
+      statement.execute(
+          "CREATE TABLE intTable ("
+              + "id INT not null primary key GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), "
+              + "keyName varchar(100), "
+              + "value int, "
+              + "foreignId int references foreignTable(id))");
       statement.execute("INSERT INTO foreignTable (foreignName, value) VALUES ('keyOne', 1)");
       statement.execute("INSERT INTO foreignTable (foreignName, value) VALUES ('keyTwo', 0)");
       statement.execute("INSERT INTO foreignTable (foreignName, value) VALUES ('keyThree', -1)");
       statement.execute("INSERT INTO intTable (keyName, value, foreignId) VALUES ('one', 1, 1)");
       statement.execute("INSERT INTO intTable (keyName, value, foreignId) VALUES ('zero', 0, 1)");
-      statement.execute("INSERT INTO intTable (keyName, value, foreignId) VALUES ('negative one', -1, 1)");
+      statement.execute(
+          "INSERT INTO intTable (keyName, value, foreignId) VALUES ('negative one', -1, 1)");
     } catch (final SQLException e) {
       LOGGER.error(format("Failed attempt to populate DerbyDB: <%s>", e.getMessage()), e);
       return false;
@@ -307,7 +317,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     return true;
   }
 
-  private static void dropTable(final Statement statement, final String tableName) throws SQLException {
+  private static void dropTable(final Statement statement, final String tableName)
+      throws SQLException {
     try {
       statement.execute("DROP TABLE " + tableName);
     } catch (SQLException e) {
@@ -319,10 +330,11 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     }
   }
 
-  private static ArrowType getArrowTypeFromJdbcType(final int jdbcDataType, final int precision, final int scale) {
+  private static ArrowType getArrowTypeFromJdbcType(
+      final int jdbcDataType, final int precision, final int scale) {
     try {
-      return JdbcToArrowUtils.getArrowTypeFromJdbcType(new JdbcFieldInfo(jdbcDataType, precision, scale),
-              DEFAULT_CALENDAR);
+      return JdbcToArrowUtils.getArrowTypeFromJdbcType(
+          new JdbcFieldInfo(jdbcDataType, precision, scale), DEFAULT_CALENDAR);
     } catch (UnsupportedOperationException ignored) {
       return ArrowType.Utf8.INSTANCE;
     }
@@ -346,19 +358,29 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
 
   private static void saveToVector(final String data, final VarCharVector vector, final int index) {
     preconditionCheckSaveToVector(vector, index);
-    vectorConsumer(data, vector, fieldVector -> fieldVector.setNull(index),
+    vectorConsumer(
+        data,
+        vector,
+        fieldVector -> fieldVector.setNull(index),
         (theData, fieldVector) -> fieldVector.setSafe(index, new Text(theData)));
   }
 
   private static void saveToVector(final Integer data, final IntVector vector, final int index) {
     preconditionCheckSaveToVector(vector, index);
-    vectorConsumer(data, vector, fieldVector -> fieldVector.setNull(index),
+    vectorConsumer(
+        data,
+        vector,
+        fieldVector -> fieldVector.setNull(index),
         (theData, fieldVector) -> fieldVector.setSafe(index, theData));
   }
 
-  private static void saveToVector(final byte[] data, final VarBinaryVector vector, final int index) {
+  private static void saveToVector(
+      final byte[] data, final VarBinaryVector vector, final int index) {
     preconditionCheckSaveToVector(vector, index);
-    vectorConsumer(data, vector, fieldVector -> fieldVector.setNull(index),
+    vectorConsumer(
+        data,
+        vector,
+        fieldVector -> fieldVector.setNull(index),
         (theData, fieldVector) -> fieldVector.setSafe(index, theData));
   }
 
@@ -367,9 +389,11 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     checkState(index >= 0, "Index must be a positive number!");
   }
 
-  private static <T, V extends FieldVector> void vectorConsumer(final T data, final V vector,
-                                                                final Consumer<V> consumerIfNullable,
-                                                                final BiConsumer<T, V> defaultConsumer) {
+  private static <T, V extends FieldVector> void vectorConsumer(
+      final T data,
+      final V vector,
+      final Consumer<V> consumerIfNullable,
+      final BiConsumer<T, V> defaultConsumer) {
     if (isNull(data)) {
       consumerIfNullable.accept(vector);
       return;
@@ -377,33 +401,41 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     defaultConsumer.accept(data, vector);
   }
 
-  private static VectorSchemaRoot getSchemasRoot(final ResultSet data, final BufferAllocator allocator)
-      throws SQLException {
+  private static VectorSchemaRoot getSchemasRoot(
+      final ResultSet data, final BufferAllocator allocator) throws SQLException {
     final VarCharVector catalogs = new VarCharVector("catalog_name", allocator);
     final VarCharVector schemas =
-        new VarCharVector("db_schema_name", FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
+        new VarCharVector(
+            "db_schema_name", FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
     final List<FieldVector> vectors = ImmutableList.of(catalogs, schemas);
     vectors.forEach(FieldVector::allocateNew);
-    final Map<FieldVector, String> vectorToColumnName = ImmutableMap.of(
-        catalogs, "TABLE_CATALOG",
-        schemas, "TABLE_SCHEM");
+    final Map<FieldVector, String> vectorToColumnName =
+        ImmutableMap.of(
+            catalogs, "TABLE_CATALOG",
+            schemas, "TABLE_SCHEM");
     saveToVectors(vectorToColumnName, data);
-    final int rows = vectors.stream().map(FieldVector::getValueCount).findAny().orElseThrow(IllegalStateException::new);
+    final int rows =
+        vectors.stream()
+            .map(FieldVector::getValueCount)
+            .findAny()
+            .orElseThrow(IllegalStateException::new);
     vectors.forEach(vector -> vector.setValueCount(rows));
     return new VectorSchemaRoot(vectors);
   }
 
-  private static <T extends FieldVector> int saveToVectors(final Map<T, String> vectorToColumnName,
-                                                           final ResultSet data, boolean emptyToNull)
+  private static <T extends FieldVector> int saveToVectors(
+      final Map<T, String> vectorToColumnName, final ResultSet data, boolean emptyToNull)
       throws SQLException {
     Predicate<ResultSet> alwaysTrue = (resultSet) -> true;
     return saveToVectors(vectorToColumnName, data, emptyToNull, alwaysTrue);
   }
 
   @SuppressWarnings("StringSplitter")
-  private static <T extends FieldVector> int saveToVectors(final Map<T, String> vectorToColumnName,
-                                                           final ResultSet data, boolean emptyToNull,
-                                                           Predicate<ResultSet> resultSetPredicate)
+  private static <T extends FieldVector> int saveToVectors(
+      final Map<T, String> vectorToColumnName,
+      final ResultSet data,
+      boolean emptyToNull,
+      Predicate<ResultSet> resultSetPredicate)
       throws SQLException {
     Objects.requireNonNull(vectorToColumnName, "vectorToColumnName cannot be null.");
     Objects.requireNonNull(data, "data cannot be null.");
@@ -419,7 +451,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
         final String columnName = vectorToColumn.getValue();
         if (vector instanceof VarCharVector) {
           String thisData = data.getString(columnName);
-          saveToVector(emptyToNull ? emptyToNull(thisData) : thisData, (VarCharVector) vector, rows);
+          saveToVector(
+              emptyToNull ? emptyToNull(thisData) : thisData, (VarCharVector) vector, rows);
         } else if (vector instanceof IntVector) {
           final int intValue = data.getInt(columnName);
           saveToVector(data.wasNull() ? null : intValue, (IntVector) vector, rows);
@@ -444,21 +477,25 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
             String[] split = createParamsValues.split(",");
 
             range(0, split.length)
-                .forEach(i -> {
-                  byte[] bytes = split[i].getBytes(StandardCharsets.UTF_8);
-                  Preconditions.checkState(bytes.length < 1024,
-                      "The amount of bytes is greater than what the ArrowBuf supports");
-                  buf.setBytes(0, bytes);
-                  writer.varChar().writeVarChar(0, bytes.length, buf);
-                });
+                .forEach(
+                    i -> {
+                      byte[] bytes = split[i].getBytes(StandardCharsets.UTF_8);
+                      Preconditions.checkState(
+                          bytes.length < 1024,
+                          "The amount of bytes is greater than what the ArrowBuf supports");
+                      buf.setBytes(0, bytes);
+                      writer.varChar().writeVarChar(0, bytes.length, buf);
+                    });
           }
           buf.close();
           writer.endList();
         } else {
-          throw CallStatus.INVALID_ARGUMENT.withDescription("Provided vector not supported").toRuntimeException();
+          throw CallStatus.INVALID_ARGUMENT
+              .withDescription("Provided vector not supported")
+              .toRuntimeException();
         }
       }
-      rows ++;
+      rows++;
     }
     for (final Entry<T, String> vectorToColumn : entrySet) {
       vectorToColumn.getKey().setValueCount(rows);
@@ -467,35 +504,38 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     return rows;
   }
 
-  private static <T extends FieldVector> void saveToVectors(final Map<T, String> vectorToColumnName,
-                                                            final ResultSet data)
-      throws SQLException {
+  private static <T extends FieldVector> void saveToVectors(
+      final Map<T, String> vectorToColumnName, final ResultSet data) throws SQLException {
     saveToVectors(vectorToColumnName, data, false);
   }
 
-  private static VectorSchemaRoot getTableTypesRoot(final ResultSet data, final BufferAllocator allocator)
-      throws SQLException {
+  private static VectorSchemaRoot getTableTypesRoot(
+      final ResultSet data, final BufferAllocator allocator) throws SQLException {
     return getRoot(data, allocator, "table_type", "TABLE_TYPE");
   }
 
-  private static VectorSchemaRoot getCatalogsRoot(final ResultSet data, final BufferAllocator allocator)
-      throws SQLException {
+  private static VectorSchemaRoot getCatalogsRoot(
+      final ResultSet data, final BufferAllocator allocator) throws SQLException {
     return getRoot(data, allocator, "catalog_name", "TABLE_CATALOG");
   }
 
-  private static VectorSchemaRoot getRoot(final ResultSet data, final BufferAllocator allocator,
-                                          final String fieldVectorName, final String columnName)
+  private static VectorSchemaRoot getRoot(
+      final ResultSet data,
+      final BufferAllocator allocator,
+      final String fieldVectorName,
+      final String columnName)
       throws SQLException {
     final VarCharVector dataVector =
-        new VarCharVector(fieldVectorName, FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
+        new VarCharVector(
+            fieldVectorName, FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
     saveToVectors(ImmutableMap.of(dataVector, columnName), data);
     final int rows = dataVector.getValueCount();
     dataVector.setValueCount(rows);
     return new VectorSchemaRoot(singletonList(dataVector));
   }
 
-  private static VectorSchemaRoot getTypeInfoRoot(CommandGetXdbcTypeInfo request, ResultSet typeInfo,
-                                                  final BufferAllocator allocator)
+  private static VectorSchemaRoot getTypeInfoRoot(
+      CommandGetXdbcTypeInfo request, ResultSet typeInfo, final BufferAllocator allocator)
       throws SQLException {
     Preconditions.checkNotNull(allocator, "BufferAllocator cannot be null.");
 
@@ -523,13 +563,14 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
 
     Predicate<ResultSet> predicate;
     if (request.hasDataType()) {
-      predicate = (resultSet) -> {
-        try {
-          return resultSet.getInt("DATA_TYPE") == request.getDataType();
-        } catch (SQLException e) {
-          throw new RuntimeException(e);
-        }
-      };
+      predicate =
+          (resultSet) -> {
+            try {
+              return resultSet.getInt("DATA_TYPE") == request.getDataType();
+            } catch (SQLException e) {
+              throw new RuntimeException(e);
+            }
+          };
     } else {
       predicate = resultSet -> true;
     }
@@ -540,13 +581,14 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     return root;
   }
 
-  private static VectorSchemaRoot getTablesRoot(final DatabaseMetaData databaseMetaData,
-                                                final BufferAllocator allocator,
-                                                final boolean includeSchema,
-                                                final String catalog,
-                                                final String schemaFilterPattern,
-                                                final String tableFilterPattern,
-                                                final String... tableTypes)
+  private static VectorSchemaRoot getTablesRoot(
+      final DatabaseMetaData databaseMetaData,
+      final BufferAllocator allocator,
+      final boolean includeSchema,
+      final String catalog,
+      final String schemaFilterPattern,
+      final String tableFilterPattern,
+      final String... tableTypes)
       throws SQLException, IOException {
     /*
      * TODO Fix DerbyDB inconsistency if possible.
@@ -562,9 +604,11 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     final VarCharVector catalogNameVector = new VarCharVector("catalog_name", allocator);
     final VarCharVector schemaNameVector = new VarCharVector("db_schema_name", allocator);
     final VarCharVector tableNameVector =
-        new VarCharVector("table_name", FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
+        new VarCharVector(
+            "table_name", FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
     final VarCharVector tableTypeVector =
-        new VarCharVector("table_type", FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
+        new VarCharVector(
+            "table_type", FieldType.notNullable(MinorType.VARCHAR.getType()), allocator);
 
     final List<FieldVector> vectors = new ArrayList<>(4);
     vectors.add(catalogNameVector);
@@ -574,30 +618,35 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
 
     vectors.forEach(FieldVector::allocateNew);
 
-    final Map<FieldVector, String> vectorToColumnName = ImmutableMap.of(
-        catalogNameVector, "TABLE_CAT",
-        schemaNameVector, "TABLE_SCHEM",
-        tableNameVector, "TABLE_NAME",
-        tableTypeVector, "TABLE_TYPE");
+    final Map<FieldVector, String> vectorToColumnName =
+        ImmutableMap.of(
+            catalogNameVector, "TABLE_CAT",
+            schemaNameVector, "TABLE_SCHEM",
+            tableNameVector, "TABLE_NAME",
+            tableTypeVector, "TABLE_TYPE");
 
     try (final ResultSet data =
-             Objects.requireNonNull(
-                     databaseMetaData,
-                     format("%s cannot be null.", databaseMetaData.getClass().getName()))
-                 .getTables(catalog, schemaFilterPattern, tableFilterPattern, tableTypes)) {
+        Objects.requireNonNull(
+                databaseMetaData,
+                format("%s cannot be null.", databaseMetaData.getClass().getName()))
+            .getTables(catalog, schemaFilterPattern, tableFilterPattern, tableTypes)) {
 
       saveToVectors(vectorToColumnName, data, true);
       final int rows =
-          vectors.stream().map(FieldVector::getValueCount).findAny().orElseThrow(IllegalStateException::new);
+          vectors.stream()
+              .map(FieldVector::getValueCount)
+              .findAny()
+              .orElseThrow(IllegalStateException::new);
       vectors.forEach(vector -> vector.setValueCount(rows));
 
       if (includeSchema) {
         final VarBinaryVector tableSchemaVector =
-            new VarBinaryVector("table_schema", FieldType.notNullable(MinorType.VARBINARY.getType()), allocator);
+            new VarBinaryVector(
+                "table_schema", FieldType.notNullable(MinorType.VARBINARY.getType()), allocator);
         tableSchemaVector.allocateNew(rows);
 
         try (final ResultSet columnsData =
-                 databaseMetaData.getColumns(catalog, schemaFilterPattern, tableFilterPattern, null)) {
+            databaseMetaData.getColumns(catalog, schemaFilterPattern, tableFilterPattern, null)) {
           final Map<String, List<Field>> tableToFields = new HashMap<>();
 
           while (columnsData.next()) {
@@ -607,23 +656,26 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
             final String typeName = columnsData.getString("TYPE_NAME");
             final String fieldName = columnsData.getString("COLUMN_NAME");
             final int dataType = columnsData.getInt("DATA_TYPE");
-            final boolean isNullable = columnsData.getInt("NULLABLE") != DatabaseMetaData.columnNoNulls;
+            final boolean isNullable =
+                columnsData.getInt("NULLABLE") != DatabaseMetaData.columnNoNulls;
             final int precision = columnsData.getInt("COLUMN_SIZE");
             final int scale = columnsData.getInt("DECIMAL_DIGITS");
             boolean isAutoIncrement =
                 Objects.equals(columnsData.getString("IS_AUTOINCREMENT"), "YES");
 
-            final List<Field> fields = tableToFields.computeIfAbsent(tableName, tableName_ -> new ArrayList<>());
+            final List<Field> fields =
+                tableToFields.computeIfAbsent(tableName, tableName_ -> new ArrayList<>());
 
-            final FlightSqlColumnMetadata columnMetadata = new FlightSqlColumnMetadata.Builder()
-                .catalogName(catalogName)
-                .schemaName(schemaName)
-                .tableName(tableName)
-                .typeName(typeName)
-                .precision(precision)
-                .scale(scale)
-                .isAutoIncrement(isAutoIncrement)
-                .build();
+            final FlightSqlColumnMetadata columnMetadata =
+                new FlightSqlColumnMetadata.Builder()
+                    .catalogName(catalogName)
+                    .schemaName(schemaName)
+                    .tableName(tableName)
+                    .typeName(typeName)
+                    .precision(precision)
+                    .scale(scale)
+                    .isAutoIncrement(isAutoIncrement)
+                    .build();
 
             final Field field =
                 new Field(
@@ -641,8 +693,7 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
             final String tableName = tableNameVector.getObject(index).toString();
             final Schema schema = new Schema(tableToFields.get(tableName));
             saveToVector(
-                copyFrom(serializeMetadata(schema)).toByteArray(),
-                tableSchemaVector, index);
+                copyFrom(serializeMetadata(schema)).toByteArray(), tableSchemaVector, index);
           }
         }
 
@@ -666,15 +717,19 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public void getStreamPreparedStatement(final CommandPreparedStatementQuery command, final CallContext context,
-                                         final ServerStreamListener listener) {
+  public void getStreamPreparedStatement(
+      final CommandPreparedStatementQuery command,
+      final CallContext context,
+      final ServerStreamListener listener) {
     final ByteString handle = command.getPreparedStatementHandle();
-    StatementContext<PreparedStatement> statementContext = preparedStatementLoadingCache.getIfPresent(handle);
+    StatementContext<PreparedStatement> statementContext =
+        preparedStatementLoadingCache.getIfPresent(handle);
     Objects.requireNonNull(statementContext);
     final PreparedStatement statement = statementContext.getStatement();
     try (final ResultSet resultSet = statement.executeQuery()) {
       final Schema schema = jdbcToArrowSchema(resultSet.getMetaData(), DEFAULT_CALENDAR);
-      try (final VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, rootAllocator)) {
+      try (final VectorSchemaRoot vectorSchemaRoot =
+          VectorSchemaRoot.create(schema, rootAllocator)) {
         final VectorLoader loader = new VectorLoader(vectorSchemaRoot);
         listener.start(vectorSchemaRoot);
 
@@ -694,60 +749,68 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
       }
     } catch (final SQLException | IOException e) {
       LOGGER.error(format("Failed to getStreamPreparedStatement: <%s>.", e.getMessage()), e);
-      listener.error(CallStatus.INTERNAL.withDescription("Failed to prepare statement: " + e).toRuntimeException());
+      listener.error(
+          CallStatus.INTERNAL
+              .withDescription("Failed to prepare statement: " + e)
+              .toRuntimeException());
     } finally {
       listener.completed();
     }
   }
 
   @Override
-  public void closePreparedStatement(final ActionClosePreparedStatementRequest request, final CallContext context,
-                                     final StreamListener<Result> listener) {
+  public void closePreparedStatement(
+      final ActionClosePreparedStatementRequest request,
+      final CallContext context,
+      final StreamListener<Result> listener) {
     // Running on another thread
-    Future<?> unused = executorService.submit(() -> {
-      try {
-        preparedStatementLoadingCache.invalidate(request.getPreparedStatementHandle());
-      } catch (final Exception e) {
-        listener.onError(e);
-        return;
-      }
-      listener.onCompleted();
-    });
+    Future<?> unused =
+        executorService.submit(
+            () -> {
+              try {
+                preparedStatementLoadingCache.invalidate(request.getPreparedStatementHandle());
+              } catch (final Exception e) {
+                listener.onError(e);
+                return;
+              }
+              listener.onCompleted();
+            });
   }
 
   @Override
-  public FlightInfo getFlightInfoStatement(final CommandStatementQuery request, final CallContext context,
-                                           final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoStatement(
+      final CommandStatementQuery request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     ByteString handle = copyFrom(randomUUID().toString().getBytes(StandardCharsets.UTF_8));
 
     try {
       // Ownership of the connection will be passed to the context. Do NOT close!
       final Connection connection = dataSource.getConnection();
-      final Statement statement = connection.createStatement(
-          ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+      final Statement statement =
+          connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
       final String query = request.getQuery();
       final StatementContext<Statement> statementContext = new StatementContext<>(statement, query);
 
       statementLoadingCache.put(handle, statementContext);
       final ResultSet resultSet = statement.executeQuery(query);
 
-      TicketStatementQuery ticket = TicketStatementQuery.newBuilder()
-          .setStatementHandle(handle)
-          .build();
-      return getFlightInfoForSchema(ticket, descriptor,
-          jdbcToArrowSchema(resultSet.getMetaData(), DEFAULT_CALENDAR));
+      TicketStatementQuery ticket =
+          TicketStatementQuery.newBuilder().setStatementHandle(handle).build();
+      return getFlightInfoForSchema(
+          ticket, descriptor, jdbcToArrowSchema(resultSet.getMetaData(), DEFAULT_CALENDAR));
     } catch (final SQLException e) {
       LOGGER.error(
-          format("There was a problem executing the prepared statement: <%s>.", e.getMessage()),
-          e);
+          format("There was a problem executing the prepared statement: <%s>.", e.getMessage()), e);
       throw CallStatus.INTERNAL.withCause(e).toRuntimeException();
     }
   }
 
   @Override
-  public FlightInfo getFlightInfoPreparedStatement(final CommandPreparedStatementQuery command,
-                                                   final CallContext context,
-                                                   final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPreparedStatement(
+      final CommandPreparedStatementQuery command,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     final ByteString preparedStatementHandle = command.getPreparedStatementHandle();
     StatementContext<PreparedStatement> statementContext =
         preparedStatementLoadingCache.getIfPresent(preparedStatementHandle);
@@ -756,19 +819,20 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
       PreparedStatement statement = statementContext.getStatement();
 
       ResultSetMetaData metaData = statement.getMetaData();
-      return getFlightInfoForSchema(command, descriptor,
-          jdbcToArrowSchema(metaData, DEFAULT_CALENDAR));
+      return getFlightInfoForSchema(
+          command, descriptor, jdbcToArrowSchema(metaData, DEFAULT_CALENDAR));
     } catch (final SQLException e) {
       LOGGER.error(
-          format("There was a problem executing the prepared statement: <%s>.", e.getMessage()),
-          e);
+          format("There was a problem executing the prepared statement: <%s>.", e.getMessage()), e);
       throw CallStatus.INTERNAL.withCause(e).toRuntimeException();
     }
   }
 
   @Override
-  public SchemaResult getSchemaStatement(final CommandStatementQuery command, final CallContext context,
-                                         final FlightDescriptor descriptor) {
+  public SchemaResult getSchemaStatement(
+      final CommandStatementQuery command,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     throw CallStatus.UNIMPLEMENTED.toRuntimeException();
   }
 
@@ -784,52 +848,68 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public void listFlights(CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
+  public void listFlights(
+      CallContext context, Criteria criteria, StreamListener<FlightInfo> listener) {
     // TODO - build example implementation
     throw CallStatus.UNIMPLEMENTED.toRuntimeException();
   }
 
   @Override
-  public void createPreparedStatement(final ActionCreatePreparedStatementRequest request, final CallContext context,
-                                      final StreamListener<Result> listener) {
+  public void createPreparedStatement(
+      final ActionCreatePreparedStatementRequest request,
+      final CallContext context,
+      final StreamListener<Result> listener) {
     // Running on another thread
-    Future<?> unused = executorService.submit(() -> {
-      try {
-        final ByteString preparedStatementHandle = copyFrom(request.getQuery().getBytes(StandardCharsets.UTF_8));
-        // Ownership of the connection will be passed to the context. Do NOT close!
-        final Connection connection = dataSource.getConnection();
-        final PreparedStatement preparedStatement = connection.prepareStatement(request.getQuery(),
-            ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-        final StatementContext<PreparedStatement> preparedStatementContext =
-            new StatementContext<>(preparedStatement, request.getQuery());
+    Future<?> unused =
+        executorService.submit(
+            () -> {
+              try {
+                final ByteString preparedStatementHandle =
+                    copyFrom(request.getQuery().getBytes(StandardCharsets.UTF_8));
+                // Ownership of the connection will be passed to the context. Do NOT close!
+                final Connection connection = dataSource.getConnection();
+                final PreparedStatement preparedStatement =
+                    connection.prepareStatement(
+                        request.getQuery(),
+                        ResultSet.TYPE_SCROLL_INSENSITIVE,
+                        ResultSet.CONCUR_READ_ONLY);
+                final StatementContext<PreparedStatement> preparedStatementContext =
+                    new StatementContext<>(preparedStatement, request.getQuery());
 
-        preparedStatementLoadingCache.put(preparedStatementHandle, preparedStatementContext);
+                preparedStatementLoadingCache.put(
+                    preparedStatementHandle, preparedStatementContext);
 
-        final Schema parameterSchema =
-            jdbcToArrowSchema(preparedStatement.getParameterMetaData(), DEFAULT_CALENDAR);
+                final Schema parameterSchema =
+                    jdbcToArrowSchema(preparedStatement.getParameterMetaData(), DEFAULT_CALENDAR);
 
-        final ResultSetMetaData metaData = preparedStatement.getMetaData();
-        final ByteString bytes = isNull(metaData) ?
-            ByteString.EMPTY :
-            ByteString.copyFrom(
-                serializeMetadata(jdbcToArrowSchema(metaData, DEFAULT_CALENDAR)));
-        final ActionCreatePreparedStatementResult result = ActionCreatePreparedStatementResult.newBuilder()
-            .setDatasetSchema(bytes)
-            .setParameterSchema(copyFrom(serializeMetadata(parameterSchema)))
-            .setPreparedStatementHandle(preparedStatementHandle)
-            .build();
-        listener.onNext(new Result(pack(result).toByteArray()));
-      } catch (final SQLException e) {
-        listener.onError(CallStatus.INTERNAL
-            .withDescription("Failed to create prepared statement: " + e)
-            .toRuntimeException());
-        return;
-      } catch (final Throwable t) {
-        listener.onError(CallStatus.INTERNAL.withDescription("Unknown error: " + t).toRuntimeException());
-        return;
-      }
-      listener.onCompleted();
-    });
+                final ResultSetMetaData metaData = preparedStatement.getMetaData();
+                final ByteString bytes =
+                    isNull(metaData)
+                        ? ByteString.EMPTY
+                        : ByteString.copyFrom(
+                            serializeMetadata(jdbcToArrowSchema(metaData, DEFAULT_CALENDAR)));
+                final ActionCreatePreparedStatementResult result =
+                    ActionCreatePreparedStatementResult.newBuilder()
+                        .setDatasetSchema(bytes)
+                        .setParameterSchema(copyFrom(serializeMetadata(parameterSchema)))
+                        .setPreparedStatementHandle(preparedStatementHandle)
+                        .build();
+                listener.onNext(new Result(pack(result).toByteArray()));
+              } catch (final SQLException e) {
+                listener.onError(
+                    CallStatus.INTERNAL
+                        .withDescription("Failed to create prepared statement: " + e)
+                        .toRuntimeException());
+                return;
+              } catch (final Throwable t) {
+                listener.onError(
+                    CallStatus.INTERNAL
+                        .withDescription("Unknown error: " + t)
+                        .toRuntimeException());
+                return;
+              }
+              listener.onCompleted();
+            });
   }
 
   @Override
@@ -839,14 +919,16 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public Runnable acceptPutStatement(CommandStatementUpdate command,
-                                     CallContext context, FlightStream flightStream,
-                                     StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutStatement(
+      CommandStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     final String query = command.getQuery();
 
     return () -> {
       try (final Connection connection = dataSource.getConnection();
-           final Statement statement = connection.createStatement()) {
+          final Statement statement = connection.createStatement()) {
         final int result = statement.executeUpdate(query);
 
         final DoPutUpdateResult build =
@@ -858,28 +940,34 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
           ackStream.onCompleted();
         }
       } catch (SQLSyntaxErrorException e) {
-        ackStream.onError(CallStatus.INVALID_ARGUMENT
-            .withDescription("Failed to execute statement (invalid syntax): " + e)
-            .toRuntimeException());
+        ackStream.onError(
+            CallStatus.INVALID_ARGUMENT
+                .withDescription("Failed to execute statement (invalid syntax): " + e)
+                .toRuntimeException());
       } catch (SQLException e) {
-        ackStream.onError(CallStatus.INTERNAL
-            .withDescription("Failed to execute statement: " + e)
-            .toRuntimeException());
+        ackStream.onError(
+            CallStatus.INTERNAL
+                .withDescription("Failed to execute statement: " + e)
+                .toRuntimeException());
       }
     };
   }
 
   @Override
-  public Runnable acceptPutPreparedStatementUpdate(CommandPreparedStatementUpdate command, CallContext context,
-                                                   FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutPreparedStatementUpdate(
+      CommandPreparedStatementUpdate command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     final StatementContext<PreparedStatement> statement =
         preparedStatementLoadingCache.getIfPresent(command.getPreparedStatementHandle());
 
     return () -> {
       if (statement == null) {
-        ackStream.onError(CallStatus.NOT_FOUND
-            .withDescription("Prepared statement does not exist")
-            .toRuntimeException());
+        ackStream.onError(
+            CallStatus.NOT_FOUND
+                .withDescription("Prepared statement does not exist")
+                .toRuntimeException());
         return;
       }
       try {
@@ -895,7 +983,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
             preparedStatement.execute();
             recordCount = preparedStatement.getUpdateCount();
           } else {
-            final JdbcParameterBinder binder = JdbcParameterBinder.builder(preparedStatement, root).bindAll().build();
+            final JdbcParameterBinder binder =
+                JdbcParameterBinder.builder(preparedStatement, root).bindAll().build();
             while (binder.next()) {
               preparedStatement.addBatch();
             }
@@ -912,7 +1001,10 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
           }
         }
       } catch (SQLException e) {
-        ackStream.onError(CallStatus.INTERNAL.withDescription("Failed to execute update: " + e).toRuntimeException());
+        ackStream.onError(
+            CallStatus.INTERNAL
+                .withDescription("Failed to execute update: " + e)
+                .toRuntimeException());
         return;
       }
       ackStream.onCompleted();
@@ -920,8 +1012,11 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public Runnable acceptPutPreparedStatementQuery(CommandPreparedStatementQuery command, CallContext context,
-                                                  FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutPreparedStatementQuery(
+      CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
     final StatementContext<PreparedStatement> statementContext =
         preparedStatementLoadingCache.getIfPresent(command.getPreparedStatementHandle());
 
@@ -932,17 +1027,19 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
       try {
         while (flightStream.next()) {
           final VectorSchemaRoot root = flightStream.getRoot();
-          final JdbcParameterBinder binder = JdbcParameterBinder.builder(preparedStatement, root).bindAll().build();
+          final JdbcParameterBinder binder =
+              JdbcParameterBinder.builder(preparedStatement, root).bindAll().build();
           while (binder.next()) {
             // Do not execute() - will be done in a getStream call
           }
         }
 
       } catch (SQLException e) {
-        ackStream.onError(CallStatus.INTERNAL
-            .withDescription("Failed to bind parameters: " + e.getMessage())
-            .withCause(e)
-            .toRuntimeException());
+        ackStream.onError(
+            CallStatus.INTERNAL
+                .withDescription("Failed to bind parameters: " + e.getMessage())
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
 
@@ -951,29 +1048,34 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoSqlInfo(final CommandGetSqlInfo request, final CallContext context,
-                                         final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSqlInfo(
+      final CommandGetSqlInfo request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_SQL_INFO_SCHEMA);
   }
 
   @Override
-  public void getStreamSqlInfo(final CommandGetSqlInfo command, final CallContext context,
-                               final ServerStreamListener listener) {
+  public void getStreamSqlInfo(
+      final CommandGetSqlInfo command,
+      final CallContext context,
+      final ServerStreamListener listener) {
     this.sqlInfoBuilder.send(command.getInfoList(), listener);
   }
 
   @Override
-  public FlightInfo getFlightInfoTypeInfo(CommandGetXdbcTypeInfo request, CallContext context,
-                                          FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTypeInfo(
+      CommandGetXdbcTypeInfo request, CallContext context, FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_TYPE_INFO_SCHEMA);
   }
 
   @Override
-  public void getStreamTypeInfo(CommandGetXdbcTypeInfo request, CallContext context,
-                                ServerStreamListener listener) {
+  public void getStreamTypeInfo(
+      CommandGetXdbcTypeInfo request, CallContext context, ServerStreamListener listener) {
     try (final Connection connection = dataSource.getConnection();
-         final ResultSet typeInfo = connection.getMetaData().getTypeInfo();
-         final VectorSchemaRoot vectorSchemaRoot = getTypeInfoRoot(request, typeInfo, rootAllocator)) {
+        final ResultSet typeInfo = connection.getMetaData().getTypeInfo();
+        final VectorSchemaRoot vectorSchemaRoot =
+            getTypeInfoRoot(request, typeInfo, rootAllocator)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (SQLException e) {
@@ -985,16 +1087,18 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoCatalogs(final CommandGetCatalogs request, final CallContext context,
-                                          final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCatalogs(
+      final CommandGetCatalogs request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_CATALOGS_SCHEMA);
   }
 
   @Override
   public void getStreamCatalogs(final CallContext context, final ServerStreamListener listener) {
     try (final Connection connection = dataSource.getConnection();
-         final ResultSet catalogs = connection.getMetaData().getCatalogs();
-         final VectorSchemaRoot vectorSchemaRoot = getCatalogsRoot(catalogs, rootAllocator)) {
+        final ResultSet catalogs = connection.getMetaData().getCatalogs();
+        final VectorSchemaRoot vectorSchemaRoot = getCatalogsRoot(catalogs, rootAllocator)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (SQLException e) {
@@ -1006,19 +1110,25 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoSchemas(final CommandGetDbSchemas request, final CallContext context,
-                                         final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoSchemas(
+      final CommandGetDbSchemas request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_SCHEMAS_SCHEMA);
   }
 
   @Override
-  public void getStreamSchemas(final CommandGetDbSchemas command, final CallContext context,
-                               final ServerStreamListener listener) {
+  public void getStreamSchemas(
+      final CommandGetDbSchemas command,
+      final CallContext context,
+      final ServerStreamListener listener) {
     final String catalog = command.hasCatalog() ? command.getCatalog() : null;
-    final String schemaFilterPattern = command.hasDbSchemaFilterPattern() ? command.getDbSchemaFilterPattern() : null;
+    final String schemaFilterPattern =
+        command.hasDbSchemaFilterPattern() ? command.getDbSchemaFilterPattern() : null;
     try (final Connection connection = dataSource.getConnection();
-         final ResultSet schemas = connection.getMetaData().getSchemas(catalog, schemaFilterPattern);
-         final VectorSchemaRoot vectorSchemaRoot = getSchemasRoot(schemas, rootAllocator)) {
+        final ResultSet schemas =
+            connection.getMetaData().getSchemas(catalog, schemaFilterPattern);
+        final VectorSchemaRoot vectorSchemaRoot = getSchemasRoot(schemas, rootAllocator)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (SQLException e) {
@@ -1030,8 +1140,10 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoTables(final CommandGetTables request, final CallContext context,
-                                        final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTables(
+      final CommandGetTables request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     Schema schemaToUse = Schemas.GET_TABLES_SCHEMA;
     if (!request.getIncludeSchema()) {
       schemaToUse = Schemas.GET_TABLES_SCHEMA_NO_SCHEMA;
@@ -1040,8 +1152,10 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public void getStreamTables(final CommandGetTables command, final CallContext context,
-                              final ServerStreamListener listener) {
+  public void getStreamTables(
+      final CommandGetTables command,
+      final CallContext context,
+      final ServerStreamListener listener) {
     final String catalog = command.hasCatalog() ? command.getCatalog() : null;
     final String schemaFilterPattern =
         command.hasDbSchemaFilterPattern() ? command.getDbSchemaFilterPattern() : null;
@@ -1054,11 +1168,15 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
         protocolSize == 0 ? null : protocolStringList.toArray(new String[protocolSize]);
 
     try (final Connection connection = DriverManager.getConnection(databaseUri);
-         final VectorSchemaRoot vectorSchemaRoot = getTablesRoot(
-             connection.getMetaData(),
-             rootAllocator,
-             command.getIncludeSchema(),
-             catalog, schemaFilterPattern, tableFilterPattern, tableTypes)) {
+        final VectorSchemaRoot vectorSchemaRoot =
+            getTablesRoot(
+                connection.getMetaData(),
+                rootAllocator,
+                command.getIncludeSchema(),
+                catalog,
+                schemaFilterPattern,
+                tableFilterPattern,
+                tableTypes)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (SQLException | IOException e) {
@@ -1070,16 +1188,18 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoTableTypes(final CommandGetTableTypes request, final CallContext context,
-                                            final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoTableTypes(
+      final CommandGetTableTypes request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_TABLE_TYPES_SCHEMA);
   }
 
   @Override
   public void getStreamTableTypes(final CallContext context, final ServerStreamListener listener) {
     try (final Connection connection = dataSource.getConnection();
-         final ResultSet tableTypes = connection.getMetaData().getTableTypes();
-         final VectorSchemaRoot vectorSchemaRoot = getTableTypesRoot(tableTypes, rootAllocator)) {
+        final ResultSet tableTypes = connection.getMetaData().getTableTypes();
+        final VectorSchemaRoot vectorSchemaRoot = getTableTypesRoot(tableTypes, rootAllocator)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (SQLException e) {
@@ -1091,14 +1211,18 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoPrimaryKeys(final CommandGetPrimaryKeys request, final CallContext context,
-                                             final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPrimaryKeys(
+      final CommandGetPrimaryKeys request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_PRIMARY_KEYS_SCHEMA);
   }
 
   @Override
-  public void getStreamPrimaryKeys(final CommandGetPrimaryKeys command, final CallContext context,
-                                   final ServerStreamListener listener) {
+  public void getStreamPrimaryKeys(
+      final CommandGetPrimaryKeys command,
+      final CallContext context,
+      final ServerStreamListener listener) {
 
     final String catalog = command.hasCatalog() ? command.getCatalog() : null;
     final String schema = command.hasDbSchema() ? command.getDbSchema() : null;
@@ -1117,7 +1241,11 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
       final List<FieldVector> vectors =
           new ArrayList<>(
               ImmutableList.of(
-                  catalogNameVector, schemaNameVector, tableNameVector, columnNameVector, keySequenceVector,
+                  catalogNameVector,
+                  schemaNameVector,
+                  tableNameVector,
+                  columnNameVector,
+                  keySequenceVector,
                   keyNameVector));
       vectors.forEach(FieldVector::allocateNew);
 
@@ -1146,21 +1274,25 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoExportedKeys(final CommandGetExportedKeys request, final CallContext context,
-                                              final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoExportedKeys(
+      final CommandGetExportedKeys request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_EXPORTED_KEYS_SCHEMA);
   }
 
   @Override
-  public void getStreamExportedKeys(final CommandGetExportedKeys command, final CallContext context,
-                                    final ServerStreamListener listener) {
+  public void getStreamExportedKeys(
+      final CommandGetExportedKeys command,
+      final CallContext context,
+      final ServerStreamListener listener) {
     String catalog = command.hasCatalog() ? command.getCatalog() : null;
     String schema = command.hasDbSchema() ? command.getDbSchema() : null;
     String table = command.getTable();
 
     try (Connection connection = DriverManager.getConnection(databaseUri);
-         ResultSet keys = connection.getMetaData().getExportedKeys(catalog, schema, table);
-         VectorSchemaRoot vectorSchemaRoot = createVectors(keys)) {
+        ResultSet keys = connection.getMetaData().getExportedKeys(catalog, schema, table);
+        VectorSchemaRoot vectorSchemaRoot = createVectors(keys)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (SQLException e) {
@@ -1171,21 +1303,25 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoImportedKeys(final CommandGetImportedKeys request, final CallContext context,
-                                              final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoImportedKeys(
+      final CommandGetImportedKeys request,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_IMPORTED_KEYS_SCHEMA);
   }
 
   @Override
-  public void getStreamImportedKeys(final CommandGetImportedKeys command, final CallContext context,
-                                    final ServerStreamListener listener) {
+  public void getStreamImportedKeys(
+      final CommandGetImportedKeys command,
+      final CallContext context,
+      final ServerStreamListener listener) {
     String catalog = command.hasCatalog() ? command.getCatalog() : null;
     String schema = command.hasDbSchema() ? command.getDbSchema() : null;
     String table = command.getTable();
 
     try (Connection connection = DriverManager.getConnection(databaseUri);
-         ResultSet keys = connection.getMetaData().getImportedKeys(catalog, schema, table);
-         VectorSchemaRoot vectorSchemaRoot = createVectors(keys)) {
+        ResultSet keys = connection.getMetaData().getImportedKeys(catalog, schema, table);
+        VectorSchemaRoot vectorSchemaRoot = createVectors(keys)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (final SQLException e) {
@@ -1196,14 +1332,14 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public FlightInfo getFlightInfoCrossReference(CommandGetCrossReference request, CallContext context,
-                                                FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoCrossReference(
+      CommandGetCrossReference request, CallContext context, FlightDescriptor descriptor) {
     return getFlightInfoForSchema(request, descriptor, Schemas.GET_CROSS_REFERENCE_SCHEMA);
   }
 
   @Override
-  public void getStreamCrossReference(CommandGetCrossReference command, CallContext context,
-                                      ServerStreamListener listener) {
+  public void getStreamCrossReference(
+      CommandGetCrossReference command, CallContext context, ServerStreamListener listener) {
     final String pkCatalog = command.hasPkCatalog() ? command.getPkCatalog() : null;
     final String pkSchema = command.hasPkDbSchema() ? command.getPkDbSchema() : null;
     final String fkCatalog = command.hasFkCatalog() ? command.getFkCatalog() : null;
@@ -1212,9 +1348,11 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     final String fkTable = command.getFkTable();
 
     try (Connection connection = DriverManager.getConnection(databaseUri);
-         ResultSet keys = connection.getMetaData()
-             .getCrossReference(pkCatalog, pkSchema, pkTable, fkCatalog, fkSchema, fkTable);
-         VectorSchemaRoot vectorSchemaRoot = createVectors(keys)) {
+        ResultSet keys =
+            connection
+                .getMetaData()
+                .getCrossReference(pkCatalog, pkSchema, pkTable, fkCatalog, fkSchema, fkTable);
+        VectorSchemaRoot vectorSchemaRoot = createVectors(keys)) {
       listener.start(vectorSchemaRoot);
       listener.putNext();
     } catch (final SQLException e) {
@@ -1254,10 +1392,21 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     vectorToColumnName.put(fkKeyNameVector, "FK_NAME");
     vectorToColumnName.put(pkKeyNameVector, "PK_NAME");
 
-    final VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.of(
-        pkCatalogNameVector, pkSchemaNameVector, pkTableNameVector, pkColumnNameVector, fkCatalogNameVector,
-        fkSchemaNameVector, fkTableNameVector, fkColumnNameVector, keySequenceVector, fkKeyNameVector,
-        pkKeyNameVector, updateRuleVector, deleteRuleVector);
+    final VectorSchemaRoot vectorSchemaRoot =
+        VectorSchemaRoot.of(
+            pkCatalogNameVector,
+            pkSchemaNameVector,
+            pkTableNameVector,
+            pkColumnNameVector,
+            fkCatalogNameVector,
+            fkSchemaNameVector,
+            fkTableNameVector,
+            fkColumnNameVector,
+            keySequenceVector,
+            fkKeyNameVector,
+            pkKeyNameVector,
+            updateRuleVector,
+            deleteRuleVector);
 
     vectorSchemaRoot.allocateNew();
     final int rowCount = saveToVectors(vectorToColumnName, keys, true);
@@ -1268,8 +1417,10 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
   }
 
   @Override
-  public void getStreamStatement(final TicketStatementQuery ticketStatementQuery, final CallContext context,
-                                 final ServerStreamListener listener) {
+  public void getStreamStatement(
+      final TicketStatementQuery ticketStatementQuery,
+      final CallContext context,
+      final ServerStreamListener listener) {
     final ByteString handle = ticketStatementQuery.getStatementHandle();
     final StatementContext<Statement> statementContext =
         Objects.requireNonNull(statementLoadingCache.getIfPresent(handle));
@@ -1298,8 +1449,8 @@ public class FlightSqlExample implements FlightSqlProducer, AutoCloseable {
     }
   }
 
-  protected <T extends Message> FlightInfo getFlightInfoForSchema(final T request, final FlightDescriptor descriptor,
-                                                                final Schema schema) {
+  protected <T extends Message> FlightInfo getFlightInfoForSchema(
+      final T request, final FlightDescriptor descriptor, final Schema schema) {
     final Ticket ticket = new Ticket(pack(request).toByteArray());
     // TODO Support multiple endpoints.
     final List<FlightEndpoint> endpoints = singletonList(new FlightEndpoint(ticket, location));

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlStatelessExample.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/FlightSqlStatelessExample.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.example;
 
 import static java.lang.String.format;
@@ -23,6 +22,7 @@ import static org.apache.arrow.adapter.jdbc.JdbcToArrowUtils.jdbcToArrowSchema;
 import static org.apache.arrow.flight.sql.impl.FlightSql.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import com.google.protobuf.ByteString;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -36,7 +36,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-
 import org.apache.arrow.adapter.jdbc.ArrowVectorIterator;
 import org.apache.arrow.adapter.jdbc.JdbcParameterBinder;
 import org.apache.arrow.flight.CallStatus;
@@ -58,55 +57,58 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel;
 import org.slf4j.Logger;
 
-import com.google.protobuf.ByteString;
-
 /**
- * Example {@link FlightSqlProducer} implementation showing an Apache Derby backed Flight SQL server that generally
- * supports all current features of Flight SQL.
+ * Example {@link FlightSqlProducer} implementation showing an Apache Derby backed Flight SQL server
+ * that generally supports all current features of Flight SQL.
  */
 public class FlightSqlStatelessExample extends FlightSqlExample {
   private static final Logger LOGGER = getLogger(FlightSqlStatelessExample.class);
   public static final String DB_NAME = "derbyStatelessDB";
-
 
   public FlightSqlStatelessExample(final Location location, final String dbName) {
     super(location, dbName);
   }
 
   @Override
-  public Runnable acceptPutPreparedStatementQuery(CommandPreparedStatementQuery command, CallContext context,
-                                                  FlightStream flightStream, StreamListener<PutResult> ackStream) {
+  public Runnable acceptPutPreparedStatementQuery(
+      CommandPreparedStatementQuery command,
+      CallContext context,
+      FlightStream flightStream,
+      StreamListener<PutResult> ackStream) {
 
     return () -> {
       final String query = new String(command.getPreparedStatementHandle().toStringUtf8());
       try (Connection connection = dataSource.getConnection();
-           PreparedStatement preparedStatement = createPreparedStatement(connection, query)) {
+          PreparedStatement preparedStatement = createPreparedStatement(connection, query)) {
         while (flightStream.next()) {
           final VectorSchemaRoot root = flightStream.getRoot();
-          final JdbcParameterBinder binder = JdbcParameterBinder.builder(preparedStatement, root).bindAll().build();
+          final JdbcParameterBinder binder =
+              JdbcParameterBinder.builder(preparedStatement, root).bindAll().build();
           while (binder.next()) {
             // Do not execute() - will be done in a getStream call
           }
 
           final ByteArrayOutputStream parametersStream = new ByteArrayOutputStream();
-          try (ArrowFileWriter writer = new ArrowFileWriter(root, null, Channels.newChannel(parametersStream))
-          ) {
+          try (ArrowFileWriter writer =
+              new ArrowFileWriter(root, null, Channels.newChannel(parametersStream))) {
             writer.start();
             writer.writeBatch();
           }
 
           if (parametersStream.size() > 0) {
             final DoPutPreparedStatementResultPOJO doPutPreparedStatementResultPOJO =
-                    new DoPutPreparedStatementResultPOJO(query, parametersStream.toByteArray());
+                new DoPutPreparedStatementResultPOJO(query, parametersStream.toByteArray());
 
-            final byte[] doPutPreparedStatementResultPOJOArr = serializePOJO(doPutPreparedStatementResultPOJO);
+            final byte[] doPutPreparedStatementResultPOJOArr =
+                serializePOJO(doPutPreparedStatementResultPOJO);
             final DoPutPreparedStatementResult doPutPreparedStatementResult =
-                    DoPutPreparedStatementResult.newBuilder()
-                            .setPreparedStatementHandle(
-                                    ByteString.copyFrom(ByteBuffer.wrap(doPutPreparedStatementResultPOJOArr)))
-                            .build();
+                DoPutPreparedStatementResult.newBuilder()
+                    .setPreparedStatementHandle(
+                        ByteString.copyFrom(ByteBuffer.wrap(doPutPreparedStatementResultPOJOArr)))
+                    .build();
 
-            try (final ArrowBuf buffer = rootAllocator.buffer(doPutPreparedStatementResult.getSerializedSize())) {
+            try (final ArrowBuf buffer =
+                rootAllocator.buffer(doPutPreparedStatementResult.getSerializedSize())) {
               buffer.writeBytes(doPutPreparedStatementResult.toByteArray());
               ackStream.onNext(PutResult.metadata(buffer));
             }
@@ -114,10 +116,11 @@ public class FlightSqlStatelessExample extends FlightSqlExample {
         }
 
       } catch (SQLException | IOException e) {
-        ackStream.onError(CallStatus.INTERNAL
-            .withDescription("Failed to bind parameters: " + e.getMessage())
-            .withCause(e)
-            .toRuntimeException());
+        ackStream.onError(
+            CallStatus.INTERNAL
+                .withDescription("Failed to bind parameters: " + e.getMessage())
+                .withCause(e)
+                .toRuntimeException());
         return;
       }
 
@@ -126,27 +129,32 @@ public class FlightSqlStatelessExample extends FlightSqlExample {
   }
 
   @Override
-  public void getStreamPreparedStatement(final CommandPreparedStatementQuery command, final CallContext context,
-                                         final ServerStreamListener listener) {
+  public void getStreamPreparedStatement(
+      final CommandPreparedStatementQuery command,
+      final CallContext context,
+      final ServerStreamListener listener) {
     final byte[] handle = command.getPreparedStatementHandle().toByteArray();
     try {
       // Case where there are parameters
       try {
         final DoPutPreparedStatementResultPOJO doPutPreparedStatementResultPOJO =
-                deserializePOJO(handle);
+            deserializePOJO(handle);
         final String query = doPutPreparedStatementResultPOJO.getQuery();
 
         try (Connection connection = dataSource.getConnection();
-             PreparedStatement statement = createPreparedStatement(connection, query);
-             ArrowFileReader reader = new ArrowFileReader(new SeekableReadChannel(
-                new ByteArrayReadableSeekableByteChannel(
-                        doPutPreparedStatementResultPOJO.getParameters())), rootAllocator)) {
+            PreparedStatement statement = createPreparedStatement(connection, query);
+            ArrowFileReader reader =
+                new ArrowFileReader(
+                    new SeekableReadChannel(
+                        new ByteArrayReadableSeekableByteChannel(
+                            doPutPreparedStatementResultPOJO.getParameters())),
+                    rootAllocator)) {
 
           for (ArrowBlock arrowBlock : reader.getRecordBlocks()) {
             reader.loadRecordBatch(arrowBlock);
             VectorSchemaRoot vectorSchemaRootRecover = reader.getVectorSchemaRoot();
-            JdbcParameterBinder binder = JdbcParameterBinder.builder(statement, vectorSchemaRootRecover)
-                    .bindAll().build();
+            JdbcParameterBinder binder =
+                JdbcParameterBinder.builder(statement, vectorSchemaRootRecover).bindAll().build();
 
             while (binder.next()) {
               executeQuery(statement, listener);
@@ -157,23 +165,27 @@ public class FlightSqlStatelessExample extends FlightSqlExample {
         // Case where there are no parameters
         final String query = new String(command.getPreparedStatementHandle().toStringUtf8());
         try (Connection connection = dataSource.getConnection();
-             PreparedStatement preparedStatement = createPreparedStatement(connection, query)) {
+            PreparedStatement preparedStatement = createPreparedStatement(connection, query)) {
           executeQuery(preparedStatement, listener);
         }
       }
     } catch (final SQLException | IOException | ClassNotFoundException e) {
       LOGGER.error(format("Failed to getStreamPreparedStatement: <%s>.", e.getMessage()), e);
-      listener.error(CallStatus.INTERNAL.withDescription("Failed to prepare statement: " + e).toRuntimeException());
+      listener.error(
+          CallStatus.INTERNAL
+              .withDescription("Failed to prepare statement: " + e)
+              .toRuntimeException());
     } finally {
       listener.completed();
     }
   }
 
-  private void executeQuery(PreparedStatement statement,
-                            final ServerStreamListener listener) throws IOException, SQLException {
+  private void executeQuery(PreparedStatement statement, final ServerStreamListener listener)
+      throws IOException, SQLException {
     try (final ResultSet resultSet = statement.executeQuery()) {
       final Schema schema = jdbcToArrowSchema(resultSet.getMetaData(), DEFAULT_CALENDAR);
-      try (final VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(schema, rootAllocator)) {
+      try (final VectorSchemaRoot vectorSchemaRoot =
+          VectorSchemaRoot.create(schema, rootAllocator)) {
         final VectorLoader loader = new VectorLoader(vectorSchemaRoot);
         listener.start(vectorSchemaRoot);
 
@@ -194,9 +206,10 @@ public class FlightSqlStatelessExample extends FlightSqlExample {
   }
 
   @Override
-  public FlightInfo getFlightInfoPreparedStatement(final CommandPreparedStatementQuery command,
-                                                   final CallContext context,
-                                                   final FlightDescriptor descriptor) {
+  public FlightInfo getFlightInfoPreparedStatement(
+      final CommandPreparedStatementQuery command,
+      final CallContext context,
+      final FlightDescriptor descriptor) {
     final byte[] handle = command.getPreparedStatementHandle().toByteArray();
     try {
       String query;
@@ -206,33 +219,38 @@ public class FlightSqlStatelessExample extends FlightSqlExample {
         query = new String(command.getPreparedStatementHandle().toStringUtf8());
       }
       try (Connection connection = dataSource.getConnection();
-           PreparedStatement statement = createPreparedStatement(connection, query)) {
+          PreparedStatement statement = createPreparedStatement(connection, query)) {
         ResultSetMetaData metaData = statement.getMetaData();
-        return getFlightInfoForSchema(command, descriptor,
-                jdbcToArrowSchema(metaData, DEFAULT_CALENDAR));
+        return getFlightInfoForSchema(
+            command, descriptor, jdbcToArrowSchema(metaData, DEFAULT_CALENDAR));
       }
     } catch (final SQLException | IOException | ClassNotFoundException e) {
-      LOGGER.error(format("There was a problem executing the prepared statement: <%s>.", e.getMessage()), e);
+      LOGGER.error(
+          format("There was a problem executing the prepared statement: <%s>.", e.getMessage()), e);
       throw CallStatus.INTERNAL.withCause(e).toRuntimeException();
     }
   }
 
-  private DoPutPreparedStatementResultPOJO deserializePOJO(byte[] handle) throws IOException, ClassNotFoundException {
+  private DoPutPreparedStatementResultPOJO deserializePOJO(byte[] handle)
+      throws IOException, ClassNotFoundException {
     try (ByteArrayInputStream bis = new ByteArrayInputStream(handle);
-         ObjectInputStream ois = new ObjectInputStream(bis)) {
+        ObjectInputStream ois = new ObjectInputStream(bis)) {
       return (DoPutPreparedStatementResultPOJO) ois.readObject();
     }
   }
 
-  private byte[] serializePOJO(DoPutPreparedStatementResultPOJO doPutPreparedStatementResultPOJO) throws IOException {
+  private byte[] serializePOJO(DoPutPreparedStatementResultPOJO doPutPreparedStatementResultPOJO)
+      throws IOException {
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-         ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
       oos.writeObject(doPutPreparedStatementResultPOJO);
       return bos.toByteArray();
     }
   }
 
-  private PreparedStatement createPreparedStatement(Connection connection, String query) throws SQLException {
-    return connection.prepareStatement(query, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+  private PreparedStatement createPreparedStatement(Connection connection, String query)
+      throws SQLException {
+    return connection.prepareStatement(
+        query, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
   }
 }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/StatementContext.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/example/StatementContext.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.example;
 
 import java.sql.Connection;
 import java.sql.Statement;
 import java.util.Objects;
-
 import org.apache.arrow.flight.sql.FlightSqlProducer;
 import org.apache.arrow.util.AutoCloseables;
 

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSql.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSql.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.test;
 
 import static java.util.Arrays.asList;
@@ -29,6 +28,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableList;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
-
 import org.apache.arrow.flight.CancelFlightInfoRequest;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightInfo;
@@ -73,23 +72,25 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import com.google.common.collect.ImmutableList;
-
-/**
- * Test direct usage of Flight SQL workflows.
- */
+/** Test direct usage of Flight SQL workflows. */
 public class TestFlightSql {
 
-  protected static final Schema SCHEMA_INT_TABLE = new Schema(asList(
-      new Field("ID", new FieldType(false, MinorType.INT.getType(), null), null),
-      Field.nullable("KEYNAME", MinorType.VARCHAR.getType()),
-      Field.nullable("VALUE", MinorType.INT.getType()),
-      Field.nullable("FOREIGNID", MinorType.INT.getType())));
-  private static final List<List<String>> EXPECTED_RESULTS_FOR_STAR_SELECT_QUERY = ImmutableList.of(
-      asList("1", "one", "1", "1"), asList("2", "zero", "0", "1"), asList("3", "negative one", "-1", "1"));
-  protected static final List<List<String>> EXPECTED_RESULTS_FOR_PARAMETER_BINDING = ImmutableList.of(
-      asList("1", "one", "1", "1"));
-  private static final Map<String, String> GET_SQL_INFO_EXPECTED_RESULTS_MAP = new LinkedHashMap<>();
+  protected static final Schema SCHEMA_INT_TABLE =
+      new Schema(
+          asList(
+              new Field("ID", new FieldType(false, MinorType.INT.getType(), null), null),
+              Field.nullable("KEYNAME", MinorType.VARCHAR.getType()),
+              Field.nullable("VALUE", MinorType.INT.getType()),
+              Field.nullable("FOREIGNID", MinorType.INT.getType())));
+  private static final List<List<String>> EXPECTED_RESULTS_FOR_STAR_SELECT_QUERY =
+      ImmutableList.of(
+          asList("1", "one", "1", "1"),
+          asList("2", "zero", "0", "1"),
+          asList("3", "negative one", "-1", "1"));
+  protected static final List<List<String>> EXPECTED_RESULTS_FOR_PARAMETER_BINDING =
+      ImmutableList.of(asList("1", "one", "1", "1"));
+  private static final Map<String, String> GET_SQL_INFO_EXPECTED_RESULTS_MAP =
+      new LinkedHashMap<>();
   protected static final String LOCALHOST = "localhost";
   protected static BufferAllocator allocator;
   protected static FlightServer server;
@@ -105,8 +106,11 @@ public class TestFlightSql {
     allocator = new RootAllocator(Integer.MAX_VALUE);
 
     final Location serverLocation = Location.forGrpcInsecure(LOCALHOST, 0);
-    server = FlightServer.builder(allocator, serverLocation,
-                    new FlightSqlExample(serverLocation, FlightSqlExample.DB_NAME))
+    server =
+        FlightServer.builder(
+                allocator,
+                serverLocation,
+                new FlightSqlExample(serverLocation, FlightSqlExample.DB_NAME))
             .build()
             .start();
 
@@ -115,38 +119,37 @@ public class TestFlightSql {
   }
 
   protected static void setUpExpectedResultsMap() {
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE), "Apache Derby");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION_VALUE), "10.14.2.0 - (1828579)");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION_VALUE), "10.14.2.0 - (1828579)");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY_VALUE), "false");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE_VALUE), "true");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(
-                    Integer.toString(FlightSql.SqlInfo.SQL_NULL_ORDERING_VALUE),
-                    Integer.toString(FlightSql.SqlNullOrdering.SQL_NULLS_SORTED_AT_END_VALUE));
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.SQL_DDL_CATALOG_VALUE), "false");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.SQL_DDL_SCHEMA_VALUE), "true");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.SQL_DDL_TABLE_VALUE), "true");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(
-                    Integer.toString(FlightSql.SqlInfo.SQL_IDENTIFIER_CASE_VALUE),
-                    Integer.toString(SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UPPERCASE_VALUE));
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.SQL_IDENTIFIER_QUOTE_CHAR_VALUE), "\"");
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(
-                    Integer.toString(FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE_VALUE),
-                    Integer.toString(SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_CASE_INSENSITIVE_VALUE));
-    GET_SQL_INFO_EXPECTED_RESULTS_MAP
-            .put(Integer.toString(FlightSql.SqlInfo.SQL_MAX_COLUMNS_IN_TABLE_VALUE), "42");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE), "Apache Derby");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION_VALUE),
+        "10.14.2.0 - (1828579)");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION_VALUE),
+        "10.14.2.0 - (1828579)");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY_VALUE), "false");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE_VALUE), "true");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_NULL_ORDERING_VALUE),
+        Integer.toString(FlightSql.SqlNullOrdering.SQL_NULLS_SORTED_AT_END_VALUE));
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_DDL_CATALOG_VALUE), "false");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_DDL_SCHEMA_VALUE), "true");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_DDL_TABLE_VALUE), "true");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_IDENTIFIER_CASE_VALUE),
+        Integer.toString(SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_UPPERCASE_VALUE));
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_IDENTIFIER_QUOTE_CHAR_VALUE), "\"");
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE_VALUE),
+        Integer.toString(SqlSupportedCaseSensitivity.SQL_CASE_SENSITIVITY_CASE_INSENSITIVE_VALUE));
+    GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
+        Integer.toString(FlightSql.SqlInfo.SQL_MAX_COLUMNS_IN_TABLE_VALUE), "42");
   }
 
   @AfterAll
@@ -155,8 +158,10 @@ public class TestFlightSql {
     FlightSqlExample.removeDerbyDatabaseIfExists(FlightSqlExample.DB_NAME);
   }
 
-  private static List<List<String>> getNonConformingResultsForGetSqlInfo(final List<? extends List<String>> results) {
-    return getNonConformingResultsForGetSqlInfo(results,
+  private static List<List<String>> getNonConformingResultsForGetSqlInfo(
+      final List<? extends List<String>> results) {
+    return getNonConformingResultsForGetSqlInfo(
+        results,
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME,
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION,
         FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION,
@@ -173,8 +178,7 @@ public class TestFlightSql {
   }
 
   private static List<List<String>> getNonConformingResultsForGetSqlInfo(
-      final List<? extends List<String>> results,
-      final FlightSql.SqlInfo... args) {
+      final List<? extends List<String>> results, final FlightSql.SqlInfo... args) {
     final List<List<String>> nonConformingResults = new ArrayList<>();
     if (results.size() == args.length) {
       for (int index = 0; index < results.size(); index++) {
@@ -182,8 +186,8 @@ public class TestFlightSql {
         final String providedName = result.get(0);
         final String expectedName = Integer.toString(args[index].getNumber());
         System.err.println(expectedName);
-        if (!(GET_SQL_INFO_EXPECTED_RESULTS_MAP.get(providedName).equals(result.get(1)) &&
-            providedName.equals(expectedName))) {
+        if (!(GET_SQL_INFO_EXPECTED_RESULTS_MAP.get(providedName).equals(result.get(1))
+            && providedName.equals(expectedName))) {
           nonConformingResults.add(result);
           break;
         }
@@ -195,181 +199,248 @@ public class TestFlightSql {
   @Test
   public void testGetTablesSchema() {
     final FlightInfo info = sqlClient.getTables(null, null, null, null, true);
-    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA)));
+    MatcherAssert.assertThat(
+        info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA)));
   }
 
   @Test
   public void testGetTablesSchemaExcludeSchema() {
     final FlightInfo info = sqlClient.getTables(null, null, null, null, false);
     MatcherAssert.assertThat(
-            info.getSchemaOptional(),
-            is(Optional.of(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA)));
+        info.getSchemaOptional(),
+        is(Optional.of(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA)));
   }
 
   @Test
   public void testGetTablesResultNoSchema() throws Exception {
     try (final FlightStream stream =
-             sqlClient.getStream(
-                 sqlClient.getTables(null, null, null, null, false)
-                     .getEndpoints().get(0).getTicket())) {
+        sqlClient.getStream(
+            sqlClient.getTables(null, null, null, null, false).getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
           () -> {
-            MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA));
+            MatcherAssert.assertThat(
+                stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA));
           },
           () -> {
             final List<List<String>> results = getResults(stream);
-            final List<List<String>> expectedResults = ImmutableList.of(
-                // catalog_name | schema_name | table_name | table_type | table_schema
-                asList(null /* TODO No catalog yet */, "SYS", "SYSALIASES", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSCHECKS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSCOLPERMS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSCOLUMNS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSCONGLOMERATES", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSCONSTRAINTS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSDEPENDS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSFILES", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSFOREIGNKEYS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSKEYS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSPERMS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSROLES", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSROUTINEPERMS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSSCHEMAS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSSEQUENCES", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSSTATEMENTS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSSTATISTICS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSTABLEPERMS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSTABLES", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSTRIGGERS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSUSERS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYS", "SYSVIEWS", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "SYSIBM", "SYSDUMMY1", "SYSTEM TABLE"),
-                asList(null /* TODO No catalog yet */, "APP", "FOREIGNTABLE", "TABLE"),
-                asList(null /* TODO No catalog yet */, "APP", "INTTABLE", "TABLE"));
+            final List<List<String>> expectedResults =
+                ImmutableList.of(
+                    // catalog_name | schema_name | table_name | table_type | table_schema
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSALIASES", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSCHECKS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSCOLPERMS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSCOLUMNS", "SYSTEM TABLE"),
+                    asList(
+                        null /* TODO No catalog yet */, "SYS", "SYSCONGLOMERATES", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSCONSTRAINTS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSDEPENDS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSFILES", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSFOREIGNKEYS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSKEYS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSPERMS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSROLES", "SYSTEM TABLE"),
+                    asList(
+                        null /* TODO No catalog yet */, "SYS", "SYSROUTINEPERMS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSSCHEMAS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSSEQUENCES", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSSTATEMENTS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSSTATISTICS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSTABLEPERMS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSTABLES", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSTRIGGERS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSUSERS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYS", "SYSVIEWS", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "SYSIBM", "SYSDUMMY1", "SYSTEM TABLE"),
+                    asList(null /* TODO No catalog yet */, "APP", "FOREIGNTABLE", "TABLE"),
+                    asList(null /* TODO No catalog yet */, "APP", "INTTABLE", "TABLE"));
             MatcherAssert.assertThat(results, is(expectedResults));
-          }
-      );
+          });
     }
   }
 
   @Test
   public void testGetTablesResultFilteredNoSchema() throws Exception {
     try (final FlightStream stream =
-             sqlClient.getStream(
-                 sqlClient.getTables(null, null, null, singletonList("TABLE"), false)
-                     .getEndpoints().get(0).getTicket())) {
+        sqlClient.getStream(
+            sqlClient
+                .getTables(null, null, null, singletonList("TABLE"), false)
+                .getEndpoints()
+                .get(0)
+                .getTicket())) {
 
       Assertions.assertAll(
-          () -> MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA)),
+          () ->
+              MatcherAssert.assertThat(
+                  stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA_NO_SCHEMA)),
           () -> {
             final List<List<String>> results = getResults(stream);
-            final List<List<String>> expectedResults = ImmutableList.of(
-                // catalog_name | schema_name | table_name | table_type | table_schema
-                asList(null /* TODO No catalog yet */, "APP", "FOREIGNTABLE", "TABLE"),
-                asList(null /* TODO No catalog yet */, "APP", "INTTABLE", "TABLE"));
+            final List<List<String>> expectedResults =
+                ImmutableList.of(
+                    // catalog_name | schema_name | table_name | table_type | table_schema
+                    asList(null /* TODO No catalog yet */, "APP", "FOREIGNTABLE", "TABLE"),
+                    asList(null /* TODO No catalog yet */, "APP", "INTTABLE", "TABLE"));
             MatcherAssert.assertThat(results, is(expectedResults));
-          }
-      );
+          });
     }
   }
 
   @Test
   public void testGetTablesResultFilteredWithSchema() throws Exception {
     try (final FlightStream stream =
-             sqlClient.getStream(
-                 sqlClient.getTables(null, null, null, singletonList("TABLE"), true)
-                     .getEndpoints().get(0).getTicket())) {
+        sqlClient.getStream(
+            sqlClient
+                .getTables(null, null, null, singletonList("TABLE"), true)
+                .getEndpoints()
+                .get(0)
+                .getTicket())) {
       Assertions.assertAll(
-          () -> MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA)),
+          () ->
+              MatcherAssert.assertThat(
+                  stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA)),
           () -> {
-            MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA));
+            MatcherAssert.assertThat(
+                stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLES_SCHEMA));
             final List<List<String>> results = getResults(stream);
-            final List<List<String>> expectedResults = ImmutableList.of(
-                // catalog_name | schema_name | table_name | table_type | table_schema
-                asList(
-                    null /* TODO No catalog yet */,
-                    "APP",
-                    "FOREIGNTABLE",
-                    "TABLE",
-                    new Schema(asList(
-                        new Field("ID", new FieldType(false, MinorType.INT.getType(), null,
-                            new FlightSqlColumnMetadata.Builder()
-                                .catalogName("")
-                                .typeName("INTEGER")
-                                .schemaName("APP")
-                                .tableName("FOREIGNTABLE")
-                                .precision(10)
-                                .scale(0)
-                                .isAutoIncrement(true)
-                                .build().getMetadataMap()), null),
-                        new Field("FOREIGNNAME", new FieldType(true, MinorType.VARCHAR.getType(), null,
-                            new FlightSqlColumnMetadata.Builder()
-                                .catalogName("")
-                                .typeName("VARCHAR")
-                                .schemaName("APP")
-                                .tableName("FOREIGNTABLE")
-                                .precision(100)
-                                .scale(0)
-                                .isAutoIncrement(false)
-                                .build().getMetadataMap()), null),
-                        new Field("VALUE", new FieldType(true, MinorType.INT.getType(), null,
-                            new FlightSqlColumnMetadata.Builder()
-                                .catalogName("")
-                                .typeName("INTEGER")
-                                .schemaName("APP")
-                                .tableName("FOREIGNTABLE")
-                                .precision(10)
-                                .scale(0)
-                                .isAutoIncrement(false)
-                                .build().getMetadataMap()), null))).toJson()),
-                asList(
-                    null /* TODO No catalog yet */,
-                    "APP",
-                    "INTTABLE",
-                    "TABLE",
-                    new Schema(asList(
-                        new Field("ID", new FieldType(false, MinorType.INT.getType(), null,
-                            new FlightSqlColumnMetadata.Builder()
-                                .catalogName("")
-                                .typeName("INTEGER")
-                                .schemaName("APP")
-                                .tableName("INTTABLE")
-                                .precision(10)
-                                .scale(0)
-                                .isAutoIncrement(true)
-                                .build().getMetadataMap()), null),
-                        new Field("KEYNAME", new FieldType(true, MinorType.VARCHAR.getType(), null,
-                            new FlightSqlColumnMetadata.Builder()
-                                .catalogName("")
-                                .typeName("VARCHAR")
-                                .schemaName("APP")
-                                .tableName("INTTABLE")
-                                .precision(100)
-                                .scale(0)
-                                .isAutoIncrement(false)
-                                .build().getMetadataMap()), null),
-                        new Field("VALUE", new FieldType(true, MinorType.INT.getType(), null,
-                            new FlightSqlColumnMetadata.Builder()
-                                .catalogName("")
-                                .typeName("INTEGER")
-                                .schemaName("APP")
-                                .tableName("INTTABLE")
-                                .precision(10)
-                                .scale(0)
-                                .isAutoIncrement(false)
-                                .build().getMetadataMap()), null),
-                        new Field("FOREIGNID", new FieldType(true, MinorType.INT.getType(), null,
-                            new FlightSqlColumnMetadata.Builder()
-                                .catalogName("")
-                                .typeName("INTEGER")
-                                .schemaName("APP")
-                                .tableName("INTTABLE")
-                                .precision(10)
-                                .scale(0)
-                                .isAutoIncrement(false)
-                                .build().getMetadataMap()), null))).toJson()));
+            final List<List<String>> expectedResults =
+                ImmutableList.of(
+                    // catalog_name | schema_name | table_name | table_type | table_schema
+                    asList(
+                        null /* TODO No catalog yet */,
+                        "APP",
+                        "FOREIGNTABLE",
+                        "TABLE",
+                        new Schema(
+                                asList(
+                                    new Field(
+                                        "ID",
+                                        new FieldType(
+                                            false,
+                                            MinorType.INT.getType(),
+                                            null,
+                                            new FlightSqlColumnMetadata.Builder()
+                                                .catalogName("")
+                                                .typeName("INTEGER")
+                                                .schemaName("APP")
+                                                .tableName("FOREIGNTABLE")
+                                                .precision(10)
+                                                .scale(0)
+                                                .isAutoIncrement(true)
+                                                .build()
+                                                .getMetadataMap()),
+                                        null),
+                                    new Field(
+                                        "FOREIGNNAME",
+                                        new FieldType(
+                                            true,
+                                            MinorType.VARCHAR.getType(),
+                                            null,
+                                            new FlightSqlColumnMetadata.Builder()
+                                                .catalogName("")
+                                                .typeName("VARCHAR")
+                                                .schemaName("APP")
+                                                .tableName("FOREIGNTABLE")
+                                                .precision(100)
+                                                .scale(0)
+                                                .isAutoIncrement(false)
+                                                .build()
+                                                .getMetadataMap()),
+                                        null),
+                                    new Field(
+                                        "VALUE",
+                                        new FieldType(
+                                            true,
+                                            MinorType.INT.getType(),
+                                            null,
+                                            new FlightSqlColumnMetadata.Builder()
+                                                .catalogName("")
+                                                .typeName("INTEGER")
+                                                .schemaName("APP")
+                                                .tableName("FOREIGNTABLE")
+                                                .precision(10)
+                                                .scale(0)
+                                                .isAutoIncrement(false)
+                                                .build()
+                                                .getMetadataMap()),
+                                        null)))
+                            .toJson()),
+                    asList(
+                        null /* TODO No catalog yet */,
+                        "APP",
+                        "INTTABLE",
+                        "TABLE",
+                        new Schema(
+                                asList(
+                                    new Field(
+                                        "ID",
+                                        new FieldType(
+                                            false,
+                                            MinorType.INT.getType(),
+                                            null,
+                                            new FlightSqlColumnMetadata.Builder()
+                                                .catalogName("")
+                                                .typeName("INTEGER")
+                                                .schemaName("APP")
+                                                .tableName("INTTABLE")
+                                                .precision(10)
+                                                .scale(0)
+                                                .isAutoIncrement(true)
+                                                .build()
+                                                .getMetadataMap()),
+                                        null),
+                                    new Field(
+                                        "KEYNAME",
+                                        new FieldType(
+                                            true,
+                                            MinorType.VARCHAR.getType(),
+                                            null,
+                                            new FlightSqlColumnMetadata.Builder()
+                                                .catalogName("")
+                                                .typeName("VARCHAR")
+                                                .schemaName("APP")
+                                                .tableName("INTTABLE")
+                                                .precision(100)
+                                                .scale(0)
+                                                .isAutoIncrement(false)
+                                                .build()
+                                                .getMetadataMap()),
+                                        null),
+                                    new Field(
+                                        "VALUE",
+                                        new FieldType(
+                                            true,
+                                            MinorType.INT.getType(),
+                                            null,
+                                            new FlightSqlColumnMetadata.Builder()
+                                                .catalogName("")
+                                                .typeName("INTEGER")
+                                                .schemaName("APP")
+                                                .tableName("INTTABLE")
+                                                .precision(10)
+                                                .scale(0)
+                                                .isAutoIncrement(false)
+                                                .build()
+                                                .getMetadataMap()),
+                                        null),
+                                    new Field(
+                                        "FOREIGNID",
+                                        new FieldType(
+                                            true,
+                                            MinorType.INT.getType(),
+                                            null,
+                                            new FlightSqlColumnMetadata.Builder()
+                                                .catalogName("")
+                                                .typeName("INTEGER")
+                                                .schemaName("APP")
+                                                .tableName("INTTABLE")
+                                                .precision(10)
+                                                .scale(0)
+                                                .isAutoIncrement(false)
+                                                .build()
+                                                .getMetadataMap()),
+                                        null)))
+                            .toJson()));
             MatcherAssert.assertThat(results, is(expectedResults));
-          }
-      );
+          });
     }
   }
 
@@ -380,25 +451,24 @@ public class TestFlightSql {
           () -> {
             final Schema actualSchema = preparedStatement.getResultSetSchema();
             MatcherAssert.assertThat(actualSchema, is(SCHEMA_INT_TABLE));
-
           },
           () -> {
             final FlightInfo info = preparedStatement.execute();
             MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(SCHEMA_INT_TABLE)));
-          }
-      );
+          });
     }
   }
 
   @Test
   public void testSimplePreparedStatementResults() throws Exception {
     try (final PreparedStatement preparedStatement = sqlClient.prepare("SELECT * FROM intTable");
-         final FlightStream stream = sqlClient.getStream(
-             preparedStatement.execute().getEndpoints().get(0).getTicket())) {
+        final FlightStream stream =
+            sqlClient.getStream(preparedStatement.execute().getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
           () -> MatcherAssert.assertThat(stream.getSchema(), is(SCHEMA_INT_TABLE)),
-          () -> MatcherAssert.assertThat(getResults(stream), is(EXPECTED_RESULTS_FOR_STAR_SELECT_QUERY))
-      );
+          () ->
+              MatcherAssert.assertThat(
+                  getResults(stream), is(EXPECTED_RESULTS_FOR_STAR_SELECT_QUERY)));
     }
   }
 
@@ -406,7 +476,8 @@ public class TestFlightSql {
   public void testSimplePreparedStatementResultsWithParameterBinding() throws Exception {
     try (PreparedStatement prepare = sqlClient.prepare("SELECT * FROM intTable WHERE id = ?")) {
       final Schema parameterSchema = prepare.getParameterSchema();
-      try (final VectorSchemaRoot insertRoot = VectorSchemaRoot.create(parameterSchema, allocator)) {
+      try (final VectorSchemaRoot insertRoot =
+          VectorSchemaRoot.create(parameterSchema, allocator)) {
         insertRoot.allocateNew();
 
         final IntVector valueVector = (IntVector) insertRoot.getVector(0);
@@ -416,24 +487,26 @@ public class TestFlightSql {
         prepare.setParameters(insertRoot);
         FlightInfo flightInfo = prepare.execute();
 
-        FlightStream stream = sqlClient.getStream(flightInfo
-            .getEndpoints()
-            .get(0).getTicket());
+        FlightStream stream = sqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket());
 
         Assertions.assertAll(
             () -> MatcherAssert.assertThat(stream.getSchema(), is(SCHEMA_INT_TABLE)),
-            () -> MatcherAssert.assertThat(getResults(stream), is(EXPECTED_RESULTS_FOR_PARAMETER_BINDING))
-        );
+            () ->
+                MatcherAssert.assertThat(
+                    getResults(stream), is(EXPECTED_RESULTS_FOR_PARAMETER_BINDING)));
       }
     }
   }
 
   @Test
   public void testSimplePreparedStatementUpdateResults() throws SQLException {
-    try (PreparedStatement prepare = sqlClient.prepare("INSERT INTO INTTABLE (keyName, value ) VALUES (?, ?)");
-         PreparedStatement deletePrepare = sqlClient.prepare("DELETE FROM INTTABLE WHERE keyName = ?")) {
+    try (PreparedStatement prepare =
+            sqlClient.prepare("INSERT INTO INTTABLE (keyName, value ) VALUES (?, ?)");
+        PreparedStatement deletePrepare =
+            sqlClient.prepare("DELETE FROM INTTABLE WHERE keyName = ?")) {
       final Schema parameterSchema = prepare.getParameterSchema();
-      try (final VectorSchemaRoot insertRoot = VectorSchemaRoot.create(parameterSchema, allocator)) {
+      try (final VectorSchemaRoot insertRoot =
+          VectorSchemaRoot.create(parameterSchema, allocator)) {
         final VarCharVector varCharVector = (VarCharVector) insertRoot.getVector(0);
         final IntVector valueVector = (IntVector) insertRoot.getVector(1);
         final int counter = 10;
@@ -441,10 +514,11 @@ public class TestFlightSql {
 
         final IntStream range = IntStream.range(0, counter);
 
-        range.forEach(i -> {
-          valueVector.setSafe(i, i * counter);
-          varCharVector.setSafe(i, new Text("value" + i));
-        });
+        range.forEach(
+            i -> {
+              valueVector.setSafe(i, i * counter);
+              varCharVector.setSafe(i, new Text("value" + i));
+            });
 
         insertRoot.setRowCount(counter);
 
@@ -458,25 +532,24 @@ public class TestFlightSql {
         }
         Assertions.assertAll(
             () -> MatcherAssert.assertThat(updatedRows, is(10L)),
-            () -> MatcherAssert.assertThat(deletedRows, is(10L))
-        );
+            () -> MatcherAssert.assertThat(deletedRows, is(10L)));
       }
     }
   }
 
   @Test
   public void testSimplePreparedStatementUpdateResultsWithoutParameters() throws SQLException {
-    try (PreparedStatement prepare = sqlClient
-        .prepare("INSERT INTO INTTABLE (keyName, value ) VALUES ('test', 1000)");
-         PreparedStatement deletePrepare = sqlClient.prepare("DELETE FROM INTTABLE WHERE keyName = 'test'")) {
+    try (PreparedStatement prepare =
+            sqlClient.prepare("INSERT INTO INTTABLE (keyName, value ) VALUES ('test', 1000)");
+        PreparedStatement deletePrepare =
+            sqlClient.prepare("DELETE FROM INTTABLE WHERE keyName = 'test'")) {
       final long updatedRows = prepare.executeUpdate();
 
       final long deletedRows = deletePrepare.executeUpdate();
 
       Assertions.assertAll(
           () -> MatcherAssert.assertThat(updatedRows, is(1L)),
-          () -> MatcherAssert.assertThat(deletedRows, is(1L))
-      );
+          () -> MatcherAssert.assertThat(deletedRows, is(1L)));
     }
   }
 
@@ -490,27 +563,28 @@ public class TestFlightSql {
         () -> {
           preparedStatement.close();
           MatcherAssert.assertThat(preparedStatement.isClosed(), is(true));
-        }
-    );
+        });
   }
 
   @Test
   public void testGetCatalogsSchema() {
     final FlightInfo info = sqlClient.getCatalogs();
-    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA)));
+    MatcherAssert.assertThat(
+        info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA)));
   }
 
   @Test
   public void testGetCatalogsResults() throws Exception {
     try (final FlightStream stream =
-             sqlClient.getStream(sqlClient.getCatalogs().getEndpoints().get(0).getTicket())) {
+        sqlClient.getStream(sqlClient.getCatalogs().getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
-          () -> MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA)),
+          () ->
+              MatcherAssert.assertThat(
+                  stream.getSchema(), is(FlightSqlProducer.Schemas.GET_CATALOGS_SCHEMA)),
           () -> {
             List<List<String>> catalogs = getResults(stream);
             MatcherAssert.assertThat(catalogs, is(emptyList()));
-          }
-      );
+          });
     }
   }
 
@@ -518,65 +592,67 @@ public class TestFlightSql {
   public void testGetTableTypesSchema() {
     final FlightInfo info = sqlClient.getTableTypes();
     MatcherAssert.assertThat(
-            info.getSchemaOptional(),
-            is(Optional.of(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA)));
+        info.getSchemaOptional(),
+        is(Optional.of(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA)));
   }
 
   @Test
   public void testGetTableTypesResult() throws Exception {
     try (final FlightStream stream =
-             sqlClient.getStream(sqlClient.getTableTypes().getEndpoints().get(0).getTicket())) {
+        sqlClient.getStream(sqlClient.getTableTypes().getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
           () -> {
-            MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA));
+            MatcherAssert.assertThat(
+                stream.getSchema(), is(FlightSqlProducer.Schemas.GET_TABLE_TYPES_SCHEMA));
           },
           () -> {
             final List<List<String>> tableTypes = getResults(stream);
-            final List<List<String>> expectedTableTypes = ImmutableList.of(
-                // table_type
-                singletonList("SYNONYM"),
-                singletonList("SYSTEM TABLE"),
-                singletonList("TABLE"),
-                singletonList("VIEW")
-            );
+            final List<List<String>> expectedTableTypes =
+                ImmutableList.of(
+                    // table_type
+                    singletonList("SYNONYM"),
+                    singletonList("SYSTEM TABLE"),
+                    singletonList("TABLE"),
+                    singletonList("VIEW"));
             MatcherAssert.assertThat(tableTypes, is(expectedTableTypes));
-          }
-      );
+          });
     }
   }
 
   @Test
   public void testGetSchemasSchema() {
     final FlightInfo info = sqlClient.getSchemas(null, null);
-    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA)));
+    MatcherAssert.assertThat(
+        info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA)));
   }
 
   @Test
   public void testGetSchemasResult() throws Exception {
     try (final FlightStream stream =
-             sqlClient.getStream(sqlClient.getSchemas(null, null).getEndpoints().get(0).getTicket())) {
+        sqlClient.getStream(sqlClient.getSchemas(null, null).getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
           () -> {
-            MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA));
+            MatcherAssert.assertThat(
+                stream.getSchema(), is(FlightSqlProducer.Schemas.GET_SCHEMAS_SCHEMA));
           },
           () -> {
             final List<List<String>> schemas = getResults(stream);
-            final List<List<String>> expectedSchemas = ImmutableList.of(
-                // catalog_name | schema_name
-                asList(null /* TODO Add catalog. */, "APP"),
-                asList(null /* TODO Add catalog. */, "NULLID"),
-                asList(null /* TODO Add catalog. */, "SQLJ"),
-                asList(null /* TODO Add catalog. */, "SYS"),
-                asList(null /* TODO Add catalog. */, "SYSCAT"),
-                asList(null /* TODO Add catalog. */, "SYSCS_DIAG"),
-                asList(null /* TODO Add catalog. */, "SYSCS_UTIL"),
-                asList(null /* TODO Add catalog. */, "SYSFUN"),
-                asList(null /* TODO Add catalog. */, "SYSIBM"),
-                asList(null /* TODO Add catalog. */, "SYSPROC"),
-                asList(null /* TODO Add catalog. */, "SYSSTAT"));
+            final List<List<String>> expectedSchemas =
+                ImmutableList.of(
+                    // catalog_name | schema_name
+                    asList(null /* TODO Add catalog. */, "APP"),
+                    asList(null /* TODO Add catalog. */, "NULLID"),
+                    asList(null /* TODO Add catalog. */, "SQLJ"),
+                    asList(null /* TODO Add catalog. */, "SYS"),
+                    asList(null /* TODO Add catalog. */, "SYSCAT"),
+                    asList(null /* TODO Add catalog. */, "SYSCS_DIAG"),
+                    asList(null /* TODO Add catalog. */, "SYSCS_UTIL"),
+                    asList(null /* TODO Add catalog. */, "SYSFUN"),
+                    asList(null /* TODO Add catalog. */, "SYSIBM"),
+                    asList(null /* TODO Add catalog. */, "SYSPROC"),
+                    asList(null /* TODO Add catalog. */, "SYSSTAT"));
             MatcherAssert.assertThat(schemas, is(expectedSchemas));
-          }
-      );
+          });
     }
   }
 
@@ -597,16 +673,15 @@ public class TestFlightSql {
               () -> MatcherAssert.assertThat(result.get(2), is("INTTABLE")),
               () -> MatcherAssert.assertThat(result.get(3), is("ID")),
               () -> MatcherAssert.assertThat(result.get(4), is("1")),
-              () -> MatcherAssert.assertThat(result.get(5), notNullValue())
-          );
-        }
-    );
+              () -> MatcherAssert.assertThat(result.get(5), notNullValue()));
+        });
   }
 
   @Test
   public void testGetSqlInfoSchema() {
     final FlightInfo info = sqlClient.getSqlInfo();
-    MatcherAssert.assertThat(info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)));
+    MatcherAssert.assertThat(
+        info.getSchemaOptional(), is(Optional.of(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)));
   }
 
   @Test
@@ -614,9 +689,12 @@ public class TestFlightSql {
     final FlightInfo info = sqlClient.getSqlInfo();
     try (final FlightStream stream = sqlClient.getStream(info.getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
-          () -> MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)),
-          () -> MatcherAssert.assertThat(getNonConformingResultsForGetSqlInfo(getResults(stream)), is(emptyList()))
-      );
+          () ->
+              MatcherAssert.assertThat(
+                  stream.getSchema(), is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)),
+          () ->
+              MatcherAssert.assertThat(
+                  getNonConformingResultsForGetSqlInfo(getResults(stream)), is(emptyList())));
     }
   }
 
@@ -626,40 +704,41 @@ public class TestFlightSql {
     final FlightInfo info = sqlClient.getSqlInfo(arg);
     try (final FlightStream stream = sqlClient.getStream(info.getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
-          () -> MatcherAssert.assertThat(stream.getSchema(), is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)),
-          () -> MatcherAssert.assertThat(getNonConformingResultsForGetSqlInfo(getResults(stream), arg), is(emptyList()))
-      );
+          () ->
+              MatcherAssert.assertThat(
+                  stream.getSchema(), is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)),
+          () ->
+              MatcherAssert.assertThat(
+                  getNonConformingResultsForGetSqlInfo(getResults(stream), arg), is(emptyList())));
     }
   }
 
   @Test
   public void testGetSqlInfoResultsWithManyArgs() throws Exception {
     final FlightSql.SqlInfo[] args = {
-        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME,
-        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION,
-        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION,
-        FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY,
-        FlightSql.SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE,
-        FlightSql.SqlInfo.SQL_NULL_ORDERING,
-        FlightSql.SqlInfo.SQL_DDL_CATALOG,
-        FlightSql.SqlInfo.SQL_DDL_SCHEMA,
-        FlightSql.SqlInfo.SQL_DDL_TABLE,
-        FlightSql.SqlInfo.SQL_IDENTIFIER_CASE,
-        FlightSql.SqlInfo.SQL_IDENTIFIER_QUOTE_CHAR,
-        FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE,
-        FlightSql.SqlInfo.SQL_MAX_COLUMNS_IN_TABLE};
+      FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME,
+      FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION,
+      FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION,
+      FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY,
+      FlightSql.SqlInfo.SQL_ALL_TABLES_ARE_SELECTABLE,
+      FlightSql.SqlInfo.SQL_NULL_ORDERING,
+      FlightSql.SqlInfo.SQL_DDL_CATALOG,
+      FlightSql.SqlInfo.SQL_DDL_SCHEMA,
+      FlightSql.SqlInfo.SQL_DDL_TABLE,
+      FlightSql.SqlInfo.SQL_IDENTIFIER_CASE,
+      FlightSql.SqlInfo.SQL_IDENTIFIER_QUOTE_CHAR,
+      FlightSql.SqlInfo.SQL_QUOTED_IDENTIFIER_CASE,
+      FlightSql.SqlInfo.SQL_MAX_COLUMNS_IN_TABLE
+    };
     final FlightInfo info = sqlClient.getSqlInfo(args);
     try (final FlightStream stream = sqlClient.getStream(info.getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
-          () -> MatcherAssert.assertThat(
-              stream.getSchema(),
-              is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)
-          ),
-          () -> MatcherAssert.assertThat(
-              getNonConformingResultsForGetSqlInfo(getResults(stream), args),
-              is(emptyList())
-          )
-      );
+          () ->
+              MatcherAssert.assertThat(
+                  stream.getSchema(), is(FlightSqlProducer.Schemas.GET_SQL_INFO_SCHEMA)),
+          () ->
+              MatcherAssert.assertThat(
+                  getNonConformingResultsForGetSqlInfo(getResults(stream), args), is(emptyList())));
     }
   }
 
@@ -667,25 +746,29 @@ public class TestFlightSql {
   public void testGetCommandExportedKeys() throws Exception {
     try (final FlightStream stream =
         sqlClient.getStream(
-            sqlClient.getExportedKeys(TableRef.of(null, null, "FOREIGNTABLE"))
-                .getEndpoints().get(0).getTicket())) {
+            sqlClient
+                .getExportedKeys(TableRef.of(null, null, "FOREIGNTABLE"))
+                .getEndpoints()
+                .get(0)
+                .getTicket())) {
 
       final List<List<String>> results = getResults(stream);
 
-      final List<Matcher<String>> matchers = asList(
-          nullValue(String.class), // pk_catalog_name
-          is("APP"), // pk_schema_name
-          is("FOREIGNTABLE"), // pk_table_name
-          is("ID"), // pk_column_name
-          nullValue(String.class), // fk_catalog_name
-          is("APP"), // fk_schema_name
-          is("INTTABLE"), // fk_table_name
-          is("FOREIGNID"), // fk_column_name
-          is("1"), // key_sequence
-          containsString("SQL"), // fk_key_name
-          containsString("SQL"), // pk_key_name
-          is("3"), // update_rule
-          is("3")); // delete_rule
+      final List<Matcher<String>> matchers =
+          asList(
+              nullValue(String.class), // pk_catalog_name
+              is("APP"), // pk_schema_name
+              is("FOREIGNTABLE"), // pk_table_name
+              is("ID"), // pk_column_name
+              nullValue(String.class), // fk_catalog_name
+              is("APP"), // fk_schema_name
+              is("INTTABLE"), // fk_table_name
+              is("FOREIGNID"), // fk_column_name
+              is("1"), // key_sequence
+              containsString("SQL"), // fk_key_name
+              containsString("SQL"), // pk_key_name
+              is("3"), // update_rule
+              is("3")); // delete_rule
 
       final List<Executable> assertions = new ArrayList<>();
       Assertions.assertEquals(1, results.size());
@@ -702,25 +785,29 @@ public class TestFlightSql {
   public void testGetCommandImportedKeys() throws Exception {
     try (final FlightStream stream =
         sqlClient.getStream(
-            sqlClient.getImportedKeys(TableRef.of(null, null, "INTTABLE"))
-                .getEndpoints().get(0).getTicket())) {
+            sqlClient
+                .getImportedKeys(TableRef.of(null, null, "INTTABLE"))
+                .getEndpoints()
+                .get(0)
+                .getTicket())) {
 
       final List<List<String>> results = getResults(stream);
 
-      final List<Matcher<String>> matchers = asList(
-          nullValue(String.class), // pk_catalog_name
-          is("APP"), // pk_schema_name
-          is("FOREIGNTABLE"), // pk_table_name
-          is("ID"), // pk_column_name
-          nullValue(String.class), // fk_catalog_name
-          is("APP"), // fk_schema_name
-          is("INTTABLE"), // fk_table_name
-          is("FOREIGNID"), // fk_column_name
-          is("1"), // key_sequence
-          containsString("SQL"), // fk_key_name
-          containsString("SQL"), // pk_key_name
-          is("3"), // update_rule
-          is("3")); // delete_rule
+      final List<Matcher<String>> matchers =
+          asList(
+              nullValue(String.class), // pk_catalog_name
+              is("APP"), // pk_schema_name
+              is("FOREIGNTABLE"), // pk_table_name
+              is("ID"), // pk_column_name
+              nullValue(String.class), // fk_catalog_name
+              is("APP"), // fk_schema_name
+              is("INTTABLE"), // fk_table_name
+              is("FOREIGNID"), // fk_column_name
+              is("1"), // key_sequence
+              containsString("SQL"), // fk_key_name
+              containsString("SQL"), // pk_key_name
+              is("3"), // update_rule
+              is("3")); // delete_rule
 
       Assertions.assertEquals(1, results.size());
       final List<Executable> assertions = new ArrayList<>();
@@ -741,73 +828,448 @@ public class TestFlightSql {
 
       final List<List<String>> results = getResults(stream);
 
-      final List<List<String>> matchers = ImmutableList.of(
-          asList("BIGINT", "-5", "19", null, null, emptyList().toString(), "1", "false", "2", "false", "false", "true",
-              "BIGINT", "0", "0",
-              null, null, "10", null),
-          asList("LONG VARCHAR FOR BIT DATA", "-4", "32700", "X'", "'", emptyList().toString(), "1", "false", "0",
-              "true", "false", "false",
-              "LONG VARCHAR FOR BIT DATA", null, null, null, null, null, null),
-          asList("VARCHAR () FOR BIT DATA", "-3", "32672", "X'", "'", singletonList("length").toString(), "1", "false",
-              "2", "true", "false",
-              "false", "VARCHAR () FOR BIT DATA", null, null, null, null, null, null),
-          asList("CHAR () FOR BIT DATA", "-2", "254", "X'", "'", singletonList("length").toString(), "1", "false", "2",
-              "true", "false", "false",
-              "CHAR () FOR BIT DATA", null, null, null, null, null, null),
-          asList("LONG VARCHAR", "-1", "32700", "'", "'", emptyList().toString(), "1", "true", "1", "true", "false",
-              "false",
-              "LONG VARCHAR", null, null, null, null, null, null),
-          asList("CHAR", "1", "254", "'", "'", singletonList("length").toString(), "1", "true", "3", "true", "false",
-              "false", "CHAR", null, null,
-              null, null, null, null),
-          asList("NUMERIC", "2", "31", null, null, Arrays.asList("precision", "scale").toString(), "1", "false", "2",
-              "false", "true", "false",
-              "NUMERIC", "0", "31", null, null, "10", null),
-          asList("DECIMAL", "3", "31", null, null, Arrays.asList("precision", "scale").toString(), "1", "false", "2",
-              "false", "true", "false",
-              "DECIMAL", "0", "31", null, null, "10", null),
-          asList("INTEGER", "4", "10", null, null, emptyList().toString(), "1", "false", "2", "false", "false", "true",
-              "INTEGER", "0", "0",
-              null, null, "10", null),
-          asList("SMALLINT", "5", "5", null, null, emptyList().toString(), "1", "false", "2", "false", "false", "true",
-              "SMALLINT", "0",
-              "0", null, null, "10", null),
-          asList("FLOAT", "6", "52", null, null, singletonList("precision").toString(), "1", "false", "2", "false",
-              "false", "false", "FLOAT", null,
-              null, null, null, "2", null),
-          asList("REAL", "7", "23", null, null, emptyList().toString(), "1", "false", "2", "false", "false", "false",
-              "REAL", null, null,
-              null, null, "2", null),
-          asList("DOUBLE", "8", "52", null, null, emptyList().toString(), "1", "false", "2", "false", "false", "false",
-              "DOUBLE", null,
-              null, null, null, "2", null),
-          asList("VARCHAR", "12", "32672", "'", "'", singletonList("length").toString(), "1", "true", "3", "true",
-              "false", "false", "VARCHAR",
-              null, null, null, null, null, null),
-          asList("BOOLEAN", "16", "1", null, null, emptyList().toString(), "1", "false", "2", "true", "false", "false",
-              "BOOLEAN", null,
-              null, null, null, null, null),
-          asList("DATE", "91", "10", "DATE'", "'", emptyList().toString(), "1", "false", "2", "true", "false", "false",
-              "DATE", "0", "0",
-              null, null, "10", null),
-          asList("TIME", "92", "8", "TIME'", "'", emptyList().toString(), "1", "false", "2", "true", "false", "false",
-              "TIME", "0", "0",
-              null, null, "10", null),
-          asList("TIMESTAMP", "93", "29", "TIMESTAMP'", "'", emptyList().toString(), "1", "false", "2", "true", "false",
-              "false",
-              "TIMESTAMP", "0", "9", null, null, "10", null),
-          asList("OBJECT", "2000", null, null, null, emptyList().toString(), "1", "false", "2", "true", "false",
-              "false", "OBJECT", null,
-              null, null, null, null, null),
-          asList("BLOB", "2004", "2147483647", null, null, singletonList("length").toString(), "1", "false", "0", null,
-              "false", null, "BLOB", null,
-              null, null, null, null, null),
-          asList("CLOB", "2005", "2147483647", "'", "'", singletonList("length").toString(), "1", "true", "1", null,
-              "false", null, "CLOB", null,
-              null, null, null, null, null),
-          asList("XML", "2009", null, null, null, emptyList().toString(), "1", "true", "0", "false", "false", "false",
-              "XML", null, null,
-              null, null, null, null));
+      final List<List<String>> matchers =
+          ImmutableList.of(
+              asList(
+                  "BIGINT",
+                  "-5",
+                  "19",
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "false",
+                  "true",
+                  "BIGINT",
+                  "0",
+                  "0",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "LONG VARCHAR FOR BIT DATA",
+                  "-4",
+                  "32700",
+                  "X'",
+                  "'",
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "0",
+                  "true",
+                  "false",
+                  "false",
+                  "LONG VARCHAR FOR BIT DATA",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "VARCHAR () FOR BIT DATA",
+                  "-3",
+                  "32672",
+                  "X'",
+                  "'",
+                  singletonList("length").toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "true",
+                  "false",
+                  "false",
+                  "VARCHAR () FOR BIT DATA",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "CHAR () FOR BIT DATA",
+                  "-2",
+                  "254",
+                  "X'",
+                  "'",
+                  singletonList("length").toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "true",
+                  "false",
+                  "false",
+                  "CHAR () FOR BIT DATA",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "LONG VARCHAR",
+                  "-1",
+                  "32700",
+                  "'",
+                  "'",
+                  emptyList().toString(),
+                  "1",
+                  "true",
+                  "1",
+                  "true",
+                  "false",
+                  "false",
+                  "LONG VARCHAR",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "CHAR",
+                  "1",
+                  "254",
+                  "'",
+                  "'",
+                  singletonList("length").toString(),
+                  "1",
+                  "true",
+                  "3",
+                  "true",
+                  "false",
+                  "false",
+                  "CHAR",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "NUMERIC",
+                  "2",
+                  "31",
+                  null,
+                  null,
+                  Arrays.asList("precision", "scale").toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "true",
+                  "false",
+                  "NUMERIC",
+                  "0",
+                  "31",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "DECIMAL",
+                  "3",
+                  "31",
+                  null,
+                  null,
+                  Arrays.asList("precision", "scale").toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "true",
+                  "false",
+                  "DECIMAL",
+                  "0",
+                  "31",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "INTEGER",
+                  "4",
+                  "10",
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "false",
+                  "true",
+                  "INTEGER",
+                  "0",
+                  "0",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "SMALLINT",
+                  "5",
+                  "5",
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "false",
+                  "true",
+                  "SMALLINT",
+                  "0",
+                  "0",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "FLOAT",
+                  "6",
+                  "52",
+                  null,
+                  null,
+                  singletonList("precision").toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "false",
+                  "false",
+                  "FLOAT",
+                  null,
+                  null,
+                  null,
+                  null,
+                  "2",
+                  null),
+              asList(
+                  "REAL",
+                  "7",
+                  "23",
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "false",
+                  "false",
+                  "REAL",
+                  null,
+                  null,
+                  null,
+                  null,
+                  "2",
+                  null),
+              asList(
+                  "DOUBLE",
+                  "8",
+                  "52",
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "false",
+                  "false",
+                  "DOUBLE",
+                  null,
+                  null,
+                  null,
+                  null,
+                  "2",
+                  null),
+              asList(
+                  "VARCHAR",
+                  "12",
+                  "32672",
+                  "'",
+                  "'",
+                  singletonList("length").toString(),
+                  "1",
+                  "true",
+                  "3",
+                  "true",
+                  "false",
+                  "false",
+                  "VARCHAR",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "BOOLEAN",
+                  "16",
+                  "1",
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "true",
+                  "false",
+                  "false",
+                  "BOOLEAN",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "DATE",
+                  "91",
+                  "10",
+                  "DATE'",
+                  "'",
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "true",
+                  "false",
+                  "false",
+                  "DATE",
+                  "0",
+                  "0",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "TIME",
+                  "92",
+                  "8",
+                  "TIME'",
+                  "'",
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "true",
+                  "false",
+                  "false",
+                  "TIME",
+                  "0",
+                  "0",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "TIMESTAMP",
+                  "93",
+                  "29",
+                  "TIMESTAMP'",
+                  "'",
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "true",
+                  "false",
+                  "false",
+                  "TIMESTAMP",
+                  "0",
+                  "9",
+                  null,
+                  null,
+                  "10",
+                  null),
+              asList(
+                  "OBJECT",
+                  "2000",
+                  null,
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "true",
+                  "false",
+                  "false",
+                  "OBJECT",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "BLOB",
+                  "2004",
+                  "2147483647",
+                  null,
+                  null,
+                  singletonList("length").toString(),
+                  "1",
+                  "false",
+                  "0",
+                  null,
+                  "false",
+                  null,
+                  "BLOB",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "CLOB",
+                  "2005",
+                  "2147483647",
+                  "'",
+                  "'",
+                  singletonList("length").toString(),
+                  "1",
+                  "true",
+                  "1",
+                  null,
+                  "false",
+                  null,
+                  "CLOB",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null),
+              asList(
+                  "XML",
+                  "2009",
+                  null,
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "true",
+                  "0",
+                  "false",
+                  "false",
+                  "false",
+                  "XML",
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null));
       MatcherAssert.assertThat(results, is(matchers));
     }
   }
@@ -820,36 +1282,57 @@ public class TestFlightSql {
 
       final List<List<String>> results = getResults(stream);
 
-      final List<List<String>> matchers = ImmutableList.of(
-          asList("BIGINT", "-5", "19", null, null, emptyList().toString(), "1", "false", "2", "false", "false", "true",
-              "BIGINT", "0", "0",
-              null, null, "10", null));
+      final List<List<String>> matchers =
+          ImmutableList.of(
+              asList(
+                  "BIGINT",
+                  "-5",
+                  "19",
+                  null,
+                  null,
+                  emptyList().toString(),
+                  "1",
+                  "false",
+                  "2",
+                  "false",
+                  "false",
+                  "true",
+                  "BIGINT",
+                  "0",
+                  "0",
+                  null,
+                  null,
+                  "10",
+                  null));
       MatcherAssert.assertThat(results, is(matchers));
     }
   }
 
   @Test
   public void testGetCommandCrossReference() throws Exception {
-    final FlightInfo flightInfo = sqlClient.getCrossReference(TableRef.of(null, null,
-        "FOREIGNTABLE"), TableRef.of(null, null, "INTTABLE"));
-    try (final FlightStream stream = sqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket())) {
+    final FlightInfo flightInfo =
+        sqlClient.getCrossReference(
+            TableRef.of(null, null, "FOREIGNTABLE"), TableRef.of(null, null, "INTTABLE"));
+    try (final FlightStream stream =
+        sqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket())) {
 
       final List<List<String>> results = getResults(stream);
 
-      final List<Matcher<String>> matchers = asList(
-          nullValue(String.class), // pk_catalog_name
-          is("APP"), // pk_schema_name
-          is("FOREIGNTABLE"), // pk_table_name
-          is("ID"), // pk_column_name
-          nullValue(String.class), // fk_catalog_name
-          is("APP"), // fk_schema_name
-          is("INTTABLE"), // fk_table_name
-          is("FOREIGNID"), // fk_column_name
-          is("1"), // key_sequence
-          containsString("SQL"), // fk_key_name
-          containsString("SQL"), // pk_key_name
-          is("3"), // update_rule
-          is("3")); // delete_rule
+      final List<Matcher<String>> matchers =
+          asList(
+              nullValue(String.class), // pk_catalog_name
+              is("APP"), // pk_schema_name
+              is("FOREIGNTABLE"), // pk_table_name
+              is("ID"), // pk_column_name
+              nullValue(String.class), // fk_catalog_name
+              is("APP"), // fk_schema_name
+              is("INTTABLE"), // fk_table_name
+              is("FOREIGNID"), // fk_column_name
+              is("1"), // key_sequence
+              containsString("SQL"), // fk_key_name
+              containsString("SQL"), // pk_key_name
+              is("3"), // update_rule
+              is("3")); // delete_rule
 
       Assertions.assertEquals(1, results.size());
       final List<Executable> assertions = new ArrayList<>();
@@ -877,16 +1360,17 @@ public class TestFlightSql {
 
   @Test
   public void testCreateStatementResults() throws Exception {
-    try (final FlightStream stream = sqlClient
-        .getStream(sqlClient.execute("SELECT * FROM intTable").getEndpoints().get(0).getTicket())) {
+    try (final FlightStream stream =
+        sqlClient.getStream(
+            sqlClient.execute("SELECT * FROM intTable").getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
           () -> {
             MatcherAssert.assertThat(stream.getSchema(), is(SCHEMA_INT_TABLE));
           },
           () -> {
-            MatcherAssert.assertThat(getResults(stream), is(EXPECTED_RESULTS_FOR_STAR_SELECT_QUERY));
-          }
-      );
+            MatcherAssert.assertThat(
+                getResults(stream), is(EXPECTED_RESULTS_FOR_STAR_SELECT_QUERY));
+          });
     }
   }
 
@@ -894,36 +1378,38 @@ public class TestFlightSql {
   public void testExecuteUpdate() {
     Assertions.assertAll(
         () -> {
-          long insertedCount = sqlClient.executeUpdate("INSERT INTO INTTABLE (keyName, value) VALUES " +
-              "('KEYNAME1', 1001), ('KEYNAME2', 1002), ('KEYNAME3', 1003)");
+          long insertedCount =
+              sqlClient.executeUpdate(
+                  "INSERT INTO INTTABLE (keyName, value) VALUES "
+                      + "('KEYNAME1', 1001), ('KEYNAME2', 1002), ('KEYNAME3', 1003)");
           MatcherAssert.assertThat(insertedCount, is(3L));
-
         },
         () -> {
-          long updatedCount = sqlClient.executeUpdate("UPDATE INTTABLE SET keyName = 'KEYNAME1' " +
-              "WHERE keyName = 'KEYNAME2' OR keyName = 'KEYNAME3'");
+          long updatedCount =
+              sqlClient.executeUpdate(
+                  "UPDATE INTTABLE SET keyName = 'KEYNAME1' "
+                      + "WHERE keyName = 'KEYNAME2' OR keyName = 'KEYNAME3'");
           MatcherAssert.assertThat(updatedCount, is(2L));
-
         },
         () -> {
-          long deletedCount = sqlClient.executeUpdate("DELETE FROM INTTABLE WHERE keyName = 'KEYNAME1'");
+          long deletedCount =
+              sqlClient.executeUpdate("DELETE FROM INTTABLE WHERE keyName = 'KEYNAME1'");
           MatcherAssert.assertThat(deletedCount, is(3L));
-        }
-    );
+        });
   }
 
   @Test
   public void testQueryWithNoResultsShouldNotHang() throws Exception {
-    try (final PreparedStatement preparedStatement = sqlClient.prepare("SELECT * FROM intTable WHERE 1 = 0");
-         final FlightStream stream = sqlClient
-             .getStream(preparedStatement.execute().getEndpoints().get(0).getTicket())) {
+    try (final PreparedStatement preparedStatement =
+            sqlClient.prepare("SELECT * FROM intTable WHERE 1 = 0");
+        final FlightStream stream =
+            sqlClient.getStream(preparedStatement.execute().getEndpoints().get(0).getTicket())) {
       Assertions.assertAll(
           () -> MatcherAssert.assertThat(stream.getSchema(), is(SCHEMA_INT_TABLE)),
           () -> {
             final List<List<String>> result = getResults(stream);
             MatcherAssert.assertThat(result, is(emptyList()));
-          }
-      );
+          });
     }
   }
 
@@ -931,22 +1417,28 @@ public class TestFlightSql {
   public void testCancelFlightInfo() {
     FlightInfo info = sqlClient.getSqlInfo();
     CancelFlightInfoRequest request = new CancelFlightInfoRequest(info);
-    FlightRuntimeException fre = assertThrows(FlightRuntimeException.class, () -> sqlClient.cancelFlightInfo(request));
+    FlightRuntimeException fre =
+        assertThrows(FlightRuntimeException.class, () -> sqlClient.cancelFlightInfo(request));
     Assertions.assertEquals(FlightStatusCode.UNIMPLEMENTED, fre.status().code());
   }
 
   @Test
   public void testCancelQuery() {
     FlightInfo info = sqlClient.getSqlInfo();
-    FlightRuntimeException fre = assertThrows(FlightRuntimeException.class, () -> sqlClient.cancelQuery(info));
+    FlightRuntimeException fre =
+        assertThrows(FlightRuntimeException.class, () -> sqlClient.cancelQuery(info));
     assertEquals(FlightStatusCode.UNIMPLEMENTED, fre.status().code());
   }
 
   @Test
   public void testRenewEndpoint() {
     FlightInfo info = sqlClient.getSqlInfo();
-    FlightRuntimeException fre = assertThrows(FlightRuntimeException.class,
-        () -> sqlClient.renewFlightEndpoint(new RenewFlightEndpointRequest(info.getEndpoints().get(0))));
+    FlightRuntimeException fre =
+        assertThrows(
+            FlightRuntimeException.class,
+            () ->
+                sqlClient.renewFlightEndpoint(
+                    new RenewFlightEndpointRequest(info.getEndpoints().get(0))));
     assertEquals(FlightStatusCode.UNIMPLEMENTED, fre.status().code());
   }
 }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSqlStateless.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSqlStateless.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.test;
 
 import static org.apache.arrow.flight.sql.util.FlightStreamUtils.getResults;
@@ -40,9 +39,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/**
- * Test direct usage of Flight SQL workflows.
- */
+/** Test direct usage of Flight SQL workflows. */
 public class TestFlightSqlStateless extends TestFlightSql {
 
   @BeforeAll
@@ -61,8 +58,11 @@ public class TestFlightSqlStateless extends TestFlightSql {
     allocator = new RootAllocator(Integer.MAX_VALUE);
 
     final Location serverLocation = Location.forGrpcInsecure(LOCALHOST, 0);
-    server = FlightServer.builder(allocator, serverLocation,
-                    new FlightSqlStatelessExample(serverLocation, FlightSqlStatelessExample.DB_NAME))
+    server =
+        FlightServer.builder(
+                allocator,
+                serverLocation,
+                new FlightSqlStatelessExample(serverLocation, FlightSqlStatelessExample.DB_NAME))
             .build()
             .start();
 
@@ -75,7 +75,8 @@ public class TestFlightSqlStateless extends TestFlightSql {
   public void testSimplePreparedStatementResultsWithParameterBinding() throws Exception {
     try (PreparedStatement prepare = sqlClient.prepare("SELECT * FROM intTable WHERE id = ?")) {
       final Schema parameterSchema = prepare.getParameterSchema();
-      try (final VectorSchemaRoot insertRoot = VectorSchemaRoot.create(parameterSchema, allocator)) {
+      try (final VectorSchemaRoot insertRoot =
+          VectorSchemaRoot.create(parameterSchema, allocator)) {
         insertRoot.allocateNew();
 
         final IntVector valueVector = (IntVector) insertRoot.getVector(0);
@@ -85,12 +86,13 @@ public class TestFlightSqlStateless extends TestFlightSql {
         prepare.setParameters(insertRoot);
         final FlightInfo flightInfo = prepare.execute();
 
-        for (FlightEndpoint endpoint: flightInfo.getEndpoints()) {
+        for (FlightEndpoint endpoint : flightInfo.getEndpoints()) {
           try (FlightStream stream = sqlClient.getStream(endpoint.getTicket())) {
             Assertions.assertAll(
                 () -> MatcherAssert.assertThat(stream.getSchema(), is(SCHEMA_INT_TABLE)),
-                () -> MatcherAssert.assertThat(getResults(stream), is(EXPECTED_RESULTS_FOR_PARAMETER_BINDING))
-            );
+                () ->
+                    MatcherAssert.assertThat(
+                        getResults(stream), is(EXPECTED_RESULTS_FOR_PARAMETER_BINDING)));
           }
         }
       }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/AdhocTestOption.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/AdhocTestOption.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.util;
 
 import com.google.protobuf.Descriptors.EnumDescriptor;
@@ -22,7 +21,9 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.ProtocolMessageEnum;
 
 enum AdhocTestOption implements ProtocolMessageEnum {
-  OPTION_A, OPTION_B, OPTION_C;
+  OPTION_A,
+  OPTION_B,
+  OPTION_C;
 
   @Override
   public int getNumber() {
@@ -40,6 +41,7 @@ enum AdhocTestOption implements ProtocolMessageEnum {
   }
 
   private UnsupportedOperationException getUnsupportedException() {
-    return new UnsupportedOperationException("Unimplemented method is irrelevant for the scope of this test.");
+    return new UnsupportedOperationException(
+        "Unimplemented method is irrelevant for the scope of this test.");
   }
 }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/SqlInfoOptionsUtilsBitmaskCreationTest.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/SqlInfoOptionsUtilsBitmaskCreationTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.util;
 
 import static java.util.Arrays.asList;
@@ -24,7 +23,6 @@ import static org.apache.arrow.flight.sql.util.AdhocTestOption.OPTION_C;
 import static org.apache.arrow.flight.sql.util.SqlInfoOptionsUtils.createBitmaskFromEnums;
 
 import java.util.List;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,23 +31,22 @@ public final class SqlInfoOptionsUtilsBitmaskCreationTest {
 
   public static List<Object[]> provideParameters() {
     return asList(
-        new Object[][]{
-            {new AdhocTestOption[0], 0L},
-            {new AdhocTestOption[]{OPTION_A}, 1L},
-            {new AdhocTestOption[]{OPTION_B}, 0b10L},
-            {new AdhocTestOption[]{OPTION_A, OPTION_B}, 0b11L},
-            {new AdhocTestOption[]{OPTION_C}, 0b100L},
-            {new AdhocTestOption[]{OPTION_A, OPTION_C}, 0b101L},
-            {new AdhocTestOption[]{OPTION_B, OPTION_C}, 0b110L},
-            {AdhocTestOption.values(), 0b111L},
+        new Object[][] {
+          {new AdhocTestOption[0], 0L},
+          {new AdhocTestOption[] {OPTION_A}, 1L},
+          {new AdhocTestOption[] {OPTION_B}, 0b10L},
+          {new AdhocTestOption[] {OPTION_A, OPTION_B}, 0b11L},
+          {new AdhocTestOption[] {OPTION_C}, 0b100L},
+          {new AdhocTestOption[] {OPTION_A, OPTION_C}, 0b101L},
+          {new AdhocTestOption[] {OPTION_B, OPTION_C}, 0b110L},
+          {AdhocTestOption.values(), 0b111L},
         });
   }
 
   @ParameterizedTest
   @MethodSource("provideParameters")
   public void testShouldBuildBitmaskFromEnums(
-      AdhocTestOption[] adhocTestOptions, long expectedBitmask
-  ) {
+      AdhocTestOption[] adhocTestOptions, long expectedBitmask) {
     Assertions.assertEquals(createBitmaskFromEnums(adhocTestOptions), expectedBitmask);
   }
 }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/SqlInfoOptionsUtilsBitmaskParsingTest.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/SqlInfoOptionsUtilsBitmaskParsingTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.flight.sql.util;
 
 import static java.util.Arrays.asList;
@@ -28,7 +27,6 @@ import static org.apache.arrow.flight.sql.util.SqlInfoOptionsUtils.doesBitmaskTr
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,21 +35,22 @@ public final class SqlInfoOptionsUtilsBitmaskParsingTest {
 
   public static List<Object[]> provideParameters() {
     return asList(
-        new Object[][]{
-            {0L, EnumSet.noneOf(AdhocTestOption.class)},
-            {1L, EnumSet.of(OPTION_A)},
-            {0b10L, EnumSet.of(OPTION_B)},
-            {0b11L, EnumSet.of(OPTION_A, OPTION_B)},
-            {0b100L, EnumSet.of(OPTION_C)},
-            {0b101L, EnumSet.of(OPTION_A, OPTION_C)},
-            {0b110L, EnumSet.of(OPTION_B, OPTION_C)},
-            {0b111L, EnumSet.allOf(AdhocTestOption.class)},
+        new Object[][] {
+          {0L, EnumSet.noneOf(AdhocTestOption.class)},
+          {1L, EnumSet.of(OPTION_A)},
+          {0b10L, EnumSet.of(OPTION_B)},
+          {0b11L, EnumSet.of(OPTION_A, OPTION_B)},
+          {0b100L, EnumSet.of(OPTION_C)},
+          {0b101L, EnumSet.of(OPTION_A, OPTION_C)},
+          {0b110L, EnumSet.of(OPTION_B, OPTION_C)},
+          {0b111L, EnumSet.allOf(AdhocTestOption.class)},
         });
   }
 
   @ParameterizedTest
   @MethodSource("provideParameters")
-  public void testShouldFilterOutEnumsBasedOnBitmask(long bitmask, Set<AdhocTestOption> expectedOptions) {
+  public void testShouldFilterOutEnumsBasedOnBitmask(
+      long bitmask, Set<AdhocTestOption> expectedOptions) {
     final Set<AdhocTestOption> actualOptions =
         stream(AdhocTestOption.values())
             .filter(enumInstance -> doesBitmaskTranslateToEnum(enumInstance, bitmask))

--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -38,6 +38,11 @@ under the License.
     <module>flight-integration-tests</module>
   </modules>
 
+  <properties>
+    <checkstyle.config.location>dev/checkstyle/checkstyle-spotless.xml</checkstyle.config.location>
+    <spotless.java.excludes>none</spotless.java.excludes>
+  </properties>
+
   <profiles>
     <profile>
       <id>pin-mockito-jdk8</id>


### PR DESCRIPTION
### Rationale for this change

Adding code style and formatting options for Flight module. 

- [X] flight-core
- [X] flight-integration-tests
- [X] flight-sql
- [X] flight-sql-jdbc-core
- [X] flight-sql-jdbc-driver

### What changes are included in this PR?

Code formatting spotless plugin has been added. 

Some explicit involvement required for the following

```
[WARN] /home/vibhatha/github/fork/arrow/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightProducer.java:94:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
[WARNING] src/main/java/org/apache/arrow/flight/FlightProducer.java:[94,3] (javadoc) MissingJavadocMethod: Missing a Javadoc comment.
```

```
[WARN] /home/vibhatha/github/fork/arrow/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java:58:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
[WARNING] src/main/java/org/apache/arrow/driver/jdbc/utils/AvaticaParameterBinder.java:[58,3] (javadoc) MissingJavadocMethod: Missing a Javadoc comment.
AvaticaParameterBinder constructor java docs manually added
```

These docs have been explicitly added. 

### Are these changes tested?

Yes, but doesn't involve test cases, the plugin itself corrects. 

* GitHub Issue: #40825