### PR TITLE
MINOR: [C#] Handle Empty Schema

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Internal/FlightMessageSerializer.cs
+++ b/csharp/src/Apache.Arrow.Flight/Internal/FlightMessageSerializer.cs
@@ -27,6 +27,7 @@ namespace Apache.Arrow.Flight
     {
         public static Schema DecodeSchema(ReadOnlyMemory<byte> buffer)
         {
+            if (buffer.IsEmpty) return null;
             int bufferPosition = 0;
             int schemaMessageLength = BinaryPrimitives.ReadInt32LittleEndian(buffer.Span.Slice(bufferPosition));
             bufferPosition += sizeof(int);


### PR DESCRIPTION


### Rationale for this change

While developing SDK encountered this error:
```
System.ArgumentOutOfRangeException : Specified argument was out of the range of valid values. (Parameter 'length')
   at Apache.Arrow.Flight.FlightMessageSerializer.DecodeSchema(ReadOnlyMemory`1 buffer)
``` 
The issue is the schema buffer is empty, and other libraries don't throw the error in this case. This PR makes this consistent with libraries for other languages.

### What changes are included in this PR?

Return null if Schema buffer is empty.

### Are these changes tested?

Tested against our Flight API.

### Are there any user-facing changes?

Fix critical bug this inability to run request against flight service, which doesn't return schema in GetFlightInfo.
