### PR TITLE
WIP: [Java] Require Java 22 to build Arrow

### DIFF
--- a/.env
+++ b/.env
@@ -61,7 +61,8 @@ GCC_VERSION=""
 GO=1.21.8
 STATICCHECK=v0.4.7
 HDFS=3.2.1
-JDK=11
+JDK=22
+TEST_JDK=11
 KARTOTHEK=latest
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=14

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,12 +32,13 @@ env:
 jobs:
 
   complete:
-    name: AMD64 Debian 12 Complete Documentation
+    name: AMD64 Ubuntu 24.04 Complete Documentation
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 150
     env:
-      JDK: 17
+      JDK: 22
+      UBUNTU: 24.04
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
@@ -50,8 +51,8 @@ jobs:
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
         with:
           path: .docker
-          key: debian-docs-${{ hashFiles('cpp/**') }}
-          restore-keys: debian-docs-
+          key: ubuntu-docs-${{ hashFiles('cpp/**') }}
+          restore-keys: ubuntu-docs-
       - name: Setup Python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
@@ -62,8 +63,8 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          JDK: 17
-        run: archery docker run debian-docs
+          JDK: 22
+        run: archery docker run ubuntu-docs
       - name: Docker Push
         if: >-
           success() &&
@@ -74,4 +75,4 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push debian-docs
+        run: archery docker push ubuntu-docs

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -62,7 +62,8 @@ jobs:
         maven: [3.9.6]
         image: [java]
     env:
-      JDK: ${{ matrix.jdk }}
+      JDK: 22
+      TEST_JDK: ${{ matrix.jdk }}
       MAVEN: ${{ matrix.maven }}
     steps:
       - name: Checkout Arrow
@@ -91,6 +92,7 @@ jobs:
           archery docker run \
             -e CI=true \
             -e "DEVELOCITY_ACCESS_KEY=$DEVELOCITY_ACCESS_KEY" \
+            -e "TEST_JDK=$TEST_JDK" \
             ${{ matrix.image }}
       - name: Docker Push
         if: >-
@@ -117,8 +119,10 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          java-version: |
+            ${{ matrix.jdk }}
+            22
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:
@@ -128,11 +132,13 @@ jobs:
         shell: bash
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          TEST_JDK: ${{ matrix.jdk }}
         run: ci/scripts/java_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          TEST_JDK: ${{ matrix.jdk }}
         run: ci/scripts/java_test.sh $(pwd) $(pwd)/build
 
   windows:
@@ -148,8 +154,10 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
+          java-version: |
+            ${{ matrix.jdk }}
+            22
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:
@@ -159,9 +167,11 @@ jobs:
         shell: bash
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          TEST_JDK: ${{ matrix.jdk }}
         run: ci/scripts/java_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+          TEST_JDK: ${{ matrix.jdk }}
         run: ci/scripts/java_test.sh $(pwd) $(pwd)/build

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   docker:
-    name: AMD64 manylinux2014 Java JNI
+    name: AMD64 manylinux Java JNI
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 240
@@ -68,8 +68,8 @@ jobs:
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
         with:
           path: .docker
-          key: java-jni-manylinux-2014-${{ hashFiles('cpp/**', 'java/**') }}
-          restore-keys: java-jni-manylinux-2014-
+          key: java-jni-manylinux-2-28-${{ hashFiles('cpp/**', 'java/**') }}
+          restore-keys: java-jni-manylinux-2-28-
       - name: Setup Python
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
@@ -80,7 +80,7 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: archery docker run java-jni-manylinux-2014
+        run: archery docker run java-jni-manylinux-2-28
       - name: Docker Push
         if: >-
           success() &&
@@ -91,7 +91,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push java-jni-manylinux-2014
+        run: archery docker push java-jni-manylinux-2-28
 
   docker_integration_python:
     name: AMD64 Conda Java C Data Interface Integration
@@ -125,6 +125,7 @@ jobs:
           archery docker run \
             -e CI=true \
             -e "DEVELOCITY_ACCESS_KEY=$DEVELOCITY_ACCESS_KEY" \
+            -e "TEST_JDK=$TEST_JDK" \
             conda-python-java-integration
       - name: Docker Push
         if: >-

--- a/ci/docker/conda-python-jpype.dockerfile
+++ b/ci/docker/conda-python-jpype.dockerfile
@@ -20,7 +20,7 @@ ARG arch=amd64
 ARG python=3.8
 FROM ${repo}:${arch}-conda-python-${python}
 
