### PR TITLE
GH-43199: [CI][Packaging] dev/release/utils-create-release-tarball.sh should not include the release candidate number in the name of the tarball's top-level directory. 

### DIFF
--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -22,7 +22,7 @@ class SourceTest < Test::Unit::TestCase
   def setup
     @current_commit = git_current_commit
     detect_versions
-    @tag_name = "apache-arrow-#{@release_version}-rc0"
+    @tag_name_no_rc = "apache-arrow-#{@release_version}"
     @archive_name = "apache-arrow-#{@release_version}.tar.gz"
     @script = File.expand_path("dev/release/02-source.sh")
     @tarball_script = File.expand_path("dev/release/utils-create-release-tarball.sh")
@@ -50,7 +50,7 @@ class SourceTest < Test::Unit::TestCase
 
   def test_symbolic_links
     source
-    Dir.chdir(@tag_name) do
+    Dir.chdir(@tag_name_no_rc) do
       assert_equal([],
                    Find.find(".").find_all {|path| File.symlink?(path)})
     end
@@ -58,7 +58,7 @@ class SourceTest < Test::Unit::TestCase
 
   def test_csharp_git_commit_information
     source
-    Dir.chdir("#{@tag_name}/csharp") do
+    Dir.chdir("#{@tag_name_no_rc}/csharp") do
       FileUtils.mv("dummy.git", "../.git")
       sh("dotnet", "pack", "-c", "Release")
       FileUtils.mv("../.git", "dummy.git")
@@ -83,7 +83,7 @@ class SourceTest < Test::Unit::TestCase
 
   def test_python_version
     source
-    Dir.chdir("#{@tag_name}/python") do
+    Dir.chdir("#{@tag_name_no_rc}/python") do
       sh("python3", "setup.py", "sdist")
       if on_release_branch?
         pyarrow_source_archive = "dist/pyarrow-#{@release_version}.tar.gz"

--- a/dev/release/utils-create-release-tarball.sh
+++ b/dev/release/utils-create-release-tarball.sh
@@ -30,26 +30,27 @@ version=$1
 rc=$2
 
 tag=apache-arrow-${version}-rc${rc}
+root_folder=apache-arrow-${version}
 tarball=apache-arrow-${version}.tar.gz
 
 : ${release_hash:=$(git rev-list --max-count=1 ${tag})}
 
-rm -rf ${tag}
+rm -rf ${root_folder}
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
 (cd "${SOURCE_TOP_DIR}" && \
-  git archive ${release_hash} --prefix ${tag}/) | \
+  git archive ${release_hash} --prefix ${root_folder}/) | \
   tar xf -
 
 # Resolve symbolic and hard links
-rm -rf ${tag}.tmp
-mv ${tag} ${tag}.tmp
-cp -R -L ${tag}.tmp ${tag}
-rm -rf ${tag}.tmp
+rm -rf ${root_folder}.tmp
+mv ${root_folder} ${root_folder}.tmp
+cp -R -L ${root_folder}.tmp ${root_folder}
+rm -rf ${root_folder}.tmp
 
 # Create a dummy .git/ directory to download the source files from GitHub with Source Link in C#.
-dummy_git=${tag}/csharp/dummy.git
+dummy_git=${root_folder}/csharp/dummy.git
 mkdir ${dummy_git}
 pushd ${dummy_git}
 echo ${release_hash} > HEAD
@@ -58,5 +59,5 @@ mkdir objects refs
 popd 
 
 # Create new tarball from modified source directory
-tar czf ${tarball} ${tag}
-rm -rf ${tag}
+tar czf ${tarball} ${root_folder}
+rm -rf ${root_folder}


### PR DESCRIPTION

### Rationale for this change

`dev/release/util-create-release-tarball.sh` should not include the release candidate number in the name of the tarball's top-level directory. If the release candidate number is included, the binaries and the release verification tasks fail because the tarball entries have an unexpected folder hierarchy. See https://github.com/apache/arrow/pull/43188#issuecomment-2215002552. 

### What changes are included in this PR?

1. Modified `dev/release/util-create-release-tarball.sh` to not include the release candidate number in the name of the source directory from which the release tarball is created.

### Are these changes tested?

Manually verified this change fixes the bug:

```bash
$ dev/release/utils-create-release-tarball.sh 17.0.0 1
$ tar zxvf apache-arrow-17.0.0.tar.gz
...
$ ls 
apache-arrow-17.0.0/       apache-arrow-17.0.0.tar.gz
```


### Are there any user-facing changes?

No

* GitHub Issue: #43199