### PR TITLE
GH-42170: [Python][CI] Update expected output for numpy 2.0.0

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4189,7 +4189,7 @@ def float16():
       32256
     ]
     >>> a.to_pylist()
-    [1.5, nan]
+    [np.float16(1.5), np.float16(nan)]
     """
     return primitive_type(_Type_HALF_FLOAT)
 


### PR DESCRIPTION
### Rationale for this change

See #42170

### What changes are included in this PR?

Updates the expected output displayed in the docstring of the `float16` function.

It looks like these tests are only run using the latest numpy, so I don't think there's a need to make them work with older numpy too?

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #42170