### PR TITLE
GH-42146:  [MATLAB] Add IPC `RecordBatchFileReader` and `RecordBatchFileWriter` MATLAB classes

### DIFF
--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -243,6 +243,7 @@ static const char* ARRAY_SLICE_FAILED_TO_CREATE_ARRAY_PROXY =
 static const char* C_EXPORT_FAILED = "arrow:c:export:ExportFailed";
 static const char* C_IMPORT_FAILED = "arrow:c:import:ImportFailed";
 static const char* IPC_RECORD_BATCH_WRITE_FAILED = "arrow:io:ipc:FailedToWriteRecordBatch";
+static const char* IPC_RECORD_BATCH_WRITE_CLOSE_FAILED = "arrow:io:ipc:CloseFailed";
 static const char* IPC_RECORD_BATCH_READER_OPEN_FAILED = "arrow:io:ipc:FailedToOpenRecordBatchReader";
 static const char* IPC_RECORD_BATCH_READ_INVALID_INDEX = "arrow:io:ipc:InvalidIndex";
 static const char* IPC_RECORD_BATCH_READ_FAILED = "arrow:io:ipc:ReadFailed";

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -244,5 +244,7 @@ static const char* C_EXPORT_FAILED = "arrow:c:export:ExportFailed";
 static const char* C_IMPORT_FAILED = "arrow:c:import:ImportFailed";
 static const char* IPC_RECORD_BATCH_WRITE_FAILED = "arrow:io:ipc:FailedToWriteRecordBatch";
 static const char* IPC_RECORD_BATCH_READER_OPEN_FAILED = "arrow:io:ipc:FailedToOpenRecordBatchReader";
+static const char* IPC_RECORD_BATCH_READ_INVALID_INDEX = "arrow:io:ipc:InvalidIndex";
+static const char* IPC_RECORD_BATCH_READ_FAILED = "arrow:io:ipc:ReadFailed";
 
 }  // namespace arrow::matlab::error

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -243,5 +243,6 @@ static const char* ARRAY_SLICE_FAILED_TO_CREATE_ARRAY_PROXY =
 static const char* C_EXPORT_FAILED = "arrow:c:export:ExportFailed";
 static const char* C_IMPORT_FAILED = "arrow:c:import:ImportFailed";
 static const char* IPC_RECORD_BATCH_WRITE_FAILED = "arrow:io:ipc:FailedToWriteRecordBatch";
+static const char* IPC_RECORD_BATCH_READER_OPEN_FAILED = "arrow:io:ipc:FailedToOpenRecordBatchReader";
 
 }  // namespace arrow::matlab::error

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -242,5 +242,6 @@ static const char* ARRAY_SLICE_FAILED_TO_CREATE_ARRAY_PROXY =
     "arrow:array:slice:FailedToCreateArrayProxy";
 static const char* C_EXPORT_FAILED = "arrow:c:export:ExportFailed";
 static const char* C_IMPORT_FAILED = "arrow:c:import:ImportFailed";
+static const char* IPC_RECORD_BATCH_WRITE_FAILED = "arrow:io:ipc:FailedToWriteRecordBatch";
 
 }  // namespace arrow::matlab::error

--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -242,9 +242,11 @@ static const char* ARRAY_SLICE_FAILED_TO_CREATE_ARRAY_PROXY =
     "arrow:array:slice:FailedToCreateArrayProxy";
 static const char* C_EXPORT_FAILED = "arrow:c:export:ExportFailed";
 static const char* C_IMPORT_FAILED = "arrow:c:import:ImportFailed";
-static const char* IPC_RECORD_BATCH_WRITE_FAILED = "arrow:io:ipc:FailedToWriteRecordBatch";
+static const char* IPC_RECORD_BATCH_WRITE_FAILED =
+    "arrow:io:ipc:FailedToWriteRecordBatch";
 static const char* IPC_RECORD_BATCH_WRITE_CLOSE_FAILED = "arrow:io:ipc:CloseFailed";
-static const char* IPC_RECORD_BATCH_READER_OPEN_FAILED = "arrow:io:ipc:FailedToOpenRecordBatchReader";
+static const char* IPC_RECORD_BATCH_READER_OPEN_FAILED =
+    "arrow:io:ipc:FailedToOpenRecordBatchReader";
 static const char* IPC_RECORD_BATCH_READ_INVALID_INDEX = "arrow:io:ipc:InvalidIndex";
 static const char* IPC_RECORD_BATCH_READ_FAILED = "arrow:io:ipc:ReadFailed";
 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
