### PR TITLE
GH-43040: [C++] Reduce the recursion of many-join test

### DIFF
--- a/cpp/src/arrow/acero/hash_join_node_test.cc
+++ b/cpp/src/arrow/acero/hash_join_node_test.cc
@@ -3220,7 +3220,7 @@ TEST(HashJoin, ManyJoins) {
   // stack), which is essentially the recursive usage of the temp vector stack.
 
   // A fair number of joins to guarantee temp vector stack overflow before GH-41335.
-  const int num_joins = 64;
+  const int num_joins = 16;
 
   // `ExecBatchBuilder::num_rows_max()` is the number of rows for swiss join to accumulate
   // before outputting.

--- a/cpp/src/arrow/acero/hash_join_node_test.cc
+++ b/cpp/src/arrow/acero/hash_join_node_test.cc
@@ -3220,7 +3220,7 @@ TEST(HashJoin, ManyJoins) {
   // stack), which is essentially the recursive usage of the temp vector stack.
 
   // A fair number of joins to guarantee temp vector stack overflow before GH-41335.
-  const int num_joins = 16;
+  const int num_joins = 72;
 
   // `ExecBatchBuilder::num_rows_max()` is the number of rows for swiss join to accumulate
   // before outputting.

--- a/cpp/src/arrow/acero/hash_join_node_test.cc
+++ b/cpp/src/arrow/acero/hash_join_node_test.cc
@@ -3220,7 +3220,7 @@ TEST(HashJoin, ManyJoins) {
   // stack), which is essentially the recursive usage of the temp vector stack.
 
   // A fair number of joins to guarantee temp vector stack overflow before GH-41335.
-  const int num_joins = 72;
+  const int num_joins = 16;
 
   // `ExecBatchBuilder::num_rows_max()` is the number of rows for swiss join to accumulate
   // before outputting.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The current recursion 64 in many-join test is too aggressive so stack (the C program stack) overflow may happen on alpine or emscripten causing issues like #43040 .

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Reduce the recursion to 16, which is strong enough for the purpose of #41335 which introduced this test.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Change is test.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43040