### PR TITLE
GH-43062: [Go] Use calloc instead of malloc

### DIFF
--- a/go/arrow/cdata/cdata.go
+++ b/go/arrow/cdata/cdata.go
@@ -32,7 +32,11 @@ package cdata
 //	memset(out, 0, sizeof(struct ArrowArray));
 //	return out;
 // }
-// struct ArrowArrayStream* get_stream() { return (struct ArrowArrayStream*)malloc(sizeof(struct ArrowArrayStream)); }
+// struct ArrowArrayStream* get_stream() {
+//	struct ArrowArrayStream* out = (struct ArrowArrayStream*)malloc(sizeof(struct ArrowArrayStream));
+//	memset(out, 0, sizeof(struct ArrowArrayStream));
+//	return out;
+// }
 //
 import "C"
 

--- a/go/arrow/cdata/cdata_exports.go
+++ b/go/arrow/cdata/cdata_exports.go
@@ -293,7 +293,7 @@ func (exp *schemaExporter) export(field arrow.Field) {
 func (exp *schemaExporter) finish(out *CArrowSchema) {
 	out.dictionary = nil
 	if exp.dict != nil {
-		out.dictionary = (*CArrowSchema)(C.malloc(C.sizeof_struct_ArrowSchema))
+		out.dictionary = (*CArrowSchema)(C.calloc(C.sizeof_struct_ArrowSchema, C.size_t(1)))
 		exp.dict.finish(out.dictionary)
 	}
 	out.name = C.CString(exp.name)
@@ -413,7 +413,7 @@ func exportArray(arr arrow.Array, out *CArrowArray, outSchema *CArrowSchema) {
 		childPtrs[0], childPtrs[1] = &children[0], &children[1]
 		out.children = (**CArrowArray)(unsafe.Pointer(&childPtrs[0]))
 	case *array.Dictionary:
-		out.dictionary = (*CArrowArray)(C.malloc(C.sizeof_struct_ArrowArray))
+		out.dictionary = (*CArrowArray)(C.calloc(C.sizeof_struct_ArrowArray, C.size_t(1)))
 		exportArray(arr.Dictionary(), out.dictionary, nil)
 	case array.Union:
 		out.n_children = C.int64_t(arr.NumFields())


### PR DESCRIPTION
### Rationale for this change
Relates to https://github.com/apache/arrow-adbc/issues/1931 where we think we may somehow be exposing the Go GC to bad Go pointers due to uninitialized memory.

### What changes are included in this PR?
Use calloc instead of malloc in a few places (or use malloc and clear the memory before returning to Go).

### Are these changes tested?
N/A

### Are there any user-facing changes?
No
* GitHub Issue: #43062