@@ -43,6 +43,7 @@ RecordBatchFileReader::RecordBatchFileReader(const std::shared_ptr<arrow::ipc::R
   : reader{std::move(reader)} {
     REGISTER_METHOD(RecordBatchFileReader, getNumRecordBatches);
     REGISTER_METHOD(RecordBatchFileReader, getSchema);
+    REGISTER_METHOD(RecordBatchFileReader, readRecordBatchAtIndex);
   }
 
 libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/io/file.h"
+#include "arrow/matlab/error/error.h"
 #include "arrow/matlab/io/ipc/proxy/record_batch_file_reader.h"
+#include "arrow/util/utf8.h"
 
 namespace arrow::matlab::io::ipc::proxy {
 
@@ -23,6 +26,25 @@ RecordBatchFileReader::RecordBatchFileReader(const std::shared_ptr<arrow::ipc::R
   : reader{std::move(reader)} {}
 
 libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
-  return libmexclass::error::Error{"arrow:matlab:NotImplemented", "Not Implemented"};
+  namespace mda = ::matlab::data;
+  using RecordBatchFileReaderProxy = arrow::matlab::io::ipc::proxy::RecordBatchFileReader;
+
+  const mda::StructArray opts = constructor_arguments[0];
+
+  const mda::StringArray filename_mda = opts[0]["Filename"];
+  const auto filename_utf16 = std::u16string(filename_mda[0]);
+  MATLAB_ASSIGN_OR_ERROR(const auto filename_utf8,
+                        arrow::util::UTF16StringToUTF8(filename_utf16),
+                        error::UNICODE_CONVERSION_ERROR_ID);
+
+  MATLAB_ASSIGN_OR_ERROR(auto input_stream,
+                        arrow::io::ReadableFile::Open(filename_utf8),
+                        error::FAILED_TO_OPEN_FILE_FOR_WRITE);
+  
+  MATLAB_ASSIGN_OR_ERROR(auto reader, 
+                        arrow::ipc::RecordBatchFileReader::Open(input_stream),
+                        error::IPC_RECORD_BATCH_READER_OPEN_FAILED);
+
+  return std::make_shared<RecordBatchFileReaderProxy>(std::move(reader));
 }
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
@@ -18,6 +18,7 @@
 #include "arrow/io/file.h"
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/io/ipc/proxy/record_batch_file_reader.h"
+#include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
 #include "arrow/util/utf8.h"
 
@@ -25,11 +26,23 @@
 
 namespace arrow::matlab::io::ipc::proxy {
 
+namespace {
+  libmexclass::error::Error makeInvalidNumericIndexError(const int32_t matlab_index,
+                                                        const int32_t num_batches) {
+    std::stringstream error_message_stream;
+    error_message_stream << "Invalid record batch index: ";
+    error_message_stream << matlab_index;
+    error_message_stream << ". Record batch index must be between 1 and the number of record batches (";
+    error_message_stream << num_batches;
+    error_message_stream << ").";
+    return libmexclass::error::Error{error::IPC_RECORD_BATCH_READ_INVALID_INDEX, error_message_stream.str()};
+  }
+}
+
 RecordBatchFileReader::RecordBatchFileReader(const std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader)
   : reader{std::move(reader)} {
     REGISTER_METHOD(RecordBatchFileReader, getNumRecordBatches);
     REGISTER_METHOD(RecordBatchFileReader, getSchema);
-
   }
 
 libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
@@ -75,9 +88,33 @@ void RecordBatchFileReader::getSchema(libmexclass::proxy::method::Context& conte
   mda::ArrayFactory factory;
   const auto schema_proxy_id_mda = factory.createScalar(schema_proxy_id);
   context.outputs[0] = schema_proxy_id_mda;
-
 }
 
+void RecordBatchFileReader::readRecordBatchAtIndex(libmexclass::proxy::method::Context& context) {
+  namespace mda = ::matlab::data;
+  using RecordBatchProxy = arrow::matlab::tabular::proxy::RecordBatch;
+
+  mda::StructArray opts = context.inputs[0];
+  const mda::TypedArray<int32_t> matlab_index_mda = opts[0]["Index"];
+
+  const auto matlab_index = matlab_index_mda[0];
+  const auto num_record_batches = reader->num_record_batches();
+  if (matlab_index < 1 || matlab_index > num_record_batches) {
+    context.error = makeInvalidNumericIndexError(matlab_index, num_record_batches);
+    return;
+  }
+  const auto arrow_index = matlab_index - 1;
+
+  MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto record_batch, reader->ReadRecordBatch(arrow_index),
+                                       context, error::IPC_RECORD_BATCH_READ_FAILED);
+
+  auto record_batch_proxy = std::make_shared<RecordBatchProxy>(std::move(record_batch));
+  const auto record_batch_proxy_id = libmexclass::proxy::ProxyManager::manageProxy(record_batch_proxy);
+
+  mda::ArrayFactory factory;
+  const auto record_batch_proxyy_id_mda = factory.createScalar(record_batch_proxy_id);
+  context.outputs[0] = record_batch_proxyy_id_mda;
+}
 
 
 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
@@ -23,7 +23,9 @@
 namespace arrow::matlab::io::ipc::proxy {
 
 RecordBatchFileReader::RecordBatchFileReader(const std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader)
-  : reader{std::move(reader)} {}
+  : reader{std::move(reader)} {
+    REGISTER_METHOD(RecordBatchFileReader, getNumRecordBatches);
+  }
 
 libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
   namespace mda = ::matlab::data;
@@ -47,4 +49,15 @@ libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::pr
 
   return std::make_shared<RecordBatchFileReaderProxy>(std::move(reader));
 }
+
+void RecordBatchFileReader::getNumRecordBatches(libmexclass::proxy::method::Context& context) {
+  namespace mda = ::matlab::data;
+
+  mda::ArrayFactory factory;
+  const auto num_batches = reader->num_record_batches();
+  context.outputs[0] = factory.createScalar(num_batches);
+}
+
+
+
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/matlab/io/ipc/proxy/record_batch_file_reader.h"
+
+namespace arrow::matlab::io::ipc::proxy {
+
+RecordBatchFileReader::RecordBatchFileReader(const std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader)
+  : reader{std::move(reader)} {}
+
+libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+  return libmexclass::error::Error{"arrow:matlab:NotImplemented", "Not Implemented"};
+}
+} // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/matlab/io/ipc/proxy/record_batch_file_reader.h"
 #include "arrow/io/file.h"
 #include "arrow/matlab/error/error.h"
-#include "arrow/matlab/io/ipc/proxy/record_batch_file_reader.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
 #include "arrow/util/utf8.h"
@@ -27,26 +27,30 @@
 namespace arrow::matlab::io::ipc::proxy {
 
 namespace {
-  libmexclass::error::Error makeInvalidNumericIndexError(const int32_t matlab_index,
-                                                        const int32_t num_batches) {
-    std::stringstream error_message_stream;
-    error_message_stream << "Invalid record batch index: ";
-    error_message_stream << matlab_index;
-    error_message_stream << ". Record batch index must be between 1 and the number of record batches (";
-    error_message_stream << num_batches;
-    error_message_stream << ").";
-    return libmexclass::error::Error{error::IPC_RECORD_BATCH_READ_INVALID_INDEX, error_message_stream.str()};
-  }
+libmexclass::error::Error makeInvalidNumericIndexError(const int32_t matlab_index,
+                                                       const int32_t num_batches) {
+  std::stringstream error_message_stream;
+  error_message_stream << "Invalid record batch index: ";
+  error_message_stream << matlab_index;
+  error_message_stream
+      << ". Record batch index must be between 1 and the number of record batches (";
+  error_message_stream << num_batches;
+  error_message_stream << ").";
+  return libmexclass::error::Error{error::IPC_RECORD_BATCH_READ_INVALID_INDEX,
+                                   error_message_stream.str()};
+}
+}  // namespace
+
+RecordBatchFileReader::RecordBatchFileReader(
+    const std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader)
+    : reader{std::move(reader)} {
+  REGISTER_METHOD(RecordBatchFileReader, getNumRecordBatches);
+  REGISTER_METHOD(RecordBatchFileReader, getSchema);
+  REGISTER_METHOD(RecordBatchFileReader, readRecordBatchAtIndex);
 }
 
-RecordBatchFileReader::RecordBatchFileReader(const std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader)
-  : reader{std::move(reader)} {
-    REGISTER_METHOD(RecordBatchFileReader, getNumRecordBatches);
-    REGISTER_METHOD(RecordBatchFileReader, getSchema);
-    REGISTER_METHOD(RecordBatchFileReader, readRecordBatchAtIndex);
-  }
-
-libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+libmexclass::proxy::MakeResult RecordBatchFileReader::make(
+    const libmexclass::proxy::FunctionArguments& constructor_arguments) {
   namespace mda = ::matlab::data;
   using RecordBatchFileReaderProxy = arrow::matlab::io::ipc::proxy::RecordBatchFileReader;
 
@@ -55,21 +59,21 @@ libmexclass::proxy::MakeResult RecordBatchFileReader::make(const libmexclass::pr
   const mda::StringArray filename_mda = opts[0]["Filename"];
   const auto filename_utf16 = std::u16string(filename_mda[0]);
   MATLAB_ASSIGN_OR_ERROR(const auto filename_utf8,
-                        arrow::util::UTF16StringToUTF8(filename_utf16),
-                        error::UNICODE_CONVERSION_ERROR_ID);
+                         arrow::util::UTF16StringToUTF8(filename_utf16),
+                         error::UNICODE_CONVERSION_ERROR_ID);
 
-  MATLAB_ASSIGN_OR_ERROR(auto input_stream,
-                        arrow::io::ReadableFile::Open(filename_utf8),
-                        error::FAILED_TO_OPEN_FILE_FOR_WRITE);
-  
-  MATLAB_ASSIGN_OR_ERROR(auto reader, 
-                        arrow::ipc::RecordBatchFileReader::Open(input_stream),
-                        error::IPC_RECORD_BATCH_READER_OPEN_FAILED);
+  MATLAB_ASSIGN_OR_ERROR(auto input_stream, arrow::io::ReadableFile::Open(filename_utf8),
+                         error::FAILED_TO_OPEN_FILE_FOR_WRITE);
+
+  MATLAB_ASSIGN_OR_ERROR(auto reader,
+                         arrow::ipc::RecordBatchFileReader::Open(input_stream),
+                         error::IPC_RECORD_BATCH_READER_OPEN_FAILED);
 
   return std::make_shared<RecordBatchFileReaderProxy>(std::move(reader));
 }
 
-void RecordBatchFileReader::getNumRecordBatches(libmexclass::proxy::method::Context& context) {
+void RecordBatchFileReader::getNumRecordBatches(
+    libmexclass::proxy::method::Context& context) {
   namespace mda = ::matlab::data;
 
   mda::ArrayFactory factory;
@@ -82,16 +86,18 @@ void RecordBatchFileReader::getSchema(libmexclass::proxy::method::Context& conte
   using SchemaProxy = arrow::matlab::tabular::proxy::Schema;
 
   auto schema = reader->schema();
-  
+
   auto schema_proxy = std::make_shared<SchemaProxy>(std::move(schema));
-  const auto schema_proxy_id = libmexclass::proxy::ProxyManager::manageProxy(schema_proxy);
+  const auto schema_proxy_id =
+      libmexclass::proxy::ProxyManager::manageProxy(schema_proxy);
 
   mda::ArrayFactory factory;
   const auto schema_proxy_id_mda = factory.createScalar(schema_proxy_id);
   context.outputs[0] = schema_proxy_id_mda;
 }
 
-void RecordBatchFileReader::readRecordBatchAtIndex(libmexclass::proxy::method::Context& context) {
+void RecordBatchFileReader::readRecordBatchAtIndex(
+    libmexclass::proxy::method::Context& context) {
   namespace mda = ::matlab::data;
   using RecordBatchProxy = arrow::matlab::tabular::proxy::RecordBatch;
 
@@ -106,17 +112,17 @@ void RecordBatchFileReader::readRecordBatchAtIndex(libmexclass::proxy::method::C
   }
   const auto arrow_index = matlab_index - 1;
 
-  MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto record_batch, reader->ReadRecordBatch(arrow_index),
-                                       context, error::IPC_RECORD_BATCH_READ_FAILED);
+  MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto record_batch,
+                                      reader->ReadRecordBatch(arrow_index), context,
+                                      error::IPC_RECORD_BATCH_READ_FAILED);
 
   auto record_batch_proxy = std::make_shared<RecordBatchProxy>(std::move(record_batch));
-  const auto record_batch_proxy_id = libmexclass::proxy::ProxyManager::manageProxy(record_batch_proxy);
+  const auto record_batch_proxy_id =
+      libmexclass::proxy::ProxyManager::manageProxy(record_batch_proxy);
 
   mda::ArrayFactory factory;
   const auto record_batch_proxyy_id_mda = factory.createScalar(record_batch_proxy_id);
   context.outputs[0] = record_batch_proxyy_id_mda;
 }
 
-
-
-} // namespace arrow::matlab::io::ipc::proxy 
+}  // namespace arrow::matlab::io::ipc::proxy

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
@@ -35,6 +35,9 @@ class RecordBatchFileReader : public libmexclass::proxy::Proxy {
 
     void getNumRecordBatches(libmexclass::proxy::method::Context& context);
 
+    void getSchema(libmexclass::proxy::method::Context& context);
+
+
 };
 
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
@@ -28,19 +28,17 @@ class RecordBatchFileReader : public libmexclass::proxy::Proxy {
 
   ~RecordBatchFileReader() = default;
 
-  static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+  static libmexclass::proxy::MakeResult make(
+      const libmexclass::proxy::FunctionArguments& constructor_arguments);
 
-  protected:
-    std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader;
+ protected:
+  std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader;
 
-    void getNumRecordBatches(libmexclass::proxy::method::Context& context);
+  void getNumRecordBatches(libmexclass::proxy::method::Context& context);
 
-    void getSchema(libmexclass::proxy::method::Context& context);
+  void getSchema(libmexclass::proxy::method::Context& context);
 
-    void readRecordBatchAtIndex(libmexclass::proxy::method::Context& context);
-
-    
-
+  void readRecordBatchAtIndex(libmexclass::proxy::method::Context& context);
 };
 
-} // namespace arrow::matlab::io::ipc::proxy 
+}  // namespace arrow::matlab::io::ipc::proxy

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/ipc/reader.h"
+#include "libmexclass/proxy/Proxy.h"
+
+namespace arrow::matlab::io::ipc::proxy {
+
+class RecordBatchFileReader : public libmexclass::proxy::Proxy {
+ public:
+  RecordBatchFileReader(std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader);
+
+  ~RecordBatchFileReader() = default;
+
+  static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+
+  protected:
+    std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader;
+};
+
+} // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
@@ -37,6 +37,9 @@ class RecordBatchFileReader : public libmexclass::proxy::Proxy {
 
     void getSchema(libmexclass::proxy::method::Context& context);
 
+    void readRecordBatchAtIndex(libmexclass::proxy::method::Context& context);
+
+    
 
 };
 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.h
