### PR TITLE
GH-41203: [Python][Packaging] Ensure to build with released numpy 2.0 (instead of RC) in the wheel building workflows

### DIFF
--- a/.env
+++ b/.env
@@ -95,7 +95,7 @@ VCPKG="a42af01b72c28a8e1d7b48107b33e4f286a55ef6"    # 2023.11.20 Release
 # ci/docker/python-wheel-windows-vs2019.dockerfile.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2024-04-09
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2024-06-18
 
 # Use conanio/${CONAN_BASE}:{CONAN_VERSION} for "docker-compose run --rm conan".
 # See https://github.com/conan-io/conan-docker-tools#readme and

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,6 +1,6 @@
 cython>=0.29.31
 oldest-supported-numpy>=0.14; python_version<'3.9'
-numpy>=2.0.0rc1; python_version>='3.9'
+numpy>=2.0.0; python_version>='3.9'
 setuptools_scm
 setuptools>=58
 wheel


### PR DESCRIPTION
### Rationale for this change

Now NumPy 2.0.0 is released, we can update the version specifier to no longer mention the RC.

* GitHub Issue: #41203