### PR TITLE
MINOR: [Docs][Python] Add missing decimal256 docs entries

### DIFF
--- a/docs/source/python/api/datatypes.rst
+++ b/docs/source/python/api/datatypes.rst
@@ -58,6 +58,7 @@ These should be used to create Arrow data types and schemas.
    binary_view
    string_view
    decimal128
+   decimal256
    list_
    large_list
    list_view
@@ -101,6 +102,7 @@ functions above.
    Time64Type
    FixedSizeBinaryType
    Decimal128Type
+   Decimal256Type
    Field
    Schema
    RunEndEncodedType


### PR DESCRIPTION
The PyArrow [Data Types and Schemas](https://arrow.apache.org/docs/dev/python/api/datatypes.html) docs is missing some links/entries to decimal256 functions/types. This adds them.