### PR TITLE
GH-43153: [R] pull on a grouped query returns the wrong column

### DIFF
--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -64,8 +64,8 @@ pull.Dataset <- function(.data,
   .data <- as_adq(.data)
   var <- vars_pull(names(.data), !!enquo(var))
   .data$selected_columns <- set_names(.data$selected_columns[var], var)
-  out <- dplyr::compute(.data)
-  handle_pull_as_vector(out[[var]], as_vector)
+  out <- dplyr::compute(.data)[[var]]
+  handle_pull_as_vector(out, as_vector)
 }
 pull.RecordBatchReader <- pull.arrow_dplyr_query <- pull.Dataset
 

--- a/r/R/dplyr-collect.R
+++ b/r/R/dplyr-collect.R
@@ -64,8 +64,8 @@ pull.Dataset <- function(.data,
   .data <- as_adq(.data)
   var <- vars_pull(names(.data), !!enquo(var))
   .data$selected_columns <- set_names(.data$selected_columns[var], var)
-  out <- dplyr::compute(.data)[[1]]
-  handle_pull_as_vector(out, as_vector)
+  out <- dplyr::compute(.data)
+  handle_pull_as_vector(out[[var]], as_vector)
 }
 pull.RecordBatchReader <- pull.arrow_dplyr_query <- pull.Dataset
 

--- a/r/tests/testthat/test-dplyr-query.R
+++ b/r/tests/testthat/test-dplyr-query.R
@@ -87,6 +87,7 @@ test_that("pull", {
     .input %>%
       filter(int > 4) %>%
       rename(strng = chr) %>%
+      group_by(dbl) %>%
       pull(strng) %>%
       as.vector(),
     tbl


### PR DESCRIPTION
### Rationale for this change

Fix a bug in our implementation of `pull` on grouped datasets

### What changes are included in this PR?

An additional test, the fix.

### Are these changes tested?

Yes, with the test I added to.

### Are there any user-facing changes?

Users will now get the expected behavior when using `pull` on grouped queries.

**This PR contains a "Critical Fix".**
* GitHub Issue: #43153