-ARG jdk=11
+ARG jdk=22
 ARG maven=3.8.7
 RUN mamba install -q -y \
         maven=${maven} \

--- a/ci/docker/java-jni-manylinux.dockerfile
+++ b/ci/docker/java-jni-manylinux.dockerfile
@@ -33,7 +33,7 @@ RUN vcpkg install \
         --x-feature=s3
 
 # Install Java
-ARG java=11
+ARG java=22
 ARG maven=3.9.3
 RUN yum install -y java-$java-openjdk-devel && \
       yum clean all && \

--- a/ci/docker/java.dockerfile
+++ b/ci/docker/java.dockerfile
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM maven:3.9.6-eclipse-temurin-22
+
+COPY --from=maven:3.9.6-eclipse-temurin-8 /opt/java/openjdk /opt/java/openjdk8
+COPY --from=maven:3.9.6-eclipse-temurin-11 /opt/java/openjdk /opt/java/openjdk11
+COPY --from=maven:3.9.6-eclipse-temurin-17 /opt/java/openjdk /opt/java/openjdk17
+COPY --from=maven:3.9.6-eclipse-temurin-21 /opt/java/openjdk /opt/java/openjdk21
+
+
+env JAVA8_HOME /opt/java/openjdk8
+env JAVA11_HOME /opt/java/openjdk11
+env JAVA17_HOME /opt/java/openjdk17
+env JAVA21_HOME /opt/java/openjdk21
+env JAVA22_HOME /opt/java/openjdk
+
+RUN find "$JAVA8_HOME/lib" "$JAVA11_HOME/lib" "$JAVA17_HOME/lib" "$JAVA21_HOME/lib" "$JAVA22_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
+    ldconfig;
+
+COPY ci/maven-toolchains.xml /usr/share/maven/conf/toolchains.xml
+
+CMD ["mvn"]

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -23,21 +23,18 @@ ARG jdk=11
 
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
-# See R install instructions at https://cloud.r-project.org/bin/linux/
+# See R install instructions at https://cloud.r-project.org/bin/linux/ubuntu
 RUN apt-get update -y && \
     apt-get install -y \
         apt-transport-https \
+        software-properties-common \
         dirmngr \
         gpg \
         lsb-release && \
-    gpg --keyserver keyserver.ubuntu.com \
-        --recv-key 95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7 && \
-    gpg --export 95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7 | \
-        gpg --no-default-keyring \
-            --keyring /usr/share/keyrings/cran.gpg \
-            --import - && \
-    echo "deb [signed-by=/usr/share/keyrings/cran.gpg] https://cloud.r-project.org/bin/linux/$(lsb_release -is | tr 'A-Z' 'a-z') $(lsb_release -cs)-cran40/" | \
-        tee /etc/apt/sources.list.d/cran.list && \
+    wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | \
+        tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc && \
+    # NOTE: Only R >= 4.0 is available in this repo
+    add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu '$(lsb_release -cs)'-cran40/' && \
     if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
         sed -i \
             -e 's/main$/main contrib non-free non-free-firmware/g' \
@@ -47,8 +44,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         autoconf-archive \
         automake \
-        chromium \
-        chromium-sandbox \
+        chromium-browser \
         curl \
         doxygen \
         gi-docgen \

--- a/ci/maven-toolchains.xml
+++ b/ci/maven-toolchains.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+<toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0 http://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>11</version>
+      <vendor>openjdk</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>${env.JAVA11_HOME}</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>17</version>
+      <vendor>openjdk</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>${env.JAVA17_HOME}</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>21</version>
+      <vendor>openjdk</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>${env.JAVA21_HOME}</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>22</version>
+      <vendor>openjdk</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>${env.JAVA22_HOME}</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -98,6 +98,10 @@ if [ "${ARROW_JAVA_JNI}" = "ON" ]; then
   mvn="${mvn} -Darrow.cpp.build.dir=${java_jni_dist_dir} -Parrow-jni"
 fi
 
+if [ "${TEST_JDK}" != "" ]; then
+  mvn="${mvn} -Darrow.test.jdk-version=${TEST_JDK}"
+fi
+
 ${mvn} clean install
 
 if [ "${BUILD_DOCS_JAVA}" == "ON" ]; then

