### PR TITLE
GH-42112: [Python] Array gracefully fails on non-cpu device

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1934,7 +1934,7 @@ cdef class Array(_PandasConvertible):
         """
         return self.device_type == DeviceAllocationType.CPU
 
-    cdef _assert_cpu(self) except -1:
+    cdef void _assert_cpu(self) except *:
         if self.sp_array.get().device_type() != CDeviceAllocationType_kCPU:
             raise NotImplementedError("Implemented only for data on CPU device")
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1658,6 +1658,7 @@ cdef class Array(_PandasConvertible):
         ArrowInvalid
         """
         if full:
+            self._assert_cpu()
             with nogil:
                 check_status(self.ap.ValidateFull())
         else:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1233,7 +1233,6 @@ cdef class Array(_PandasConvertible):
             yield self.getitem(i)
 
     def __repr__(self):
-        self._assert_cpu()
         type_format = object.__repr__(self)
         return '{0}\n{1}'.format(type_format, str(self))
 
@@ -1320,7 +1319,7 @@ cdef class Array(_PandasConvertible):
         bool
         """
         self._assert_cpu()
-        self.other._assert_cpu()
+        other._assert_cpu()
         return self.ap.Equals(deref(other.ap))
 
     def __len__(self):
@@ -1424,8 +1423,6 @@ cdef class Array(_PandasConvertible):
         -------
         sliced : RecordBatch
         """
-        self._assert_cpu()
-
         cdef shared_ptr[CArray] result
 
         if offset < 0:
@@ -1937,8 +1934,8 @@ cdef class Array(_PandasConvertible):
         """
         return self.device_type == DeviceAllocationType.CPU
 
-    def _assert_cpu(self):
-        if not self.is_cpu:
+    cdef _assert_cpu(self) except -1:
+        if self.sp_array.get().device_type() != CDeviceAllocationType_kCPU:
             raise NotImplementedError("Implemented only for data on CPU device")
 
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1108,7 +1108,6 @@ cdef class Array(_PandasConvertible):
         array : pyarrow.Array or pyarrow.ChunkedArray
             ChunkedArray is returned if object data overflows binary buffer.
         """
-        self._assert_cpu()
         return array(obj, mask=mask, type=type, safe=safe, from_pandas=True,
                      memory_pool=memory_pool)
 
@@ -1300,7 +1299,6 @@ cdef class Array(_PandasConvertible):
         return self.to_string(**kwargs)
 
     def __str__(self):
-        self._assert_cpu()
         return self.to_string()
 
     def __eq__(self, other):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -234,6 +234,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CStatus Validate() const
         CStatus ValidateFull() const
         CResult[shared_ptr[CArray]] View(const shared_ptr[CDataType]& type)