@@ -32,6 +32,9 @@ class RecordBatchFileReader : public libmexclass::proxy::Proxy {
 
   protected:
     std::shared_ptr<arrow::ipc::RecordBatchFileReader> reader;
+
+    void getNumRecordBatches(libmexclass::proxy::method::Context& context);
+
 };
 
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
@@ -15,7 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/io/file.h"
+#include "arrow/matlab/error/error.h"
 #include "arrow/matlab/io/ipc/proxy/record_batch_file_writer.h"
+#include "arrow/matlab/tabular/proxy/record_batch.h"
+#include "arrow/matlab/tabular/proxy/schema.h"
+#include "arrow/util/utf8.h"
+
+#include "libmexclass/proxy/ProxyManager.h"
+
 
 namespace arrow::matlab::io::ipc::proxy {
 
@@ -23,6 +31,32 @@ RecordBatchFileWriter::RecordBatchFileWriter(const std::shared_ptr<arrow::ipc::R
   : writer{std::move(writer)} {}
 
 libmexclass::proxy::MakeResult RecordBatchFileWriter::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
-  return libmexclass::error::Error{"arrow:matlab:NotImplemented", "Not Implemented"};
+  namespace mda = ::matlab::data;
+  using RecordBatchFileWriterProxy = arrow::matlab::io::ipc::proxy::RecordBatchFileWriter;
+  using SchemaProxy = arrow::matlab::tabular::proxy::Schema;
+
+  const mda::StructArray opts = constructor_arguments[0];
+
+  const mda::StringArray filename_mda = opts[0]["Filename"];
+  const auto filename_utf16 = std::u16string(filename_mda[0]);
+  MATLAB_ASSIGN_OR_ERROR(const auto filename_utf8,
+                        arrow::util::UTF16StringToUTF8(filename_utf16),
+                        error::UNICODE_CONVERSION_ERROR_ID);
+
+  const mda::TypedArray<uint64_t> arrow_schema_proxy_id_mda = opts[0]["SchemaProxyID"];
+  auto proxy = libmexclass::proxy::ProxyManager::getProxy(arrow_schema_proxy_id_mda[0]);
+  auto arrow_schema_proxy = std::static_pointer_cast<SchemaProxy>(proxy);
+  auto arrow_schema = arrow_schema_proxy->unwrap();
+
+  MATLAB_ASSIGN_OR_ERROR(auto output_stream,
+                        arrow::io::FileOutputStream::Open(filename_utf8),
+                        error::FAILED_TO_OPEN_FILE_FOR_WRITE);
+
+  MATLAB_ASSIGN_OR_ERROR(auto writer, 
+                        arrow::ipc::MakeFileWriter(output_stream, arrow_schema),
+                        "arrow:matlab:MakeFailed");
+
+  return std::make_shared<RecordBatchFileWriterProxy>(std::move(writer));
 }
+
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/matlab/io/ipc/proxy/record_batch_file_writer.h"
 #include "arrow/io/file.h"
 #include "arrow/matlab/error/error.h"
-#include "arrow/matlab/io/ipc/proxy/record_batch_file_writer.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
 #include "arrow/matlab/tabular/proxy/table.h"
@@ -25,17 +25,18 @@
 
 #include "libmexclass/proxy/ProxyManager.h"
 
-
 namespace arrow::matlab::io::ipc::proxy {
 
-RecordBatchFileWriter::RecordBatchFileWriter(const std::shared_ptr<arrow::ipc::RecordBatchWriter> writer)
-  : writer{std::move(writer)} {
-    REGISTER_METHOD(RecordBatchFileWriter, close);
-    REGISTER_METHOD(RecordBatchFileWriter, writeRecordBatch);
-    REGISTER_METHOD(RecordBatchFileWriter, writeTable);
-  }
+RecordBatchFileWriter::RecordBatchFileWriter(
+    const std::shared_ptr<arrow::ipc::RecordBatchWriter> writer)
+    : writer{std::move(writer)} {
+  REGISTER_METHOD(RecordBatchFileWriter, close);
+  REGISTER_METHOD(RecordBatchFileWriter, writeRecordBatch);
+  REGISTER_METHOD(RecordBatchFileWriter, writeTable);
+}
 
-libmexclass::proxy::MakeResult RecordBatchFileWriter::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+libmexclass::proxy::MakeResult RecordBatchFileWriter::make(
+    const libmexclass::proxy::FunctionArguments& constructor_arguments) {
   namespace mda = ::matlab::data;
   using RecordBatchFileWriterProxy = arrow::matlab::io::ipc::proxy::RecordBatchFileWriter;
   using SchemaProxy = arrow::matlab::tabular::proxy::Schema;
@@ -45,8 +46,8 @@ libmexclass::proxy::MakeResult RecordBatchFileWriter::make(const libmexclass::pr
   const mda::StringArray filename_mda = opts[0]["Filename"];
   const auto filename_utf16 = std::u16string(filename_mda[0]);
   MATLAB_ASSIGN_OR_ERROR(const auto filename_utf8,
-                        arrow::util::UTF16StringToUTF8(filename_utf16),
-                        error::UNICODE_CONVERSION_ERROR_ID);
+                         arrow::util::UTF16StringToUTF8(filename_utf16),
+                         error::UNICODE_CONVERSION_ERROR_ID);
 
   const mda::TypedArray<uint64_t> arrow_schema_proxy_id_mda = opts[0]["SchemaProxyID"];
   auto proxy = libmexclass::proxy::ProxyManager::getProxy(arrow_schema_proxy_id_mda[0]);
@@ -54,30 +55,32 @@ libmexclass::proxy::MakeResult RecordBatchFileWriter::make(const libmexclass::pr
   auto arrow_schema = arrow_schema_proxy->unwrap();
 
   MATLAB_ASSIGN_OR_ERROR(auto output_stream,
-                        arrow::io::FileOutputStream::Open(filename_utf8),
-                        error::FAILED_TO_OPEN_FILE_FOR_WRITE);
+                         arrow::io::FileOutputStream::Open(filename_utf8),
+                         error::FAILED_TO_OPEN_FILE_FOR_WRITE);
 
-  MATLAB_ASSIGN_OR_ERROR(auto writer, 
-                        arrow::ipc::MakeFileWriter(output_stream, arrow_schema),
-                        "arrow:matlab:MakeFailed");
+  MATLAB_ASSIGN_OR_ERROR(auto writer,
+                         arrow::ipc::MakeFileWriter(output_stream, arrow_schema),
+                         "arrow:matlab:MakeFailed");
 
   return std::make_shared<RecordBatchFileWriterProxy>(std::move(writer));
 }
 
-void RecordBatchFileWriter::writeRecordBatch(libmexclass::proxy::method::Context& context) {
+void RecordBatchFileWriter::writeRecordBatch(
+    libmexclass::proxy::method::Context& context) {
   namespace mda = ::matlab::data;
   using RecordBatchProxy = ::arrow::matlab::tabular::proxy::RecordBatch;
 
   mda::StructArray opts = context.inputs[0];
-  const mda::TypedArray<uint64_t> record_batch_proxy_id_mda = opts[0]["RecordBatchProxyID"];
+  const mda::TypedArray<uint64_t> record_batch_proxy_id_mda =
+      opts[0]["RecordBatchProxyID"];
   const uint64_t record_batch_proxy_id = record_batch_proxy_id_mda[0];
 
   auto proxy = libmexclass::proxy::ProxyManager::getProxy(record_batch_proxy_id);
   auto record_batch_proxy = std::static_pointer_cast<RecordBatchProxy>(proxy);
   auto record_batch = record_batch_proxy->unwrap();
 
-  MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->WriteRecordBatch(*record_batch), 
-                                      context, error::IPC_RECORD_BATCH_WRITE_FAILED);
+  MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->WriteRecordBatch(*record_batch), context,
+                                      error::IPC_RECORD_BATCH_WRITE_FAILED);
 }
 
 void RecordBatchFileWriter::writeTable(libmexclass::proxy::method::Context& context) {
@@ -92,13 +95,13 @@ void RecordBatchFileWriter::writeTable(libmexclass::proxy::method::Context& cont
   auto table_proxy = std::static_pointer_cast<TableProxy>(proxy);
   auto table = table_proxy->unwrap();
 
-  MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->WriteTable(*table), 
-                                      context, error::IPC_RECORD_BATCH_WRITE_FAILED);
+  MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->WriteTable(*table), context,
+                                      error::IPC_RECORD_BATCH_WRITE_FAILED);
 }
 
 void RecordBatchFileWriter::close(libmexclass::proxy::method::Context& context) {
-    MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->Close(), context, error::IPC_RECORD_BATCH_WRITE_CLOSE_FAILED);
+  MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->Close(), context,
+                                      error::IPC_RECORD_BATCH_WRITE_CLOSE_FAILED);
 }
 
