### PR TITLE
GH-43076: [C#] Upgrade Xunit and change how Python integration tests are skipped

### DIFF
--- a/csharp/test/Apache.Arrow.Compression.Tests/Apache.Arrow.Compression.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Compression.Tests/Apache.Arrow.Compression.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
   </ItemGroup>
 

--- a/csharp/test/Apache.Arrow.Flight.Sql.Tests/Apache.Arrow.Flight.Sql.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Flight.Sql.Tests/Apache.Arrow.Flight.Sql.Tests.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-      <PackageReference Include="xunit" Version="2.8.0" />
+      <PackageReference Include="xunit" Version="2.8.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
       <PackageReference Include="coverlet.collector" Version="6.0.2" />
     </ItemGroup>

--- a/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Flight.Tests/Apache.Arrow.Flight.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
   </ItemGroup>

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
### Rationale for this change

See #43076. The previous Xunit upgrade was reverted due to this breaking how the Python C Data Interface integration tests were skipped. It looks like this is unlikely to be fixed in xunit or xunit.skippablefact soon (see https://github.com/AArnott/Xunit.SkippableFact/issues/32), so I've refactored the tests to work around the issue.

### What changes are included in this PR?

Re-update xunit to 2.8.1 and refactor the `CDataSchemaPythonTest` class construction so that skipping these tests when the `PYTHONNET_PYDLL` environment variable isn't set works again.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #43076