### PR TITLE
GH-43122: [CI][Packaging][RPM][CentOS] Use vault.centos.org for SCL

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -201,6 +201,11 @@ echo "::group::Test Apache Arrow C++"
 ${install_command} ${enablerepo_epel} arrow-devel-${package_version}
 if [ -n "${devtoolset}" ]; then
   ${install_command} ${scl_package}
+  sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 fi
 ${install_command} \
   ${cmake_package} \

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
@@ -24,7 +24,7 @@ ENV \
 ARG DEBUG
 
 # GH-42128
-# Switch repos to point to to vault.centos.org because Centos 7 is EOL
+# Switch repos to point to to vault.centos.org because CentOS 7 is EOL
 RUN sed -i \
   -e 's/^mirrorlist/#mirrorlist/' \
   -e 's/^#baseurl/baseurl/' \
@@ -37,6 +37,11 @@ RUN \
   yum install -y ${quiet} \
     centos-release-scl-rh \
     epel-release && \
+  sed -i \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/mirror\.centos\.org/vault.centos.org/' \
+    /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
   yum install -y ${quiet} \
     ${SCL}-gcc-c++ \
     ${SCL}-make \


### PR DESCRIPTION
### Rationale for this change

We can't use http://mirrorlist.centos.org because CentOS 7 reached EOL.

### What changes are included in this PR?

Use https://vault.centos.org/ instead.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43122