-
-} // namespace arrow::matlab::io::ipc::proxy 
+}  // namespace arrow::matlab::io::ipc::proxy

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
@@ -30,6 +30,7 @@ namespace arrow::matlab::io::ipc::proxy {
 
 RecordBatchFileWriter::RecordBatchFileWriter(const std::shared_ptr<arrow::ipc::RecordBatchWriter> writer)
   : writer{std::move(writer)} {
+    REGISTER_METHOD(RecordBatchFileWriter, close);
     REGISTER_METHOD(RecordBatchFileWriter, writeRecordBatch);
     REGISTER_METHOD(RecordBatchFileWriter, writeTable);
   }
@@ -94,5 +95,10 @@ void RecordBatchFileWriter::writeTable(libmexclass::proxy::method::Context& cont
   MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->WriteTable(*table), 
                                       context, error::IPC_RECORD_BATCH_WRITE_FAILED);
 }
+
+void RecordBatchFileWriter::close(libmexclass::proxy::method::Context& context) {
+    MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->Close(), context, error::IPC_RECORD_BATCH_WRITE_CLOSE_FAILED);
+}
+
 
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
@@ -20,6 +20,7 @@
 #include "arrow/matlab/io/ipc/proxy/record_batch_file_writer.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
+#include "arrow/matlab/tabular/proxy/table.h"
 #include "arrow/util/utf8.h"
 
 #include "libmexclass/proxy/ProxyManager.h"
@@ -30,6 +31,7 @@ namespace arrow::matlab::io::ipc::proxy {
 RecordBatchFileWriter::RecordBatchFileWriter(const std::shared_ptr<arrow::ipc::RecordBatchWriter> writer)
   : writer{std::move(writer)} {
     REGISTER_METHOD(RecordBatchFileWriter, writeRecordBatch);
+    REGISTER_METHOD(RecordBatchFileWriter, writeTable);
   }
 
 libmexclass::proxy::MakeResult RecordBatchFileWriter::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
@@ -74,6 +76,22 @@ void RecordBatchFileWriter::writeRecordBatch(libmexclass::proxy::method::Context
   auto record_batch = record_batch_proxy->unwrap();
 
   MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->WriteRecordBatch(*record_batch), 
+                                      context, error::IPC_RECORD_BATCH_WRITE_FAILED);
+}
+
+void RecordBatchFileWriter::writeTable(libmexclass::proxy::method::Context& context) {
+  namespace mda = ::matlab::data;
+  using TableProxy = ::arrow::matlab::tabular::proxy::Table;
+
+  mda::StructArray opts = context.inputs[0];
+  const mda::TypedArray<uint64_t> table_proxy_id_mda = opts[0]["TableProxyID"];
+  const uint64_t table_proxy_id = table_proxy_id_mda[0];
+
+  auto proxy = libmexclass::proxy::ProxyManager::getProxy(table_proxy_id);
+  auto table_proxy = std::static_pointer_cast<TableProxy>(proxy);
+  auto table = table_proxy->unwrap();
+
+  MATLAB_ERROR_IF_NOT_OK_WITH_CONTEXT(writer->WriteTable(*table), 
                                       context, error::IPC_RECORD_BATCH_WRITE_FAILED);
 }
 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/matlab/io/ipc/proxy/record_batch_file_writer.h"
+
+namespace arrow::matlab::io::ipc::proxy {
+
+RecordBatchFileWriter::RecordBatchFileWriter(const std::shared_ptr<arrow::ipc::RecordBatchWriter> writer)
+  : writer{std::move(writer)} {}
+
+libmexclass::proxy::MakeResult RecordBatchFileWriter::make(const libmexclass::proxy::FunctionArguments& constructor_arguments) {
+  return libmexclass::error::Error{"arrow:matlab:NotImplemented", "Not Implemented"};
+}
+} // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
@@ -30,6 +30,9 @@ class RecordBatchFileWriter : public libmexclass::proxy::Proxy {
 
   protected:
     std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+
+    void writeRecordBatch(libmexclass::proxy::method::Context& context);
+
 };
 
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
@@ -35,6 +35,8 @@ class RecordBatchFileWriter : public libmexclass::proxy::Proxy {
 
     void writeTable(libmexclass::proxy::method::Context& context);
 
+    void close(libmexclass::proxy::method::Context& context);
+
 };
 
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/ipc/writer.h"
+#include "libmexclass/proxy/Proxy.h"
+
+namespace arrow::matlab::io::ipc::proxy {
+
+class RecordBatchFileWriter : public libmexclass::proxy::Proxy {
+ public:
+  RecordBatchFileWriter(std::shared_ptr<arrow::ipc::RecordBatchWriter> writer);
+
+  ~RecordBatchFileWriter() = default;
+
+  static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+
+  protected:
+    std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+};
+
+} // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
@@ -33,6 +33,8 @@ class RecordBatchFileWriter : public libmexclass::proxy::Proxy {
 
     void writeRecordBatch(libmexclass::proxy::method::Context& context);
 
+    void writeTable(libmexclass::proxy::method::Context& context);
+
 };
 
 } // namespace arrow::matlab::io::ipc::proxy 

