### PR TITLE
GH-43075: [CI][Crossbow][Docker] Set timeout for docker-tests

### DIFF
--- a/dev/tasks/docker-tests/github.cuda.yml
+++ b/dev/tasks/docker-tests/github.cuda.yml
@@ -23,8 +23,9 @@ jobs:
   test:
     name: |
       Docker Test {{ flags|default("") }} {{ image }} {{ command|default("") }}
-    runs-on: ['self-hosted', 'cuda'] 
+    runs-on: ['self-hosted', 'cuda']
 {{ macros.github_set_env(env) }}
+    timeout-minutes: {{ timeout|default(60) }}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth|default(1))|indent }}
       # python 3.8 is installed on the runner, no need to install

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -25,6 +25,7 @@ jobs:
       Docker Test {{ flags|default("") }} {{ image }} {{ command|default("") }}
     runs-on: ubuntu-latest
 {{ macros.github_set_env(env) }}
+    timeout-minutes: {{ timeout|default(60) }}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth|default(1))|indent }}
       {{ macros.github_free_space()|indent }}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1271,6 +1271,7 @@ tasks:
       env:
         ARROW_R_DEV: "TRUE"
       image: ubuntu-r-valgrind
+      timeout: 300 # 5 hours
 
   test-r-linux-rchk:
     ci: github
@@ -1555,10 +1556,11 @@ tasks:
         TEST_PYARROW_ONLY: "{{ test_pyarrow_only }}"
         NUMPY: "{{ numpy_version }}"
         JDK: "{{ jdk_version }}"
+      fetch_depth: 0
       # use the branch-3.0 of spark, so prevent reusing any layers
       flags: --no-leaf-cache
       image: conda-python-spark
-      fetch_depth: 0
+      timeout: 90
 {% endfor %}
 
 {% for kind in ["static", "static-system-dependency"] %}


### PR DESCRIPTION
### Rationale for this change

If we don't have timeout and a test gets stuck, the job takes 6 hours.

### What changes are included in this PR?

Set timeout.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43075