### PR TITLE
GH-42102: [C++][Parquet] Add binary that extracts a footer from a parquet file

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -39,6 +39,9 @@
 #include "parquet/schema_internal.h"
 #include "parquet/thrift_internal.h"
 
+// Include this after thrift_internal.h
+#include <thrift/protocol/TJSONProtocol.h>
+
 namespace parquet {
 
 const ApplicationVersion& ApplicationVersion::PARQUET_251_FIXED_VERSION() {
@@ -869,9 +872,7 @@ class FileMetaData::FileMetaDataImpl {
     auto md = *metadata_;
     if (scrub) Scrub(&md);
     if (json) {
-      std::ostringstream ss;
-      md.printTo(ss);
-      return ss.str();
+      return apache::thrift::ThriftJSONString(md);
     } else {
       ThriftSerializer serializer;
       std::string out;

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -21,6 +21,8 @@
 #include <cinttypes>
 #include <memory>
 #include <ostream>
+#include <random>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -29,6 +31,7 @@
 #include "arrow/io/memory.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/pcg_random.h"
 #include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/exception.h"
@@ -599,6 +602,47 @@ std::vector<SortingColumn> RowGroupMetaData::sorting_columns() const {
   return impl_->sorting_columns();
 }
 
+static void Scrub(std::string* s) {
+  static ::arrow::random::pcg64 rng;
+  std::uniform_int_distribution<> caps(65, 90);
+  for (auto& c : *s) c = caps(rng);
+}
+
+static void Scrub(format::FileMetaData* md) {
+  for (auto& s : md->schema) {
+    Scrub(&s.name);
+  }
+  for (auto& r : md->row_groups) {
+    for (auto& c : r.columns) {
+      Scrub(&c.file_path);
+      if (c.__isset.meta_data) {
+        auto& m = c.meta_data;
+        for (auto& p : m.path_in_schema) Scrub(&p);
+        for (auto& kv : m.key_value_metadata) {
+          Scrub(&kv.key);
+          Scrub(&kv.value);
+        }
+        Scrub(&m.statistics.max_value);
+        Scrub(&m.statistics.min_value);
+        Scrub(&m.statistics.min);
+        Scrub(&m.statistics.max);
+      }
+
+      if (c.crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY) {
+        auto& m = c.crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY;
+        for (auto& p : m.path_in_schema) Scrub(&p);
+        Scrub(&m.key_metadata);
+      }
+      Scrub(&c.encrypted_column_metadata);
+    }
+  }
+  for (auto& kv : md->key_value_metadata) {
+    Scrub(&kv.key);
+    Scrub(&kv.value);
+  }
+  Scrub(&md->footer_signing_key_metadata);
+}
+
 // file metadata
 class FileMetaData::FileMetaDataImpl {
  public:
@@ -821,6 +865,21 @@ class FileMetaData::FileMetaDataImpl {
     return out;
   }
 
+  std::string SerializeUnencrypted(bool scrub, bool json) const {
+    auto md = *metadata_;
+    if (scrub) Scrub(&md);
+    if (json) {
+      std::ostringstream ss;
+      md.printTo(ss);
+      return ss.str();
+    } else {
+      ThriftSerializer serializer;
+      std::string out;
+      serializer.SerializeToString(&md, &out);
+      return out;
+    }
+  }
+
   void set_file_decryptor(std::shared_ptr<InternalFileDecryptor> file_decryptor) {
     file_decryptor_ = std::move(file_decryptor);
   }
@@ -990,6 +1049,10 @@ void FileMetaData::AppendRowGroups(const FileMetaData& other) {
 std::shared_ptr<FileMetaData> FileMetaData::Subset(
     const std::vector<int>& row_groups) const {
   return impl_->Subset(row_groups);
+}
+
+std::string FileMetaData::SerializeUnencrypted(bool scrub, bool json) const {
+  return impl_->SerializeUnencrypted(scrub, json);
 }
 
 void FileMetaData::WriteTo(::arrow::io::OutputStream* dst,

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -867,10 +867,10 @@ class FileMetaData::FileMetaDataImpl {
     return out;
   }
 
-  std::string SerializeUnencrypted(bool scrub, bool json) const {
+  std::string SerializeUnencrypted(bool scrub, bool debug) const {
     auto md = *metadata_;
     if (scrub) Scrub(&md);
-    if (json) {
+    if (debug) {
       std::ostringstream ss;
       md.printTo(ss);
       return ss.str();

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -39,9 +39,6 @@
 #include "parquet/schema_internal.h"
 #include "parquet/thrift_internal.h"
 
-// Include this after thrift_internal.h
-#include <thrift/protocol/TJSONProtocol.h>
-
 namespace parquet {
 
 const ApplicationVersion& ApplicationVersion::PARQUET_251_FIXED_VERSION() {
@@ -874,7 +871,9 @@ class FileMetaData::FileMetaDataImpl {
     auto md = *metadata_;
     if (scrub) Scrub(&md);
     if (json) {
-      return apache::thrift::ThriftJSONString(md);
+      std::ostringstream ss;
+      md.printTo(ss);
+      return ss.str();
     } else {
       ThriftSerializer serializer;
       std::string out;

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -605,12 +605,14 @@ std::vector<SortingColumn> RowGroupMetaData::sorting_columns() const {
   return impl_->sorting_columns();
 }
 
+// Replace string data with random-generated uppercase characters
 static void Scrub(std::string* s) {
   static ::arrow::random::pcg64 rng;
   std::uniform_int_distribution<> caps(65, 90);
   for (auto& c : *s) c = caps(rng);
 }
 
+// Replace potentially sensitive metadata with random data
 static void Scrub(format::FileMetaData* md) {
   for (auto& s : md->schema) {
     Scrub(&s.name);

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -399,9 +399,9 @@ class PARQUET_EXPORT FileMetaData {
   /// \brief Serialize metadata unencrypted as string
   ///
   /// \param[in] scrub whether to remove sensitive information from the metadata.
-  /// \param[in] json whether to serialize the metadata as JSON (if true), otherwise
-  /// as Thrift (if false).
-  std::string SerializeUnencrypted(bool scrub, bool json) const;
+  /// \param[in] debug whether to serialize the metadata as Thrift (if false) or
+  /// debug text (if true).
+  std::string SerializeUnencrypted(bool scrub, bool debug) const;
 
  private:
   friend FileMetaDataBuilder;

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -396,11 +396,11 @@ class PARQUET_EXPORT FileMetaData {
   /// FileMetaData.
   std::shared_ptr<FileMetaData> Subset(const std::vector<int>& row_groups) const;
 
-  /// \brief Serializes metadata unencrypted to a string.
+  /// \brief Serialize metadata unencrypted as string
   ///
-  /// \param[in] scrub removes sensitive information from the metadata.
-  /// \param[in] json indicates if the metadata should be serialized as JSON, otherwise
-  /// thrift.
+  /// \param[in] scrub whether to remove sensitive information from the metadata.
+  /// \param[in] json whether to serialize the metadata as JSON (if true), otherwise
+  /// as Thrift (if false).
   std::string SerializeUnencrypted(bool scrub, bool json) const;
 
  private:

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -396,6 +396,13 @@ class PARQUET_EXPORT FileMetaData {
   /// FileMetaData.
   std::shared_ptr<FileMetaData> Subset(const std::vector<int>& row_groups) const;
 
+  /// \brief Serializes metadata unencrypted to a string.
+  ///
+  /// \param[in] scrub removes sensitive information from the metadata.
+  /// \param[in] json indicates if the metadata should be serialized as JSON, otherwise
+  /// thrift.
+  std::string SerializeUnencrypted(bool scrub, bool json) const;
+
  private:
   friend FileMetaDataBuilder;
   friend class SerializedFile;

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -34,11 +34,11 @@ if(PARQUET_BUILD_EXECUTABLES)
 
   # Only build parquet-dump-footer when statically linking.
   if(ARROW_BUILD_SHARED)
+
   else()
     add_executable(parquet-dump-footer parquet-dump-footer.cc)
     target_link_libraries(parquet-dump-footer parquet_static thrift::thrift)
-    set_target_properties(parquet-dump-footer PROPERTIES
-                          INSTALL_RPATH_USE_LINK_PATH TRUE)
+    set_target_properties(parquet-dump-footer PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
     install(TARGETS parquet-dump-footer ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 if(PARQUET_BUILD_EXECUTABLES)
-  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan parquet-dump-footer)
+  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan)
 
   foreach(TOOL ${PARQUET_TOOLS})
     string(REGEX REPLACE "-" "_" TOOL_SOURCE ${TOOL})
@@ -31,7 +31,13 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  target_link_libraries(parquet-dump-footer thrift::thrift)
+
+  # Only build parquet-dump-footer when statically linking.
+  if(ARROW_BUILD_SHARED)
+  else()
+    add_executable(parquet-dump-footer parquet-dump-footer.cc)
+    target_link_libraries(parquet-dump-footer parquet_static thrift::thrift)
+  endif()
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,12 +31,7 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  target_link_libraries(parquet-dump-footer thrift::thrift)
-  if(ARROW_BUILD_SHARED)
-    target_link_libraries(parquet-dump-footer arrow_shared)
-  else()
-    target_link_libraries(parquet-dump-footer arrow_static)
-  endif()
+  target_link_libraries(parquet-dump-footer thrift::thrift ${ARROW_LIBRARIES})
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,7 +31,12 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  target_link_libraries(parquet-dump-footer thrift::thrift arrow_static)
+  target_link_libraries(parquet-dump-footer thrift::thrift)
+  if(ARROW_BUILD_SHARED)
+    target_link_libraries(parquet-dump-footer arrow_shared)
+  else()
+    target_link_libraries(parquet-dump-footer arrow_static)
+  endif()
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -37,6 +37,10 @@ if(PARQUET_BUILD_EXECUTABLES)
   else()
     add_executable(parquet-dump-footer parquet-dump-footer.cc)
     target_link_libraries(parquet-dump-footer parquet_static thrift::thrift)
+    set_target_properties(parquet-dump-footer PROPERTIES
+                          INSTALL_RPATH_USE_LINK_PATH TRUE)
+    install(TARGETS parquet-dump-footer ${INSTALL_IS_OPTIONAL}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif()
 
   add_dependencies(parquet ${PARQUET_TOOLS})

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 if(PARQUET_BUILD_EXECUTABLES)
-  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan)
+  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan parquet-dump-footer)
 
   foreach(TOOL ${PARQUET_TOOLS})
     string(REGEX REPLACE "-" "_" TOOL_SOURCE ${TOOL})
@@ -31,6 +31,7 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
+  target_link_libraries(parquet-dump-footer thrift)
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,7 +31,7 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  target_link_libraries(parquet-dump-footer thrift)
+  target_link_libraries(parquet-dump-footer thrift::thrift arrow_static)
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,12 +31,12 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  target_link_libraries(parquet-dump-footer thrift::thrift)
   if(ARROW_BUILD_SHARED)
     target_link_libraries(parquet-dump-footer arrow_shared)
   else()
     target_link_libraries(parquet-dump-footer arrow_static)
   endif()
+  target_link_libraries(parquet-dump-footer thrift::thrift)
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,7 +31,12 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  target_link_libraries(parquet-dump-footer thrift::thrift ${ARROW_LIBRARIES})
+  target_link_libraries(parquet-dump-footer thrift::thrift)
+  if(ARROW_BUILD_SHARED)
+    target_link_libraries(parquet-dump-footer arrow_shared)
+  else()
+    target_link_libraries(parquet-dump-footer arrow_static)
+  endif()
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 if(PARQUET_BUILD_EXECUTABLES)
-  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan parquet-dump-footer)
+  set(PARQUET_TOOLS parquet-dump-footer parquet-dump-schema parquet-reader parquet-scan)
 
   foreach(TOOL ${PARQUET_TOOLS})
     string(REGEX REPLACE "-" "_" TOOL_SOURCE ${TOOL})

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,6 +31,7 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
+  target_link_libraries(parquet-dump-footer ${ARROW_LIBRARIES})
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 if(PARQUET_BUILD_EXECUTABLES)
-  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan)
+  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan parquet-dump-footer)
 
   foreach(TOOL ${PARQUET_TOOLS})
     string(REGEX REPLACE "-" "_" TOOL_SOURCE ${TOOL})
@@ -31,17 +31,6 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-
-  # Only build parquet-dump-footer when statically linking.
-  if(ARROW_BUILD_SHARED)
-
-  else()
-    add_executable(parquet-dump-footer parquet-dump-footer.cc)
-    target_link_libraries(parquet-dump-footer parquet_static thrift::thrift)
-    set_target_properties(parquet-dump-footer PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-    install(TARGETS parquet-dump-footer ${INSTALL_IS_OPTIONAL}
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-  endif()
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,11 +31,6 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  if(ARROW_BUILD_SHARED)
-    target_link_libraries(parquet-dump-footer arrow_shared)
-  else()
-    target_link_libraries(parquet-dump-footer arrow_static)
-  endif()
   target_link_libraries(parquet-dump-footer thrift::thrift)
 
   add_dependencies(parquet ${PARQUET_TOOLS})

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -203,13 +203,13 @@ static int PrintHelp() {
   std::cerr << R"(
 Usage: parquet-dump-footer
   -h|--help    Print help and exit
-  --no-scrub   Do not scrub potentially user specific metadata
+  --no-scrub   Do not scrub potentially confidential metadata
   --json       Output JSON instead of binary
   --in         Input file: required
   --out        Output file: defaults to stdout
 
   Dumps the footer of a Parquet file to stdout or a file, optionally with
-  potentially user specific metadata scrubbed.
+  potentially confidential metadata scrubbed.
 )";
   return 1;
 }

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -1,0 +1,230 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <utility>
+
+#include <thrift/protocol/TCompactProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+
+#include "parquet_types.h"
+
+using apache::thrift::protocol::TCompactProtocol;
+using apache::thrift::transport::TMemoryBuffer;
+using apache::thrift::transport::TTransport;
+
+namespace {
+int PrintHelp() {
+  std::cerr << R"(
+Usage: parquet-dump-footer
+  -h|--help    Print help and exit
+  --no-scrub   Do not scrub potentially PII metadata
+  --json       Output JSON instead of binary
+  --in         Input file: required
+  --out        Output file: defaults to stdout
+
+  Dumps the footer of a Parquet file to stdout or a file, optionally with
+  potentially PII metadata scrubbed.
+)";
+  return 1;
+}
+
+uint32_t ReadLE32(const void* p) {
+  auto* b = reinterpret_cast<const uint8_t*>(p);
+  return uint32_t{b[3]} << 24 | uint32_t{b[2]} << 16 | uint32_t{b[1]} << 8 |
+         uint32_t{b[0]};
+}
+
+void AppendLE32(uint32_t v, std::string* out) {
+  out->push_back(v & 0xff);
+  out->push_back((v >> 8) & 0xff);
+  out->push_back((v >> 16) & 0xff);
+  out->push_back((v >> 24) & 0xff);
+}
+
+std::pair<char*, size_t> MmapFile(const std::string& fname) {
+  int fd = open(fname.c_str(), O_RDONLY);
+  if (fd < 0) return {nullptr, 0};
+  struct stat st;
+  if (fstat(fd, &st)) return {nullptr, 0};
+  size_t sz = st.st_size;
+  void* map = mmap(nullptr, sz, PROT_READ, MAP_SHARED, fd, 0);
+  return {map == MAP_FAILED ? nullptr : static_cast<char*>(map), sz};
+}
+
+template <typename T>
+bool Deserialize(const char* data, size_t len, T* obj) {
+  TMemoryBuffer buf(reinterpret_cast<uint8_t*>(const_cast<char*>(data)), len);
+  TCompactProtocol proto(std::shared_ptr<TTransport>(&buf, [](auto*) {}));
+  try {
+    obj->read(&proto);
+    return true;
+  } catch (const std::exception& e) {
+    std::cerr << "Failed to deserialize: " << e.what() << "\n";
+    return false;
+  }
+}
+
+template <typename T>
+bool Serialize(const T& obj, std::string* out) {
+  TMemoryBuffer buf;
+  TCompactProtocol proto(std::shared_ptr<TTransport>(&buf, [](auto*) {}));
+  try {
+    obj.write(&proto);
+    uint8_t* data;
+    uint32_t len;
+    buf.getBuffer(&data, &len);
+    out->assign(reinterpret_cast<char*>(data), len);
+    return true;
+  } catch (const std::exception& e) {
+    std::cerr << "Failed to serialize: " << e.what() << "\n";
+    return false;
+  }
+}
+
+void Scrub(std::string* s) {
+  static char pool[4096];
+  static std::mt19937 rng(std::random_device{}());
+  static const bool kPoolInit = [] {
+    std::uniform_int_distribution<> caps(65, 90);
+    for (size_t i = 0; i < sizeof(pool); i++) pool[i] = caps(rng);
+    return true;
+  }();
+  (void)kPoolInit;
+
+  const size_t n = s->size();
+  s->clear();
+  while (s->size() < n) {
+    size_t m = std::min(n, sizeof(pool) / 2);
+    std::uniform_int_distribution<> start(0, sizeof(pool) / 2);
+    s->append(&pool[start(rng)], m);
+  }
+}
+
+void Scrub(parquet::format::FileMetaData* md) {
+  for (auto& s : md->schema) {
+    Scrub(&s.name);
+  }
+  for (auto& r : md->row_groups) {
+    for (auto& c : r.columns) {
+      Scrub(&c.file_path);
+      if (c.__isset.meta_data) {
+        auto& m = c.meta_data;
+        for (auto& p : m.path_in_schema) Scrub(&p);
+        for (auto& kv : m.key_value_metadata) {
+          Scrub(&kv.key);
+          Scrub(&kv.value);
+        }
+        Scrub(&m.statistics.max_value);
+        Scrub(&m.statistics.min_value);
+        Scrub(&m.statistics.min);
+        Scrub(&m.statistics.max);
+      }
+
+      if (c.crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY) {
+        auto& m = c.crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY;
+        for (auto& p : m.path_in_schema) Scrub(&p);
+        Scrub(&m.key_metadata);
+      }
+      Scrub(&c.encrypted_column_metadata);
+    }
+  }
+  for (auto& kv : md->key_value_metadata) {
+    Scrub(&kv.key);
+    Scrub(&kv.value);
+  }
+  Scrub(&md->footer_signing_key_metadata);
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+  bool help = false;
+  bool scrub = true;
+  bool json = false;
+  std::string in;
+  std::string out;
+  for (int i = 1; i < argc; i++) {
+    char* arg = argv[i];
+    help |= !std::strcmp(arg, "-h") || !std::strcmp(arg, "--help");
+    scrub &= std::strcmp(arg, "--no-scrub");
+    json |= !std::strcmp(arg, "--json");
+    if (!std::strcmp(arg, "--in")) {
+      if (i + 1 >= argc) return PrintHelp();
+      in = argv[++i];
+    }
+    if (!std::strcmp(arg, "--out")) {
+      if (i + 1 >= argc) return PrintHelp();
+      out = argv[++i];
+    }
+  }
+  if (help || in.empty()) return PrintHelp();
+  auto [data, len] = MmapFile(in);
+
+  if (len == 0) {
+    std::cerr << "Failed to read file: " << in << "\n";
+    return 3;
+  }
+  if (len < 8 || ReadLE32(data + len - 4) != ReadLE32("PAR1")) {
+    std::cerr << "Not a Parquet file: " << in << "\n";
+    return 4;
+  }
+  size_t footer_len = ReadLE32(data + len - 8);
+  if (footer_len > len - 8) {
+    std::cerr << "Invalid footer length: " << footer_len << "\n";
+    return 5;
+  }
+  char* footer = data + len - 8 - footer_len;
+  parquet::format::FileMetaData md;
+  if (!Deserialize(footer, footer_len, &md)) return 5;
+  if (scrub) Scrub(&md);
+
+  std::string ser;
+  if (json) {
+    if (out.empty()) {
+      md.printTo(std::cout);
+    } else {
+      std::fstream fout(out, std::ios::out);
+      md.printTo(fout);
+    }
+  } else {
+    int out_fd = out.empty() ? 1 : open(out.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (out_fd < 0) {
+      std::cerr << "Failed to open output file: " << out << "\n";
+      return 2;
+    }
+    if (!Serialize(md, &ser)) return 6;
+    AppendLE32(ser.size(), &ser);
+    ser.append("PAR1", 4);
+    if (write(out_fd, ser.data(), ser.size()) != static_cast<ssize_t>(ser.size())) {
+      std::cerr << "Failed to write to output file: " << out << "\n";
+      return 7;
+    }
+    close(out_fd);
+  }
+
+  return 0;
+}

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -30,8 +30,8 @@
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/ubsan.h"
-#include "parquet/thrift_internal.h"
 #include "generated/parquet_types.h"
+#include "parquet/thrift_internal.h"
 
 using apache::thrift::protocol::TCompactProtocol;
 using apache::thrift::transport::TMemoryBuffer;
@@ -91,7 +91,7 @@ bool Serialize(const T& obj, std::string* out) {
 // Replace the contents of s with random data of the same length.
 void Scrub(std::string* s) {
   static char pool[4096];
-  static std::mt19937 rng(std::random_device {}());
+  static std::mt19937 rng(std::random_device{}());
   static const bool kPoolInit = [] {
     std::uniform_int_distribution<> caps(65, 90);
     for (size_t i = 0; i < sizeof(pool); i++) pool[i] = caps(rng);

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -17,25 +17,14 @@
 
 #include <cstdint>
 #include <cstring>
-#include <exception>
 #include <fstream>
 #include <iostream>
-#include <limits>
 #include <optional>
-#include <random>
-
-#include <thrift/protocol/TCompactProtocol.h>
-#include <thrift/transport/TBufferTransports.h>
 
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/ubsan.h"
-#include "generated/parquet_types.h"
-#include "parquet/thrift_internal.h"
-
-using apache::thrift::protocol::TCompactProtocol;
-using apache::thrift::transport::TMemoryBuffer;
-using apache::thrift::transport::TTransport;
+#include "parquet/metadata.h"
 
 namespace parquet {
 namespace {
@@ -48,90 +37,6 @@ void AppendLE32(uint32_t v, std::string* out) {
   v = ::arrow::bit_util::ToLittleEndian(v);
   out->append(reinterpret_cast<const char*>(&v), sizeof(v));
 }
-
-template <typename T>
-bool Deserialize(const char* data, uint32_t len, T* obj) {
-  parquet::ThriftDeserializer des(/*string_size_limit=*/1 << 30,
-                                  /*container_size_limit=*/1 << 30);
-  try {
-    des.DeserializeMessage(reinterpret_cast<const uint8_t*>(data), &len, obj);
-    return true;
-  } catch (const std::exception& e) {
-    std::cerr << "Failed to deserialize: " << e.what() << "\n";
-    return false;
-  }
-}
-
-template <typename T>
-bool Serialize(const T& obj, std::string* out) {
-  parquet::ThriftSerializer ser(/*initial_buffer_size=*/10 << 20);
-  try {
-    ser.SerializeToString(&obj, out);
-    return true;
-  } catch (const std::exception& e) {
-    std::cerr << "Failed to serialize: " << e.what() << "\n";
-    return false;
-  }
-}
-
-// Replace the contents of s with random data of the same length.
-void Scrub(std::string* s) {
-  static std::mt19937 rng(std::random_device{}());
-  std::uniform_int_distribution<> caps(65, 90);
-  for (auto& c : *s) c = caps(rng);
-}
-
-void Scrub(parquet::format::FileMetaData* md) {
-  for (auto& s : md->schema) {
-    Scrub(&s.name);
-  }
-  for (auto& r : md->row_groups) {
-    for (auto& c : r.columns) {
-      Scrub(&c.file_path);
-      if (c.__isset.meta_data) {
-        auto& m = c.meta_data;
-        for (auto& p : m.path_in_schema) Scrub(&p);
-        for (auto& kv : m.key_value_metadata) {
-          Scrub(&kv.key);
-          Scrub(&kv.value);
-        }
-        Scrub(&m.statistics.max_value);
-        Scrub(&m.statistics.min_value);
-        Scrub(&m.statistics.min);
-        Scrub(&m.statistics.max);
-      }
-
-      if (c.crypto_metadata.__isset.ENCRYPTION_WITH_COLUMN_KEY) {
-        auto& m = c.crypto_metadata.ENCRYPTION_WITH_COLUMN_KEY;
-        for (auto& p : m.path_in_schema) Scrub(&p);
-        Scrub(&m.key_metadata);
-      }
-      Scrub(&c.encrypted_column_metadata);
-    }
-  }
-  for (auto& kv : md->key_value_metadata) {
-    Scrub(&kv.key);
-    Scrub(&kv.value);
-  }
-  Scrub(&md->footer_signing_key_metadata);
-}
-
-// Returns:
-// - 0 on success
-// - -1 on error
-// - the size of the footer if tail is too small
-int64_t ParseFooter(const std::string& tail, parquet::format::FileMetaData* md) {
-  if (tail.size() > std::numeric_limits<int32_t>::max()) return -1;
-
-  const char* p = tail.data();
-  const int32_t n = static_cast<int32_t>(tail.size());
-  int32_t len = ReadLE32(p + n - 8);
-  if (len > n - 8) return len;
-
-  if (!Deserialize(tail.data() + n - 8 - len, len, md)) return -1;
-  return 0;
-}
-}  // namespace
 
 int DoIt(std::string in, bool scrub, bool json, std::string out) {
   std::string path;
@@ -147,56 +52,38 @@ int DoIt(std::string in, bool scrub, bool json, std::string out) {
   tail.resize(tail_len);
   char* data = tail.data();
   file->ReadAt(file_len - tail_len, tail_len, data).ValueOrDie();
-  if (ReadLE32(data + tail_len - 4) != ReadLE32("PAR1")) {
+  if (auto magic = ReadLE32(data + tail_len - 4); magic != ReadLE32("PAR1")) {
     std::cerr << "Not a Parquet file: " << in << "\n";
     return 4;
   }
-  parquet::format::FileMetaData md;
-  int64_t res = ParseFooter(tail, &md);
-  if (res < 0) {
-    std::cerr << "Failed to parse footer: " << in << "\n";
-    return 5;
-  } else if (res > 0) {
-    if (res > file_len) {
+  uint32_t metadata_len = ReadLE32(data + tail_len - 8);
+  if (metadata_len > tail_len - 8) {
+    if (metadata_len > file_len) {
       std::cerr << "File too short: " << in << "\n";
-      return 6;
+      return 5;
     }
-    tail_len = res + 8;
+    tail_len = metadata_len + 8;
     tail.resize(tail_len);
     data = tail.data();
     file->ReadAt(file_len - tail_len, tail_len, data).ValueOrDie();
   }
-  if (ParseFooter(tail, &md) != 0) {
-    std::cerr << "Failed to parse footer: " << in << "\n";
-    return 7;
-  }
-
-  if (scrub) Scrub(&md);
-
-  std::optional<std::fstream> fout;
-  if (json) {
-    if (!out.empty()) fout.emplace(out, std::ios::out);
-    std::ostream& os = fout ? *fout : std::cout;
-    md.printTo(os);
-  } else {
-    if (!out.empty()) fout.emplace(out, std::ios::out | std::ios::binary);
-    std::ostream& os = fout ? *fout : std::cout;
-    if (!os) {
-      std::cerr << "Failed to open output file: " << out << "\n";
-      return 8;
-    }
-    std::string ser;
-    if (!Serialize(md, &ser)) return 6;
+  auto md = FileMetaData::Make(tail.data(), &metadata_len);
+  std::string ser = md->SerializeUnencrypted(scrub, json);
+  if (!json) {
     AppendLE32(static_cast<uint32_t>(ser.size()), &ser);
     ser.append("PAR1", 4);
-    if (!os.write(ser.data(), ser.size())) {
-      std::cerr << "Failed to write to output file: " << out << "\n";
-      return 9;
-    }
+  }
+  std::optional<std::fstream> fout;
+  if (!out.empty()) fout.emplace(out, std::ios::out);
+  std::ostream& os = fout ? *fout : std::cout;
+  if (!os.write(ser.data(), ser.size())) {
+    std::cerr << "Failed to write to output file: " << out << "\n";
+    return 6;
   }
 
   return 0;
 }
+}  // namespace
 }  // namespace parquet
 
 static int PrintHelp() {

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -92,8 +92,7 @@ int DoIt(std::string in, bool scrub, bool json, std::string out) {
 }  // namespace parquet
 
 static int PrintHelp() {
-  std::cerr << R"(
-Usage: parquet-dump-footer
+  std::cerr << R"(Usage: parquet-dump-footer
   -h|--help    Print help and exit
   --no-scrub   Do not scrub potentially confidential metadata
   --json       Output JSON instead of binary

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -95,7 +95,7 @@ static int PrintHelp() {
   std::cerr << R"(Usage: parquet-dump-footer
   -h|--help    Print help and exit
   --no-scrub   Do not scrub potentially confidential metadata
-  --json       Output JSON instead of binary
+  --debug      Output text represenation of footer for inspection
   --in <uri>   Input file (required): must be an URI or an absolute local path
   --out <path> Output file (optional, default stdout)
 

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -29,7 +29,7 @@
 
 #include "arrow/filesystem/filesystem.h"
 #include "parquet/thrift_internal.h"
-#include "parquet_types.h"
+#include "generated/parquet_types.h"
 
 using apache::thrift::protocol::TCompactProtocol;
 using apache::thrift::transport::TMemoryBuffer;
@@ -90,7 +90,7 @@ bool Serialize(const T& obj, std::string* out) {
 
 void Scrub(std::string* s) {
   static char pool[4096];
-  static std::mt19937 rng(std::random_device{}());
+  static std::mt19937 rng(std::random_device {}());
   static const bool kPoolInit = [] {
     std::uniform_int_distribution<> caps(65, 90);
     for (size_t i = 0; i < sizeof(pool); i++) pool[i] = caps(rng);

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -48,7 +48,7 @@ Usage: parquet-dump-footer
   --out        Output file: defaults to stdout
 
   Dumps the footer of a Parquet file to stdout or a file, optionally with
-  potentially PII metadata scrubbed.
+  potentially user specific metadata scrubbed.
 )";
   return 1;
 }


### PR DESCRIPTION
### Rationale for this change

This binary will make it a lot easier for customers to share their parquet metadata with the community so that we can build a repository of footers that can be used for advancing the state of metadata in parquet.

### What changes are included in this PR?

Usage from the file binary itself:
```
Usage: parquet-dump-footer
  -h|--help    Print help and exit
  --no-scrub   Do not scrub potentially confidential metadata
  --debug      Output text represenation of footer for inspection
  --in <uri>   Input file (required): must be an URI or an absolute local path
  --out <path> Output file (optional, default stdout)

  Dump the footer of a Parquet file to stdout or to a file, optionally with
  potentially confidential metadata scrubbed.
```

### Are these changes tested?

Manually on existing parquet files.

### Are there any user-facing changes?

No.

* GitHub Issue: #42102