### PR TITLE
GH-43245: [Packaging][deb] Add missing libabsl-dev dependency

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-trixie/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-trixie/Dockerfile
@@ -70,7 +70,6 @@ RUN \
     llvm-dev \
     lsb-release \
     meson \
-    mold \
     ninja-build \
     nlohmann-json3-dev \
     pkg-config \

--- a/dev/tasks/linux-packages/apache-arrow/debian/control.in
+++ b/dev/tasks/linux-packages/apache-arrow/debian/control.in
@@ -140,6 +140,7 @@ Multi-Arch: same
 Depends:
   ${misc:Depends},
   libarrow1700 (= ${binary:Version}),
+@USE_SYSTEM_GRPC@  libabsl-dev,
   libbrotli-dev,
   libbz2-dev,
   libcurl4-openssl-dev,


### PR DESCRIPTION
### Rationale for this change

If `libabsl-dev` dependency is missed from `libarrow-dev`, `find_package(Arrow)` is failed.

### What changes are included in this PR?

* Add missing `libabsl-dev` dependency.
* Remove `mold` from debian-trixie because `mold` is removed from debian-trixie: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1073168


### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #43245