### PR TITLE
GH-42015: [MATLAB] Executing `tfeather.m` test class causes MATLAB to crash on `windows-2022` after MSVC update from 14.39.33519 to 14.40.33807

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -34,11 +34,14 @@ function(build_arrow)
 
   set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-prefix")
   set(ARROW_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-build")
+
   # Supply -DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR to fix 
   # a segfault on windows. See https://github.com/apache/arrow/issues/42015.
   set(ARROW_CMAKE_ARGS
-      "-DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}" "-DCMAKE_INSTALL_LIBDIR=lib"
-      "-DARROW_BUILD_STATIC=OFF" "-DARROW_CSV=ON"
+      "-DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+      "-DARROW_BUILD_STATIC=OFF"
+      "-DARROW_CSV=ON"
       "-DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
 
   add_library(arrow_shared SHARED IMPORTED)

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -35,7 +35,7 @@ function(build_arrow)
   set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-prefix")
   set(ARROW_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-build")
 
-  # Supply -DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR to fix 
+  # Supply -DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR to fix
   # a segfault on windows. See https://github.com/apache/arrow/issues/42015.
   set(ARROW_CMAKE_ARGS
       "-DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}"

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -34,9 +34,17 @@ function(build_arrow)
 
   set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-prefix")
   set(ARROW_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-build")
+  # Supply -DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR to 
+  # workaround windows-2022 GitHub Runner bug involving the VC Runtime:
+  # 
+  # See issues below for details:
+  #
+  # https://github.com/actions/runner-images/issues/10020
+  # https://github.com/actions/runner-images/issues/10004
   set(ARROW_CMAKE_ARGS
       "-DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}" "-DCMAKE_INSTALL_LIBDIR=lib"
-      "-DARROW_BUILD_STATIC=OFF" "-DARROW_CSV=ON")
+      "-DARROW_BUILD_STATIC=OFF" "-DARROW_CSV=ON"
+      "-DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR")
 
   add_library(arrow_shared SHARED IMPORTED)
   set(ARROW_LIBRARY_TARGET arrow_shared)

--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -34,13 +34,8 @@ function(build_arrow)
 
   set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-prefix")
   set(ARROW_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep-build")
-  # Supply -DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR to 
-  # workaround windows-2022 GitHub Runner bug involving the VC Runtime:
-  # 
-  # See issues below for details:
-  #
-  # https://github.com/actions/runner-images/issues/10020
-  # https://github.com/actions/runner-images/issues/10004
+  # Supply -DARROW_CXXFLAGS=-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR to fix 
+  # a segfault on windows. See https://github.com/apache/arrow/issues/42015.
   set(ARROW_CMAKE_ARGS
       "-DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}" "-DCMAKE_INSTALL_LIBDIR=lib"
       "-DARROW_BUILD_STATIC=OFF" "-DARROW_CSV=ON"


### PR DESCRIPTION
### Rationale for this change

After the `windows-2022` GitHub runner image was updated last week, MATLAB began crashing when running the unit tests in `arrow/matlab/test/tfeather.m` on Windows. As part of the update, VS 2022 was updated from 
`17.9.34902.65` to `17.10.34928.147` and MSVC was updated from `14.39.33519` to `14.40.33807`. 

It looks like many other projects have run into this issue as well:

1. https://github.com/actions/runner-images/issues/10004
2. https://github.com/actions/runner-images/issues/10020

The suggested workaround for this crash is to supply  the flag `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` when building. 

### What changes are included in this PR?

1. Supply `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` flag when building  Arrow C++.

### Are these changes tested?

N/A. Existing tests used.

### Are there any user-facing changes?

No.
* GitHub Issue: #42015