### PR TITLE
GH-43152: [Release] Require "digest/sha1" explicitly for thread safety

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -16,6 +16,7 @@
 # under the License.
 
 require "cgi/util"
+require "digest/sha1"
 require "digest/sha2"
 require "io/console"
 require "json"


### PR DESCRIPTION
### Rationale for this change

If we don't require `digest/sha1` explicitly, it's required automatically when it's needed. But it's not thread safe.

### What changes are included in this PR?

Require `digest/sha1` explicitly in the main thread to avoid auto require.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #43152