### PR TITLE
moved appropriate dependencies to dev dependencies

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -52,12 +52,6 @@
     "jest.config.js"
   ],
   "dependencies": {
-    "@swc/helpers": "^0.5.11",
-    "@types/command-line-args": "^5.2.3",
-    "@types/command-line-usage": "^5.0.4",
-    "@types/node": "^20.13.0",
-    "command-line-args": "^5.2.1",
-    "command-line-usage": "^7.0.1",
     "flatbuffers": "^24.3.25",
     "json-bignum": "^0.0.3",
     "tslib": "^2.6.2"
@@ -116,7 +110,13 @@
     "webpack": "5.91.0",
     "webpack-bundle-analyzer": "4.10.2",
     "webpack-stream": "7.0.0",
-    "xml2js": "0.6.2"
+    "xml2js": "0.6.2",
+    "@types/node": "^20.13.0",
+    "@swc/helpers": "^0.5.11",
+    "@types/command-line-args": "^5.2.3",
+    "@types/command-line-usage": "^5.0.4",
+    "command-line-args": "^5.2.1",
+    "command-line-usage": "^7.0.1"
   },
   "engines": {
     "node": ">=12.0"


### PR DESCRIPTION
moved dependencies which are only required while testing and development and not in runtime to dev dependencies

dependencies which are moved:
![photo_2024-07-11_01-55-56](https://github.com/apache/arrow/assets/95514575/b251266d-79e4-4a32-9e95-c4c4b47c60ce)
