### PR TITLE
GH-43238: [C++][FlightRPC] Reduce repetition in flight/types.cc in serde functions

### DIFF
--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -43,13 +43,23 @@ namespace arrow {
 namespace flight {
 namespace {
 
+ARROW_NOINLINE
+Status ProtoStringInputTooBig(const char* name) {
+  return Status::Invalid("Serialized ", name, " size should not exceed 2 GiB");
+}
+
+ARROW_NOINLINE
+Status InvalidProtoString(const char* name) {
+  return Status::Invalid("Not a valid ", name);
+}
+
 template <class PBType>
 Status ParseFromString(const char* name, std::string_view serialized, PBType* out) {
   if (serialized.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
-    return Status::Invalid("Serialized ", name, " size should not exceed 2 GiB");
+    return ProtoStringInputTooBig(name);
   }
   if (!out->ParseFromArray(serialized.data(), static_cast<int>(serialized.size()))) {
-    return Status::Invalid("Not a valid ", name);
+    return InvalidProtoString(name);
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -48,9 +48,7 @@ Status ParseFromString(const char* name, std::string_view serialized, PBType* ou
   if (serialized.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
     return Status::Invalid("Serialized ", name, " size should not exceed 2 GiB");
   }
-  google::protobuf::io::ArrayInputStream input(serialized.data(),
-                                               static_cast<int>(serialized.size()));
-  if (!out->ParseFromZeroCopyStream(&input)) {
+  if (!out->ParseFromArray(serialized.data(), static_cast<int>(serialized.size()))) {
     return Status::Invalid("Not a valid ", name);
   }
   return Status::OK();


### PR DESCRIPTION
### Rationale for this change

Local templates can be used to reduce repetition in serde code.

### What changes are included in this PR?

 - `Deserialize` and `SerializeToString` on the types in `flight/types.cc` are now defined in terms of a few templates
 - Use of `ParseFromArray` to parse `std::string_view` inputs instead of wrapping it in a `google::protobuf::io::ArrayInputStream`

### Are these changes tested?

By existing tests.

* GitHub Issue: #43238