### PR TITLE
GH-42213: [Swift] Use "--warnings-as-errors" only on CI

### DIFF
--- a/ci/scripts/swift_test.sh
+++ b/ci/scripts/swift_test.sh
@@ -34,10 +34,14 @@ popd
 
 source_dir=${1}/swift/Arrow
 pushd ${source_dir}
+sed  's/\/\/ build://g' Package.swift > Package.swift.build
+mv Package.swift.build Package.swift
 swift test
 popd
 
 source_dir=${1}/swift/ArrowFlight
 pushd ${source_dir}
+sed  's/\/\/ build://g' Package.swift > Package.swift.build
+mv Package.swift.build Package.swift
 swift test
 popd

--- a/ci/scripts/swift_test.sh
+++ b/ci/scripts/swift_test.sh
@@ -34,14 +34,14 @@ popd
 
 source_dir=${1}/swift/Arrow
 pushd ${source_dir}
-sed  's/\/\/ build://g' Package.swift > Package.swift.build
+sed 's/\/\/ build://g' Package.swift > Package.swift.build
 mv Package.swift.build Package.swift
 swift test
 popd
 
 source_dir=${1}/swift/ArrowFlight
 pushd ${source_dir}
-sed  's/\/\/ build://g' Package.swift > Package.swift.build
+sed 's/\/\/ build://g' Package.swift > Package.swift.build
 mv Package.swift.build Package.swift
 swift test
 popd

--- a/swift/Arrow/Package.swift
+++ b/swift/Arrow/Package.swift
@@ -46,8 +46,9 @@ let package = Package(
             name: "ArrowC",
             path: "Sources/ArrowC",
             swiftSettings: [
-                .unsafeFlags(["-warnings-as-errors"])
+                 // build: .unsafeFlags(["-warnings-as-errors"])
             ]
+
         ),
         .target(
             name: "Arrow",
@@ -56,14 +57,14 @@ let package = Package(
                 .product(name: "Atomics", package: "swift-atomics")
             ],
             swiftSettings: [
-                .unsafeFlags(["-warnings-as-errors"])
+                 // build: .unsafeFlags(["-warnings-as-errors"])
             ]
         ),
         .testTarget(
             name: "ArrowTests",
             dependencies: ["Arrow", "ArrowC"],
             swiftSettings: [
-                .unsafeFlags(["-warnings-as-errors"])
+                 // build: .unsafeFlags(["-warnings-as-errors"])
             ]
         )
     ]

--- a/swift/ArrowFlight/Package.swift
+++ b/swift/ArrowFlight/Package.swift
@@ -47,14 +47,14 @@ let package = Package(
                 .product(name: "SwiftProtobuf", package: "swift-protobuf")
             ],
             swiftSettings: [
-                .unsafeFlags(["-warnings-as-errors"])
+                // build: .unsafeFlags(["-warnings-as-errors"])
             ]
         ),
         .testTarget(
             name: "ArrowFlightTests",
             dependencies: ["ArrowFlight"],
             swiftSettings: [
-                .unsafeFlags(["-warnings-as-errors"])
+                // build: .unsafeFlags(["-warnings-as-errors"])
             ]
         )
     ]


### PR DESCRIPTION
### Rationale for this change
Downstream clients are getting a conflicting options error when building with the "-warnings-as-errors" swift option. 

### What changes are included in this PR?
This PR disables the "-warnings-as-errors" swift options by default and enables them for CI builds only.  The Swift CI script will enable the options in the Package.swift files before running the build.

* GitHub Issue: #42213