### PR TITLE
GH-39294: [C++][Python] DLPack on Tensor class

### DIFF
--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -154,7 +154,7 @@ Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   if (t->size() == 0) {
     ctx->tensor.dl_tensor.data = NULL;
   } else {
-    ctx->tensor.dl_tensor.data = const_cast<uint8_t*>(t->raw_data());
+    ctx->tensor.dl_tensor.data = t->raw_mutable_data();
   }
 
   ctx->tensor.dl_tensor.device = device;

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -165,16 +165,16 @@ Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   std::vector<int64_t>& shape_arr = ctx->shape;
   shape_arr.reserve(t->ndim());
   for (auto i : t->shape()) {
-      shape_arr.emplace_back(i);
-    }
+    shape_arr.emplace_back(i);
+  }
   ctx->tensor.dl_tensor.shape = shape_arr.data();
 
   std::vector<int64_t>& strides_arr = ctx->strides;
   strides_arr.reserve(t->ndim());
   auto byte_width = t->type()->byte_width();
   for (auto i : t->strides()) {
-      strides_arr.emplace_back(i/ byte_width);
-    }
+    strides_arr.emplace_back(i / byte_width);
+  }
   ctx->tensor.dl_tensor.strides = strides_arr.data();
 
   ctx->t = std::move(t);

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -78,7 +78,7 @@ Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Array>& arr) {
   ARROW_ASSIGN_OR_RAISE(DLDataType dlpack_type, GetDLDataType(type));
 
   // Create ManagerCtx that will serve as the owner of the DLManagedTensor
-  std::unique_ptr<ManagerCtx> ctx(new ManagerCtx);
+  auto ctx = std::make_unique<ManagerCtx>();
 
   // Define the data pointer to the DLTensor
   // If array is of length 0, data pointer should be NULL
@@ -147,7 +147,7 @@ Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   ARROW_ASSIGN_OR_RAISE(DLDevice device, ExportDevice(t))
 
   // Create TensorManagerCtx that will serve as the owner of the DLManagedTensor
-  std::unique_ptr<TensorManagerCtx> ctx(new TensorManagerCtx);
+  auto ctx = std::make_unique<TensorManagerCtx>();
 
   // Define the data pointer to the DLTensor
   // If tensor is of length 0, data pointer should be NULL

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -70,12 +70,12 @@ Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Array>& arr) {
   // Define DLDevice struct and check if array type is supported
   // by the DLPack protocol at the same time. Raise TypeError if not.
   // Supported data types: int, uint, float with no validity buffer.
-  ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(arr))
+  ARROW_ASSIGN_OR_RAISE(DLDevice device, ExportDevice(arr))
 
   // Define the DLDataType struct
   const DataType& type = *arr->type();
   std::shared_ptr<ArrayData> data = arr->data();
-  ARROW_ASSIGN_OR_RAISE(auto dlpack_type, GetDLDataType(type));
+  ARROW_ASSIGN_OR_RAISE(DLDataType dlpack_type, GetDLDataType(type));
 
   // Create ManagerCtx that will serve as the owner of the DLManagedTensor
   std::unique_ptr<ManagerCtx> ctx(new ManagerCtx);
