### PR TITLE
GH-43142: [C++][Parquet] Refactor Encryptor API to use arrow::util::span instead of raw pointers

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -303,7 +303,7 @@ class SerializedPageWriter : public PageWriter {
     if (data_encryptor_.get()) {
       UpdateEncryption(encryption::kDictionaryPage);
       PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
-          data_encryptor_->CiphertextSizeDelta() + output_data_len, false));
+          data_encryptor_->CiphertextLength(output_data_len), false));
       output_data_len =
           data_encryptor_->Encrypt(compressed_data->span_as<uint8_t>(),
                                    encryption_buffer_->mutable_span_as<uint8_t>());
@@ -396,7 +396,7 @@ class SerializedPageWriter : public PageWriter {
 
     if (data_encryptor_.get()) {
       PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
-          data_encryptor_->CiphertextSizeDelta() + output_data_len, false));
+          data_encryptor_->CiphertextLength(output_data_len), false));
       UpdateEncryption(encryption::kDataPage);
       output_data_len =
           data_encryptor_->Encrypt(compressed_data->span_as<uint8_t>(),

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -304,8 +304,9 @@ class SerializedPageWriter : public PageWriter {
       UpdateEncryption(encryption::kDictionaryPage);
       PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
           data_encryptor_->CiphertextSizeDelta() + output_data_len, false));
-      output_data_len = data_encryptor_->Encrypt(compressed_data->data(), output_data_len,
-                                                 encryption_buffer_->mutable_data());
+      output_data_len =
+          data_encryptor_->Encrypt(compressed_data->span_as<uint8_t>(),
+                                   encryption_buffer_->mutable_span_as<uint8_t>());
       output_data_buffer = encryption_buffer_->data();
     }
 
@@ -397,9 +398,9 @@ class SerializedPageWriter : public PageWriter {
       PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
           data_encryptor_->CiphertextSizeDelta() + output_data_len, false));
       UpdateEncryption(encryption::kDataPage);
-      output_data_len = data_encryptor_->Encrypt(compressed_data->data(),
-                                                 static_cast<int32_t>(output_data_len),
-                                                 encryption_buffer_->mutable_data());
+      output_data_len =
+          data_encryptor_->Encrypt(compressed_data->span_as<uint8_t>(),
+                                   encryption_buffer_->mutable_span_as<uint8_t>());
       output_data_buffer = encryption_buffer_->data();
     }
 

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -167,10 +167,10 @@ int AesEncryptor::AesEncryptorImpl::SignedFooterEncrypt(span<const uint8_t> foot
     throw ParquetException(ss.str());
   }
 
