### PR TITLE
GH-42218: [Java] MapVector cannot be loaded via IPC

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1896,9 +1896,10 @@ def get_generated_json_files(tempdir=None):
         generate_map_case(),
 
         generate_non_canonical_map_case()
-        .skip_tester('Java')  # TODO(ARROW-8715)
+        # .skip_tester('Java')  # TODO(ARROW-8715)
         # Canonical map names are restored on import, so the schemas are unequal
-        .skip_format(SKIP_C_SCHEMA, 'C++'),
+        .skip_format(SKIP_C_SCHEMA, 'C++')
+        .skip_format(SKIP_C_SCHEMA, 'Java'),
 
         generate_nested_case(),
 

--- a/java/c/src/test/java/org/apache/arrow/c/StreamTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/StreamTest.java
@@ -313,8 +313,6 @@ final class StreamTest {
       mapWriter.setValueCount(1);
       vectorSchemaRoot.setRowCount(1);
 
-      System.out.println(vectorSchemaRoot.contentToTSVString());
-
       VectorUnloader unloader = new VectorUnloader(vectorSchemaRoot);
       batches.add(unloader.getRecordBatch());
       roundtrip(schema, batches);

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -142,25 +142,25 @@ public class UnionMapWriter extends UnionListWriter {
 
   private String getWriteFieldName() {
     Field mapField = this.vector.getField();
-    if (mapField == null) {
-      throw new UnsupportedOperationException("MapVector does not have a field.");
-    }
-    if (mapField.getChildren().size() != 1) {
-      throw new UnsupportedOperationException("MapVector does not have a single struct field.");
-    }
+    Preconditions.checkNotNull(mapField, "MapVector does not have a field.");
+    Preconditions.checkArgument(mapField.getChildren().size() == 1,
+        "MapVector does not have a single struct field.");
     Field structField = mapField.getChildren().get(0);
     switch (mode) {
       case KEY:
-        if (structField.getChildren().size() == 2) {
-          return structField.getChildren().get(0).getName();
-        } else {
+        if (structField.getChildren().size() == 0) {
+          // key is not defined in the struct, use default name
           return MapVector.KEY_NAME;
+        } else {
+          return structField.getChildren().get(0).getName();
         }
       case VALUE:
-        if (structField.getChildren().size() == 2) {
-          return structField.getChildren().get(1).getName();
-        } else {
+        if (structField.getChildren().size() < 2) {
+          // key may or may not have been defined in the struct, but
+          // value has not been defined.
           return MapVector.VALUE_NAME;
+        } else {
+          return structField.getChildren().get(1).getName();
         }
       default:
         throw new UnsupportedOperationException("Cannot get field name in OFF mode");

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -140,6 +140,33 @@ public class UnionMapWriter extends UnionListWriter {
     return this;
   }
 
+  private String getWriteFieldName() {
+    Field mapField = this.vector.getField();
+    if (mapField == null) {
+      throw new UnsupportedOperationException("MapVector does not have a field.");
+    }
+    if (mapField.getChildren().size() != 1) {
+      throw new UnsupportedOperationException("MapVector does not have a single struct field.");
+    }
+    Field structField = mapField.getChildren().get(0);
+    switch (mode) {
+      case KEY:
+        if (structField.getChildren().size() == 2) {
+          return structField.getChildren().get(0).getName();
+        } else {
+          return MapVector.KEY_NAME;
+        }
+      case VALUE:
+        if (structField.getChildren().size() == 2) {
+          return structField.getChildren().get(1).getName();
+        } else {
+          return MapVector.VALUE_NAME;
+        }
+      default:
+        throw new UnsupportedOperationException("Cannot get field name in OFF mode");
+    }
+  }
+
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
   <#assign fields = minor.fields!type.fields />
   <#assign uncappedName = name?uncap_first/>
@@ -149,9 +176,9 @@ public class UnionMapWriter extends UnionListWriter {
   public ${name}Writer ${uncappedName}() {
     switch (mode) {
       case KEY:
-        return entryWriter.${uncappedName}(MapVector.KEY_NAME);
+        return entryWriter.${uncappedName}(getWriteFieldName());
       case VALUE:
-        return entryWriter.${uncappedName}(MapVector.VALUE_NAME);
+        return entryWriter.${uncappedName}(getWriteFieldName());
       default:
         return this;
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -71,11 +71,22 @@ public class MapVector extends ListVector {
    */
   public MapVector(String name, BufferAllocator allocator, FieldType fieldType, CallBack callBack) {
     super(name, allocator, fieldType, callBack);
+    KEY_NAME = "key";
+    VALUE_NAME = "value";
     defaultDataVectorName = DATA_VECTOR_NAME;
   }
 
+  /**
+   * Construct a MapVector instance.
+   *
+   * @param field The name of the field.
+   * @param allocator The allocator used for allocating/reallocating buffers.
+   * @param callBack A schema change callback.
+   */
   public MapVector(Field field, BufferAllocator allocator, CallBack callBack) {
     super(field, allocator, callBack);
+    KEY_NAME = "key";
+    VALUE_NAME = "value";
     defaultDataVectorName = DATA_VECTOR_NAME;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -45,8 +45,8 @@ import org.apache.arrow.vector.util.TransferPair;
  */
 public class MapVector extends ListVector {
 
-  public static final String KEY_NAME = "key";
-  public static final String VALUE_NAME = "value";
+  public static String KEY_NAME = "key";
+  public static String VALUE_NAME = "value";
   public static final String DATA_VECTOR_NAME = "entries";
 
   /**
@@ -103,6 +103,11 @@ public class MapVector extends ListVector {
 
     Field keyField = structField.getChildren().get(0);
     checkArgument(!keyField.isNullable(), "Map data key type should be a non-nullable");
+
+    Field valueField = structField.getChildren().get(1);
+    // set the KEY_NAME and VALUE_NAME from the field names
+    KEY_NAME = keyField.getName();
+    VALUE_NAME = valueField.getName();
 
     AddOrGetResult<FieldVector> addOrGetVector = addOrGetVector(structField.getFieldType());
     checkArgument(

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -45,8 +45,11 @@ import org.apache.arrow.vector.util.TransferPair;
  */
 public class MapVector extends ListVector {
 
+  /** The default name of the key field in the MapVector. */
   public static String KEY_NAME = "key";
+  /** The default name of the value field in the MapVector. */
   public static String VALUE_NAME = "value";
+
   public static final String DATA_VECTOR_NAME = "entries";
 
   /**
@@ -71,8 +74,6 @@ public class MapVector extends ListVector {
    */
   public MapVector(String name, BufferAllocator allocator, FieldType fieldType, CallBack callBack) {
     super(name, allocator, fieldType, callBack);
-    KEY_NAME = "key";
-    VALUE_NAME = "value";
     defaultDataVectorName = DATA_VECTOR_NAME;
   }
 
@@ -85,8 +86,6 @@ public class MapVector extends ListVector {
    */
   public MapVector(Field field, BufferAllocator allocator, CallBack callBack) {
     super(field, allocator, callBack);
-    KEY_NAME = "key";
-    VALUE_NAME = "value";
     defaultDataVectorName = DATA_VECTOR_NAME;
   }
 
@@ -114,11 +113,6 @@ public class MapVector extends ListVector {
 
     Field keyField = structField.getChildren().get(0);
     checkArgument(!keyField.isNullable(), "Map data key type should be a non-nullable");
-
-    Field valueField = structField.getChildren().get(1);
-    // set the KEY_NAME and VALUE_NAME from the field names
-    KEY_NAME = keyField.getName();
-    VALUE_NAME = valueField.getName();
 
     AddOrGetResult<FieldVector> addOrGetVector = addOrGetVector(structField.getFieldType());
     checkArgument(

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -46,9 +46,9 @@ import org.apache.arrow.vector.util.TransferPair;
 public class MapVector extends ListVector {
 
   /** The default name of the key field in the MapVector. */
-  public static String KEY_NAME = "key";
+  public static final String KEY_NAME = "key";
   /** The default name of the value field in the MapVector. */
-  public static String VALUE_NAME = "value";
+  public static final String VALUE_NAME = "value";
 
   public static final String DATA_VECTOR_NAME = "entries";
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -1208,15 +1209,13 @@ public class TestMapVector {
 
   @Test
   public void testValidateKeyValueFieldNames() {
-    FieldType keyType = new FieldType(false, MinorType.BIGINT.getType(), null, null);
+    FieldType keyType = FieldType.notNullable(MinorType.BIGINT.getType());
     FieldType valueType = FieldType.nullable(MinorType.FLOAT8.getType());
 
     Field keyField = new Field("myKey", keyType, null);
     Field valueField = new Field("myValue", valueType, null);
 
-    List<Field> structFields = new ArrayList<>(2);
-    structFields.add(keyField);
-    structFields.add(valueField);
+    List<Field> structFields = Arrays.asList(keyField, valueField);
 
     Field structField =
         new Field("entry", FieldType.notNullable(ArrowType.Struct.INSTANCE), structFields);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
@@ -1214,7 +1214,7 @@ public class TestMapVector {
     Field keyField = new Field("myKey", keyType, null);
     Field valueField = new Field("myValue", valueType, null);
 
-    List<Field> structFields = new ArrayList<>();
+    List<Field> structFields = new ArrayList<>(2);
     structFields.add(keyField);
     structFields.add(valueField);
 


### PR DESCRIPTION
### Rationale for this change

The `MapVector` keeps the `KEY_NAME` and `VALUE_NAME` as a constant values but rather it should be extracted from the provided fields. 

### What changes are included in this PR?

Updating `KEY_NAME` and `VALUE_NAME` from the provided fields. Adding a test case to validate that. 
- [x] Add IPC Test Cases
- [x] Add C Data Test Cases

### Are these changes tested?

Yes. A test case has been added to validate this. 

### Are there any user-facing changes?

No
* GitHub Issue: apache/arrow-java#71
* GitHub Issue: apache/arrow#71
* GitHub Issue: #71