@@ -140,17 +140,17 @@ struct TensorManagerCtx {
 
 Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   // Define the DLDataType struct
-  std::shared_ptr<DataType> type = t->type();
-  ARROW_ASSIGN_OR_RAISE(auto dlpack_type, GetDLDataType(*type.get()));
+  const DataType& type = *t->type();
+  ARROW_ASSIGN_OR_RAISE(DLDataType dlpack_type, GetDLDataType(type));
 
   // Define DLDevice struct
-  ARROW_ASSIGN_OR_RAISE(auto device, ExportTensorDevice(t))
+  ARROW_ASSIGN_OR_RAISE(DLDevice device, ExportTensorDevice(t))
 
   // Create ManagerCtx that will serve as the owner of the DLManagedTensor
   std::unique_ptr<TensorManagerCtx> ctx(new TensorManagerCtx);
 
   // Define the data pointer to the DLTensor
-  // If array is of length 0, data pointer should be NULL
+  // If tensor is of length 0, data pointer should be NULL
   if (t->size() == 0) {
     ctx->tensor.dl_tensor.data = NULL;
   } else {

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -144,7 +144,7 @@ Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   ARROW_ASSIGN_OR_RAISE(DLDataType dlpack_type, GetDLDataType(type));
 
   // Define DLDevice struct
-  ARROW_ASSIGN_OR_RAISE(DLDevice device, ExportTensorDevice(t))
+  ARROW_ASSIGN_OR_RAISE(DLDevice device, ExportDevice(t))
 
   // Create ManagerCtx that will serve as the owner of the DLManagedTensor
   std::unique_ptr<TensorManagerCtx> ctx(new TensorManagerCtx);
@@ -181,7 +181,7 @@ Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   return &ctx.release()->tensor;
 }
 
-Result<DLDevice> ExportTensorDevice(const std::shared_ptr<Tensor>& t) {
+Result<DLDevice> ExportDevice(const std::shared_ptr<Tensor>& t) {
   // Define DLDevice struct
   DLDevice device;
   if (t->data()->device_type() == DeviceAllocationType::kCPU) {

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -136,11 +136,11 @@ struct TensorManagerCtx {
   DLManagedTensor tensor;
 };
 
-Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Tensor>& t) {
+Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   // Define DLDevice struct nad check if array type is supported
   // by the DLPack protocol at the same time. Raise TypeError if not.
   // Supported data types: int, uint, float with no validity buffer.
-  ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(t))
+  ARROW_ASSIGN_OR_RAISE(auto device, ExportTensorDevice(t))
 
   // Define the DLDataType struct
   const DataType& type = *t->type();
@@ -175,7 +175,7 @@ Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Tensor>& t) {
   return &ctx.release()->tensor;
 }
 
-Result<DLDevice> ExportDevice(const std::shared_ptr<Tensor>& t) {
+Result<DLDevice> ExportTensorDevice(const std::shared_ptr<Tensor>& t) {
   // Check if array is supported by the DLPack protocol.
   const DataType& type = *t->type();
   if (type.id() == Type::BOOL) {

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -70,12 +70,12 @@ Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Array>& arr) {
   // Define DLDevice struct and check if array type is supported
   // by the DLPack protocol at the same time. Raise TypeError if not.
   // Supported data types: int, uint, float with no validity buffer.
-  ARROW_ASSIGN_OR_RAISE(DLDevice device, ExportDevice(arr))
+  ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(arr))
 
   // Define the DLDataType struct
   const DataType& type = *arr->type();
   std::shared_ptr<ArrayData> data = arr->data();
-  ARROW_ASSIGN_OR_RAISE(DLDataType dlpack_type, GetDLDataType(type));
+  ARROW_ASSIGN_OR_RAISE(auto dlpack_type, GetDLDataType(type));
 
   // Create ManagerCtx that will serve as the owner of the DLManagedTensor
   auto ctx = std::make_unique<ManagerCtx>();
@@ -141,10 +141,10 @@ struct TensorManagerCtx {
 Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t) {
   // Define the DLDataType struct
   const DataType& type = *t->type();
-  ARROW_ASSIGN_OR_RAISE(DLDataType dlpack_type, GetDLDataType(type));
+  ARROW_ASSIGN_OR_RAISE(auto dlpack_type, GetDLDataType(type));
 
   // Define DLDevice struct
-  ARROW_ASSIGN_OR_RAISE(DLDevice device, ExportDevice(t))
+  ARROW_ASSIGN_OR_RAISE(auto device, ExportDevice(t))
 
   // Create TensorManagerCtx that will serve as the owner of the DLManagedTensor
   auto ctx = std::make_unique<TensorManagerCtx>();

--- a/cpp/src/arrow/c/dlpack.h
+++ b/cpp/src/arrow/c/dlpack.h
@@ -39,6 +39,9 @@ namespace arrow::dlpack {
 ARROW_EXPORT
 Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Array>& arr);
 
+ARROW_EXPORT
+Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Tensor>& t);
+
 /// \brief Get DLDevice with enumerator specifying the
 /// type of the device data is stored on and index of the
 /// device which is 0 by default for CPU.
@@ -47,5 +50,8 @@ Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Array>& arr);
 /// \return DLDevice struct
 ARROW_EXPORT
 Result<DLDevice> ExportDevice(const std::shared_ptr<Array>& arr);
+
+ARROW_EXPORT
+Result<DLDevice> ExportDevice(const std::shared_ptr<Tensor>& t);
 
 }  // namespace arrow::dlpack

--- a/cpp/src/arrow/c/dlpack.h
+++ b/cpp/src/arrow/c/dlpack.h
@@ -40,7 +40,7 @@ ARROW_EXPORT
 Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Array>& arr);
 
 ARROW_EXPORT
-Result<DLManagedTensor*> ExportArray(const std::shared_ptr<Tensor>& t);
+Result<DLManagedTensor*> ExportTensor(const std::shared_ptr<Tensor>& t);
 
 /// \brief Get DLDevice with enumerator specifying the
 /// type of the device data is stored on and index of the
@@ -52,6 +52,6 @@ ARROW_EXPORT
 Result<DLDevice> ExportDevice(const std::shared_ptr<Array>& arr);
 
 ARROW_EXPORT
-Result<DLDevice> ExportDevice(const std::shared_ptr<Tensor>& t);
+Result<DLDevice> ExportTensorDevice(const std::shared_ptr<Tensor>& t);
 
 }  // namespace arrow::dlpack

