### PR TITLE
GH-43015: [Go] Reuse column compressors in IPC module

### DIFF
--- a/go/arrow/ipc/file_writer.go
+++ b/go/arrow/ipc/file_writer.go
@@ -278,6 +278,7 @@ type FileWriter struct {
 	mapper          dictutils.Mapper
 	codec           flatbuf.CompressionType
 	compressNP      int
+	compressors     []compressor
 	minSpaceSavings *float64
 
 	// map of the last written dictionaries by id
@@ -302,6 +303,7 @@ func NewFileWriter(w io.WriteSeeker, opts ...Option) (*FileWriter, error) {
 		codec:           cfg.codec,
 		compressNP:      cfg.compressNP,
 		minSpaceSavings: cfg.minSpaceSavings,
+		compressors:     make([]compressor, cfg.compressNP),
 	}
 
 	pos, err := f.w.Seek(0, io.SeekCurrent)
@@ -345,7 +347,9 @@ func (f *FileWriter) Write(rec arrow.Record) error {
 	const allow64b = true
 	var (
 		data = Payload{msg: MessageRecordBatch}
-		enc  = newRecordEncoder(f.mem, 0, kMaxNestingDepth, allow64b, f.codec, f.compressNP, f.minSpaceSavings)
+		enc  = newRecordEncoder(
+			f.mem, 0, kMaxNestingDepth, allow64b, f.codec, f.compressNP, f.minSpaceSavings, f.compressors,
+		)
 	)
 	defer data.Release()
 

--- a/go/arrow/ipc/ipc.go
+++ b/go/arrow/ipc/ipc.go
@@ -79,6 +79,7 @@ func newConfig(opts ...Option) *config {
 		alloc:              memory.NewGoAllocator(),
 		codec:              -1, // uncompressed
 		ensureNativeEndian: true,
+		compressNP:         1,
 	}
 
 	for _, opt := range opts {
@@ -135,6 +136,9 @@ func WithZstd() Option {
 // parallelization. Default is 0.
 func WithCompressConcurrency(n int) Option {
 	return func(cfg *config) {
+		if n <= 0 {
+			n = 1
+		}
 		cfg.compressNP = n
 	}
 }

--- a/go/arrow/ipc/ipc.go
+++ b/go/arrow/ipc/ipc.go
@@ -133,7 +133,7 @@ func WithZstd() Option {
 // WithCompressConcurrency specifies a number of goroutines to spin up for
 // concurrent compression of the body buffers when writing compress IPC records.
 // If n <= 1 then compression will be done serially without goroutine
-// parallelization. Default is 0.
+// parallelization. Default is 1.
 func WithCompressConcurrency(n int) Option {
 	return func(cfg *config) {
 		if n <= 0 {

--- a/go/arrow/ipc/writer_test.go
+++ b/go/arrow/ipc/writer_test.go
@@ -193,7 +193,8 @@ func TestWriteWithCompressionAndMinSavings(t *testing.T) {
 	}
 
 	for _, codec := range []flatbuf.CompressionType{flatbuf.CompressionTypeLZ4_FRAME, flatbuf.CompressionTypeZSTD} {
-		enc := newRecordEncoder(mem, 0, 5, true, codec, 1, nil)
+		compressors := []compressor{getCompressor(codec)}
+		enc := newRecordEncoder(mem, 0, 5, true, codec, 1, nil, compressors)
 		var payload Payload
 		require.NoError(t, enc.encode(&payload, batch))
 		assert.Len(t, payload.body, 2)
@@ -205,7 +206,7 @@ func TestWriteWithCompressionAndMinSavings(t *testing.T) {
 		assert.Greater(t, compressedSize, int64(0))
 		expectedSavings := 1.0 - float64(compressedSize)/float64(uncompressedSize)
 
-		compressEncoder := newRecordEncoder(mem, 0, 5, true, codec, 1, &expectedSavings)
+		compressEncoder := newRecordEncoder(mem, 0, 5, true, codec, 1, &expectedSavings, compressors)
 		payload.Release()
 		payload.body = payload.body[:0]
 		require.NoError(t, compressEncoder.encode(&payload, batch))


### PR DESCRIPTION
This changes the IPC writer to reuse lz4 or zstd compressors instead of instantiating new ones on each call to Write. Prior to this commit we would instantiate as many encoders per Write call as the configured number of concurrent compression workers, even though the compressors are reusable across calls.

### Are these changes tested?
I have added no tests and have not yet closely verified the patch. There's no functional change to test and I want to get agreement on the approach before solidifying it. I have not tested the lz4 change at all.
* GitHub Issue: #43015