### PR TITLE
GH-39220: [Python] Let RecordBatch.filter accept a boolean expression in addition to mask array

### DIFF
--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2959,13 +2959,29 @@ def test_table_join_collisions():
 
 
 @pytest.mark.acero
-def test_table_filter_expression():
+@pytest.mark.parametrize('cls', [(pa.Table), (pa.RecordBatch)])
+def test_table_filter_expression(cls):
+    t1 = cls.from_pydict({
+        "colA": [1, 2, 3, 6],
+        "colB": [10, 20, None, 60],
+        "colVals": ["a", "b", "c", "f"]
+    })
+
+    result = t1.filter(pc.field("colB") < 50)
+    assert result == cls.from_pydict({
+        "colA": [1, 2],
+        "colB": [10, 20],
+        "colVals": ["a", "b"]
+    })
+
+
+@pytest.mark.acero
+def test_table_filter_expression_chunks():
     t1 = pa.table({
         "colA": [1, 2, 6],
         "colB": [10, 20, 60],
         "colVals": ["a", "b", "f"]
     })
-
     t2 = pa.table({
         "colA": [99, 2, 1],
         "colB": [99, 20, 10],


### PR DESCRIPTION
### Rationale for this change

`Table.filter()` already accepted either a boolean mask array or a boolean expression. But the equivalent method on `RecordBatch` only accepted the array. This makes both methods consistent in accepting both types of mask.

### What changes are included in this PR?

Consolidate the `Table.filter` and `RecordBatch.fitler` methods into a single shared method on the base class, and expanded the `_filter_table` Acero helper to also work with RecordBatch in addition to Table (and ensure to return a batch if the input was a batch)

### Are these changes tested?
Yes
* GitHub Issue: #39220