--- a/cpp/src/arrow/c/dlpack.h
+++ b/cpp/src/arrow/c/dlpack.h
@@ -52,6 +52,6 @@ ARROW_EXPORT
 Result<DLDevice> ExportDevice(const std::shared_ptr<Array>& arr);
 
 ARROW_EXPORT
-Result<DLDevice> ExportTensorDevice(const std::shared_ptr<Tensor>& t);
+Result<DLDevice> ExportDevice(const std::shared_ptr<Tensor>& t);
 
 }  // namespace arrow::dlpack

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -152,7 +152,7 @@ void CheckDLTensor(const std::shared_ptr<Tensor>& t,
   ASSERT_EQ(DLDeviceType::kDLCPU, dltensor.device.device_type);
   ASSERT_EQ(0, dltensor.device.device_id);
 
-  ASSERT_OK_AND_ASSIGN(auto device, arrow::dlpack::ExportTensorDevice(t));
+  ASSERT_OK_AND_ASSIGN(auto device, arrow::dlpack::ExportDevice(t));
   ASSERT_EQ(DLDeviceType::kDLCPU, device.device_type);
   ASSERT_EQ(0, device.device_id);
 

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -198,15 +198,19 @@ TEST_F(TestExportTensor, TestTensor) {
 
 TEST_F(TestExportTensor, TestTensorStrided) {
   std::vector<int64_t> shape = {2, 2, 2};
-  std::vector<int64_t> strides = {sizeof(float) * 4, sizeof(float) * 2, sizeof(float) * 1};
+  std::vector<int64_t> strides = {sizeof(float) * 4, sizeof(float) * 2,
+                                  sizeof(float) * 1};
   std::vector<int64_t> dlpack_strides = {4, 2, 1};
-  std::shared_ptr<Tensor> tensor = TensorFromJSON(float32(), "[1, 2, 3, 4, 5, 6, 1, 1]", shape, strides);
+  std::shared_ptr<Tensor> tensor =
+      TensorFromJSON(float32(), "[1, 2, 3, 4, 5, 6, 1, 1]", shape, strides);
 
   CheckDLTensor(tensor, float32(), DLDataTypeCode::kDLFloat, shape, dlpack_strides);
 
-  std::vector<int64_t> f_strides = {sizeof(float) * 1, sizeof(float) * 2, sizeof(float) * 4};
+  std::vector<int64_t> f_strides = {sizeof(float) * 1, sizeof(float) * 2,
+                                    sizeof(float) * 4};
   std::vector<int64_t> f_dlpack_strides = {1, 2, 4};
-  std::shared_ptr<Tensor> f_tensor = TensorFromJSON(float32(), "[1, 2, 3, 4, 5, 6, 1, 1]", shape, f_strides);
+  std::shared_ptr<Tensor> f_tensor =
+      TensorFromJSON(float32(), "[1, 2, 3, 4, 5, 6, 1, 1]", shape, f_strides);
 
   CheckDLTensor(f_tensor, float32(), DLDataTypeCode::kDLFloat, shape, f_dlpack_strides);
 }

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -21,6 +21,7 @@
 #include "arrow/c/dlpack.h"
 #include "arrow/c/dlpack_abi.h"
 #include "arrow/memory_pool.h"
+#include "arrow/tensor.h"
 #include "arrow/testing/gtest_util.h"
 
 namespace arrow::dlpack {
@@ -138,21 +139,15 @@ void CheckDLTensor(const std::shared_ptr<Tensor>& t,
   ASSERT_OK_AND_ASSIGN(auto dlmtensor, arrow::dlpack::ExportTensor(t));
   auto dltensor = dlmtensor->dl_tensor;
 
-//   const auto byte_width = t->type()->byte_width();
-//   const auto start = arr->offset() * byte_width;
-//   ASSERT_OK_AND_ASSIGN(auto sliced_buffer,
-//                        SliceBufferSafe(arr->data()->buffers[1], start));
-//   ASSERT_EQ(sliced_buffer->data(), dltensor.data);
-
+  ASSERT_EQ(t->data()->data(), dltensor.data);
+  ASSERT_EQ(t->ndim(), dltensor.ndim);
   ASSERT_EQ(0, dltensor.byte_offset);
-//   ASSERT_EQ(shape.data()[0], dltensor.shape[0]);
-//   ASSERT_EQ(strides.data()[0], dltensor.strides[0]);
-  ASSERT_EQ(shape.data()[1], dltensor.shape[1]);
-  ASSERT_EQ(strides.data()[1], dltensor.strides[1]);
-  ASSERT_EQ(2, dltensor.ndim);
+  for (int i = 0; i < t->ndim(); i++) {
+    ASSERT_EQ(shape.data()[i], dltensor.shape[i]);
+    ASSERT_EQ(strides.data()[i], dltensor.strides[i]);
+  }
 
   ASSERT_EQ(dlpack_type, dltensor.dtype.code);
-
   ASSERT_EQ(tensor_type->bit_width(), dltensor.dtype.bits);
   ASSERT_EQ(1, dltensor.dtype.lanes);
   ASSERT_EQ(DLDeviceType::kDLCPU, dltensor.device.device_type);
@@ -188,45 +183,18 @@ TEST_F(TestExportTensor, TestSupportedTensor) {
       {float32(), DLDataTypeCode::kDLFloat},
       {float64(), DLDataTypeCode::kDLFloat}};
 
-  const auto allocated_bytes = arrow::default_memory_pool()->bytes_allocated();
+  // const auto allocated_bytes = arrow::default_memory_pool()->bytes_allocated();
 
   for (auto [arrow_type, dlpack_type] : cases) {
-    std::vector<int64_t> shape = {9, 2};
-    const int64_t f32_size = sizeof(float);
-    std::vector<int64_t> f_strides = {f32_size, f32_size * shape[0]};
+    std::vector<int64_t> shape = {3, 6};
+    std::vector<int64_t> dlpack_strides = {6, 1};
     std::shared_ptr<Tensor> tensor = TensorFromJSON(
-        float32(), "[1, 2,  3,  4,  5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80, 90]",
-        shape, f_strides);
+        arrow_type, "[1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9]", shape);
 
-    CheckDLTensor(tensor, arrow_type, dlpack_type, shape, f_strides);
+    CheckDLTensor(tensor, arrow_type, dlpack_type, shape, dlpack_strides);
   }
 
-  ASSERT_EQ(allocated_bytes, arrow::default_memory_pool()->bytes_allocated());
+  // ASSERT_EQ(allocated_bytes, arrow::default_memory_pool()->bytes_allocated());
 }
-
-// TEST_F(TestExportTensor, TestErrors) {
-//   const std::shared_ptr<Array> array_null = ArrayFromJSON(null(), "[]");
-//   ASSERT_RAISES_WITH_MESSAGE(TypeError,
-//                              "Type error: DataType is not compatible with DLPack spec: " +
-//                                  array_null->type()->ToString(),
-//                              arrow::dlpack::ExportArray(array_null));
-
-//   const std::shared_ptr<Array> array_with_null = ArrayFromJSON(int8(), "[1, 100, null]");
-//   ASSERT_RAISES_WITH_MESSAGE(TypeError,
-//                              "Type error: Can only use DLPack on arrays with no nulls.",
-//                              arrow::dlpack::ExportArray(array_with_null));
-
-//   const std::shared_ptr<Array> array_string =
-//       ArrayFromJSON(utf8(), R"(["itsy", "bitsy", "spider"])");
-//   ASSERT_RAISES_WITH_MESSAGE(TypeError,
-//                              "Type error: DataType is not compatible with DLPack spec: " +
-//                                  array_string->type()->ToString(),
-//                              arrow::dlpack::ExportArray(array_string));
-
-//   const std::shared_ptr<Array> array_boolean = ArrayFromJSON(boolean(), "[true, false]");
-//   ASSERT_RAISES_WITH_MESSAGE(
-//       TypeError, "Type error: Bit-packed boolean data type not supported by DLPack.",
-//       arrow::dlpack::ExportDevice(array_boolean));
-// }
 
 }  // namespace arrow::dlpack

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -159,7 +159,7 @@ void CheckDLTensor(const std::shared_ptr<Tensor>& t,
   dlmtensor->deleter(dlmtensor);
 }
 
-TEST_F(TestExportTensor, TestSupportedTensor) {
+TEST_F(TestExportTensor, TestTensor) {
   const std::vector<std::pair<std::shared_ptr<DataType>, DLDataTypeCode>> cases = {
       {int8(), DLDataTypeCode::kDLInt},
       {uint8(), DLDataTypeCode::kDLUInt},
@@ -194,6 +194,21 @@ TEST_F(TestExportTensor, TestSupportedTensor) {
   }
 
   ASSERT_EQ(allocated_bytes, arrow::default_memory_pool()->bytes_allocated());
+}
+
+TEST_F(TestExportTensor, TestTensorStrided) {
+  std::vector<int64_t> shape = {2, 2, 2};
+  std::vector<int64_t> strides = {sizeof(float) * 4, sizeof(float) * 2, sizeof(float) * 1};
+  std::vector<int64_t> dlpack_strides = {4, 2, 1};
+  std::shared_ptr<Tensor> tensor = TensorFromJSON(float32(), "[1, 2, 3, 4, 5, 6, 1, 1]", shape, strides);
+
+  CheckDLTensor(tensor, float32(), DLDataTypeCode::kDLFloat, shape, dlpack_strides);
+
+  std::vector<int64_t> f_strides = {sizeof(float) * 1, sizeof(float) * 2, sizeof(float) * 4};
+  std::vector<int64_t> f_dlpack_strides = {1, 2, 4};
+  std::shared_ptr<Tensor> f_tensor = TensorFromJSON(float32(), "[1, 2, 3, 4, 5, 6, 1, 1]", shape, f_strides);
+
+  CheckDLTensor(f_tensor, float32(), DLDataTypeCode::kDLFloat, shape, f_dlpack_strides);
 }
 
 }  // namespace arrow::dlpack

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -49,7 +49,6 @@ void CheckDLTensor(const std::shared_ptr<Array>& arr,
   ASSERT_EQ(1, dltensor.ndim);
 
   ASSERT_EQ(dlpack_type, dltensor.dtype.code);
-
   ASSERT_EQ(arrow_type->bit_width(), dltensor.dtype.bits);
   ASSERT_EQ(1, dltensor.dtype.lanes);
   ASSERT_EQ(DLDeviceType::kDLCPU, dltensor.device.device_type);
@@ -183,7 +182,7 @@ TEST_F(TestExportTensor, TestSupportedTensor) {
       {float32(), DLDataTypeCode::kDLFloat},
       {float64(), DLDataTypeCode::kDLFloat}};
 
-  // const auto allocated_bytes = arrow::default_memory_pool()->bytes_allocated();
+  const auto allocated_bytes = arrow::default_memory_pool()->bytes_allocated();
 
   for (auto [arrow_type, dlpack_type] : cases) {
     std::vector<int64_t> shape = {3, 6};
@@ -194,7 +193,7 @@ TEST_F(TestExportTensor, TestSupportedTensor) {
     CheckDLTensor(tensor, arrow_type, dlpack_type, shape, dlpack_strides);
   }
 
-  // ASSERT_EQ(allocated_bytes, arrow::default_memory_pool()->bytes_allocated());
+  ASSERT_EQ(allocated_bytes, arrow::default_memory_pool()->bytes_allocated());
 }
 
 }  // namespace arrow::dlpack

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2144,7 +2144,8 @@ cdef class Array(_PandasConvertible):
         return pyarrow_wrap_array(array)
 
     def __dlpack__(self, stream=None):
-        """Export a primitive array as a DLPack capsule.
+        """
+        Export a primitive array as a DLPack capsule.
 
         Parameters
         ----------
@@ -2159,7 +2160,7 @@ cdef class Array(_PandasConvertible):
             A DLPack capsule for the array, pointing to a DLManagedTensor.
         """
         if stream is None:
-            dlm_tensor = GetResultValue(ExportToDLPack(self.sp_array))
+            dlm_tensor = GetResultValue(ExportArrayToDLPack(self.sp_array))
 
             return PyCapsule_New(dlm_tensor, 'dltensor', dlpack_pycapsule_deleter)
         else:

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1452,10 +1452,13 @@ cdef extern from "arrow/c/dlpack_abi.h" nogil:
 
 
 cdef extern from "arrow/c/dlpack.h" namespace "arrow::dlpack" nogil:
-    CResult[DLManagedTensor*] ExportToDLPack" arrow::dlpack::ExportArray"(
+    CResult[DLManagedTensor*] ExportArrayToDLPack" arrow::dlpack::ExportArray"(
         const shared_ptr[CArray]& arr)
+    CResult[DLManagedTensor*] ExportTensorToDLPack" arrow::dlpack::ExportTensor"(
+        const shared_ptr[CTensor]& tensor)
 
     CResult[DLDevice] ExportDevice(const shared_ptr[CArray]& arr)
+    CResult[DLDevice] ExportTensorDevice(const shared_ptr[CTensor]& tensor)
 
 
 cdef extern from "arrow/builder.h" namespace "arrow" nogil:

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1458,7 +1458,7 @@ cdef extern from "arrow/c/dlpack.h" namespace "arrow::dlpack" nogil:
         const shared_ptr[CTensor]& tensor)
 
     CResult[DLDevice] ExportDevice(const shared_ptr[CArray]& arr)
-    CResult[DLDevice] ExportTensorDevice(const shared_ptr[CTensor]& tensor)
+    CResult[DLDevice] ExportDevice(const shared_ptr[CTensor]& tensor)
 
 
 cdef extern from "arrow/builder.h" namespace "arrow" nogil:

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -336,7 +336,7 @@ strides: {self.strides}"""
             CPU = 1, see cpp/src/arrow/c/dpack_abi.h) and index of the
             device which is 0 by default for CPU.
         """
-        device = GetResultValue(ExportTensorDevice(self.sp_tensor))
+        device = GetResultValue(ExportDevice(self.sp_tensor))
         return device.device_type, device.device_id
 
 

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -300,6 +300,45 @@ strides: {self.strides}"""
         buffer.strides = <Py_ssize_t *> cp.PyBytes_AsString(self._ssize_t_strides)
         buffer.suboffsets = NULL
 
+    def __dlpack__(self, stream=None):
+        """
+        Export a Tensor as a DLPack capsule.
+
+        Parameters
+        ----------
+        stream : int, optional
+            A Python integer representing a pointer to a stream. Currently not supported.
+            Stream is provided by the consumer to the producer to instruct the producer
+            to ensure that operations can safely be performed on the array.
+
+        Returns
+        -------
+        capsule : PyCapsule
+            A DLPack capsule for the tensor, pointing to a DLManagedTensor.
+        """
+        if stream is None:
+            dlm_tensor = GetResultValue(ExportTensorToDLPack(self.sp_tensor))
+
+            return PyCapsule_New(dlm_tensor, 'dltensor', dlpack_pycapsule_deleter)
+        else:
+            raise NotImplementedError(
+                "Only stream=None is supported."
+            )
+
+    def __dlpack_device__(self):
+        """
+        Return the DLPack device tuple this tensor resides on.
+
+        Returns
+        -------
+        tuple : Tuple[int, int]
+            Tuple with index specifying the type of the device (where
+            CPU = 1, see cpp/src/arrow/c/dpack_abi.h) and index of the
+            device which is 0 by default for CPU.
+        """
+        device = GetResultValue(ExportTensorDevice(self.sp_tensor))
+        return device.device_type, device.device_id
+
 
 ctypedef CSparseCOOIndex* _CSparseCOOIndexPtr
 

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -117,11 +117,11 @@ def test_tensor_dlpack(np_type):
                     "1.24.0")
 
     arr = np.array([1, 2, 3, 4, 5, 6, 1, 1])