--- a/ci/scripts/java_jni_manylinux_build.sh
+++ b/ci/scripts/java_jni_manylinux_build.sh
@@ -35,9 +35,14 @@ echo "=== Clear output directories and leftovers ==="
 rm -rf ${build_dir}
 
 echo "=== Building Arrow C++ libraries ==="
-devtoolset_version=$(rpm -qa "devtoolset-*-gcc" --queryformat %{VERSION} | \
+devtoolset_version=$(rpm -qa "devtoolset-*-gcc" "gcc-toolset-*-gcc" --queryformat %{VERSION} | \
                        grep -o "^[0-9]*")
-devtoolset_include_cpp="/opt/rh/devtoolset-${devtoolset_version}/root/usr/include/c++/${devtoolset_version}"
+if [ -d "/opt/rh/devtoolset-${devtoolset_version}" ]; then
+  devtoolset_include_cpp="/opt/rh/devtoolset-${devtoolset_version}/root/usr/include/c++/${devtoolset_version}"
+else
+  devtoolset_include_cpp="/opt/rh/gcc-toolset-${devtoolset_version}/root/usr/include/c++/${devtoolset_version}"
+fi
+
 : ${ARROW_ACERO:=ON}
 export ARROW_ACERO
 : ${ARROW_BUILD_TESTS:=ON}

--- a/ci/scripts/java_test.sh
+++ b/ci/scripts/java_test.sh
@@ -35,6 +35,10 @@ mvn="${mvn} -T 2C"
 
 pushd ${source_dir}
 
+if [ "${TEST_JDK}" != "" ]; then
+  mvn="${mvn} -Darrow.test.jdk-version=${TEST_JDK}"
+fi
+
 ${mvn} clean test
 
 projects=()

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -57,7 +57,7 @@ jobs:
           archery docker run \
             -e ARROW_JAVA_BUILD=OFF \
             -e ARROW_JAVA_TEST=OFF \
-            java-jni-manylinux-2014
+            java-jni-manylinux-2-28
       - name: Compress into single artifact to keep directory structure
         run: tar -cvzf arrow-shared-libs-linux-{{ arch }}.tar.gz arrow/java-dist/
       - name: Upload artifacts
@@ -69,7 +69,7 @@ jobs:
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker image
         shell: bash
-        run: archery docker push java-jni-manylinux-2014
+        run: archery docker push java-jni-manylinux-2-28
     {% endif %}
 
   build-cpp-macos:
@@ -151,7 +151,7 @@ jobs:
         run: |
           set -e
           # make brew Java available to CMake
-          export JAVA_HOME=$(brew --prefix openjdk@11)/libexec/openjdk.jdk/Contents/Home
+          export JAVA_HOME=$(brew --prefix openjdk@22)/libexec/openjdk.jdk/Contents/Home
           arrow/ci/scripts/java_jni_macos_build.sh \
             $GITHUB_WORKSPACE/arrow \
             $GITHUB_WORKSPACE/arrow/cpp-build \
@@ -172,7 +172,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '22'
           distribution: 'temurin'
       - name: Download Timezone Database
         shell: bash

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -65,7 +65,7 @@ groups:
     - r-binary-packages
     - ubuntu-*
     - wheel-*
-    - test-debian-*-docs
+    - test-ubuntu-*-docs
 
 {############################# Testing tasks #################################}
 
@@ -1465,15 +1465,16 @@ tasks:
   {% endfor %}
 
   # be sure to update binary-task.rb when upgrading ubuntu
-  test-debian-12-docs:
+  test-ubuntu-24.04-docs:
     ci: github
     template: docs/github.linux.yml
     params:
       env:
-        JDK: 17
+        JDK: 22
+        UBUNTU: 24.04
       pr_number: Unset
       flags: "-v $PWD/build/:/build/"
-      image: debian-docs
+      image: ubuntu-docs
       publish: false
     artifacts:
       - docs.tar.gz
@@ -1601,8 +1602,9 @@ tasks:
     template: docs/github.linux.yml
     params:
       env:
-        JDK: 17
+        JDK: 22
+        UBUNTU: 24.04
       pr_number: Unset
       flags: "-v $PWD/build/:/build/"
-      image: debian-docs
+      image: ubuntu-docs
       publish: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,8 +132,7 @@ x-hierarchy:
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby
-    - debian-python:
-      - debian-docs
+    - debian-python
   - debian-go:
     - debian-go-cgo
     - debian-go-cgo-python
@@ -147,7 +146,8 @@ x-hierarchy:
     - ubuntu-c-glib:
       - ubuntu-ruby
     - ubuntu-lint
-    - ubuntu-python
+    - ubuntu-python:
+      - ubuntu-docs
     - ubuntu-python-sdist-test
     - ubuntu-r
     - ubuntu-r-only-r
@@ -169,9 +169,9 @@ x-hierarchy:
   # helper services
   - impala
   - postgres
-  - python-wheel-manylinux-2014:
-    - java-jni-manylinux-2014
-  - python-wheel-manylinux-2-28
+  - python-wheel-manylinux-2014
+  - python-wheel-manylinux-2-28:
+    - java-jni-manylinux-2-28
   - python-wheel-manylinux-test-imports
   - python-wheel-manylinux-test-unittests
   - python-wheel-windows-vs2019
@@ -1197,22 +1197,22 @@ services:
         target: "C:/arrow"
     command: arrow\\ci\\scripts\\python_wheel_windows_test.bat
 
-  java-jni-manylinux-2014:
-    image: ${REPO}:${ARCH}-java-jni-manylinux-2014-vcpkg-${VCPKG}
+  java-jni-manylinux-2-28:
+    image: ${REPO}:${ARCH}-java-jni-manylinux-2-28-vcpkg-${VCPKG}
     build:
       args:
-        base: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
-        java: 11
+        base: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2-28-vcpkg-${VCPKG}
+        java: 22
       context: .
-      dockerfile: ci/docker/java-jni-manylinux-201x.dockerfile
+      dockerfile: ci/docker/java-jni-manylinux.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-java-jni-manylinux-2014-vcpkg-${VCPKG}
+        - ${REPO}:${ARCH}-java-jni-manylinux-2-28-vcpkg-${VCPKG}
     environment:
       <<: [*common, *ccache]
     volumes:
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_PREFIX}maven-cache:/root/.m2:delegated
-      - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux2014-ccache:/ccache:delegated
+      - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux-2-28-ccache:/ccache:delegated
     command:
       ["pip install -e /arrow/dev/archery && \
         /arrow/ci/scripts/java_jni_manylinux_build.sh /arrow /build /arrow/java-dist && \
@@ -1747,8 +1747,13 @@ services:
     #   docker-compose run java
     # Parameters:
     #   MAVEN: 3.9.5
-    #   JDK: 11, 17, 21
-    image: ${ARCH}/maven:${MAVEN}-eclipse-temurin-${JDK}
+    #   JDK: 11, 17, 21, 22
+    image: ${REPO}:${ARCH}-java
+    build:
+      context: .
+      dockerfile: ci/docker/java.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-java
     shm_size: *shm-size
     volumes: &java-volumes
       - .:/arrow:delegated
@@ -1775,7 +1780,7 @@ services:
         repo: ${REPO}
         arch: ${ARCH}
         # Use a newer JDK as it seems to improve stability
-        jdk: 17
+        jdk: 22
         maven: ${MAVEN}
         node: ${NODE}
         go: ${GO}
@@ -1794,24 +1799,24 @@ services:
 
   ################################ Docs #######################################
 
-  debian-docs:
+  ubuntu-docs:
     # Usage:
-    #   docker-compose build debian-cpp
-    #   docker-compose build debian-python
-    #   docker-compose build debian-docs
-    #   docker-compose run --rm debian-docs
-    image: ${REPO}:${ARCH}-debian-${DEBIAN}-docs
+    #   docker-compose build ubuntu-cpp
+    #   docker-compose build ubuntu-python
+    #   docker-compose build ubuntu-docs
+    #   docker-compose run --rm ubuntu-docs
+    image: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-docs
     build:
       context: .
       dockerfile: ci/docker/linux-apt-docs.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-debian-${DEBIAN}-docs
+        - ${REPO}:${ARCH}-ubuntu-${UBUNTU}-docs
       args:
         r: ${R}
         jdk: ${JDK}
         maven: ${MAVEN}
         node: ${NODE}
-        base: ${REPO}:${ARCH}-debian-${DEBIAN}-python-3
+        base: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-python-3
     # This is for Chromium used by Mermaid. Chromium uses namespace
     # isolation for security by default.
     cap_add:
@@ -1830,7 +1835,7 @@ services:
       BUILD_DOCS_JS: "ON"
       BUILD_DOCS_PYTHON: "ON"
       BUILD_DOCS_R: "ON"
-    volumes: *debian-volumes
+    volumes: *ubuntu-volumes
     command: >
       /bin/bash -c "
         sudo mkdir -p /build /ccache &&

--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -32,8 +32,12 @@ Arrow Java uses the `Maven <https://maven.apache.org/>`_ build system.
 
 Building requires:
 
+* JDK 22+
+* Maven 3.6.3+
+
+Testing requires:
+
 * JDK 11+
-* Maven 3+
 
 .. note::
     CI will test all supported JDK LTS versions, plus the latest non-LTS version.

--- a/docs/source/python/getstarted.rst
+++ b/docs/source/python/getstarted.rst
@@ -138,6 +138,7 @@ Loading back the partitioned dataset will detect the chunks
 and will lazily load chunks of data only when iterating over them
 
 .. ipython:: python
+    :okwarning:
 
     import datetime
 

--- a/java/Brewfile
+++ b/java/Brewfile
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-brew "openjdk@11"
+brew "openjdk@22"
 brew "sccache"

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -80,7 +80,7 @@ under the License.
   <properties>
     <arrow.vector.classifier></arrow.vector.classifier>
     <!-- org.apache:apache overrides -->
-    <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>22</minimalJavaBuildVersion>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>

--- a/java/c/src/test/python/integration_tests.py
+++ b/java/c/src/test/python/integration_tests.py
@@ -52,13 +52,15 @@ def setup_jvm():
     # This will be the default behaviour in jpype 0.8+
     kwargs['convertStrings'] = False
 
-    # For debugging purpose please uncomment the following, and include *jvm_args, before **kwargs
-    # in startJVM function call
-    # jvm_args = [
+    jvm_args = [
+        "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
+    ]
+    # For debugging purpose please uncomment the following
+    # jvm_args += [
     #     "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     # ]
 
-    jpype.startJVM(jpype.getDefaultJVMPath(), "-Djava.class.path=" + jar_path, **kwargs)
+    jpype.startJVM(jpype.getDefaultJVMPath(), "-Djava.class.path=" + jar_path, *jvm_args, **kwargs)
 
 
 class Bridge:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,15 +115,10 @@ under the License.
     <!-- List of add-opens arg line arguments for tests -->
     <surefire.add-opens.argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</surefire.add-opens.argLine>
     <!-- org.apache:apache overrides -->
-    <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>22</minimalJavaBuildVersion>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
-    <!--
-      Downgrade maven-jar-plugin until https://github.com/codehaus-plexus/plexus-archiver/issues/332
-      is addressed
-    -->
-    <version.maven-jar-plugin>3.2.2</version.maven-jar-plugin>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
** This is work in progress **

### Rationale for this change

This change demonstrates how to modernize Java toolchain to build Arrow and open opportunities to introduce support for some of the recent Java new features while maintaining compatibility with Java 11.

Java tools used by our build system (like spotless, google-java-format, error-prone, etc.) have dropped support for Java 8 and may do so as well with Java 11 causing the build system to use unsupported versions.

The lack of recent java versions in our toolchains also means that adopting recent Java features (through mechanisms like [multi-release jars ](https://openjdk.org/jeps/238)for example) is currently not possible.

### What changes are included in this PR?

This change makes Java 22 the minimum version required to build Arrow while Java 11 remains the minimum Java version required to use Arrow libraries and tools.

For the purpose of demonstrating the end result, this change actually captures multiple changes:

* ~Compile arrow code base with [`--release`](https://openjdk.org/jeps/247) flag, allowing true Java 11 compilation independently of the JDK version used by the build~
* ~Add support for cross version testing: Introduce a property `arrow.test.jdk-version` which accepts a JDK version to run unit and integration tests with (the JDK needs to be declared in Maven toolchains first), which is different from the JDK version used to build Arrow~
* Finally make Java 22 the minimum version required to build Arrow and update CI builds accordingly (there are several image changes needed to support Java 22. This change also introduces a new multi-JDK docker image)

### Are these changes tested?

Those changes have been tested via github actions as much as possible. I haven't tested with crossbow yet/

### Are there any user-facing changes?

No direct user-facing changes but developers will be required to update their Java toolchain.
