### PR TITLE
GH-42087: [Swift] refactored to remove build warnings

### DIFF
--- a/swift/Arrow/Package.swift
+++ b/swift/Arrow/Package.swift
@@ -44,16 +44,27 @@ let package = Package(
     targets: [
         .target(
             name: "ArrowC",
-            path: "Sources/ArrowC"
+            path: "Sources/ArrowC",
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"])
+            ]
         ),
         .target(
             name: "Arrow",
             dependencies: ["ArrowC",
                 .product(name: "FlatBuffers", package: "flatbuffers"),
                 .product(name: "Atomics", package: "swift-atomics")
-            ]),
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"])
+            ]
+        ),
         .testTarget(
             name: "ArrowTests",
-            dependencies: ["Arrow", "ArrowC"])
+            dependencies: ["Arrow", "ArrowC"],
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"])
+            ]
+        )
     ]
 )

--- a/swift/Arrow/Sources/Arrow/ArrowCExporter.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowCExporter.swift
@@ -61,11 +61,17 @@ public class ArrowCExporter {
             // deallocated
             self.arrowData = arrowData
             for arrowBuffer in arrowData.buffers {
-                data.append(arrowBuffer.rawPointer)
+                self.data.append(arrowBuffer.rawPointer)
             }
 
-            self.buffers = UnsafeMutablePointer(mutating: data)
+            self.buffers = UnsafeMutablePointer<UnsafeRawPointer?>.allocate(capacity: self.data.count)
+            self.buffers.initialize(from: &self.data, count: self.data.count)
             super.init()
+        }
+
+        deinit {
+            self.buffers.deinitialize(count: self.data.count)
+            self.buffers.deallocate()
         }
     }
 

--- a/swift/Arrow/Tests/ArrowTests/CodableTests.swift
+++ b/swift/Arrow/Tests/ArrowTests/CodableTests.swift
@@ -98,7 +98,7 @@ final class CodableTests: XCTestCase {
         switch result {
         case .success(let rb):
             let decoder = ArrowDecoder(rb)
-            var testClasses = try decoder.decode(TestClass.self)
+            let testClasses = try decoder.decode(TestClass.self)
             for index in 0..<testClasses.count {
                 let testClass = testClasses[index]
                 XCTAssertEqual(testClass.propBool, index % 2 == 0 ? false : true)

--- a/swift/ArrowFlight/Package.swift
+++ b/swift/ArrowFlight/Package.swift
@@ -45,9 +45,17 @@ let package = Package(
                 .product(name: "Arrow", package: "Arrow"),
                 .product(name: "GRPC", package: "grpc-swift"),
                 .product(name: "SwiftProtobuf", package: "swift-protobuf")
-            ]),
+            ],
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"])
+            ]
+        ),
         .testTarget(
             name: "ArrowFlightTests",
-            dependencies: ["ArrowFlight"])
+            dependencies: ["ArrowFlight"],
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"])
+            ]
+        )
     ]
 )


### PR DESCRIPTION
### Rationale for this change
Building warnings were being generated from the swift code.

### What changes are included in this PR?
Refactored the code in ArrowCExporter and CodableTests to remove the build warnings.  

### Are these changes tested?
Yes, also ran CDataWGo tests locally to test CData interface changes.

* GitHub Issue: #42087