### PR TITLE
GH-43048: [JAVA] Fix IndexOutOfBoundsException message by reporting index correctly

### DIFF
--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -954,7 +954,7 @@ public final class ArrowBuf implements AutoCloseable {
     if (isOutOfBounds(srcIndex, length, src.capacity())) {
       throw new IndexOutOfBoundsException(
           String.format(
-              "index: %d, length: %d (expected: range(0, %d))", index, length, src.capacity()));
+              "index: %d, length: %d (expected: range(0, %d))", srcIndex, length, src.capacity()));
     }
     if (length != 0) {
       // copy length bytes of data from src ArrowBuf starting at


### PR DESCRIPTION
The detailed message for IndexOutOfBoundsException should report the srcIndex that was previously passed to the isOutOfBounds() check

Fixes https://github.com/apache/arrow/issues/43048
* GitHub Issue: #43048