### PR TITLE
GH-43060: [C++][Parquet] Optimize memory usage in buffering parquet::ReaderProperties::GetStream

### DIFF
--- a/cpp/src/parquet/properties.cc
+++ b/cpp/src/parquet/properties.cc
@@ -34,10 +34,10 @@ std::shared_ptr<ArrowInputStream> ReaderProperties::GetStream(
     // of source
     PARQUET_ASSIGN_OR_THROW(
         std::shared_ptr<::arrow::io::InputStream> safe_stream,
-        ::arrow::io::RandomAccessFile::GetStream(source, start, num_bytes));
-    PARQUET_ASSIGN_OR_THROW(
-        auto stream, ::arrow::io::BufferedInputStream::Create(buffer_size_, pool_,
-                                                              safe_stream, num_bytes));
+        ::arrow::io::RandomAccessFile::GetStream(std::move(source), start, num_bytes));
+    PARQUET_ASSIGN_OR_THROW(auto stream, ::arrow::io::BufferedInputStream::Create(
+                                             std::min(buffer_size_, num_bytes), pool_,
+                                             safe_stream, num_bytes));
     return stream;
   } else {
     PARQUET_ASSIGN_OR_THROW(auto data, source->ReadAt(start, num_bytes));


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://github.com/apache/arrow/issues/43060 . This patch optimize memory-usage for column is not so large and buffering is enabled.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change buffer-size in `parquet::ReaderProperties::GetStream` and making it not greater than column-chunk size.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered by existing

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43060