### PR TITLE
GH-42234: [CI][R] Disable libarrow binary use on valgrind tests 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1565,6 +1565,7 @@ services:
       # so some build might pass without this setting, but we want to ensure that we stay to AVX2 regardless of runner.
       EXTRA_CMAKE_FLAGS: "-DARROW_RUNTIME_SIMD_LEVEL=AVX2"
       ARROW_SOURCE_HOME: "/arrow"
+      LIBARROW_DOWNLOAD: "false"
     volumes: *ubuntu-volumes
     command: >
       /bin/bash -c "


### PR DESCRIPTION
Which is making the tests fail. Resolves #42234 

* GitHub Issue: #42234