### PR TITLE
GH-43131: [CI] Attach lint failures to PR diff view

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -60,7 +60,8 @@ jobs:
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: |
-          pre-commit run --all-files --color=always --show-diff-on-failure
+          pre-commit run --all-files --color=always --show-diff-on-failure | \
+            dev/filter_pre_commit_diff.rb
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
       - name: Execute Docker Build

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -21,7 +21,8 @@ message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 # https://www.cmake.org/cmake/help/latest/policy/CMP0025.html
 #
 # Compiler id for Apple Clang is now AppleClang.
-cmake_policy(SET CMP0025 NEW)
+cmake_policy(
+SET CMP0025 NEW)
 
 # https://cmake.org/cmake/help/latest/policy/CMP0042.html
 #
@@ -68,7 +69,8 @@ cmake_policy(SET CMP0091 NEW)
 # but we use the NEW behavior explicitly to suppress CMP0135
 # warnings.
 if(POLICY CMP0135)
-  cmake_policy(SET CMP0135 NEW)
+  cmake_policy(
+SET CMP0135 NEW)
 endif()
 
 set(ARROW_VERSION "17.0.0-SNAPSHOT")

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -35,7 +35,7 @@ Result<std::shared_ptr<Buffer>> Buffer::CopySlice(const int64_t start,
                                                   const int64_t nbytes,
                                                   MemoryPool* pool) const {
   // Sanity checks
-  ARROW_CHECK_LE(start, size_);
+  ARROW_CHECK_LE(start,  size_);
   ARROW_CHECK_LE(nbytes, size_ - start);
   DCHECK_GE(nbytes, 0);
 
@@ -58,7 +58,7 @@ Status CheckBufferSlice(const Buffer& buffer, int64_t offset) {
     // Avoid UBSAN in subtraction below
     return Status::IndexError("Negative buffer slice offset");
   }
-  return CheckBufferSlice(buffer, offset, buffer.size() - offset);
+  return CheckBufferSlice(buffer,  offset, buffer.size() - offset);
 }
 
 }  // namespace

--- a/dev/filter_pre_commit_diff.rb
+++ b/dev/filter_pre_commit_diff.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Workflow commands for GitHub Actions:
+# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+
+diff_from = nil
+diff_to = nil
+diff_from_line = nil
+diff_to_line = nil
+in_diff = false
+diff_content = +""
+
+def remove_escape_sequences(text)
+  text.gsub(/\e\[.*?m/, "")
+end
+
+flush_diff = lambda do
+  return unless in_diff
+
+  parameters = [
+    "file=#{diff_to}",
+    "line=#{diff_to_line[0]}",
+    "endLine=#{diff_to_line[1]}",
+    "title=diff",
+  ].join(",")
+  # We need to use URL encode for new line:
+  # https://github.com/actions/toolkit/issues/193
+  message = remove_escape_sequences(diff_content).gsub("\n", "%0A")
+  puts("::error #{parameters}::#{message}")
+  in_diff = false
+  diff_content = +""
+end
+
+ARGF.each_line do |line|
+  raw_line = remove_escape_sequences(line)
+  case raw_line
+  when /\A--- a\/(.+)$/ # git diff
+    path = $1
+    flush_diff.call
+    diff_from = path
+    diff_to = nil
+    diff_from_line = nil
+    diff_to_line = nil
+  when /\A?\+\+\+ b\/(.+)$/ # git diff
+    diff_to = $1
+  when /\A?@@ -(\d+),(\d+) \+(\d+),(\d+) @@/
+    diff_from_start = $1.to_i
+    diff_from_end = diff_from_start + $2.to_i
+    diff_to_start = $3.to_i
+    diff_to_end = diff_to_start + $4.to_i
+    flush_diff.call
+    diff_from_line = [diff_from_start, diff_from_end]
+    diff_to_line = [diff_to_start, diff_to_end]
+    in_diff = (diff_from and diff_to)
+  when /\A[-+ ]/
+    diff_content << line if in_diff
+  else
+    flush_diff.call
+  end
+  print(line)
+end
+
+flush_diff.call


### PR DESCRIPTION
### Rationale for this change

If we can attach lint failures to PR diff view, PR authors will fix lint failures without comments from reviewers.

### What changes are included in this PR?

Detect diffs from `pre-commit run --show-diff-on-failure` and convert them to "error" workflow commands.

See also: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43131