### PR TITLE
GH-42124: [Swift] Add methods for loading and validating builder by type

### DIFF
--- a/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
@@ -119,6 +119,56 @@ public class Time64ArrayBuilder: ArrowArrayBuilder<FixedBufferBuilder<Time64>, T
 }
 
 public class ArrowArrayBuilders {
+    public static func loadBuilder( // swiftlint:disable:this cyclomatic_complexity
+        _ builderType: Any.Type) throws -> ArrowArrayHolderBuilder {
+        if builderType == Int8.self || builderType == Int8?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<Int8>
+        } else if builderType == Int16.self || builderType == Int16?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<Int16>
+        } else if builderType == Int32.self || builderType == Int32?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<Int32>
+        } else if builderType == Int64.self || builderType == Int64?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<Int64>
+        } else if builderType == Float.self || builderType == Float?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<Float>
+        } else if builderType == UInt8.self || builderType == UInt8?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<UInt8>
+        } else if builderType == UInt16.self || builderType == UInt16?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<UInt16>
+        } else if builderType == UInt32.self || builderType == UInt32?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<UInt32>
+        } else if builderType == UInt64.self || builderType == UInt64?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<UInt64>
+        } else if builderType == Double.self || builderType == Double?.self {
+            return try ArrowArrayBuilders.loadNumberArrayBuilder() as NumberArrayBuilder<Double>
+        } else if builderType == String.self || builderType == String?.self {
+            return try ArrowArrayBuilders.loadStringArrayBuilder()
+        } else if builderType == Bool.self || builderType == Bool?.self {
+            return try ArrowArrayBuilders.loadBoolArrayBuilder()
+        } else if builderType == Date.self || builderType == Date?.self {
+            return try ArrowArrayBuilders.loadDate64ArrayBuilder()
+        } else {
+            throw ArrowError.invalid("Invalid type for builder: \(builderType)")
+        }
+    }
+
+    public static func isValidBuilderType<T>(_: T) -> Bool {
+        let type = T.self
+        return type == Int8?.self || type == Int16?.self ||
+            type == Int32?.self || type == Int64?.self ||
+            type == UInt8?.self || type == UInt16?.self ||
+            type == UInt32?.self || type == UInt64?.self ||
+            type == String?.self || type == Double?.self ||
+            type == Float?.self || type == Date?.self ||
+            type == Bool?.self || type == Bool.self ||
+            type == Int8.self || type == Int16.self ||
+            type == Int32.self || type == Int64.self ||
+            type == UInt8.self || type == UInt16.self ||
+            type == UInt32.self || type == UInt64.self ||
+            type == String.self || type == Double.self ||
+            type == Float.self || type == Date.self
+    }
+
     public static func loadNumberArrayBuilder<T>() throws -> NumberArrayBuilder<T> {
         let type = T.self
         if type == Int8.self {

--- a/swift/Arrow/Tests/ArrowTests/ArrayBuilderTest.swift
+++ b/swift/Arrow/Tests/ArrowTests/ArrayBuilderTest.swift
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import XCTest
+@testable import Arrow
+
+final class ArrayBuilderTests: XCTestCase {
+    func testIsValidTypeForBuilder() throws {
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int8(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int16(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int32(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int64(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt8(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt16(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt32(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt64(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Float(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Double(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Date.now))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(true))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int8?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int16?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int32?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Int64?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt8?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt16?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt32?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(UInt64?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Float?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Double?(0)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Date?(Date.now)))
+        XCTAssertTrue(ArrowArrayBuilders.isValidBuilderType(Bool?(true)))
+
+        XCTAssertFalse(ArrowArrayBuilders.isValidBuilderType(Int(0)))
+        XCTAssertFalse(ArrowArrayBuilders.isValidBuilderType(UInt(0)))
+        XCTAssertFalse(ArrowArrayBuilders.isValidBuilderType(Int?(0)))
+        XCTAssertFalse(ArrowArrayBuilders.isValidBuilderType(UInt?(0)))
+    }
+
+    func testLoadArrayBuilders() throws {
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int8.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int16.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int32.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int64.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt8.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt16.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt32.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt64.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Float.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Double.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Date.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Bool.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int8?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int16?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int32?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Int64?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt8?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt16?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt32?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(UInt64?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Float?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Double?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Date?.self))
+        XCTAssertNotNil(try ArrowArrayBuilders.loadBuilder(Bool?.self))
+
+        XCTAssertThrowsError(try ArrowArrayBuilders.loadBuilder(Int.self))
+        XCTAssertThrowsError(try ArrowArrayBuilders.loadBuilder(UInt.self))
+        XCTAssertThrowsError(try ArrowArrayBuilders.loadBuilder(Int?.self))
+        XCTAssertThrowsError(try ArrowArrayBuilders.loadBuilder(UInt?.self))
+    }
+}


### PR DESCRIPTION
### Rationale for this change
Adding convenience method for loading a builder from a type.  This will be used by ArrowEncoder (upcoming PR) to load builders for a class/structs's properties.


### What changes are included in this PR?
Two methods have been added to ArrowArrayBuilders: 
loadBuilder: method for loading a builder for a Type.
isValidBuilderType: method for checking if a Type is supported by a builder.

### Are these changes tested?
Yes

* GitHub Issue: #42124