### PR TITLE
GH-43249: [C++][Parquet] remove useless template parameter of `DeltaLengthByteArrayEncoder`

### DIFF
--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2821,8 +2821,8 @@ void DeltaLengthByteArrayEncoder::Put(const T* src, int num_values) {
 }
 
 void DeltaLengthByteArrayEncoder::PutSpaced(const T* src, int num_values,
-                                                   const uint8_t* valid_bits,
-                                                   int64_t valid_bits_offset) {
+                                            const uint8_t* valid_bits,
+                                            int64_t valid_bits_offset) {
   if (valid_bits != NULLPTR) {
     PARQUET_ASSIGN_OR_THROW(auto buffer, ::arrow::AllocateBuffer(num_values * sizeof(T),
                                                                  this->memory_pool()));

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -2732,7 +2732,6 @@ class DeltaBitPackDecoder : public DecoderImpl, virtual public TypedDecoder<DTyp
 // ----------------------------------------------------------------------
 // DeltaLengthByteArrayEncoder
 
-template <typename DType>
 class DeltaLengthByteArrayEncoder : public EncoderImpl,
                                     virtual public TypedEncoder<ByteArrayType> {
  public:
@@ -2783,8 +2782,7 @@ class DeltaLengthByteArrayEncoder : public EncoderImpl,
   DeltaBitPackEncoder<Int32Type> length_encoder_;
 };
 
-template <typename DType>
-void DeltaLengthByteArrayEncoder<DType>::Put(const ::arrow::Array& values) {
+void DeltaLengthByteArrayEncoder::Put(const ::arrow::Array& values) {
   AssertBaseBinary(values);
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
@@ -2793,8 +2791,7 @@ void DeltaLengthByteArrayEncoder<DType>::Put(const ::arrow::Array& values) {
   }
 }
 
-template <typename DType>
-void DeltaLengthByteArrayEncoder<DType>::Put(const T* src, int num_values) {
+void DeltaLengthByteArrayEncoder::Put(const T* src, int num_values) {
   if (num_values == 0) {
     return;
   }
@@ -2823,8 +2820,7 @@ void DeltaLengthByteArrayEncoder<DType>::Put(const T* src, int num_values) {
   }
 }
 
-template <typename DType>
-void DeltaLengthByteArrayEncoder<DType>::PutSpaced(const T* src, int num_values,
+void DeltaLengthByteArrayEncoder::PutSpaced(const T* src, int num_values,
                                                    const uint8_t* valid_bits,
                                                    int64_t valid_bits_offset) {
   if (valid_bits != NULLPTR) {
@@ -2839,8 +2835,7 @@ void DeltaLengthByteArrayEncoder<DType>::PutSpaced(const T* src, int num_values,
   }
 }
 
-template <typename DType>
-std::shared_ptr<Buffer> DeltaLengthByteArrayEncoder<DType>::FlushValues() {
+std::shared_ptr<Buffer> DeltaLengthByteArrayEncoder::FlushValues() {
   std::shared_ptr<Buffer> encoded_lengths = length_encoder_.FlushValues();
 
   std::shared_ptr<Buffer> data;
@@ -3366,7 +3361,7 @@ class DeltaByteArrayEncoder : public EncoderImpl, virtual public TypedEncoder<DT
 
   ::arrow::BufferBuilder sink_;
   DeltaBitPackEncoder<Int32Type> prefix_length_encoder_;
-  DeltaLengthByteArrayEncoder<ByteArrayType> suffix_encoder_;
+  DeltaLengthByteArrayEncoder suffix_encoder_;
   std::string last_value_;
   const ByteArray empty_;
   std::unique_ptr<ResizableBuffer> buffer_;
@@ -3934,7 +3929,7 @@ std::unique_ptr<Encoder> MakeEncoder(Type::type type_num, Encoding::type encodin
   } else if (encoding == Encoding::DELTA_LENGTH_BYTE_ARRAY) {
     switch (type_num) {
       case Type::BYTE_ARRAY:
-        return std::make_unique<DeltaLengthByteArrayEncoder<ByteArrayType>>(descr, pool);
+        return std::make_unique<DeltaLengthByteArrayEncoder>(descr, pool);
       default:
         throw ParquetException("DELTA_LENGTH_BYTE_ARRAY only supports BYTE_ARRAY");
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

see https://github.com/apache/arrow/issues/43249

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

remove template parameter of DeltaLengthByteArrayEncoder

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Covered by existing

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43249