### PR TITLE
GH-42014: [Python] Let StructArray.from_array accept a type in addition to names or fields

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3982,7 +3982,7 @@ cdef class StructArray(Array):
         Construct StructArray from collection of arrays representing
         each field in the struct.
 
-        Either field names, field instances or a structtype must be passed.
+        Either field names, field instances or a struct type must be passed.
 
         Parameters
         ----------

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3976,13 +3976,13 @@ cdef class StructArray(Array):
         return [pyarrow_wrap_array(arr) for arr in arrays]
 
     @staticmethod
-    def from_arrays(arrays, names=None, fields=None, structtype=None, mask=None,
-                    memory_pool=None):
+    def from_arrays(arrays, names=None, fields=None, mask=None,
+                    memory_pool=None, type=None):
         """
         Construct StructArray from collection of arrays representing
         each field in the struct.
 
-        Either field names or field instances must be passed.
+        Either field names, field instances or a structtype must be passed.
 
         Parameters
         ----------
@@ -3991,12 +3991,12 @@ cdef class StructArray(Array):
             Field names for each struct child.
         fields : List[Field] (optional)
             Field instances for each struct child.
-        structtype : pyarrow.StructType (optional)
-            Struct type for name and type of each child. 
         mask : pyarrow.Array[bool] (optional)
             Indicate which values are null (True) or not null (False).
         memory_pool : MemoryPool (optional)
             For memory allocations, if required, otherwise uses default pool.
+        type : pyarrow.StructType (optional)
+            Struct type for name and type of each child. 
 
         Returns
         -------
@@ -4015,12 +4015,12 @@ cdef class StructArray(Array):
             Field py_field
             DataType struct_type
 
-        if fields is not None and structtype is not None:
+        if fields is not None and type is not None:
             raise ValueError('Must pass either fields or type, not both')
-        
-        if structtype is not None:
+
+        if type is not None:
             fields = []
-            for field in structtype:
+            for field in type:
                 fields.append(field)
 
         if names is None and fields is None:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3976,7 +3976,7 @@ cdef class StructArray(Array):
         return [pyarrow_wrap_array(arr) for arr in arrays]
 
     @staticmethod
-    def from_arrays(arrays, names=None, fields=None, mask=None,
+    def from_arrays(arrays, names=None, fields=None, structtype=None, mask=None,
                     memory_pool=None):
         """
         Construct StructArray from collection of arrays representing
@@ -3991,6 +3991,8 @@ cdef class StructArray(Array):
             Field names for each struct child.
         fields : List[Field] (optional)
             Field instances for each struct child.
+        structtype : pyarrow.StructType (optional)
+            Struct type for name and type of each child. 
         mask : pyarrow.Array[bool] (optional)
             Indicate which values are null (True) or not null (False).
         memory_pool : MemoryPool (optional)
@@ -4012,6 +4014,14 @@ cdef class StructArray(Array):
             ssize_t i
             Field py_field
             DataType struct_type
+
+        if fields is not None and structtype is not None:
+            raise ValueError('Must pass either fields or type, not both')
+        
+        if structtype is not None:
+            fields = []
+            for field in structtype:
+                fields.append(field)
 
         if names is None and fields is None:
             raise ValueError('Must pass either names or fields')

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -709,7 +709,7 @@ def test_struct_from_arrays():
 
     # From structtype
     structtype = pa.struct([fa, fb, fc])
-    arr = pa.StructArray.from_arrays([a, b, c], structtype=structtype)
+    arr = pa.StructArray.from_arrays([a, b, c], type=structtype)
     assert arr.type == pa.struct([fa, fb, fc])
     assert not arr.type[0].nullable
     assert arr.to_pylist() == expected_list

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -707,6 +707,13 @@ def test_struct_from_arrays():
     assert not arr.type[0].nullable
     assert arr.to_pylist() == expected_list
 
+    # From structtype
+    structtype = pa.struct([fa, fb, fc])
+    arr = pa.StructArray.from_arrays([a, b, c], structtype=structtype)
+    assert arr.type == pa.struct([fa, fb, fc])
+    assert not arr.type[0].nullable
+    assert arr.to_pylist() == expected_list
+
     with pytest.raises(ValueError):
         pa.StructArray.from_arrays([a, b, c], fields=[fa, fb])
 


### PR DESCRIPTION
### Rationale for this change

StructArray.from_array currently accepts names or fields to create the struct array. However if you already have a struct type it's more convenient to pass that in and allow the function to use it to build the StructArray instead of the user having to pull out the fields themselves. 

### What changes are included in this PR?

Add a new argument to StructArray.from_array called structtype. The function will prevent both fields and structype from being passed by raising a ValueError. If structtype is not null then the existing fields argument is set from the structtype fields. This allows all of the existing code in the function to remain untouched. 

### Are these changes tested?

Yes. Testing creating the structarray from fields a test is added to make sure that a struct type can be used to create the array.

### Are there any user-facing changes?
Yes, the StructArray.from_arrays function now has an extra optional argument
* GitHub Issue: #42014