### PR TITLE
GH-42139: [C++] Fix some potential uninitialized variable warnings

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -528,7 +528,7 @@ namespace {
 struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> {
   // The buffers are owned by the ArrayData member
   SmallVector<const void*, 3> buffers_;
-  struct ArrowArray dictionary_;
+  struct ArrowArray dictionary_{};
   SmallVector<struct ArrowArray, 1> children_;
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -528,7 +528,7 @@ namespace {
 struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> {
   // The buffers are owned by the ArrayData member
   SmallVector<const void*, 3> buffers_;
-  struct ArrowArray dictionary_{};
+  struct ArrowArray dictionary_ {};
   SmallVector<struct ArrowArray, 1> children_;
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 

--- a/cpp/src/arrow/gpu/cuda_benchmark.cc
+++ b/cpp/src/arrow/gpu/cuda_benchmark.cc
@@ -36,7 +36,7 @@ constexpr int64_t kGpuNumber = 0;
 static void CudaBufferWriterBenchmark(benchmark::State& state, const int64_t total_bytes,
                                       const int64_t chunksize,
                                       const int64_t buffer_size) {
-  CudaDeviceManager* manager;
+  CudaDeviceManager* manager = nullptr;
   ABORT_NOT_OK(CudaDeviceManager::Instance().Value(&manager));
   std::shared_ptr<CudaContext> context;
   ABORT_NOT_OK(manager->GetContext(kGpuNumber).Value(&context));


### PR DESCRIPTION
### Rationale for this change

Fix a couple warnings about potentially uninitialized variables

### What changes are included in this PR?

Fix the warnings

### Are these changes tested?

Test via CI.

### Are there any user-facing changes?

No
* GitHub Issue: #42139