### PR TITLE
GH-43232: [Release][Packaging][Python] Add tzdata as conda env requirement to avoid ORC failure

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1153,7 +1153,7 @@ test_linux_wheels() {
     local pyver=${python/m}
     for platform in ${platform_tags}; do
       show_header "Testing Python ${pyver} wheel for platform ${platform}"
-      CONDA_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_conda
+      CONDA_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_conda tzdata
       if ! VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv; then
         continue
       fi


### PR DESCRIPTION
### Rationale for this change

Binary verifications for wheels on conda are failing on ORC test due to missing tzdata

### What changes are included in this PR?

Adding tzdata as conda requirement when setting up the environment on the verification script

### Are these changes tested?

Those changes have been tested locally

### Are there any user-facing changes?
No
* GitHub Issue: #43232