### PR TITLE
[C++] Remove superfluous static constexpr definitions

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -54,60 +54,6 @@ namespace arrow {
 
 using internal::checked_cast;
 
-constexpr Type::type NullType::type_id;
-constexpr Type::type ListType::type_id;
-constexpr Type::type LargeListType::type_id;
-constexpr Type::type ListViewType::type_id;
-constexpr Type::type LargeListViewType::type_id;
-
-constexpr Type::type MapType::type_id;
-
-constexpr Type::type FixedSizeListType::type_id;
-
-constexpr Type::type BinaryType::type_id;
-
-constexpr Type::type BinaryViewType::type_id;
-
-constexpr Type::type LargeBinaryType::type_id;
-
-constexpr Type::type StringType::type_id;
-
-constexpr Type::type StringViewType::type_id;
-
-constexpr Type::type LargeStringType::type_id;
-
-constexpr Type::type FixedSizeBinaryType::type_id;
-
-constexpr Type::type StructType::type_id;
-
-constexpr Type::type Decimal128Type::type_id;
-
-constexpr Type::type Decimal256Type::type_id;
-
-constexpr Type::type SparseUnionType::type_id;
-
-constexpr Type::type DenseUnionType::type_id;
-
-constexpr Type::type Date32Type::type_id;
-
-constexpr Type::type Date64Type::type_id;
-
-constexpr Type::type Time32Type::type_id;
-
-constexpr Type::type Time64Type::type_id;
-
-constexpr Type::type TimestampType::type_id;
-
-constexpr Type::type MonthIntervalType::type_id;
-
-constexpr Type::type DayTimeIntervalType::type_id;
-
-constexpr Type::type MonthDayNanoIntervalType::type_id;
-
-constexpr Type::type DurationType::type_id;
-
-constexpr Type::type DictionaryType::type_id;
-
 std::vector<Type::type> AllTypeIds() {
   return {Type::NA,
           Type::BOOL,

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -550,7 +550,7 @@ namespace detail {
 template <typename DERIVED, typename BASE, Type::type TYPE_ID, typename C_TYPE>
 class ARROW_EXPORT CTypeImpl : public BASE {
  public:
-  static constexpr Type::type type_id = TYPE_ID;
+  static inline constexpr Type::type type_id = TYPE_ID;
   using c_type = C_TYPE;
   using PhysicalType = DERIVED;
 
@@ -581,7 +581,7 @@ class IntegerTypeImpl : public detail::CTypeImpl<DERIVED, IntegerType, TYPE_ID, 
 /// Concrete type class for always-null data
 class ARROW_EXPORT NullType : public DataType {
  public:
-  static constexpr Type::type type_id = Type::NA;
+  static inline constexpr Type::type type_id = Type::NA;
 
   static constexpr const char* type_name() { return "null"; }
 
@@ -754,7 +754,7 @@ constexpr int64_t kBinaryMemoryLimit = std::numeric_limits<int32_t>::max() - 1;
 /// \brief Concrete type class for variable-size binary data
 class ARROW_EXPORT BinaryType : public BaseBinaryType {
  public:
-  static constexpr Type::type type_id = Type::BINARY;
+  static inline constexpr Type::type type_id = Type::BINARY;
   static constexpr bool is_utf8 = false;
   using offset_type = int32_t;
   using PhysicalType = BinaryType;
@@ -782,7 +782,7 @@ class ARROW_EXPORT BinaryType : public BaseBinaryType {
 /// \brief Concrete type class for variable-size binary view data
 class ARROW_EXPORT BinaryViewType : public DataType {
  public:
-  static constexpr Type::type type_id = Type::BINARY_VIEW;
+  static inline constexpr Type::type type_id = Type::BINARY_VIEW;
   static constexpr bool is_utf8 = false;
   using PhysicalType = BinaryViewType;
 
@@ -879,7 +879,7 @@ class ARROW_EXPORT BinaryViewType : public DataType {
 /// \brief Concrete type class for large variable-size binary data
 class ARROW_EXPORT LargeBinaryType : public BaseBinaryType {
  public:
-  static constexpr Type::type type_id = Type::LARGE_BINARY;
+  static inline constexpr Type::type type_id = Type::LARGE_BINARY;
   static constexpr bool is_utf8 = false;
   using offset_type = int64_t;
   using PhysicalType = LargeBinaryType;
@@ -907,7 +907,7 @@ class ARROW_EXPORT LargeBinaryType : public BaseBinaryType {
 /// \brief Concrete type class for variable-size string data, utf8-encoded
 class ARROW_EXPORT StringType : public BinaryType {
  public:
-  static constexpr Type::type type_id = Type::STRING;
+  static inline constexpr Type::type type_id = Type::STRING;
   static constexpr bool is_utf8 = true;
   using PhysicalType = BinaryType;
 
@@ -925,7 +925,7 @@ class ARROW_EXPORT StringType : public BinaryType {
 /// \brief Concrete type class for variable-size string data, utf8-encoded
 class ARROW_EXPORT StringViewType : public BinaryViewType {
  public:
-  static constexpr Type::type type_id = Type::STRING_VIEW;
+  static inline constexpr Type::type type_id = Type::STRING_VIEW;
   static constexpr bool is_utf8 = true;
   using PhysicalType = BinaryViewType;
 
@@ -943,7 +943,7 @@ class ARROW_EXPORT StringViewType : public BinaryViewType {
 /// \brief Concrete type class for large variable-size string data, utf8-encoded
 class ARROW_EXPORT LargeStringType : public LargeBinaryType {
  public:
-  static constexpr Type::type type_id = Type::LARGE_STRING;
+  static inline constexpr Type::type type_id = Type::LARGE_STRING;
   static constexpr bool is_utf8 = true;
   using PhysicalType = LargeBinaryType;
 
@@ -961,7 +961,7 @@ class ARROW_EXPORT LargeStringType : public LargeBinaryType {
 /// \brief Concrete type class for fixed-size binary data
 class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType, public ParametricType {
  public:
-  static constexpr Type::type type_id = Type::FIXED_SIZE_BINARY;
+  static inline constexpr Type::type type_id = Type::FIXED_SIZE_BINARY;
   static constexpr bool is_utf8 = false;
 
   static constexpr const char* type_name() { return "fixed_size_binary"; }
@@ -1040,7 +1040,7 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
 /// If higher precision is needed, consider using Decimal256Type.
 class ARROW_EXPORT Decimal128Type : public DecimalType {
  public:
-  static constexpr Type::type type_id = Type::DECIMAL128;
+  static inline constexpr Type::type type_id = Type::DECIMAL128;
 
   static constexpr const char* type_name() { return "decimal128"; }
 
@@ -1073,7 +1073,7 @@ class ARROW_EXPORT Decimal128Type : public DecimalType {
 /// encoding.
 class ARROW_EXPORT Decimal256Type : public DecimalType {
  public:
-  static constexpr Type::type type_id = Type::DECIMAL256;
+  static inline constexpr Type::type type_id = Type::DECIMAL256;
 
   static constexpr const char* type_name() { return "decimal256"; }
 
@@ -1116,7 +1116,7 @@ class ARROW_EXPORT BaseListType : public NestedType {
 /// list(list(int32)).
 class ARROW_EXPORT ListType : public BaseListType {
  public:
-  static constexpr Type::type type_id = Type::LIST;
+  static inline constexpr Type::type type_id = Type::LIST;
   using offset_type = int32_t;
 
   static constexpr const char* type_name() { return "list"; }
@@ -1147,7 +1147,7 @@ class ARROW_EXPORT ListType : public BaseListType {
 /// LargeListType is like ListType but with 64-bit rather than 32-bit offsets.
 class ARROW_EXPORT LargeListType : public BaseListType {
  public:
-  static constexpr Type::type type_id = Type::LARGE_LIST;
+  static inline constexpr Type::type type_id = Type::LARGE_LIST;
   using offset_type = int64_t;
 
   static constexpr const char* type_name() { return "large_list"; }
@@ -1176,7 +1176,7 @@ class ARROW_EXPORT LargeListType : public BaseListType {
 /// \brief Type class for array of list views
 class ARROW_EXPORT ListViewType : public BaseListType {
  public:
-  static constexpr Type::type type_id = Type::LIST_VIEW;
+  static inline constexpr Type::type type_id = Type::LIST_VIEW;
   using offset_type = int32_t;
 
   static constexpr const char* type_name() { return "list_view"; }
@@ -1210,7 +1210,7 @@ class ARROW_EXPORT ListViewType : public BaseListType {
 /// sizes.
 class ARROW_EXPORT LargeListViewType : public BaseListType {
  public:
-  static constexpr Type::type type_id = Type::LARGE_LIST_VIEW;
+  static inline constexpr Type::type type_id = Type::LARGE_LIST_VIEW;
   using offset_type = int64_t;
 
   static constexpr const char* type_name() { return "large_list_view"; }
@@ -1247,7 +1247,7 @@ class ARROW_EXPORT LargeListViewType : public BaseListType {
 /// Maps can be recursively nested, for example map(utf8, map(utf8, int32)).
 class ARROW_EXPORT MapType : public ListType {
  public:
-  static constexpr Type::type type_id = Type::MAP;
+  static inline constexpr Type::type type_id = Type::MAP;
 
   static constexpr const char* type_name() { return "map"; }
 
@@ -1287,7 +1287,7 @@ class ARROW_EXPORT MapType : public ListType {
 /// \brief Concrete type class for fixed size list data
 class ARROW_EXPORT FixedSizeListType : public BaseListType {
  public:
-  static constexpr Type::type type_id = Type::FIXED_SIZE_LIST;
+  static inline constexpr Type::type type_id = Type::FIXED_SIZE_LIST;
   // While the individual item size is 32-bit, the overall data size
   // (item size * list length) may not fit in a 32-bit int.
   using offset_type = int64_t;
@@ -1323,7 +1323,7 @@ class ARROW_EXPORT FixedSizeListType : public BaseListType {
 /// \brief Concrete type class for struct data
 class ARROW_EXPORT StructType : public NestedType {
  public:
-  static constexpr Type::type type_id = Type::STRUCT;
+  static inline constexpr Type::type type_id = Type::STRUCT;
 
   static constexpr const char* type_name() { return "struct"; }
 
@@ -1427,7 +1427,7 @@ class ARROW_EXPORT UnionType : public NestedType {
 /// Note that, unlike most other types, unions don't have a top-level validity bitmap.
 class ARROW_EXPORT SparseUnionType : public UnionType {
  public:
-  static constexpr Type::type type_id = Type::SPARSE_UNION;
+  static inline constexpr Type::type type_id = Type::SPARSE_UNION;
 
   static constexpr const char* type_name() { return "sparse_union"; }
 
@@ -1456,7 +1456,7 @@ class ARROW_EXPORT SparseUnionType : public UnionType {
 /// Note that, unlike most other types, unions don't have a top-level validity bitmap.
 class ARROW_EXPORT DenseUnionType : public UnionType {
  public:
-  static constexpr Type::type type_id = Type::DENSE_UNION;
+  static inline constexpr Type::type type_id = Type::DENSE_UNION;
 
   static constexpr const char* type_name() { return "dense_union"; }
 
@@ -1472,7 +1472,7 @@ class ARROW_EXPORT DenseUnionType : public UnionType {
 /// \brief Type class for run-end encoded data
 class ARROW_EXPORT RunEndEncodedType : public NestedType {
  public:
-  static constexpr Type::type type_id = Type::RUN_END_ENCODED;
+  static inline constexpr Type::type type_id = Type::RUN_END_ENCODED;
 
   static constexpr const char* type_name() { return "run_end_encoded"; }
 
@@ -1533,7 +1533,7 @@ class ARROW_EXPORT DateType : public TemporalType {
 /// Concrete type class for 32-bit date data (as number of days since UNIX epoch)
 class ARROW_EXPORT Date32Type : public DateType {
  public:
-  static constexpr Type::type type_id = Type::DATE32;
+  static inline constexpr Type::type type_id = Type::DATE32;
   static constexpr DateUnit UNIT = DateUnit::DAY;
   using c_type = int32_t;
   using PhysicalType = Int32Type;
@@ -1556,7 +1556,7 @@ class ARROW_EXPORT Date32Type : public DateType {
 /// Concrete type class for 64-bit date data (as number of milliseconds since UNIX epoch)
 class ARROW_EXPORT Date64Type : public DateType {
  public:
-  static constexpr Type::type type_id = Type::DATE64;
+  static inline constexpr Type::type type_id = Type::DATE64;
   static constexpr DateUnit UNIT = DateUnit::MILLI;
   using c_type = int64_t;
   using PhysicalType = Int64Type;
@@ -1595,7 +1595,7 @@ class ARROW_EXPORT TimeType : public TemporalType, public ParametricType {
 /// since midnight)
 class ARROW_EXPORT Time32Type : public TimeType {
  public:
-  static constexpr Type::type type_id = Type::TIME32;
+  static inline constexpr Type::type type_id = Type::TIME32;
   using c_type = int32_t;
   using PhysicalType = Int32Type;
 
@@ -1614,7 +1614,7 @@ class ARROW_EXPORT Time32Type : public TimeType {
 /// since midnight)
 class ARROW_EXPORT Time64Type : public TimeType {
  public:
-  static constexpr Type::type type_id = Type::TIME64;
+  static inline constexpr Type::type type_id = Type::TIME64;
   using c_type = int64_t;
   using PhysicalType = Int64Type;
 
@@ -1665,7 +1665,7 @@ class ARROW_EXPORT TimestampType : public TemporalType, public ParametricType {
  public:
   using Unit = TimeUnit;
 
-  static constexpr Type::type type_id = Type::TIMESTAMP;
+  static inline constexpr Type::type type_id = Type::TIMESTAMP;
   using c_type = int64_t;
   using PhysicalType = Int64Type;
 
@@ -1711,7 +1711,7 @@ class ARROW_EXPORT IntervalType : public TemporalType, public ParametricType {
 /// in Schema.fbs (years are defined as 12 months).
 class ARROW_EXPORT MonthIntervalType : public IntervalType {
  public:
-  static constexpr Type::type type_id = Type::INTERVAL_MONTHS;
+  static inline constexpr Type::type type_id = Type::INTERVAL_MONTHS;
   using c_type = int32_t;
   using PhysicalType = Int32Type;
 
@@ -1751,7 +1751,7 @@ class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
 
   static_assert(sizeof(DayMilliseconds) == 8,
                 "DayMilliseconds struct assumed to be of size 8 bytes");
-  static constexpr Type::type type_id = Type::INTERVAL_DAY_TIME;
+  static inline constexpr Type::type type_id = Type::INTERVAL_DAY_TIME;
 
   static constexpr const char* type_name() { return "day_time_interval"; }
 
@@ -1791,7 +1791,7 @@ class ARROW_EXPORT MonthDayNanoIntervalType : public IntervalType {
 
   static_assert(sizeof(MonthDayNanos) == 16,
                 "MonthDayNanos struct assumed to be of size 16 bytes");
-  static constexpr Type::type type_id = Type::INTERVAL_MONTH_DAY_NANO;
+  static inline constexpr Type::type type_id = Type::INTERVAL_MONTH_DAY_NANO;
 
   static constexpr const char* type_name() { return "month_day_nano_interval"; }
 
@@ -1818,7 +1818,7 @@ class ARROW_EXPORT DurationType : public TemporalType, public ParametricType {
  public:
   using Unit = TimeUnit;
 
-  static constexpr Type::type type_id = Type::DURATION;
+  static inline constexpr Type::type type_id = Type::DURATION;
   using c_type = int64_t;
   using PhysicalType = Int64Type;
 
@@ -1851,7 +1851,7 @@ class ARROW_EXPORT DurationType : public TemporalType, public ParametricType {
 /// dictionary. Indices are represented by any integer types.
 class ARROW_EXPORT DictionaryType : public FixedWidthType {
  public:
-  static constexpr Type::type type_id = Type::DICTIONARY;
+  static inline constexpr Type::type type_id = Type::DICTIONARY;
 
   static constexpr const char* type_name() { return "dictionary"; }
 


### PR DESCRIPTION
Since C++17, static constexpr members are automatically considered inline.


<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->