### PR TITLE
GH-31924: [FlightRPC][Java] Provide standard way to get client IP address

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallInfo.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallInfo.java
@@ -19,12 +19,22 @@ package org.apache.arrow.flight;
 /** A description of a Flight call for middleware to inspect. */
 public final class CallInfo {
   private final FlightMethod method;
+  private final RequestInfo requestInfo;
+
+  public CallInfo(FlightMethod method, RequestInfo requestInfo) {
+    this.method = method;
+    this.requestInfo = requestInfo;
+  }
 
   public CallInfo(FlightMethod method) {
-    this.method = method;
+    this(method, null);
   }
 
   public FlightMethod method() {
     return method;
+  }
+
+  public RequestInfo getRequestInfo() {
+    return requestInfo;
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RequestInfo.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RequestInfo.java
@@ -16,11 +16,10 @@
  */
 package org.apache.arrow.flight;
 
-import java.net.SocketAddress;
-
 import io.grpc.Attributes;
 import io.grpc.Grpc;
 import io.grpc.ServerCall;
+import java.net.SocketAddress;
 
 /** Information about a request. */
 public final class RequestInfo {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RequestInfo.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/RequestInfo.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.flight;
+
+import java.net.SocketAddress;
+
+import io.grpc.Attributes;
+import io.grpc.Grpc;
+import io.grpc.ServerCall;
+
+/** Information about a request. */
+public final class RequestInfo {
+
+  private final SocketAddress remoteAddress;
+  private final SocketAddress localAddress;
+
+  RequestInfo(final SocketAddress remoteAddress, final SocketAddress localAddress) {
+    this.remoteAddress = remoteAddress;
+    this.localAddress = localAddress;
+  }
+
+  RequestInfo() {
+    this(null, null);
+  }
+
+  /**
+   * Returns the SocketAddress associated with the client.
+   *
+   * @return SocketAddress
+   */
+  public SocketAddress getRemoteAddress() {
+    return remoteAddress;
+  }
+
+  /**
+   * Returns the SocketAddress associated with the server.
+   *
+   * @return SocketAddress
+   */
+  public SocketAddress getLocalAddress() {
+    return localAddress;
+  }
+
+  /**
+   * Creates a new RequestInfo from the information present on the ServerCall.
+   *
+   * @param call with the information
+   * @return a RequestInfo with information extracted from ServerCall
+   */
+  public static <ReqT, RespT> RequestInfo fromCall(ServerCall<ReqT, RespT> call) {
+    final Attributes attrs = call.getAttributes();
+    if (attrs != null) {
+      return new RequestInfo(
+          attrs.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR), attrs.get(Grpc.TRANSPORT_ATTR_LOCAL_ADDR));
+    }
+    return new RequestInfo();
+  }
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BearerTokenAuthenticator.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/BearerTokenAuthenticator.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.RequestInfo;
 
 /**
  * Partial implementation of {@link CallHeaderAuthenticator} for bearer-token based authentication.
@@ -31,16 +32,21 @@ public abstract class BearerTokenAuthenticator implements CallHeaderAuthenticato
 
   @Override
   public AuthResult authenticate(CallHeaders incomingHeaders) {
+    return authenticate(incomingHeaders, null);
+  }
+
+  @Override
+  public AuthResult authenticate(CallHeaders incomingHeaders, RequestInfo requestInfo) {
     // Check if headers contain a bearer token and if so, validate the token.
     final String bearerToken =
         AuthUtilities.getValueFromAuthHeader(incomingHeaders, Auth2Constants.BEARER_PREFIX);
     if (bearerToken != null) {
-      return validateBearer(bearerToken);
+      return validateBearer(bearerToken, requestInfo);
     }
 
     // Delegate to the basic auth handler to do the validation.
     final CallHeaderAuthenticator.AuthResult result =
-        initialAuthenticator.authenticate(incomingHeaders);
+        initialAuthenticator.authenticate(incomingHeaders, requestInfo);
     return getAuthResultWithBearerToken(result);
   }
 
@@ -60,4 +66,15 @@ public abstract class BearerTokenAuthenticator implements CallHeaderAuthenticato
    * @return A successful AuthResult if validation succeeded.
    */
   protected abstract AuthResult validateBearer(String bearerToken);
+
+  /**
+   * Validate the bearer token.
+   *
+   * @param bearerToken The bearer token to validate.
+   * @param requestInfo Information about the request.
+   * @return A successful AuthResult if validation succeeded.
+   */
+  protected AuthResult validateBearer(String bearerToken, RequestInfo requestInfo) {
+    return validateBearer(bearerToken);
+  }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/CallHeaderAuthenticator.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/CallHeaderAuthenticator.java
@@ -18,6 +18,7 @@ package org.apache.arrow.flight.auth2;
 
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.RequestInfo;
 
 /**
  * Interface for Server side authentication handlers.
@@ -76,6 +77,19 @@ public interface CallHeaderAuthenticator {
    *     or if credentials were supplied but were not valid.
    */
   AuthResult authenticate(CallHeaders incomingHeaders);
+
+  /**
+   * Validate the auth headers sent by the client.
+   *
+   * @param incomingHeaders The incoming headers to authenticate.
+   * @param requestInfo Information about the request.
+   * @return an auth result containing a peer identity and optionally a bearer token.
+   * @throws FlightRuntimeException with CallStatus.UNAUTHENTICATED if credentials were not supplied
+   *     or if credentials were supplied but were not valid.
+   */
+  default AuthResult authenticate(CallHeaders incomingHeaders, RequestInfo requestInfo) {
+    return authenticate(incomingHeaders);
+  }
 
   /** An auth handler that does nothing. */
   CallHeaderAuthenticator NO_OP =

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ServerCallHeaderAuthMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/auth2/ServerCallHeaderAuthMiddleware.java
@@ -46,7 +46,8 @@ public class ServerCallHeaderAuthMiddleware implements FlightServerMiddleware {
     @Override
     public ServerCallHeaderAuthMiddleware onCallStarted(
         CallInfo callInfo, CallHeaders incomingHeaders, RequestContext context) {
-      final AuthResult result = authHandler.authenticate(incomingHeaders);
+      final AuthResult result =
+          authHandler.authenticate(incomingHeaders, callInfo.getRequestInfo());
       context.put(Auth2Constants.PEER_IDENTITY_KEY, result.getPeerIdentity());
       return new ServerCallHeaderAuthMiddleware(result);
     }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/ServerInterceptorAdapter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/ServerInterceptorAdapter.java
@@ -38,6 +38,7 @@ import org.apache.arrow.flight.FlightProducer.CallContext;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.FlightServerMiddleware;
 import org.apache.arrow.flight.FlightServerMiddleware.Key;
+import org.apache.arrow.flight.RequestInfo;
 
 /**
  * An adapter between Flight middleware and a gRPC interceptor.
@@ -88,7 +89,9 @@ public class ServerInterceptorAdapter implements ServerInterceptor {
     }
 
     final CallInfo info =
-        new CallInfo(FlightMethod.fromProtocol(call.getMethodDescriptor().getFullMethodName()));
+        new CallInfo(
+            FlightMethod.fromProtocol(call.getMethodDescriptor().getFullMethodName()),
+            RequestInfo.fromCall(call));
     final List<FlightServerMiddleware> middleware = new ArrayList<>();
     // Use LinkedHashMap to preserve insertion order
     final Map<FlightServerMiddleware.Key<?>, FlightServerMiddleware> middlewareMap =


### PR DESCRIPTION
### Rationale for this change

Give access to information about the requests executing the current action to the authentication processs and middlewares.
Adding for now the client and server socket addresses.

This can be useful for checking client origin at authentication phase and to audit accesses on a custom middleware. 

### What changes are included in this PR?

Create the class `org.apache.arrow.flight.RequestInfo` for storing the information.
This `RequestInfo` is also available through `org.apache.arrow.flight.CallInfo`. By this way, it is available for the middlewares.
Make also available `RequestInfo` to the `CallHeaderAuthenticator`, `BearerTokenAuthenticator` and `ServerCallHeaderAuthMiddleware`.

I overloaded the methods:
- `org.apache.arrow.flight.auth2.CallHeaderAuthenticator#authenticate(org.apache.arrow.flight.CallHeaders, org.apache.arrow.flight.RequestInfo)`
- `org.apache.arrow.flight.auth2.BearerTokenAuthenticator#validateBearer(java.lang.String, org.apache.arrow.flight.RequestInfo)` 

with a default implementation for maintaining backward compatibility and not breaking previous implementations. 

### Are these changes tested?

Tested manually after generated the artifacts with the changes. For now, there are no automated tests until checking if the changes are suitable. 


* GitHub Issue: apache/arrow-java#316
* GitHub Issue: #316