### PR TITLE
MINOR: [DEV] Add sgilmore10 to CODEOWNERS for `/matlab/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@
 /go/ @zeroshade
 /java/ @lidavidm
 /js/ @domoritz @trxcllnt
-/matlab/ @kevingurney @kou
+/matlab/ @kevingurney @kou @sgilmore10
 /python/pyarrow/_flight.pyx @lidavidm
 /python/pyarrow/**/*gandiva* @wjones127
 /r/ @paleolimbot @thisisnic


### PR DESCRIPTION

### Rationale for this change

Adding myself as a CODEOWNER for `/matlab/` so I can help review MATLAB PRs.