+        CDeviceAllocationType device_type()
 
     shared_ptr[CArray] MakeArray(const shared_ptr[CArrayData]& data)
     CResult[shared_ptr[CArray]] MakeArrayOfNull(

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -286,6 +286,7 @@ cdef class Array(_PandasConvertible):
     cdef void init(self, const shared_ptr[CArray]& sp_array) except *
     cdef getitem(self, int64_t i)
     cdef int64_t length(self)
+    cdef void _assert_cpu(self) except *
 
 
 cdef class Tensor(_Weakrefable):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4030,7 +4030,7 @@ def test_non_cpu_array():
     # Supported
     arr.validate()
     arr.validate(full=True)
-    assert arr.offset() == 0
+    assert arr.offset == 0
     assert arr.buffers() == [None, cuda_data_buf]
     assert arr.device_type == pa.DeviceAllocationType.CUDA
     assert arr.is_cpu is False

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4035,9 +4035,7 @@ def test_non_cpu_array():
     assert arr.device_type == pa.DeviceAllocationType.CUDA
     assert arr.is_cpu is False
     assert len(arr) == 4
-    assert arr.slice(2, 2) == pa.RecordBatch.from_arrays([
-        ctx.buffer_from_data(data[2:])
-    ])
+    assert arr.slice(2, 2).offset == 2
 
     # TODO support DLPack for CUDA
     with pytest.raises(NotImplementedError):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4024,7 +4024,8 @@ def test_non_cpu_array():
     cuda_validity_buf = ctx.buffer_from_data(validity)
     arr = pa.Array.from_buffers(pa.int32(), 4, [None, cuda_data_buf])
     arr2 = pa.Array.from_buffers(pa.int32(), 4, [None, cuda_data_buf])
-    arr_with_nulls = pa.Array.from_buffers(pa.int32(), 4, [cuda_validity_buf, cuda_data_buf])
+    arr_with_nulls = pa.Array.from_buffers(
+        pa.int32(), 4, [cuda_validity_buf, cuda_data_buf])
 
     # Supported
     arr.validate()
@@ -4050,7 +4051,7 @@ def test_non_cpu_array():
     with pytest.raises(NotImplementedError):
         arr.value_counts()
     with pytest.raises(NotImplementedError):
-        arr.null_count
+        arr_with_nulls.null_count
     with pytest.raises(NotImplementedError):
         arr.nbytes
     with pytest.raises(NotImplementedError):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4034,6 +4034,16 @@ def test_non_cpu_array():
     assert arr.buffers() == [None, cuda_data_buf]
     assert arr.device_type == pa.DeviceAllocationType.CUDA
     assert arr.is_cpu is False
+    assert len(arr) == 4
+    assert arr.slice(2, 2) == pa.RecordBatch.from_arrays([
+        ctx.buffer_from_data(data[2:])
+    ])
+
+    # TODO support DLPack for CUDA
+    with pytest.raises(NotImplementedError):
+        arr.__dlpack__()
+    with pytest.raises(NotImplementedError):
+        arr.__dlpack_device__()
 
     # Not Supported
     with pytest.raises(NotImplementedError):
@@ -4073,11 +4083,7 @@ def test_non_cpu_array():
     with pytest.raises(NotImplementedError):
         arr.fill_null(0)
     with pytest.raises(NotImplementedError):
-        arr.__getitem__(0)
-    with pytest.raises(NotImplementedError):
-        arr.getitem(0)
-    with pytest.raises(NotImplementedError):
-        arr.slice()
+        arr[0]
     with pytest.raises(NotImplementedError):
         arr.take([0])
     with pytest.raises(NotImplementedError):
@@ -4094,7 +4100,3 @@ def test_non_cpu_array():
         arr.to_numpy()
     with pytest.raises(NotImplementedError):
         arr.to_list()
-    with pytest.raises(NotImplementedError):
-        arr.__dlpack__()
-    with pytest.raises(NotImplementedError):
-        arr.__dlpack_device__()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4097,4 +4097,4 @@ def test_non_cpu_array():
     with pytest.raises(NotImplementedError):
         arr.to_numpy()
     with pytest.raises(NotImplementedError):
-        arr.to_list()
+        arr.tolist()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4029,7 +4029,6 @@ def test_non_cpu_array():
 
     # Supported
     arr.validate()
-    arr.validate(full=True)
     assert arr.offset == 0
     assert arr.buffers() == [None, cuda_data_buf]
     assert arr.device_type == pa.DeviceAllocationType.CUDA
@@ -4098,3 +4097,5 @@ def test_non_cpu_array():
         arr.to_numpy()
     with pytest.raises(NotImplementedError):
         arr.tolist()
+    with pytest.raises(NotImplementedError):
+        arr.validate(full=True)


### PR DESCRIPTION
### Rationale for this change

Common `Array` APIs should not segfault or abort on non-cpu devices.

### What changes are included in this PR?

* `device_type` and `is_cpu` methods added to the `Array` class
* Any function that segfaults, aborts, or gives incorrect results on non-cpu devices now raises an exception 

### Are these changes tested?

* Unit tests added

### Are there any user-facing changes?

* `device_type` and `is_cpu` methods added to the `Array` class
* GitHub Issue: #42112