### PR TITLE
GH-42107: [C++][FS][Azure] Ensure setting BlobSasBuilder::Protocol

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -418,6 +418,9 @@ AzureOptions::MakeDataLakeServiceClient() const {
 
 Result<std::string> AzureOptions::GenerateSASToken(
     Storage::Sas::BlobSasBuilder* builder, Blobs::BlobServiceClient* client) const {
+  using SasProtocol = Storage::Sas::SasProtocol;
+  builder->Protocol =
+      blob_storage_scheme == "http" ? SasProtocol::HttpsAndHttp : SasProtocol::HttpsOnly;
   if (storage_shared_key_credential_) {
     return builder->GenerateSasToken(*storage_shared_key_credential_);
   } else {


### PR DESCRIPTION
### Rationale for this change

`BlobSasBuilder::Protocol` is used in `BlobSasBuilder::GenerateSasToken()` and it doesn't have the default value. If we don't specify it explicitly, `GenerateSasToken()` result may be unexpected.

### What changes are included in this PR?

Set `BlobSasBuilder::Protocol` explicitly based on `AzureOptions::blob_storage_scheme`. It's `https` by default but can be `http` when `enable_tls=false` query parameter is specified.

If it's `http`, both of `https` and `http` are accepted as protocol.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #42107