### PR TITLE
GH-43185: [C++] Suggest a cast when Concatenate fails due to offsets overflow

### DIFF
--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -921,6 +921,8 @@ namespace internal {
 Result<std::shared_ptr<Array>> Concatenate(
     const ArrayVector& arrays, MemoryPool* pool,
     std::shared_ptr<DataType>* out_suggested_cast) {
+  DCHECK(out_suggested_cast);
+  *out_suggested_cast = nullptr;
   if (arrays.size() == 0) {
     return Status::Invalid("Must pass at least one array");
   }

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -916,6 +916,8 @@ class ConcatenateImpl {
 
 }  // namespace
 
+namespace internal {
+
 Result<std::shared_ptr<Array>> Concatenate(
     const ArrayVector& arrays, MemoryPool* pool,
     std::shared_ptr<DataType>* out_suggested_cast) {
@@ -947,9 +949,11 @@ Result<std::shared_ptr<Array>> Concatenate(
   return MakeArray(std::move(out_data));
 }
 
+}  // namespace internal
+
 Result<std::shared_ptr<Array>> Concatenate(const ArrayVector& arrays, MemoryPool* pool) {
   std::shared_ptr<DataType> suggested_cast;
-  auto result = Concatenate(arrays, pool, &suggested_cast);
+  auto result = internal::Concatenate(arrays, pool, &suggested_cast);
   if (!result.ok() && suggested_cast && arrays.size() > 0) {
     DCHECK(result.status().IsInvalid());
     return Status::Invalid(result.status().message(), ", consider casting input from `",

--- a/cpp/src/arrow/array/concatenate.h
+++ b/cpp/src/arrow/array/concatenate.h
@@ -24,6 +24,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace internal {
 
 /// \brief Concatenate arrays
 ///
@@ -38,6 +39,8 @@ namespace arrow {
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> Concatenate(const ArrayVector& arrays, MemoryPool* pool,
                                            std::shared_ptr<DataType>* out_suggested_cast);
+
+}  // namespace internal
 
 /// \brief Concatenate arrays
 ///

--- a/cpp/src/arrow/array/concatenate.h
+++ b/cpp/src/arrow/array/concatenate.h
@@ -30,10 +30,9 @@ namespace internal {
 ///
 /// \param[in] arrays a vector of arrays to be concatenated
 /// \param[in] pool memory to store the result will be allocated from this memory pool
-/// \param[out] out_suggested_cast if non-NULL, the function might set it to a cast
-///                                suggestion that would allow concatenating the arrays
-///                                without overflow of offsets (e.g. string to
-///                                large_string)
+/// \param[out] out_suggested_cast if a non-OK Result is returned, the function might set
+///   out_suggested_cast to a cast suggestion that would allow concatenating the arrays
+///   without overflow of offsets (e.g. string to large_string)
 ///
 /// \return the concatenated array
 ARROW_EXPORT

--- a/cpp/src/arrow/array/concatenate.h
+++ b/cpp/src/arrow/array/concatenate.h
@@ -29,6 +29,20 @@ namespace arrow {
 ///
 /// \param[in] arrays a vector of arrays to be concatenated
 /// \param[in] pool memory to store the result will be allocated from this memory pool
+/// \param[out] out_suggested_cast if non-NULL, the function might set it to a cast
+///                                suggestion that would allow concatenating the arrays
+///                                without overflow of offsets (e.g. string to
+///                                large_string)
+///
+/// \return the concatenated array
+ARROW_EXPORT
+Result<std::shared_ptr<Array>> Concatenate(const ArrayVector& arrays, MemoryPool* pool,
+                                           std::shared_ptr<DataType>* out_suggested_cast);
+
+/// \brief Concatenate arrays
+///
+/// \param[in] arrays a vector of arrays to be concatenated
+/// \param[in] pool memory to store the result will be allocated from this memory pool
 /// \return the concatenated array
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> Concatenate(const ArrayVector& arrays,

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -712,7 +712,8 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
                          ty->ToString() + "` to `large_" + ty->ToString() + "` first."),
         concatenate_status);
 
-    concatenate_status = Concatenate({fake_long, fake_long}, pool, &suggested_cast);
+    concatenate_status =
+        internal::Concatenate({fake_long, fake_long}, pool, &suggested_cast);
     // Message is doesn't contain the suggested cast type when the caller
     // asks for it by passing the output parameter.
     EXPECT_RAISES_WITH_MESSAGE_THAT(
@@ -728,9 +729,9 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
       auto fake_long_list = ArrayFromJSON(nested_ty, "[[\"\"]]");
       fake_long_list->data()->child_data[0] = fake_long->data();
 
-      ASSERT_RAISES(
-          Invalid,
-          Concatenate({fake_long_list, fake_long_list}, pool, &suggested_cast).status());
+      ASSERT_RAISES(Invalid, internal::Concatenate({fake_long_list, fake_long_list}, pool,
+                                                   &suggested_cast)
+                                 .status());
       ASSERT_TRUE(suggested_cast->Equals(*expected_suggestion));
     }
   }
@@ -739,9 +740,9 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
   auto fake_long_list = ArrayFromJSON(list_ty, "[[\"Hello\"]]");
   fake_long_list->data()->GetMutableValues<int32_t>(1)[1] =
       std::numeric_limits<int32_t>::max();
-  ASSERT_RAISES(
-      Invalid,
-      Concatenate({fake_long_list, fake_long_list}, pool, &suggested_cast).status());
+  ASSERT_RAISES(Invalid, internal::Concatenate({fake_long_list, fake_long_list}, pool,
+                                               &suggested_cast)
+                             .status());
   ASSERT_TRUE(suggested_cast->Equals(LargeVersionOfType(list_ty)));
 
   auto list_view_ty = list_view(null());
@@ -756,8 +757,8 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
     mutable_offsets[0] = kInt32Max;
     mutable_sizes[0] = kInt32Max;
   }
-  ASSERT_RAISES(Invalid, Concatenate({fake_long_list_view, fake_long_list_view}, pool,
-                                     &suggested_cast)
+  ASSERT_RAISES(Invalid, internal::Concatenate({fake_long_list_view, fake_long_list_view},
+                                               pool, &suggested_cast)
                              .status());
   ASSERT_TRUE(suggested_cast->Equals(LargeVersionOfType(list_view_ty)));
 }

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -680,7 +680,6 @@ std::shared_ptr<DataType> LargeVersionOfType(const std::shared_ptr<DataType>& ty
       return type;
     default:
       Unreachable();
-      break;
   }
 }
 

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -684,13 +684,14 @@ std::shared_ptr<DataType> LargeVersionOfType(const std::shared_ptr<DataType>& ty
   }
 }
 
+std::shared_ptr<DataType> fixed_size_list_of_1(std::shared_ptr<DataType> type) {
+  return fixed_size_list(std::move(type), 1);
+}
+
 TEST_F(ConcatenateTest, OffsetOverflow) {
   using TypeFactory = std::shared_ptr<DataType> (*)(std::shared_ptr<DataType>);
   static const std::vector<TypeFactory> kNestedTypeFactories = {
-      list,
-      large_list,
-      list_view,
-      large_list_view,
+      list, large_list, list_view, large_list_view, fixed_size_list_of_1,
   };
 
   auto* pool = default_memory_pool();


### PR DESCRIPTION
## Rationale for this change

When arrays using 32-bit offsets into data buffers are concatenated and the data buffers of the results grow beyond 2GB, `Concatenate` returns a bad `Status` with a very simple message:

`"offset overflow while concatenating arrays"`

The contract that `Concatenate` honors is very simple: arrays of input type T lead to output of the same type T, so we can't, for instance, return a `LARGE_STRING` [1] array when the input is `STRING`.

But we can **suggest a cast** to the caller in case an overflow error is detected. Either programatically (by taking an output parameter) or by giving a better error message to users.

[1] `LARGE_STRING` can use 64-bit offsets


### What changes are included in this PR?

 - Suggest casts when concatenation of the values of an FSL fail due to overflow
 - Suggest casts when concatenation of [LARGE_]LIST_VIEW array fails due to overflow
 - Suggest casts when concatenation of [LARGE_]LIST array fails due to overflow
 - Suggest a cast to LARGE_(BINARY|STRING) when offsets overflow

### Are these changes tested?

Yes.
* GitHub Issue: #43185