### PR TITLE
GH-42228: [CI][Java] Suppress transfer progress log in java-jars

### DIFF
--- a/ci/scripts/java_full_build.sh
+++ b/ci/scripts/java_full_build.sh
@@ -53,7 +53,8 @@ mvn clean \
     -Parrow-c-data \
     -Parrow-jni \
     -Darrow.cpp.build.dir=$dist_dir \
-    -Darrow.c.jni.dist.dir=$dist_dir
+    -Darrow.c.jni.dist.dir=$dist_dir \
+    --no-transfer-progress
 
 # copy all jar, zip and pom files to the distribution folder
 find ~/.m2/repository/org/apache/arrow \

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -242,6 +242,9 @@ jobs:
           test -f arrow/java-dist/arrow_dataset_jni/x86_64/arrow_dataset_jni.dll
           test -f arrow/java-dist/arrow_orc_jni/x86_64/arrow_orc_jni.dll
       - name: Build bundled jar
+        env:
+          MAVEN_ARGS: >-
+            --no-transfer-progress
         run: |
           set -e
           pushd arrow/java


### PR DESCRIPTION
### Rationale for this change

Transfer progress log is meaningless and noisy in CI log.

### What changes are included in this PR?

Use the `--no-transfer-progress` option that is available Maven 3.6.1: https://maven.apache.org/ref/3.6.1/maven-embedder/cli.html

Other approach is using `-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn` like other our scripts do.

I chose `--no-transfer-progress` because it's shorter.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #42228