### PR TITLE
GH-41094: [C++] Support scalar expression special form

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -717,6 +717,8 @@ set(ARROW_COMPUTE_SRCS
     compute/row/compare_internal.cc
     compute/row/grouper.cc
     compute/row/row_internal.cc
+    compute/special_form.cc
+    compute/special_forms/if_else_special_form.cc
     compute/util.cc
     compute/util_internal.cc)
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -1355,19 +1355,15 @@ const CpuInfo* ExecContext::cpu_info() const { return CpuInfo::GetInstance(); }
 
 SelectionVector::SelectionVector(std::shared_ptr<ArrayData> data)
     : data_(std::move(data)) {
-  DCHECK_EQ(Type::INT32, data_->type->id());
+  DCHECK_EQ(Type::BOOL, data_->type->id());
   DCHECK_EQ(0, data_->GetNullCount());
-  indices_ = data_->GetValues<int32_t>(1);
 }
 
 SelectionVector::SelectionVector(const Array& arr) : SelectionVector(arr.data()) {}
 
-int32_t SelectionVector::length() const { return static_cast<int32_t>(data_->length); }
+std::shared_ptr<ArrayData> SelectionVector::data() const { return data_; }
 
-Result<std::shared_ptr<SelectionVector>> SelectionVector::FromMask(
-    const BooleanArray& arr) {
-  return Status::NotImplemented("FromMask");
-}
+int32_t SelectionVector::length() const { return static_cast<int32_t>(data_->length); }
 
 Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,
                            const FunctionOptions* options, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -427,6 +427,7 @@ struct ARROW_EXPORT ExecSpan {
 
   int64_t length = 0;
   std::vector<ExecValue> values;
+  // A non-owning selection vector to be used by selection-vector-aware kernels.
   SelectionVector* selection_vector = NULLPTR;
 };
 

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -140,15 +140,11 @@ class ARROW_EXPORT SelectionVector {
 
   explicit SelectionVector(const Array& arr);
 
-  /// \brief Create SelectionVector from boolean mask
-  static Result<std::shared_ptr<SelectionVector>> FromMask(const BooleanArray& arr);
-
-  const int32_t* indices() const { return indices_; }
+  std::shared_ptr<ArrayData> data() const;
   int32_t length() const;
 
  private:
   std::shared_ptr<ArrayData> data_;
-  const int32_t* indices_;
 };
 
 /// An index to represent that a batch does not belong to an ordered stream

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -140,6 +140,15 @@ class ARROW_EXPORT SelectionVector {
 
   explicit SelectionVector(const Array& arr);
 
+  Result<std::unique_ptr<SelectionVector>> Copy(
+      const std::shared_ptr<MemoryManager>& mm) const;
+
+  Status Intersect(const ArrayData& other);
+
+  Status Intersect(const SelectionVector& other);
+
+  Status Invert();
+
   std::shared_ptr<ArrayData> data() const;
   int32_t length() const;
 
@@ -418,7 +427,7 @@ struct ARROW_EXPORT ExecSpan {
 
   int64_t length = 0;
   std::vector<ExecValue> values;
-  SelectionVector *selection_vector = NULLPTR;
+  SelectionVector* selection_vector = NULLPTR;
 };
 
 /// \defgroup compute-call-function One-shot calls to compute functions

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -422,6 +422,7 @@ struct ARROW_EXPORT ExecSpan {
 
   int64_t length = 0;
   std::vector<ExecValue> values;
+  SelectionVector *selection_vector = NULLPTR;
 };
 
 /// \defgroup compute-call-function One-shot calls to compute functions

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -48,7 +48,7 @@ class ARROW_EXPORT Expression {
     std::string function_name;
     std::vector<Expression> arguments;
     std::shared_ptr<FunctionOptions> options;
-    bool special_form = false;
+    bool is_special_form = false;
     // Cached hash value
     size_t hash;
 
@@ -58,6 +58,7 @@ class ARROW_EXPORT Expression {
     std::shared_ptr<KernelState> kernel_state;
     TypeHolder type;
     bool selection_vector_aware = false;
+    std::shared_ptr<SpecialForm> special_form{};
 
     void ComputeHash();
   };
@@ -120,7 +121,7 @@ class ARROW_EXPORT Expression {
   // XXX someday
   // NullGeneralization::type nullable() const;
 
-  const bool selection_vector_aware() const;
+  bool selection_vector_aware() const;
 
   struct Parameter {
     FieldRef ref;
@@ -164,14 +165,14 @@ Expression field_ref(FieldRef ref);
 ARROW_EXPORT
 Expression call(std::string function, std::vector<Expression> arguments,
                 std::shared_ptr<FunctionOptions> options = NULLPTR,
-                bool special_form = false);
+                bool is_special_form = false);
 
 template <typename Options, typename = typename std::enable_if<
                                 std::is_base_of<FunctionOptions, Options>::value>::type>
 Expression call(std::string function, std::vector<Expression> arguments, Options options,
-                bool special_form = false) {
+                bool is_special_form = false) {
   return call(std::move(function), std::move(arguments),
-              std::make_shared<Options>(std::move(options)), special_form);
+              std::make_shared<Options>(std::move(options)), is_special_form);
 }
 
 /// Assemble a list of all fields referenced by an Expression at any depth.

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -61,7 +61,7 @@ class ARROW_EXPORT Expression {
     TypeHolder type;
     // Whether the entire call (including all its arguments) is selection-vector-aware
     bool selection_vector_aware = false;
-    std::shared_ptr<SpecialForm> special_form = nullptr;
+    std::shared_ptr<SpecialForm> special_form = NULLPTR;
 
     void ComputeHash();
   };

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -57,6 +57,7 @@ class ARROW_EXPORT Expression {
     const Kernel* kernel = NULLPTR;
     std::shared_ptr<KernelState> kernel_state;
     TypeHolder type;
+    bool selection_vector_aware = false;
 
     void ComputeHash();
   };
@@ -118,6 +119,8 @@ class ARROW_EXPORT Expression {
   const DataType* type() const;
   // XXX someday
   // NullGeneralization::type nullable() const;
+
+  const bool selection_vector_aware() const;
 
   struct Parameter {
     FieldRef ref;

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -48,6 +48,8 @@ class ARROW_EXPORT Expression {
     std::string function_name;
     std::vector<Expression> arguments;
     std::shared_ptr<FunctionOptions> options;
+    // Whether this call is a special form (e.g. if-else). If true, the `special_form`
+    // field will be resolved in binding.
     bool is_special_form = false;
     // Cached hash value
     size_t hash;
@@ -57,8 +59,9 @@ class ARROW_EXPORT Expression {
     const Kernel* kernel = NULLPTR;
     std::shared_ptr<KernelState> kernel_state;
     TypeHolder type;
+    // Whether the entire call (including all its arguments) is selection-vector-aware
     bool selection_vector_aware = false;
-    std::shared_ptr<SpecialForm> special_form{};
+    std::shared_ptr<SpecialForm> special_form = nullptr;
 
     void ComputeHash();
   };
@@ -121,6 +124,10 @@ class ARROW_EXPORT Expression {
   // XXX someday
   // NullGeneralization::type nullable() const;
 
+  /// Whether the entire expression (including all its subexpressions) is
+  /// selection-vector-aware. If true, then the expression can be executed using the "fast
+  /// path" - all kernels directly working on the selection vector. Otherwise the
+  /// execution takes the "slow path" - gathering the input and scattering the output.
   bool selection_vector_aware() const;
 
   struct Parameter {

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -48,22 +48,7 @@ class ARROW_EXPORT Expression {
     std::string function_name;
     std::vector<Expression> arguments;
     std::shared_ptr<FunctionOptions> options;
-    // Cached hash value
-    size_t hash;
-
-    // post-Bind properties:
-    std::shared_ptr<Function> function;
-    const Kernel* kernel = NULLPTR;
-    std::shared_ptr<KernelState> kernel_state;
-    TypeHolder type;
-
-    void ComputeHash();
-  };
-
-  struct SpecialCall {
-    std::string function_name;
-    std::vector<Expression> arguments;
-    std::shared_ptr<FunctionOptions> options;
+    bool special_form = false;
     // Cached hash value
     size_t hash;
 
@@ -175,14 +160,15 @@ Expression field_ref(FieldRef ref);
 
 ARROW_EXPORT
 Expression call(std::string function, std::vector<Expression> arguments,
-                std::shared_ptr<FunctionOptions> options = NULLPTR);
+                std::shared_ptr<FunctionOptions> options = NULLPTR,
+                bool special_form = false);
 
 template <typename Options, typename = typename std::enable_if<
                                 std::is_base_of<FunctionOptions, Options>::value>::type>
-Expression call(std::string function, std::vector<Expression> arguments,
-                Options options) {
+Expression call(std::string function, std::vector<Expression> arguments, Options options,
+                bool special_form = false) {
   return call(std::move(function), std::move(arguments),
-              std::make_shared<Options>(std::move(options)));
+              std::make_shared<Options>(std::move(options)), special_form);
 }
 
 /// Assemble a list of all fields referenced by an Expression at any depth.

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -60,6 +60,22 @@ class ARROW_EXPORT Expression {
     void ComputeHash();
   };
 
+  struct SpecialCall {
+    std::string function_name;
+    std::vector<Expression> arguments;
+    std::shared_ptr<FunctionOptions> options;
+    // Cached hash value
+    size_t hash;
+
+    // post-Bind properties:
+    std::shared_ptr<Function> function;
+    const Kernel* kernel = NULLPTR;
+    std::shared_ptr<KernelState> kernel_state;
+    TypeHolder type;
+
+    void ComputeHash();
+  };
+
   std::string ToString() const;
   bool Equals(const Expression& other) const;
   size_t hash() const;

--- a/cpp/src/arrow/compute/expression_internal.h
+++ b/cpp/src/arrow/compute/expression_internal.h
@@ -291,6 +291,7 @@ inline Result<std::shared_ptr<compute::Function>> GetFunction(
   return GetCastFunction(*to_type);
 }
 
+// Execute a call expression with all arguments already evaluated.
 inline Result<Datum> ExecuteCallNonRecursive(const Expression::Call& call,
                                              const ExecBatch& input,
                                              const std::vector<Datum>& arguments,

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -525,6 +525,10 @@ struct ARROW_EXPORT Kernel {
   // Additional kernel-specific data
   std::shared_ptr<KernelState> data;
 
+  /// \brief Indicates whether the kernel is selection-vector-aware. A
+  /// selection-vector-aware kernel is able to emit a partial result based on a given
+  /// selection vector without having to gathering the input and scattering the output,
+  /// aka. the "slow path", in the caller.
   bool selection_vector_aware = false;
 };
 

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -524,6 +524,8 @@ struct ARROW_EXPORT Kernel {
 
   // Additional kernel-specific data
   std::shared_ptr<KernelState> data;
+
+  bool selection_vector_aware = false;
 };
 
 /// \brief The scalar kernel execution API that must be implemented for SCALAR
@@ -566,7 +568,6 @@ struct ARROW_EXPORT ScalarKernel : public Kernel {
   // bitmaps is a reasonable default
   NullHandling::type null_handling = NullHandling::INTERSECTION;
   MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE;
-  bool selection_vector_aware = false;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -566,6 +566,7 @@ struct ARROW_EXPORT ScalarKernel : public Kernel {
   // bitmaps is a reasonable default
   NullHandling::type null_handling = NullHandling::INTERSECTION;
   MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE;
+  bool selection_vector_aware = false;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -418,27 +418,6 @@ static void VisitTwoArrayValuesInline(const ArraySpan& arr0, const ArraySpan& ar
                         std::move(visit_null));
 }
 
-template <typename Arg0Type, typename Arg1Type, typename VisitFunc, typename NullFunc>
-static void VisitTwoArrayValuesWithSelInline(const ArraySpan& arr0, const ArraySpan& arr1,
-                                             VisitFunc&& valid_func, NullFunc&& null_func,
-                                             SelectionVector* sel) {
-  ArrayIterator<Arg0Type> arr0_it(arr0);
-  ArrayIterator<Arg1Type> arr1_it(arr1);
-
-  auto visit_valid = [&](int64_t i) {
-    valid_func(GetViewType<Arg0Type>::LogicalValue(arr0_it()),
-               GetViewType<Arg1Type>::LogicalValue(arr1_it()));
-  };
-  auto visit_null = [&]() {
-    arr0_it();
-    arr1_it();
-    null_func();
-  };
-  VisitTwoBitBlocksVoid(arr0.buffers[0].data, arr0.offset, arr1.buffers[0].data,
-                        arr1.offset, arr0.length, std::move(visit_valid),
-                        std::move(visit_null));
-}
-
 // ----------------------------------------------------------------------
 // Reusable type resolvers
 
@@ -802,19 +781,6 @@ struct ScalarBinaryNotNullStateful {
     return st;
   }
 
-  Status ArrayArrayWithSel(KernelContext* ctx, const ArraySpan& arg0,
-                           const ArraySpan& arg1, SelectionVector* sel, ExecResult* out) {
-    Status st = Status::OK();
-    OutputArrayWriter<OutType> writer(out->array_span_mutable());
-    VisitTwoArrayValuesInline<Arg0Type, Arg1Type>(
-        arg0, arg1,
-        [&](Arg0Value u, Arg1Value v) {
-          writer.Write(op.template Call<OutValue, Arg0Value, Arg1Value>(ctx, u, v, &st));
-        },
-        [&]() { writer.WriteNull(); });
-    return st;
-  }
-
   Status ArrayScalar(KernelContext* ctx, const ArraySpan& arg0, const Scalar& arg1,
                      ExecResult* out) {
     Status st = Status::OK();
@@ -835,48 +801,8 @@ struct ScalarBinaryNotNullStateful {
     return st;
   }
 
-  Status ArrayScalarWithSel(KernelContext* ctx, const ArraySpan& arg0, const Scalar& arg1,
-                            SelectionVector* sel, ExecResult* out) {
-    Status st = Status::OK();
-    ArraySpan* out_span = out->array_span_mutable();
-    OutputArrayWriter<OutType> writer(out_span);
-    if (arg1.is_valid) {
-      const auto arg1_val = UnboxScalar<Arg1Type>::Unbox(arg1);
-      VisitArrayValuesInline<Arg0Type>(
-          arg0,
-          [&](Arg0Value u) {
-            writer.Write(
-                op.template Call<OutValue, Arg0Value, Arg1Value>(ctx, u, arg1_val, &st));
-          },
-          [&]() { writer.WriteNull(); });
-    } else {
-      writer.WriteAllNull(out_span->length);
-    }
-    return st;
-  }
-
   Status ScalarArray(KernelContext* ctx, const Scalar& arg0, const ArraySpan& arg1,
                      ExecResult* out) {
-    Status st = Status::OK();
-    ArraySpan* out_span = out->array_span_mutable();
-    OutputArrayWriter<OutType> writer(out_span);
-    if (arg0.is_valid) {
-      const auto arg0_val = UnboxScalar<Arg0Type>::Unbox(arg0);
-      VisitArrayValuesInline<Arg1Type>(
-          arg1,
-          [&](Arg1Value v) {
-            writer.Write(
-                op.template Call<OutValue, Arg0Value, Arg1Value>(ctx, arg0_val, v, &st));
-          },
-          [&]() { writer.WriteNull(); });
-    } else {
-      writer.WriteAllNull(out_span->length);
-    }
-    return st;
-  }
-
-  Status ScalarArrayWithSel(KernelContext* ctx, const Scalar& arg0, const ArraySpan& arg1,
-                            SelectionVector* sel, ExecResult* out) {
     Status st = Status::OK();
     ArraySpan* out_span = out->array_span_mutable();
     OutputArrayWriter<OutType> writer(out_span);

--- a/cpp/src/arrow/compute/special_form.cc
+++ b/cpp/src/arrow/compute/special_form.cc
@@ -15,45 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
+// NOTE: API is EXPERIMENTAL and will change without going through a
+// deprecation cycle.
 
-#include "arrow/util/visibility.h"
+#include "arrow/compute/special_form.h"
+#include "arrow/compute/api_vector.h"
+#include "arrow/compute/exec.h"
+#include "arrow/compute/special_forms/if_else_special_form.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
-
-struct Datum;
-struct TypeHolder;
-
 namespace compute {
 
-class Function;
-class ScalarAggregateFunction;
-class FunctionExecutor;
-class FunctionOptions;
-class FunctionRegistry;
-
-/// \brief Return the process-global function registry.
-// Defined in registry.cc
-ARROW_EXPORT FunctionRegistry* GetFunctionRegistry();
-
-class CastOptions;
-
-struct ExecBatch;
-class ExecContext;
-class KernelContext;
-
-struct Kernel;
-struct ScalarKernel;
-struct ScalarAggregateKernel;
-struct VectorKernel;
-
-struct KernelState;
-
-class Expression;
-class SpecialForm;
-
-ARROW_EXPORT ExecContext* default_exec_context();
-ARROW_EXPORT ExecContext* threaded_exec_context();
+Result<std::unique_ptr<SpecialForm>> SpecialForm::Make(const std::string& name) {
+  if (name == "if_else") {
+    return std::make_unique<IfElseSpecialForm>();
+  }
+  return Status::Invalid("Unknown special form: ", name);
+}
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/special_form.h
+++ b/cpp/src/arrow/compute/special_form.h
@@ -15,45 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// NOTE: API is EXPERIMENTAL and will change without going through a
+// deprecation cycle.
+
 #pragma once
 
+#include "arrow/compute/expression.h"
 #include "arrow/util/visibility.h"
 
+#include <vector>
+
 namespace arrow {
-
-struct Datum;
-struct TypeHolder;
-
 namespace compute {
 
-class Function;
-class ScalarAggregateFunction;
-class FunctionExecutor;
-class FunctionOptions;
-class FunctionRegistry;
+class ARROW_EXPORT SpecialForm {
+ public:
+  static Result<std::unique_ptr<SpecialForm>> Make(const std::string& name);
 
-/// \brief Return the process-global function registry.
-// Defined in registry.cc
-ARROW_EXPORT FunctionRegistry* GetFunctionRegistry();
+  virtual ~SpecialForm() = default;
 
-class CastOptions;
-
-struct ExecBatch;
-class ExecContext;
-class KernelContext;
-
-struct Kernel;
-struct ScalarKernel;
-struct ScalarAggregateKernel;
-struct VectorKernel;
-
-struct KernelState;
-
-class Expression;
-class SpecialForm;
-
-ARROW_EXPORT ExecContext* default_exec_context();
-ARROW_EXPORT ExecContext* threaded_exec_context();
+  virtual Result<Datum> Execute(const Expression::Call& call, const ExecBatch& input,
+                                ExecContext* exec_context) = 0;
+};
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/special_forms/if_else_special_form.cc
+++ b/cpp/src/arrow/compute/special_forms/if_else_special_form.cc
@@ -36,6 +36,7 @@ Result<Datum> IfElseSpecialForm::Execute(const Expression::Call& call,
   ARROW_ASSIGN_OR_RAISE(arguments[0],
                         ExecuteScalarExpression(call.arguments[0], input, exec_context));
   // Use cond as selection vector for IF.
+  // TODO: Consider chunked array for arguments[0].
   auto if_sel = std::make_shared<SelectionVector>(arguments[0].array());
   // Duplicate and invert cond as selection vector for ELSE.
   ARROW_ASSIGN_OR_RAISE(

--- a/cpp/src/arrow/compute/special_forms/if_else_special_form.cc
+++ b/cpp/src/arrow/compute/special_forms/if_else_special_form.cc
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// NOTE: API is EXPERIMENTAL and will change without going through a
+// deprecation cycle.
+
+#include "arrow/compute/special_forms/if_else_special_form.h"
+#include "arrow/compute/exec.h"
+#include "arrow/compute/expression.h"
+#include "arrow/compute/expression_internal.h"
+
+namespace arrow {
+namespace compute {
+
+Result<Datum> IfElseSpecialForm::Execute(const Expression::Call& call,
+                                         const ExecBatch& input,
+                                         ExecContext* exec_context) {
+  DCHECK(!call.kernel->selection_vector_aware);
+  DCHECK(!input.selection_vector);
+
+  std::vector<Datum> arguments(call.arguments.size());
+  ARROW_ASSIGN_OR_RAISE(arguments[0],
+                        ExecuteScalarExpression(call.arguments[0], input, exec_context));
+  // Use cond as selection vector for IF.
+  auto if_sel = std::make_shared<SelectionVector>(arguments[0].array());
+  // Duplicate and invert cond as selection vector for ELSE.
+  ARROW_ASSIGN_OR_RAISE(
+      auto else_sel,
+      if_sel->Copy(CPUDevice::memory_manager(exec_context->memory_pool())));
+  RETURN_NOT_OK(else_sel->Invert());
+
+  ExecBatch if_input = input;
+  if_input.selection_vector = std::move(if_sel);
+  ARROW_ASSIGN_OR_RAISE(
+      arguments[1], ExecuteScalarExpression(call.arguments[1], if_input, exec_context));
+  ExecBatch else_input = input;
+  else_input.selection_vector = std::move(else_sel);
+  ARROW_ASSIGN_OR_RAISE(
+      arguments[2], ExecuteScalarExpression(call.arguments[2], else_input, exec_context));
+
+  return ExecuteCallNonRecursive(call, input, arguments, exec_context);
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/special_forms/if_else_special_form.h
+++ b/cpp/src/arrow/compute/special_forms/if_else_special_form.h
@@ -15,45 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// NOTE: API is EXPERIMENTAL and will change without going through a
+// deprecation cycle.
+
 #pragma once
 
-#include "arrow/util/visibility.h"
+#include "arrow/compute/special_form.h"
 
 namespace arrow {
-
-struct Datum;
-struct TypeHolder;
-
 namespace compute {
 
-class Function;
-class ScalarAggregateFunction;
-class FunctionExecutor;
-class FunctionOptions;
-class FunctionRegistry;
-
-/// \brief Return the process-global function registry.
-// Defined in registry.cc
-ARROW_EXPORT FunctionRegistry* GetFunctionRegistry();
-
-class CastOptions;
-
-struct ExecBatch;
-class ExecContext;
-class KernelContext;
-
-struct Kernel;
-struct ScalarKernel;
-struct ScalarAggregateKernel;
-struct VectorKernel;
-
-struct KernelState;
-
-class Expression;
-class SpecialForm;
-
-ARROW_EXPORT ExecContext* default_exec_context();
-ARROW_EXPORT ExecContext* threaded_exec_context();
+class ARROW_EXPORT IfElseSpecialForm : public SpecialForm {
+ public:
+  Result<Datum> Execute(const Expression::Call& call, const ExecBatch& input,
+                        ExecContext* exec_context) override;
+};
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit_block_counter.h
+++ b/cpp/src/arrow/util/bit_block_counter.h
@@ -480,6 +480,35 @@ static void VisitBitBlocksVoid(const uint8_t* bitmap, int64_t offset, int64_t le
 }
 
 template <typename VisitNotNull, typename VisitNull>
+static void VisitBitBlocksWithSelVoid(const uint8_t* bitmap, int64_t offset,
+                                      int64_t length, const int32_t* sel,
+                                      int64_t sel_length, VisitNotNull&& visit_not_null,
+                                      VisitNull&& visit_null) {
+  internal::OptionalBitBlockCounter bit_counter(bitmap, offset, length);
+  int64_t position = 0;
+  while (position < length) {
+    internal::BitBlockCount block = bit_counter.NextBlock();
+    if (block.AllSet()) {
+      for (int64_t i = 0; i < block.length; ++i, ++position) {
+        visit_not_null(position);
+      }
+    } else if (block.NoneSet()) {
+      for (int64_t i = 0; i < block.length; ++i, ++position) {
+        visit_null();
+      }
+    } else {
+      for (int64_t i = 0; i < block.length; ++i, ++position) {
+        if (bit_util::GetBit(bitmap, offset + position)) {
+          visit_not_null(position);
+        } else {
+          visit_null();
+        }
+      }
+    }
+  }
+}
+
+template <typename VisitNotNull, typename VisitNull>
 static Status VisitTwoBitBlocks(const uint8_t* left_bitmap, int64_t left_offset,
                                 const uint8_t* right_bitmap, int64_t right_offset,
                                 int64_t length, VisitNotNull&& visit_not_null,
@@ -538,6 +567,50 @@ static void VisitTwoBitBlocksVoid(const uint8_t* left_bitmap, int64_t left_offse
       return VisitBitBlocksVoid(left_bitmap, left_offset, length,
                                 std::forward<VisitNotNull>(visit_not_null),
                                 std::forward<VisitNull>(visit_null));
+    }
+  }
+  BinaryBitBlockCounter bit_counter(left_bitmap, left_offset, right_bitmap, right_offset,
+                                    length);
+  int64_t position = 0;
+  while (position < length) {
+    BitBlockCount block = bit_counter.NextAndWord();
+    if (block.AllSet()) {
+      for (int64_t i = 0; i < block.length; ++i, ++position) {
+        visit_not_null(position);
+      }
+    } else if (block.NoneSet()) {
+      for (int64_t i = 0; i < block.length; ++i, ++position) {
+        visit_null();
+      }
+    } else {
+      for (int64_t i = 0; i < block.length; ++i, ++position) {
+        if (bit_util::GetBit(left_bitmap, left_offset + position) &&
+            bit_util::GetBit(right_bitmap, right_offset + position)) {
+          visit_not_null(position);
+        } else {
+          visit_null();
+        }
+      }
+    }
+  }
+}
+
+template <typename VisitNotNull, typename VisitNull>
+static void VisitTwoBitBlocksWithSelVoid(const uint8_t* left_bitmap, int64_t left_offset,
+                                         const uint8_t* right_bitmap,
+                                         int64_t right_offset, const int32_t* sel,
+                                         int64_t length, VisitNotNull&& visit_not_null,
+                                         VisitNull&& visit_null) {
+  if (left_bitmap == NULLPTR || right_bitmap == NULLPTR) {
+    // At most one bitmap is present
+    if (left_bitmap == NULLPTR) {
+      return VisitBitBlocksWithSelVoid(right_bitmap, right_offset, length,
+                                       std::forward<VisitNotNull>(visit_not_null),
+                                       std::forward<VisitNull>(visit_null));
+    } else {
+      return VisitBitBlocksWithSelVoid(left_bitmap, left_offset, length,
+                                       std::forward<VisitNotNull>(visit_not_null),
+                                       std::forward<VisitNull>(visit_null));
     }
   }
   BinaryBitBlockCounter bit_counter(left_bitmap, left_offset, right_bitmap, right_offset,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

@felipecrv gave a very descriptive rationale in comment https://github.com/apache/arrow/issues/41094#issuecomment-2087716483. This PR follows it mostly, with the following exceptions:
1. I found bit mask is more preferable to be used as the "selection vector", e.g., the first argument of `if_else` evaluates a boolean column, which is exactly the mask we need for `if` branch and saves the indices collection. (but I guess the naming should be revised as I saw other usage of term "selection vector" is referring to indices, not mask?)
2. I didn't make the special form the fourth impl of `Expression` as I found for most cases, e.g. creation and binding, a special form is just a `Call` - there would be too much duplicated code if we differentiate `SpeicalForm` from `Call`. So I made it a `Call` with a special flag, and did little specialization in binding and evaluation.
3. A special form `Call` contains a post-bound polymorphic `SpecialForm` pointer, which will take over the evaluation of the whole expression.
4. Special form `if_else` is implemented to show-case how a special form leverages selection vector to mask the evaluation of certain arguments. Another thing to note is that `if_else` special form still leverages `if_else` kernel to do the final function evaluation (with all arguments properly evaluated).
5. The kernels are not bothered with the concept "special form", they only need to sense the existence of selection vector. If they support selection-vector-aware execution, they just claim this fact when registration. Otherwise they can keep being dumb and the `Expression` evaluation will take care of the selection vector on their behalves, i.e., the "slow path".
6. The `Function` structure is not touched at all. Because when a `Function` is called, all arguments are already evaluated, so special forms don't come into play.
7. I'm also working on a "scatter" operation, as well as piloting some simple kernels to be selection-vector-aware elsewhere. The code is not included in this PR because I don't want them to distract the attention on the main sketch. I'll send out those code separately, or include them in this PR in the future - I'm not sure yet.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
8. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41094