### PR TITLE
GH-43130: [C++][ArrowFlight] Crash due to UCS thread mode

### DIFF
--- a/cpp/src/arrow/flight/transport/ucx/ucx_client.cc
+++ b/cpp/src/arrow/flight/transport/ucx/ucx_client.cc
@@ -97,7 +97,7 @@ class ClientConnection {
       ucp_worker_params_t worker_params;
       std::memset(&worker_params, 0, sizeof(worker_params));
       worker_params.field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
-      worker_params.thread_mode = UCS_THREAD_MODE_SERIALIZED;
+      worker_params.thread_mode = UCS_THREAD_MODE_MULTI;
 
       ucp_worker_h ucp_worker;
       status = ucp_worker_create(ucp_context->get(), &worker_params, &ucp_worker);


### PR DESCRIPTION
When mode is `UCS_THREAD_MODE_SERIALIZED`, UCX crash due to mpool corruption.    
This happens when buffer is deallocated on a different thread. In such case two threads access UCX memory pool simultaneously.

See discussion on UCX forum: https://github.com/openucx/ucx/discussions/9987
* GitHub Issue: #43130