### PR TITLE
MINOR: [CI] Remove paleolimbot from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,7 @@
 /matlab/ @kevingurney @kou @sgilmore10
 /python/pyarrow/_flight.pyx @lidavidm
 /python/pyarrow/**/*gandiva* @wjones127
-/r/ @paleolimbot @thisisnic
+/r/ @thisisnic
 /ruby/ @kou
 /swift/ @kou
 


### PR DESCRIPTION
This is part of a larger effort in reconfiguring my personal GitHub notification strategy. I'm still happy to be pinged on any R things as required!

### What changes are included in this PR?

Remove myself from the CODEOWNERS file

### Are these changes tested?

Not needed!

### Are there any user-facing changes?

Nope!