### PR TITLE
GH-43012:[Go] Fixes record builder support for not-nullable fixed-size lists

### DIFF
--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -357,7 +357,7 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 		return bldr
 	case arrow.FIXED_SIZE_LIST:
 		typ := dtype.(*arrow.FixedSizeListType)
-		return NewFixedSizeListBuilder(mem, typ.Len(), typ.Elem())
+		return NewFixedSizeListBuilderWithField(mem, typ.Len(), typ.ElemField())
 	case arrow.DURATION:
 		typ := dtype.(*arrow.DurationType)
 		return NewDurationBuilder(mem, typ)


### PR DESCRIPTION
Prior to this commit, the builder constructor for fixed-length lists would lose information as to whether the list elements were marked not-nullable, which meant the data type available from the builder would always reflect "nullable". When NewRecord was invoked, this type would get checked against the type present in the original schema. If the schema requested a not-nullable fixed-size array, this check would always fail and cause a panic.

This commit introduces an alternative builder constructor "NewFixedSizeListBuilderWithField" for fixed-size lists that takes the entire field context, similar to what already exists for lists and large lists.


**This PR contains a "Critical Fix".**
* GitHub Issue: #43012