### PR TITLE
GH-43119: [CI][Packaging] Update manylinux 2014 CentOS repos that have been deprecated

### DIFF
--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -30,7 +30,7 @@ RUN \
   yum install -y \
     centos-release-scl \
     epel-release && \
-    sed -i \
+  sed -i \
     -e 's/^mirrorlist/#mirrorlist/' \
     -e 's/^#baseurl/baseurl/' \
     -e 's/mirror\.centos\.org/vault.centos.org/' \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -17,6 +17,14 @@
 
 FROM centos:centos7
 
+# Update mirrors to use vault.centos.org as Centos 7
+# is EOL since 2024-06-30
+RUN sed -i \
+      -e 's/^mirrorlist/#mirrorlist/' \
+      -e 's/^#baseurl/baseurl/' \
+      -e 's/mirror\.centos\.org/vault.centos.org/' \
+      /etc/yum.repos.d/*.repo
+
 # devtoolset is required for C++17
 RUN \
   yum install -y \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -29,13 +29,12 @@ RUN sed -i \
 RUN \
   yum install -y \
     centos-release-scl \
-    epel-release
-RUN ls -lrt /etc/yum.repos.d/
-RUN sed -i \
+    epel-release && \
+    sed -i \
     -e 's/^mirrorlist/#mirrorlist/' \
     -e 's/^#baseurl/baseurl/' \
     -e 's/mirror\.centos\.org/vault.centos.org/' \
-    /etc/yum.repos.d/CentOS-SCLo.repo && \
+    /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
   yum install -y \
     cmake3 \
     curl \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -33,10 +33,9 @@ RUN \
   sed -i \
     -e 's/^mirrorlist/#mirrorlist/' \
     -e 's/^#baseurl/baseurl/' \
+    -e 's/^# baseurl/baseurl/' \
     -e 's/mirror\.centos\.org/vault.centos.org/' \
     /etc/yum.repos.d/CentOS-SCLo-scl*.repo && \
-  cat /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
-  cat /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
   yum install -y \
     cmake3 \
     curl \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -26,12 +26,12 @@ RUN sed -i \
       /etc/yum.repos.d/*.repo
 
 # devtoolset is required for C++17
-RUN ls -lrt /etc/yum.repos.d/
 RUN \
   yum install -y \
     centos-release-scl \
-    epel-release && \
-    sed -i \
+    epel-release
+RUN ls -lrt /etc/yum.repos.d/
+RUN sed -i \
     -e 's/^mirrorlist/#mirrorlist/' \
     -e 's/^#baseurl/baseurl/' \
     -e 's/mirror\.centos\.org/vault.centos.org/' \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -35,6 +35,8 @@ RUN \
     -e 's/^#baseurl/baseurl/' \
     -e 's/mirror\.centos\.org/vault.centos.org/' \
     /etc/yum.repos.d/CentOS-SCLo-scl*.repo && \
+  cat /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
+  cat /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
   yum install -y \
     cmake3 \
     curl \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -34,7 +34,7 @@ RUN \
     -e 's/^mirrorlist/#mirrorlist/' \
     -e 's/^#baseurl/baseurl/' \
     -e 's/mirror\.centos\.org/vault.centos.org/' \
-    /etc/yum.repos.d/CentOS-SCLo-scl.repo && \
+    /etc/yum.repos.d/CentOS-SCLo-scl*.repo && \
   yum install -y \
     cmake3 \
     curl \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -26,6 +26,7 @@ RUN sed -i \
       /etc/yum.repos.d/*.repo
 
 # devtoolset is required for C++17
+RUN ls -lrt /etc/yum.repos.d/
 RUN \
   yum install -y \
     centos-release-scl \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -17,7 +17,7 @@
 
 FROM centos:centos7
 
-# Update mirrors to use vault.centos.org as Centos 7
+# Update mirrors to use vault.centos.org as CentOS 7
 # is EOL since 2024-06-30
 RUN sed -i \
       -e 's/^mirrorlist/#mirrorlist/' \
@@ -30,6 +30,11 @@ RUN \
   yum install -y \
     centos-release-scl \
     epel-release && \
+    sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
   yum install -y \
     cmake3 \
     curl \

--- a/ci/docker/centos-7-cpp.dockerfile
+++ b/ci/docker/centos-7-cpp.dockerfile
@@ -34,7 +34,7 @@ RUN \
     -e 's/^mirrorlist/#mirrorlist/' \
     -e 's/^#baseurl/baseurl/' \
     -e 's/mirror\.centos\.org/vault.centos.org/' \
-    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
+    /etc/yum.repos.d/CentOS-SCLo.repo && \
   yum install -y \
     cmake3 \
     curl \

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -25,10 +25,17 @@ ARG manylinux
 ENV MANYLINUX_VERSION=${manylinux}
 
 # Ensure dnf is installed, especially for the manylinux2014 base
-RUN if [ "${MANYLINUX_VERSION}" == "2014" ]; then \
-        sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
-        sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
-        sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo; \
+RUN if [ "${MANYLINUX_VERSION}" = "2014" ]; then \
+      sed -i \
+        -e 's/^mirrorlist/#mirrorlist/' \
+        -e 's/^#baseurl/baseurl/' \
+        -e 's/mirror\.centos\.org/vault.centos.org/' \
+        /etc/yum.repos.d/*.repo; \
+      if [ "${arch}" != "amd64" ]; then \
+        sed -i \
+          -e 's,vault\.centos\.org/centos,vault.centos.org/altarch,' \
+          /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
+      fi; \
     fi
 RUN yum install -y dnf
 

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -25,6 +25,11 @@ ARG manylinux
 ENV MANYLINUX_VERSION=${manylinux}
 
 # Ensure dnf is installed, especially for the manylinux2014 base
+RUN if [ "${MANYLINUX_VERSION}" == "2014" ]; then \
+        sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+        sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+        sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo; \
+    fi
 RUN yum install -y dnf
 
 # Install basic dependencies


### PR DESCRIPTION
### Rationale for this change

Jobs are failing to find mirrorlist.centos.org

### What changes are included in this PR?

Updating repos based on solution from: https://github.com/apache/arrow/issues/43119#issuecomment-2203534492

### Are these changes tested?

Via archery

### Are there any user-facing changes?
No
* GitHub Issue: #43119