### PR TITLE
GH-40036: [C++] Azure file system write buffering & async writes

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -968,6 +968,7 @@ Status StageBlock(Blobs::BlockBlobClient* block_blob_client, const std::string& 
 /// Writes will be buffered up to this size (in bytes) before actually uploading them.
 static constexpr int64_t kBlockUploadSizeBytes = 10 * 1024 * 1024;
 
+/// This output stream, similar to other arrow OutputStreams, is not thread-safe.
 class ObjectAppendStream final : public io::OutputStream {
  private:
   struct UploadState;

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -970,6 +970,8 @@ Status StageBlock(Blobs::BlockBlobClient* block_blob_client, const std::string& 
 
 /// Writes will be buffered up to this size (in bytes) before actually uploading them.
 static constexpr int64_t kBlockUploadSizeBytes = 10 * 1024 * 1024;
+/// The maximum size of a block in Azure Blob (as per docs).
+static constexpr int64_t kMaxBlockSizeBytes = 4UL * 1024 * 1024 * 1024;
 
 /// This output stream, similar to other arrow OutputStreams, is not thread-safe.
 class ObjectAppendStream final : public io::OutputStream {
@@ -1196,9 +1198,9 @@ class ObjectAppendStream final : public io::OutputStream {
     }
 
     // We can upload chunks without copying them into a buffer
-    while (nbytes >= kBlockUploadSizeBytes) {
-      RETURN_NOT_OK(AppendBlock(data_ptr, kBlockUploadSizeBytes));
-      advance_ptr(kBlockUploadSizeBytes);
+    while (nbytes >= kMaxBlockSizeBytes) {
+      RETURN_NOT_OK(AppendBlock(data_ptr, kMaxBlockSizeBytes));
+      advance_ptr(kMaxBlockSizeBytes);
     }
 
     // Buffer remaining bytes

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1141,6 +1141,7 @@ class ObjectAppendStream final : public io::OutputStream {
       current_block_size_ += to_copy;
       advance_ptr(to_copy);
       pos_ += to_copy;
+      content_length_ += to_copy;
 
       // If buffer isn't full, break
       if (current_block_size_ < kBlockUploadSize) {
@@ -1156,6 +1157,7 @@ class ObjectAppendStream final : public io::OutputStream {
       RETURN_NOT_OK(AppendBlock(data_ptr, kBlockUploadSize));
       advance_ptr(kBlockUploadSize);
       pos_ += kBlockUploadSize;
+      content_length_ += kBlockUploadSize;
     }
 
     // Buffer remaining bytes
@@ -1165,6 +1167,7 @@ class ObjectAppendStream final : public io::OutputStream {
                                                 kBlockUploadSize, io_context_.pool()));
       RETURN_NOT_OK(current_block_->Write(data_ptr, current_block_size_));
       pos_ += current_block_size_;
+      content_length_ += current_block_size_;
     }
 
     return Status::OK();
@@ -1244,9 +1247,6 @@ class ObjectAppendStream final : public io::OutputStream {
 
       RETURN_NOT_OK(StageBlock(block_blob_client_.get(), block_id, block_content));
     }
-
-    pos_ += nbytes;
-    content_length_ += nbytes;
 
     return Status::OK();
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1198,9 +1198,10 @@ class ObjectAppendStream final : public io::OutputStream {
     }
 
     // We can upload chunks without copying them into a buffer
-    while (nbytes >= kMaxBlockSizeBytes) {
-      RETURN_NOT_OK(AppendBlock(data_ptr, kMaxBlockSizeBytes));
-      advance_ptr(kMaxBlockSizeBytes);
+    while (nbytes >= kBlockUploadSizeBytes) {
+      const auto upload_size = std::min(nbytes, kMaxBlockSizeBytes);
+      RETURN_NOT_OK(AppendBlock(data_ptr, upload_size));
+      advance_ptr(upload_size);
     }
 
     // Buffer remaining bytes

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1067,7 +1067,7 @@ class ObjectAppendStream final : public io::OutputStream {
 
     if (current_block_) {
       // Upload remaining buffer
-      RETURN_NOT_OK(WriteBuffer());
+      RETURN_NOT_OK(AppendCurrentBlock());
     }
 
     RETURN_NOT_OK(Flush());
@@ -1083,7 +1083,7 @@ class ObjectAppendStream final : public io::OutputStream {
 
     if (current_block_) {
       // Upload remaining buffer
-      RETURN_NOT_OK(WriteBuffer());
+      RETURN_NOT_OK(AppendCurrentBlock());
     }
 
     return FlushAsync().Then([self = Self()]() {
@@ -1156,7 +1156,7 @@ class ObjectAppendStream final : public io::OutputStream {
   }
 
  private:
-  Status WriteBuffer() {
+  Status AppendCurrentBlock() {
     ARROW_ASSIGN_OR_RAISE(auto buf, current_block_->Finish());
     current_block_.reset();
     current_block_size_ = 0;
@@ -1192,7 +1192,7 @@ class ObjectAppendStream final : public io::OutputStream {
       }
 
       // Upload current buffer
-      RETURN_NOT_OK(WriteBuffer());
+      RETURN_NOT_OK(AppendCurrentBlock());
     }
 
     // We can upload chunks without copying them into a buffer
@@ -1220,10 +1220,6 @@ class ObjectAppendStream final : public io::OutputStream {
     }
 
     return Status::OK();
-  }
-
-  Status AppendBlock(std::shared_ptr<Buffer> buffer) {
-    return AppendBlock(buffer->data(), buffer->size(), buffer);
   }
 
   std::string CreateBlock() {
@@ -1298,6 +1294,10 @@ class ObjectAppendStream final : public io::OutputStream {
     }
 
     return Status::OK();
+  }
+
+  Status AppendBlock(std::shared_ptr<Buffer> buffer) {
+    return AppendBlock(buffer->data(), buffer->size(), buffer);
   }
 
   static void HandleUploadOutcome(const std::shared_ptr<UploadState>& state,

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -112,6 +112,9 @@ struct ARROW_EXPORT AzureOptions {
   /// This will be ignored if non-empty metadata is passed to OpenOutputStream.
   std::shared_ptr<const KeyValueMetadata> default_metadata;
 
+  /// Whether OutputStream writes will be issued in the background, without blocking.
+  bool background_writes = true;
+
  private:
   enum class CredentialKind {
     kDefault,

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -113,7 +113,7 @@ struct ARROW_EXPORT AzureOptions {
   std::shared_ptr<const KeyValueMetadata> default_metadata;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.
-  bool background_writes = true;
+  bool background_writes = false;
 
  private:
   enum class CredentialKind {

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -113,7 +113,7 @@ struct ARROW_EXPORT AzureOptions {
   std::shared_ptr<const KeyValueMetadata> default_metadata;
 
   /// Whether OutputStream writes will be issued in the background, without blocking.
-  bool background_writes = false;
+  bool background_writes = true;
 
  private:
   enum class CredentialKind {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1510,7 +1510,7 @@ class TestAzureFileSystem : public ::testing::Test {
     auto data = SetUpPreexistingData();
     const auto path = data.ContainerPath("test-write-object");
     ASSERT_OK_AND_ASSIGN(auto output, fs->OpenOutputStream(path, {}));
-    std::array<std::int64_t, 3> sizes{257 * 1024, 258 * 1024, 259 * 1024};
+    std::array<std::int64_t, 3> sizes{2570 * 1024, 258 * 1024, 259 * 1024};
     std::array<std::string, 3> buffers{
         std::string(sizes[0], 'A'),
         std::string(sizes[1], 'B'),

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -631,6 +631,16 @@ class TestAzureOptions : public ::testing::Test {
     ASSERT_EQ(path, "container/dir/blob");
   }
 
+  void TestFromUriEnableBackgroundWrites() {
+    std::string path;
+    ASSERT_OK_AND_ASSIGN(auto options,
+                         AzureOptions::FromUri(
+                             "abfs://account:password@127.0.0.1:10000/container/dir/blob?"
+                             "background_writes=true",
+                             &path));
+    ASSERT_EQ(options.background_writes, true);
+  }
+
   void TestFromUriCredentialDefault() {
     ASSERT_OK_AND_ASSIGN(
         auto options,
@@ -774,6 +784,9 @@ TEST_F(TestAzureOptions, FromUriDfsStorage) { TestFromUriDfsStorage(); }
 TEST_F(TestAzureOptions, FromUriAbfs) { TestFromUriAbfs(); }
 TEST_F(TestAzureOptions, FromUriAbfss) { TestFromUriAbfss(); }
 TEST_F(TestAzureOptions, FromUriEnableTls) { TestFromUriEnableTls(); }
+TEST_F(TestAzureOptions, FromUriEnableBackgroundWrites) {
+  TestFromUriEnableBackgroundWrites();
+}
 TEST_F(TestAzureOptions, FromUriCredentialDefault) { TestFromUriCredentialDefault(); }
 TEST_F(TestAzureOptions, FromUriCredentialAnonymous) { TestFromUriCredentialAnonymous(); }
 TEST_F(TestAzureOptions, FromUriCredentialStorageSharedKey) {
@@ -1483,7 +1496,6 @@ class TestAzureFileSystem : public ::testing::Test {
     std::shared_ptr<Buffer> buffer;
     do {
       ASSERT_OK_AND_ASSIGN(buffer, input->Read(128 * 1024));
-      ASSERT_TRUE(buffer);
       contents.append(buffer->ToString());
     } while (buffer->size() != 0);
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1590,6 +1590,9 @@ class TestAzureFileSystem : public ::testing::Test {
     //
     // TODO perhaps remove this skip once we can rely on
     // https://github.com/Azure/azure-sdk-for-cpp/pull/5767
+    //
+    // Also note that ClickHouse has a workaround for a similar issue:
+    // https://github.com/ClickHouse/ClickHouse/pull/45796
     if (options_.background_writes) {
       GTEST_SKIP() << "False positive memory leak in libxml2 with CloseAsync";
     }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1569,6 +1569,31 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestOpenOutputStreamCloseAsync() {
+#if defined(ADDRESS_SANITIZER) || defined(ARROW_VALGRIND)
+    // This false positive leak is similar to the one pinpointed in the
+    // have_false_positive_memory_leak_with_generator() comments above,
+    // though the stack trace is different. It happens when a block list
+    // is committed from a background thread.
+    //
+    // clang-format off
+    // Direct leak of 968 byte(s) in 1 object(s) allocated from:
+    //   #0 calloc
+    //   #1 (/lib/x86_64-linux-gnu/libxml2.so.2+0xe25a4)
+    //   #2 __xmlDefaultBufferSize
+    //   #3 xmlBufferCreate
+    //   #4 Azure::Storage::_internal::XmlWriter::XmlWriter()
+    //   #5 Azure::Storage::Blobs::_detail::BlockBlobClient::CommitBlockList
+    //   #6 Azure::Storage::Blobs::BlockBlobClient::CommitBlockList
+    //   #7 arrow::fs::(anonymous namespace)::CommitBlockList
+    //   #8 arrow::fs::(anonymous namespace)::ObjectAppendStream::FlushAsync()::'lambda'
+    // clang-format on
+    //
+    // TODO perhaps remove this skip once we can rely on
+    // https://github.com/Azure/azure-sdk-for-cpp/pull/5767
+    if (options_.background_writes) {
+      GTEST_SKIP() << "False positive memory leak in libxml2 with CloseAsync";
+    }
+#endif
     ASSERT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options_));
     auto data = SetUpPreexistingData();
     const std::string path = data.ContainerPath("test-write-object");
@@ -1584,6 +1609,12 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestOpenOutputStreamCloseAsyncDestructor() {
+#if defined(ADDRESS_SANITIZER) || defined(ARROW_VALGRIND)
+    // See above.
+    if (options_.background_writes) {
+      GTEST_SKIP() << "False positive memory leak in libxml2 with CloseAsync";
+    }
+#endif
     ASSERT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options_));
     auto data = SetUpPreexistingData();
     const std::string path = data.ContainerPath("test-write-object");

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -39,6 +39,7 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <vector>
 
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock-more-matchers.h>
@@ -46,7 +47,6 @@
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/common/storage_credential.hpp>
 #include <azure/storage/files/datalake.hpp>
-#include <vector>
 
 #include "arrow/filesystem/path_util.h"
 #include "arrow/filesystem/test_util.h"


### PR DESCRIPTION
### Rationale for this change

See #40036.

### What changes are included in this PR?

Write buffering and async writes (similar to what the S3 file system does) in the `ObjectAppendStream` for the Azure file system.

With write buffering and async writes, the input scenario creation runtime in the tests (which uses the `ObjectAppendStream` against Azurite) decreased from ~25s (see [here](https://github.com/apache/arrow/issues/40036)) to ~800ms:
```
[ RUN      ] TestAzuriteFileSystem.OpenInputFileMixedReadVsReadAt
[       OK ] TestAzuriteFileSystem.OpenInputFileMixedReadVsReadAt (787 ms)
```

### Are these changes tested?
Added some tests with background writes enabled and disabled (some were taken from the S3 tests). Everything changed should be covered.

### Are there any user-facing changes?
`AzureOptions` now allows for `background_writes` to be set (default: true). No breaking changes.

### Notes

- The code in `DoWrite` is very similar to [the code in the S3 FS](https://github.com/apache/arrow/blob/edfa343eeca008513f0300924380e1b187cc976b/cpp/src/arrow/filesystem/s3fs.cc#L1753). Maybe this could be unified? I didn't see this in the scope of the PR though.
* GitHub Issue: #40036