### PR TITLE
GH-43070: [C++][Parquet] Check for valid ciphertext length to prevent segfault

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -414,6 +414,7 @@ if(PARQUET_REQUIRE_ENCRYPTION)
                    encryption/test_encryption_util.cc)
   add_parquet_test(encryption-key-management-test
                    SOURCES
+                   encryption/encryption_internal_test.cc
                    encryption/key_management_test.cc
                    encryption/key_metadata_test.cc
                    encryption/key_wrapping_test.cc

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -408,13 +408,13 @@ add_parquet_test(arrow-internals-test SOURCES arrow/path_internal_test.cc
 if(PARQUET_REQUIRE_ENCRYPTION)
   add_parquet_test(encryption-test
                    SOURCES
+                   encryption/encryption_internal_test.cc
                    encryption/write_configurations_test.cc
                    encryption/read_configurations_test.cc
                    encryption/properties_test.cc
                    encryption/test_encryption_util.cc)
   add_parquet_test(encryption-key-management-test
                    SOURCES
-                   encryption/encryption_internal_test.cc
                    encryption/key_management_test.cc
                    encryption/key_metadata_test.cc
                    encryption/key_wrapping_test.cc

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -515,7 +515,8 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
           crypto_ctx_.data_decryptor->PlaintextLength(compressed_len),
           /*shrink_to_fit=*/false));
       compressed_len = crypto_ctx_.data_decryptor->Decrypt(
-          page_buffer->data(), compressed_len, decryption_buffer_->mutable_data());
+          page_buffer->span_as<uint8_t>(),
+          decryption_buffer_->mutable_span_as<uint8_t>());
 
       page_buffer = decryption_buffer_;
     }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -512,7 +512,7 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
     // Decrypt it if we need to
     if (crypto_ctx_.data_decryptor != nullptr) {
       PARQUET_THROW_NOT_OK(decryption_buffer_->Resize(
-          compressed_len - crypto_ctx_.data_decryptor->CiphertextSizeDelta(),
+          crypto_ctx_.data_decryptor->PlaintextLength(compressed_len),
           /*shrink_to_fit=*/false));
       compressed_len = crypto_ctx_.data_decryptor->Decrypt(
           page_buffer->data(), compressed_len, decryption_buffer_->mutable_data());

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -89,6 +89,14 @@ inline const uint8_t* str2bytes(const std::string& str) {
   return reinterpret_cast<const uint8_t*>(cbytes);
 }
 
+inline ::arrow::util::span<const uint8_t> str2span(const std::string& str) {
+  if (str.empty()) {
+    return {};
+  }
+
+  return {reinterpret_cast<const uint8_t*>(str.data()), str.size()};
+}
+
 class PARQUET_EXPORT ColumnEncryptionProperties {
  public:
   class PARQUET_EXPORT Builder {

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -337,6 +337,11 @@ class AesDecryptor::AesDecryptorImpl {
   }
 
   [[nodiscard]] int CiphertextLength(int plaintext_len) const {
+    if (plaintext_len < 0) {
+      std::stringstream ss;
+      ss << "Negative plaintext length " << plaintext_len;
+      throw ParquetException(ss.str());
+    }
     return plaintext_len + ciphertext_size_delta_;
   }
 

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -501,7 +501,7 @@ int AesDecryptor::AesDecryptorImpl::GetCiphertextLength(
 
     return written_ciphertext_len + length_buffer_length_;
   } else {
-    if (ciphertext.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    if (ciphertext.size() > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
       std::stringstream ss;
       ss << "Ciphertext buffer length " << ciphertext.size() << " overflows int32";
       throw ParquetException(ss.str());

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -471,10 +471,12 @@ int AesDecryptor::CiphertextLength(int plaintext_len) const {
 int AesDecryptor::AesDecryptorImpl::GetCiphertextLength(
     span<const uint8_t> ciphertext) const {
   if (length_buffer_length_ > 0) {
-    if (ciphertext.size() < static_cast<size_t>(length_buffer_length_)) {
+    // Note: length_buffer_length_ must be either 0 or kBufferSizeLength
+    if (ciphertext.size() < static_cast<size_t>(kBufferSizeLength)) {
       std::stringstream ss;
       ss << "Ciphertext buffer length " << ciphertext.size()
-         << " is insufficient to read the ciphertext length";
+         << " is insufficient to read the ciphertext length."
+         << " At least " << kBufferSizeLength << " bytes are required.";
       throw ParquetException(ss.str());
     }
 

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -340,10 +340,11 @@ class AesDecryptor::AesDecryptorImpl {
                  int key_len, uint8_t* plaintext);
 };
 
-int AesDecryptor::Decrypt(const uint8_t* plaintext, int plaintext_len, const uint8_t* key,
-                          int key_len, const uint8_t* aad, int aad_len,
-                          uint8_t* ciphertext) {
-  return impl_->Decrypt(plaintext, plaintext_len, key, key_len, aad, aad_len, ciphertext);
+int AesDecryptor::Decrypt(const uint8_t* ciphertext, int ciphertext_len,
+                          const uint8_t* key, int key_len, const uint8_t* aad,
+                          int aad_len, uint8_t* plaintext) {
+  return impl_->Decrypt(ciphertext, ciphertext_len, key, key_len, aad, aad_len,
+                        plaintext);
 }
 
 void AesDecryptor::WipeOut() { impl_->WipeOut(); }

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -463,10 +463,13 @@ int AesDecryptor::AesDecryptorImpl::GcmDecrypt(const uint8_t* ciphertext,
       throw ParquetException("Wrong ciphertext length");
     }
     ciphertext_len = written_ciphertext_len + length_buffer_length_;
-  } else {
-    if (ciphertext_len == 0) {
-      throw ParquetException("Zero ciphertext length");
-    }
+  }
+
+  if (ciphertext_len < length_buffer_length_ + kNonceLength + kGcmTagLength) {
+    std::stringstream ss;
+    ss << "Invalid ciphertext length " << ciphertext_len << ". Expected at least "
+       << length_buffer_length_ + kNonceLength + kGcmTagLength << "\n";
+    throw ParquetException(ss.str());
   }
 
   // Extracting IV and tag
@@ -528,10 +531,13 @@ int AesDecryptor::AesDecryptorImpl::CtrDecrypt(const uint8_t* ciphertext,
       throw ParquetException("Wrong ciphertext length");
     }
     ciphertext_len = written_ciphertext_len;
-  } else {
-    if (ciphertext_len == 0) {
-      throw ParquetException("Zero ciphertext length");
-    }
+  }
+
+  if (ciphertext_len < kNonceLength) {
+    std::stringstream ss;
+    ss << "Invalid ciphertext length " << ciphertext_len << ". Expected at least "
+       << kNonceLength << "\n";
+    throw ParquetException(ss.str());
   }
 
   // Extracting nonce

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -325,7 +325,19 @@ class AesDecryptor::AesDecryptorImpl {
     }
   }
 
-  int ciphertext_size_delta() { return ciphertext_size_delta_; }
+  [[nodiscard]] int PlaintextLength(int ciphertext_len) const {
+    if (ciphertext_len < ciphertext_size_delta_) {
+      std::stringstream ss;
+      ss << "Ciphertext length " << ciphertext_len << " is invalid, expected at least "
+         << ciphertext_size_delta_;
+      throw ParquetException(ss.str());
+    }
+    return ciphertext_len - ciphertext_size_delta_;
+  }
+
+  [[nodiscard]] int CiphertextLength(int plaintext_len) const {
+    return plaintext_len + ciphertext_size_delta_;
+  }
 
  private:
   EVP_CIPHER_CTX* ctx_;
@@ -444,7 +456,13 @@ std::shared_ptr<AesDecryptor> AesDecryptor::Make(
   return decryptor;
 }
 
-int AesDecryptor::CiphertextSizeDelta() { return impl_->ciphertext_size_delta(); }
+int AesDecryptor::PlaintextLength(int ciphertext_len) const {
+  return impl_->PlaintextLength(ciphertext_len);
+}
+
+int AesDecryptor::CiphertextLength(int plaintext_len) const {
+  return impl_->CiphertextLength(plaintext_len);
+}
 
 int AesDecryptor::AesDecryptorImpl::GetCiphertextLength(const uint8_t* ciphertext,
                                                         int ciphertext_buffer_len) const {

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -31,6 +31,7 @@
 #include "parquet/encryption/openssl_internal.h"
 #include "parquet/exception.h"
 
+using ::arrow::util::span;
 using parquet::ParquetException;
 
 namespace parquet::encryption {
@@ -315,10 +316,8 @@ class AesDecryptor::AesDecryptorImpl {
 
   ~AesDecryptorImpl() { WipeOut(); }
 
-  int Decrypt(::arrow::util::span<const uint8_t> ciphertext,
-              ::arrow::util::span<const uint8_t> key,
-              ::arrow::util::span<const uint8_t> aad,
-              ::arrow::util::span<uint8_t> plaintext);
+  int Decrypt(span<const uint8_t> ciphertext, span<const uint8_t> key,
+              span<const uint8_t> aad, span<uint8_t> plaintext);
 
   void WipeOut() {
     if (nullptr != ctx_) {
@@ -350,23 +349,17 @@ class AesDecryptor::AesDecryptorImpl {
 
   /// Get the actual ciphertext length, inclusive of the length buffer length,
   /// and validate that the provided buffer size is large enough.
-  [[nodiscard]] int GetCiphertextLength(
-      ::arrow::util::span<const uint8_t> ciphertext) const;
+  [[nodiscard]] int GetCiphertextLength(span<const uint8_t> ciphertext) const;
 
-  int GcmDecrypt(::arrow::util::span<const uint8_t> ciphertext,
-                 ::arrow::util::span<const uint8_t> key,
-                 ::arrow::util::span<const uint8_t> aad,
-                 ::arrow::util::span<uint8_t> plaintext);
+  int GcmDecrypt(span<const uint8_t> ciphertext, span<const uint8_t> key,
+                 span<const uint8_t> aad, span<uint8_t> plaintext);
 
-  int CtrDecrypt(::arrow::util::span<const uint8_t> ciphertext,
-                 ::arrow::util::span<const uint8_t> key,
-                 ::arrow::util::span<uint8_t> plaintext);
+  int CtrDecrypt(span<const uint8_t> ciphertext, span<const uint8_t> key,
+                 span<uint8_t> plaintext);
 };
 
-int AesDecryptor::Decrypt(::arrow::util::span<const uint8_t> ciphertext,
-                          ::arrow::util::span<const uint8_t> key,
-                          ::arrow::util::span<const uint8_t> aad,
-                          ::arrow::util::span<uint8_t> plaintext) {
+int AesDecryptor::Decrypt(span<const uint8_t> ciphertext, span<const uint8_t> key,
+                          span<const uint8_t> aad, span<uint8_t> plaintext) {
   return impl_->Decrypt(ciphertext, key, aad, plaintext);
 }
 
@@ -471,7 +464,7 @@ int AesDecryptor::CiphertextLength(int plaintext_len) const {
 }
 
 int AesDecryptor::AesDecryptorImpl::GetCiphertextLength(
-    ::arrow::util::span<const uint8_t> ciphertext) const {
+    span<const uint8_t> ciphertext) const {
   if (length_buffer_length_ > 0) {
     if (ciphertext.size() < static_cast<size_t>(length_buffer_length_)) {
       std::stringstream ss;
@@ -510,9 +503,10 @@ int AesDecryptor::AesDecryptorImpl::GetCiphertextLength(
   }
 }
 
-int AesDecryptor::AesDecryptorImpl::GcmDecrypt(
-    ::arrow::util::span<const uint8_t> ciphertext, ::arrow::util::span<const uint8_t> key,
-    ::arrow::util::span<const uint8_t> aad, ::arrow::util::span<uint8_t> plaintext) {
+int AesDecryptor::AesDecryptorImpl::GcmDecrypt(span<const uint8_t> ciphertext,
+                                               span<const uint8_t> key,
+                                               span<const uint8_t> aad,
+                                               span<uint8_t> plaintext) {
   int len;
   int plaintext_len;
 
@@ -578,9 +572,9 @@ int AesDecryptor::AesDecryptorImpl::GcmDecrypt(
   return plaintext_len;
 }
 
-int AesDecryptor::AesDecryptorImpl::CtrDecrypt(
-    ::arrow::util::span<const uint8_t> ciphertext, ::arrow::util::span<const uint8_t> key,
-    ::arrow::util::span<uint8_t> plaintext) {
+int AesDecryptor::AesDecryptorImpl::CtrDecrypt(span<const uint8_t> ciphertext,
+                                               span<const uint8_t> key,
+                                               span<uint8_t> plaintext) {
   int len;
   int plaintext_len;
 
@@ -635,10 +629,10 @@ int AesDecryptor::AesDecryptorImpl::CtrDecrypt(
   return plaintext_len;
 }
 
-int AesDecryptor::AesDecryptorImpl::Decrypt(::arrow::util::span<const uint8_t> ciphertext,
-                                            ::arrow::util::span<const uint8_t> key,
-                                            ::arrow::util::span<const uint8_t> aad,
-                                            ::arrow::util::span<uint8_t> plaintext) {
+int AesDecryptor::AesDecryptorImpl::Decrypt(span<const uint8_t> ciphertext,
+                                            span<const uint8_t> key,
+                                            span<const uint8_t> aad,
+                                            span<uint8_t> plaintext) {
   if (static_cast<size_t>(key_length_) != key.size()) {
     std::stringstream ss;
     ss << "Wrong key length " << key.size() << ". Should be " << key_length_;

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -104,11 +104,16 @@ class PARQUET_EXPORT AesDecryptor {
   ~AesDecryptor();
   void WipeOut();
 
-  /// Size difference between plaintext and ciphertext, for this cipher.
-  int CiphertextSizeDelta();
+  /// The size of the plaintext, for this cipher and the specified ciphertext length.
+  [[nodiscard]] int PlaintextLength(int ciphertext_len) const;
+
+  /// The size of the ciphertext, for this cipher and the specified plaintext length.
+  [[nodiscard]] int CiphertextLength(int plaintext_len) const;
 
   /// Decrypts ciphertext with the key and aad. Key length is passed only for
   /// validation. If different from value in constructor, exception will be thrown.
+  /// The caller is responsible for ensuring that the plaintext buffer is at least as
+  /// large as PlaintextLength(ciphertext_len).
   int Decrypt(const uint8_t* ciphertext, int ciphertext_len, const uint8_t* key,
               int key_len, const uint8_t* aad, int aad_len, uint8_t* plaintext);
 

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/util/span.h"
 #include "parquet/properties.h"
 #include "parquet/types.h"
 
@@ -114,8 +115,10 @@ class PARQUET_EXPORT AesDecryptor {
   /// validation. If different from value in constructor, exception will be thrown.
   /// The caller is responsible for ensuring that the plaintext buffer is at least as
   /// large as PlaintextLength(ciphertext_len).
-  int Decrypt(const uint8_t* ciphertext, int ciphertext_len, const uint8_t* key,
-              int key_len, const uint8_t* aad, int aad_len, uint8_t* plaintext);
+  int Decrypt(::arrow::util::span<const uint8_t> ciphertext,
+              ::arrow::util::span<const uint8_t> key,
+              ::arrow::util::span<const uint8_t> aad,
+              ::arrow::util::span<uint8_t> plaintext);
 
  private:
   // PIMPL Idiom

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -44,7 +44,7 @@ constexpr int8_t kBloomFilterHeader = 8;
 constexpr int8_t kBloomFilterBitset = 9;
 
 /// Performs AES encryption operations with GCM or CTR ciphers.
-class AesEncryptor {
+class PARQUET_EXPORT AesEncryptor {
  public:
   /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
   /// If write_length is true, prepend ciphertext length to the ciphertext
@@ -82,7 +82,7 @@ class AesEncryptor {
 };
 
 /// Performs AES decryption operations with GCM or CTR ciphers.
-class AesDecryptor {
+class PARQUET_EXPORT AesDecryptor {
  public:
   /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
   /// If contains_length is true, expect ciphertext length prepended to the ciphertext

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -91,7 +91,12 @@ std::shared_ptr<AesDecryptor> AesDecryptor::Make(
   return NULLPTR;
 }
 
-int AesDecryptor::CiphertextSizeDelta() {
+int AesDecryptor::PlaintextLength(int ciphertext_len) const {
+  ThrowOpenSSLRequiredException();
+  return -1;
+}
+
+int AesDecryptor::CiphertextLength(int plaintext_len) const {
   ThrowOpenSSLRequiredException();
   return -1;
 }

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -58,9 +58,10 @@ AesEncryptor::AesEncryptor(ParquetCipher::type alg_id, int key_len, bool metadat
 
 class AesDecryptor::AesDecryptorImpl {};
 
-int AesDecryptor::Decrypt(const uint8_t* plaintext, int plaintext_len, const uint8_t* key,
-                          int key_len, const uint8_t* aad, int aad_len,
-                          uint8_t* ciphertext) {
+int AesDecryptor::Decrypt(::arrow::util::span<const uint8_t> ciphertext,
+                          ::arrow::util::span<const uint8_t> key,
+                          ::arrow::util::span<const uint8_t> aad,
+                          ::arrow::util::span<uint8_t> plaintext) {
   ThrowOpenSSLRequiredException();
   return -1;
 }

--- a/cpp/src/parquet/encryption/encryption_internal_test.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_test.cc
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "parquet/encryption/encryption_internal.h"
+
+namespace parquet::encryption::test {
+
+class TestAesEncryption : public ::testing::Test {
+ protected:
+  static void EncryptionRoundTrip(ParquetCipher::type cipher_type, bool write_length) {
+    int key_length = 16;
+    std::string key = "1234567890123450";
+    std::string aad = "abcdefgh";
+    bool metadata = false;
+    std::string plaintext =
+        "Apache Parquet is an open source, column-oriented data file format designed for "
+        "efficient data storage and retrieval";
+
+    AesEncryptor encryptor(cipher_type, key_length, metadata, write_length);
+
+    int expected_ciphertext_len =
+        static_cast<int>(plaintext.size()) + encryptor.CiphertextSizeDelta();
+    std::string ciphertext(expected_ciphertext_len, '\0');
+
+    int ciphertext_length = encryptor.Encrypt(
+        str2bytes(plaintext), static_cast<int>(plaintext.size()), str2bytes(key),
+        static_cast<int>(key.size()), str2bytes(aad), static_cast<int>(aad.size()),
+        reinterpret_cast<uint8_t*>(&ciphertext[0]));
+
+    ASSERT_EQ(ciphertext_length, expected_ciphertext_len);
+
+    AesDecryptor decryptor(cipher_type, key_length, metadata, write_length);
+
+    int expected_plaintext_length = ciphertext_length - decryptor.CiphertextSizeDelta();
+    std::string decrypted_text(expected_plaintext_length, '\0');
+
+    int plaintext_length = decryptor.Decrypt(
+        str2bytes(ciphertext), ciphertext_length, str2bytes(key),
+        static_cast<int>(key.size()), str2bytes(aad), static_cast<int>(aad.size()),
+        reinterpret_cast<uint8_t*>(&decrypted_text[0]));
+
+    ASSERT_EQ(plaintext_length, static_cast<int>(plaintext.size()));
+    ASSERT_EQ(plaintext_length, expected_plaintext_length);
+    ASSERT_EQ(decrypted_text, plaintext);
+  }
+};
+
+TEST_F(TestAesEncryption, AesGcmRoundTrip) {
+  EncryptionRoundTrip(ParquetCipher::AES_GCM_V1, /*write_length=*/true);
+  EncryptionRoundTrip(ParquetCipher::AES_GCM_V1, /*write_length=*/false);
+}
+
+TEST_F(TestAesEncryption, AesGcmCtrRoundTrip) {
+  EncryptionRoundTrip(ParquetCipher::AES_GCM_CTR_V1, /*write_length=*/true);
+  EncryptionRoundTrip(ParquetCipher::AES_GCM_CTR_V1, /*write_length=*/false);
+}
+
+}  // namespace parquet::encryption::test

--- a/cpp/src/parquet/encryption/encryption_internal_test.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_test.cc
@@ -48,7 +48,7 @@ class TestAesEncryption : public ::testing::Test {
 
     AesDecryptor decryptor(cipher_type, kKeyLength, metadata, write_length);
 
-    int expected_plaintext_length = ciphertext_length - decryptor.CiphertextSizeDelta();
+    int expected_plaintext_length = decryptor.PlaintextLength(ciphertext_length);
     std::string decrypted_text(expected_plaintext_length, '\0');
 
     int plaintext_length = decryptor.Decrypt(
@@ -71,7 +71,7 @@ class TestAesEncryption : public ::testing::Test {
     const int ciphertext_length = 100;
     std::string ciphertext(ciphertext_length, '\0');
 
-    int expected_plaintext_length = ciphertext_length - decryptor.CiphertextSizeDelta();
+    int expected_plaintext_length = decryptor.PlaintextLength(ciphertext_length);
     std::string decrypted_text(expected_plaintext_length, '\0');
 
     EXPECT_THROW(decryptor.Decrypt(str2bytes(ciphertext), 0, str2bytes(kKey),
@@ -98,7 +98,7 @@ class TestAesEncryption : public ::testing::Test {
 
     AesDecryptor decryptor(cipher_type, kKeyLength, metadata, write_length);
 
-    int expected_plaintext_length = ciphertext_length - decryptor.CiphertextSizeDelta();
+    int expected_plaintext_length = decryptor.PlaintextLength(ciphertext_length);
     std::string decrypted_text(expected_plaintext_length, '\0');
 
     EXPECT_THROW(decryptor.Decrypt(str2bytes(ciphertext), ciphertext_length - 1,

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -41,11 +41,9 @@ int Decryptor::CiphertextLength(int plaintext_len) const {
   return aes_decryptor_->CiphertextLength(plaintext_len);
 }
 
-int Decryptor::Decrypt(const uint8_t* ciphertext, int ciphertext_len,
-                       uint8_t* plaintext) {
-  return aes_decryptor_->Decrypt(ciphertext, ciphertext_len, str2bytes(key_),
-                                 static_cast<int>(key_.size()), str2bytes(aad_),
-                                 static_cast<int>(aad_.size()), plaintext);
+int Decryptor::Decrypt(::arrow::util::span<const uint8_t> ciphertext,
+                       ::arrow::util::span<uint8_t> plaintext) {
+  return aes_decryptor_->Decrypt(ciphertext, str2span(key_), str2span(aad_), plaintext);
 }
 
 // InternalFileDecryptor

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -33,7 +33,13 @@ Decryptor::Decryptor(std::shared_ptr<encryption::AesDecryptor> aes_decryptor,
       aad_(aad),
       pool_(pool) {}
 
-int Decryptor::CiphertextSizeDelta() { return aes_decryptor_->CiphertextSizeDelta(); }
+int Decryptor::PlaintextLength(int ciphertext_len) const {
+  return aes_decryptor_->PlaintextLength(ciphertext_len);
+}
+
+int Decryptor::CiphertextLength(int plaintext_len) const {
+  return aes_decryptor_->CiphertextLength(plaintext_len);
+}
 
 int Decryptor::Decrypt(const uint8_t* ciphertext, int ciphertext_len,
                        uint8_t* plaintext) {

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -45,7 +45,8 @@ class PARQUET_EXPORT Decryptor {
   void UpdateAad(const std::string& aad) { aad_ = aad; }
   ::arrow::MemoryPool* pool() { return pool_; }
 
-  int CiphertextSizeDelta();
+  [[nodiscard]] int PlaintextLength(int ciphertext_len) const;
+  [[nodiscard]] int CiphertextLength(int plaintext_len) const;
   int Decrypt(const uint8_t* ciphertext, int ciphertext_len, uint8_t* plaintext);
 
  private:

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -47,7 +47,8 @@ class PARQUET_EXPORT Decryptor {
 
   [[nodiscard]] int PlaintextLength(int ciphertext_len) const;
   [[nodiscard]] int CiphertextLength(int plaintext_len) const;
-  int Decrypt(const uint8_t* ciphertext, int ciphertext_len, uint8_t* plaintext);
+  int Decrypt(::arrow::util::span<const uint8_t> ciphertext,
+              ::arrow::util::span<uint8_t> plaintext);
 
  private:
   std::shared_ptr<encryption::AesDecryptor> aes_decryptor_;

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -55,7 +55,7 @@ std::string DecryptKeyLocally(const std::string& encoded_encrypted_key,
                              false /*contains_length*/);
 
   int decrypted_key_len =
-      static_cast<int>(encrypted_key.size()) - key_decryptor.CiphertextSizeDelta();
+      key_decryptor.PlaintextLength(static_cast<int>(encrypted_key.size()));
   std::string decrypted_key(decrypted_key_len, '\0');
 
   decrypted_key_len = key_decryptor.Decrypt(

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -57,13 +57,11 @@ std::string DecryptKeyLocally(const std::string& encoded_encrypted_key,
   int decrypted_key_len =
       key_decryptor.PlaintextLength(static_cast<int>(encrypted_key.size()));
   std::string decrypted_key(decrypted_key_len, '\0');
+  ::arrow::util::span<uint8_t> decrypted_key_span(
+      reinterpret_cast<uint8_t*>(&decrypted_key[0]), decrypted_key_len);
 
-  decrypted_key_len = key_decryptor.Decrypt(
-      reinterpret_cast<const uint8_t*>(encrypted_key.data()),
-      static_cast<int>(encrypted_key.size()),
-      reinterpret_cast<const uint8_t*>(master_key.data()),
-      static_cast<int>(master_key.size()), reinterpret_cast<const uint8_t*>(aad.data()),
-      static_cast<int>(aad.size()), reinterpret_cast<uint8_t*>(&decrypted_key[0]));
+  decrypted_key_len = key_decryptor.Decrypt(str2span(encrypted_key), str2span(master_key),
+                                            str2span(aad), decrypted_key_span);
 
   return decrypted_key;
 }

--- a/cpp/src/parquet/encryption/read_configurations_test.cc
+++ b/cpp/src/parquet/encryption/read_configurations_test.cc
@@ -22,6 +22,7 @@
 
 #include "arrow/io/file.h"
 #include "arrow/testing/gtest_compat.h"
+#include "arrow/util/config.h"
 
 #include "parquet/column_reader.h"
 #include "parquet/column_writer.h"

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -419,9 +419,9 @@ class ThriftDeserializer {
       // decrypt
       auto decrypted_buffer = std::static_pointer_cast<ResizableBuffer>(AllocateBuffer(
           decryptor->pool(), decryptor->PlaintextLength(static_cast<int32_t>(clen))));
-      const uint8_t* cipher_buf = buf;
-      uint32_t decrypted_buffer_len = decryptor->Decrypt(
-          cipher_buf, static_cast<int32_t>(clen), decrypted_buffer->mutable_data());
+      ::arrow::util::span<const uint8_t> cipher_buf(buf, clen);
+      uint32_t decrypted_buffer_len =
+          decryptor->Decrypt(cipher_buf, decrypted_buffer->mutable_span_as<uint8_t>());
       if (decrypted_buffer_len <= 0) {
         throw ParquetException("Couldn't decrypt buffer\n");
       }

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -416,7 +416,7 @@ class ThriftDeserializer {
           AllocateBuffer(decryptor->pool(),
                          static_cast<int64_t>(clen - decryptor->CiphertextSizeDelta())));
       const uint8_t* cipher_buf = buf;
-      if (clen > std::numeric_limits<int32_t>::max()) {
+      if (clen > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
         std::stringstream ss;
         ss << "Cannot decrypt buffer with length " << clen << ", which overflows int32\n";
         throw ParquetException(ss.str());


### PR DESCRIPTION
### Rationale for this change

See #43070

### What changes are included in this PR?

Checks that the ciphertext length is at least enough to hold the length (if written), nonce and GCM tag for the GCM cipher type.

Also enforces that the input ciphertext length parameter is provided (is > 0) and verifies that the ciphertext size read from the file isn't going to cause reads beyond the end of the ciphertext buffer.

### Are these changes tested?

Yes I've added new unit tests for this.

### Are there any user-facing changes?

No
* GitHub Issue: #43070