### PR TITLE
MINOR: [Go] check nil buffer in SizeInBytes

### DIFF
--- a/go/arrow/array/data.go
+++ b/go/arrow/array/data.go
@@ -201,7 +201,9 @@ func (d *Data) SizeInBytes() uint64 {
 	}
 
 	for _, b := range d.Buffers() {
-		size += uint64(b.Len())
+		if b != nil {
+			size += uint64(b.Len())
+		}
 	}
 	for _, c := range d.Children() {
 		size += c.SizeInBytes()

--- a/go/arrow/array/data_test.go
+++ b/go/arrow/array/data_test.go
@@ -17,6 +17,7 @@
 package array
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/apache/arrow/go/v17/arrow"
@@ -56,7 +57,7 @@ func TestSizeInBytes(t *testing.T) {
 	for i := 0; i < cap(buffers1); i++ {
 		buffers1 = append(buffers1, memory.NewBufferBytes([]byte("15-bytes-buffer")))
 	}
-	data := NewData(&arrow.StringType{}, 10, buffers1, nil, 0, 0)
+	data := NewData(&arrow.StringType{}, 10, slices.Clone(buffers1), nil, 0, 0)
 	var arrayData arrow.ArrayData = data
 	dataWithChild := NewData(&arrow.StringType{}, 10, buffers1, []arrow.ArrayData{arrayData}, 0, 0)
 

--- a/go/arrow/array/data_test.go
+++ b/go/arrow/array/data_test.go
@@ -60,6 +60,16 @@ func TestSizeInBytes(t *testing.T) {
 	var arrayData arrow.ArrayData = data
 	dataWithChild := NewData(&arrow.StringType{}, 10, buffers1, []arrow.ArrayData{arrayData}, 0, 0)
 
+	buffers1[0] = nil
+	dataWithNilBuffer := NewData(&arrow.StringType{}, 10, buffers1, nil, 0, 0)
+
+	t.Run("nil buffers", func(t *testing.T) {
+		expectedSize := uint64(30)
+		if actualSize := dataWithNilBuffer.SizeInBytes(); actualSize != expectedSize {
+			t.Errorf("expected size %d, got %d", expectedSize, actualSize)
+		}
+	})
+
 	t.Run("buffers only", func(t *testing.T) {
 		expectedSize := uint64(45)
 		if actualSize := data.SizeInBytes(); actualSize != expectedSize {

--- a/go/arrow/array/data_test.go
+++ b/go/arrow/array/data_test.go
@@ -57,12 +57,13 @@ func TestSizeInBytes(t *testing.T) {
 	for i := 0; i < cap(buffers1); i++ {
 		buffers1 = append(buffers1, memory.NewBufferBytes([]byte("15-bytes-buffer")))
 	}
-	data := NewData(&arrow.StringType{}, 10, slices.Clone(buffers1), nil, 0, 0)
+	data := NewData(&arrow.StringType{}, 10, buffers1, nil, 0, 0)
 	var arrayData arrow.ArrayData = data
 	dataWithChild := NewData(&arrow.StringType{}, 10, buffers1, []arrow.ArrayData{arrayData}, 0, 0)
 
-	buffers1[0] = nil
-	dataWithNilBuffer := NewData(&arrow.StringType{}, 10, buffers1, nil, 0, 0)
+	buffers2 := slices.Clone(buffers1)
+	buffers2[0] = nil
+	dataWithNilBuffer := NewData(&arrow.StringType{}, 10, buffers2, nil, 0, 0)
 
 	t.Run("nil buffers", func(t *testing.T) {
 		expectedSize := uint64(30)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

![image](https://github.com/apache/arrow/assets/86254270/15265fff-03b3-4c8a-9599-a07675eb1e60)

Saw a nil error. Unclear to me how this nil buffer got constructed, because when building the arrow data we seem to already check it. But we should do a nil check here anyway 

### What changes are included in this PR?

Added a nil check. 

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No. 