### PR TITLE
GH-43033: [CI][Docker] Enable linter for python-wheel-windows-test-vs2019

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,13 @@ repos:
     hooks:
       - id: hadolint-docker
         name: Docker Format
-        exclude: ^dev/.*$
+        # We can enable this after we fix all existing lint failures.
+        # files: (/Dockerfile|\.dockerfile)$
+        files: >-
+          (
+          ?^ci/docker/python-wheel-windows-test-vs2019\.dockerfile$|
+          )
+        types: []
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -22,6 +22,8 @@
 # contains choco and vs2019 preinstalled
 FROM abrarov/msvc-2019:2.11.0
 
+# hadolint shell=cmd.exe
+
 # Add unix tools to path
 RUN setx path "%path%;C:\Program Files\Git\usr\bin"
 
@@ -40,8 +42,8 @@ RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10" && setx PATH "%PATH%;C:\P
     (if "%python%"=="3.10" setx PYTHON_VERSION "3.10.11" && setx PATH "%PATH%;C:\Python310;C:\Python310\Scripts") & \
     (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.5" && setx PATH "%PATH%;C:\Python311;C:\Python311\Scripts") & \
     (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.0" && setx PATH "%PATH%;C:\Python312;C:\Python312\Scripts")
-RUN choco install -r -y --no-progress python --version=%PYTHON_VERSION%
-RUN python -m pip install -U pip setuptools
 
 # Install archiver to extract xz archives
-RUN choco install --no-progress -r -y archiver
+RUN choco install -r -y --no-progress python --version=%PYTHON_VERSION% & \
+    python -m pip install --no-cache-dir -U pip setuptools & \
+    choco install --no-progress -r -y archiver


### PR DESCRIPTION
### Rationale for this change

The current result:

```text
ci/docker/python-wheel-windows-test-vs2019.dockerfile:38 SC1072 error: Expected 'then'. Fix any mentioned problems and try again.
ci/docker/python-wheel-windows-test-vs2019.dockerfile:43 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
ci/docker/python-wheel-windows-test-vs2019.dockerfile:44 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
ci/docker/python-wheel-windows-test-vs2019.dockerfile:44 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
ci/docker/python-wheel-windows-test-vs2019.dockerfile:47 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
```

### What changes are included in this PR?

* Add `hadolint shell=cmd.exe`
* Consolidate multiple `RUN`s
* Don't use cache with `pip`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43033