### PR TITLE
GH-43229: [Java] Update Maven project info

### DIFF
--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -323,14 +323,8 @@ class PrepareTest < Test::Unit::TestCase
           "+#{new_line}",
         ]
       end
-      expected_changes << {hunks: hunks, path: path}
-    end
-
-    Dir.glob("java/**/pom.xml") do |path|
-      version = "<tag>#{@snapshot_version}</tag>"
-      lines = File.readlines(path, chomp: true)
-      target_lines = lines.grep(/#{Regexp.escape(version)}/)
-      hunks = []
+      tag = "<tag>main</tag>"
+      target_lines = lines.grep(/#{Regexp.escape(tag)}/)
       target_lines.each do |line|
         new_line = line.gsub("main") do
           "apache-arrow-#{@release_version}"
@@ -339,7 +333,6 @@ class PrepareTest < Test::Unit::TestCase
           "-#{line}",
           "+#{new_line}",
         ]
-      end
       expected_changes << {hunks: hunks, path: path}
     end
 

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -326,6 +326,23 @@ class PrepareTest < Test::Unit::TestCase
       expected_changes << {hunks: hunks, path: path}
     end
 
+    Dir.glob("java/**/pom.xml") do |path|
+      version = "<tag>#{@snapshot_version}</tag>"
+      lines = File.readlines(path, chomp: true)
+      target_lines = lines.grep(/#{Regexp.escape(version)}/)
+      hunks = []
+      target_lines.each do |line|
+        new_line = line.gsub("main") do
+          "apache-arrow-#{@release_version}"
+        end
+        hunks << [
+          "-#{line}",
+          "+#{new_line}",
+        ]
+      end
+      expected_changes << {hunks: hunks, path: path}
+    end
+
     Dir.glob("ruby/**/version.rb") do |path|
       version = "  VERSION = \"#{@snapshot_version}\""
       new_version = "  VERSION = \"#{@release_version}\""

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -333,6 +333,7 @@ class PrepareTest < Test::Unit::TestCase
           "-#{line}",
           "+#{new_line}",
         ]
+      end
       expected_changes << {hunks: hunks, path: path}
     end
 

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -83,8 +83,13 @@ update_versions() {
   popd
 
   pushd "${ARROW_DIR}/java"
-  mvn versions:set -DnewVersion=${version} -DprocessAllModules
-  find . -type f -name pom.xml.versionsBackup -delete
+  mvn versions:set -DnewVersion=${version} -DprocessAllModules -DgenerateBackupPoms=false
+  if [ "${type}" = "release" ]; then
+    # versions-maven-plugin:set-scm-tag does not update the whole reactor. Invoking separately
+    mvn versions:set-scm-tag -DnewTag=apache-arrow-${version} -DgenerateBackupPoms=false -pl :arrow-java-root
+    mvn versions:set-scm-tag -DnewTag=apache-arrow-${version} -DgenerateBackupPoms=false -pl :arrow-bom
+    mvn versions:set-scm-tag -DnewTag=apache-arrow-${version} -DgenerateBackupPoms=false -pl :arrow-maven-plugins
+  fi
   git add "pom.xml"
   git add "**/pom.xml"
   popd

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -61,6 +61,7 @@ under the License.
       <subscribe>github-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
       <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>
+    </mailingList>
   </mailingLists>
 
   <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -41,21 +41,26 @@ under the License.
       <subscribe>dev-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@arrow.apache.org</unsubscribe>
       <post>dev@arrow.apache.org</post>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-dev/</archive>
+      <archive>https://lists.apache.org/list.html?dev@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>Commits List</name>
       <subscribe>commits-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>commits-unsubscribe@arrow.apache.org</unsubscribe>
       <post>commits@arrow.apache.org</post>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-commits/</archive>
+      <archive>https://lists.apache.org/list.html?commits@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>Issues List</name>
       <subscribe>issues-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>issues-unsubscribe@arrow.apache.org</unsubscribe>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-issues/</archive>
+      <archive>https://lists.apache.org/list.html?issues@arrow.apache.org</archive>
     </mailingList>
+    <mailingList>
+      <name>Github List</name>
+      <subscribe>github-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
+      <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>
   </mailingLists>
 
   <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -57,7 +57,7 @@ under the License.
       <archive>https://lists.apache.org/list.html?issues@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
-      <name>Github List</name>
+      <name>GitHub List</name>
       <subscribe>github-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
       <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -30,8 +30,45 @@ under the License.
   <artifactId>arrow-bom</artifactId>
   <version>17.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
   <name>Arrow Bill of Materials</name>
   <description>Arrow Bill of Materials</description>
+  <url>https://arrow.apache.org/</url>
+
+  <mailingLists>
+    <mailingList>
+      <name>Developer List</name>
+      <subscribe>dev-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>dev-unsubscribe@arrow.apache.org</unsubscribe>
+      <post>dev@arrow.apache.org</post>
+      <archive>https://mail-archives.apache.org/mod_mbox/arrow-dev/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Commits List</name>
+      <subscribe>commits-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>commits-unsubscribe@arrow.apache.org</unsubscribe>
+      <post>commits@arrow.apache.org</post>
+      <archive>https://mail-archives.apache.org/mod_mbox/arrow-commits/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Issues List</name>
+      <subscribe>issues-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>issues-unsubscribe@arrow.apache.org</unsubscribe>
+      <archive>https://mail-archives.apache.org/mod_mbox/arrow-issues/</archive>
+    </mailingList>
+  </mailingLists>
+
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://github.com/apache/arrow.git</connection>
+    <developerConnection>scm:git:https://github.com/apache/arrow.git</developerConnection>
+    <tag>main</tag>
+    <url>https://github.com/apache/arrow/tree/${project.scm.tag}</url>
+  </scm>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/apache/arrow/issues</url>
+  </issueManagement>
 
   <properties>
     <arrow.vector.classifier></arrow.vector.classifier>
@@ -168,6 +205,11 @@ under the License.
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>2.30.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.17.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -64,6 +64,7 @@ under the License.
       <subscribe>github-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
       <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>
+    </mailingList>
   </mailingLists>
 
   <modules>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -44,21 +44,26 @@ under the License.
       <subscribe>dev-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@arrow.apache.org</unsubscribe>
       <post>dev@arrow.apache.org</post>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-dev/</archive>
+      <archive>https://lists.apache.org/list.html?dev@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>Commits List</name>
       <subscribe>commits-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>commits-unsubscribe@arrow.apache.org</unsubscribe>
       <post>commits@arrow.apache.org</post>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-commits/</archive>
+      <archive>https://lists.apache.org/list.html?commits@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>Issues List</name>
       <subscribe>issues-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>issues-unsubscribe@arrow.apache.org</unsubscribe>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-issues/</archive>
+      <archive>https://lists.apache.org/list.html?issues@arrow.apache.org</archive>
     </mailingList>
+    <mailingList>
+      <name>Github List</name>
+      <subscribe>github-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
+      <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>
   </mailingLists>
 
   <modules>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <!--
     Note: Do not inherit from the Arrow parent POM as plugins can be referenced
@@ -34,11 +34,48 @@ under the License.
   <artifactId>arrow-maven-plugins</artifactId>
   <version>17.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
   <name>Arrow Maven Plugins</name>
+  <url>https://arrow.apache.org/</url>
+
+  <mailingLists>
+    <mailingList>
+      <name>Developer List</name>
+      <subscribe>dev-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>dev-unsubscribe@arrow.apache.org</unsubscribe>
+      <post>dev@arrow.apache.org</post>
+      <archive>https://mail-archives.apache.org/mod_mbox/arrow-dev/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Commits List</name>
+      <subscribe>commits-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>commits-unsubscribe@arrow.apache.org</unsubscribe>
+      <post>commits@arrow.apache.org</post>
+      <archive>https://mail-archives.apache.org/mod_mbox/arrow-commits/</archive>
+    </mailingList>
+    <mailingList>
+      <name>Issues List</name>
+      <subscribe>issues-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>issues-unsubscribe@arrow.apache.org</unsubscribe>
+      <archive>https://mail-archives.apache.org/mod_mbox/arrow-issues/</archive>
+    </mailingList>
+  </mailingLists>
 
   <modules>
     <module>module-info-compiler-maven-plugin</module>
   </modules>
+
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://github.com/apache/arrow.git</connection>
+    <developerConnection>scm:git:https://github.com/apache/arrow.git</developerConnection>
+    <tag>main</tag>
+    <url>https://github.com/apache/arrow/tree/${project.scm.tag}</url>
+  </scm>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/apache/arrow/issues</url>
+  </issueManagement>
 
   <properties>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
@@ -74,6 +111,11 @@ under the License.
           <groupId>org.cyclonedx</groupId>
           <artifactId>cyclonedx-maven-plugin</artifactId>
           <version>2.8.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.17.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/java/maven/pom.xml
+++ b/java/maven/pom.xml
@@ -60,7 +60,7 @@ under the License.
       <archive>https://lists.apache.org/list.html?issues@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
-      <name>Github List</name>
+      <name>GitHub List</name>
       <subscribe>github-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
       <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,21 +41,26 @@ under the License.
       <subscribe>dev-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@arrow.apache.org</unsubscribe>
       <post>dev@arrow.apache.org</post>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-dev/</archive>
+      <archive>https://lists.apache.org/list.html?dev@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>Commits List</name>
       <subscribe>commits-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>commits-unsubscribe@arrow.apache.org</unsubscribe>
       <post>commits@arrow.apache.org</post>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-commits/</archive>
+      <archive>https://lists.apache.org/list.html?commits@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
       <name>Issues List</name>
       <subscribe>issues-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>issues-unsubscribe@arrow.apache.org</unsubscribe>
-      <archive>https://mail-archives.apache.org/mod_mbox/arrow-issues/</archive>
+      <archive>https://lists.apache.org/list.html?issues@arrow.apache.org</archive>
     </mailingList>
+    <mailingList>
+      <name>Github List</name>
+      <subscribe>github-subscribe@arrow.apache.org</subscribe>
+      <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
+      <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>
   </mailingLists>
 
   <modules>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,7 +57,7 @@ under the License.
       <archive>https://lists.apache.org/list.html?issues@arrow.apache.org</archive>
     </mailingList>
     <mailingList>
-      <name>Github List</name>
+      <name>GitHub List</name>
       <subscribe>github-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
       <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -61,6 +61,7 @@ under the License.
       <subscribe>github-subscribe@arrow.apache.org</subscribe>
       <unsubscribe>github-unsubscribe@arrow.apache.org</unsubscribe>
       <archive>https://lists.apache.org/list.html?github@arrow.apache.org</archive>
+    </mailingList>
   </mailingLists>
 
   <modules>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -73,11 +73,11 @@ under the License.
     <module>compression</module>
   </modules>
 
-  <scm>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/apache/arrow.git</connection>
     <developerConnection>scm:git:https://github.com/apache/arrow.git</developerConnection>
-    <tag>apache-arrow-2.0.0</tag>
-    <url>https://github.com/apache/arrow</url>
+    <tag>main</tag>
+    <url>https://github.com/apache/arrow/tree/${project.scm.tag}</url>
   </scm>
 
   <issueManagement>
@@ -506,6 +506,11 @@ under the License.
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.17.0</version>
         </plugin>
         <plugin>
           <groupId>pl.project13.maven</groupId>


### PR DESCRIPTION
### Rationale for this change

Some Maven modules are missing project information like the website url, the mailing lists, and scm and issues url

Other may have incorrect links because of the way Maven interpolates those values at build time

### What changes are included in this PR?

Update/Fix Maven project information for all modules:
* Add project url, mailing lists, scm and issueManagement information to bom and maven parent modules
* Fix top-level parent by preventing Maven to rewrite project url, and scm connections/urls based on the module hierarchy
* Change project.scm.tag to `main` and update version change script to also change the tag value to `apache-arrow-${version}`

### Are these changes tested?

CI/CD only

### Are there any user-facing changes?

No
* GitHub Issue: #43229