--- a/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
+++ b/matlab/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.h
@@ -26,17 +26,17 @@ class RecordBatchFileWriter : public libmexclass::proxy::Proxy {
 
   ~RecordBatchFileWriter() = default;
 
-  static libmexclass::proxy::MakeResult make(const libmexclass::proxy::FunctionArguments& constructor_arguments);
+  static libmexclass::proxy::MakeResult make(
+      const libmexclass::proxy::FunctionArguments& constructor_arguments);
 
-  protected:
-    std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+ protected:
+  std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
 
-    void writeRecordBatch(libmexclass::proxy::method::Context& context);
+  void writeRecordBatch(libmexclass::proxy::method::Context& context);
 
-    void writeTable(libmexclass::proxy::method::Context& context);
+  void writeTable(libmexclass::proxy::method::Context& context);
 
-    void close(libmexclass::proxy::method::Context& context);
-
+  void close(libmexclass::proxy::method::Context& context);
 };
 
-} // namespace arrow::matlab::io::ipc::proxy 
+}  // namespace arrow::matlab::io::ipc::proxy

--- a/matlab/src/cpp/arrow/matlab/proxy/factory.cc
+++ b/matlab/src/cpp/arrow/matlab/proxy/factory.cc
@@ -34,6 +34,8 @@
 #include "arrow/matlab/io/csv/proxy/table_writer.h"
 #include "arrow/matlab/io/feather/proxy/reader.h"
 #include "arrow/matlab/io/feather/proxy/writer.h"
+#include "arrow/matlab/io/ipc/proxy/record_batch_file_reader.h"
+#include "arrow/matlab/io/ipc/proxy/record_batch_file_writer.h"
 #include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
 #include "arrow/matlab/tabular/proxy/table.h"
