### PR TITLE
GH-42168: [Python][Parquet] Pyarrow store decimal as integer

### DIFF
--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -613,9 +613,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             write_page_index=self._properties["write_page_index"],
             write_page_checksum=self._properties["write_page_checksum"],
             sorting_columns=self._properties["sorting_columns"],
-            store_decimal_as_integer=(
-                self._properties["store_decimal_as_integer"]
-            ),
+            store_decimal_as_integer=self._properties["store_decimal_as_integer"],
         )
 
     def _set_arrow_properties(self):

--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -613,6 +613,9 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             write_page_index=self._properties["write_page_index"],
             write_page_checksum=self._properties["write_page_checksum"],
             sorting_columns=self._properties["sorting_columns"],
+            store_decimal_as_integer=(
+                self._properties["store_decimal_as_integer"]
+            ),
         )
 
     def _set_arrow_properties(self):
@@ -664,6 +667,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             encryption_config=None,
             write_page_checksum=False,
             sorting_columns=None,
+            store_decimal_as_integer=False,
         )
 
         self._set_properties()

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -594,6 +594,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     write_page_index=*,
     write_page_checksum=*,
     sorting_columns=*,
+    store_decimal_as_integer=*,
 ) except *
 
 

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -431,6 +431,8 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* disable_statistics()
             Builder* enable_statistics()
             Builder* enable_statistics(const c_string& path)
+            Builder* enable_store_decimal_as_integer()
+            Builder* disable_store_decimal_as_integer()
             Builder* data_pagesize(int64_t size)
             Builder* encoding(ParquetEncoding encoding)
             Builder* encoding(const c_string& path,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1951,7 +1951,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
         else:
             props.disable_store_decimal_as_integer()
     else:
-        raise ValueError("'store_decimal_as_integer' must type boolean")
+        raise TypeError("'store_decimal_as_integer' must type boolean")
 
 
     # column_encoding

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1832,7 +1832,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
         write_page_checksum=False,
         sorting_columns=None,
         store_decimal_as_integer=False) except *:
-    
+
     """General writer properties"""
     cdef:
         shared_ptr[WriterProperties] properties
@@ -1950,7 +1950,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
             props.enable_store_decimal_as_integer()
         else:
             props.disable_store_decimal_as_integer()
-    
+
     # column_encoding
     # encoding map - encode individual columns
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1947,17 +1947,9 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
 
     if isinstance(store_decimal_as_integer, bool):
         if store_decimal_as_integer:
-            props.encoding(ParquetEncoding_BYTE_STREAM_SPLIT)
-    elif store_decimal_as_integer is not None:
-        for column in store_decimal_as_integer:
-            if column_encoding is None:
-                column_encoding = {column: 'BYTE_STREAM_SPLIT'}
-            elif column_encoding.get(column, None) is None:
-                column_encoding[column] = 'BYTE_STREAM_SPLIT'
-            else:
-                raise ValueError(
-                    "'store_decimal_as_integer' cannot be passed"
-                    "together with 'column_encoding'")
+            props.enable_store_decimal_as_integer()
+        else:
+            props.disable_store_decimal_as_integer()
     
     # column_encoding
     # encoding map - encode individual columns

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1951,7 +1951,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
         else:
             props.disable_store_decimal_as_integer()
     else:
-        raise TypeError("'store_decimal_as_integer' must type boolean")
+        raise TypeError("'store_decimal_as_integer' must be a boolean")
 
     # column_encoding
     # encoding map - encode individual columns

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1953,7 +1953,6 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     else:
         raise TypeError("'store_decimal_as_integer' must type boolean")
 
-
     # column_encoding
     # encoding map - encode individual columns
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1950,6 +1950,9 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
             props.enable_store_decimal_as_integer()
         else:
             props.disable_store_decimal_as_integer()
+    else:
+        raise ValueError("'store_decimal_as_integer' must type boolean")
+
 
     # column_encoding
     # encoding map - encode individual columns

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -884,7 +884,7 @@ store_decimal_as_integer : bool, default False
       unscaled value is used.
 
     By default, this is DISABLED and all decimal types annotate fixed_len_byte_array.
