### PR TITLE
GH-42240: [R] Fix crash in ParquetFileWriter$WriteTable and add WriteBatch

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - cpp_version: "13.0.0"
+          - cpp_version: "15.0.0"
     steps:
     - name: Checkout Arrow
       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - cpp_version: "15.0.0"
+          - cpp_version: "15.0.2"
     steps:
     - name: Checkout Arrow
       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -24,6 +24,7 @@
 * `summarize()` supports more complex expressions, and correctly handles cases where column names are reused in expressions. 
 * The `na_matches` argument to the `dplyr::*_join()` functions is now supported. This argument controls whether `NA` values are considered equal when joining. (#41358)
 * R metadata, stored in the Arrow schema to support round-tripping data between R and Arrow/Parquet, is now serialized and deserialized more strictly. This makes it safer to load data from files from unknown sources into R data.frames. (#41969)
+* The minimum version of the Arrow C++ library the Arrow R package can be built with has been bumped to 15.0.0 (#42241)
 
 # arrow 16.1.0
 

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -419,6 +419,7 @@ ParquetWriterProperties$create <- function(column_names,
 #' @section Methods:
 #'
 #' - `WriteTable` Write a [Table] to `sink`
+#' - `WriteBatch` Write a [Batch] to `sink`
 #' - `Close` Close the writer. Note: does not close the `sink`.
 #'   [arrow::io::OutputStream][OutputStream] has its own `close()` method.
 #'

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -428,6 +428,7 @@ ParquetFileWriter <- R6Class("ParquetFileWriter",
   inherit = ArrowObject,
   public = list(
     WriteTable = function(table, chunk_size) {
+      assert_is(table, "Table")
       parquet___arrow___FileWriter__WriteTable(self, table, chunk_size)
     },
     Close = function() parquet___arrow___FileWriter__Close(self)

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -419,7 +419,7 @@ ParquetWriterProperties$create <- function(column_names,
 #' @section Methods:
 #'
 #' - `WriteTable` Write a [Table] to `sink`
-#' - `WriteBatch` Write a [Batch] to `sink`
+#' - `WriteBatch` Write a [RecordBatch] to `sink`
 #' - `Close` Close the writer. Note: does not close the `sink`.
 #'   [arrow::io::OutputStream][OutputStream] has its own `close()` method.
 #'

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -431,6 +431,11 @@ ParquetFileWriter <- R6Class("ParquetFileWriter",
       assert_is(table, "Table")
       parquet___arrow___FileWriter__WriteTable(self, table, chunk_size)
     },
+    WriteBatch = function(batch, chunk_size) {
+      assert_is(batch, "RecordBatch")
+      table <- Table$create(batch)
+      parquet___arrow___FileWriter__WriteTable(self, table, chunk_size)
+    },
     Close = function() parquet___arrow___FileWriter__Close(self)
   )
 )

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -431,10 +431,10 @@ ParquetFileWriter <- R6Class("ParquetFileWriter",
       assert_is(table, "Table")
       parquet___arrow___FileWriter__WriteTable(self, table, chunk_size)
     },
-    WriteBatch = function(batch, chunk_size) {
+    WriteBatch = function(batch, ...) {
       assert_is(batch, "RecordBatch")
       table <- Table$create(batch)
-      parquet___arrow___FileWriter__WriteTable(self, table, chunk_size)
+      self$WriteTable(table, ...)
     },
     Close = function() parquet___arrow___FileWriter__Close(self)
   )

--- a/r/man/ParquetFileWriter.Rd
+++ b/r/man/ParquetFileWriter.Rd
@@ -24,6 +24,7 @@ takes the following arguments:
 
 \itemize{
 \item \code{WriteTable} Write a \link{Table} to \code{sink}
+\item \code{WriteBatch} Write a \link{Batch} to \code{sink}
 \item \code{Close} Close the writer. Note: does not close the \code{sink}.
 \link[=OutputStream]{arrow::io::OutputStream} has its own \code{close()} method.
 }

--- a/r/man/ParquetFileWriter.Rd
+++ b/r/man/ParquetFileWriter.Rd
@@ -24,7 +24,7 @@ takes the following arguments:
 
 \itemize{
 \item \code{WriteTable} Write a \link{Table} to \code{sink}
-\item \code{WriteBatch} Write a \link{Batch} to \code{sink}
+\item \code{WriteBatch} Write a \link{RecordBatch} to \code{sink}
 \item \code{Close} Close the writer. Note: does not close the \code{sink}.
 \link[=OutputStream]{arrow::io::OutputStream} has its own \code{close()} method.
 }

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -1050,7 +1050,6 @@ class RDictionaryConverter<ValueType, enable_if_has_string_view<ValueType>>
 template <typename T, typename Enable = void>
 struct RConverterTrait;
 
-#if ARROW_VERSION_MAJOR >= 15
 template <typename T>
 struct RConverterTrait<
     T, enable_if_t<!is_nested_type<T>::value && !is_interval_type<T>::value &&
@@ -1062,14 +1061,6 @@ template <typename T>
 struct RConverterTrait<T, enable_if_binary_view_like<T>> {
   // not implemented
 };
-#else
-template <typename T>
-struct RConverterTrait<
-    T, enable_if_t<!is_nested_type<T>::value && !is_interval_type<T>::value &&
-                   !is_extension_type<T>::value>> {
-  using type = RPrimitiveConverter<T>;
-};
-#endif
 
 template <typename T>
 struct RConverterTrait<T, enable_if_list_like<T>> {

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -110,18 +110,6 @@ skip_on_r_older_than <- function(r_version) {
   }
 }
 
-skip_on_cpp_older_than <- function(cpp_version) {
-  if (force_tests()) {
-    return()
-  }
-
-  current_version <- arrow_info()$build_info$cpp_version
-
-  if (current_version < cpp_version) {
-    skip(paste("C++ version:", current_version))
-  }
-}
-
 skip_on_python_older_than <- function(python_version) {
   if (force_tests()) {
     return()

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -110,6 +110,18 @@ skip_on_r_older_than <- function(r_version) {
   }
 }
 
+skip_on_cpp_older_than <- function(cpp_version) {
+  if (force_tests()) {
+    return()
+  }
+
+  current_version <- arrow_info()$build_info$cpp_version
+
+  if (current_version < cpp_version) {
+    skip(paste("C++ version:", current_version))
+  }
+}
+
 skip_on_python_older_than <- function(python_version) {
   if (force_tests()) {
     return()

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -550,11 +550,6 @@ test_that("We can use WriteBatch on ParquetFileWriter", {
 })
 
 test_that("WriteBatch on ParquetFileWriter errors when called on closed sink", {
-  # Skip this test if the Arrow C++ version is <15.0.0 because a check for the
-  # writer being in the closed state wasn't added until 15 which means this will
-  # segfault on lower versions.
-  skip_on_cpp_older_than("15.0.0")
-
   sink <- FileOutputStream$create(tempfile())
   sch <- schema(a = int32())
   props <- ParquetWriterProperties$create(column_names = names(sch))

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -550,6 +550,11 @@ test_that("We can use WriteBatch on ParquetFileWriter", {
 })
 
 test_that("WriteBatch on ParquetFileWriter errors when called on closed sink", {
+  # Skip this test if the Arrow C++ version is <15.0.0 because a check for the
+  # writer being in the closed state wasn't added until 15 which means this will
+  # segfault on lower versions.
+  skip_on_cpp_older_than("15.0.0")
+
   sink <- FileOutputStream$create(tempfile())
   sch <- schema(a = int32())
   props <- ParquetWriterProperties$create(column_names = names(sch))

--- a/r/tools/check-versions.R
+++ b/r/tools/check-versions.R
@@ -27,7 +27,7 @@ release_version_supported <- function(r_version, cpp_version) {
   minimum_cpp_version <- package_version("15.0.0")
 
   allow_mismatch <- identical(tolower(Sys.getenv("ARROW_R_ALLOW_CPP_VERSION_MISMATCH", "false")), "true")
-  # If we allow a version mismatch we still need to cover the minimum version (13.0.0 for now)
+  # If we allow a version mismatch we still need to cover the minimum version (15.0.0 for now)
   # we don't allow newer C++ versions as new features without additional feature gates are likely to
   # break the R package
   version_valid <- cpp_version >= minimum_cpp_version && major(cpp_version) <= major(r_version)

--- a/r/tools/check-versions.R
+++ b/r/tools/check-versions.R
@@ -24,7 +24,7 @@ release_version_supported <- function(r_version, cpp_version) {
   r_version <- package_version(r_version)
   cpp_version <- package_version(cpp_version)
   major <- function(x) as.numeric(x[1, 1])
-  minimum_cpp_version <- package_version("13.0.0")
+  minimum_cpp_version <- package_version("15.0.0")
 
   allow_mismatch <- identical(tolower(Sys.getenv("ARROW_R_ALLOW_CPP_VERSION_MISMATCH", "false")), "true")
   # If we allow a version mismatch we still need to cover the minimum version (13.0.0 for now)

--- a/r/tools/test-check-versions.R
+++ b/r/tools/test-check-versions.R
@@ -61,14 +61,22 @@ test_that("check_versions without mismatch", {
 test_that("check_versions with mismatch", {
   withr::local_envvar(.new = c(ARROW_R_ALLOW_CPP_VERSION_MISMATCH = "false"))
 
+  expect_true(
+    release_version_supported("15.0.0", "15.0.0")
+  )
+
   expect_false(
     release_version_supported("15.0.0", "13.0.0")
   )
 
   withr::local_envvar(.new = c(ARROW_R_ALLOW_CPP_VERSION_MISMATCH = "true"))
 
-  expect_true(
+  expect_false(
     release_version_supported("15.0.0", "13.0.0")
+  )
+
+  expect_true(
+    release_version_supported("16.0.0", "15.0.0")
   )
 
   expect_false(


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/issues/42240.

### What changes are included in this PR?

- Fixes a crash in `ParquetFileWriter$WriteTable` by asserting the class of what's passed in and stopping if it's not a `Table`
- Since I was already there, added `WriteBatch` to match [`pyarrow.parquet.ParquetWriter.write_batch`](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html#pyarrow.parquet.ParquetWriter.write_batch) which is just a convenience
- Adds a test for the behavior of trying to write to a closed sink
- Bumps the minimum Arrow C++ test version we test the R package with on CI from 13 to 15
- Removes one ARROW_VERSION_MAJOR >= 15 guard

### Are these changes tested?

Yes.

### Are there any user-facing changes?

New method on ParquetFileWriter (WriteBatch).
* GitHub Issue: #42240