### PR TITLE
GH-43186: [Go] Use auto-aligned atomic int64 for pqarrow pathbuilders

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -191,9 +191,8 @@ jobs:
         run: GOARCH=386 go build ./...
         working-directory: ./go
       - name: Run test
-        # No asm simd support for 386
         # WIP refactor, only tests in the specified dirs have been fixed
-        run: GOARCH=386 go test -tags noasm ./parquet/file/...
+        run: GOARCH=386 go test ./parquet/file/...
         working-directory: ./go
 
   docker_cgo:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -168,8 +168,8 @@ jobs:
           python3 -m pip install benchadapt@git+https://github.com/conbench/conbench.git@main#subdirectory=benchadapt/python
           python3 ci/scripts/go_bench_adapt.py
 
-  build386:
-    name: Go Cross-build for 386
+  build_test_386:
+    name: Go Cross-build and test for 386
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 20
@@ -191,6 +191,10 @@ jobs:
         run: |
           cd go
           GOARCH=386 go build ./...
+      - name: Run test
+        run: |
+          cd go
+          GOARCH=386 go test -tags noasm ./...
 
   docker_cgo:
     name: AMD64 Debian 12 Go ${{ matrix.go }} - CGO

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -194,7 +194,9 @@ jobs:
       - name: Run test
         run: |
           cd go
-          GOARCH=386 go test -tags noasm ./...
+          # No asm simd support for 386
+          # WIP refactor, only tests in the specified dirs have been fixed
+          GOARCH=386 go test -tags noasm ./parquet/file/...
 
   docker_cgo:
     name: AMD64 Debian 12 Go ${{ matrix.go }} - CGO

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -188,15 +188,13 @@ jobs:
           cache: true
           cache-dependency-path: go/go.sum
       - name: Run build
-        run: |
-          cd go
-          GOARCH=386 go build ./...
+        run: GOARCH=386 go build ./...
+        working-directory: ./go
       - name: Run test
-        run: |
-          cd go
-          # No asm simd support for 386
-          # WIP refactor, only tests in the specified dirs have been fixed
-          GOARCH=386 go test -tags noasm ./parquet/file/...
+        # No asm simd support for 386
+        # WIP refactor, only tests in the specified dirs have been fixed
+        run: GOARCH=386 go test -tags noasm ./parquet/file/...
+        working-directory: ./go
 
   docker_cgo:
     name: AMD64 Debian 12 Go ${{ matrix.go }} - CGO

--- a/go/internal/utils/ref_count.go
+++ b/go/internal/utils/ref_count.go
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "sync/atomic"
+
+// NewRefCount creates a new atomic counter set to the specified initial value.
+func NewRefCount(initial int64) *atomic.Int64 {
+	var val atomic.Int64
+	val.Store(initial)
+	return &val
+}

--- a/go/parquet/internal/bmi/bitmap_bmi2_386.go
+++ b/go/parquet/internal/bmi/bitmap_bmi2_386.go
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !noasm
+// +build !noasm
+
+package bmi
+
+func init() {
+	funclist.extractBits = extractBitsGo
+	funclist.gtbitmap = greaterThanBitmapGo
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Fixes: #43186

Improves 32-bit support for the pqarrow writer. We may want to push similar changes to other refcount implementations to more completely support running on 32-bit system.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Update `pathBuilder` and `multipathLevelBuilder` refCounts to use `atomic.Int64` which is automatically aligned on 32-bit systems.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

The issue reproduces with existing tests when building for a 32-bit architecture, so no new tests were added. This PR adds a "test" step to the existing workflow for 386 architecture builds, currently limited to run the tests fixed in this PR.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

32-bit systems should no longer panic when writing parquet files.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43186