@@ -107,6 +109,8 @@ libmexclass::proxy::MakeResult Factory::make_proxy(
   REGISTER_PROXY(arrow.c.proxy.ArrayImporter       , arrow::matlab::c::proxy::ArrayImporter);
   REGISTER_PROXY(arrow.c.proxy.Schema              , arrow::matlab::c::proxy::Schema);
   REGISTER_PROXY(arrow.c.proxy.RecordBatchImporter , arrow::matlab::c::proxy::RecordBatchImporter);
+  REGISTER_PROXY(arrow.io.ipc.proxy.RecordBatchFileReader , arrow::matlab::io::ipc::proxy::RecordBatchFileReader);
+  REGISTER_PROXY(arrow.io.ipc.proxy.RecordBatchFileWriter , arrow::matlab::io::ipc::proxy::RecordBatchFileWriter);
   // clang-format on
 
   return libmexclass::error::Error{error::UNKNOWN_PROXY_ERROR_ID,

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
@@ -22,6 +22,10 @@ classdef RecordBatchFileReader < matlab.mixin.Scalar
         Proxy
     end
 
+    properties (Dependent, SetAccess=private, GetAccess=public)
+        NumRecordBatches
+    end
+
     methods
         function obj = RecordBatchFileReader(filename)
             arguments
@@ -31,5 +35,11 @@ classdef RecordBatchFileReader < matlab.mixin.Scalar
             proxyName = "arrow.io.ipc.proxy.RecordBatchFileReader";
             obj.Proxy = arrow.internal.proxy.create(proxyName, args);
         end
+
+        function numRecordBatches = get.NumRecordBatches(obj)
+            numRecordBatches = obj.Proxy.NumRecordBatches();
+        end
     end
+
+
 end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
@@ -43,10 +43,22 @@ classdef RecordBatchFileReader < matlab.mixin.Scalar
 
         function schema = get.Schema(obj)
             proxyID = obj.Proxy.getSchema();
-            proxy = libmexclass.proxy.Proxy(ID=proxyID, Name="arrow.tabular.proxy.Schema");
+            proxyName = "arrow.tabular.proxy.Schema";
+            proxy = libmexclass.proxy.Proxy(ID=proxyID, Name=proxyName);
             schema = arrow.tabular.Schema(proxy);
         end
+
+        function rb = read(obj, index)
+            arguments
+                obj(1, 1) arrow.io.ipc.RecordBatchFileReader
+                index(1, 1) int32
+            end
+
+            args = struct(Index=index);
+            proxyID = obj.Proxy.readRecordBatchAtIndex(args);
+            proxyName = "arrow.tabular.proxy.RecordBatch";
+            proxy = libmexclass.proxy.Proxy(ID=proxyID, Name=proxyName);
+            rb = arrow.tabular.RecordBatch(proxy);
+        end
     end
-
-
 end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
@@ -51,9 +51,9 @@ classdef RecordBatchFileReader < matlab.mixin.Scalar
         function rb = read(obj, index)
             arguments
                 obj(1, 1) arrow.io.ipc.RecordBatchFileReader
-                index(1, 1) int32
+                index(1, 1)
             end
-
+            index = arrow.internal.validate.index.numeric(index, "int32");
             args = struct(Index=index);
             proxyID = obj.Proxy.readRecordBatchAtIndex(args);
             proxyName = "arrow.tabular.proxy.RecordBatch";

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
@@ -38,7 +38,7 @@ classdef RecordBatchFileReader < matlab.mixin.Scalar
         end
 
         function numRecordBatches = get.NumRecordBatches(obj)
-            numRecordBatches = obj.Proxy.NumRecordBatches();
+            numRecordBatches = obj.Proxy.getNumRecordBatches();
         end
 
         function schema = get.Schema(obj)

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
@@ -24,6 +24,7 @@ classdef RecordBatchFileReader < matlab.mixin.Scalar
 
     properties (Dependent, SetAccess=private, GetAccess=public)
         NumRecordBatches
+        Schema
     end
 
     methods
@@ -38,6 +39,12 @@ classdef RecordBatchFileReader < matlab.mixin.Scalar
 
         function numRecordBatches = get.NumRecordBatches(obj)
             numRecordBatches = obj.Proxy.NumRecordBatches();
+        end
+
+        function schema = get.Schema(obj)
+            proxyID = obj.Proxy.getSchema();
+            proxy = libmexclass.proxy.Proxy(ID=proxyID, Name="arrow.tabular.proxy.Schema");
+            schema = arrow.tabular.Schema(proxy);
         end
     end
 

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
@@ -18,13 +18,18 @@
 
 classdef RecordBatchFileReader < matlab.mixin.Scalar
 
-    properties
-        
+    properties(SetAccess=private, GetAccess=public, Hidden)
+        Proxy
     end
 
     methods
         function obj = RecordBatchFileReader(filename)
-        
+            arguments
+                filename(1, 1) string {mustBeNonzeroLengthText} 
+            end
+            args = struct(Filename=filename);
+            proxyName = "arrow.io.ipc.proxy.RecordBatchFileReader";
+            obj.Proxy = arrow.internal.proxy.create(proxyName, args);
         end
     end
 end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileReader.m
@@ -1,0 +1,30 @@
+%RECORDBATCHFILEREADER Class for reading Arrow RecordBatches from the 
+% Arrow binary (IPC) format.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef RecordBatchFileReader < matlab.mixin.Scalar
+
+    properties
+        
+    end
+
+    methods
+        function obj = RecordBatchFileReader(filename)
+        
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -59,10 +59,10 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
                 tabularObj(1, 1)
             end
             if isa(tabularObj, "arrow.tabular.RecordBatch")
-                args = struct(RecordBatchProxyID=recordBatch.Proxy.ID);
+                args = struct(RecordBatchProxyID=tabularObj.Proxy.ID);
                 obj.Proxy.writeRecordBatch(args);
             elseif isa(tabularObj, "arrow.tabular.Table")
-                args = struct(TableProxyID=arrowTable.Proxy.ID);
+                args = struct(TableProxyID=tabularObj.Proxy.ID);
                 obj.Proxy.writeTable(args);
             else
                 id = "arrow:matlab:ipc:write:InvalidType";

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -66,7 +66,7 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
                 obj.Proxy.writeTable(args);
             else
                 id = "arrow:matlab:ipc:write:InvalidType";
-                msg = "tabularObj input argument must be an instance of" + ...
+                msg = "tabularObj input argument must be an instance of " + ...
                     "either arrow.tabular.RecordBatch or arrow.tabular.Table.";
                 error(id, msg);
             end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -1,0 +1,36 @@
+%RECORDBATCHFILEWRITER Class for serializing record batches to a file using
+% the IPC format.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef RecordBatchFileWriter < matlab.mixin.Scalar
+
+    properties(SetAccess=private, GetAccess=public, Hidden)
+        Proxy
+    end
+
+    methods
+        function obj = RecordBatchFileWriter(filename, schema)
+            arguments
+                filename(1, 1) string {mustBeNonzeroLengthText} 
+                schema(1, 1) arrow.tabular.Schema
+            end
+            args = struct(Filename=filename, SchemaProxyID=schema.Proxy.ID);
+            proxyName = "arrow.io.ipc.proxy.RecordBatchFileWriter";
+            obj.Proxy = arrow.internal.proxy.create(proxyName, args);
+        end
+    end
+end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -46,7 +46,7 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
         function writeTable(obj, arrowTable)
             arguments
                 obj(1, 1) arrow.io.ipc.RecordBatchFileWriter
-                arrowTable(1, 1) arrow.tabular.RecordBatch
+                arrowTable(1, 1) arrow.tabular.Table
             end
 
             args = struct(TableProxyID=arrowTable.Proxy.ID);

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -59,11 +59,9 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
                 tabularObj(1, 1)
             end
             if isa(tabularObj, "arrow.tabular.RecordBatch")
-                args = struct(RecordBatchProxyID=tabularObj.Proxy.ID);
-                obj.Proxy.writeRecordBatch(args);
+                obj.writeRecordBatch(tabularObj);
             elseif isa(tabularObj, "arrow.tabular.Table")
-                args = struct(TableProxyID=tabularObj.Proxy.ID);
-                obj.Proxy.writeTable(args);
+                obj.writeTable(tabularObj);
             else
                 id = "arrow:matlab:ipc:write:InvalidType";
                 msg = "tabularObj input argument must be an instance of " + ...

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -42,5 +42,15 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
             args = struct(RecordBatchProxyID=recordBatch.Proxy.ID);
             obj.Proxy.writeRecordBatch(args);
         end
+
+        function writeTable(obj, arrowTable)
+            arguments
+                obj(1, 1) arrow.io.ipc.RecordBatchFileWriter
+                arrowTable(1, 1) arrow.tabular.RecordBatch
+            end
+
+            args = struct(TableProxyID=arrowTable.Proxy.ID);
+            obj.Proxy.writeTable(args);
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -32,5 +32,15 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
             proxyName = "arrow.io.ipc.proxy.RecordBatchFileWriter";
             obj.Proxy = arrow.internal.proxy.create(proxyName, args);
         end
+
+        function writeRecordBatch(obj, recordBatch)
+            arguments
+                obj(1, 1) arrow.io.ipc.RecordBatchFileWriter
+                recordBatch(1, 1) arrow.tabular.RecordBatch
+            end
+
+            args = struct(RecordBatchProxyID=recordBatch.Proxy.ID);
+            obj.Proxy.writeRecordBatch(args);
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -52,5 +52,24 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
             args = struct(TableProxyID=arrowTable.Proxy.ID);
             obj.Proxy.writeTable(args);
         end
+
+        function write(obj, tabularObj)
+            arguments
+                obj(1, 1) arrow.io.ipc.RecordBatchFileWriter
+                tabularObj(1, 1)
+            end
+            if isa(tabularObj, "arrow.tabular.RecordBatch")
+                args = struct(RecordBatchProxyID=recordBatch.Proxy.ID);
+                obj.Proxy.writeRecordBatch(args);
+            elseif isa(tabularObj, "arrow.tabular.Table")
+                args = struct(TableProxyID=arrowTable.Proxy.ID);
+                obj.Proxy.writeTable(args);
+            else
+                id = "arrow:matlab:ipc:write:InvalidType";
+                msg = "tabularObj input argument must be an instance of" + ...
+                    "either arrow.tabular.RecordBatch or arrow.tabular.Table.";
+                error(id, msg);
+            end
+        end
     end
 end

--- a/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
+++ b/matlab/src/matlab/+arrow/+io/+ipc/RecordBatchFileWriter.m
@@ -71,5 +71,9 @@ classdef RecordBatchFileWriter < matlab.mixin.Scalar
                 error(id, msg);
             end
         end
+
+        function close(obj)
+            obj.Proxy.close();
+        end
     end
 end

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileReader.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileReader.m
@@ -66,21 +66,32 @@ classdef tRecordBatchFileReader < matlab.unittest.TestCase
 
     methods (Test)
         function ZeroLengthFilenameError(testCase)
+            % Verify RecordBatchFileReader throws an exception with the
+            % identifier MATLAB:validators:mustBeNonzeroLengthText if the
+            % filename input argument given is a zero length string.
             fcn = @() arrow.io.ipc.RecordBatchFileReader("");
             testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
         end
 
         function MissingStringFilenameError(testCase)
+            % Verify RecordBatchFileReader throws an exception with the
+            % identifier MATLAB:validators:mustBeNonzeroLengthText if the
+            % filename input argument given is a missing string.
             fcn = @() arrow.io.ipc.RecordBatchFileReader(string(missing));
             testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
         end
 
         function FilenameInvalidTypeError(testCase)
+            % Verify RecordBatchFileReader throws an exception with the
+            % identifier MATLAB:validators:UnableToConvert if the filename
+            % input argument is neither a scalar string nor a char vector.
             fcn = @() arrow.io.ipc.RecordBatchFileReader(table);
             testCase.verifyError(fcn, "MATLAB:validation:UnableToConvert");
         end
 
         function NumRecordBatches(testCase)
+            % Verify the getter method for NumRecordBatches returns the
+            % expected value.
             reader = arrow.io.ipc.RecordBatchFileReader(testCase.ZeroBatchFile);
             testCase.verifyEqual(reader.NumRecordBatches, int32(0));
 
@@ -92,11 +103,14 @@ classdef tRecordBatchFileReader < matlab.unittest.TestCase
         end
 
         function NumRecordNoSetter(testCase)
+            % Verify the NumRecordBatches property is not settable.
             reader = arrow.io.ipc.RecordBatchFileReader(testCase.ZeroBatchFile);
             testCase.verifyError(@() setfield(reader, "NumRecordBatches", int32(10)), "MATLAB:class:SetProhibited");
         end
 
         function Schema(testCase)
+            % Verify the getter method for Schema returns the
+            % expected value.
             fieldA = arrow.field("A", arrow.string());
             fieldB = arrow.field("B", arrow.float32());
             expectedSchema = arrow.schema([fieldA fieldB]);
@@ -112,6 +126,7 @@ classdef tRecordBatchFileReader < matlab.unittest.TestCase
         end
 
         function SchemaNoSetter(testCase)
+            % Verify the Schema property is not settable.
             fieldC = arrow.field("C", arrow.date32());
             schema = arrow.schema(fieldC);
             reader = arrow.io.ipc.RecordBatchFileReader(testCase.ZeroBatchFile);
@@ -119,6 +134,9 @@ classdef tRecordBatchFileReader < matlab.unittest.TestCase
         end
 
         function readInvalidIndexType(testCase)
+            % Verify read throws an exception with the identifier
+            % arrow:badsubscript:NonNumeric if the index argument given is
+            % not numeric.
             reader = arrow.io.ipc.RecordBatchFileReader(testCase.MultipleBatchFile);
 
             fcn = @() reader.read("index");
@@ -126,6 +144,8 @@ classdef tRecordBatchFileReader < matlab.unittest.TestCase
         end
 
         function readInvalidNumericIndex(testCase)
+            % Verify read throws an exception if the index argument given
+            % is nonpositive or noninteger number.
             reader = arrow.io.ipc.RecordBatchFileReader(testCase.MultipleBatchFile);
             fcn = @() reader.read(-1);
             testCase.verifyError(fcn, "arrow:badsubscript:NonPositive");
@@ -136,12 +156,17 @@ classdef tRecordBatchFileReader < matlab.unittest.TestCase
         end
 
         function readInvalidNumericIndexValue(testCase)
+            % Verify read throws an exception with the identifier 
+            % arrow:io:ipc:InvalidIndex if the index given is greater
+            % than the NumRecordBatches in the file.
             reader = arrow.io.ipc.RecordBatchFileReader(testCase.MultipleBatchFile);
             fcn = @() reader.read(3);
             testCase.verifyError(fcn, "arrow:io:ipc:InvalidIndex");
         end
 
         function readAtIndex(testCase)
+            % Verify read returns the expected RecordBatch for the given
+            % index.
             t1 = table(["Row1"; "Row2"], single([1; 2]), VariableNames=["A", "B"]);
             t2 = table(["Row3"; "Row4"], single([3; 4]), VariableNames=["A", "B"]);
 

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileReader.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileReader.m
@@ -16,6 +16,54 @@
 % permissions and limitations under the License.
 classdef tRecordBatchFileReader < matlab.unittest.TestCase
 
+    properties
+        DataFolder
+        ZeroBatchFile
+        OneBatchFile
+        MultipleBatchFile
+    end
+
+    methods(TestClassSetup)
+        function setupDataFolder(testCase)
+            import matlab.unittest.fixtures.TemporaryFolderFixture
+            fixture = testCase.applyFixture(TemporaryFolderFixture);
+            testCase.DataFolder = string(fixture.Folder);
+        end
+
+        function setupZeroBatchFile(testCase)
+            fieldA = arrow.field("A", arrow.string());
+            fieldB = arrow.field("B", arrow.float32());
+            schema = arrow.schema([fieldA, fieldB]);
+            fname = fullfile(testCase.DataFolder, "ZeroBatchFile.arrow");
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            writer.close();
+            testCase.ZeroBatchFile = fname;
+        end
+
+        function setupOneBatchFile(testCase)
+            t = table(["Row1"; "Row2"], single([1; 2]), VariableNames=["A", "B"]);
+            recordBatch = arrow.recordBatch(t);
+            fname = fullfile(testCase.DataFolder, "OneBatchFile.arrow");
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, recordBatch.Schema);
+            writer.writeRecordBatch(recordBatch);
+            writer.close();
+            testCase.OneBatchFile = fname;
+        end
+
+        function setupMultipleBatchFile(testCase)
+            t1 = table(["Row1"; "Row2"], single([1; 2]), VariableNames=["A", "B"]);
+            t2 = table(["Row3"; "Row4"], single([3; 4]), VariableNames=["A", "B"]);
+            recordBatch1 = arrow.recordBatch(t1);
+            recordBatch2 = arrow.recordBatch(t2);
+            fname = fullfile(testCase.DataFolder, "MultipleBatchFile.arrow");
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, recordBatch1.Schema);
+            writer.writeRecordBatch(recordBatch1);
+            writer.writeRecordBatch(recordBatch2);
+            writer.close();
+            testCase.OneBatchFile = fname;
+        end
+    end
+
     methods (Test)
         function ZeroLengthFilenameError(testCase)
             fcn = @() arrow.io.ipc.RecordBatchFileReader("");

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileReader.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileReader.m
@@ -1,0 +1,35 @@
+%TRECORDBATCHFILEREADER Unit tests for arrow.io.ipc.RecordBatchFileReader.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+classdef tRecordBatchFileReader < matlab.unittest.TestCase
+
+    methods (Test)
+        function ZeroLengthFilenameError(testCase)
+            fcn = @() arrow.io.ipc.RecordBatchFileReader("");
+            testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
+        end
+
+        function MissingStringFilenameError(testCase)
+            fcn = @() arrow.io.ipc.RecordBatchFileReader(string(missing));
+            testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
+        end
+
+        function FilenameInvalidTypeError(testCase)
+            fcn = @() arrow.io.ipc.RecordBatchFileReader(table);
+            testCase.verifyError(fcn, "MATLAB:validation:UnableToConvert");
+        end
+    end
+end

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
@@ -85,8 +85,9 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
-            arrowRecordBatch = arrow.recordBatch(table([1 2 3 4]', VariableNames="B"));
             writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+
+            arrowRecordBatch = arrow.recordBatch(table([1 2 3 4]', VariableNames="B"));
             fcn = @() writer.writeRecordBatch(arrowRecordBatch);
             testCase.verifyError(fcn, "arrow:io:ipc:FailedToWriteRecordBatch");
         end
@@ -95,10 +96,72 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
-            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="B"));
             writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+
+            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="B"));
             fcn = @() writer.writeTable(arrowTable);
             testCase.verifyError(fcn, "arrow:io:ipc:FailedToWriteRecordBatch");