-    expected = np.ndarray((2, 2, 2), dtype=np_type, buffer=arr, order='C')
+    expected = np.array(arr, dtype=np_type).reshape((2, 2, 2), order='C')
     t = pa.Tensor.from_numpy(expected)
     check_dlpack_export(t, expected)
 
-    expected = np.ndarray((2, 2, 2), dtype=np_type, buffer=arr, order='F')
+    expected = np.array(arr, dtype=np_type).reshape((2, 2, 2), order='F')
     t = pa.Tensor.from_numpy(expected)
     check_dlpack_export(t, expected)
 

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -87,6 +87,9 @@ def test_dlpack(value_type, np_type_str):
     arr = pa.array(expected, type=value_type)
     check_dlpack_export(arr, expected)
 
+    t = pa.Tensor.from_numpy(expected)
+    check_dlpack_export(t, expected)
+
     arr_sliced = arr.slice(1, 1)
     expected = np.array([2], dtype=np.dtype(np_type_str))
     check_dlpack_export(arr_sliced, expected)
@@ -102,6 +105,37 @@ def test_dlpack(value_type, np_type_str):
     arr_zero = pa.array([], type=value_type)
     expected = np.array([], dtype=np.dtype(np_type_str))
     check_dlpack_export(arr_zero, expected)
