### PR TITLE
MINOR: [Dev][Docs] Fix references to archery docker run command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ x-with-gpus:
 x-hierarchy:
   # This section is used by the archery tool to enable building nested images,
   # so it is enough to call:
-  #   archery run debian-ruby
+  #   archery docker run debian-ruby
   # instead of a sequence of docker-compose commands:
   #   docker-compose build debian-cpp
   #   docker-compose build debian-c-glib

--- a/docs/source/developers/continuous_integration/overview.rst
+++ b/docs/source/developers/continuous_integration/overview.rst
@@ -30,7 +30,7 @@ Some files central to Arrow CI are:
 
 We use :ref:`Docker<docker-builds>` in order to have portable and reproducible Linux builds, as well as running Windows builds in Windows containers.  We use :ref:`Archery<Archery>` and :ref:`Crossbow<Crossbow>` to help co-ordinate the various CI tasks.
 
-One thing to note is that some of the services defined in ``docker-compose.yml`` are interdependent.  When running services locally, you must either manually build its dependencies first, or build it via the use of ``archery run ...`` which automatically finds and builds dependencies.
+One thing to note is that some of the services defined in ``docker-compose.yml`` are interdependent.  When running services locally, you must either manually build its dependencies first, or build it via the use of ``archery docker run ...`` which automatically finds and builds dependencies.
 
 There are numerous important directories in the Arrow project which relate to CI:
 


### PR DESCRIPTION
### Rationale for this change

I noticed two instances where we refer to "archery run" but I think the command is "archery docker run".

```
❯ archery run
Usage: archery [OPTIONS] COMMAND [ARGS]...
Try 'archery -h' for help.

Error: No such command 'run'.
❯ archery docker run --help
Usage: archery docker run [OPTIONS] IMAGE [COMMAND]
```

### What changes are included in this PR?

Fixed two places we refer to "archery run".

### Are these changes tested?

No.

### Are there any user-facing changes?

No.