### PR TITLE
GH-43164: [C++] Fix CMake link order for AWS SDK

### DIFF
--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -63,6 +63,23 @@ if(ARROW_AZURE)
 endif()
 
 if(ARROW_S3)
+  set(ARROW_S3_TEST_EXTRA_LINK_LIBS)
+  # arrow_shared/arrow_static is specified implicitly via
+  # arrow_testing_shared/arrow_testing_static but we specify
+  # arrow_shared/arrow_static explicitly here to ensure using libarrow
+  # before libaws* on link. If we use libaws*.a before libarrow,
+  # static variables storage of AWS SDK for C++ in libaws*.a may be
+  # mixed with one in libarrow.
+  if(ARROW_TEST_LINKAGE STREQUAL "shared")
+    list(APPEND ARROW_S3_TEST_EXTRA_LINK_LIBS arrow_shared)
+  else()
+    list(APPEND ARROW_S3_TEST_EXTRA_LINK_LIBS arrow_static)
+  endif()
+  list(APPEND
+       ARROW_S3_TEST_EXTRA_LINK_LIBS
+       ${AWSSDK_LINK_LIBRARIES}
+       Boost::filesystem
+       Boost::system)
   add_arrow_test(s3fs_test
                  SOURCES
                  s3fs_test.cc
@@ -70,18 +87,17 @@ if(ARROW_S3)
                  EXTRA_LABELS
                  filesystem
                  EXTRA_LINK_LIBS
-                 ${AWSSDK_LINK_LIBRARIES}
-                 Boost::filesystem
-                 Boost::system)
+                 ${ARROW_S3_TEST_EXTRA_LINK_LIBS})
   if(TARGET arrow-s3fs-test)
     set(ARROW_S3FS_TEST_COMPILE_DEFINITIONS)
     get_target_property(AWS_CPP_SDK_S3_TYPE aws-cpp-sdk-s3 TYPE)
-    # We need to initialize AWS C++ SDK for direct use (not via
+    # We need to initialize AWS SDK for C++ for direct use (not via
     # arrow::fs::S3FileSystem) in arrow-s3fs-test if we use static AWS
-    # C++ SDK and hide symbols of them. Because AWS C++ SDK has
-    # internal static variables that aren't shared in libarrow and
+    # SDK for C++ and hide symbols of them. Because AWS SDK for C++
+    # has internal static variables that aren't shared in libarrow and
     # arrow-s3fs-test. It means that arrow::fs::InitializeS3() doesn't
-    # initialize AWS C++ SDK that is directly used in arrow-s3fs-test.
+    # initialize AWS SDK for C++ that is directly used in
+    # arrow-s3fs-test.
     if(AWS_CPP_SDK_S3_TYPE STREQUAL "STATIC_LIBRARY"
        AND CXX_LINKER_SUPPORTS_VERSION_SCRIPT)
       list(APPEND ARROW_S3FS_TEST_COMPILE_DEFINITIONS "AWS_CPP_SDK_S3_PRIVATE_STATIC")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

To resolve conflicts with AWS SDK for C++ static variables when linked with libarrow by ensuring correct link order.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Adjusted `CMakeLists.txt` to set `ARROW_S3_TEST_EXTRA_LINK_LIBS`.
- Ensured `libarrow` is linked before `libaws*` libraries.
- Updated `s3fs_test` configuration to use the new link order.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

I ran the test locally and observed the same result as mentioned. Additionally, I confirmed that if `ARROW_S3` is set to OFF or if the configuration includes `exclude_tests=arrow-s3fs-test`, the test is excluded.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43164