### PR TITLE
GH-43045: [CI][Python] Pin openjdk=17 in python substrait integration

### DIFF
--- a/ci/docker/conda-python-substrait.dockerfile
+++ b/ci/docker/conda-python-substrait.dockerfile
@@ -24,11 +24,16 @@ FROM ${repo}:${arch}-conda-python-${python}
 COPY ci/conda_env_python.txt \
      ci/conda_env_sphinx.txt \
      /arrow/ci/
+
+# Note: openjdk is pinned to <22 because Gradle v8.8 does not
+# support Java 22 yet, which is configured by the
+# install_substrait_consumer.sh script below.
 RUN mamba install -q -y -v \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \
         $([ "$python" == "3.9" ] && echo "pickle5") \
-        python=${python} openjdk=17 \
+        python=${python} \
+        openjdk"<22" \
         nomkl && \
     mamba clean --all
 

--- a/ci/docker/conda-python-substrait.dockerfile
+++ b/ci/docker/conda-python-substrait.dockerfile
@@ -30,6 +30,7 @@ COPY ci/conda_env_python.txt \
 # Newer jdk versions are currently failing
 # due to the recent upgrade to Gradle 8 in
 # install_substrait_consumer.sh.
+# https://github.com/substrait-io/substrait-java/issues/274
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \

--- a/ci/docker/conda-python-substrait.dockerfile
+++ b/ci/docker/conda-python-substrait.dockerfile
@@ -28,7 +28,7 @@ COPY ci/conda_env_python.txt \
 # Note: openjdk is pinned to 17 because the
 # substrait repo currently pins to jdk 17.
 # Newer jdk versions are currently failing
-# due to the recent upgrade to Gradle 8 in
+# due to the recent upgrade to Gradle 8 via
 # install_substrait_consumer.sh.
 # https://github.com/substrait-io/substrait-java/issues/274
 RUN mamba install -q -y \

--- a/ci/docker/conda-python-substrait.dockerfile
+++ b/ci/docker/conda-python-substrait.dockerfile
@@ -24,7 +24,7 @@ FROM ${repo}:${arch}-conda-python-${python}
 COPY ci/conda_env_python.txt \
      ci/conda_env_sphinx.txt \
      /arrow/ci/
-RUN mamba install -q -y \
+RUN mamba install -q -y -v \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \
         $([ "$python" == "3.9" ] && echo "pickle5") \

--- a/ci/docker/conda-python-substrait.dockerfile
+++ b/ci/docker/conda-python-substrait.dockerfile
@@ -25,15 +25,17 @@ COPY ci/conda_env_python.txt \
      ci/conda_env_sphinx.txt \
      /arrow/ci/
 
-# Note: openjdk is pinned to <22 because Gradle v8.8 does not
-# support Java 22 yet, which is configured by the
-# install_substrait_consumer.sh script below.
+# Note: openjdk is pinned to 17 because the
+# substrait repo currently pins to jdk 17.
+# Newer jdk versions are currently failing
+# due to the recent upgrade to Gradle 8 in
+# install_substrait_consumer.sh.
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \
         $([ "$python" == "3.9" ] && echo "pickle5") \
         python=${python} \
-        openjdk"<22" \
+        openjdk=17 \
         nomkl && \
     mamba clean --all
 

--- a/ci/docker/conda-python-substrait.dockerfile
+++ b/ci/docker/conda-python-substrait.dockerfile
@@ -28,7 +28,7 @@ RUN mamba install -q -y -v \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \
         $([ "$python" == "3.9" ] && echo "pickle5") \
-        python=${python} openjdk \
+        python=${python} openjdk=17 \
         nomkl && \
     mamba clean --all
 

--- a/ci/docker/conda-python-substrait.dockerfile
+++ b/ci/docker/conda-python-substrait.dockerfile
@@ -28,7 +28,7 @@ COPY ci/conda_env_python.txt \
 # Note: openjdk is pinned to <22 because Gradle v8.8 does not
 # support Java 22 yet, which is configured by the
 # install_substrait_consumer.sh script below.
-RUN mamba install -q -y -v \
+RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
         --file arrow/ci/conda_env_sphinx.txt \
         $([ "$python" == "3.9" ] && echo "pickle5") \


### PR DESCRIPTION
### Rationale for this change

Substrait builds and releases using JDK 17.

In the Substrait repo, Gradle was updated from 7.4.2 -> 8.8. https://github.com/substrait-io/substrait-java/commit/77e79ad6fc7f100d38bbe12d9e83ad03adff313b

Gradle 8.8 can not be used with openjdk 22 yet, which is the latest version downloaded from condaforge. My testing showed that openjdk 21 also fails with the same error.

### What changes are included in this PR?

* Pin openjdk=17

### Are these changes tested?

Testing via crossbow

### Are there any user-facing changes?

No
* GitHub Issue: #43045