### PR TITLE
GH-42128: [Packaging][CentOS] Migrate CentOS 7 and CentOS Stream 8 packaging jobs to use vault.centos.org

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -69,9 +69,9 @@ should_fix_eol_repositories=no
 # Switch all repos to point to to vault.centos.org, use for EOL distros
 fix_eol_repositories() {
   sed -i \
-    -e 's/mirrorlist/#mirrorlist/' \
-    -e 's/#baseurl/baseurl/' \
-    -e 's/mirror.centos.org/vault.centos.org/' \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
     /etc/yum.repos.d/*.repo
 }
 

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -63,7 +63,6 @@ install_command="dnf install -y --enablerepo=crb"
 uninstall_command="dnf remove -y"
 clean_command="dnf clean"
 info_command="dnf info --enablerepo=crb"
-should_fix_eol_repositories=no
 
 # GH-42128
 # Switch all repos to point to to vault.centos.org, use for EOL distros
@@ -110,7 +109,7 @@ case "${distribution}-${distribution_version}" in
     uninstall_command="yum remove -y"
     clean_command="yum clean"
     info_command="yum info"
-    should_fix_eol_repositories=yes
+    fix_eol_repositories
     ;;
   centos-8)
     distribution_prefix="centos"
@@ -118,7 +117,7 @@ case "${distribution}-${distribution_version}" in
     ruby_devel_packages+=(redhat-rpm-config)
     install_command="dnf install -y --enablerepo=powertools"
     info_command="dnf info --enablerepo=powertools"
-    should_fix_eol_repositories=yes
+    fix_eol_repositories
     ;;
   centos-*)
     distribution_prefix="centos"
@@ -159,9 +158,6 @@ if [ "${TYPE}" = "local" ]; then
   esac
   release_path+="/${repository_version}/$(arch)/Packages"
   release_path+="/apache-arrow-release-${package_version}.noarch.rpm"
-  if [ "${should_fix_eol_repositories}" = "yes" ]; then
-    fix_eol_repositories
-  fi
   ${install_command} "${release_path}"
 else
   package_version="${VERSION}"

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/centos-7/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/centos-7/Dockerfile
@@ -19,6 +19,14 @@ FROM centos:7
 
 ARG DEBUG
 
+# GH-42128
+# Switch repos to point to to vault.centos.org because Centos Stream 8 is EOL
+RUN sed -i \
+  -e 's/^mirrorlist/#mirrorlist/' \
+  -e 's/^#baseurl/baseurl/' \
+  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
+  /etc/yum.repos.d/*.repo
+
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   yum install -y ${quiet} \

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/centos-7/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/centos-7/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN sed -i \
   -e 's/^mirrorlist/#mirrorlist/' \
   -e 's/^#baseurl/baseurl/' \
-  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
+  -e 's/mirror\.centos\.org/vault.centos.org/' \
   /etc/yum.repos.d/*.repo
 
 RUN \

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/centos-8-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/centos-8-stream/Dockerfile
@@ -19,6 +19,14 @@ FROM quay.io/centos/centos:stream8
 
 ARG DEBUG
 
+# GH-42128
+# Switch repos to point to to vault.centos.org because Centos Stream 8 is EOL
+RUN sed -i \
+  -e 's/^mirrorlist/#mirrorlist/' \
+  -e 's/^#baseurl/baseurl/' \
+  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
+  /etc/yum.repos.d/*.repo
+
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install --enablerepo=powertools -y ${quiet} \

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/centos-8-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/centos-8-stream/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN sed -i \
   -e 's/^mirrorlist/#mirrorlist/' \
   -e 's/^#baseurl/baseurl/' \
-  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
+  -e 's/mirror\.centos\.org/vault.centos.org/' \
   /etc/yum.repos.d/*.repo
 
 RUN \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
@@ -28,7 +28,7 @@ ARG DEBUG
 RUN sed -i \
   -e 's/^mirrorlist/#mirrorlist/' \
   -e 's/^#baseurl/baseurl/' \
-  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
+  -e 's/mirror\.centos\.org/vault.centos.org/' \
   /etc/yum.repos.d/*.repo
 
 RUN \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
@@ -26,9 +26,9 @@ ARG DEBUG
 # GH-42128
 # Switch repos to point to to vault.centos.org because Centos 7 is EOL
 RUN sed -i \
-  -e 's/mirrorlist/#mirrorlist/' \
-  -e 's/#baseurl/baseurl/' \
-  -e 's/mirror.centos.org/vault.centos.org/' \
+  -e 's/^mirrorlist/#mirrorlist/' \
+  -e 's/^#baseurl/baseurl/' \
+  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
   /etc/yum.repos.d/*.repo
 
 RUN \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
@@ -23,6 +23,14 @@ ENV \
 
 ARG DEBUG
 
+# GH-42128
+# Switch repos to point to to vault.centos.org because Centos 7 is EOL
+RUN sed -i \
+  -e 's/mirrorlist/#mirrorlist/' \
+  -e 's/#baseurl/baseurl/' \
+  -e 's/mirror.centos.org/vault.centos.org/' \
+  /etc/yum.repos.d/*.repo
+
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   yum update -y ${quiet} && \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
@@ -25,7 +25,7 @@ ARG DEBUG
 RUN sed -i \
   -e 's/^mirrorlist/#mirrorlist/' \
   -e 's/^#baseurl/baseurl/' \
-  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
+  -e 's/mirror\.centos\.org/vault.centos.org/' \
   /etc/yum.repos.d/*.repo
 
 RUN \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
@@ -23,9 +23,9 @@ ARG DEBUG
 # GH-42128
 # Switch repos to point to to vault.centos.org because Centos Stream 8 is EOL
 RUN sed -i \
-  -e 's/mirrorlist/#mirrorlist/' \
-  -e 's/#baseurl/baseurl/' \
-  -e 's/mirror.centos.org/vault.centos.org/' \
+  -e 's/^mirrorlist/#mirrorlist/' \
+  -e 's/^#baseurl/baseurl/' \
+  -e 's/mirror\\.centos\\.org/vault.centos.org/' \
   /etc/yum.repos.d/*.repo
 
 RUN \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8-stream/Dockerfile
@@ -20,6 +20,14 @@ FROM ${FROM}
 
 ARG DEBUG
 
+# GH-42128
+# Switch repos to point to to vault.centos.org because Centos Stream 8 is EOL
+RUN sed -i \
+  -e 's/mirrorlist/#mirrorlist/' \
+  -e 's/#baseurl/baseurl/' \
+  -e 's/mirror.centos.org/vault.centos.org/' \
+  /etc/yum.repos.d/*.repo
+
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} epel-release && \


### PR DESCRIPTION
### Rationale for this change

Fixes https://github.com/apache/arrow/issues/42128.

### What changes are included in this PR?

- Updates to the CentOS 7 and CentOS Stream 8 Dockerfiles we use in the Crossbow packaging job to point to vault.centos.org so they continue to run now that both distros are EOL

### Are these changes tested?

Yes, I successfully built both updated Dockerfiles locally.

### Are there any user-facing changes?

No.
* GitHub Issue: #42128