### PR TITLE
GH-37333: [Python] Replace pandas.util.testing.rands with vendored version

### DIFF
--- a/docs/source/python/benchmarks.rst
+++ b/docs/source/python/benchmarks.rst
@@ -27,8 +27,7 @@ run with `ASV`_.  You'll need to install the ``asv`` package first
 Running the benchmarks
 ----------------------
 
-To run the benchmarks for a locally-built Arrow, run ``asv dev`` or
-``asv run --python=same``.
+To run the benchmarks for a locally-built Arrow, run ``asv run --python=same``.
 
 We use conda environments as part of running the benchmarks. To use the ``asv``
 setup, you must set the ``$CONDA_HOME`` environment variable to point to the

--- a/python/benchmarks/common.py
+++ b/python/benchmarks/common.py
@@ -32,9 +32,6 @@ MEGABYTE = KILOBYTE * KILOBYTE
 
 DEFAULT_NONE_PROB = 0.3
 
-# Copied from https://github.com/pandas-dev/pandas for use in rands() below
-RANDS_CHARS = np.array(list(string.ascii_letters + string.digits), dtype=(np.str_, 1))
-
 
 def _multiplicate_sequence(base, target_size):
     q, r = divmod(target_size, len(base))
@@ -352,10 +349,13 @@ class BuiltinsGenerator(object):
         return ty, data
 
 
+# RANDS_CHARS and rands are copyright pandas, see
+# https://github.com/pandas-dev/pandas/blob/main/LICENSE.
+RANDS_CHARS = np.array(list(string.ascii_letters + string.digits), dtype=(np.str_, 1))
+
+
 def rands(nchars) -> str:
     """
     Generate one random byte string.
-
-    Copied from https://github.com/pandas-dev/pandas.
     """
     return "".join(np.random.default_rng(2).choice(RANDS_CHARS, nchars))

--- a/python/benchmarks/common.py
+++ b/python/benchmarks/common.py
@@ -19,7 +19,6 @@ import codecs
 import decimal
 from functools import partial
 import itertools
-import string
 import sys
 import unicodedata
 
@@ -347,15 +346,3 @@ class BuiltinsGenerator(object):
         }
         data = factories[kind](n)
         return ty, data
-
-
-# RANDS_CHARS and rands are copyright pandas, see
-# https://github.com/pandas-dev/pandas/blob/main/LICENSE.
-RANDS_CHARS = np.array(list(string.ascii_letters + string.digits), dtype=(np.str_, 1))
-
-
-def rands(nchars) -> str:
-    """
-    Generate one random byte string.
-    """
-    return "".join(np.random.default_rng(2).choice(RANDS_CHARS, nchars))

--- a/python/benchmarks/common.py
+++ b/python/benchmarks/common.py
@@ -19,6 +19,7 @@ import codecs
 import decimal
 from functools import partial
 import itertools
+import string
 import sys
 import unicodedata
 
@@ -26,11 +27,13 @@ import numpy as np
 
 import pyarrow as pa
 
-
 KILOBYTE = 1 << 10
 MEGABYTE = KILOBYTE * KILOBYTE
 
 DEFAULT_NONE_PROB = 0.3
+
+# Copied from https://github.com/pandas-dev/pandas for use in rands() below
+RANDS_CHARS = np.array(list(string.ascii_letters + string.digits), dtype=(np.str_, 1))
 
 
 def _multiplicate_sequence(base, target_size):
@@ -347,3 +350,12 @@ class BuiltinsGenerator(object):
         }
         data = factories[kind](n)
         return ty, data
+
+
+def rands(nchars) -> str:
+    """
+    Generate one random byte string.
+
+    Copied from https://github.com/pandas-dev/pandas.
+    """
+    return "".join(np.random.default_rng(2).choice(RANDS_CHARS, nchars))

--- a/python/benchmarks/convert_pandas.py
+++ b/python/benchmarks/convert_pandas.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 
 import pyarrow as pa
-from .common import rands
+from pyarrow.tests.util import rands
 
 
 class PandasConversionsBase(object):

--- a/python/benchmarks/convert_pandas.py
+++ b/python/benchmarks/convert_pandas.py
@@ -17,9 +17,9 @@
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
 
 import pyarrow as pa
+from .common import rands
 
 
 class PandasConversionsBase(object):
@@ -60,7 +60,7 @@ class ToPandasStrings(object):
 
     def setup(self, uniqueness, total):
         nunique = int(total * uniqueness)
-        unique_values = [tm.rands(self.string_length) for i in range(nunique)]
+        unique_values = [rands(self.string_length) for i in range(nunique)]
         values = unique_values * (total // nunique)
         self.arr = pa.array(values, type=pa.string())
         self.table = pa.Table.from_arrays([self.arr], ['f0'])

--- a/python/benchmarks/parquet.py
+++ b/python/benchmarks/parquet.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pandas.util.testing import rands
 import numpy as np
 
 import pyarrow as pa
@@ -23,6 +22,7 @@ try:
     import pyarrow.parquet as pq
 except ImportError:
     pq = None
+from .common import rands
 
 
 class ParquetWriteBinary(object):

--- a/python/benchmarks/parquet.py
+++ b/python/benchmarks/parquet.py
@@ -22,7 +22,7 @@ try:
     import pyarrow.parquet as pq
 except ImportError:
     pq = None
-from .common import rands
+from pyarrow.tests.util import rands
 
 
 class ParquetWriteBinary(object):


### PR DESCRIPTION
### Rationale for this change

Fixes https://github.com/apache/arrow/issues/37333.

### What changes are included in this PR?

- Replaces the calls to `pandas.util.testing.rands` with existing `pyarrow.tests.util.rands`
- Updated benchmarks.rst to remove a mention of the now-deprecated `asv dev` command.

### Are these changes tested?

I tested locally in a freshly-created python venv and a conda environment and the benchmarks run without error.

### Are there any user-facing changes?

No.
* GitHub Issue: #37333