### PR TITLE
GH-36518: [Java] Fix ArrowFlightJdbcTimeStampVectorAccessor to return Timestamp objects with date and time that corresponds with local time instead of UTC date and time

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
+import static java.util.Objects.nonNull;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Getter;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Holder;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.createGetter;
@@ -25,7 +26,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -85,13 +85,11 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     long value = holder.value;
 
     LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);
+    ZoneId defaultTimeZone = TimeZone.getDefault().toZoneId();
+    ZoneId sourceTimeZone = nonNull(this.timeZone) ? this.timeZone.toZoneId() :
+            nonNull(calendar) ? calendar.getTimeZone().toZoneId() : defaultTimeZone;
 
-    ZoneId sourceTimeZone = this.timeZone != null ? this.timeZone.toZoneId() :
-            calendar == null ? TimeZone.getDefault().toZoneId() : calendar.getTimeZone().toZoneId();
-    ZonedDateTime sourceTZDateTime = localDateTime.atZone(sourceTimeZone);
-    localDateTime = sourceTZDateTime.withZoneSameInstant(TimeZone.getDefault().toZoneId()).toLocalDateTime();
-
-    return localDateTime;
+    return localDateTime.atZone(sourceTimeZone).withZoneSameInstant(defaultTimeZone).toLocalDateTime();
   }
 
   @Override

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -40,7 +40,6 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
 
   private final TimeZone timeZone;
   private final Getter getter;
-  private final TimeUnit timeUnit;
   private final LongToUTCDateTime longToUTCDateTime;
   private final Holder holder;
 
@@ -59,7 +58,6 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     this.getter = createGetter(vector);
 
     this.timeZone = getTimeZoneForVector(vector);
-    this.timeUnit = getTimeUnitForVector(vector);
     this.longToUTCDateTime = getLongToUTCDateTimeForVector(vector);
   }
 
@@ -150,8 +148,6 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
   }
 
   protected static LongToUTCDateTime getLongToUTCDateTimeForVector(TimeStampVector vector) {
-    String timeZoneID = "UTC";
-
     ArrowType.Timestamp arrowType =
         (ArrowType.Timestamp) vector.getField().getFieldType().getType();
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -16,7 +16,6 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 
-import static java.util.Objects.nonNull;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Getter;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Holder;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.createGetter;
@@ -85,9 +84,16 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     long value = holder.value;
 
     LocalDateTime localDateTime = this.longToLocalDateTime.fromLong(value);
-    ZoneId defaultTimeZone = TimeZone.getDefault().toZoneId();
-    ZoneId sourceTimeZone = nonNull(this.timeZone) ? this.timeZone.toZoneId() :
-            nonNull(calendar) ? calendar.getTimeZone().toZoneId() : defaultTimeZone;
+    ZoneId defaultTimeZone = Calendar.getInstance().getTimeZone().toZoneId();
+    ZoneId sourceTimeZone;
+
+    if (this.timeZone != null) {
+      sourceTimeZone = this.timeZone.toZoneId();
+    } else if (calendar != null) {
+      sourceTimeZone = calendar.getTimeZone().toZoneId();
+    } else {
+      sourceTimeZone = defaultTimeZone;
+    }
 
     return localDateTime.atZone(sourceTimeZone).withZoneSameInstant(defaultTimeZone).toLocalDateTime();
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -95,7 +95,10 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
       sourceTimeZone = defaultTimeZone;
     }
 
-    return localDateTime.atZone(sourceTimeZone).withZoneSameInstant(defaultTimeZone).toLocalDateTime();
+    return localDateTime
+        .atZone(sourceTimeZone)
+        .withZoneSameInstant(defaultTimeZone)
+        .toLocalDateTime();
   }
 
   @Override
@@ -160,8 +163,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
       case MILLISECOND:
         return DateUtility::getLocalDateTimeFromEpochMilli;
       case SECOND:
-        return seconds -> DateUtility.getLocalDateTimeFromEpochMilli(
-            TimeUnit.SECONDS.toMillis(seconds));
+        return seconds ->
+            DateUtility.getLocalDateTimeFromEpochMilli(TimeUnit.SECONDS.toMillis(seconds));
       default:
         throw new UnsupportedOperationException("Invalid Arrow time unit");
     }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -34,7 +34,7 @@ public class DateTimeUtils {
     // Prevent instantiation.
   }
 