-  if (encrypted_footer.size() < footer.size() + ciphertext_size_delta_) {
+  if (encrypted_footer.size() != footer.size() + ciphertext_size_delta_) {
     std::stringstream ss;
     ss << "Encrypted footer buffer length " << encrypted_footer.size()
-       << " is insufficient for footer length " << footer.size();
+       << " does not match expected length " << (footer.size() + ciphertext_size_delta_);
     throw ParquetException(ss.str());
   }
 
@@ -191,10 +191,11 @@ int AesEncryptor::AesEncryptorImpl::Encrypt(span<const uint8_t> plaintext,
     throw ParquetException(ss.str());
   }
 
-  if (ciphertext.size() < plaintext.size() + ciphertext_size_delta_) {
+  if (ciphertext.size() != plaintext.size() + ciphertext_size_delta_) {
     std::stringstream ss;
     ss << "Ciphertext buffer length " << ciphertext.size()
-       << " is insufficient for plaintext length " << plaintext.size();
+       << " does not match expected length "
+       << (plaintext.size() + ciphertext_size_delta_);
     throw ParquetException(ss.str());
   }
 
@@ -221,9 +222,9 @@ int AesEncryptor::AesEncryptorImpl::GcmEncrypt(span<const uint8_t> plaintext,
   uint8_t tag[kGcmTagLength];
   memset(tag, 0, kGcmTagLength);
 
-  if (nonce.size() < static_cast<size_t>(kNonceLength)) {
+  if (nonce.size() != static_cast<size_t>(kNonceLength)) {
     std::stringstream ss;
-    ss << "Invalid nonce size " << nonce.size() << ", require at least " << kNonceLength;
+    ss << "Invalid nonce size " << nonce.size() << ", expected " << kNonceLength;
     throw ParquetException(ss.str());
   }
 
@@ -284,9 +285,9 @@ int AesEncryptor::AesEncryptorImpl::CtrEncrypt(span<const uint8_t> plaintext,
   int len;
   int ciphertext_len;
 
-  if (nonce.size() < static_cast<size_t>(kNonceLength)) {
+  if (nonce.size() != static_cast<size_t>(kNonceLength)) {
     std::stringstream ss;
-    ss << "Invalid nonce size " << nonce.size() << ", require at least " << kNonceLength;
+    ss << "Invalid nonce size " << nonce.size() << ", expected " << kNonceLength;
     throw ParquetException(ss.str());
   }
 

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -76,20 +76,15 @@ class AesEncryptor::AesEncryptorImpl {
       std::stringstream ss;
       ss << "Negative plaintext length " << plaintext_len;
       throw ParquetException(ss.str());
-    } else if (plaintext_len > std::numeric_limits<int32_t>::max()) {
+    } else if (plaintext_len >
+               std::numeric_limits<int32_t>::max() - ciphertext_size_delta_) {
       std::stringstream ss;
-      ss << "Plaintext length " << plaintext_len << " overflows int32";
+      ss << "Plaintext length " << plaintext_len << " plus ciphertext size delta "
+         << ciphertext_size_delta_ << " overflows int32";
       throw ParquetException(ss.str());
     }
 
-    int64_t ciphertext_len = plaintext_len + ciphertext_size_delta_;
-    if (ciphertext_len > std::numeric_limits<int32_t>::max()) {
-      std::stringstream ss;
-      ss << "Ciphertext length " << ciphertext_len << " overflows int32";
-      throw ParquetException(ss.str());
-    }
-
-    return static_cast<int32_t>(ciphertext_len);
+    return static_cast<int32_t>(plaintext_len + ciphertext_size_delta_);
   }
 
  private:
@@ -392,6 +387,11 @@ class AesDecryptor::AesDecryptorImpl {
     if (plaintext_len < 0) {
       std::stringstream ss;
       ss << "Negative plaintext length " << plaintext_len;
+      throw ParquetException(ss.str());
+    } else if (plaintext_len > std::numeric_limits<int>::max() - ciphertext_size_delta_) {
+      std::stringstream ss;
+      ss << "Plaintext length " << plaintext_len << " plus ciphertext size delta "
+         << ciphertext_size_delta_ << " overflows int32";
       throw ParquetException(ss.str());
     }
     return plaintext_len + ciphertext_size_delta_;

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -553,9 +553,9 @@ int AesDecryptor::AesDecryptorImpl::GetCiphertextLength(
 
     return static_cast<int>(written_ciphertext_len) + length_buffer_length_;
   } else {
-    if (ciphertext.size() > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+    if (ciphertext.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
       std::stringstream ss;
-      ss << "Ciphertext buffer length " << ciphertext.size() << " overflows int32";
+      ss << "Ciphertext buffer length " << ciphertext.size() << " overflows int";
       throw ParquetException(ss.str());
     }
     return static_cast<int>(ciphertext.size());

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -71,7 +71,7 @@ class AesEncryptor::AesEncryptorImpl {
     }
   }
 
-  [[nodiscard]] int CiphertextLength(int64_t plaintext_len) const {
+  [[nodiscard]] int32_t CiphertextLength(int64_t plaintext_len) const {
     if (plaintext_len < 0) {
       std::stringstream ss;
       ss << "Negative plaintext length " << plaintext_len;
@@ -346,7 +346,7 @@ int AesEncryptor::SignedFooterEncrypt(span<const uint8_t> footer, span<const uin
 
 void AesEncryptor::WipeOut() { impl_->WipeOut(); }
 
-int AesEncryptor::CiphertextLength(int64_t plaintext_len) const {
+int32_t AesEncryptor::CiphertextLength(int64_t plaintext_len) const {
   return impl_->CiphertextLength(plaintext_len);
 }
 

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -61,8 +61,8 @@ class PARQUET_EXPORT AesEncryptor {
 
   ~AesEncryptor();
 
-  /// Size difference between plaintext and ciphertext, for this cipher.
-  int CiphertextSizeDelta();
+  /// The size of the ciphertext, for this cipher and the specified plaintext length.
+  [[nodiscard]] int CiphertextLength(int64_t plaintext_len) const;
 
   /// Encrypts plaintext with the key and aad. Key length is passed only for validation.
   /// If different from value in constructor, exception will be thrown.

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -62,7 +62,7 @@ class PARQUET_EXPORT AesEncryptor {
   ~AesEncryptor();
 
   /// The size of the ciphertext, for this cipher and the specified plaintext length.
-  [[nodiscard]] int CiphertextLength(int64_t plaintext_len) const;
+  [[nodiscard]] int32_t CiphertextLength(int64_t plaintext_len) const;
 
   /// Encrypts plaintext with the key and aad. Key length is passed only for validation.
   /// If different from value in constructor, exception will be thrown.

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -66,13 +66,17 @@ class PARQUET_EXPORT AesEncryptor {
 
   /// Encrypts plaintext with the key and aad. Key length is passed only for validation.
   /// If different from value in constructor, exception will be thrown.
-  int Encrypt(const uint8_t* plaintext, int plaintext_len, const uint8_t* key,
-              int key_len, const uint8_t* aad, int aad_len, uint8_t* ciphertext);
+  int Encrypt(::arrow::util::span<const uint8_t> plaintext,
+              ::arrow::util::span<const uint8_t> key,
+              ::arrow::util::span<const uint8_t> aad,
+              ::arrow::util::span<uint8_t> ciphertext);
 
   /// Encrypts plaintext footer, in order to compute footer signature (tag).
-  int SignedFooterEncrypt(const uint8_t* footer, int footer_len, const uint8_t* key,
-                          int key_len, const uint8_t* aad, int aad_len,
-                          const uint8_t* nonce, uint8_t* encrypted_footer);
+  int SignedFooterEncrypt(::arrow::util::span<const uint8_t> footer,
+                          ::arrow::util::span<const uint8_t> key,
+                          ::arrow::util::span<const uint8_t> aad,
+                          ::arrow::util::span<const uint8_t> nonce,
+                          ::arrow::util::span<uint8_t> encrypted_footer);
 
   void WipeOut();
 

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -29,10 +29,11 @@ class AesEncryptor::AesEncryptorImpl {};
 
 AesEncryptor::~AesEncryptor() {}
 
-int AesEncryptor::SignedFooterEncrypt(const uint8_t* footer, int footer_len,
-                                      const uint8_t* key, int key_len, const uint8_t* aad,
-                                      int aad_len, const uint8_t* nonce,
-                                      uint8_t* encrypted_footer) {
+int AesEncryptor::SignedFooterEncrypt(::arrow::util::span<const uint8_t> footer,
+                                      ::arrow::util::span<const uint8_t> key,
+                                      ::arrow::util::span<const uint8_t> aad,
+                                      ::arrow::util::span<const uint8_t> nonce,
+                                      ::arrow::util::span<uint8_t> encrypted_footer) {
   ThrowOpenSSLRequiredException();
   return -1;
 }
@@ -44,9 +45,10 @@ int AesEncryptor::CiphertextSizeDelta() {
   return -1;
 }
 
-int AesEncryptor::Encrypt(const uint8_t* plaintext, int plaintext_len, const uint8_t* key,
-                          int key_len, const uint8_t* aad, int aad_len,
-                          uint8_t* ciphertext) {
+int AesEncryptor::Encrypt(::arrow::util::span<const uint8_t> plaintext,
+                          ::arrow::util::span<const uint8_t> key,
+                          ::arrow::util::span<const uint8_t> aad,
+                          ::arrow::util::span<uint8_t> ciphertext) {
   ThrowOpenSSLRequiredException();
   return -1;
 }

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -40,7 +40,7 @@ int AesEncryptor::SignedFooterEncrypt(::arrow::util::span<const uint8_t> footer,
 
 void AesEncryptor::WipeOut() { ThrowOpenSSLRequiredException(); }
 
-int AesEncryptor::CiphertextSizeDelta() {
+int AesEncryptor::CiphertextLength(int64_t plaintext_len) const {
   ThrowOpenSSLRequiredException();
   return -1;
 }

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -40,7 +40,7 @@ int AesEncryptor::SignedFooterEncrypt(::arrow::util::span<const uint8_t> footer,
 
 void AesEncryptor::WipeOut() { ThrowOpenSSLRequiredException(); }
 
-int AesEncryptor::CiphertextLength(int64_t plaintext_len) const {
+int32_t AesEncryptor::CiphertextLength(int64_t plaintext_len) const {
   ThrowOpenSSLRequiredException();
   return -1;
 }

--- a/cpp/src/parquet/encryption/encryption_internal_test.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_test.cc
@@ -41,10 +41,8 @@ class TestAesEncryption : public ::testing::Test {
         static_cast<int>(plain_text_.size()) + encryptor.CiphertextSizeDelta();
     std::vector<uint8_t> ciphertext(expected_ciphertext_len, '\0');
 
-    int ciphertext_length =
-        encryptor.Encrypt(str2bytes(plain_text_), static_cast<int>(plain_text_.size()),
-                          str2bytes(key_), static_cast<int>(key_.size()), str2bytes(aad_),
-                          static_cast<int>(aad_.size()), ciphertext.data());
+    int ciphertext_length = encryptor.Encrypt(str2span(plain_text_), str2span(key_),
+                                              str2span(aad_), ciphertext);
 
     ASSERT_EQ(ciphertext_length, expected_ciphertext_len);
 
@@ -91,10 +89,8 @@ class TestAesEncryption : public ::testing::Test {
         static_cast<int>(plain_text_.size()) + encryptor.CiphertextSizeDelta();
     std::vector<uint8_t> ciphertext(expected_ciphertext_len, '\0');
 
-    int ciphertext_length =
-        encryptor.Encrypt(str2bytes(plain_text_), static_cast<int>(plain_text_.size()),
-                          str2bytes(key_), static_cast<int>(key_.size()), str2bytes(aad_),
-                          static_cast<int>(aad_.size()), ciphertext.data());
+    int ciphertext_length = encryptor.Encrypt(str2span(plain_text_), str2span(key_),
+                                              str2span(aad_), ciphertext);
 
     AesDecryptor decryptor(cipher_type, key_length_, metadata, write_length);
 

--- a/cpp/src/parquet/encryption/encryption_internal_test.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_test.cc
@@ -38,7 +38,7 @@ class TestAesEncryption : public ::testing::Test {
     AesEncryptor encryptor(cipher_type, key_length_, metadata, write_length);
 
     int expected_ciphertext_len =
-        static_cast<int>(plain_text_.size()) + encryptor.CiphertextSizeDelta();
+        encryptor.CiphertextLength(static_cast<int64_t>(plain_text_.size()));
     std::vector<uint8_t> ciphertext(expected_ciphertext_len, '\0');
 
     int ciphertext_length = encryptor.Encrypt(str2span(plain_text_), str2span(key_),
@@ -86,7 +86,7 @@ class TestAesEncryption : public ::testing::Test {
     AesEncryptor encryptor(cipher_type, key_length_, metadata, write_length);
 
     int expected_ciphertext_len =
-        static_cast<int>(plain_text_.size()) + encryptor.CiphertextSizeDelta();
+        encryptor.CiphertextLength(static_cast<int64_t>(plain_text_.size()));
     std::vector<uint8_t> ciphertext(expected_ciphertext_len, '\0');
 
     int ciphertext_length = encryptor.Encrypt(str2span(plain_text_), str2span(key_),

--- a/cpp/src/parquet/encryption/encryption_internal_test.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_test.cc
@@ -37,7 +37,7 @@ class TestAesEncryption : public ::testing::Test {
 
     AesEncryptor encryptor(cipher_type, key_length_, metadata, write_length);
 
-    int expected_ciphertext_len =
+    int32_t expected_ciphertext_len =
         encryptor.CiphertextLength(static_cast<int64_t>(plain_text_.size()));
     std::vector<uint8_t> ciphertext(expected_ciphertext_len, '\0');
 
@@ -85,7 +85,7 @@ class TestAesEncryption : public ::testing::Test {
 
     AesEncryptor encryptor(cipher_type, key_length_, metadata, write_length);
 
-    int expected_ciphertext_len =
+    int32_t expected_ciphertext_len =
         encryptor.CiphertextLength(static_cast<int64_t>(plain_text_.size()));
     std::vector<uint8_t> ciphertext(expected_ciphertext_len, '\0');
 

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -31,7 +31,9 @@ Encryptor::Encryptor(encryption::AesEncryptor* aes_encryptor, const std::string&
       aad_(aad),
       pool_(pool) {}
 
-int Encryptor::CiphertextSizeDelta() { return aes_encryptor_->CiphertextSizeDelta(); }
+int Encryptor::CiphertextLength(int64_t plaintext_len) const {
+  return aes_encryptor_->CiphertextLength(plaintext_len);
+}
 
 int Encryptor::Encrypt(::arrow::util::span<const uint8_t> plaintext,
                        ::arrow::util::span<uint8_t> ciphertext) {

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -33,10 +33,9 @@ Encryptor::Encryptor(encryption::AesEncryptor* aes_encryptor, const std::string&
 
 int Encryptor::CiphertextSizeDelta() { return aes_encryptor_->CiphertextSizeDelta(); }
 
-int Encryptor::Encrypt(const uint8_t* plaintext, int plaintext_len, uint8_t* ciphertext) {
-  return aes_encryptor_->Encrypt(plaintext, plaintext_len, str2bytes(key_),
-                                 static_cast<int>(key_.size()), str2bytes(aad_),
-                                 static_cast<int>(aad_.size()), ciphertext);
+int Encryptor::Encrypt(::arrow::util::span<const uint8_t> plaintext,
+                       ::arrow::util::span<uint8_t> ciphertext) {
+  return aes_encryptor_->Encrypt(plaintext, str2span(key_), str2span(aad_), ciphertext);
 }
 
 // InternalFileEncryptor

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -31,7 +31,7 @@ Encryptor::Encryptor(encryption::AesEncryptor* aes_encryptor, const std::string&
       aad_(aad),
       pool_(pool) {}
 
-int Encryptor::CiphertextLength(int64_t plaintext_len) const {
+int32_t Encryptor::CiphertextLength(int64_t plaintext_len) const {
   return aes_encryptor_->CiphertextLength(plaintext_len);
 }
 

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -43,7 +43,8 @@ class PARQUET_EXPORT Encryptor {
   void UpdateAad(const std::string& aad) { aad_ = aad; }
   ::arrow::MemoryPool* pool() { return pool_; }
 
-  int CiphertextSizeDelta();
+  [[nodiscard]] int CiphertextLength(int64_t plaintext_len) const;
+
   int Encrypt(::arrow::util::span<const uint8_t> plaintext,
               ::arrow::util::span<uint8_t> ciphertext);
 

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -44,7 +44,8 @@ class PARQUET_EXPORT Encryptor {
   ::arrow::MemoryPool* pool() { return pool_; }
 
   int CiphertextSizeDelta();
-  int Encrypt(const uint8_t* plaintext, int plaintext_len, uint8_t* ciphertext);
+  int Encrypt(::arrow::util::span<const uint8_t> plaintext,
+              ::arrow::util::span<uint8_t> ciphertext);
 
   bool EncryptColumnMetaData(
       bool encrypted_footer,

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -43,7 +43,7 @@ class PARQUET_EXPORT Encryptor {
   void UpdateAad(const std::string& aad) { aad_ = aad; }
   ::arrow::MemoryPool* pool() { return pool_; }
 
-  [[nodiscard]] int CiphertextLength(int64_t plaintext_len) const;
+  [[nodiscard]] int32_t CiphertextLength(int64_t plaintext_len) const;
 
   int Encrypt(::arrow::util::span<const uint8_t> plaintext,
               ::arrow::util::span<uint8_t> ciphertext);

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -33,7 +33,7 @@ std::string EncryptKeyLocally(const std::string& key_bytes, const std::string& m
                              false /*write_length*/);
 
   int encrypted_key_len =
-      static_cast<int>(key_bytes.size()) + key_encryptor.CiphertextSizeDelta();
+      key_encryptor.CiphertextLength(static_cast<int64_t>(key_bytes.size()));
   std::string encrypted_key(encrypted_key_len, '\0');
   ::arrow::util::span<uint8_t> encrypted_key_span(
       reinterpret_cast<uint8_t*>(&encrypted_key[0]), encrypted_key_len);

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -32,7 +32,7 @@ std::string EncryptKeyLocally(const std::string& key_bytes, const std::string& m
                              static_cast<int>(master_key.size()), false,
                              false /*write_length*/);
 
-  int encrypted_key_len =
+  int32_t encrypted_key_len =
       key_encryptor.CiphertextLength(static_cast<int64_t>(key_bytes.size()));
   std::string encrypted_key(encrypted_key_len, '\0');
   ::arrow::util::span<uint8_t> encrypted_key_span(

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -35,12 +35,11 @@ std::string EncryptKeyLocally(const std::string& key_bytes, const std::string& m
   int encrypted_key_len =
       static_cast<int>(key_bytes.size()) + key_encryptor.CiphertextSizeDelta();
   std::string encrypted_key(encrypted_key_len, '\0');
-  encrypted_key_len = key_encryptor.Encrypt(
-      reinterpret_cast<const uint8_t*>(key_bytes.data()),
-      static_cast<int>(key_bytes.size()),
-      reinterpret_cast<const uint8_t*>(master_key.data()),
-      static_cast<int>(master_key.size()), reinterpret_cast<const uint8_t*>(aad.data()),
-      static_cast<int>(aad.size()), reinterpret_cast<uint8_t*>(&encrypted_key[0]));
+  ::arrow::util::span<uint8_t> encrypted_key_span(
+      reinterpret_cast<uint8_t*>(&encrypted_key[0]), encrypted_key_len);
+
+  encrypted_key_len = key_encryptor.Encrypt(str2span(key_bytes), str2span(master_key),
+                                            str2span(aad), encrypted_key_span);
 
   return ::arrow::util::base64_encode(
       ::std::string_view(encrypted_key.data(), encrypted_key_len));

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -640,11 +640,13 @@ class FileMetaData::FileMetaDataImpl {
     uint32_t serialized_len = metadata_len_;
     ThriftSerializer serializer;
     serializer.SerializeToBuffer(metadata_.get(), &serialized_len, &serialized_data);
+    ::arrow::util::span<const uint8_t> serialized_data_span(serialized_data,
+                                                            serialized_len);
 
     // encrypt with nonce
-    auto nonce = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(signature));
-    auto tag = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(signature)) +
-               encryption::kNonceLength;
+    ::arrow::util::span<const uint8_t> nonce(reinterpret_cast<const uint8_t*>(signature),
+                                             encryption::kNonceLength);
+    auto tag = reinterpret_cast<const uint8_t*>(signature) + encryption::kNonceLength;
 
     std::string key = file_decryptor_->GetFooterKey();
     std::string aad = encryption::CreateFooterAad(file_decryptor_->file_aad());
@@ -657,9 +659,8 @@ class FileMetaData::FileMetaDataImpl {
         AllocateBuffer(file_decryptor_->pool(),
                        aes_encryptor->CiphertextSizeDelta() + serialized_len));
     uint32_t encrypted_len = aes_encryptor->SignedFooterEncrypt(
-        serialized_data, serialized_len, str2bytes(key), static_cast<int>(key.size()),
-        str2bytes(aad), static_cast<int>(aad.size()), nonce,
-        encrypted_buffer->mutable_data());
+        serialized_data_span, str2span(key), str2span(aad), nonce,
+        encrypted_buffer->mutable_span_as<uint8_t>());
     // Delete AES encryptor object. It was created only to verify the footer signature.
     aes_encryptor->WipeOut();
     delete aes_encryptor;
@@ -701,12 +702,13 @@ class FileMetaData::FileMetaDataImpl {
       uint8_t* serialized_data;
       uint32_t serialized_len;
       serializer.SerializeToBuffer(metadata_.get(), &serialized_len, &serialized_data);
+      ::arrow::util::span<const uint8_t> serialized_data_span(serialized_data,
+                                                              serialized_len);
 
       // encrypt the footer key
       std::vector<uint8_t> encrypted_data(encryptor->CiphertextSizeDelta() +
                                           serialized_len);
-      unsigned encrypted_len =
-          encryptor->Encrypt(serialized_data, serialized_len, encrypted_data.data());
+      unsigned encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
 
       // write unencrypted footer
       PARQUET_THROW_NOT_OK(dst->Write(serialized_data, serialized_len));
@@ -1559,11 +1561,12 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
 
         serializer.SerializeToBuffer(&column_chunk_->meta_data, &serialized_len,
                                      &serialized_data);
+        ::arrow::util::span<const uint8_t> serialized_data_span(serialized_data,
+                                                                serialized_len);
 
         std::vector<uint8_t> encrypted_data(encryptor->CiphertextSizeDelta() +
                                             serialized_len);
-        unsigned encrypted_len =
-            encryptor->Encrypt(serialized_data, serialized_len, encrypted_data.data());
+        unsigned encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
 
         const char* temp =
             const_cast<const char*>(reinterpret_cast<char*>(encrypted_data.data()));

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -707,7 +707,7 @@ class FileMetaData::FileMetaDataImpl {
 
       // encrypt the footer key
       std::vector<uint8_t> encrypted_data(encryptor->CiphertextLength(serialized_len));
-      unsigned encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
+      int encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
 
       // write unencrypted footer
       PARQUET_THROW_NOT_OK(dst->Write(serialized_data, serialized_len));

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -655,9 +655,9 @@ class FileMetaData::FileMetaDataImpl {
         file_decryptor_->algorithm(), static_cast<int>(key.size()), true,
         false /*write_length*/, nullptr);
 
-    std::shared_ptr<Buffer> encrypted_buffer = std::static_pointer_cast<ResizableBuffer>(
-        AllocateBuffer(file_decryptor_->pool(),
-                       aes_encryptor->CiphertextSizeDelta() + serialized_len));
+    std::shared_ptr<Buffer> encrypted_buffer =
+        std::static_pointer_cast<ResizableBuffer>(AllocateBuffer(
+            file_decryptor_->pool(), aes_encryptor->CiphertextLength(serialized_len)));
     uint32_t encrypted_len = aes_encryptor->SignedFooterEncrypt(
         serialized_data_span, str2span(key), str2span(aad), nonce,
         encrypted_buffer->mutable_span_as<uint8_t>());
@@ -706,8 +706,7 @@ class FileMetaData::FileMetaDataImpl {
                                                               serialized_len);
 
       // encrypt the footer key
-      std::vector<uint8_t> encrypted_data(encryptor->CiphertextSizeDelta() +
-                                          serialized_len);
+      std::vector<uint8_t> encrypted_data(encryptor->CiphertextLength(serialized_len));
       unsigned encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
 
       // write unencrypted footer
@@ -1564,8 +1563,7 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
         ::arrow::util::span<const uint8_t> serialized_data_span(serialized_data,
                                                                 serialized_len);
 
-        std::vector<uint8_t> encrypted_data(encryptor->CiphertextSizeDelta() +
-                                            serialized_len);
+        std::vector<uint8_t> encrypted_data(encryptor->CiphertextLength(serialized_len));
         unsigned encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
 
         const char* temp =

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -655,9 +655,8 @@ class FileMetaData::FileMetaDataImpl {
         file_decryptor_->algorithm(), static_cast<int>(key.size()), true,
         false /*write_length*/, nullptr);
 
-    std::shared_ptr<Buffer> encrypted_buffer =
-        std::static_pointer_cast<ResizableBuffer>(AllocateBuffer(
-            file_decryptor_->pool(), aes_encryptor->CiphertextLength(serialized_len)));
+    std::shared_ptr<Buffer> encrypted_buffer = AllocateBuffer(
+        file_decryptor_->pool(), aes_encryptor->CiphertextLength(serialized_len));
     uint32_t encrypted_len = aes_encryptor->SignedFooterEncrypt(
         serialized_data_span, str2span(key), str2span(aad), nonce,
         encrypted_buffer->mutable_span_as<uint8_t>());

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -1563,7 +1563,7 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
                                                                 serialized_len);
 
         std::vector<uint8_t> encrypted_data(encryptor->CiphertextLength(serialized_len));
-        unsigned encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
+        int encrypted_len = encryptor->Encrypt(serialized_data_span, encrypted_data);
 
         const char* temp =
             const_cast<const char*>(reinterpret_cast<char*>(encrypted_data.data()));

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -527,9 +527,8 @@ class ThriftSerializer {
 
   int64_t SerializeEncryptedObj(ArrowOutputStream* out, const uint8_t* out_buffer,
                                 uint32_t out_length, Encryptor* encryptor) {
-    auto cipher_buffer = std::static_pointer_cast<ResizableBuffer>(AllocateBuffer(
-        encryptor->pool(),
-        static_cast<int64_t>(encryptor->CiphertextSizeDelta() + out_length)));
+    auto cipher_buffer = std::static_pointer_cast<ResizableBuffer>(
+        AllocateBuffer(encryptor->pool(), encryptor->CiphertextLength(out_length)));
     ::arrow::util::span<const uint8_t> out_span(out_buffer, out_length);
     int cipher_buffer_len =
         encryptor->Encrypt(out_span, cipher_buffer->mutable_span_as<uint8_t>());

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -417,8 +417,8 @@ class ThriftDeserializer {
         throw ParquetException(ss.str());
       }
       // decrypt
-      auto decrypted_buffer = std::static_pointer_cast<ResizableBuffer>(AllocateBuffer(
-          decryptor->pool(), decryptor->PlaintextLength(static_cast<int32_t>(clen))));
+      auto decrypted_buffer = AllocateBuffer(
+          decryptor->pool(), decryptor->PlaintextLength(static_cast<int32_t>(clen)));
       ::arrow::util::span<const uint8_t> cipher_buf(buf, clen);
       uint32_t decrypted_buffer_len =
           decryptor->Decrypt(cipher_buf, decrypted_buffer->mutable_span_as<uint8_t>());
@@ -527,8 +527,8 @@ class ThriftSerializer {
 
   int64_t SerializeEncryptedObj(ArrowOutputStream* out, const uint8_t* out_buffer,
                                 uint32_t out_length, Encryptor* encryptor) {
-    auto cipher_buffer = std::static_pointer_cast<ResizableBuffer>(
-        AllocateBuffer(encryptor->pool(), encryptor->CiphertextLength(out_length)));
+    auto cipher_buffer =
+        AllocateBuffer(encryptor->pool(), encryptor->CiphertextLength(out_length));
     ::arrow::util::span<const uint8_t> out_span(out_buffer, out_length);
     int cipher_buffer_len =
         encryptor->Encrypt(out_span, cipher_buffer->mutable_span_as<uint8_t>());


### PR DESCRIPTION
### Rationale for this change

See #43142. This is a follow up to #43071 which refactored the Decryptor API and added extra checks to prevent segfaults. This PR makes similar changes to the Encryptor API for consistency and better maintainability.

### What changes are included in this PR?

* Change `AesEncryptor::Encrypt` and `Encryptor::Encrypt` to use `arrow::util::span` instead of raw pointers
* Replace the `AesEncryptor::CiphertextSizeDelta` method with a `CiphertextLength` method that checks for overflow and abstracts the size difference behaviour away from consumer code for improved readability.

### Are these changes tested?

* This is mostly a refactoring of existing code so is covered by existing tests.

### Are there any user-facing changes?

No
* GitHub Issue: #43142