### PR TITLE
GH-42109: [C++][CMake] Add preset for Valgrind

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -222,17 +222,10 @@
     },
     {
       "name": "features-valgrind",
-      "inherits": [
-        "features-maximal"
-      ],
       "hidden": true,
       "cacheVariables": {
-        "ARROW_FLIGHT": "OFF",
-        "ARROW_GANDIVA": "OFF",
-        "ARROW_JEMALLOC": "OFF",
         "ARROW_RUNTIME_SIMD_LEVEL": "AVX2",
-        "ARROW_TEST_MEMCHECK": "ON",
-        "BUILD_WARNING_LEVEL": "PRODUCTION"
+        "ARROW_TEST_MEMCHECK": "ON"
       }
     },
     {
@@ -347,12 +340,43 @@
       "cacheVariables": {}
     },
     {
+      "name": "ninja-debug-valgrind-basic",
+      "inherits": [
+        "base-debug",
+        "features-basic",
+        "features-valgrind"
+      ],
+      "displayName": "Debug build for Valgrind with reduced dependencies",
+      "cacheVariables": {}
+    },
+    {
       "name": "ninja-debug-valgrind",
       "inherits": [
         "base-debug",
+        "features-main",
         "features-valgrind"
       ],
-      "displayName": "Debug build for Valgrind",
+      "displayName": "Debug build for Valgrind with more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-valgrind-minimal",
+      "inherits": [
+        "base-debug",
+        "features-minimal",
+        "features-valgrind"
+      ],
+      "displayName": "Debug build for Valgrind without anything enabled",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-valgrind-maximal",
+      "inherits": [
+        "base-debug",
+        "features-maximal",
+        "features-valgrind"
+      ],
+      "displayName": "Debug build for Valgrind with everything enabled",
       "cacheVariables": {}
     },
     {

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -221,6 +221,21 @@
       }
     },
     {
+      "name": "features-valgrind",
+      "inherits": [
+        "features-maximal"
+      ],
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_FLIGHT": "OFF",
+        "ARROW_GANDIVA": "OFF",
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_RUNTIME_SIMD_LEVEL": "AVX2",
+        "ARROW_TEST_MEMCHECK": "ON",
+        "BUILD_WARNING_LEVEL": "PRODUCTION"
+      }
+    },
+    {
       "name": "ninja-debug-minimal",
       "inherits": [
         "base-debug",
@@ -329,6 +344,15 @@
         "features-maximal"
       ],
       "displayName": "Debug build with everything enabled (except benchmarks)",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-valgrind",
+      "inherits": [
+        "base-debug",
+        "features-valgrind"
+      ],
+      "displayName": "Debug build for Valgrind",
       "cacheVariables": {}
     },
     {


### PR DESCRIPTION
### Rationale for this change

If we want to use Valgrind for our tests, we need to specify at least the following CMake options:

* `ARROW_RUNTIME_SIMD_LEVEL=AVX2`
* `ARROW_TEST_MEMCHECK=ON`

If we have a CMake preset for Valgrind, we don't need to remember them.

### What changes are included in this PR?

Add `features-valgrind` and `ninja-debug-valgrind` preset. `features-valgrind` is a hidden preset.

### Are these changes tested?

Yes. I used this to reproduce #42107 on local.

### Are there any user-facing changes?

No.
* GitHub Issue: #42109