-  /** Subtracts given Calendar's TimeZone offset from epoch milliseconds. */
+  /** Apply calendar timezone to epoch milliseconds. */
   public static long applyCalendarOffset(long milliseconds, Calendar calendar) {
     if (calendar == null) {
       calendar = Calendar.getInstance();

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -19,9 +19,11 @@ package org.apache.arrow.driver.jdbc.utils;
 import static org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -37,15 +39,11 @@ public class DateTimeUtils {
     if (calendar == null) {
       calendar = Calendar.getInstance();
     }
-
-    final TimeZone tz = calendar.getTimeZone();
-    final TimeZone defaultTz = TimeZone.getDefault();
-
-    if (tz != defaultTz) {
-      milliseconds -= tz.getOffset(milliseconds) - defaultTz.getOffset(milliseconds);
-    }
-
-    return milliseconds;
+    Instant currInstant = Instant.ofEpochMilli(milliseconds);
+    LocalDateTime getTimestampWithoutTZ = LocalDateTime.ofInstant(currInstant,
+            TimeZone.getTimeZone("UTC").toZoneId());
+    ZonedDateTime parsedTime = getTimestampWithoutTZ.atZone(calendar.getTimeZone().toZoneId());
+    return parsedTime.toEpochSecond() * 1000;
   }
 
   /**

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -40,8 +40,8 @@ public class DateTimeUtils {
       calendar = Calendar.getInstance();
     }
     Instant currInstant = Instant.ofEpochMilli(milliseconds);
-    LocalDateTime getTimestampWithoutTZ = LocalDateTime.ofInstant(currInstant,
-            TimeZone.getTimeZone("UTC").toZoneId());
+    LocalDateTime getTimestampWithoutTZ =
+        LocalDateTime.ofInstant(currInstant, TimeZone.getTimeZone("UTC").toZoneId());
     ZonedDateTime parsedTime = getTimestampWithoutTZ.atZone(calendar.getTimeZone().toZoneId());
     return parsedTime.toEpochSecond() * 1000;
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtils.java
@@ -43,7 +43,7 @@ public class DateTimeUtils {
     LocalDateTime getTimestampWithoutTZ =
         LocalDateTime.ofInstant(currInstant, TimeZone.getTimeZone("UTC").toZoneId());
     ZonedDateTime parsedTime = getTimestampWithoutTZ.atZone(calendar.getTimeZone().toZoneId());
-    return parsedTime.toEpochSecond() * 1000;
+    return parsedTime.toInstant().toEpochMilli();
   }
 
   /**

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -193,8 +193,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
       final Timestamp result = accessor.getTimestamp(calendar);
 
-      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
-              accessor);
+      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
+              resultWithoutCalendar.getTime(), accessor);
     });
   }
 
@@ -238,8 +238,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Date resultWithoutCalendar = accessor.getDate(null);
           final Date result = accessor.getDate(calendar);
 
-      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
-              accessor);
+      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
+              resultWithoutCalendar.getTime(), accessor);
     });
   }
 
@@ -283,8 +283,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Time resultWithoutCalendar = accessor.getTime(null);
           final Time result = accessor.getTime(calendar);
 
-      compareOffset(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(), resultWithoutCalendar.getTime(),
-              accessor);
+      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
+              resultWithoutCalendar.getTime(), accessor);
     });
   }
 
@@ -308,11 +308,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       TimeUnit timeUnit = getTimeUnitForVector(vector);
       long millis = timeUnit.toMillis((Long) object);
 
-      Instant currInstant = Instant.ofEpochMilli(millis);
-      LocalDateTime getTimestampWithoutTZ = LocalDateTime.ofInstant(currInstant,
-              TimeZone.getTimeZone("UTC").toZoneId());
-
-      ZonedDateTime sourceTZDateTime = getTimestampWithoutTZ.atZone(TimeZone.getTimeZone(timeZone).toZoneId());
+      ZonedDateTime sourceTZDateTime = LocalDateTime
+              .ofInstant(Instant.ofEpochMilli(millis), TimeZone.getTimeZone("UTC").toZoneId())
+              .atZone(TimeZone.getTimeZone(timeZone).toZoneId());
       expectedTimestamp = new Timestamp(sourceTZDateTime.toEpochSecond() * 1000);
     }
     return expectedTimestamp;
@@ -372,8 +370,10 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     }
   }
 
-  private void compareOffset(TimeZone timeZone, TimeZone finalTimeZoneForResultWithoutCalendar, long result,
-                             long resultWithoutCalendar, ArrowFlightJdbcTimeStampVectorAccessor accessor) {
+  private void assertOffsetIsConsistentWithAccessorGetters(TimeZone timeZone,
+                                                           TimeZone finalTimeZoneForResultWithoutCalendar, long result,
+                                                           long resultWithoutCalendar,
+                                                           ArrowFlightJdbcTimeStampVectorAccessor accessor) {
     final TimeZone timeZoneForResult = getTimeZoneForVector(vector) == null ? timeZone :
             finalTimeZoneForResultWithoutCalendar;
 

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -183,11 +183,13 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
   public void testShouldGetTimestampReturnValidTimestampWithCalendar(
       Supplier<TimeStampVector> vectorSupplier) throws Exception {
     setup(vectorSupplier);
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Hong_Kong"));
+
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
     TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
-            .orElse(TimeZone.getDefault());
+            .orElse(TimeZone.getTimeZone("Asia/Hong_Kong"));
 
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
@@ -196,6 +198,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
               resultWithoutCalendar.getTime(), accessor);
     });
+    TimeZone.setDefault(null);
   }
 
   @ParameterizedTest

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -29,7 +29,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
@@ -188,16 +187,22 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
-            .orElse(TimeZone.getTimeZone("Asia/Hong_Kong"));
+    TimeZone finalTimeZoneForResultWithoutCalendar =
+        ofNullable(getTimeZoneForVector(vector)).orElse(TimeZone.getTimeZone("Asia/Hong_Kong"));
 
-    accessorIterator.iterate(vector, (accessor, currentRow) -> {
-      final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
-      final Timestamp result = accessor.getTimestamp(calendar);
+    accessorIterator.iterate(
+        vector,
+        (accessor, currentRow) -> {
+          final Timestamp resultWithoutCalendar = accessor.getTimestamp(null);
+          final Timestamp result = accessor.getTimestamp(calendar);
 
-      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
-              resultWithoutCalendar.getTime(), accessor);
-    });
+          assertOffsetIsConsistentWithAccessorGetters(
+              timeZone,
+              finalTimeZoneForResultWithoutCalendar,
+              result.getTime(),
+              resultWithoutCalendar.getTime(),
+              accessor);
+        });
     TimeZone.setDefault(null);
   }
 
@@ -232,8 +237,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
-            .orElse(TimeZone.getDefault());
+    TimeZone finalTimeZoneForResultWithoutCalendar =
+        ofNullable(getTimeZoneForVector(vector)).orElse(TimeZone.getDefault());
 
     accessorIterator.iterate(
         vector,
@@ -241,9 +246,13 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Date resultWithoutCalendar = accessor.getDate(null);
           final Date result = accessor.getDate(calendar);
 
-      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
-              resultWithoutCalendar.getTime(), accessor);
-    });
+          assertOffsetIsConsistentWithAccessorGetters(
+              timeZone,
+              finalTimeZoneForResultWithoutCalendar,
+              result.getTime(),
+              resultWithoutCalendar.getTime(),
+              accessor);
+        });
   }
 
   @ParameterizedTest
@@ -277,8 +286,8 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     TimeZone timeZone = TimeZone.getTimeZone(AMERICA_SAO_PAULO);
     Calendar calendar = Calendar.getInstance(timeZone);
 
-    TimeZone finalTimeZoneForResultWithoutCalendar = ofNullable(getTimeZoneForVector(vector))
-            .orElse(TimeZone.getDefault());
+    TimeZone finalTimeZoneForResultWithoutCalendar =
+        ofNullable(getTimeZoneForVector(vector)).orElse(TimeZone.getDefault());
 
     accessorIterator.iterate(
         vector,
@@ -286,9 +295,13 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           final Time resultWithoutCalendar = accessor.getTime(null);
           final Time result = accessor.getTime(calendar);
 
-      assertOffsetIsConsistentWithAccessorGetters(timeZone, finalTimeZoneForResultWithoutCalendar, result.getTime(),
-              resultWithoutCalendar.getTime(), accessor);
-    });
+          assertOffsetIsConsistentWithAccessorGetters(
+              timeZone,
+              finalTimeZoneForResultWithoutCalendar,
+              result.getTime(),
+              resultWithoutCalendar.getTime(),
+              accessor);
+        });
   }
 
   @ParameterizedTest
@@ -311,8 +324,9 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
       TimeUnit timeUnit = getTimeUnitForVector(vector);
       long millis = timeUnit.toMillis((Long) object);
 
-      ZonedDateTime sourceTZDateTime = LocalDateTime
-              .ofInstant(Instant.ofEpochMilli(millis), TimeZone.getTimeZone("UTC").toZoneId())
+      ZonedDateTime sourceTZDateTime =
+          LocalDateTime.ofInstant(
+                  Instant.ofEpochMilli(millis), TimeZone.getTimeZone("UTC").toZoneId())
               .atZone(TimeZone.getTimeZone(timeZone).toZoneId());
       expectedTimestamp = new Timestamp(sourceTZDateTime.toEpochSecond() * 1000);
     }
@@ -373,15 +387,18 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
     }
   }
 
-  private void assertOffsetIsConsistentWithAccessorGetters(TimeZone timeZone,
-                                                           TimeZone finalTimeZoneForResultWithoutCalendar, long result,
-                                                           long resultWithoutCalendar,
-                                                           ArrowFlightJdbcTimeStampVectorAccessor accessor) {
-    final TimeZone timeZoneForResult = getTimeZoneForVector(vector) == null ? timeZone :
-            finalTimeZoneForResultWithoutCalendar;
+  private void assertOffsetIsConsistentWithAccessorGetters(
+      TimeZone timeZone,
+      TimeZone finalTimeZoneForResultWithoutCalendar,
+      long result,
+      long resultWithoutCalendar,
+      ArrowFlightJdbcTimeStampVectorAccessor accessor) {
+    final TimeZone timeZoneForResult =
+        getTimeZoneForVector(vector) == null ? timeZone : finalTimeZoneForResultWithoutCalendar;
 
-    long offset = timeZoneForResult.getOffset(result) -
-            finalTimeZoneForResultWithoutCalendar.getOffset(resultWithoutCalendar);
+    long offset =
+        timeZoneForResult.getOffset(result)
+            - finalTimeZoneForResultWithoutCalendar.getOffset(resultWithoutCalendar);
 
     assertThat(resultWithoutCalendar - result, is(offset));
     assertThat(accessor.wasNull(), is(false));

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessorTest.java
@@ -328,7 +328,7 @@ public class ArrowFlightJdbcTimeStampVectorAccessorTest {
           LocalDateTime.ofInstant(
                   Instant.ofEpochMilli(millis), TimeZone.getTimeZone("UTC").toZoneId())
               .atZone(TimeZone.getTimeZone(timeZone).toZoneId());
-      expectedTimestamp = new Timestamp(sourceTZDateTime.toEpochSecond() * 1000);
+      expectedTimestamp = new Timestamp(sourceTZDateTime.toInstant().toEpochMilli());
     }
     return expectedTimestamp;
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
@@ -64,8 +64,8 @@ public class DateTimeUtilsTest {
 
     try { // Trying to guarantee timezone returns to its original value
       final long expectedEpochMillis = epochMillis - offset;
-      final long actualEpochMillis = DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(
-              alternateTimezone));
+      final long actualEpochMillis =
+          DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(alternateTimezone));
 
       assertThat(actualEpochMillis, is(expectedEpochMillis));
     } finally {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/utils/DateTimeUtilsTest.java
@@ -63,9 +63,9 @@ public class DateTimeUtilsTest {
     TimeZone.setDefault(alternateTimezone);
 
     try { // Trying to guarantee timezone returns to its original value
-      final long expectedEpochMillis = epochMillis + offset;
-      final long actualEpochMillis =
-          DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(defaultTimezone));
+      final long expectedEpochMillis = epochMillis - offset;
+      final long actualEpochMillis = DateTimeUtils.applyCalendarOffset(epochMillis, Calendar.getInstance(
+              alternateTimezone));
 
       assertThat(actualEpochMillis, is(expectedEpochMillis));
     } finally {


### PR DESCRIPTION
### Rationale for this change

I opened this PR for continuing the work done at this one https://github.com/apache/arrow/pull/36519. 
I copy the description from there.

When calling the getTimestamp method from the ArrowFlightJdbcTimeStampVectorAccessor class, the timezone of the Timestamp object returned is incorrect. The timestamp itself appears to be in GMT/UTC time but the timezone field of the Timestamp object is populated with the timezone of the JDBC client instead.

Example

timestamp on db: 2021-03-28T00:15:00.000 (UTC)

timezone of JDBC client: PST/PDT (Vancouver Time)
Calendar cal <- Calendar with UTC timezone
calling getTimestamp(cal) on a result set will return a timestamp like this: 2021-03-28T00:15:00.000 (PST/PDT)
where 2021-03-28T00:15:00.000 appears to be in UTC time but the timezone of the object itself is PST/PDT

### What changes are included in this PR?

- Fixed: Correct behaviour is that the calendar object is used to extend the data into the timezone of the calendar object, essentially asserting that the data is at the timezone defined in the calendar object and returns a time-related object that has local date and time and local timezone
- Fixed: for vectors that do store timezone information (ie. TimestampVector), the getter methods will use the timezone defined in vector as the timezone assertion and ignores the calendar object if one was passed in
- Fixed: applyCalendarOffset now correctly creates a corresponding time-related object using the supplied calendar timezone and returns a time-related object that has local date and time and local timezone

### Are these changes tested?

Many of the time related tests also face this issue and this fixes them all. Also tested the driver jar in a JDBC client and behaviour is fixed.

Also tested behavior with Oracle and SQLServer.

Test table
```
-- sqlserver
create table ts_table ( 
	c1 int,
	c2 datetime2 
);
insert into ts_table (c1, c2) values (1, '2005-06-29 19:19:41');

-- oracle
create table ts_table ( 
	c1 int,
	c2 timestamp
);
insert into ts_table (c1, c2) values (1, to_timestamp('2005-06-29 19:19:41', 'YYYY-MM-dd HH24:MI:SS'));
```
Attached `TestTs.zip` with sample class for testing the behavior. 

Obtained results (local time zone is `Europe/Madrid`)

```
Oracle...
Timestamp at default tz (Central European Standard Time): 2005-06-29 19:19:41.0
Timestamp at America/Los_Angeles tz: 2005-06-30 04:19:41.0

SQL Server...
Timestamp at default tz (Central European Standard Time): 2005-06-29 19:19:41.0
Timestamp at America/Los_Angeles tz: 2005-06-30 04:19:41.0

Flight SQL (16.1.0)
Timestamp at default tz (Central European Standard Time): 2005-06-29 17:19:41.0
Timestamp at America/Los_Angeles tz: 2005-06-30 02:19:41.0

Flight SQL (fix )
Timestamp at default tz (Central European Standard Time): 2005-06-29 19:19:41.0
Timestamp at America/Los_Angeles tz: 2005-06-30 04:19:41.0
```
Note than result with `America/Los_Angeles` prints the timestamp on my machine (which is at Europe/Madrid) with a difference of 9 hours. That is correct, `Europe/Madrid is 9 hours forward than `America/Los_Angeles`.

With Flight-SQL JDBC driver **16.1.0** version results are wrong.  With these changes returned timestamp is fine. 

### Are there any user-facing changes?

- No. Closes: https://github.com/apache/arrow/issues/36518
- Closes: https://github.com/apache/arrow/issues/36518

















[TestTs.zip](https://github.com/user-attachments/files/16100625/TestTs.zip)




* GitHub Issue: #36518