-    When enabled, the writer will use following physical types to store decimals:
+    When enabled, the writer will use the following physical types to store decimals:
     - int32: for 1 <= precision <= 9.
     - int64: for 10 <= precision <= 18.
     - fixed_len_byte_array: for precision > 18.

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -873,6 +873,21 @@ sorting_columns : Sequence of SortingColumn, default None
     Specify the sort order of the data being written. The writer does not sort
     the data nor does it verify that the data is sorted. The sort order is
     written to the row group metadata, which can then be used by readers.
+store_decimal_as_integer : bool or list, default False
+    Allow decimals with 1 <= precision <= 18 to be stored as integers.
+    In Parquet, DECIMAL can be stored in any of the following physical types:
+    - int32: for 1 <= precision <= 9.
+    - int64: for 10 <= precision <= 18.
+    - fixed_len_byte_array: precision is limited by the array size. Length n can store <= floor(log_10(2^(8*n - 1) - 1)) base-10 digits.
+    - binary: precision is unlimited. The minimum number of bytes to store the unscaled value is used.
+    
+    By default, this is DISABLED and all decimal types annotate fixed_len_byte_array.
+    When enabled, the writer will use following physical types to store decimals:
+    - int32: for 1 <= precision <= 9.
+    - int64: for 10 <= precision <= 18.
+    - fixed_len_byte_array: for precision > 18.
+    
+    As a consequence, decimal columns stored in integer types are more compact.
 """
 
 _parquet_writer_example_doc = """\
@@ -968,6 +983,7 @@ Examples
                  write_page_index=False,
                  write_page_checksum=False,
                  sorting_columns=None,
+                 store_decimal_as_integer=False,
                  **options):
         if use_deprecated_int96_timestamps is None:
             # Use int96 timestamps for Spark
@@ -1020,6 +1036,7 @@ Examples
             write_page_index=write_page_index,
             write_page_checksum=write_page_checksum,
             sorting_columns=sorting_columns,
+            store_decimal_as_integer=store_decimal_as_integer,
             **options)
         self.is_open = True
 
@@ -1873,6 +1890,7 @@ def write_table(table, where, row_group_size=None, version='2.6',
                 write_page_index=False,
                 write_page_checksum=False,
                 sorting_columns=None,
+                store_decimal_as_integer=False,
                 **kwargs):
     # Implementor's note: when adding keywords here / updating defaults, also
     # update it in write_to_dataset and _dataset_parquet.pyx ParquetFileWriteOptions
@@ -1903,6 +1921,7 @@ def write_table(table, where, row_group_size=None, version='2.6',
                 write_page_index=write_page_index,
                 write_page_checksum=write_page_checksum,
                 sorting_columns=sorting_columns,
+                store_decimal_as_integer=store_decimal_as_integer,
                 **kwargs) as writer:
             writer.write_table(table, row_group_size=row_group_size)
     except Exception:

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -873,7 +873,7 @@ sorting_columns : Sequence of SortingColumn, default None
     Specify the sort order of the data being written. The writer does not sort
     the data nor does it verify that the data is sorted. The sort order is
     written to the row group metadata, which can then be used by readers.
-store_decimal_as_integer : bool or list, default False
+store_decimal_as_integer : bool, default False
     Allow decimals with 1 <= precision <= 18 to be stored as integers.
     In Parquet, DECIMAL can be stored in any of the following physical types:
     - int32: for 1 <= precision <= 9.

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -878,15 +878,17 @@ store_decimal_as_integer : bool, default False
     In Parquet, DECIMAL can be stored in any of the following physical types:
     - int32: for 1 <= precision <= 9.
     - int64: for 10 <= precision <= 18.