+         end
+
+         function writeInvalidSchema(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+
+            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="B"));
+            fcn = @() writer.write(arrowTable);
+            testCase.verifyError(fcn, "arrow:io:ipc:FailedToWriteRecordBatch");
+
+            arrowRecordBatch = arrow.recordBatch(table([1 2 3 4]', VariableNames="B"));
+            fcn = @() writer.write(arrowRecordBatch);
+            testCase.verifyError(fcn, "arrow:io:ipc:FailedToWriteRecordBatch");
+         end
+
+         function writeRecordBatchSmoke(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            arrowRecordBatch = arrow.recordBatch(table([1 2 3 4]', VariableNames="A"));
+
+            fcn = @() writer.writeRecordBatch(arrowRecordBatch);
+            testCase.verifyWarningFree(fcn);
+         end
+
+        function writeTableBatchSmoke(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="A"));
+
+            fcn = @() writer.writeTable(arrowTable);
+            testCase.verifyWarningFree(fcn);
+        end
+
+        function writeSmoke(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            arrowRecordBatch = arrow.recordBatch(table([1 2 3 4]', VariableNames="A"));
+
+            fcn = @() writer.write(arrowRecordBatch);
+            testCase.verifyWarningFree(fcn);
+
+            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="A"));
+            fcn = @() writer.write(arrowTable);
+            testCase.verifyWarningFree(fcn);
+        end
+
+        function closeSmoke(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            fcn = @() writer.close();
+            testCase.verifyWarningFree(fcn);
         end
     end
 end

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
@@ -1,0 +1,84 @@
+%TRECORDBATCHFILEWRITER Unit tests for arrow.io.ipc.RecordBatchFileWriter.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tRecordBatchFileWriter < matlab.unittest.TestCase
+
+    methods
+        function folder = setupTemporaryFolder(testCase)
+            import matlab.unittest.fixtures.TemporaryFolderFixture
+            fixture = testCase.applyFixture(TemporaryFolderFixture);
+            folder = string(fixture.Folder);
+        end
+    end
+
+    methods (Test)
+        function ZeroLengthFilenameError(testCase)
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            fcn = @() arrow.io.ipc.RecordBatchFileWriter("", schema);
+            testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
+        end
+
+        function MissingStringFilenameError(testCase)
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            fcn = @() arrow.io.ipc.RecordBatchFileWriter(string(missing), schema);
+            testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
+        end
+
+        function FilenameInvalidTypeError(testCase)
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            fcn = @() arrow.io.ipc.RecordBatchFileWriter(table, schema);
+            testCase.verifyError(fcn, "MATLAB:validation:UnableToConvert");
+        end
+
+        function InvalidSchemaType(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.field("A", arrow.float64());
+            fcn = @() arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            testCase.verifyError(fcn, "MATLAB:validation:UnableToConvert");
+        end
+
+        function writeRecordBatchInvalidType(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="A"));
+            fcn = @() writer.writeRecordBatch(arrowTable);
+            testCase.verifyError(fcn, "MATLAB:validation:UnableToConvert");
+        end
+
+        function writeTableInvalidType(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            arrowRecordBatch = arrow.recordBatch(table([1 2 3 4]', VariableNames="A"));
+            fcn = @() writer.writeTable(arrowRecordBatch);
+            testCase.verifyError(fcn, "MATLAB:validation:UnableToConvert");
+        end
+
+        function writeInvalidType(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            fcn = @() writer.write(schema);
+            testCase.verifyError(fcn, "arrow:matlab:ipc:write:InvalidType");
+        end
+    end
+end

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
@@ -160,8 +160,11 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
             writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="A"));
+            writer.write(arrowTable);
             fcn = @() writer.close();
             testCase.verifyWarningFree(fcn);
+            writer.close();
         end
     end
 end

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
@@ -27,24 +27,36 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
 
     methods (Test)
         function ZeroLengthFilenameError(testCase)
+            % Verify RecordBatchFileWriter throws an exception with the
+            % identifier MATLAB:validators:mustBeNonzeroLengthText if the
+            % filename input argument given is a zero length string.
             schema = arrow.schema(arrow.field("A", arrow.float64()));
             fcn = @() arrow.io.ipc.RecordBatchFileWriter("", schema);
             testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
         end
 
         function MissingStringFilenameError(testCase)
+            % Verify RecordBatchFileWriter throws an exception with the
+            % identifier MATLAB:validators:mustBeNonzeroLengthText if the
+            % filename input argument given is  a missing string.
             schema = arrow.schema(arrow.field("A", arrow.float64()));
             fcn = @() arrow.io.ipc.RecordBatchFileWriter(string(missing), schema);
             testCase.verifyError(fcn, "MATLAB:validators:mustBeNonzeroLengthText");
         end
 
         function FilenameInvalidTypeError(testCase)
+            % Verify RecordBatchFileWriter throws an exception with the
+            % identifier MATLAB:validators:UnableToConvert if the filename
+            % input argument is neither a scalar string nor a char vector.
             schema = arrow.schema(arrow.field("A", arrow.float64()));
             fcn = @() arrow.io.ipc.RecordBatchFileWriter(table, schema);
             testCase.verifyError(fcn, "MATLAB:validation:UnableToConvert");
         end
 
         function InvalidSchemaType(testCase)
+            % Verify RecordBatchFileWriter throws an exception with the
+            % identifier MATLAB:validators:UnableToConvert if the schema
+            % input argument is not an arrow.tabular.Schema instance.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.field("A", arrow.float64());
@@ -53,6 +65,10 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
         end
 
         function writeRecordBatchInvalidType(testCase)
+            % Verify writeRecordBatch throws an exception with the
+            % identifier MATLAB:validators:UnableToConvert if the
+            % recordBatch input argument given is not an
+            % arrow.tabular.RecordBatch instance.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -63,6 +79,9 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
         end
 
         function writeTableInvalidType(testCase)
+            % Verify writeTable throws an exception with the
+            % identifier MATLAB:validators:UnableToConvert if the table 
+            % input argument given is not an arrow.tabular.Table instance.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -73,6 +92,10 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
         end
 
         function writeInvalidType(testCase)
+            % Verify writeTable throws an exception with the
+            % identifier arrow:matlab:ipc:write:InvalidType if the 
+            % tabularObj input argument given is neither an
+            % arrow.tabular.Table or an arrow.tabular.RecordBatch.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -82,6 +105,10 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
         end
 
         function writeRecordBatchInvalidSchema(testCase)
+            % Verify writeRecordBatch throws an exception with the
+            % identifier arrow:io:ipc:FailedToWriteRecordBatch if the
+            % schema of the given record batch does match the expected 
+            % schema.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -93,6 +120,9 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
         end
 
          function writeTableInvalidSchema(testCase)
+            % Verify writeTable throws an exception with the
+            % identifier arrow:io:ipc:FailedToWriteRecordBatch if the
+            % schema of the given table does match the expected schema.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -104,6 +134,10 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
          end
 
          function writeInvalidSchema(testCase)
+            % Verify write throws an exception with the
+            % identifier arrow:io:ipc:FailedToWriteRecordBatch if the
+            % schema of the given record batch or table does match the 
+            % expected schema.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -119,6 +153,8 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
          end
 
          function writeRecordBatchSmoke(testCase)
+            % Verify writeRecordBatch does not error or issue a warning
+            % if it successfully writes the record batch to the file.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -130,6 +166,8 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
          end
 
         function writeTableBatchSmoke(testCase)
+            % Verify writeTable does not error or issue a warning
+            % if it successfully writes the table to the file.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -141,6 +179,8 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
         end
 
         function writeSmoke(testCase)
+            % Verify write does not error or issue a warning if it
+            % successfully writes the record batch or table to the file.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -156,6 +196,8 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
         end
 
         function closeSmoke(testCase)
+            % Verify close does not error or issue a warning if it was
+            % successful.
             folder = testCase.setupTemporaryFolder();
             fname = fullfile(folder, "data.arrow");
             schema = arrow.schema(arrow.field("A", arrow.float64()));
@@ -164,7 +206,6 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
             writer.write(arrowTable);
             fcn = @() writer.close();
             testCase.verifyWarningFree(fcn);
-            writer.close();
         end
     end
 end

--- a/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
+++ b/matlab/test/arrow/io/ipc/tRecordBatchFileWriter.m
@@ -80,5 +80,25 @@ classdef tRecordBatchFileWriter < matlab.unittest.TestCase
             fcn = @() writer.write(schema);
             testCase.verifyError(fcn, "arrow:matlab:ipc:write:InvalidType");
         end
+
+        function writeRecordBatchInvalidSchema(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            arrowRecordBatch = arrow.recordBatch(table([1 2 3 4]', VariableNames="B"));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            fcn = @() writer.writeRecordBatch(arrowRecordBatch);
+            testCase.verifyError(fcn, "arrow:io:ipc:FailedToWriteRecordBatch");
+        end
+
+         function writeTableInvalidSchema(testCase)
+            folder = testCase.setupTemporaryFolder();
+            fname = fullfile(folder, "data.arrow");
+            schema = arrow.schema(arrow.field("A", arrow.float64()));
+            arrowTable = arrow.table(table([1 2 3 4]', VariableNames="B"));
+            writer = arrow.io.ipc.RecordBatchFileWriter(fname, schema);
+            fcn = @() writer.writeTable(arrowTable);
+            testCase.verifyError(fcn, "arrow:io:ipc:FailedToWriteRecordBatch");
+        end
     end
 end

--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -79,7 +79,9 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_SOURCES "${CMAKE_SOURCE_DIR}/src/cpp/a
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/c/proxy/array.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/c/proxy/array_importer.cc"
                                                   "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/c/proxy/schema.cc"
-                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/c/proxy/record_batch_importer.cc")
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/c/proxy/record_batch_importer.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_reader.cc"
+                                                  "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/io/ipc/proxy/record_batch_file_writer.cc")
 
 
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_PROXY_FACTORY_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/src/cpp/arrow/matlab/proxy")


### PR DESCRIPTION
### Rationale for this change

To enable initial IPC I/O support in the MATLAB interface, we should add a `RecordBatchFileReader` class and a `RecordBatchFileWriter` class.

### What changes are included in this PR?

1. Added a new `arrow.io.ipc.RecordBatchFileWriter` class.
2. Added a new `arrow.io.ipc.RecordBatchFileReader` class.

**Example**

```matlab
>> city = ["Boston" "Seattle" "Denver" "Juno" "Anchorage" "Chicago"]';
>> daylength = duration(["15:17:01" "15:59:16" "14:59:14" "19:21:23" "14:18:24" "15:13:39"])';
>> matlabTable = table(city, daylength, VariableNames=["City", "DayLength"]);
>> recordBatch1 = arrow.recordBatch(matlabTable(1:4, :))
>> recordBatch2 = arrow.recordBatch(matlabTable(5:end, :));

>> writer = arrow.io.ipc.RecordBatchFileWriter("daylight.arrow", recordBatch1.Schema);
>> writer.writeRecordBatch(recordBatch1);
>> writer.writeRecordBatch(recordBatch2);
>> writer.close();

>> reader = arrow.io.ipc.RecordBatchFileReader("daylight.arrow"); 

reader = 

  RecordBatchFileReader with properties:

    NumRecordBatches: 2
              Schema: [1×1 arrow.tabular.Schema]

>> reader.Schema

ans = 

  Arrow Schema with 2 fields:

    City: String | DayLength: Time64

>> rb1 = reader.read(1);
>> isequal(rb1, recordBatch1)

ans =

  logical

   1

>> rb2 = reader.read(2);
>> isequal(rb2, recordBatch2)

ans =

  logical

   1

```

### Are these changes tested?

Yes.  Added two new test files:

1. `arrow/matlab/test/io/ipc/tRecordBatchFileWriter.m`
2. `arrow/matlab/test/io/ipc/tRecordBatchFileReader.m`

### Are there any user-facing changes?

Yes. Users can now serialize `RecordBatch`es and `Table`s to files using the Arrow IPC data format as well as read in `RecordBatch`es from Arrow IPC data files.

### Future Directions

1. Add `RecordBatchStreamWriter` and `RecordBatchStreamReader`
2. Expose options for [controlling](https://github.com/apache/arrow/blob/main/cpp/src/arrow/ipc/options.h)  IPC reading and writing in MATLAB.
3. Add more methods to `RecordBatchFileReader` to read in multiple record batches at once as well as importing the data as an Arrow `Table`.

* GitHub Issue: #42146