### PR TITLE
GH-43020: [Java] Simplify flight.properties generation

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -21,6 +21,3 @@ arrow-git.properties
 cmake_install.cmake
 install_manifest.txt
 target/
-
-# Generated properties file
-flight/flight-sql-jdbc-core/src/main/resources/properties/flight.properties

--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -31,13 +31,6 @@ under the License.
   <description>Core implementation of JDBC driver based on Arrow Flight SQL.</description>
   <url>https://arrow.apache.org</url>
 
-  <properties>
-    <org.apache.arrow.flight.name>${project.parent.groupId}:${project.parent.artifactId}</org.apache.arrow.flight.name>
-    <org.apache.arrow.flight.version>${project.parent.version}</org.apache.arrow.flight.version>
-    <org.apache.arrow.flight.jdbc-driver.name>${project.name}</org.apache.arrow.flight.jdbc-driver.name>
-    <org.apache.arrow.flight.jdbc-driver.version>${project.version}</org.apache.arrow.flight.jdbc-driver.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.arrow</groupId>
@@ -147,6 +140,13 @@ under the License.
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -156,22 +156,6 @@ under the License.
             <arrow.test.dataRoot>${project.basedir}/../../../testing/data</arrow.test.dataRoot>
           </systemPropertyVariables>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>properties-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>write-project-properties-to-file</id>
-            <goals>
-              <goal>write-project-properties</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <outputFile>src/main/resources/properties/flight.properties</outputFile>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/java/flight/flight-sql-jdbc-core/src/main/resources/properties/flight.properties
+++ b/java/flight/flight-sql-jdbc-core/src/main/resources/properties/flight.properties
@@ -1,0 +1,4 @@
+org.apache.arrow.flight.jdbc-driver.name=${project.name}
+org.apache.arrow.flight.jdbc-driver.version=${project.version}
+org.apache.arrow.flight.name=${project.groupId}\:${project.artifactId}
+org.apache.arrow.flight.version=${project.version}

--- a/java/flight/flight-sql-jdbc-core/src/main/resources/properties/flight.properties
+++ b/java/flight/flight-sql-jdbc-core/src/main/resources/properties/flight.properties
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 org.apache.arrow.flight.jdbc-driver.name=${project.name}
 org.apache.arrow.flight.jdbc-driver.version=${project.version}
 org.apache.arrow.flight.name=${project.groupId}\:${project.artifactId}


### PR DESCRIPTION
### Rationale for this change

`flight.properties` is a generated file created under `src/main/resources` (which is not a valid location per convention) which dumps *ALL* maven properties instead of the 4 properties needed by the driver.

### What changes are included in this PR?

Replace use of plugin by a template file located under `src/main/resources/properties/flight.properties` and configure Maven to perform variable substitution when copying the resources under the output directory.

### Are these changes tested?

Yes, through existing tests

### Are there any user-facing changes?

No


* GitHub Issue: #43020