-    - fixed_len_byte_array: precision is limited by the array size. Length n can store <= floor(log_10(2^(8*n - 1) - 1)) base-10 digits.
-    - binary: precision is unlimited. The minimum number of bytes to store the unscaled value is used.
-    
+    - fixed_len_byte_array: precision is limited by the array size.
+      Length n can store <= floor(log_10(2^(8*n - 1) - 1)) base-10 digits.
+    - binary: precision is unlimited. The minimum number of bytes to store the
+      unscaled value is used.
+
     By default, this is DISABLED and all decimal types annotate fixed_len_byte_array.
     When enabled, the writer will use following physical types to store decimals:
     - int32: for 1 <= precision <= 9.
     - int64: for 10 <= precision <= 18.
     - fixed_len_byte_array: for precision > 18.
-    
+
     As a consequence, decimal columns stored in integer types are more compact.
 """
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -359,9 +359,15 @@ def test_byte_stream_split():
 
 
 def test_store_decimal_as_integer():
-    arr_decimal_1_9 = pa.array(list(map(float, range(100))), type=pa.decimal128(5,2))
-    arr_decimal_10_18 = pa.array(list(map(float, range(100))), type=pa.decimal128(16,9))
-    arr_decimal_gt18 = pa.array(list(map(float, range(100))), type=pa.decimal128(22,2))
+    arr_decimal_1_9 = pa.array(list(map(float, range(100))), 
+                               type=pa.decimal128(5,2)
+                              )
+    arr_decimal_10_18 = pa.array(list(map(float, range(100))), 
+                                 type=pa.decimal128(16,9)
+                                )
+    arr_decimal_gt18 = pa.array(list(map(float, range(100))), 
+                                type=pa.decimal128(22,2)
+                               )
     arr_bool = pa.array([True, False] * 50)
     data_decimal = [arr_decimal_1_9, arr_decimal_10_18, arr_decimal_gt18]
     table = pa.Table.from_arrays(data_decimal, names=['a', 'b', 'c'])
@@ -374,7 +380,9 @@ def test_store_decimal_as_integer():
     _check_roundtrip(table, expected=table, compression="gzip",
                      use_dictionary=False,
                      store_decimal_as_integer=True,
-                     column_encoding="DELTA_BINARY_PACKED")
+                     column_encoding={'a': 'DELTA_BINARY_PACKED',
+                                      'b': 'DELTA_BINARY_PACKED'}
+                    )
   
     # Check with mixed column types.
     mixed_table = pa.Table.from_arrays([arr_decimal_1_9, arr_decimal_10_18, 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -359,39 +359,42 @@ def test_byte_stream_split():
 
 
 def test_store_decimal_as_integer():
-    arr_decimal_1_9 = pa.array(list(map(Decimal, range(100))), 
-                               type=pa.decimal128(5,2)
-                              )
-    arr_decimal_10_18 = pa.array(list(map(Decimal, range(100))), 
-                                 type=pa.decimal128(16,9)
-                                )
-    arr_decimal_gt18 = pa.array(list(map(Decimal, range(100))), 
-                                type=pa.decimal128(22,2)
-                               )
+    arr_decimal_1_9 = pa.array(list(map(Decimal, range(100))),
+                               type=pa.decimal128(5, 2))
+    arr_decimal_10_18 = pa.array(list(map(Decimal, range(100))),
+                                 type=pa.decimal128(16, 9))
+    arr_decimal_gt18 = pa.array(list(map(Decimal, range(100))),
+                                type=pa.decimal128(22, 2))
     arr_bool = pa.array([True, False] * 50)
     data_decimal = [arr_decimal_1_9, arr_decimal_10_18, arr_decimal_gt18]
     table = pa.Table.from_arrays(data_decimal, names=['a', 'b', 'c'])
 
     # Check with store_decimal_as_integer.
-    _check_roundtrip(table, expected=table, compression="gzip",
-                     use_dictionary=False, store_decimal_as_integer=True)
-
-  # Check with store_decimal_as_integer and delta-int encoding.
-    _check_roundtrip(table, expected=table, compression="gzip",
+    _check_roundtrip(table,
+                     expected=table,
+                     compression="gzip",
                      use_dictionary=False,
-                     store_decimal_as_integer=True,
-                     column_encoding={'a': 'DELTA_BINARY_PACKED',
-                                      'b': 'DELTA_BINARY_PACKED'}
-                    )
-  
-    # Check with mixed column types.
-    mixed_table = pa.Table.from_arrays([arr_decimal_1_9, arr_decimal_10_18, 
-                                        arr_decimal_gt18, arr_bool],
-                                       names=['a', 'b', 'c', 'd'])
-    _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
                      store_decimal_as_integer=True)
 
-    
+    # Check with store_decimal_as_integer and delta-int encoding.
+    _check_roundtrip(table,
+                     expected=table,
+                     compression="gzip",
+                     use_dictionary=False,
+                     store_decimal_as_integer=True,
+                     column_encoding={
+                         'a': 'DELTA_BINARY_PACKED',
+                         'b': 'DELTA_BINARY_PACKED'
+                     })
+
+    # Check with mixed column types.
+    mixed_table = pa.Table.from_arrays(
+        [arr_decimal_1_9, arr_decimal_10_18, arr_decimal_gt18, arr_bool],
+        names=['a', 'b', 'c', 'd'])
+    _check_roundtrip(mixed_table,
+                     expected=mixed_table,
+                     use_dictionary=False,
+                     store_decimal_as_integer=True) 
 
 
 def test_column_encoding():

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -386,7 +386,7 @@ def test_store_decimal_as_integer():
   
     # Check with mixed column types.
     mixed_table = pa.Table.from_arrays([arr_decimal_1_9, arr_decimal_10_18, 
-                                        arr_decimal_gt18, aar_bool],
+                                        arr_decimal_gt18, arr_bool],
                                        names=['a', 'b', 'c', 'd'])
     _check_roundtrip(mixed_table, expected=mixed_table, use_dictionary=False,
                      store_decimal_as_integer=True)

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -357,6 +357,44 @@ def test_byte_stream_split():
                          use_dictionary=False)
 
 
+def test_store_decimal_as_integer():
+    # This is only a smoke test.
+    arr_float = pa.array(list(map(float, range(100))))
+    arr_int = pa.array(list(map(int, range(100))))
+    arr_bool = pa.array([True, False] * 50)
+    data_float = [arr_float, arr_float]
+    table = pa.Table.from_arrays(data_float, names=['a', 'b'])
+
+    # Check with byte_stream_split for both columns.
+    _check_roundtrip(table, expected=table, compression="gzip",
+                     use_dictionary=False, use_byte_stream_split=True)
+
+    # Check with byte_stream_split for column 'b' and dictionary
+    # for column 'a'.
+    _check_roundtrip(table, expected=table, compression="gzip",
+                     use_dictionary=['a'],
+                     use_byte_stream_split=['b'])
+
+    # Check with a collision for both columns.
+    _check_roundtrip(table, expected=table, compression="gzip",
+                     use_dictionary=['a', 'b'],
+                     use_byte_stream_split=['a', 'b'])
+
+    # Check with mixed column types.
+    mixed_table = pa.Table.from_arrays([arr_float, arr_float, arr_int, arr_int],
+                                       names=['a', 'b', 'c', 'd'])
+    _check_roundtrip(mixed_table, expected=mixed_table,
+                     use_dictionary=['b', 'd'],
+                     use_byte_stream_split=['a', 'c'])
+
+    # Try to use the wrong data type with the byte_stream_split encoding.
+    # This should throw an exception.
+    table = pa.Table.from_arrays([arr_bool], names=['tmp'])
+    with pytest.raises(IOError, match='BYTE_STREAM_SPLIT only supports'):
+        _check_roundtrip(table, expected=table, use_byte_stream_split=True,
+                         use_dictionary=False)
+
+
 def test_column_encoding():
     arr_float = pa.array(list(map(float, range(100))))
     arr_int = pa.array(list(map(int, range(100))))

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -392,6 +392,7 @@ def test_store_decimal_as_integer(tempdir):
     assert pqcol_decimal_10_18.physical_type == 'INT64'
 
     # Check with store_decimal_as_integer and delta-int encoding.
+    # DELTA_BINARY_PACKED requires parquet physical type to be INT64 or INT32
     _check_roundtrip(table,
                      expected=table,
                      compression="gzip",

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -394,7 +394,7 @@ def test_store_decimal_as_integer():
     _check_roundtrip(mixed_table,
                      expected=mixed_table,
                      use_dictionary=False,
-                     store_decimal_as_integer=True) 
+                     store_decimal_as_integer=True)
 
 
 def test_column_encoding():

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -15,9 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 from collections import OrderedDict
 import io
 import warnings
+import tempfile
 from shutil import copytree
 from decimal import Decimal
 
@@ -375,6 +377,21 @@ def test_store_decimal_as_integer():
                      compression="gzip",
                      use_dictionary=False,
                      store_decimal_as_integer=True)
+
+    # Check physical type in parquet schema
+    with tempfile.TemporaryDirectory() as tempdir:
+        pqtestfile_path = os.path.join(tempdir, 'test.parquet')
+        pq.write_table(table, pqtestfile_path,
+                       compression="gzip",
+                       use_dictionary=False,
+                       store_decimal_as_integer=True)
+
+        pqtestfile = pq.ParquetFile(pqtestfile_path)
+        pqcol_decimal_1_9 = pqtestfile.schema.column(0)
+        pqcol_decimal_10_18 = pqtestfile.schema.column(1)
+
+        assert pqcol_decimal_1_9.physical_type == 'INT32'
+        assert pqcol_decimal_10_18.physical_type == 'INT64'
 
     # Check with store_decimal_as_integer and delta-int encoding.
     _check_roundtrip(table,

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -380,9 +380,9 @@ def test_store_decimal_as_integer(tempdir):
     # Check physical type in parquet schema
     pqtestfile_path = os.path.join(tempdir, 'test.parquet')
     pq.write_table(table, pqtestfile_path,
-                    compression="gzip",
-                    use_dictionary=False,
-                    store_decimal_as_integer=True)
+                   compression="gzip",
+                   use_dictionary=False,
+                   store_decimal_as_integer=True)
 
     pqtestfile = pq.ParquetFile(pqtestfile_path)
     pqcol_decimal_1_9 = pqtestfile.schema.column(0)

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -19,7 +19,7 @@ from collections import OrderedDict
 import io
 import warnings
 from shutil import copytree
-import decimal
+from decimal import Decimal
 
 import numpy as np
 import pytest
@@ -359,13 +359,13 @@ def test_byte_stream_split():
 
 
 def test_store_decimal_as_integer():
-    arr_decimal_1_9 = pa.array(list(map(float, range(100))), 
+    arr_decimal_1_9 = pa.array(list(map(Decimal, range(100))), 
                                type=pa.decimal128(5,2)
                               )
-    arr_decimal_10_18 = pa.array(list(map(float, range(100))), 
+    arr_decimal_10_18 = pa.array(list(map(Decimal, range(100))), 
                                  type=pa.decimal128(16,9)
                                 )
-    arr_decimal_gt18 = pa.array(list(map(float, range(100))), 
+    arr_decimal_gt18 = pa.array(list(map(Decimal, range(100))), 
                                 type=pa.decimal128(22,2)
                                )
     arr_bool = pa.array([True, False] * 50)


### PR DESCRIPTION
This PR exposes the [store_decimal_as_integer](https://arrow.apache.org/docs/cpp/api/formats.html#_CPPv4N7parquet16WriterProperties7Builder31enable_store_decimal_as_integerEv) parquet writer property to pyarrow

### Rationale for this change

This will allow storing fixed-point decimals as integers in the parquet format and take advantage of more efficient storage codecs

### What changes are included in this PR?

Pyarrow parquet writer and related Cython 

### Are these changes tested?

Tests were included for the new parameter

### Are there any user-facing changes?

Docstrings were updated


* GitHub Issue: #42168