### PR TITLE
GH-38012: [python] remove mention of ds creation with recordbatchreader

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -953,7 +953,7 @@ cdef class InMemoryDataset(Dataset):
     ----------
     source : RecordBatch, Table, list, tuple
         The data for this dataset. Can be a RecordBatch, Table, list of
-        RecordBatch/Table, iterable of RecordBatch, or a RecordBatchReader
+        RecordBatch/Table, or an iterable of RecordBatch
         If an iterable is provided, the schema must also be provided.
     schema : Schema, optional
         Only required if passing an iterable as the source

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -603,7 +603,7 @@ def dataset(source, schema=None, format=None, filesystem=None,
     Parameters
     ----------
     source : path, list of paths, dataset, list of datasets, (list of) \
-RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
+RecordBatch or Table, iterable of RecordBatch, or URI
         Path pointing to a single file:
             Open a FileSystemDataset from a single file.
         Path pointing to a directory:
@@ -619,11 +619,11 @@ RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
             A nested UnionDataset gets constructed, it allows arbitrary
             composition of other datasets.
             Note that additional keyword arguments are not allowed.
-        (List of) batches or tables, iterable of batches, or RecordBatchReader:
+        (List of) batches or tables, or iterable of batches:
             Create an InMemoryDataset. If an iterable or empty list is given,
-            a schema must also be given. If an iterable or RecordBatchReader
-            is given, the resulting dataset can only be scanned once; further
-            attempts will raise an error.
+            a schema must also be given. If an iterable is given, the resulting
+            dataset can only be scanned once; further attempts will raise an
+            error.
     schema : Schema, optional
         Optionally provide the Schema for the Dataset, in which case it will
         not be inferred from the source.


### PR DESCRIPTION
### Rationale for this change

`pyarrow.dataset` construction doesn't support RecordBatchReaders, but the docstrings still suggest that they are valid.

### What changes are included in this PR?

Removing mention of RBRs from relevant docstrings

### Are these changes tested?

I confirmed that trying to pass a record batch reader to the constructors in question (`ds.dataset`, `ds.InMemoryDataset`) errors and says they aren't supported.

### Are there any user-facing changes?

Docstrings will change.
* GitHub Issue: #38012