### PR TITLE
MINOR: Move tests, skip when no dataset is available

### DIFF
--- a/r/tests/testthat/test-dplyr-across.R
+++ b/r/tests/testthat/test-dplyr-across.R
@@ -116,14 +116,6 @@ test_that("expand_across correctly expands quosures", {
     example_data
   )
 
-  # ellipses (...) are a deprecated argument
-  # abandon_ship message offers multiple suggestions
-  expect_snapshot(
-    InMemoryDataset$create(example_data) %>%
-      mutate(across(c(dbl, dbl2), round, digits = -1)),
-    error = TRUE
-  )
-
   # alternative ways of specifying .fns - as a list
   expect_across_equal(
     quos(across(1:dbl2, list(round))),
@@ -229,6 +221,15 @@ test_that("expand_across correctly expands quosures", {
       dbl2_2 = base::sqrt(dbl2)
     ),
     example_data
+  )
+
+  skip_if_not_available("dataset")
+  # ellipses (...) are a deprecated argument
+  # abandon_ship message offers multiple suggestions
+  expect_snapshot(
+    InMemoryDataset$create(example_data) %>%
+      mutate(across(c(dbl, dbl2), round, digits = -1)),
+    error = TRUE
   )
 })
 

--- a/r/tests/testthat/test-dplyr-eval.R
+++ b/r/tests/testthat/test-dplyr-eval.R
@@ -53,6 +53,7 @@ test_that("try_arrow_dplyr/abandon_ship adds the right message about collect()",
     })
   }
 
+  skip_if_not_available("dataset")
   ds <- InMemoryDataset$create(arrow_table(x = 1))
   for (i in 0:2) {
     expect_snapshot(tester(ds, i), error = TRUE)

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -1885,21 +1885,6 @@ test_that("`as.Date()` and `as_date()`", {
     test_df
   )
 
-  # we do not support multiple tryFormats
-  # Use a dataset to test the alternative suggestion message
-  expect_snapshot(
-    test_df %>%
-      InMemoryDataset$create() %>%
-      transmute(
-        date_char_ymd = as.Date(
-          character_ymd_var,
-          tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
-        )
-      ) %>%
-      collect(),
-    error = TRUE
-  )
-
   # strptime does not support a partial format - Arrow returns NA, while
   # lubridate parses correctly
   # TODO: revisit after ARROW-15813
@@ -1956,6 +1941,22 @@ test_that("`as.Date()` and `as_date()`", {
       ) %>%
       collect(),
     test_df
+  )
+
+  skip_if_not_available("dataset")
+  # we do not support multiple tryFormats
+  # Use a dataset to test the alternative suggestion message
+  expect_snapshot(
+    test_df %>%
+      InMemoryDataset$create() %>%
+      transmute(
+        date_char_ymd = as.Date(
+          character_ymd_var,
+          tryFormats = c("%Y-%m-%d", "%Y/%m/%d")
+        )
+      ) %>%
+      collect(),
+    error = TRUE
   )
 })
 


### PR DESCRIPTION
Update tests that are making our minimal builds fail. The tests are unchanged and no new functionality is added. I moved the tests that were failing to the end of their blocks and added `skip_if_not_available("dataset")` since our minimal builds _don't_ include datasets and thus the snapshots that use datasets will be wrong there.