### PR TITLE
GH-42167: [CI] Upgrade the version of vcpkg in .env

### DIFF
--- a/.env
+++ b/.env
@@ -89,7 +89,7 @@ TZ=UTC
 # Used through docker-compose.yml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the
 # docker tags more readable.
-VCPKG="a42af01b72c28a8e1d7b48107b33e4f286a55ef6"    # 2023.11.20 Release
+VCPKG="943c5ef1c8f6b5e6ced092b242c8299caae2ff01"    # 2024.04.26 Release
 
 # This must be updated when we update
 # ci/docker/python-wheel-windows-vs2019.dockerfile.

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -54,7 +54,7 @@ jobs:
     name: AMD64 manylinux2014 Java JNI
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -54,7 +54,7 @@ jobs:
     name: AMD64 manylinux2014 Java JNI
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -39,8 +39,7 @@ ENV CPYTHON_VERSION=cp38
 ENV PATH=/opt/python/${CPYTHON_VERSION}-${CPYTHON_VERSION}/bin:${PATH}
 
 # Install CMake
-# AWS SDK doesn't work with CMake=3.22 due to https://gitlab.kitware.com/cmake/cmake/-/issues/22524
-ARG cmake=3.21.4
+ARG cmake=3.29.2
 COPY ci/scripts/install_cmake.sh arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_cmake.sh ${arch} linux ${cmake} /usr/local
 

--- a/ci/vcpkg/ports.patch
+++ b/ci/vcpkg/ports.patch
@@ -1,11 +1,11 @@
 diff --git a/ports/curl/portfile.cmake b/ports/curl/portfile.cmake
-index bdc544e9e..53f6bbc3b 100644
+index 7cab6f726..697ab1bb4 100644
 --- a/ports/curl/portfile.cmake
 +++ b/ports/curl/portfile.cmake
-@@ -74,9 +74,12 @@ vcpkg_cmake_configure(
-         -DENABLE_MANUAL=OFF
+@@ -84,9 +84,12 @@ vcpkg_cmake_configure(
+         -DBUILD_TESTING=OFF
+         -DENABLE_CURL_MANUAL=OFF
          -DCURL_CA_FALLBACK=ON
-         -DCURL_USE_LIBPSL=OFF
 +        -DCURL_CA_PATH=none
 +        -DCURL_CA_BUNDLE=none
          -DCMAKE_DISABLE_FIND_PACKAGE_Perl=ON
@@ -15,6 +15,19 @@ index bdc544e9e..53f6bbc3b 100644
  )
  vcpkg_cmake_install()
  vcpkg_copy_pdbs()
+diff --git a/ports/llvm/portfile.cmake b/ports/llvm/portfile.cmake
+index a79c72a59..6b7fa6a66 100644
+--- a/ports/llvm/portfile.cmake
++++ b/ports/llvm/portfile.cmake
+@@ -292,6 +292,8 @@ vcpkg_cmake_configure(
+         ${FEATURE_OPTIONS}
+     MAYBE_UNUSED_VARIABLES 
+         COMPILER_RT_ENABLE_IOS
++        BOLT_TOOLS_INSTALL_DIR
++        LIBOMP_INSTALL_ALIASES
+ )
+ 
+ vcpkg_cmake_install(ADD_BIN_TO_PATH)
 diff --git a/ports/snappy/portfile.cmake b/ports/snappy/portfile.cmake
 index 0c7098082..c603c3653 100644
 --- a/ports/snappy/portfile.cmake
@@ -52,16 +65,3 @@ index 000000000..e839c93a4
 + }
 + 
 + static inline bool LeftShiftOverflows(uint8_t value, uint32_t shift) {
-diff --git a/ports/llvm/portfile.cmake b/ports/llvm/portfile.cmake
-index bf9397b66..c3112b673 100644
---- a/ports/llvm/portfile.cmake
-+++ b/ports/llvm/portfile.cmake
-@@ -293,6 +293,8 @@ vcpkg_cmake_configure(
-         ${FEATURE_OPTIONS}
-     MAYBE_UNUSED_VARIABLES 
-         COMPILER_RT_ENABLE_IOS
-+        BOLT_TOOLS_INSTALL_DIR
-+        LIBOMP_INSTALL_ALIASES
- )
- 
- vcpkg_cmake_install(ADD_BIN_TO_PATH)


### PR DESCRIPTION
### Rationale for this change

See #42167

### What changes are included in this PR?

* Upgrades the version of vcpkg in .env to the 2024.04.26 version
  * I didn't use the more recent 2024.05.24 release tag as this fails to build boost libraries due to boost updating the tags of the 1.85.0 release and causing hash mismatches
* Upgrade the version of CMake installed in the Python Manylinux docker build due to glog requiring 3.22 or higher
* Rebase the `ports.patch` file

### Are these changes tested?

Yes, this doesn't change behaviour so should be covered by existing tests

### Are there any user-facing changes?

No
* GitHub Issue: #42167