### PR TITLE
MINOR: [Java] Remove superfluous add-source execution

### DIFF
--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -262,25 +262,6 @@ under the License.
         </executions>
       </plugin>
       <plugin>
-        <!-- add generated sources to classpath -->
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>add-generated-sources-to-classpath</id>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated-sources/protobuf</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptorRefs>


### PR DESCRIPTION
### Rationale for this change

protobuf plugin already adds generated protobuf classes to the list of source directories, so remove the superfluous build-helper:add-source execution

### Are these changes tested?

Yes via CI/CD

### Are there any user-facing changes?

No