### PR TITLE
GH-41993 [Go] IPC writer shift voffsets when offsets array does not start from zero

### DIFF
--- a/go/arrow/ipc/ipc_test.go
+++ b/go/arrow/ipc/ipc_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/apache/arrow/go/v17/arrow"
 	"github.com/apache/arrow/go/v17/arrow/array"
+	"github.com/apache/arrow/go/v17/arrow/bitutil"
 	"github.com/apache/arrow/go/v17/arrow/ipc"
 	"github.com/apache/arrow/go/v17/arrow/memory"
 )
@@ -619,4 +620,62 @@ func TestIpcEmptyMap(t *testing.T) {
 	assert.True(t, r.Next())
 	assert.Zero(t, r.Record().NumRows())
 	assert.True(t, arrow.TypeEqual(dt, r.Record().Column(0).DataType()))
+}
+
+func TestArrow41993(t *testing.T) {
+
+	var buf bytes.Buffer
+	buf.WriteString("apple")
+	buf.WriteString("pear")
+	buf.WriteString("banana")
+	values := buf.Bytes()
+
+	offsets := []int32{5, 9, 15} // <-- only "pear" and "banana"
+	voffsets := arrow.Int32Traits.CastToBytes(offsets)
+
+	validity := []byte{0}
+	bitutil.SetBit(validity, 0)
+	bitutil.SetBit(validity, 1)
+
+	data := array.NewData(
+		arrow.BinaryTypes.String,
+		2, // <-- only "pear" and "banana"
+		[]*memory.Buffer{
+			memory.NewBufferBytes(validity),
+			memory.NewBufferBytes(voffsets),
+			memory.NewBufferBytes(values),
+		},
+		nil,
+		0,
+		0,
+	)
+
+	str := array.NewStringData(data)
+	fmt.Println(str) // outputs: ["pear" "banana"]
+	require.Equal(t, 2, str.Len())
+	require.Equal(t, "pear", str.Value(0))
+	require.Equal(t, "banana", str.Value(1))
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{
+			Name:     "string",
+			Type:     arrow.BinaryTypes.String,
+			Nullable: true,
+		},
+	}, nil)
+	record := array.NewRecord(schema, []arrow.Array{str}, 2)
+
+	var output bytes.Buffer
+	writer := ipc.NewWriter(&output, ipc.WithSchema(schema))
+
+	err := writer.Write(record)
+	require.NoError(t, err)
+
+	require.NoError(t, writer.Close())
+
+	reader, err := ipc.NewReader(bytes.NewReader(output.Bytes()), ipc.WithSchema(schema))
+	require.NoError(t, err)
+
+	reader.Next()
+	require.NoError(t, reader.Err())
 }

--- a/go/arrow/ipc/ipc_test.go
+++ b/go/arrow/ipc/ipc_test.go
@@ -676,5 +676,15 @@ func TestArrowBinaryIPCWriterTruncatedVOffsets(t *testing.T) {
 
 	require.True(t, reader.Next())
 	require.NoError(t, reader.Err())
+
+	rec := reader.Record()
+	require.EqualValues(t, 1, rec.NumCols())
+	require.EqualValues(t, 2, rec.NumRows())
+
+	col, ok := rec.Column(0).(*array.String)
+	require.True(t, ok)
+	require.Equal(t, "pear", col.Value(0))
+	require.Equal(t, "banana", col.Value(1))
+
 	require.False(t, reader.Next())
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It should be valid to specify offset buffers that do not start from zero. This particularly important for when multiple arrays share a single value buffer.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add condition to shift offsets buffer when it does not start from zero
- Test to reproduce failure and then validate fix

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes

### Are there any user-facing changes?

Variable-length binary arrays that share a value buffer will not result in errors.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41993