+
+    t = pa.Tensor.from_numpy(expected)
+    check_dlpack_export(t, expected)
+
+
+@check_bytes_allocated
+@pytest.mark.parametrize('np_type',
+    [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.float16,
+        np.float32,
+        np.float64,
+    ]
+)
+def test_tensor_dlpack(np_type):
+    if Version(np.__version__) < Version("1.24.0"):
+        pytest.skip("No dlpack support in numpy versions older than 1.22.0, "
+                    "strict keyword in assert_array_equal added in numpy version "
+                    "1.24.0")
+
+    arr = np.array([1,2,3, 4, 5, 6, 1, 1])
+    expected = np.ndarray((2,2,2), buffer=arr, dtype=np_type)
+    t = pa.Tensor.from_numpy(expected)
+    check_dlpack_export(t, expected)
 
 
 def test_dlpack_not_supported():

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -117,7 +117,7 @@ def test_tensor_dlpack(np_type):
                     "1.24.0")
 
     arr = np.array([1, 2, 3, 4, 5, 6, 1, 1])
-    expected = np.ndarray((2, 2, 2), dtype=np_type, buffer=arr)
+    expected = np.ndarray((2, 2, 2), dtype=np_type, buffer=arr, order='C')
     t = pa.Tensor.from_numpy(expected)
     check_dlpack_export(t, expected)
 

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -23,7 +23,7 @@ import pytest
 try:
     import numpy as np
 except ImportError:
