### PR TITLE
MINOR: [Swift] Add missing Bool type to decoder type checks

### DIFF
--- a/swift/Arrow/Sources/Arrow/ArrowDecoder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowDecoder.swift
@@ -146,6 +146,7 @@ private struct ArrowUnkeyedDecoding: UnkeyedDecodingContainer {
             type == UInt32?.self || type == UInt64?.self ||
             type == String?.self || type == Double?.self ||
             type == Float?.self || type == Date?.self ||
+            type == Bool?.self || type == Bool.self ||
             type == Int8.self || type == Int16.self ||
             type == Int32.self || type == Int64.self ||
             type == UInt8.self || type == UInt16.self ||
@@ -359,7 +360,8 @@ private struct ArrowSingleValueDecoding: SingleValueDecodingContainer {
             type == UInt8.self || type == UInt16.self ||
             type == UInt32.self || type == UInt64.self ||
             type == String.self || type == Double.self ||
-            type == Float.self || type == Date.self {
+            type == Float.self || type == Date.self ||
+            type == Bool.self {
             return try self.decoder.doDecode(0)!
         } else {
             throw ArrowError.invalid("Type \(type) is currently not supported")


### PR DESCRIPTION
### What changes are included in this PR?

Adding Bool and Bool? as valid types for decoding.
