### PR TITLE
GH-43129: [C++][Compute] Fix the unnecessary allocation of extra bytes when encoding row table

### DIFF
--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -92,6 +92,7 @@ add_arrow_test(internals_test
                key_hash_test.cc
                row/compare_test.cc
                row/grouper_test.cc
+               row/row_test.cc
                util_internal_test.cc)
 
 add_arrow_compute_test(expression_test SOURCES expression_test.cc)

--- a/cpp/src/arrow/compute/row/encode_internal.cc
+++ b/cpp/src/arrow/compute/row/encode_internal.cc
@@ -158,8 +158,6 @@ Status RowTableEncoder::EncodeSelected(RowTableImpl* rows, uint32_t num_selected
   EncoderOffsets::GetRowOffsetsSelected(rows, batch_varbinary_cols_, num_selected,
                                         selection);
 
-  // RETURN_NOT_OK(rows->AppendEmpty(static_cast<uint32_t>(0),
-  //                                 static_cast<uint32_t>(rows->offsets()[num_selected])));
   RETURN_NOT_OK(rows->AppendEmpty(static_cast<uint32_t>(0), static_cast<uint32_t>(0)));
 
   for (size_t icol = 0; icol < batch_all_cols_.size(); ++icol) {

--- a/cpp/src/arrow/compute/row/encode_internal.cc
+++ b/cpp/src/arrow/compute/row/encode_internal.cc
@@ -158,6 +158,8 @@ Status RowTableEncoder::EncodeSelected(RowTableImpl* rows, uint32_t num_selected
   EncoderOffsets::GetRowOffsetsSelected(rows, batch_varbinary_cols_, num_selected,
                                         selection);
 
+  // RETURN_NOT_OK(rows->AppendEmpty(static_cast<uint32_t>(0),
+  //                                 static_cast<uint32_t>(rows->offsets()[num_selected])));
   RETURN_NOT_OK(rows->AppendEmpty(static_cast<uint32_t>(0), static_cast<uint32_t>(0)));
 
   for (size_t icol = 0; icol < batch_all_cols_.size(); ++icol) {

--- a/cpp/src/arrow/compute/row/encode_internal.cc
+++ b/cpp/src/arrow/compute/row/encode_internal.cc
@@ -158,8 +158,7 @@ Status RowTableEncoder::EncodeSelected(RowTableImpl* rows, uint32_t num_selected
   EncoderOffsets::GetRowOffsetsSelected(rows, batch_varbinary_cols_, num_selected,
                                         selection);
 
-  RETURN_NOT_OK(rows->AppendEmpty(static_cast<uint32_t>(0),
-                                  static_cast<uint32_t>(rows->offsets()[num_selected])));
+  RETURN_NOT_OK(rows->AppendEmpty(static_cast<uint32_t>(0), static_cast<uint32_t>(0)));
 
   for (size_t icol = 0; icol < batch_all_cols_.size(); ++icol) {
     if (batch_all_cols_[icol].metadata().is_fixed_length) {

--- a/cpp/src/arrow/compute/row/encode_internal.cc
+++ b/cpp/src/arrow/compute/row/encode_internal.cc
@@ -152,13 +152,21 @@ void RowTableEncoder::PrepareEncodeSelected(int64_t start_row, int64_t num_rows,
 Status RowTableEncoder::EncodeSelected(RowTableImpl* rows, uint32_t num_selected,
                                        const uint16_t* selection) {
   rows->Clean();
-  RETURN_NOT_OK(
-      rows->AppendEmpty(static_cast<uint32_t>(num_selected), static_cast<uint32_t>(0)));
 
+  // First AppendEmpty with num_selected rows and zero extra bytes to resize the
+  // fixed-length buffers (including buffer for offsets).
+  RETURN_NOT_OK(
+      rows->AppendEmpty(static_cast<uint32_t>(num_selected),
+                        /*num_extra_bytes_to_append=*/static_cast<uint32_t>(0)));
+  // Then populate the offsets of the var-length columns, which will be used as the target
+  // size of the var-length buffers resizing below.
   EncoderOffsets::GetRowOffsetsSelected(rows, batch_varbinary_cols_, num_selected,
                                         selection);
-
-  RETURN_NOT_OK(rows->AppendEmpty(static_cast<uint32_t>(0), static_cast<uint32_t>(0)));
+  // Last AppendEmpty with zero rows and zero extra bytes to resize the var-length buffers
+  // based on the populated offsets.
+  RETURN_NOT_OK(
+      rows->AppendEmpty(/*num_rows_to_append=*/static_cast<uint32_t>(0),
+                        /*num_extra_bytes_to_append=*/static_cast<uint32_t>(0)));
 
   for (size_t icol = 0; icol < batch_all_cols_.size(); ++icol) {
     if (batch_all_cols_[icol].metadata().is_fixed_length) {

--- a/cpp/src/arrow/compute/row/row_internal.cc
+++ b/cpp/src/arrow/compute/row/row_internal.cc
@@ -246,13 +246,13 @@ int64_t RowTableImpl::size_rows_varying_length(int64_t num_bytes) const {
 }
 
 void RowTableImpl::UpdateBufferPointers() {
-  buffers_[0] = null_masks_->mutable_data();
+  buffers_[0] = null_masks_.get();
   if (metadata_.is_fixed_length) {
-    buffers_[1] = rows_->mutable_data();
+    buffers_[1] = rows_.get();
     buffers_[2] = nullptr;
   } else {
-    buffers_[1] = offsets_->mutable_data();
-    buffers_[2] = rows_->mutable_data();
+    buffers_[1] = offsets_.get();
+    buffers_[2] = rows_.get();
   }
 }
 

--- a/cpp/src/arrow/compute/row/row_test.cc
+++ b/cpp/src/arrow/compute/row/row_test.cc
@@ -1,0 +1,259 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <numeric>
+
+#include "arrow/compute/row/compare_internal.h"
+#include "arrow/testing/generator.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/bitmap_ops.h"
+
+namespace arrow {
+namespace compute {
+
+using arrow::bit_util::BytesForBits;
+using arrow::internal::CpuInfo;
+using arrow::random::RandomArrayGenerator;
+using arrow::util::MiniBatch;
+using arrow::util::TempVectorStack;
+
+namespace {
+
+Result<RowTableImpl> MakeRowTableFromColumn(const std::shared_ptr<Array>& column,
+                                            // int64_t num_rows) {
+                                            int64_t num_rows, int row_alignment,
+                                            int string_alignment) {
+  DCHECK_GE(column->length(), num_rows);
+  MemoryPool* pool = default_memory_pool();
+
+  std::vector<KeyColumnArray> column_arrays;
+  std::vector<Datum> values{column};
+  ExecBatch batch(std::move(values), num_rows);
+  RETURN_NOT_OK(ColumnArraysFromExecBatch(batch, &column_arrays));
+
+  std::vector<KeyColumnMetadata> column_metadatas;
+  RETURN_NOT_OK(ColumnMetadatasFromExecBatch(batch, &column_metadatas));
+  RowTableMetadata table_metadata;
+  table_metadata.FromColumnMetadataVector(column_metadatas, row_alignment,
+                                          string_alignment);
+
+  RowTableImpl row_table;
+  RETURN_NOT_OK(row_table.Init(pool, table_metadata));
+
+  RowTableEncoder row_encoder;
+  row_encoder.Init(column_metadatas, row_alignment, string_alignment);
+  row_encoder.PrepareEncodeSelected(0, num_rows, column_arrays);
+
+  std::vector<uint16_t> row_ids(num_rows);
+  std::iota(row_ids.begin(), row_ids.end(), 0);
+
+  RETURN_NOT_OK(row_encoder.EncodeSelected(&row_table, static_cast<uint32_t>(num_rows),
+                                           row_ids.data()));
+
+  return std::move(row_table);
+}
+
+}  // namespace
+
+TEST(RowTableMemoryConsumption, Encode) {
+  constexpr int64_t num_rows_max = 8192;
+  constexpr int64_t padding_for_vectors = 64;
+
+  ASSERT_OK_AND_ASSIGN(
+      auto fixed_length_column,
+      ::arrow::gen::Constant(std::make_shared<UInt32Scalar>(0))->Generate(num_rows_max));
+  ASSERT_OK_AND_ASSIGN(auto var_length_column,
+                       ::arrow::gen::Constant(std::make_shared<BinaryScalar>("X"))
+                           ->Generate(num_rows_max));
+
+  for (int64_t num_rows : {1023, 1024, 1025, 4095, 4096, 4097}) {
+    // Fixed length column.
+    {
+      SCOPED_TRACE("encoding fixed length column of " + std::to_string(num_rows) +
+                   " rows");
+      ASSERT_OK_AND_ASSIGN(auto row_table,
+                           MakeRowTableFromColumn(fixed_length_column, num_rows,
+                                                  uint32()->byte_width(), 0));
+      ASSERT_NE(row_table.data(0), NULLPTR);
+      ASSERT_NE(row_table.data(1), NULLPTR);
+      ASSERT_EQ(row_table.data(2), NULLPTR);
+
+      auto null_bytes_per_row = row_table.metadata().null_masks_bytes_per_row;
+      int64_t actual_null_mask_size = num_rows * null_bytes_per_row;
+      ASSERT_GT(actual_null_mask_size * 2,
+                row_table.buffer_size(0) - padding_for_vectors);
+      int64_t actual_rows_size = num_rows * uint32()->byte_width();
+      ASSERT_GT(actual_rows_size * 2, row_table.buffer_size(1) - padding_for_vectors);
+    }
+
+    // Var length column.
+    {
+      SCOPED_TRACE("encoding var length column of " + std::to_string(num_rows) + " rows");
+      ASSERT_OK_AND_ASSIGN(auto row_table,
+                           MakeRowTableFromColumn(var_length_column, num_rows, 4, 4));
+      ASSERT_NE(row_table.data(0), NULLPTR);
+      ASSERT_NE(row_table.data(1), NULLPTR);
+      ASSERT_NE(row_table.data(2), NULLPTR);
+
+      auto null_bytes_per_row = row_table.metadata().null_masks_bytes_per_row;
+      int64_t actual_null_mask_size = num_rows * null_bytes_per_row;
+      ASSERT_GT(actual_null_mask_size * 2,
+                row_table.buffer_size(0) - padding_for_vectors);
+      constexpr int64_t offset_width = sizeof(uint32_t);
+      int64_t actual_offset_size = num_rows * offset_width;
+      ASSERT_GT(actual_offset_size * 2, row_table.buffer_size(1) - padding_for_vectors);
+      auto row_width = row_table.offsets()[1];
+      int64_t actual_rows_size = num_rows * row_width;
+      ASSERT_GT(actual_rows_size * 2, row_table.buffer_size(2) - padding_for_vectors);
+    }
+  }
+}
+
+TEST(RowTableMemoryConsumption, Append) {
+  if constexpr (sizeof(void*) == 4) {
+    GTEST_SKIP() << "Test only works on 64-bit platforms";
+  }
+
+  // The idea of this case is to create a row table using one fixed length column and
+  // one var length column (so the row is hence var length and has offset buffer), with
+  // more than 2^31 rows. Then compare the rows with row ids larger than 2^31.
+
+  // A small batch to append to the row table repeatedly to grow the row table to big
+  // enough.
+  constexpr int64_t num_rows_batch = std::numeric_limits<uint16_t>::max() + 1ll;
+  // The number of rows in the row table is one batch larger than 2^31, and we'll
+  // compare the last num_rows_batch rows.
+  constexpr int64_t num_rows_row_table =
+      std::numeric_limits<int32_t>::max() + 1ll + num_rows_batch;
+
+  MemoryPool* pool = default_memory_pool();
+
+  // The left side columns with num_rows_batch rows.
+  std::vector<KeyColumnArray> columns_left;
+  ExecBatch batch_left;
+  {
+    std::vector<Datum> values;
+
+    // A fixed length array containing random values.
+    ASSERT_OK_AND_ASSIGN(auto value_fixed_length,
+                         ::arrow::gen::Random(uint32())->Generate(num_rows_batch));
+    values.push_back(std::move(value_fixed_length));
+
+    // A var length array containing small var length values ("X").
+    ASSERT_OK_AND_ASSIGN(auto value_var_length,
+                         ::arrow::gen::Constant(std::make_shared<BinaryScalar>("X"))
+                             ->Generate(num_rows_batch));
+    values.push_back(std::move(value_var_length));
+
+    batch_left = ExecBatch(std::move(values), num_rows_batch);
+    ASSERT_OK(ColumnArraysFromExecBatch(batch_left, &columns_left));
+  }
+
+  // The right side row table with num_rows_row_table rows.
+  RowTableImpl row_table_right;
+  {
+    // Encode the row table with the left columns repeatedly.
+    std::vector<KeyColumnMetadata> column_metadatas;
+    ASSERT_OK(ColumnMetadatasFromExecBatch(batch_left, &column_metadatas));
+    RowTableMetadata table_metadata;
+    table_metadata.FromColumnMetadataVector(column_metadatas, sizeof(uint64_t),
+                                            sizeof(uint64_t));
+    ASSERT_OK(row_table_right.Init(pool, table_metadata));
+    RowTableImpl row_table_batch;
+    ASSERT_OK(row_table_batch.Init(pool, table_metadata));
+    std::vector<uint16_t> row_ids(num_rows_batch);
+    std::iota(row_ids.begin(), row_ids.end(), 0);
+    RowTableEncoder row_encoder;
+    row_encoder.Init(column_metadatas, sizeof(uint64_t), sizeof(uint64_t));
+    row_encoder.PrepareEncodeSelected(0, num_rows_batch, columns_left);
+    ASSERT_OK(row_encoder.EncodeSelected(
+        &row_table_batch, static_cast<uint32_t>(num_rows_batch), row_ids.data()));
+    for (int i = 0; i < num_rows_row_table / num_rows_batch; ++i) {
+      ASSERT_OK(row_table_right.AppendSelectionFrom(row_table_batch, num_rows_batch,
+                                                    /*source_row_ids=*/NULLPTR));
+    }
+
+    // The row table must contain an offset buffer.
+    ASSERT_NE(row_table_right.offsets(), NULLPTR);
+    ASSERT_EQ(row_table_right.length(), num_rows_row_table);
+  }
+
+  // The rows to compare, left row i to right row 2^31 + i.
+  std::vector<uint32_t> row_ids_to_compare(num_rows_batch);
+  std::iota(row_ids_to_compare.begin(), row_ids_to_compare.end(),
+            num_rows_row_table - num_rows_batch);
+
+  TempVectorStack stack;
+  ASSERT_OK(
+      stack.Init(pool, KeyCompare::CompareColumnsToRowsTempStackUsage(num_rows_batch)));
+  LightContext ctx{CpuInfo::GetInstance()->hardware_flags(), &stack};
+
+  {
+    // No selection, output no match row ids.
+    uint32_t num_rows_no_match;
+    std::vector<uint16_t> row_ids_out(num_rows_batch);
+    KeyCompare::CompareColumnsToRows(num_rows_batch, /*sel_left_maybe_null=*/NULLPTR,
+                                     row_ids_to_compare.data(), &ctx, &num_rows_no_match,
+                                     row_ids_out.data(), columns_left, row_table_right,
+                                     /*are_cols_in_encoding_order=*/true,
+                                     /*out_match_bitvector_maybe_null=*/NULLPTR);
+    ASSERT_EQ(num_rows_no_match, 0);
+  }
+
+  {
+    // No selection, output match bit vector.
+    std::vector<uint8_t> match_bitvector(BytesForBits(num_rows_batch));
+    KeyCompare::CompareColumnsToRows(
+        num_rows_batch, /*sel_left_maybe_null=*/NULLPTR, row_ids_to_compare.data(), &ctx,
+        /*out_num_rows=*/NULLPTR, /*out_sel_left_maybe_same=*/NULLPTR, columns_left,
+        row_table_right,
+        /*are_cols_in_encoding_order=*/true, match_bitvector.data());
+    ASSERT_EQ(arrow::internal::CountSetBits(match_bitvector.data(), 0, num_rows_batch),
+              num_rows_batch);
+  }
+
+  std::vector<uint16_t> selection_left(num_rows_batch);
+  std::iota(selection_left.begin(), selection_left.end(), 0);
+
+  {
+    // With selection, output no match row ids.
+    uint32_t num_rows_no_match;
+    std::vector<uint16_t> row_ids_out(num_rows_batch);
+    KeyCompare::CompareColumnsToRows(num_rows_batch, selection_left.data(),
+                                     row_ids_to_compare.data(), &ctx, &num_rows_no_match,
+                                     row_ids_out.data(), columns_left, row_table_right,
+                                     /*are_cols_in_encoding_order=*/true,
+                                     /*out_match_bitvector_maybe_null=*/NULLPTR);
+    ASSERT_EQ(num_rows_no_match, 0);
+  }
+
+  {
+    // With selection, output match bit vector.
+    std::vector<uint8_t> match_bitvector(BytesForBits(num_rows_batch));
+    KeyCompare::CompareColumnsToRows(
+        num_rows_batch, selection_left.data(), row_ids_to_compare.data(), &ctx,
+        /*out_num_rows=*/NULLPTR, /*out_sel_left_maybe_same=*/NULLPTR, columns_left,
+        row_table_right,
+        /*are_cols_in_encoding_order=*/true, match_bitvector.data());
+    ASSERT_EQ(arrow::internal::CountSetBits(match_bitvector.data(), 0, num_rows_batch),
+              num_rows_batch);
+  }
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/row/row_test.cc
+++ b/cpp/src/arrow/compute/row/row_test.cc
@@ -93,10 +93,11 @@ TEST(RowTableMemoryConsumption, Encode) {
       ASSERT_NE(row_table.data(1), NULLPTR);
       ASSERT_EQ(row_table.data(2), NULLPTR);
 
-      auto null_bytes_per_row = row_table.metadata().null_masks_bytes_per_row;
-      int64_t actual_null_mask_size = num_rows * null_bytes_per_row;
+      int64_t actual_null_mask_size =
+          num_rows * row_table.metadata().null_masks_bytes_per_row;
       ASSERT_GT(actual_null_mask_size * 2,
                 row_table.buffer_size(0) - padding_for_vectors);
+
       int64_t actual_rows_size = num_rows * uint32()->byte_width();
       ASSERT_GT(actual_rows_size * 2, row_table.buffer_size(1) - padding_for_vectors);
     }
@@ -110,15 +111,15 @@ TEST(RowTableMemoryConsumption, Encode) {
       ASSERT_NE(row_table.data(1), NULLPTR);
       ASSERT_NE(row_table.data(2), NULLPTR);
 
-      auto null_bytes_per_row = row_table.metadata().null_masks_bytes_per_row;
-      int64_t actual_null_mask_size = num_rows * null_bytes_per_row;
+      int64_t actual_null_mask_size =
+          num_rows * row_table.metadata().null_masks_bytes_per_row;
       ASSERT_GT(actual_null_mask_size * 2,
                 row_table.buffer_size(0) - padding_for_vectors);
-      constexpr int64_t offset_width = sizeof(uint32_t);
-      int64_t actual_offset_size = num_rows * offset_width;
+
+      int64_t actual_offset_size = num_rows * sizeof(uint32_t);
       ASSERT_GT(actual_offset_size * 2, row_table.buffer_size(1) - padding_for_vectors);
-      auto row_width = row_table.offsets()[1];
-      int64_t actual_rows_size = num_rows * row_width;
+
+      int64_t actual_rows_size = num_rows * row_table.offsets()[1];
       ASSERT_GT(actual_rows_size * 2, row_table.buffer_size(2) - padding_for_vectors);
     }
   }

--- a/cpp/src/arrow/compute/row/row_test.cc
+++ b/cpp/src/arrow/compute/row/row_test.cc
@@ -28,7 +28,6 @@ namespace compute {
 namespace {
 
 Result<RowTableImpl> MakeRowTableFromColumn(const std::shared_ptr<Array>& column,
-                                            // int64_t num_rows) {
                                             int64_t num_rows, int row_alignment,
                                             int string_alignment) {
   DCHECK_GE(column->length(), num_rows);

--- a/cpp/src/arrow/compute/row/row_test.cc
+++ b/cpp/src/arrow/compute/row/row_test.cc
@@ -17,20 +17,13 @@
 
 #include <numeric>
 
-#include "arrow/compute/row/compare_internal.h"
+#include "arrow/compute/row/encode_internal.h"
+#include "arrow/compute/row/row_internal.h"
 #include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/testing/random.h"
-#include "arrow/util/bitmap_ops.h"
 
 namespace arrow {
 namespace compute {
-
-using arrow::bit_util::BytesForBits;
-using arrow::internal::CpuInfo;
-using arrow::random::RandomArrayGenerator;
-using arrow::util::MiniBatch;
-using arrow::util::TempVectorStack;
 
 namespace {
 
@@ -122,137 +115,6 @@ TEST(RowTableMemoryConsumption, Encode) {
       int64_t actual_rows_size = num_rows * row_table.offsets()[1];
       ASSERT_GT(actual_rows_size * 2, row_table.buffer_size(2) - padding_for_vectors);
     }
-  }
-}
-
-TEST(RowTableMemoryConsumption, Append) {
-  if constexpr (sizeof(void*) == 4) {
-    GTEST_SKIP() << "Test only works on 64-bit platforms";
-  }
-
-  // The idea of this case is to create a row table using one fixed length column and
-  // one var length column (so the row is hence var length and has offset buffer), with
-  // more than 2^31 rows. Then compare the rows with row ids larger than 2^31.
-
-  // A small batch to append to the row table repeatedly to grow the row table to big
-  // enough.
-  constexpr int64_t num_rows_batch = std::numeric_limits<uint16_t>::max() + 1ll;
-  // The number of rows in the row table is one batch larger than 2^31, and we'll
-  // compare the last num_rows_batch rows.
-  constexpr int64_t num_rows_row_table =
-      std::numeric_limits<int32_t>::max() + 1ll + num_rows_batch;
-
-  MemoryPool* pool = default_memory_pool();
-
-  // The left side columns with num_rows_batch rows.
-  std::vector<KeyColumnArray> columns_left;
-  ExecBatch batch_left;
-  {
-    std::vector<Datum> values;
-
-    // A fixed length array containing random values.
-    ASSERT_OK_AND_ASSIGN(auto value_fixed_length,
-                         ::arrow::gen::Random(uint32())->Generate(num_rows_batch));
-    values.push_back(std::move(value_fixed_length));
-
-    // A var length array containing small var length values ("X").
-    ASSERT_OK_AND_ASSIGN(auto value_var_length,
-                         ::arrow::gen::Constant(std::make_shared<BinaryScalar>("X"))
-                             ->Generate(num_rows_batch));
-    values.push_back(std::move(value_var_length));
-
-    batch_left = ExecBatch(std::move(values), num_rows_batch);
-    ASSERT_OK(ColumnArraysFromExecBatch(batch_left, &columns_left));
-  }
-
-  // The right side row table with num_rows_row_table rows.
-  RowTableImpl row_table_right;
-  {
-    // Encode the row table with the left columns repeatedly.
-    std::vector<KeyColumnMetadata> column_metadatas;
-    ASSERT_OK(ColumnMetadatasFromExecBatch(batch_left, &column_metadatas));
-    RowTableMetadata table_metadata;
-    table_metadata.FromColumnMetadataVector(column_metadatas, sizeof(uint64_t),
-                                            sizeof(uint64_t));
-    ASSERT_OK(row_table_right.Init(pool, table_metadata));
-    RowTableImpl row_table_batch;
-    ASSERT_OK(row_table_batch.Init(pool, table_metadata));
-    std::vector<uint16_t> row_ids(num_rows_batch);
-    std::iota(row_ids.begin(), row_ids.end(), 0);
-    RowTableEncoder row_encoder;
-    row_encoder.Init(column_metadatas, sizeof(uint64_t), sizeof(uint64_t));
-    row_encoder.PrepareEncodeSelected(0, num_rows_batch, columns_left);
-    ASSERT_OK(row_encoder.EncodeSelected(
-        &row_table_batch, static_cast<uint32_t>(num_rows_batch), row_ids.data()));
-    for (int i = 0; i < num_rows_row_table / num_rows_batch; ++i) {
-      ASSERT_OK(row_table_right.AppendSelectionFrom(row_table_batch, num_rows_batch,
-                                                    /*source_row_ids=*/NULLPTR));
-    }
-
-    // The row table must contain an offset buffer.
-    ASSERT_NE(row_table_right.offsets(), NULLPTR);
-    ASSERT_EQ(row_table_right.length(), num_rows_row_table);
-  }
-
-  // The rows to compare, left row i to right row 2^31 + i.
-  std::vector<uint32_t> row_ids_to_compare(num_rows_batch);
-  std::iota(row_ids_to_compare.begin(), row_ids_to_compare.end(),
-            num_rows_row_table - num_rows_batch);
-
-  TempVectorStack stack;
-  ASSERT_OK(
-      stack.Init(pool, KeyCompare::CompareColumnsToRowsTempStackUsage(num_rows_batch)));
-  LightContext ctx{CpuInfo::GetInstance()->hardware_flags(), &stack};
-
-  {
-    // No selection, output no match row ids.
-    uint32_t num_rows_no_match;
-    std::vector<uint16_t> row_ids_out(num_rows_batch);
-    KeyCompare::CompareColumnsToRows(num_rows_batch, /*sel_left_maybe_null=*/NULLPTR,
-                                     row_ids_to_compare.data(), &ctx, &num_rows_no_match,
-                                     row_ids_out.data(), columns_left, row_table_right,
-                                     /*are_cols_in_encoding_order=*/true,
-                                     /*out_match_bitvector_maybe_null=*/NULLPTR);
-    ASSERT_EQ(num_rows_no_match, 0);
-  }
-
-  {
-    // No selection, output match bit vector.
-    std::vector<uint8_t> match_bitvector(BytesForBits(num_rows_batch));
-    KeyCompare::CompareColumnsToRows(
-        num_rows_batch, /*sel_left_maybe_null=*/NULLPTR, row_ids_to_compare.data(), &ctx,
-        /*out_num_rows=*/NULLPTR, /*out_sel_left_maybe_same=*/NULLPTR, columns_left,
-        row_table_right,
-        /*are_cols_in_encoding_order=*/true, match_bitvector.data());
-    ASSERT_EQ(arrow::internal::CountSetBits(match_bitvector.data(), 0, num_rows_batch),
-              num_rows_batch);
-  }
-
-  std::vector<uint16_t> selection_left(num_rows_batch);
-  std::iota(selection_left.begin(), selection_left.end(), 0);
-
-  {
-    // With selection, output no match row ids.
-    uint32_t num_rows_no_match;
-    std::vector<uint16_t> row_ids_out(num_rows_batch);
-    KeyCompare::CompareColumnsToRows(num_rows_batch, selection_left.data(),
-                                     row_ids_to_compare.data(), &ctx, &num_rows_no_match,
-                                     row_ids_out.data(), columns_left, row_table_right,
-                                     /*are_cols_in_encoding_order=*/true,
-                                     /*out_match_bitvector_maybe_null=*/NULLPTR);
-    ASSERT_EQ(num_rows_no_match, 0);
-  }
-
-  {
-    // With selection, output match bit vector.
-    std::vector<uint8_t> match_bitvector(BytesForBits(num_rows_batch));
-    KeyCompare::CompareColumnsToRows(
-        num_rows_batch, selection_left.data(), row_ids_to_compare.data(), &ctx,
-        /*out_num_rows=*/NULLPTR, /*out_sel_left_maybe_same=*/NULLPTR, columns_left,
-        row_table_right,
-        /*are_cols_in_encoding_order=*/true, match_bitvector.data());
-    ASSERT_EQ(arrow::internal::CountSetBits(match_bitvector.data(), 0, num_rows_batch),
-              num_rows_batch);
   }
 }
 

--- a/cpp/src/arrow/compute/row/row_test.cc
+++ b/cpp/src/arrow/compute/row/row_test.cc
@@ -57,7 +57,7 @@ Result<RowTableImpl> MakeRowTableFromColumn(const std::shared_ptr<Array>& column
   RETURN_NOT_OK(row_encoder.EncodeSelected(&row_table, static_cast<uint32_t>(num_rows),
                                            row_ids.data()));
 
-  return std::move(row_table);
+  return row_table;
 }
 
 }  // namespace


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

As described in #43129 , current row table occupies more memory than expected. The memory consumption is double of necessary. The reason listed below.

When encoding var length columns into into the row table:
https://github.com/apache/arrow/blob/e59832fb05dc40a85fa63297c77c8f134c9ac8e0/cpp/src/arrow/compute/row/encode_internal.cc#L155-L162

We first call `AppendEmpty` to reserve space for `x` rows but `0` bytes. This is to reserve enough size for the underlying fixed-length buffers: null masks and offsets (for var-length columns).

Then we call `GetRowOffsetsSelected` to populate the offsets.

At last we call `AppendEmpty` again with `0` rows but `y` bytes, where `y` is the last offset element which is essentially the whole size of the var-length columns.

Sounds all reasonable so far.

However, `AppendEmpty` calls `ResizeOptionalVaryingLengthBuffer`, in which:
https://github.com/apache/arrow/blob/e59832fb05dc40a85fa63297c77c8f134c9ac8e0/cpp/src/arrow/compute/row/row_internal.cc#L294-L303

We calculate `bytes_capacity_new` by keeping doubling it until it's big enough for `num_bytes + num_extra_bytes`.

Note by the time of this point, `num_bytes == offsets()[num_rows_]` is already `y`, meanwhile `num_extra_bytes` is also `y`, hence the unexpected doubled size than necessary.

### What changes are included in this PR?

Fix the wasted half size for buffers in row table. Also add tests to make sure the buffer size is as expected.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

UT included.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43129