### PR TITLE
GH-43124: [C++] Initialize offset vector head as 0 after memory allocated in grouper.cc

### DIFF
--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -877,8 +877,8 @@ struct GrouperFastImpl : public Grouper {
       } else {
         ARROW_ASSIGN_OR_RAISE(fixedlen_bufs[i],
                               AllocatePaddedBuffer((num_groups + 1) * sizeof(uint32_t)));
-        // init offset[0] as 0, avoid when num_groups == 0 
-        // fixedlen_bufs won't be initialized
+        // Set offset[0] to 0 so the later allocation of varlen_bufs doesn't see an
+        // uninitialized value when num_groups == 0.
         reinterpret_cast<uint32_t*>(fixedlen_bufs[i]->mutable_data())[0] = 0;
       }
       cols_[i] =

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -877,6 +877,9 @@ struct GrouperFastImpl : public Grouper {
       } else {
         ARROW_ASSIGN_OR_RAISE(fixedlen_bufs[i],
                               AllocatePaddedBuffer((num_groups + 1) * sizeof(uint32_t)));
+        // init offset[0] as 0, avoid when num_groups == 0 
+        // fixedlen_bufs won't be initialized
+        reinterpret_cast<uint32_t*>(fixedlen_bufs[i]->mutable_data())[0] = 0;
       }
       cols_[i] =
           KeyColumnArray(col_metadata_[i], num_groups, non_null_bufs[i]->mutable_data(),


### PR DESCRIPTION
## bug description
In grouper.cc:780, memory is allocated for offset vector of varlen column, however the vector is initialized in  `encoder_.DecodeFixedLengthBuffers`, which will never be called when `num_groups==0`(see line 786). Then `fixedlen_bufs[i][0]` will be a uninitialized value that means a random uint32_t. Later this random uint32_t is used to `AllocatePaddedBuffer(varlen_size)`. However an random uint32_t is up to 4GB memory, the program may run normally without being affected.

## how to fix
set offset vector head as 0 after memory allocated in case it won't be initialized when `num_groups==0`

* GitHub Issue: #43124