### PR TITLE
GH-43059: [CI][Gandiva] Disable Python Gandiva tests on AlmaLinux 8

### DIFF
--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -67,6 +67,7 @@ jobs:
           ALMALINUX: "8"
         run: |
           archery docker run \
+            -e ARROW_GANDIVA=OFF \
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -38,6 +38,9 @@ jobs:
         run: |
           archery docker run \
             -e VERIFY_VERSION="{{ release|default("") }}" \
+            {% if distro == 'almalinux' %}
+            -e ARROW_GANDIVA=OFF \
+            {% endif %}
             -e VERIFY_RC="{{ rc|default("") }}" \
             -e TEST_DEFAULT=0 \
             -e TEST_{{ target|upper }}=1 \

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           archery docker run \
             -e VERIFY_VERSION="{{ release|default("") }}" \
-            {% if distro == 'almalinux' %}
+            {% if distro == 'almalinux' and target|upper == 'PYTHON' %}
             -e ARROW_GANDIVA=OFF \
             {% endif %}
             -e VERIFY_RC="{{ rc|default("") }}" \


### PR DESCRIPTION
### Rationale for this change

The newer version of LLVM on AlmaLinux 8 fails on the pyarrow.gandiva tests

### What changes are included in this PR?

Temporarily remove Gandiva on Python checks for AlmaLinux 8.

### Are these changes tested?

Via CI
### Are there any user-facing changes?

No
* GitHub Issue: #43059