### PR TITLE
GH-41349: [C#] Optimize DecimalUtility.GetBytes(SqlDecimal) on .NET 7+

### DIFF
--- a/csharp/src/Apache.Arrow/Apache.Arrow.csproj
+++ b/csharp/src/Apache.Arrow/Apache.Arrow.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsWindows)'=='true'">
-    <TargetFrameworks>netstandard2.0;net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net462</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsWindows)'!='true'">
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFramework)' == 'net462'">

--- a/csharp/src/Apache.Arrow/DecimalUtility.cs
+++ b/csharp/src/Apache.Arrow/DecimalUtility.cs
@@ -431,9 +431,12 @@ namespace Apache.Arrow
                 value = SqlDecimal.ConvertToPrecScale(value, precision, scale);
             }
 
-            // TODO: Consider groveling in the internals to avoid the probable allocation
-            Span<int> span = bytes.CastTo<int>();
-            value.Data.AsSpan().CopyTo(span);
+#if NET7_0_OR_GREATER
+            value.WriteTdsValue(bytes.CastTo<uint>());
+#else
+            value.Data.AsSpan().CopyTo(bytes.CastTo<int>());
+#endif
+
             if (!value.IsPositive)
             {
                 Span<long> longSpan = bytes.CastTo<long>();

--- a/csharp/src/Apache.Arrow/Scalars/BinaryView.cs
+++ b/csharp/src/Apache.Arrow/Scalars/BinaryView.cs
@@ -83,7 +83,7 @@ namespace Apache.Arrow.Scalars
         public bool IsInline => Length <= MaxInlineLength;
 
 #if NET5_0_OR_GREATER
-        public ReadOnlySpan<byte> Bytes => MemoryMarshal.CreateReadOnlySpan<byte>(ref Unsafe.AsRef(_inline[0]), IsInline ? Length : PrefixLength);
+        public ReadOnlySpan<byte> Bytes => MemoryMarshal.CreateReadOnlySpan<byte>(ref Unsafe.AsRef(in _inline[0]), IsInline ? Length : PrefixLength);
 #else
         public unsafe ReadOnlySpan<byte> Bytes => new ReadOnlySpan<byte>(Unsafe.AsPointer(ref _inline[0]), IsInline ? Length : PrefixLength);
 #endif


### PR DESCRIPTION
### What changes are included in this PR?

Adds code to avoid an allocation when converting from SqlDecimal to Decimal128.
Adds a .NET 8 target to Apache.Arrow.csproj to enable the optimization.
Makes a small source change to build successfully with latest C# version.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

Closes #41349 
* GitHub Issue: #41349