### PR TITLE
GH-43092: [Swift] Update ArrowData for Nested Types (allow children)

### DIFF
--- a/swift/Arrow/Sources/Arrow/ArrowData.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowData.swift
@@ -20,11 +20,18 @@ import Foundation
 public class ArrowData {
     public let type: ArrowType
     public let buffers: [ArrowBuffer]
+    public let children: [ArrowData]
     public let nullCount: UInt
     public let length: UInt
     public let stride: Int
 
-    init(_ arrowType: ArrowType, buffers: [ArrowBuffer], nullCount: UInt) throws {
+    convenience init(_ arrowType: ArrowType, buffers: [ArrowBuffer], nullCount: UInt) throws {
+        try self.init(arrowType, buffers: buffers,
+                      children: [ArrowData](), nullCount: nullCount,
+                      length: buffers[1].length)
+    }
+
+    init(_ arrowType: ArrowType, buffers: [ArrowBuffer], children: [ArrowData], nullCount: UInt, length: UInt) throws {
         let infoType = arrowType.info
         switch infoType {
         case let .primitiveInfo(typeId):
@@ -47,8 +54,9 @@ public class ArrowData {
 
         self.type = arrowType
         self.buffers = buffers
+        self.children = children
         self.nullCount = nullCount
-        self.length = buffers[1].length
+        self.length = length
         self.stride = arrowType.getStride()
     }
 


### PR DESCRIPTION
### Rationale for this change
Struct (Nested Types) need children property on ArrowData 

### What changes are included in this PR?
children property added to ArrowData an constructor updated (original constructor moved to convenience constructor so it must call the updated constructor but keeps the original behavior for existing types)


* GitHub Issue: #43092