### PR TITLE
GH-42136: [CI][Go][Java][JS] Use AMD64-based macOS explicitly

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -307,7 +307,7 @@ jobs:
 
   macos:
     name: AMD64 macOS 11 Go ${{ matrix.go }}
-    runs-on: macos-latest
+    runs-on: macos-11
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:
@@ -365,7 +365,7 @@ jobs:
 
   macos-cgo:
     name: AMD64 macOS 11 Go ${{ matrix.go }} - CGO
-    runs-on: macos-latest
+    runs-on: macos-11
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -306,8 +306,8 @@ jobs:
         run: ci/scripts/go_test.sh $(pwd)
 
   macos:
-    name: AMD64 macOS 11 Go ${{ matrix.go }}
-    runs-on: macos-11
+    name: AMD64 macOS 12 Go ${{ matrix.go }}
+    runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:
@@ -364,8 +364,8 @@ jobs:
 
 
   macos-cgo:
-    name: AMD64 macOS 11 Go ${{ matrix.go }} - CGO
-    runs-on: macos-11
+    name: AMD64 macOS 12 Go ${{ matrix.go }} - CGO
+    runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -105,9 +105,9 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: AMD64 macOS 12 Java JDK ${{ matrix.jdk }}
-    runs-on: macos-12
-    if: github.event_name == 'push'
+    name: AMD64 macOS 13 Java JDK ${{ matrix.jdk }}
+    runs-on: macos-13
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -105,8 +105,8 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: AMD64 macOS 13 Java JDK ${{ matrix.jdk }}
-    runs-on: macos-13
+    name: AMD64 macOS 12 Java JDK ${{ matrix.jdk }}
+    runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -105,8 +105,8 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: AMD64 macOS 11 Java JDK ${{ matrix.jdk }}
-    runs-on: macos-latest
+    name: AMD64 macOS 12 Java JDK ${{ matrix.jdk }}
+    runs-on: macos-12
     if: github.event_name == 'push'
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -81,9 +81,9 @@ jobs:
         run: archery docker push debian-js
 
   macos:
-    name: AMD64 macOS 12 NodeJS ${{ matrix.node }}
-    runs-on: macos-12
-    if: github.event_name == 'push'
+    name: AMD64 macOS 13 NodeJS ${{ matrix.node }}
+    runs-on: macos-13
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -114,7 +114,7 @@ jobs:
   windows:
     name: AMD64 Windows NodeJS ${{ matrix.node }}
     runs-on: windows-latest
-    if: github.event_name == 'push'
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -84,7 +84,7 @@ jobs:
     name: AMD64 macOS 12 NodeJS ${{ matrix.node }}
     runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 90
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +115,7 @@ jobs:
     name: AMD64 Windows NodeJS ${{ matrix.node }}
     runs-on: windows-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -81,8 +81,8 @@ jobs:
         run: archery docker push debian-js
 
   macos:
-    name: AMD64 macOS 13 NodeJS ${{ matrix.node }}
-    runs-on: macos-13
+    name: AMD64 macOS 12 NodeJS ${{ matrix.node }}
+    runs-on: macos-12
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -81,8 +81,8 @@ jobs:
         run: archery docker push debian-js
 
   macos:
-    name: AMD64 macOS 11 NodeJS ${{ matrix.node }}
-    runs-on: macos-latest
+    name: AMD64 macOS 12 NodeJS ${{ matrix.node }}
+    runs-on: macos-12
     if: github.event_name == 'push'
     timeout-minutes: 90
     strategy:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

To support AMD64-based macOS in CI jobs. We can no longer use `macos-11` on GitHub Actions [1]. Since `macos-latest` operates based on ARM64 [2], we are changing to `macos-12` to maintain an AMD64-based workflow.

- [1] [Actions: Upcoming changes to GitHub-hosted macOS runners](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/)
- [2] [Available-images](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images)

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Updating CI jobs to support AMD64-based macOS (`macos-12`).
  - [x] Go
  - [x] Java
  - [x] JS
- Updating CI condition to trigger workflow 
  - from `github.event_name == 'push'` 
  - to `${{ !contains(github.event.pull_request.title, 'WIP') }}`

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes. tested via CI.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #42136