### PR TITLE
GH-43039: Unable to create a list of Maps with Decimal key or value

### DIFF
--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -233,6 +233,15 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   }
   </#if>
 
+  <#if lowerName?contains("decimal")>
+
+  @Override
+  public ${capName}Writer ${lowerName}(<#list minor.typeParams as typeParam>${typeParam.type} ${typeParam.name}<#if typeParam_has_next>, </#if></#list>) {
+    fail("${capName}(" + <#list minor.typeParams as typeParam>"${typeParam.name}: " + ${typeParam.name} + ", " + </#list>")");
+    return null;
+  }
+  </#if>
+
   @Override
   public ${capName}Writer ${lowerName}(String name) {
     fail("${capName}");

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -84,6 +84,13 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     <#assign capName = minor.class?cap_first />
     ${capName}Writer ${lowerName}();
     </#list></#list>
+
+    default Decimal256Writer decimal256(int scale, int precision) {
+      return null;
+    }
+    default DecimalWriter decimal(int scale, int precision) {
+      return null;
+    }
   }
 
   public interface MapWriter extends ListWriter {

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -56,6 +56,9 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     <#if minor.typeParams?? >
     ${capName}Writer ${lowerName}(String name<#list minor.typeParams as typeParam>, ${typeParam.type} ${typeParam.name}</#list>);
     </#if>
+    <#if lowerName?contains("decimal")>
+    ${capName}Writer ${lowerName}(<#list minor.typeParams as typeParam>${typeParam.type} ${typeParam.name}<#if typeParam_has_next>, </#if></#list>);
+    </#if>
     ${capName}Writer ${lowerName}(String name);
     </#list></#list>
 
@@ -83,14 +86,10 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     <#assign upperName = minor.class?upper_case />
     <#assign capName = minor.class?cap_first />
     ${capName}Writer ${lowerName}();
+    <#if lowerName?contains("decimal")>
+    ${capName}Writer ${lowerName}(<#list minor.typeParams as typeParam>${typeParam.type} ${typeParam.name}<#if typeParam_has_next>, </#if></#list>);
+    </#if>
     </#list></#list>
-
-    default Decimal256Writer decimal256(int scale, int precision) {
-      return null;
-    }
-    default DecimalWriter decimal(int scale, int precision) {
-      return null;
-    }
   }
 
   public interface MapWriter extends ListWriter {

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -127,6 +127,12 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   public ${minor.class}Writer ${lowerName}(String name<#list minor.typeParams as typeParam>, ${typeParam.type} ${typeParam.name}</#list>) {
     return writer.${lowerName}(name<#list minor.typeParams as typeParam>, ${typeParam.name}</#list>);
   }
+  <#if lowerName?contains("decimal")>
+  @Override
+  public ${capName}Writer ${lowerName}(<#list minor.typeParams as typeParam>${typeParam.type} ${typeParam.name}<#if typeParam_has_next>, </#if></#list>) {
+    return writer.${lowerName}(<#list minor.typeParams as typeParam>${typeParam.name}<#if typeParam_has_next>, </#if></#list>);
+  }
+  </#if>
   </#if>
 
   @Override

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -207,7 +207,6 @@ public class UnionMapWriter extends UnionListWriter {
     }
   }
 
-
   @Override
   public StructWriter struct() {
     switch (mode) {

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -183,6 +183,30 @@ public class UnionMapWriter extends UnionListWriter {
     }
   }
 
+  @Override
+  public DecimalWriter decimal(int scale, int precision) {
+    switch (mode) {
+      case KEY:
+        return entryWriter.decimal(MapVector.KEY_NAME, scale, precision);
+      case VALUE:
+        return entryWriter.decimal(MapVector.VALUE_NAME, scale, precision);
+      default:
+        return this;
+    }
+  }
+
+  @Override
+  public Decimal256Writer decimal256(int scale, int precision) {
+    switch (mode) {
+      case KEY:
+        return entryWriter.decimal256(MapVector.KEY_NAME, scale, precision);
+      case VALUE:
+        return entryWriter.decimal256(MapVector.VALUE_NAME, scale, precision);
+      default:
+        return this;
+    }
+  }
+
 
   @Override
   public StructWriter struct() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -289,6 +289,9 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   protected FieldWriter getWriter(MinorType type, ArrowType arrowType) {
     if (state == State.UNION) {
       if (requiresArrowType(type)) {
+        if (arrowType == null) {
+          arrowType = type.getType();
+        }
         ((UnionWriter) writer).getWriter(type, arrowType);
       } else {
         ((UnionWriter) writer).getWriter(type);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -693,7 +693,7 @@ public class Types {
         return new DenseUnionWriter((DenseUnionVector) vector);
       }
     },
-    MAP(null) {
+    MAP(new Map(false)) {
       @Override
       public FieldVector getNewVector(
           Field field, BufferAllocator allocator, CallBack schemaChangeCallback) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
@@ -1270,37 +1270,4 @@ public class TestMapVector {
           structVector.getChildrenFromFields().get(1).getObject(1), BigDecimal.valueOf(3.0));
     }
   }
-
-  @Test
-  public void testListOfStruct() {
-    try (ListVector from = ListVector.empty("v", new RootAllocator())) {
-
-      UnionListWriter listWriter = from.getWriter();
-      listWriter.allocate();
-
-      // write null, [null,{"f1":1,"f2":2},null,
-      // {"f1":1,"f2":2},null] alternatively
-      for (int i = 0; i < 10; i++) {
-        listWriter.setPosition(i);
-        if (i % 2 == 0) {
-          listWriter.writeNull();
-          continue;
-        }
-        listWriter.startList();
-        listWriter.struct().writeNull();
-        listWriter.struct().start();
-        listWriter.struct().decimal("f1", 1, 2).writeDecimal(BigDecimal.valueOf(2.0));
-        listWriter.struct().end();
-        listWriter.struct().writeNull();
-        listWriter.struct().start();
-        listWriter.struct().decimal("f1", 1, 2).writeDecimal(BigDecimal.valueOf(3.0));
-        listWriter.struct().end();
-        listWriter.struct().writeNull();
-        listWriter.endList();
-      }
-      from.setValueCount(10);
-
-      System.out.println(from);
-    }
-  }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestMapVector.java
@@ -1236,8 +1236,8 @@ public class TestMapVector {
 
   @Test
   public void testWritingDecimals() {
-    try (ListVector from = ListVector.empty("v", allocator)) {
-      UnionListWriter listWriter = from.getWriter();
+    try (ListVector vector = ListVector.empty("v", allocator)) {
+      UnionListWriter listWriter = vector.getWriter();
       listWriter.allocate();
 
       listWriter.setPosition(0);
@@ -1255,9 +1255,19 @@ public class TestMapVector {
       listWriter.endList();
 
       listWriter.setValueCount(1);
-      from.setValueCount(1);
+      vector.setValueCount(1);
 
-      System.out.println(from);
+      assertEquals(vector.getChildrenFromFields().size(), 1);
+      MapVector mapVector = (MapVector) vector.getChildrenFromFields().get(0);
+      assertEquals(mapVector.getChildrenFromFields().size(), 1);
+      StructVector structVector = (StructVector) mapVector.getChildrenFromFields().get(0);
+      assertEquals(structVector.getChildrenFromFields().size(), 2);
+      assertEquals(structVector.getChildrenFromFields().get(0).getObject(0), 10);
+      assertEquals(
+          structVector.getChildrenFromFields().get(0).getObject(1), BigDecimal.valueOf(2.0));
+      assertEquals(structVector.getChildrenFromFields().get(1).getObject(0), 20);
+      assertEquals(
+          structVector.getChildrenFromFields().get(1).getObject(1), BigDecimal.valueOf(3.0));
     }
   }
 


### PR DESCRIPTION
## WIP: DO NOT REVIEW

### Rationale for this change

The `MapVector` creation with `Decimal` keys or values contains an issue as reported https://github.com/apache/arrow-java/issues/69. MapVector writers are missing support for defining a decimal based key or value. 

### What changes are included in this PR?

Test cases for creating a `MapVector` with decimal keys and values. Adding a new methods for `ListWriter` interface to accommodate decimal inclusion. 

### Are these changes tested?

Tested via existing test cases and new test cases. 

### Are there any user-facing changes?

Yes. New API has been added to support decimal based keys and values in `MapVector` creation. 
* GitHub Issue: apache/arrow-java#69
* GitHub Issue: #69