### PR TITLE
GH-43017: [C++] Make the set of casts and hash kernels involving float16 consistent with other floating types

### DIFF
--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -913,6 +913,16 @@ TEST(RowSegmenter, RowConstantBatch) {
   }
 }
 
+// XXX: float16 is not part of NumericTypes() yet
+auto& AllNumericTypes() {
+  static auto types = []() {
+    auto types = NumericTypes();
+    types.push_back(float16());
+    return types;
+  }();
+  return types;
+}
+
 TEST(Grouper, SupportedKeys) { TestGroupClassSupportedKeys<Grouper>(MakeGrouper); }
 
 struct TestGrouper {
@@ -2403,7 +2413,7 @@ TEST_P(GroupBy, MinMaxOnly) {
 
 TEST_P(GroupBy, MinMaxTypes) {
   std::vector<std::shared_ptr<DataType>> types;
-  types.insert(types.end(), NumericTypes().begin(), NumericTypes().end());
+  types.insert(types.end(), AllNumericTypes().begin(), AllNumericTypes().end());
   types.insert(types.end(), TemporalTypes().begin(), TemporalTypes().end());
   types.push_back(month_interval());
 
@@ -3324,7 +3334,7 @@ TEST_P(GroupBy, OneMiscTypes) {
 
 TEST_P(GroupBy, OneNumericTypes) {
   std::vector<std::shared_ptr<DataType>> types;
-  types.insert(types.end(), NumericTypes().begin(), NumericTypes().end());
+  types.insert(types.end(), AllNumericTypes().begin(), AllNumericTypes().end());
   types.insert(types.end(), TemporalTypes().begin(), TemporalTypes().end());
   types.push_back(month_interval());
 
@@ -3485,7 +3495,7 @@ TEST_P(GroupBy, OneScalar) {
 }
 
 TEST_P(GroupBy, ListNumeric) {
-  for (const auto& type : NumericTypes()) {
+  for (const auto& type : AllNumericTypes()) {
     for (auto use_threads : {true, false}) {
       SCOPED_TRACE(use_threads ? "parallel/merged" : "serial");
       {
@@ -4386,7 +4396,7 @@ TEST_P(GroupBy, MinMaxWithNewGroupsInChunkedArray) {
 TEST_P(GroupBy, FirstLastBasicTypes) {
   std::vector<std::shared_ptr<DataType>> types;
   types.insert(types.end(), boolean());
-  types.insert(types.end(), NumericTypes().begin(), NumericTypes().end());
+  types.insert(types.end(), AllNumericTypes().begin(), AllNumericTypes().end());
   types.insert(types.end(), TemporalTypes().begin(), TemporalTypes().end());
 
   const std::vector<std::string> numeric_table = {R"([

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -914,7 +914,7 @@ TEST(RowSegmenter, RowConstantBatch) {
 }
 
 // XXX: float16 is not part of NumericTypes() yet
-auto& AllNumericTypes() {
+const auto& AllNumericTypes() {
   static auto types = []() {
     auto types = NumericTypes();
     types.push_back(float16());

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -915,19 +915,6 @@ struct GetTypeId {
       : id(id) {}
 };
 
-template <template <typename...> class Generator, typename Type0, typename Type1,
-          typename... Args>
-struct is_generator {
-  template <typename T0, typename T1,
-            typename = typename Generator<T0, T1, Args...>::value_type>
-  static std::true_type Test(T0*, T1*);
-
-  template <typename T0, typename T1>
-  static std::false_type Test(...);
-
-  static constexpr bool value = decltype(Test<Type0, Type1>(NULLPTR, NULLPTR))::value;
-};
-
 }  // namespace detail
 
 template <typename KernelType>
@@ -973,15 +960,9 @@ KernelType GenerateNumeric(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return Generator<Type0, DoubleType, Args...>::Exec;
     case Type::HALF_FLOAT:
-      // NOTE: `Type::HALF_FLOAT` used to not be part of the list of numeric types.
-      // To avoid compilation errors for users that upgrade to Arrow 17.x,
-      // we only instantiate the kernel for `HalfFloatType` if a matching template
-      // specialization is found.
-      if constexpr (detail::is_generator<Generator, Type0, HalfFloatType,
-                                         Args...>::value) {
-        return Generator<Type0, HalfFloatType, Args...>::Exec;
-      }
-      [[fallthrough]];
+      // NOTE: Type::HALF_FLOAT used to not be part of the list of numeric types,
+      // so users of this template might start failing to compiler after Arrow 17.x.
+      return Generator<Type0, HalfFloatType, Args...>::Exec;
     default:
       DCHECK(false);
       return FailFunctor<KernelType>::Exec;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -960,8 +960,6 @@ KernelType GenerateNumeric(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return Generator<Type0, DoubleType, Args...>::Exec;
     case Type::HALF_FLOAT:
-      // NOTE: Type::HALF_FLOAT used to not be part of the list of numeric types,
-      // so users of this template might start failing to compiler after Arrow 17.x.
       return Generator<Type0, HalfFloatType, Args...>::Exec;
     default:
       DCHECK(false);
@@ -980,8 +978,6 @@ ArrayKernelExec GenerateFloatingPoint(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return Generator<Type0, DoubleType, Args...>::Exec;
     case Type::HALF_FLOAT:
-      // NOTE: Type::HALF_FLOAT used to not be part of the list of numeric types,
-      // so users of this template might start failing to compiler after Arrow 17.x.
       return Generator<Type0, HalfFloatType, Args...>::Exec;
     default:
       DCHECK(false);

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -959,6 +959,10 @@ KernelType GenerateNumeric(detail::GetTypeId get_id) {
       return Generator<Type0, FloatType, Args...>::Exec;
     case Type::DOUBLE:
       return Generator<Type0, DoubleType, Args...>::Exec;
+    case Type::HALF_FLOAT:
+      // NOTE: Type::HALF_FLOAT used to not be part of the list of numeric types,
+      // so users of this template might start failing to compiler after Arrow 17.x.
+      return Generator<Type0, HalfFloatType, Args...>::Exec;
     default:
       DCHECK(false);
       return FailFunctor<KernelType>::Exec;
@@ -975,6 +979,10 @@ ArrayKernelExec GenerateFloatingPoint(detail::GetTypeId get_id) {
       return Generator<Type0, FloatType, Args...>::Exec;
     case Type::DOUBLE:
       return Generator<Type0, DoubleType, Args...>::Exec;
+    case Type::HALF_FLOAT:
+      // NOTE: Type::HALF_FLOAT used to not be part of the list of numeric types,
+      // so users of this template might start failing to compiler after Arrow 17.x.
+      return Generator<Type0, HalfFloatType, Args...>::Exec;
     default:
       DCHECK(false);
       return nullptr;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -319,15 +319,6 @@ struct CastFunctor<
   }
 };
 
-template <>
-struct CastFunctor<HalfFloatType, StringType, enable_if_t<true>> {
-  static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-    return applicator::ScalarUnaryNotNull<HalfFloatType, StringType,
-                                          ParseString<HalfFloatType>>::Exec(ctx, batch,
-                                                                            out);
-  }
-};
-
 // ----------------------------------------------------------------------
 // Decimal to integer
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -745,18 +745,8 @@ std::shared_ptr<CastFunction> GetCastToFloating(std::string name) {
     DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, out_ty, CastFloatingToFloating));
   }
 
-  if constexpr (OutType::type_id == Type::HALF_FLOAT) {
-    AddCommonCasts(Type::HALF_FLOAT, out_ty, func.get());
-
-    // Cast from other strings to half float.
-    for (const std::shared_ptr<DataType>& in_ty : BaseBinaryTypes()) {
-      auto exec = GenerateVarBinaryBase<CastFunctor, HalfFloatType>(*in_ty);
-      DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, out_ty, exec));
-    }
-  } else {
-    // From other numbers to floating point
-    AddCommonNumberCasts<OutType>(out_ty, func.get());
-  }
+  // From other numbers to floating point
+  AddCommonNumberCasts<OutType>(out_ty, func.get());
 
   // From decimal to {float, double}
   if constexpr (OutType::type_id != Type::HALF_FLOAT) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -191,6 +191,8 @@ TEST(Cast, CanCast) {
 
   for (auto from_numeric : kNumericTypes) {
     ExpectCanCast(from_numeric, {boolean()});
+    // XXX: float16() is not part of kNumericTypes
+    ExpectCanCast(float16(), {boolean()});
     ExpectCanCast(from_numeric, kNumericTypes);
     ExpectCanCast(from_numeric, {utf8(), large_utf8()});
     ExpectCanCast(dictionary(int32(), from_numeric), {from_numeric});
@@ -201,6 +203,8 @@ TEST(Cast, CanCast) {
   for (auto from_base_binary : kBaseBinaryTypes) {
     ExpectCanCast(from_base_binary, {boolean()});
     ExpectCanCast(from_base_binary, kNumericTypes);
+    // XXX: float16() is not part of kNumericTypes
+    ExpectCanCast(from_base_binary, {float16()});
     ExpectCanCast(from_base_binary, kBaseBinaryTypes);
     ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -181,6 +181,8 @@ TEST(Cast, CanCast) {
 
   ExpectCanCast(boolean(), {boolean()});
   ExpectCanCast(boolean(), kNumericTypes);
+  // XXX: float16() is not part of kNumericTypes
+  ExpectCanCast(boolean(), {float16()});
   ExpectCanCast(boolean(), {utf8(), large_utf8()});
   ExpectCanCast(dictionary(int32(), boolean()), {boolean()});
 
@@ -2766,12 +2768,12 @@ static void CheckStructToStructSubsetWithNulls(
   }
 }
 
-TEST(Cast, StructToSameSizedAndNamedStruct) { CheckStructToStruct(NumericTypes()); }
+TEST(Cast, StructToSameSizedAndNamedStruct) { CheckStructToStruct(kNumericTypes); }
 
-TEST(Cast, StructToStructSubset) { CheckStructToStructSubset(NumericTypes()); }
+TEST(Cast, StructToStructSubset) { CheckStructToStructSubset(kNumericTypes); }
 
 TEST(Cast, StructToStructSubsetWithNulls) {
-  CheckStructToStructSubsetWithNulls(NumericTypes());
+  CheckStructToStructSubsetWithNulls(kNumericTypes);
 }
 
 TEST(Cast, StructToSameSizedButDifferentNamedStruct) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -86,8 +86,8 @@ static std::shared_ptr<Array> FixedSizeInvalidUtf8(std::shared_ptr<DataType> typ
 }
 
 static std::vector<std::shared_ptr<DataType>> kNumericTypes = {
-    uint8(), int8(),   uint16(), int16(),   uint32(),
-    int32(), uint64(), int64(),  float32(), float64()};
+    uint8(),  int8(),  uint16(),  int16(),   uint32(), int32(),
+    uint64(), int64(), float16(), float32(), float64()};
 
 static std::vector<std::shared_ptr<DataType>> kIntegerTypes = {
     int8(), uint8(), int16(), uint16(), int32(), uint32(), int64(), uint64()};
@@ -181,8 +181,6 @@ TEST(Cast, CanCast) {
 
   ExpectCanCast(boolean(), {boolean()});
   ExpectCanCast(boolean(), kNumericTypes);
-  // XXX: float16() is not part of kNumericTypes
-  ExpectCanCast(boolean(), {float16()});
   ExpectCanCast(boolean(), {utf8(), large_utf8()});
   ExpectCanCast(dictionary(int32(), boolean()), {boolean()});
 
@@ -193,8 +191,6 @@ TEST(Cast, CanCast) {
 
   for (auto from_numeric : kNumericTypes) {
     ExpectCanCast(from_numeric, {boolean()});
-    // XXX: float16() is not part of kNumericTypes
-    ExpectCanCast(float16(), {boolean()});
     ExpectCanCast(from_numeric, kNumericTypes);
     ExpectCanCast(from_numeric, {utf8(), large_utf8()});
     ExpectCanCast(dictionary(int32(), from_numeric), {from_numeric});
@@ -205,8 +201,6 @@ TEST(Cast, CanCast) {
   for (auto from_base_binary : kBaseBinaryTypes) {
     ExpectCanCast(from_base_binary, {boolean()});
     ExpectCanCast(from_base_binary, kNumericTypes);
-    // XXX: float16() is not part of kNumericTypes
-    ExpectCanCast(from_base_binary, {float16()});
     ExpectCanCast(from_base_binary, kBaseBinaryTypes);
     ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
 

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -590,6 +590,13 @@ void AddArraySortingKernels(VectorKernel base, VectorFunction* func) {
     base.exec = GenerateNumeric<ExecTemplate, UInt64Type>(*physical_type);
     DCHECK_OK(func->AddKernel(base));
   }
+  {
+    // XXX: float16() is not in NumericTypes() yet
+    auto physical_type = GetPhysicalType(float16());
+    base.signature = KernelSignature::Make({float16()}, uint64());
+    base.exec = GenerateNumeric<ExecTemplate, UInt64Type>(*physical_type);
+    DCHECK_OK(func->AddKernel(base));
+  }
   for (const auto& ty : TemporalTypes()) {
     auto physical_type = GetPhysicalType(ty);
     base.signature = KernelSignature::Make({ty->id()}, uint64());

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -592,7 +592,8 @@ void AddArraySortingKernels(VectorKernel base, VectorFunction* func) {
   }
   {
     // XXX: float16() is not in NumericTypes() yet
-    auto physical_type = GetPhysicalType(float16());
+    auto physical_type = float16();
+    DCHECK_EQ(physical_type->id(), GetPhysicalType(float16())->id());
     base.signature = KernelSignature::Make({float16()}, uint64());
     base.exec = GenerateNumeric<ExecTemplate, UInt64Type>(*physical_type);
     DCHECK_OK(func->AddKernel(base));

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -548,6 +548,7 @@ KernelInit GetHashInit(Type::type type_id) {
       return HashInit<RegularHashKernel<UInt8Type, Action>>;
     case Type::INT16:
     case Type::UINT16:
+    case Type::HALF_FLOAT:
       return HashInit<RegularHashKernel<UInt16Type, Action>>;
     case Type::INT32:
     case Type::UINT32:
@@ -695,6 +696,12 @@ void AddHashKernels(VectorFunction* func, VectorKernel base, OutputType out_ty) 
   for (const auto& ty : PrimitiveTypes()) {
     base.init = GetHashInit<Action>(ty->id());
     base.signature = KernelSignature::Make({ty}, out_ty);
+    DCHECK_OK(func->AddKernel(base));
+  }
+  {
+    // XXX: float16() is not in PrimitiveTypes()
+    base.init = GetHashInit<Action>(Type::HALF_FLOAT);
+    base.signature = KernelSignature::Make({float16()}, out_ty);
     DCHECK_OK(func->AddKernel(base));
   }
 

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -1003,8 +1003,8 @@ Status ChunkedArrayFromJSON(const std::shared_ptr<DataType>& type,
   ArrayVector out_chunks;
   out_chunks.reserve(json_strings.size());
   for (const std::string& chunk_json : json_strings) {
-    out_chunks.emplace_back();
-    ARROW_ASSIGN_OR_RAISE(out_chunks.back(), ArrayFromJSON(type, chunk_json));
+    auto& out_chunk = out_chunks.emplace_back();
+    ARROW_ASSIGN_OR_RAISE(out_chunk, ArrayFromJSON(type, chunk_json));
   }
   *out = std::make_shared<ChunkedArray>(std::move(out_chunks), type);
   return Status::OK();


### PR DESCRIPTION
### Rationale for this change

To simplify loops and unit tests involving numeric types. Special-casing float16 adds complexity.

### What changes are included in this PR?

 - Complete the set of casts involving half-float casts (with the exception of half-float -> decimal128/256 casts)
 - Make half-floats supported in hash kernels (kernels defined in terms of the equality of physical representation of values)

### Are these changes tested?

By existing tests that are now extended to run with `float16` as input.
* GitHub Issue: #43017