### PR TITLE
GH-42190: [Python] Add CI job for Numpy 1.X

### DIFF
--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -43,7 +43,7 @@ elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
   pip install pandas
-elif [[ "${pandas}" = [0-9]* ]]; then
+elif [[ ${pandas} = [0-9]* ]]; then
   pip install pandas==${pandas}
 else
   pip install pandas${pandas}

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -31,10 +31,8 @@ if [ "${numpy}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre numpy
 elif [ "${numpy}" = "latest" ]; then
   pip install numpy
-elif [[ ${numpy} = [0-9]* ]]; then
-  pip install numpy==${numpy}
 else
-  pip install numpy${numpy}
+  pip install numpy==${numpy}
 fi
 
 if [ "${pandas}" = "upstream_devel" ]; then
@@ -43,8 +41,6 @@ elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
   pip install pandas
-elif [[ ${pandas} = [0-9]* ]]; then
-  pip install pandas==${pandas}
 else
-  pip install pandas${pandas}
+  pip install pandas==${pandas}
 fi

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -31,7 +31,7 @@ if [ "${numpy}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre numpy
 elif [ "${numpy}" = "latest" ]; then
   pip install numpy
-elif [ "${numpy}" = [0-9]* ]; then
+elif [[ ${numpy} = [0-9]* ]]; then
   pip install numpy==${numpy}
 else
   pip install numpy${numpy}
@@ -43,7 +43,7 @@ elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
   pip install pandas
-elif [ "${pandas}" = [0-9]* ]; then
+elif [[ "${pandas}" = [0-9]* ]]; then
   pip install pandas==${pandas}
 else
   pip install pandas${pandas}

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -31,6 +31,8 @@ if [ "${numpy}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre numpy
 elif [ "${numpy}" = "latest" ]; then
   pip install numpy
+elif [ "${numpy}" = "~="* ]; then
+  pip install numpy${numpy}
 else
   pip install numpy==${numpy}
 fi
@@ -41,6 +43,8 @@ elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
   pip install pandas
+elif [ "${pandas}" = "~="* ]; then
+  pip install pandas${pandas}
 else
   pip install pandas==${pandas}
 fi

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -31,10 +31,10 @@ if [ "${numpy}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre numpy
 elif [ "${numpy}" = "latest" ]; then
   pip install numpy
-elif [ "${numpy}" = "~="* ]; then
-  pip install numpy${numpy}
-else
+elif [ "${numpy}" = [0-9]* ]; then
   pip install numpy==${numpy}
+else
+  pip install numpy${numpy}
 fi
 
 if [ "${pandas}" = "upstream_devel" ]; then
@@ -43,8 +43,8 @@ elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
   pip install pandas
-elif [ "${pandas}" = "~="* ]; then
-  pip install pandas${pandas}
-else
+elif [ "${pandas}" = [0-9]* ]; then
   pip install pandas==${pandas}
+else
+  pip install pandas${pandas}
 fi

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1494,7 +1494,7 @@ tasks:
 
 {% for python_version, pandas_version, numpy_version, cache_leaf in [("3.8", "1.0", "1.19", True),
                                                                      ("3.9", "latest", "latest", False),
-                                                                     ("3.10", "latest", "1", False),
+                                                                     ("3.10", "latest", "<2.0.0", False),
                                                                      ("3.10", "latest", "latest", False),
                                                                      ("3.10", "nightly", "nightly", False),
                                                                      ("3.11", "upstream_devel", "nightly", False)] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1494,7 +1494,7 @@ tasks:
 
 {% for python_version, pandas_version, numpy_version, cache_leaf in [("3.8", "1.0", "1.19", True),
                                                                      ("3.9", "latest", "latest", False),
-                                                                     ("3.10", "latest", "<2.0.0", False),
+                                                                     ("3.10", "latest", "1.*", False),
                                                                      ("3.10", "latest", "latest", False),
                                                                      ("3.10", "nightly", "nightly", False),
                                                                      ("3.11", "upstream_devel", "nightly", False)] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1494,6 +1494,7 @@ tasks:
 
 {% for python_version, pandas_version, numpy_version, cache_leaf in [("3.8", "1.0", "1.19", True),
                                                                      ("3.9", "latest", "latest", False),
+                                                                     ("3.10", "latest", "1", False),
                                                                      ("3.10", "latest", "latest", False),
                                                                      ("3.10", "nightly", "nightly", False),
                                                                      ("3.11", "upstream_devel", "nightly", False)] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1494,7 +1494,7 @@ tasks:
 
 {% for python_version, pandas_version, numpy_version, cache_leaf in [("3.8", "1.0", "1.19", True),
                                                                      ("3.9", "latest", "latest", False),
-                                                                     ("3.10", "latest", "~=1", False),
+                                                                     ("3.10", "latest", "<2.0.0", False),
                                                                      ("3.10", "latest", "latest", False),
                                                                      ("3.10", "nightly", "nightly", False),
                                                                      ("3.11", "upstream_devel", "nightly", False)] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1498,7 +1498,7 @@ tasks:
                                                                      ("3.10", "latest", "latest", False),
                                                                      ("3.10", "nightly", "nightly", False),
                                                                      ("3.11", "upstream_devel", "nightly", False)] %}
-  test-conda-python-{{ python_version }}-pandas-{{ pandas_version }}:
+  test-conda-python-{{ python_version }}-pandas-{{ pandas_version }}-numpy-{{ numpy_version }}:
     ci: github
     template: docker-tests/github.linux.yml
     params:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1494,7 +1494,7 @@ tasks:
 
 {% for python_version, pandas_version, numpy_version, cache_leaf in [("3.8", "1.0", "1.19", True),
                                                                      ("3.9", "latest", "latest", False),
-                                                                     ("3.10", "latest", "<2.0.0", False),
+                                                                     ("3.10", "latest", "1.26", False),
                                                                      ("3.10", "latest", "latest", False),
                                                                      ("3.10", "nightly", "nightly", False),
                                                                      ("3.11", "upstream_devel", "nightly", False)] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1494,7 +1494,7 @@ tasks:
 
 {% for python_version, pandas_version, numpy_version, cache_leaf in [("3.8", "1.0", "1.19", True),
                                                                      ("3.9", "latest", "latest", False),
-                                                                     ("3.10", "latest", "1.*", False),
+                                                                     ("3.10", "latest", "~=1", False),
                                                                      ("3.10", "latest", "latest", False),
                                                                      ("3.10", "nightly", "nightly", False),
                                                                      ("3.11", "upstream_devel", "nightly", False)] %}


### PR DESCRIPTION
### Rationale for this change

Numpy 2.0 released and most CI jobs test Numpy's latest version. Let's ensure Numpy 1.X continues to work with pandas in our integration testing.

### What changes are included in this PR?

* Add CI job to test integration with latest pandas and 1.X numpy

### Are these changes tested?

Yes, in CI

### Are there any user-facing changes?

No
* GitHub Issue: #42190