-    np = None
+    pytestmark = pytest.mark.numpy
 
 import pyarrow as pa
 from pyarrow.vendored.version import Version

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -112,28 +112,21 @@ def test_dlpack(value_type, np_type_str):
 
 @check_bytes_allocated
 @pytest.mark.parametrize('np_type',
-    [
-        np.uint8,
-        np.uint16,
-        np.uint32,
-        np.uint64,
-        np.int8,
-        np.int16,
-        np.int32,
-        np.int64,
-        np.float16,
-        np.float32,
-        np.float64,
-    ]
-)
+                         [np.uint8, np.uint16, np.uint32, np.uint64,
+                          np.int8, np.int16, np.int32, np.int64,
+                          np.float16, np.float32, np.float64,])
 def test_tensor_dlpack(np_type):
     if Version(np.__version__) < Version("1.24.0"):
         pytest.skip("No dlpack support in numpy versions older than 1.22.0, "
                     "strict keyword in assert_array_equal added in numpy version "
                     "1.24.0")
 
-    arr = np.array([1,2,3, 4, 5, 6, 1, 1])
-    expected = np.ndarray((2,2,2), buffer=arr, dtype=np_type)
+    arr = np.array([1, 2, 3, 4, 5, 6, 1, 1])
+    expected = np.ndarray((2, 2, 2), dtype=np_type, buffer=arr)
+    t = pa.Tensor.from_numpy(expected)
+    check_dlpack_export(t, expected)
+
+    expected = np.ndarray((2, 2, 2), dtype=np_type, buffer=arr, order='F')
     t = pa.Tensor.from_numpy(expected)
     check_dlpack_export(t, expected)
 

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -20,18 +20,13 @@ from functools import wraps
 import gc
 import pytest
 
-try:
-    import numpy as np
-except ImportError:
-    pytestmark = pytest.mark.numpy
-
 import pyarrow as pa
 from pyarrow.vendored.version import Version
-
 
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not numpy'
 pytestmark = pytest.mark.numpy
+np = pytest.importorskip("numpy")
 
 
 def PyCapsule_IsValid(capsule, name):


### PR DESCRIPTION
### Rationale for this change

Producing part of DLPack protocol [has been added to Arrow Arrays](https://github.com/apache/arrow/issues/33984) but is missing on Arrow Tensor class.

### What changes are included in this PR?

This PR adds support for producing DLPack struct and bindings to it in Python:

- `ExportTensor` and `ExportTensorDevice` methods on Arrow C++ Tensor class
- `__dlpack__` method on PyArrow Tensor class exposing ExportTensor method
- `__dlpack_device__` method on PyArrow Tensor class exposing ExportTensorDevice method

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #39294