### PR TITLE
GH-43258: [C++][Flight] Use a Base CRTP type for the types used in RPC calls

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -584,8 +584,8 @@ arrow::Result<std::unique_ptr<ResultStream>> FlightClient::DoAction(
 
 arrow::Result<CancelFlightInfoResult> FlightClient::CancelFlightInfo(
     const FlightCallOptions& options, const CancelFlightInfoRequest& request) {
-  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToString());
-  Action action{ActionType::kCancelFlightInfo.type, Buffer::FromString(body)};
+  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToBuffer());
+  Action action{ActionType::kCancelFlightInfo.type, std::move(body)};
   ARROW_ASSIGN_OR_RAISE(auto stream, DoAction(options, action));
   ARROW_ASSIGN_OR_RAISE(auto result, stream->Next());
   ARROW_ASSIGN_OR_RAISE(auto cancel_result, CancelFlightInfoResult::Deserialize(
@@ -596,8 +596,8 @@ arrow::Result<CancelFlightInfoResult> FlightClient::CancelFlightInfo(
 
 arrow::Result<FlightEndpoint> FlightClient::RenewFlightEndpoint(
     const FlightCallOptions& options, const RenewFlightEndpointRequest& request) {
-  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToString());
-  Action action{ActionType::kRenewFlightEndpoint.type, Buffer::FromString(body)};
+  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToBuffer());
+  Action action{ActionType::kRenewFlightEndpoint.type, std::move(body)};
   ARROW_ASSIGN_OR_RAISE(auto stream, DoAction(options, action));
   ARROW_ASSIGN_OR_RAISE(auto result, stream->Next());
   ARROW_ASSIGN_OR_RAISE(auto renewed_endpoint,
@@ -716,8 +716,8 @@ arrow::Result<FlightClient::DoExchangeResult> FlightClient::DoExchange(
 ::arrow::Result<SetSessionOptionsResult> FlightClient::SetSessionOptions(
     const FlightCallOptions& options, const SetSessionOptionsRequest& request) {
   RETURN_NOT_OK(CheckOpen());
-  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToString());
-  Action action{ActionType::kSetSessionOptions.type, Buffer::FromString(body)};
+  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToBuffer());
+  Action action{ActionType::kSetSessionOptions.type, std::move(body)};
   ARROW_ASSIGN_OR_RAISE(auto stream, DoAction(options, action));
   ARROW_ASSIGN_OR_RAISE(auto result, stream->Next());
   ARROW_ASSIGN_OR_RAISE(
@@ -730,8 +730,8 @@ arrow::Result<FlightClient::DoExchangeResult> FlightClient::DoExchange(
 ::arrow::Result<GetSessionOptionsResult> FlightClient::GetSessionOptions(
     const FlightCallOptions& options, const GetSessionOptionsRequest& request) {
   RETURN_NOT_OK(CheckOpen());
-  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToString());
-  Action action{ActionType::kGetSessionOptions.type, Buffer::FromString(body)};
+  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToBuffer());
+  Action action{ActionType::kGetSessionOptions.type, std::move(body)};
   ARROW_ASSIGN_OR_RAISE(auto stream, DoAction(options, action));
   ARROW_ASSIGN_OR_RAISE(auto result, stream->Next());
   ARROW_ASSIGN_OR_RAISE(
@@ -744,8 +744,8 @@ arrow::Result<FlightClient::DoExchangeResult> FlightClient::DoExchange(
 ::arrow::Result<CloseSessionResult> FlightClient::CloseSession(
     const FlightCallOptions& options, const CloseSessionRequest& request) {
   RETURN_NOT_OK(CheckOpen());
-  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToString());
-  Action action{ActionType::kCloseSession.type, Buffer::FromString(body)};
+  ARROW_ASSIGN_OR_RAISE(auto body, request.SerializeToBuffer());
+  Action action{ActionType::kCloseSession.type, std::move(body)};
   ARROW_ASSIGN_OR_RAISE(auto stream, DoAction(options, action));
   ARROW_ASSIGN_OR_RAISE(auto result, stream->Next());
   ARROW_ASSIGN_OR_RAISE(auto close_session_result,

--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -79,8 +79,9 @@ void TestRoundtrip(const std::vector<FlightType>& values,
     ASSERT_OK(internal::ToProto(values[i], &pb_value));
 
     if constexpr (std::is_same_v<FlightType, FlightInfo>) {
-      ASSERT_OK_AND_ASSIGN(FlightInfo value, internal::FromProto(pb_value));
-      EXPECT_EQ(values[i], value);
+      FlightInfo::Data info_data;
+      ASSERT_OK(internal::FromProto(pb_value, &info_data));
+      EXPECT_EQ(values[i], FlightInfo{std::move(info_data)});
     } else if constexpr (std::is_same_v<FlightType, SchemaResult>) {
       std::string data;
       ASSERT_OK(internal::FromProto(pb_value, &data));

--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -152,9 +152,11 @@ TEST(FlightTypes, BasicAuth) {
 }
 
 TEST(FlightTypes, Criteria) {
-  std::vector<Criteria> values = {{""}, {"criteria"}};
-  std::vector<std::string> reprs = {"<Criteria expression=''>",
-                                    "<Criteria expression='criteria'>"};
+  std::vector<Criteria> values = {Criteria{""}, Criteria{"criteria"}};
+  std::vector<std::string> reprs = {
+      "<Criteria expression=''>",
+      "<Criteria expression='criteria'>",
+  };
   ASSERT_NO_FATAL_FAILURE(TestRoundtrip<pb::Criteria>(values, reprs));
 }
 
@@ -191,14 +193,14 @@ TEST(FlightTypes, FlightEndpoint) {
   Timestamp expiration_time(
       std::chrono::duration_cast<Timestamp::duration>(expiration_time_duration));
   std::vector<FlightEndpoint> values = {
-      {{""}, {}, std::nullopt, {}},
-      {{"foo"}, {}, std::nullopt, {}},
-      {{"bar"}, {}, std::nullopt, {"\xDE\xAD\xBE\xEF"}},
-      {{"foo"}, {}, expiration_time, {}},
-      {{"foo"}, {location1}, std::nullopt, {}},
-      {{"bar"}, {location1}, std::nullopt, {}},
-      {{"foo"}, {location2}, std::nullopt, {}},
-      {{"foo"}, {location1, location2}, std::nullopt, {"\xba\xdd\xca\xfe"}},
+      {Ticket{""}, {}, std::nullopt, {}},
+      {Ticket{"foo"}, {}, std::nullopt, {}},
+      {Ticket{"bar"}, {}, std::nullopt, {"\xDE\xAD\xBE\xEF"}},
+      {Ticket{"foo"}, {}, expiration_time, {}},
+      {Ticket{"foo"}, {location1}, std::nullopt, {}},
+      {Ticket{"bar"}, {location1}, std::nullopt, {}},
+      {Ticket{"foo"}, {location2}, std::nullopt, {}},
+      {Ticket{"foo"}, {location1, location2}, std::nullopt, {"\xba\xdd\xca\xfe"}},
   };
   std::vector<std::string> reprs = {
       "<FlightEndpoint ticket=<Ticket ticket=''> locations=[] "
@@ -299,9 +301,9 @@ TEST(FlightTypes, PollInfo) {
 
 TEST(FlightTypes, Result) {
   std::vector<Result> values = {
-      {Buffer::FromString("")},
-      {Buffer::FromString("foo")},
-      {Buffer::FromString("bar")},
+      Result{Buffer::FromString("")},
+      Result{Buffer::FromString("foo")},
+      Result{Buffer::FromString("bar")},
   };
   std::vector<std::string> reprs = {
       "<Result body=(0 bytes)>",
@@ -333,9 +335,9 @@ TEST(FlightTypes, SchemaResult) {
 
 TEST(FlightTypes, Ticket) {
   std::vector<Ticket> values = {
-      {""},
-      {"foo"},
-      {"bar"},
+      Ticket{""},
+      Ticket{"foo"},
+      Ticket{"bar"},
   };
   std::vector<std::string> reprs = {
       "<Ticket ticket=''>",

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -998,7 +998,8 @@ TEST_F(TestFlightClient, ListFlights) {
 }
 
 TEST_F(TestFlightClient, ListFlightsWithCriteria) {
-  ASSERT_OK_AND_ASSIGN(auto listing, client_->ListFlights(FlightCallOptions(), {"foo"}));
+  ASSERT_OK_AND_ASSIGN(auto listing,
+                       client_->ListFlights(FlightCallOptions{}, Criteria{"foo"}));
   std::unique_ptr<FlightInfo> info;
   ASSERT_OK_AND_ASSIGN(info, listing->Next());
   ASSERT_TRUE(info == nullptr);

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -268,6 +268,13 @@ Status FromProto(const pb::FlightInfo& pb_info, FlightInfo::Data* info) {
   return Status::OK();
 }
 
+Status FromProto(const pb::FlightInfo& pb_info, std::unique_ptr<FlightInfo>* info) {
+  FlightInfo::Data info_data;
+  RETURN_NOT_OK(FromProto(pb_info, &info_data));
+  *info = std::make_unique<FlightInfo>(std::move(info_data));
+  return Status::OK();
+}
+
 Status FromProto(const pb::BasicAuth& pb_basic_auth, BasicAuth* basic_auth) {
   basic_auth->password = pb_basic_auth.password();
   basic_auth->username = pb_basic_auth.username();
@@ -337,6 +344,13 @@ Status FromProto(const pb::PollInfo& pb_info, PollInfo* info) {
   } else {
     info->expiration_time = std::nullopt;
   }
+  return Status::OK();
+}
+
+Status FromProto(const pb::PollInfo& pb_info, std::unique_ptr<PollInfo>* info) {
+  PollInfo poll_info;
+  RETURN_NOT_OK(FromProto(pb_info, &poll_info));
+  *info = std::make_unique<PollInfo>(std::move(poll_info));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -251,22 +251,21 @@ Status ToProto(const FlightDescriptor& descriptor, pb::FlightDescriptor* pb_desc
 
 // FlightInfo
 
-arrow::Result<FlightInfo> FromProto(const pb::FlightInfo& pb_info) {
-  FlightInfo::Data info;
-  RETURN_NOT_OK(FromProto(pb_info.flight_descriptor(), &info.descriptor));
+Status FromProto(const pb::FlightInfo& pb_info, FlightInfo::Data* info) {
+  RETURN_NOT_OK(FromProto(pb_info.flight_descriptor(), &info->descriptor));
 
-  info.schema = pb_info.schema();
+  info->schema = pb_info.schema();
 
-  info.endpoints.resize(pb_info.endpoint_size());
+  info->endpoints.resize(pb_info.endpoint_size());
   for (int i = 0; i < pb_info.endpoint_size(); ++i) {
-    RETURN_NOT_OK(FromProto(pb_info.endpoint(i), &info.endpoints[i]));
+    RETURN_NOT_OK(FromProto(pb_info.endpoint(i), &info->endpoints[i]));
   }
 
-  info.total_records = pb_info.total_records();
-  info.total_bytes = pb_info.total_bytes();
-  info.ordered = pb_info.ordered();
-  info.app_metadata = pb_info.app_metadata();
-  return FlightInfo(std::move(info));
+  info->total_records = pb_info.total_records();
+  info->total_bytes = pb_info.total_bytes();
+  info->ordered = pb_info.ordered();
+  info->app_metadata = pb_info.app_metadata();
+  return Status::OK();
 }
 
 Status FromProto(const pb::BasicAuth& pb_basic_auth, BasicAuth* basic_auth) {
@@ -315,8 +314,9 @@ Status ToProto(const FlightInfo& info, pb::FlightInfo* pb_info) {
 
 Status FromProto(const pb::PollInfo& pb_info, PollInfo* info) {
   if (pb_info.has_info()) {
-    ARROW_ASSIGN_OR_RAISE(auto flight_info, FromProto(pb_info.info()));
-    info->info = std::make_unique<FlightInfo>(std::move(flight_info));
+    FlightInfo::Data info_data;
+    RETURN_NOT_OK(FromProto(pb_info.info(), &info_data));
+    info->info = std::make_unique<FlightInfo>(std::move(info_data));
   }
   if (pb_info.has_flight_descriptor()) {
     FlightDescriptor descriptor;
@@ -360,8 +360,9 @@ Status ToProto(const PollInfo& info, pb::PollInfo* pb_info) {
 
 Status FromProto(const pb::CancelFlightInfoRequest& pb_request,
                  CancelFlightInfoRequest* request) {
-  ARROW_ASSIGN_OR_RAISE(FlightInfo info, FromProto(pb_request.info()));
-  request->info = std::make_unique<FlightInfo>(std::move(info));
+  FlightInfo::Data info_data;
+  RETURN_NOT_OK(FromProto(pb_request.info(), &info_data));
+  request->info = std::make_unique<FlightInfo>(std::move(info_data));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -60,7 +60,7 @@ Status FromProto(const pb::FlightDescriptor& pb_descr, FlightDescriptor* descr);
 Status FromProto(const pb::FlightEndpoint& pb_endpoint, FlightEndpoint* endpoint);
 Status FromProto(const pb::RenewFlightEndpointRequest& pb_request,
                  RenewFlightEndpointRequest* request);
-arrow::Result<FlightInfo> FromProto(const pb::FlightInfo& pb_info);
+Status FromProto(const pb::FlightInfo& pb_info, FlightInfo::Data* info);
 Status FromProto(const pb::PollInfo& pb_info, PollInfo* info);
 Status FromProto(const pb::CancelFlightInfoRequest& pb_request,
                  CancelFlightInfoRequest* request);

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -61,7 +61,9 @@ Status FromProto(const pb::FlightEndpoint& pb_endpoint, FlightEndpoint* endpoint
 Status FromProto(const pb::RenewFlightEndpointRequest& pb_request,
                  RenewFlightEndpointRequest* request);
 Status FromProto(const pb::FlightInfo& pb_info, FlightInfo::Data* info);
+Status FromProto(const pb::FlightInfo& pb_info, std::unique_ptr<FlightInfo>* info);
 Status FromProto(const pb::PollInfo& pb_info, PollInfo* info);
+Status FromProto(const pb::PollInfo& pb_info, std::unique_ptr<PollInfo>* info);
 Status FromProto(const pb::CancelFlightInfoRequest& pb_request,
                  CancelFlightInfoRequest* request);
 Status FromProto(const pb::SchemaResult& pb_result, std::string* result);

--- a/cpp/src/arrow/flight/sql/example/sqlite_server.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_server.cc
@@ -126,7 +126,7 @@ arrow::Result<std::unique_ptr<FlightDataStream>> DoGetSQLiteQuery(
 arrow::Result<std::unique_ptr<FlightInfo>> GetFlightInfoForCommand(
     const FlightDescriptor& descriptor, const std::shared_ptr<Schema>& schema) {
   std::vector<FlightEndpoint> endpoints{
-      FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, ""}};
+      FlightEndpoint{Ticket{descriptor.cmd}, {}, std::nullopt, ""}};
   ARROW_ASSIGN_OR_RAISE(auto result,
                         FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false))
 
@@ -389,7 +389,7 @@ class SQLiteFlightSqlServer::Impl {
       const ServerCallContext& context, const GetTables& command,
       const FlightDescriptor& descriptor) {
     std::vector<FlightEndpoint> endpoints{
-        FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, ""}};
+        FlightEndpoint{Ticket{descriptor.cmd}, {}, std::nullopt, ""}};
 
     bool include_schema = command.include_schema;
     ARROW_LOG(INFO) << "GetTables include_schema=" << include_schema;

--- a/cpp/src/arrow/flight/sql/server.cc
+++ b/cpp/src/arrow/flight/sql/server.cc
@@ -1063,7 +1063,7 @@ arrow::Result<std::unique_ptr<FlightInfo>> FlightSqlServerBase::GetFlightInfoSql
   }
 
   std::vector<FlightEndpoint> endpoints{
-      FlightEndpoint{{descriptor.cmd}, {}, std::nullopt, {}}};
+      FlightEndpoint{Ticket{descriptor.cmd}, {}, std::nullopt, {}}};
   ARROW_ASSIGN_OR_RAISE(
       auto result, FlightInfo::Make(*SqlSchema::GetSqlInfoSchema(), descriptor, endpoints,
                                     -1, -1, false))

--- a/cpp/src/arrow/flight/sql/server.cc
+++ b/cpp/src/arrow/flight/sql/server.cc
@@ -477,13 +477,11 @@ arrow::Result<Result> PackActionResult(ActionBeginTransactionResult result) {
 }
 
 arrow::Result<Result> PackActionResult(CancelFlightInfoResult result) {
-  ARROW_ASSIGN_OR_RAISE(auto serialized, result.SerializeToString());
-  return Result{Buffer::FromString(std::move(serialized))};
+  return result.SerializeToBuffer();
 }
 
 arrow::Result<Result> PackActionResult(const FlightEndpoint& endpoint) {
-  ARROW_ASSIGN_OR_RAISE(auto serialized, endpoint.SerializeToString());
-  return Result{Buffer::FromString(std::move(serialized))};
+  return endpoint.SerializeToBuffer();
 }
 
 arrow::Result<Result> PackActionResult(CancelResult result) {
@@ -523,21 +521,6 @@ arrow::Result<Result> PackActionResult(ActionCreatePreparedStatementResult resul
   }
 
   return PackActionResult(pb_result);
-}
-
-arrow::Result<Result> PackActionResult(SetSessionOptionsResult result) {
-  ARROW_ASSIGN_OR_RAISE(auto serialized, result.SerializeToString());
-  return Result{Buffer::FromString(std::move(serialized))};
-}
-
-arrow::Result<Result> PackActionResult(GetSessionOptionsResult result) {
-  ARROW_ASSIGN_OR_RAISE(auto serialized, result.SerializeToString());
-  return Result{Buffer::FromString(std::move(serialized))};
-}
-
-arrow::Result<Result> PackActionResult(CloseSessionResult result) {
-  ARROW_ASSIGN_OR_RAISE(auto serialized, result.SerializeToString());
-  return Result{Buffer::FromString(std::move(serialized))};
 }
 
 }  // namespace
@@ -908,23 +891,23 @@ Status FlightSqlServerBase::DoAction(const ServerCallContext& context,
     std::string_view body(*action.body);
     ARROW_ASSIGN_OR_RAISE(auto request, SetSessionOptionsRequest::Deserialize(body));
     ARROW_ASSIGN_OR_RAISE(auto result, SetSessionOptions(context, request));
-    ARROW_ASSIGN_OR_RAISE(auto packed_result, PackActionResult(std::move(result)));
+    ARROW_ASSIGN_OR_RAISE(auto packed_result, result.SerializeToBuffer());
 
-    results.push_back(std::move(packed_result));
+    results.emplace_back(std::move(packed_result));
   } else if (action.type == ActionType::kGetSessionOptions.type) {
     std::string_view body(*action.body);
     ARROW_ASSIGN_OR_RAISE(auto request, GetSessionOptionsRequest::Deserialize(body));
     ARROW_ASSIGN_OR_RAISE(auto result, GetSessionOptions(context, request));
-    ARROW_ASSIGN_OR_RAISE(auto packed_result, PackActionResult(std::move(result)));
+    ARROW_ASSIGN_OR_RAISE(auto packed_result, result.SerializeToBuffer());
 
-    results.push_back(std::move(packed_result));
+    results.emplace_back(std::move(packed_result));
   } else if (action.type == ActionType::kCloseSession.type) {
     std::string_view body(*action.body);
     ARROW_ASSIGN_OR_RAISE(auto request, CloseSessionRequest::Deserialize(body));
     ARROW_ASSIGN_OR_RAISE(auto result, CloseSession(context, request));
-    ARROW_ASSIGN_OR_RAISE(auto packed_result, PackActionResult(std::move(result)));
+    ARROW_ASSIGN_OR_RAISE(auto packed_result, result.SerializeToBuffer());
 
-    results.push_back(std::move(packed_result));
+    results.emplace_back(std::move(packed_result));
   } else {
     google::protobuf::Any any;
     if (!any.ParseFromArray(action.body->data(), static_cast<int>(action.body->size()))) {

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -604,11 +604,11 @@ std::vector<FlightInfo> ExampleFlightInfo() {
   Location location4 = *Location::ForGrpcTcp("foo4.bar.com", 12345);
   Location location5 = *Location::ForGrpcTcp("foo5.bar.com", 12345);
 
-  FlightEndpoint endpoint1({{"ticket-ints-1"}, {location1}, std::nullopt, {}});
-  FlightEndpoint endpoint2({{"ticket-ints-2"}, {location2}, std::nullopt, {}});
-  FlightEndpoint endpoint3({{"ticket-cmd"}, {location3}, std::nullopt, {}});
-  FlightEndpoint endpoint4({{"ticket-dicts-1"}, {location4}, std::nullopt, {}});
-  FlightEndpoint endpoint5({{"ticket-floats-1"}, {location5}, std::nullopt, {}});
+  FlightEndpoint endpoint1({Ticket{"ticket-ints-1"}, {location1}, std::nullopt, {}});
+  FlightEndpoint endpoint2({Ticket{"ticket-ints-2"}, {location2}, std::nullopt, {}});
+  FlightEndpoint endpoint3({Ticket{"ticket-cmd"}, {location3}, std::nullopt, {}});
+  FlightEndpoint endpoint4({Ticket{"ticket-dicts-1"}, {location4}, std::nullopt, {}});
+  FlightEndpoint endpoint5({Ticket{"ticket-floats-1"}, {location5}, std::nullopt, {}});
 
   FlightDescriptor descr1{FlightDescriptor::PATH, "", {"examples", "ints"}};
   FlightDescriptor descr2{FlightDescriptor::CMD, "my_command", {}};

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -648,10 +648,10 @@ class UnaryUnaryAsyncCall : public ::grpc::ClientUnaryReactor, public internal::
 
   void OnDone(const ::grpc::Status& status) override {
     if (status.ok()) {
-      auto result = internal::FromProto(pb_response);
-      client_status = result.status();
+      FlightInfo::Data info_data;
+      client_status = internal::FromProto(pb_response, &info_data);
       if (client_status.ok()) {
-        listener->OnNext(std::move(result).MoveValueUnsafe());
+        listener->OnNext(FlightInfo{std::move(info_data)});
       }
     }
     Finish(status);
@@ -889,7 +889,8 @@ class GrpcClientImpl : public internal::ClientTransport {
 
     pb::FlightInfo pb_info;
     while (!options.stop_token.IsStopRequested() && stream->Read(&pb_info)) {
-      ARROW_ASSIGN_OR_RAISE(FlightInfo info_data, internal::FromProto(pb_info));
+      FlightInfo::Data info_data;
+      RETURN_NOT_OK(internal::FromProto(pb_info, &info_data));
       flights.emplace_back(std::move(info_data));
     }
     if (options.stop_token.IsStopRequested()) rpc.context.TryCancel();
@@ -939,7 +940,8 @@ class GrpcClientImpl : public internal::ClientTransport {
         stub_->GetFlightInfo(&rpc.context, pb_descriptor, &pb_response), &rpc.context);
     RETURN_NOT_OK(s);
 
-    ARROW_ASSIGN_OR_RAISE(auto info_data, internal::FromProto(pb_response));
+    FlightInfo::Data info_data;
+    RETURN_NOT_OK(internal::FromProto(pb_response, &info_data));
     *info = std::make_unique<FlightInfo>(std::move(info_data));
     return Status::OK();
   }

--- a/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
+++ b/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
@@ -376,7 +376,7 @@ class UcxServerImpl : public arrow::flight::internal::ServerTransport {
     std::unique_ptr<FlightInfo> info;
     std::string response;
     SERVER_RETURN_NOT_OK(driver, base_->GetFlightInfo(context, descriptor, &info));
-    SERVER_RETURN_NOT_OK(driver, info->SerializeToString().Value(&response));
+    SERVER_RETURN_NOT_OK(driver, info->DoSerializeToString(&response));
     RETURN_NOT_OK(driver->SendFrame(FrameType::kBuffer,
                                     reinterpret_cast<const uint8_t*>(response.data()),
                                     static_cast<int64_t>(response.size())));
@@ -397,7 +397,7 @@ class UcxServerImpl : public arrow::flight::internal::ServerTransport {
     std::unique_ptr<PollInfo> info;
     std::string response;
     SERVER_RETURN_NOT_OK(driver, base_->PollFlightInfo(context, descriptor, &info));
-    SERVER_RETURN_NOT_OK(driver, info->SerializeToString().Value(&response));
+    SERVER_RETURN_NOT_OK(driver, info->DoSerializeToString(&response));
     RETURN_NOT_OK(driver->SendFrame(FrameType::kBuffer,
                                     reinterpret_cast<const uint8_t*>(response.data()),
                                     static_cast<int64_t>(response.size())));

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -277,7 +277,7 @@ arrow::Result<FlightInfo> FlightInfo::Make(const Schema& schema,
   data.ordered = ordered;
   data.app_metadata = std::move(app_metadata);
   RETURN_NOT_OK(internal::SchemaToString(schema, &data.schema));
-  return FlightInfo(data);
+  return FlightInfo(std::move(data));
 }
 
 arrow::Result<std::shared_ptr<Schema>> FlightInfo::GetSchema(
@@ -300,8 +300,9 @@ arrow::Result<std::unique_ptr<FlightInfo>> FlightInfo::Deserialize(
     std::string_view serialized) {
   pb::FlightInfo pb_info;
   RETURN_NOT_OK(ParseFromString("FlightInfo", serialized, &pb_info));
-  ARROW_ASSIGN_OR_RAISE(FlightInfo info, internal::FromProto(pb_info));
-  return std::make_unique<FlightInfo>(std::move(info));
+  FlightInfo::Data info_data;
+  RETURN_NOT_OK(internal::FromProto(pb_info, &info_data));
+  return std::make_unique<FlightInfo>(std::move(info_data));
 }
 
 std::string FlightInfo::ToString() const {

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -227,24 +227,23 @@ bool SchemaResult::Equals(const SchemaResult& other) const {
   return raw_schema_ == other.raw_schema_;
 }
 
-arrow::Status SchemaResult::DoSerializeToString(std::string* out) const {
+arrow::Status SchemaResult::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::SchemaResult>("SchemaResult", *this, out);
 }
 
-arrow::Status SchemaResult::DoDeserialize(std::string_view serialized,
-                                          SchemaResult* out) {
+arrow::Status SchemaResult::Deserialize(std::string_view serialized, SchemaResult* out) {
   pb::SchemaResult pb_schema_result;
   RETURN_NOT_OK(ParseFromString("SchemaResult", serialized, &pb_schema_result));
   *out = SchemaResult{pb_schema_result.schema()};
   return Status::OK();
 }
 
-arrow::Status FlightDescriptor::DoSerializeToString(std::string* out) const {
+arrow::Status FlightDescriptor::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::FlightDescriptor>("FlightDescriptor", *this, out);
 }
 
-arrow::Status FlightDescriptor::DoDeserialize(std::string_view serialized,
-                                              FlightDescriptor* out) {
+arrow::Status FlightDescriptor::Deserialize(std::string_view serialized,
+                                            FlightDescriptor* out) {
   return DeserializeProtoString<pb::FlightDescriptor, FlightDescriptor>(
       "FlightDescriptor", serialized, out);
 }
@@ -257,11 +256,11 @@ std::string Ticket::ToString() const {
 
 bool Ticket::Equals(const Ticket& other) const { return ticket == other.ticket; }
 
-arrow::Status Ticket::DoSerializeToString(std::string* out) const {
+arrow::Status Ticket::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::Ticket>("Ticket", *this, out);
 }
 
-arrow::Status Ticket::DoDeserialize(std::string_view serialized, Ticket* out) {
+arrow::Status Ticket::Deserialize(std::string_view serialized, Ticket* out) {
   return DeserializeProtoString<pb::Ticket, Ticket>("Ticket", serialized, out);
 }
 
@@ -293,12 +292,12 @@ arrow::Result<std::shared_ptr<Schema>> FlightInfo::GetSchema(
   return schema_;
 }
 
-arrow::Status FlightInfo::DoSerializeToString(std::string* out) const {
+arrow::Status FlightInfo::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::FlightInfo>("FlightInfo", *this, out);
 }
 
-arrow::Status FlightInfo::DoDeserialize(std::string_view serialized,
-                                        std::unique_ptr<FlightInfo>* out) {
+arrow::Status FlightInfo::Deserialize(std::string_view serialized,
+                                      std::unique_ptr<FlightInfo>* out) {
   return DeserializeProtoString<pb::FlightInfo, std::unique_ptr<FlightInfo>>(
       "FlightInfo", serialized, out);
 }
@@ -337,12 +336,12 @@ bool FlightInfo::Equals(const FlightInfo& other) const {
          data_.app_metadata == other.data_.app_metadata;
 }
 
-arrow::Status PollInfo::DoSerializeToString(std::string* out) const {
+arrow::Status PollInfo::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::PollInfo>("PollInfo", *this, out);
 }
 
-arrow::Status PollInfo::DoDeserialize(std::string_view serialized,
-                                      std::unique_ptr<PollInfo>* out) {
+arrow::Status PollInfo::Deserialize(std::string_view serialized,
+                                    std::unique_ptr<PollInfo>* out) {
   return DeserializeProtoString<pb::PollInfo, std::unique_ptr<PollInfo>>("PollInfo",
                                                                          serialized, out);
 }
@@ -421,13 +420,13 @@ bool CancelFlightInfoRequest::Equals(const CancelFlightInfoRequest& other) const
   return info == other.info;
 }
 
-arrow::Status CancelFlightInfoRequest::DoSerializeToString(std::string* out) const {
+arrow::Status CancelFlightInfoRequest::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::CancelFlightInfoRequest>("CancelFlightInfoRequest",
                                                              *this, out);
 }
 
-arrow::Status CancelFlightInfoRequest::DoDeserialize(std::string_view serialized,
-                                                     CancelFlightInfoRequest* out) {
+arrow::Status CancelFlightInfoRequest::Deserialize(std::string_view serialized,
+                                                   CancelFlightInfoRequest* out) {
   return DeserializeProtoString<pb::CancelFlightInfoRequest, CancelFlightInfoRequest>(
       "CancelFlightInfoRequest", serialized, out);
 }
@@ -550,13 +549,13 @@ bool SetSessionOptionsRequest::Equals(const SetSessionOptionsRequest& other) con
   return CompareSessionOptionMaps(session_options, other.session_options);
 }
 
-arrow::Status SetSessionOptionsRequest::DoSerializeToString(std::string* out) const {
+arrow::Status SetSessionOptionsRequest::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::SetSessionOptionsRequest>("SetSessionOptionsRequest",
                                                               *this, out);
 }
 
-arrow::Status SetSessionOptionsRequest::DoDeserialize(std::string_view serialized,
-                                                      SetSessionOptionsRequest* out) {
+arrow::Status SetSessionOptionsRequest::Deserialize(std::string_view serialized,
+                                                    SetSessionOptionsRequest* out) {
   return DeserializeProtoString<pb::SetSessionOptionsRequest, SetSessionOptionsRequest>(
       "SetSessionOptionsRequest", serialized, out);
 }
@@ -578,13 +577,13 @@ bool SetSessionOptionsResult::Equals(const SetSessionOptionsResult& other) const
   return true;
 }
 
-arrow::Status SetSessionOptionsResult::DoSerializeToString(std::string* out) const {
+arrow::Status SetSessionOptionsResult::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::SetSessionOptionsResult>("SetSessionOptionsResult",
                                                              *this, out);
 }
 
-arrow::Status SetSessionOptionsResult::DoDeserialize(std::string_view serialized,
-                                                     SetSessionOptionsResult* out) {
+arrow::Status SetSessionOptionsResult::Deserialize(std::string_view serialized,
+                                                   SetSessionOptionsResult* out) {
   return DeserializeProtoString<pb::SetSessionOptionsResult, SetSessionOptionsResult>(
       "SetSessionOptionsResult", serialized, out);
 }
@@ -599,13 +598,13 @@ bool GetSessionOptionsRequest::Equals(const GetSessionOptionsRequest& other) con
   return true;
 }
 
-arrow::Status GetSessionOptionsRequest::DoSerializeToString(std::string* out) const {
+arrow::Status GetSessionOptionsRequest::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::GetSessionOptionsRequest>("GetSessionOptionsRequest",
                                                               *this, out);
 }
 
-arrow::Status GetSessionOptionsRequest::DoDeserialize(std::string_view serialized,
-                                                      GetSessionOptionsRequest* out) {
+arrow::Status GetSessionOptionsRequest::Deserialize(std::string_view serialized,
+                                                    GetSessionOptionsRequest* out) {
   return DeserializeProtoString<pb::GetSessionOptionsRequest, GetSessionOptionsRequest>(
       "GetSessionOptionsRequest", serialized, out);
 }
@@ -622,13 +621,13 @@ bool GetSessionOptionsResult::Equals(const GetSessionOptionsResult& other) const
   return CompareSessionOptionMaps(session_options, other.session_options);
 }
 
-arrow::Status GetSessionOptionsResult::DoSerializeToString(std::string* out) const {
+arrow::Status GetSessionOptionsResult::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::GetSessionOptionsResult>("GetSessionOptionsResult",
                                                              *this, out);
 }
 
-arrow::Status GetSessionOptionsResult::DoDeserialize(std::string_view serialized,
-                                                     GetSessionOptionsResult* out) {
+arrow::Status GetSessionOptionsResult::Deserialize(std::string_view serialized,
+                                                   GetSessionOptionsResult* out) {
   return DeserializeProtoString<pb::GetSessionOptionsResult, GetSessionOptionsResult>(
       "GetSessionOptionsResult", serialized, out);
 }
@@ -639,13 +638,13 @@ std::string CloseSessionRequest::ToString() const { return "<CloseSessionRequest
 
 bool CloseSessionRequest::Equals(const CloseSessionRequest& other) const { return true; }
 
-arrow::Status CloseSessionRequest::DoSerializeToString(std::string* out) const {
+arrow::Status CloseSessionRequest::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::CloseSessionRequest>("CloseSessionRequest", *this,
                                                          out);
 }
 
-arrow::Status CloseSessionRequest::DoDeserialize(std::string_view serialized,
-                                                 CloseSessionRequest* out) {
+arrow::Status CloseSessionRequest::Deserialize(std::string_view serialized,
+                                               CloseSessionRequest* out) {
   return DeserializeProtoString<pb::CloseSessionRequest, CloseSessionRequest>(
       "CloseSessionRequest", serialized, out);
 }
@@ -664,12 +663,12 @@ bool CloseSessionResult::Equals(const CloseSessionResult& other) const {
   return status == other.status;
 }
 
-arrow::Status CloseSessionResult::DoSerializeToString(std::string* out) const {
+arrow::Status CloseSessionResult::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::CloseSessionResult>("CloseSessionResult", *this, out);
 }
 
-arrow::Status CloseSessionResult::DoDeserialize(std::string_view serialized,
-                                                CloseSessionResult* out) {
+arrow::Status CloseSessionResult::Deserialize(std::string_view serialized,
+                                              CloseSessionResult* out) {
   return DeserializeProtoString<pb::CloseSessionResult, CloseSessionResult>(
       "CloseSessionResult", serialized, out);
 }
@@ -776,12 +775,12 @@ bool FlightEndpoint::Equals(const FlightEndpoint& other) const {
   return true;
 }
 
-arrow::Status FlightEndpoint::DoSerializeToString(std::string* out) const {
+arrow::Status FlightEndpoint::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::FlightEndpoint>("FlightEndpoint", *this, out);
 }
 
-arrow::Status FlightEndpoint::DoDeserialize(std::string_view serialized,
-                                            FlightEndpoint* out) {
+arrow::Status FlightEndpoint::Deserialize(std::string_view serialized,
+                                          FlightEndpoint* out) {
   return DeserializeProtoString<pb::FlightEndpoint, FlightEndpoint>("FlightEndpoint",
                                                                     serialized, out);
 }
@@ -796,13 +795,13 @@ bool RenewFlightEndpointRequest::Equals(const RenewFlightEndpointRequest& other)
   return endpoint == other.endpoint;
 }
 
-arrow::Status RenewFlightEndpointRequest::DoSerializeToString(std::string* out) const {
+arrow::Status RenewFlightEndpointRequest::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::RenewFlightEndpointRequest>(
       "RenewFlightEndpointRequest", *this, out);
 }
 
-arrow::Status RenewFlightEndpointRequest::DoDeserialize(std::string_view serialized,
-                                                        RenewFlightEndpointRequest* out) {
+arrow::Status RenewFlightEndpointRequest::Deserialize(std::string_view serialized,
+                                                      RenewFlightEndpointRequest* out) {
   return DeserializeProtoString<pb::RenewFlightEndpointRequest,
                                 RenewFlightEndpointRequest>("RenewFlightEndpointRequest",
                                                             serialized, out);
@@ -843,11 +842,11 @@ bool ActionType::Equals(const ActionType& other) const {
   return type == other.type && description == other.description;
 }
 
-arrow::Status ActionType::DoSerializeToString(std::string* out) const {
+arrow::Status ActionType::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::ActionType>("ActionType", *this, out);
 }
 
-arrow::Status ActionType::DoDeserialize(std::string_view serialized, ActionType* out) {
+arrow::Status ActionType::Deserialize(std::string_view serialized, ActionType* out) {
   return DeserializeProtoString<pb::ActionType, ActionType>("ActionType", serialized,
                                                             out);
 }
@@ -860,11 +859,11 @@ bool Criteria::Equals(const Criteria& other) const {
   return expression == other.expression;
 }
 
-arrow::Status Criteria::DoSerializeToString(std::string* out) const {
+arrow::Status Criteria::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::Criteria>("Criteria", *this, out);
 }
 
-arrow::Status Criteria::DoDeserialize(std::string_view serialized, Criteria* out) {
+arrow::Status Criteria::Deserialize(std::string_view serialized, Criteria* out) {
   return DeserializeProtoString<pb::Criteria, Criteria>("Criteria", serialized, out);
 }
 
@@ -886,11 +885,11 @@ bool Action::Equals(const Action& other) const {
          ((body == other.body) || (body && other.body && body->Equals(*other.body)));
 }
 
-arrow::Status Action::DoSerializeToString(std::string* out) const {
+arrow::Status Action::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::Action>("Action", *this, out);
 }
 
-arrow::Status Action::DoDeserialize(std::string_view serialized, Action* out) {
+arrow::Status Action::Deserialize(std::string_view serialized, Action* out) {
   return DeserializeProtoString<pb::Action, Action>("Action", serialized, out);
 }
 
@@ -909,11 +908,11 @@ bool Result::Equals(const Result& other) const {
   return (body == other.body) || (body && other.body && body->Equals(*other.body));
 }
 
-arrow::Status Result::DoSerializeToString(std::string* out) const {
+arrow::Status Result::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::Result>("Result", *this, out);
 }
 
-arrow::Status Result::DoDeserialize(std::string_view serialized, Result* out) {
+arrow::Status Result::Deserialize(std::string_view serialized, Result* out) {
   return DeserializeProtoString<pb::Result, Result>("Result", serialized, out);
 }
 
@@ -927,13 +926,13 @@ bool CancelFlightInfoResult::Equals(const CancelFlightInfoResult& other) const {
   return status == other.status;
 }
 
-arrow::Status CancelFlightInfoResult::DoSerializeToString(std::string* out) const {
+arrow::Status CancelFlightInfoResult::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::CancelFlightInfoResult>("CancelFlightInfoResult",
                                                             *this, out);
 }
 
-arrow::Status CancelFlightInfoResult::DoDeserialize(std::string_view serialized,
-                                                    CancelFlightInfoResult* out) {
+arrow::Status CancelFlightInfoResult::Deserialize(std::string_view serialized,
+                                                  CancelFlightInfoResult* out) {
   return DeserializeProtoString<pb::CancelFlightInfoResult, CancelFlightInfoResult>(
       "CancelFlightInfoResult", serialized, out);
 }
@@ -1052,11 +1051,11 @@ bool BasicAuth::Equals(const BasicAuth& other) const {
   return (username == other.username) && (password == other.password);
 }
 
-arrow::Status BasicAuth::DoDeserialize(std::string_view serialized, BasicAuth* out) {
+arrow::Status BasicAuth::Deserialize(std::string_view serialized, BasicAuth* out) {
   return DeserializeProtoString<pb::BasicAuth, BasicAuth>("BasicAuth", serialized, out);
 }
 
-arrow::Status BasicAuth::DoSerializeToString(std::string* out) const {
+arrow::Status BasicAuth::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::BasicAuth>("BasicAuth", *this, out);
 }
 

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -90,11 +90,9 @@ arrow::Result<T> DeserializeProtoString(const char* name, std::string_view seria
 }
 
 template <class PBType, class T>
-arrow::Result<std::string> SerializeToProtoString(const char* name, const T& in) {
+Status SerializeToProtoString(const char* name, const T& in, std::string* out) {
   PBType pb;
-  std::string out;
-  RETURN_NOT_OK(SerializeToString<PBType>(name, in, &pb, &out));
-  return out;
+  return SerializeToString<PBType>(name, in, &pb, out);
 }
 
 }  // namespace
@@ -230,8 +228,8 @@ bool SchemaResult::Equals(const SchemaResult& other) const {
   return raw_schema_ == other.raw_schema_;
 }
 
-arrow::Result<std::string> SchemaResult::SerializeToString() const {
-  return SerializeToProtoString<pb::SchemaResult>("SchemaResult", *this);
+arrow::Status SchemaResult::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::SchemaResult>("SchemaResult", *this, out);
 }
 
 arrow::Result<SchemaResult> SchemaResult::Deserialize(std::string_view serialized) {
@@ -240,8 +238,8 @@ arrow::Result<SchemaResult> SchemaResult::Deserialize(std::string_view serialize
   return SchemaResult{pb_schema_result.schema()};
 }
 
-arrow::Result<std::string> FlightDescriptor::SerializeToString() const {
-  return SerializeToProtoString<pb::FlightDescriptor>("FlightDescriptor", *this);
+arrow::Status FlightDescriptor::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::FlightDescriptor>("FlightDescriptor", *this, out);
 }
 
 arrow::Result<FlightDescriptor> FlightDescriptor::Deserialize(
@@ -258,8 +256,8 @@ std::string Ticket::ToString() const {
 
 bool Ticket::Equals(const Ticket& other) const { return ticket == other.ticket; }
 
-arrow::Result<std::string> Ticket::SerializeToString() const {
-  return SerializeToProtoString<pb::Ticket>("Ticket", *this);
+arrow::Status Ticket::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::Ticket>("Ticket", *this, out);
 }
 
 arrow::Result<Ticket> Ticket::Deserialize(std::string_view serialized) {
@@ -294,8 +292,8 @@ arrow::Result<std::shared_ptr<Schema>> FlightInfo::GetSchema(
   return schema_;
 }
 
-arrow::Result<std::string> FlightInfo::SerializeToString() const {
-  return SerializeToProtoString<pb::FlightInfo>("FlightInfo", *this);
+arrow::Status FlightInfo::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::FlightInfo>("FlightInfo", *this, out);
 }
 
 arrow::Result<std::unique_ptr<FlightInfo>> FlightInfo::Deserialize(
@@ -340,8 +338,8 @@ bool FlightInfo::Equals(const FlightInfo& other) const {
          data_.app_metadata == other.data_.app_metadata;
 }
 
-arrow::Result<std::string> PollInfo::SerializeToString() const {
-  return SerializeToProtoString<pb::PollInfo>("PollInfo", *this);
+arrow::Status PollInfo::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::PollInfo>("PollInfo", *this, out);
 }
 
 arrow::Result<std::unique_ptr<PollInfo>> PollInfo::Deserialize(
@@ -427,9 +425,9 @@ bool CancelFlightInfoRequest::Equals(const CancelFlightInfoRequest& other) const
   return info == other.info;
 }
 
-arrow::Result<std::string> CancelFlightInfoRequest::SerializeToString() const {
+arrow::Status CancelFlightInfoRequest::DoSerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::CancelFlightInfoRequest>("CancelFlightInfoRequest",
-                                                             *this);
+                                                             *this, out);
 }
 
 arrow::Result<CancelFlightInfoRequest> CancelFlightInfoRequest::Deserialize(
@@ -556,9 +554,9 @@ bool SetSessionOptionsRequest::Equals(const SetSessionOptionsRequest& other) con
   return CompareSessionOptionMaps(session_options, other.session_options);
 }
 
-arrow::Result<std::string> SetSessionOptionsRequest::SerializeToString() const {
+arrow::Status SetSessionOptionsRequest::DoSerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::SetSessionOptionsRequest>("SetSessionOptionsRequest",
-                                                              *this);
+                                                              *this, out);
 }
 
 arrow::Result<SetSessionOptionsRequest> SetSessionOptionsRequest::Deserialize(
@@ -584,9 +582,9 @@ bool SetSessionOptionsResult::Equals(const SetSessionOptionsResult& other) const
   return true;
 }
 
-arrow::Result<std::string> SetSessionOptionsResult::SerializeToString() const {
+arrow::Status SetSessionOptionsResult::DoSerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::SetSessionOptionsResult>("SetSessionOptionsResult",
-                                                             *this);
+                                                             *this, out);
 }
 
 arrow::Result<SetSessionOptionsResult> SetSessionOptionsResult::Deserialize(
@@ -605,9 +603,9 @@ bool GetSessionOptionsRequest::Equals(const GetSessionOptionsRequest& other) con
   return true;
 }
 
-arrow::Result<std::string> GetSessionOptionsRequest::SerializeToString() const {
+arrow::Status GetSessionOptionsRequest::DoSerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::GetSessionOptionsRequest>("GetSessionOptionsRequest",
-                                                              *this);
+                                                              *this, out);
 }
 
 arrow::Result<GetSessionOptionsRequest> GetSessionOptionsRequest::Deserialize(
@@ -628,9 +626,9 @@ bool GetSessionOptionsResult::Equals(const GetSessionOptionsResult& other) const
   return CompareSessionOptionMaps(session_options, other.session_options);
 }
 
-arrow::Result<std::string> GetSessionOptionsResult::SerializeToString() const {
+arrow::Status GetSessionOptionsResult::DoSerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::GetSessionOptionsResult>("GetSessionOptionsResult",
-                                                             *this);
+                                                             *this, out);
 }
 
 arrow::Result<GetSessionOptionsResult> GetSessionOptionsResult::Deserialize(
@@ -645,8 +643,9 @@ std::string CloseSessionRequest::ToString() const { return "<CloseSessionRequest
 
 bool CloseSessionRequest::Equals(const CloseSessionRequest& other) const { return true; }
 
-arrow::Result<std::string> CloseSessionRequest::SerializeToString() const {
-  return SerializeToProtoString<pb::CloseSessionRequest>("CloseSessionRequest", *this);
+arrow::Status CloseSessionRequest::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::CloseSessionRequest>("CloseSessionRequest", *this,
+                                                         out);
 }
 
 arrow::Result<CloseSessionRequest> CloseSessionRequest::Deserialize(
@@ -669,8 +668,8 @@ bool CloseSessionResult::Equals(const CloseSessionResult& other) const {
   return status == other.status;
 }
 
-arrow::Result<std::string> CloseSessionResult::SerializeToString() const {
-  return SerializeToProtoString<pb::CloseSessionResult>("CloseSessionResult", *this);
+arrow::Status CloseSessionResult::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::CloseSessionResult>("CloseSessionResult", *this, out);
 }
 
 arrow::Result<CloseSessionResult> CloseSessionResult::Deserialize(
@@ -781,8 +780,8 @@ bool FlightEndpoint::Equals(const FlightEndpoint& other) const {
   return true;
 }
 
-arrow::Result<std::string> FlightEndpoint::SerializeToString() const {
-  return SerializeToProtoString<pb::FlightEndpoint>("FlightEndpoint", *this);
+arrow::Status FlightEndpoint::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::FlightEndpoint>("FlightEndpoint", *this, out);
 }
 
 arrow::Result<FlightEndpoint> FlightEndpoint::Deserialize(std::string_view serialized) {
@@ -800,9 +799,9 @@ bool RenewFlightEndpointRequest::Equals(const RenewFlightEndpointRequest& other)
   return endpoint == other.endpoint;
 }
 
-arrow::Result<std::string> RenewFlightEndpointRequest::SerializeToString() const {
+arrow::Status RenewFlightEndpointRequest::DoSerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::RenewFlightEndpointRequest>(
-      "RenewFlightEndpointRequest", *this);
+      "RenewFlightEndpointRequest", *this, out);
 }
 
 arrow::Result<RenewFlightEndpointRequest> RenewFlightEndpointRequest::Deserialize(
@@ -847,8 +846,8 @@ bool ActionType::Equals(const ActionType& other) const {
   return type == other.type && description == other.description;
 }
 
-arrow::Result<std::string> ActionType::SerializeToString() const {
-  return SerializeToProtoString<pb::ActionType>("ActionType", *this);
+arrow::Status ActionType::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::ActionType>("ActionType", *this, out);
 }
 
 arrow::Result<ActionType> ActionType::Deserialize(std::string_view serialized) {
@@ -863,8 +862,8 @@ bool Criteria::Equals(const Criteria& other) const {
   return expression == other.expression;
 }
 
-arrow::Result<std::string> Criteria::SerializeToString() const {
-  return SerializeToProtoString<pb::Criteria>("Criteria", *this);
+arrow::Status Criteria::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::Criteria>("Criteria", *this, out);
 }
 
 arrow::Result<Criteria> Criteria::Deserialize(std::string_view serialized) {
@@ -889,8 +888,8 @@ bool Action::Equals(const Action& other) const {
          ((body == other.body) || (body && other.body && body->Equals(*other.body)));
 }
 
-arrow::Result<std::string> Action::SerializeToString() const {
-  return SerializeToProtoString<pb::Action>("Action", *this);
+arrow::Status Action::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::Action>("Action", *this, out);
 }
 
 arrow::Result<Action> Action::Deserialize(std::string_view serialized) {
@@ -912,8 +911,8 @@ bool Result::Equals(const Result& other) const {
   return (body == other.body) || (body && other.body && body->Equals(*other.body));
 }
 
-arrow::Result<std::string> Result::SerializeToString() const {
-  return SerializeToProtoString<pb::Result>("Result", *this);
+arrow::Status Result::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::Result>("Result", *this, out);
 }
 
 arrow::Result<Result> Result::Deserialize(std::string_view serialized) {
@@ -930,9 +929,9 @@ bool CancelFlightInfoResult::Equals(const CancelFlightInfoResult& other) const {
   return status == other.status;
 }
 
-arrow::Result<std::string> CancelFlightInfoResult::SerializeToString() const {
+arrow::Status CancelFlightInfoResult::DoSerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::CancelFlightInfoResult>("CancelFlightInfoResult",
-                                                            *this);
+                                                            *this, out);
 }
 
 arrow::Result<CancelFlightInfoResult> CancelFlightInfoResult::Deserialize(
@@ -1059,8 +1058,8 @@ arrow::Result<BasicAuth> BasicAuth::Deserialize(std::string_view serialized) {
   return DeserializeProtoString<pb::BasicAuth, BasicAuth>("BasicAuth", serialized);
 }
 
-arrow::Result<std::string> BasicAuth::SerializeToString() const {
-  return SerializeToProtoString<pb::BasicAuth>("BasicAuth", *this);
+arrow::Status BasicAuth::DoSerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::BasicAuth>("BasicAuth", *this, out);
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -31,6 +31,7 @@
 #include <variant>
 #include <vector>
 
+#include "arrow/buffer.h"
 #include "arrow/flight/type_fwd.h"
 #include "arrow/flight/visibility.h"
 #include "arrow/ipc/options.h"
@@ -179,6 +180,12 @@ struct BaseType {
     std::string out;
     ARROW_RETURN_NOT_OK(self().DoSerializeToString(&out));
     return out;
+  }
+
+  inline arrow::Result<std::shared_ptr<Buffer>> SerializeToBuffer() const {
+    std::string out;
+    ARROW_RETURN_NOT_OK(self().DoSerializeToString(&out));
+    return Buffer::FromString(std::move(out));
   }
 };
 

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -198,6 +198,12 @@ struct BaseType {
     return out;
   }
 
+  inline static arrow::Result<T> Deserialize(std::string_view serialized) {
+    T out;
+    ARROW_RETURN_NOT_OK(SelfT::DoDeserialize(serialized, &out));
+    return out;
+  }
+
   inline arrow::Result<std::shared_ptr<Buffer>> SerializeToBuffer() const {
     std::string out;
     ARROW_RETURN_NOT_OK(self().DoSerializeToString(&out));
@@ -227,7 +233,7 @@ struct ARROW_FLIGHT_EXPORT ActionType : public internal::BaseType<ActionType> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<ActionType> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, ActionType* out);
 
   static const ActionType kCancelFlightInfo;
   static const ActionType kRenewFlightEndpoint;
@@ -252,7 +258,7 @@ struct ARROW_FLIGHT_EXPORT Criteria : public internal::BaseType<Criteria> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<Criteria> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, Criteria* out);
 };
 
 /// \brief An action to perform with the DoAction RPC
@@ -274,7 +280,7 @@ struct ARROW_FLIGHT_EXPORT Action : public internal::BaseType<Action> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<Action> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, Action* out);
 };
 
 /// \brief Opaque result returned after executing an action
@@ -292,7 +298,7 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<Result> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, Result* out);
 };
 
 enum class CancelStatus {
@@ -327,7 +333,8 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<CancelFlightInfoResult> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     CancelFlightInfoResult* out);
 };
 
 ARROW_FLIGHT_EXPORT
@@ -345,10 +352,11 @@ struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
   std::string ToString() const;
   bool Equals(const BasicAuth& other) const;
 
-  /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<BasicAuth> Deserialize(std::string_view serialized);
   /// \brief Serialize this message to its wire-format representation.
   arrow::Status DoSerializeToString(std::string* out) const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  static arrow::Status DoDeserialize(std::string_view serialized, BasicAuth* out);
 };
 
 /// \brief A request to retrieve or generate a dataset
@@ -391,7 +399,7 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  static arrow::Result<FlightDescriptor> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, FlightDescriptor* out);
 
   // Convenience factory functions
 
@@ -426,7 +434,7 @@ struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  static arrow::Result<Ticket> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, Ticket* out);
 };
 
 class FlightClient;
@@ -530,7 +538,7 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndp
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<FlightEndpoint> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, FlightEndpoint* out);
 };
 
 /// \brief The request of the RenewFlightEndpoint action.
@@ -549,8 +557,8 @@ struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<RenewFlightEndpointRequest> Deserialize(
-      std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     RenewFlightEndpointRequest* out);
 };
 
 /// \brief Staging data structure for messages about to be put on the wire
@@ -597,7 +605,7 @@ struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<SchemaResult> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized, SchemaResult* out);
 
  private:
   std::string raw_schema_;
@@ -668,8 +676,8 @@ class ARROW_FLIGHT_EXPORT FlightInfo
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  static arrow::Result<std::unique_ptr<FlightInfo>> Deserialize(
-      std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     std::unique_ptr<FlightInfo>* out);
 
   std::string ToString() const;
 
@@ -740,8 +748,8 @@ class ARROW_FLIGHT_EXPORT PollInfo
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  static arrow::Result<std::unique_ptr<PollInfo>> Deserialize(
-      std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     std::unique_ptr<PollInfo>* out);
 
   std::string ToString() const;
 
@@ -767,7 +775,8 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<CancelFlightInfoRequest> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     CancelFlightInfoRequest* out);
 };
 
 /// \brief Variant supporting all possible value types for {Set,Get}SessionOptions
@@ -834,7 +843,8 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<SetSessionOptionsRequest> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     SetSessionOptionsRequest* out);
 };
 
 /// \brief The result(s) of setting session option(s).
@@ -865,7 +875,8 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<SetSessionOptionsResult> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     SetSessionOptionsResult* out);
 };
 
 /// \brief A request to get current session options.
@@ -880,7 +891,8 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<GetSessionOptionsRequest> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     GetSessionOptionsRequest* out);
 };
 
 /// \brief The current session options.
@@ -900,7 +912,8 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<GetSessionOptionsResult> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     GetSessionOptionsResult* out);
 };
 
 /// \brief A request to close the open client session.
@@ -915,7 +928,8 @@ struct ARROW_FLIGHT_EXPORT CloseSessionRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<CloseSessionRequest> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     CloseSessionRequest* out);
 };
 
 /// \brief The result of attempting to close the client session.
@@ -934,7 +948,8 @@ struct ARROW_FLIGHT_EXPORT CloseSessionResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
-  static arrow::Result<CloseSessionResult> Deserialize(std::string_view serialized);
+  static arrow::Status DoDeserialize(std::string_view serialized,
+                                     CloseSessionResult* out);
 };
 
 /// \brief An iterator to FlightInfo instances returned by ListFlights.

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -230,6 +230,8 @@ struct ARROW_FLIGHT_EXPORT ActionType : public internal::BaseType<ActionType> {
   bool Equals(const ActionType& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -255,6 +257,8 @@ struct ARROW_FLIGHT_EXPORT Criteria : public internal::BaseType<Criteria> {
   bool Equals(const Criteria& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -277,6 +281,8 @@ struct ARROW_FLIGHT_EXPORT Action : public internal::BaseType<Action> {
   bool Equals(const Action& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -295,6 +301,8 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   bool Equals(const Result& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -330,6 +338,8 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
   bool Equals(const CancelFlightInfoResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -353,6 +363,8 @@ struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
   bool Equals(const BasicAuth& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -393,6 +405,8 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
@@ -428,6 +442,8 @@ struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
@@ -535,6 +551,8 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndp
   bool Equals(const FlightEndpoint& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -554,6 +572,8 @@ struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
   bool Equals(const RenewFlightEndpointRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -602,6 +622,8 @@ struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult
   bool Equals(const SchemaResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -670,6 +692,8 @@ class ARROW_FLIGHT_EXPORT FlightInfo
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
@@ -742,6 +766,8 @@ class ARROW_FLIGHT_EXPORT PollInfo
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
@@ -772,6 +798,8 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
   bool Equals(const CancelFlightInfoRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -840,6 +868,8 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
   bool Equals(const SetSessionOptionsRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -872,6 +902,8 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
   bool Equals(const SetSessionOptionsResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -888,6 +920,8 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest
   bool Equals(const GetSessionOptionsRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -909,6 +943,8 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult
   bool Equals(const GetSessionOptionsResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -925,6 +961,8 @@ struct ARROW_FLIGHT_EXPORT CloseSessionRequest
   bool Equals(const CloseSessionRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
@@ -945,6 +983,8 @@ struct ARROW_FLIGHT_EXPORT CloseSessionResult
   bool Equals(const CloseSessionResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString` if you want a Result-returning version.
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -210,7 +210,8 @@ struct ARROW_FLIGHT_EXPORT Criteria : public internal::BaseType<Criteria> {
   std::string expression;
 
   Criteria() = default;
-  explicit Criteria(std::string expression) : expression(std::move(expression)) {}
+  Criteria(std::string expression)  // NOLINT runtime/explicit
+      : expression(std::move(expression)) {}
 
   std::string ToString() const;
   bool Equals(const Criteria& other) const;
@@ -249,7 +250,8 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   std::shared_ptr<Buffer> body;
 
   Result() = default;
-  explicit Result(std::shared_ptr<Buffer> body) : body(std::move(body)) {}
+  Result(std::shared_ptr<Buffer> body)  // NOLINT runtime/explicit
+      : body(std::move(body)) {}
 
   std::string ToString() const;
   bool Equals(const Result& other) const;
@@ -283,7 +285,8 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
   CancelStatus status = CancelStatus::kUnspecified;
 
   CancelFlightInfoResult() = default;
-  explicit CancelFlightInfoResult(CancelStatus status) : status(status) {}
+  CancelFlightInfoResult(CancelStatus status)  // NOLINT runtime/explicit
+      : status(status) {}
 
   std::string ToString() const;
   bool Equals(const CancelFlightInfoResult& other) const;
@@ -374,7 +377,8 @@ struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   std::string ticket;
 
   Ticket() = default;
-  explicit Ticket(std::string ticket) : ticket(std::move(ticket)) {}
+  Ticket(std::string ticket)  // NOLINT runtime/explicit
+      : ticket(std::move(ticket)) {}
 
   std::string ToString() const;
   bool Equals(const Ticket& other) const;
@@ -718,7 +722,7 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
   std::unique_ptr<FlightInfo> info;
 
   CancelFlightInfoRequest() = default;
-  explicit CancelFlightInfoRequest(std::unique_ptr<FlightInfo> info)
+  CancelFlightInfoRequest(std::unique_ptr<FlightInfo> info)  // NOLINT runtime/explicit
       : info(std::move(info)) {}
 
   std::string ToString() const;
@@ -816,7 +820,7 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
   std::map<std::string, Error> errors;
 
   SetSessionOptionsResult() = default;
-  explicit SetSessionOptionsResult(std::map<std::string, Error> errors)
+  SetSessionOptionsResult(std::map<std::string, Error> errors)  // NOLINT runtime/explicit
       : errors(std::move(errors)) {}
 
   std::string ToString() const;
@@ -850,7 +854,7 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult
   std::map<std::string, SessionOptionValue> session_options;
 
   GetSessionOptionsResult() = default;
-  explicit GetSessionOptionsResult(
+  GetSessionOptionsResult(  // NOLINT runtime/explicit
       std::map<std::string, SessionOptionValue> session_options)
       : session_options(std::move(session_options)) {}
 

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -176,6 +176,7 @@ struct remove_unique_ptr<std::unique_ptr<T>> {
 template <class T>
 struct BaseType {
  protected:
+  using SuperT = BaseType<T>;
   using SelfT = typename remove_unique_ptr<T>::type;
 
   const SelfT& self() const { return static_cast<const SelfT&>(*this); }
@@ -194,19 +195,19 @@ struct BaseType {
   /// \brief Serialize this message to its wire-format representation.
   inline arrow::Result<std::string> SerializeToString() const {
     std::string out;
-    ARROW_RETURN_NOT_OK(self().DoSerializeToString(&out));
+    ARROW_RETURN_NOT_OK(self().SerializeToString(&out));
     return out;
   }
 
   inline static arrow::Result<T> Deserialize(std::string_view serialized) {
     T out;
-    ARROW_RETURN_NOT_OK(SelfT::DoDeserialize(serialized, &out));
+    ARROW_RETURN_NOT_OK(SelfT::Deserialize(serialized, &out));
     return out;
   }
 
   inline arrow::Result<std::shared_ptr<Buffer>> SerializeToBuffer() const {
     std::string out;
-    ARROW_RETURN_NOT_OK(self().DoSerializeToString(&out));
+    ARROW_RETURN_NOT_OK(self().SerializeToString(&out));
     return Buffer::FromString(std::move(out));
   }
 };
@@ -229,15 +230,18 @@ struct ARROW_FLIGHT_EXPORT ActionType : public internal::BaseType<ActionType> {
   std::string ToString() const;
   bool Equals(const ActionType& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, ActionType* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, ActionType* out);
 
   static const ActionType kCancelFlightInfo;
   static const ActionType kRenewFlightEndpoint;
@@ -258,15 +262,18 @@ struct ARROW_FLIGHT_EXPORT Criteria : public internal::BaseType<Criteria> {
   std::string ToString() const;
   bool Equals(const Criteria& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, Criteria* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, Criteria* out);
 };
 
 /// \brief An action to perform with the DoAction RPC
@@ -284,15 +291,18 @@ struct ARROW_FLIGHT_EXPORT Action : public internal::BaseType<Action> {
   std::string ToString() const;
   bool Equals(const Action& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, Action* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, Action* out);
 };
 
 /// \brief Opaque result returned after executing an action
@@ -306,15 +316,18 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   std::string ToString() const;
   bool Equals(const Result& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, Result* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, Result* out);
 };
 
 enum class CancelStatus {
@@ -345,16 +358,19 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
   std::string ToString() const;
   bool Equals(const CancelFlightInfoResult& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     CancelFlightInfoResult* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   CancelFlightInfoResult* out);
 };
 
 ARROW_FLIGHT_EXPORT
@@ -372,15 +388,18 @@ struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
   std::string ToString() const;
   bool Equals(const BasicAuth& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, BasicAuth* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, BasicAuth* out);
 };
 
 /// \brief A request to retrieve or generate a dataset
@@ -413,21 +432,24 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   /// \brief Get a human-readable form of this descriptor.
   std::string ToString() const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Get the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, FlightDescriptor* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, FlightDescriptor* out);
 
   // Convenience factory functions
 
@@ -452,21 +474,24 @@ struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   std::string ToString() const;
   bool Equals(const Ticket& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Get the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, Ticket* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, Ticket* out);
 };
 
 class FlightClient;
@@ -566,15 +591,18 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndp
   std::string ToString() const;
   bool Equals(const FlightEndpoint& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, FlightEndpoint* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, FlightEndpoint* out);
 };
 
 /// \brief The request of the RenewFlightEndpoint action.
@@ -589,16 +617,19 @@ struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
   std::string ToString() const;
   bool Equals(const RenewFlightEndpointRequest& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     RenewFlightEndpointRequest* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   RenewFlightEndpointRequest* out);
 };
 
 /// \brief Staging data structure for messages about to be put on the wire
@@ -641,15 +672,18 @@ struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult
   std::string ToString() const;
   bool Equals(const SchemaResult& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized, SchemaResult* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, SchemaResult* out);
 
  private:
   std::string raw_schema_;
@@ -710,22 +744,25 @@ class ARROW_FLIGHT_EXPORT FlightInfo
   /// Application-defined opaque metadata
   const std::string& app_metadata() const { return data_.app_metadata; }
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Get the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     std::unique_ptr<FlightInfo>* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   std::unique_ptr<FlightInfo>* out);
 
   std::string ToString() const;
 
@@ -786,22 +823,25 @@ class ARROW_FLIGHT_EXPORT PollInfo
   }
   PollInfo& operator=(PollInfo&& other) = default;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Get the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     std::unique_ptr<PollInfo>* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   std::unique_ptr<PollInfo>* out);
 
   std::string ToString() const;
 
@@ -823,16 +863,19 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
   std::string ToString() const;
   bool Equals(const CancelFlightInfoRequest& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     CancelFlightInfoRequest* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   CancelFlightInfoRequest* out);
 };
 
 /// \brief Variant supporting all possible value types for {Set,Get}SessionOptions
@@ -895,16 +938,19 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
   std::string ToString() const;
   bool Equals(const SetSessionOptionsRequest& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     SetSessionOptionsRequest* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   SetSessionOptionsRequest* out);
 };
 
 /// \brief The result(s) of setting session option(s).
@@ -931,16 +977,19 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
   std::string ToString() const;
   bool Equals(const SetSessionOptionsResult& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     SetSessionOptionsResult* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   SetSessionOptionsResult* out);
 };
 
 /// \brief A request to get current session options.
@@ -951,16 +1000,19 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest
   std::string ToString() const;
   bool Equals(const GetSessionOptionsRequest& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     GetSessionOptionsRequest* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   GetSessionOptionsRequest* out);
 };
 
 /// \brief The current session options.
@@ -976,16 +1028,19 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult
   std::string ToString() const;
   bool Equals(const GetSessionOptionsResult& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     GetSessionOptionsResult* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   GetSessionOptionsResult* out);
 };
 
 /// \brief A request to close the open client session.
@@ -996,16 +1051,18 @@ struct ARROW_FLIGHT_EXPORT CloseSessionRequest
   std::string ToString() const;
   bool Equals(const CloseSessionRequest& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     CloseSessionRequest* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, CloseSessionRequest* out);
 };
 
 /// \brief The result of attempting to close the client session.
@@ -1020,16 +1077,18 @@ struct ARROW_FLIGHT_EXPORT CloseSessionResult
   std::string ToString() const;
   bool Equals(const CloseSessionResult& other) const;
 
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
   /// \brief Serialize this message to its wire-format representation.
   ///
-  /// Use `SerializeToString` if you want a Result-returning version.
-  arrow::Status DoSerializeToString(std::string* out) const;
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   ///
-  /// Use `Deserialize` if you want a Result-returning version.
-  static arrow::Status DoDeserialize(std::string_view serialized,
-                                     CloseSessionResult* out);
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, CloseSessionResult* out);
 };
 
 /// \brief An iterator to FlightInfo instances returned by ListFlights.

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -235,6 +235,8 @@ struct ARROW_FLIGHT_EXPORT ActionType : public internal::BaseType<ActionType> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, ActionType* out);
 
   static const ActionType kCancelFlightInfo;
@@ -262,6 +264,8 @@ struct ARROW_FLIGHT_EXPORT Criteria : public internal::BaseType<Criteria> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, Criteria* out);
 };
 
@@ -286,6 +290,8 @@ struct ARROW_FLIGHT_EXPORT Action : public internal::BaseType<Action> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, Action* out);
 };
 
@@ -306,6 +312,8 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, Result* out);
 };
 
@@ -343,6 +351,8 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      CancelFlightInfoResult* out);
 };
@@ -368,6 +378,8 @@ struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, BasicAuth* out);
 };
 
@@ -413,6 +425,8 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, FlightDescriptor* out);
 
   // Convenience factory functions
@@ -450,6 +464,8 @@ struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, Ticket* out);
 };
 
@@ -556,6 +572,8 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndp
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, FlightEndpoint* out);
 };
 
@@ -577,6 +595,8 @@ struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      RenewFlightEndpointRequest* out);
 };
@@ -627,6 +647,8 @@ struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized, SchemaResult* out);
 
  private:
@@ -700,6 +722,8 @@ class ARROW_FLIGHT_EXPORT FlightInfo
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      std::unique_ptr<FlightInfo>* out);
 
@@ -774,6 +798,8 @@ class ARROW_FLIGHT_EXPORT PollInfo
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      std::unique_ptr<PollInfo>* out);
 
@@ -803,6 +829,8 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      CancelFlightInfoRequest* out);
 };
@@ -873,6 +901,8 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      SetSessionOptionsRequest* out);
 };
@@ -907,6 +937,8 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      SetSessionOptionsResult* out);
 };
@@ -925,6 +957,8 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      GetSessionOptionsRequest* out);
 };
@@ -948,6 +982,8 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      GetSessionOptionsResult* out);
 };
@@ -966,6 +1002,8 @@ struct ARROW_FLIGHT_EXPORT CloseSessionRequest
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      CloseSessionRequest* out);
 };
@@ -988,6 +1026,8 @@ struct ARROW_FLIGHT_EXPORT CloseSessionResult
   arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize` if you want a Result-returning version.
   static arrow::Status DoDeserialize(std::string_view serialized,
                                      CloseSessionResult* out);
 };

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -169,8 +169,17 @@ struct BaseType {
   T& self() { return static_cast<T&>(*this); }
 
  public:
+  BaseType() = default;
+
   friend bool operator==(const T& left, const T& right) { return left.Equals(right); }
   friend bool operator!=(const T& left, const T& right) { return !left.Equals(right); }
+
+  /// \brief Serialize this message to its wire-format representation.
+  inline arrow::Result<std::string> SerializeToString() const {
+    std::string out;
+    ARROW_RETURN_NOT_OK(self().DoSerializeToString(&out));
+    return out;
+  }
 };
 
 }  // namespace internal
@@ -192,7 +201,7 @@ struct ARROW_FLIGHT_EXPORT ActionType : public internal::BaseType<ActionType> {
   bool Equals(const ActionType& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<ActionType> Deserialize(std::string_view serialized);
@@ -217,7 +226,7 @@ struct ARROW_FLIGHT_EXPORT Criteria : public internal::BaseType<Criteria> {
   bool Equals(const Criteria& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<Criteria> Deserialize(std::string_view serialized);
@@ -239,7 +248,7 @@ struct ARROW_FLIGHT_EXPORT Action : public internal::BaseType<Action> {
   bool Equals(const Action& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<Action> Deserialize(std::string_view serialized);
@@ -257,7 +266,7 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   bool Equals(const Result& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<Result> Deserialize(std::string_view serialized);
@@ -292,7 +301,7 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
   bool Equals(const CancelFlightInfoResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<CancelFlightInfoResult> Deserialize(std::string_view serialized);
@@ -316,7 +325,7 @@ struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<BasicAuth> Deserialize(std::string_view serialized);
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 };
 
 /// \brief A request to retrieve or generate a dataset
@@ -340,6 +349,7 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   std::vector<std::string> path;
 
   FlightDescriptor() = default;
+
   FlightDescriptor(DescriptorType type, std::string cmd, std::vector<std::string> path)
       : type(type), cmd(std::move(cmd)), path(std::move(path)) {}
 
@@ -352,7 +362,7 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
@@ -387,7 +397,7 @@ struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
@@ -494,7 +504,7 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndp
   bool Equals(const FlightEndpoint& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<FlightEndpoint> Deserialize(std::string_view serialized);
@@ -513,7 +523,7 @@ struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
   bool Equals(const RenewFlightEndpointRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<RenewFlightEndpointRequest> Deserialize(
@@ -561,7 +571,7 @@ struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult
   bool Equals(const SchemaResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<SchemaResult> Deserialize(std::string_view serialized);
@@ -628,7 +638,7 @@ class ARROW_FLIGHT_EXPORT FlightInfo : public internal::BaseType<FlightInfo> {
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
@@ -699,7 +709,7 @@ class ARROW_FLIGHT_EXPORT PollInfo : public internal::BaseType<PollInfo> {
   ///
   /// Useful when interoperating with non-Flight systems (e.g. REST
   /// services) that may want to return Flight types.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Parse the wire-format representation of this type.
   ///
@@ -729,7 +739,7 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
   bool Equals(const CancelFlightInfoRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<CancelFlightInfoRequest> Deserialize(std::string_view serialized);
@@ -796,7 +806,7 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
   bool Equals(const SetSessionOptionsRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<SetSessionOptionsRequest> Deserialize(std::string_view serialized);
@@ -827,7 +837,7 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
   bool Equals(const SetSessionOptionsResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<SetSessionOptionsResult> Deserialize(std::string_view serialized);
@@ -842,7 +852,7 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest
   bool Equals(const GetSessionOptionsRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<GetSessionOptionsRequest> Deserialize(std::string_view serialized);
@@ -862,7 +872,7 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult
   bool Equals(const GetSessionOptionsResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<GetSessionOptionsResult> Deserialize(std::string_view serialized);
@@ -877,7 +887,7 @@ struct ARROW_FLIGHT_EXPORT CloseSessionRequest
   bool Equals(const CloseSessionRequest& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<CloseSessionRequest> Deserialize(std::string_view serialized);
@@ -896,7 +906,7 @@ struct ARROW_FLIGHT_EXPORT CloseSessionResult
   bool Equals(const CloseSessionResult& other) const;
 
   /// \brief Serialize this message to its wire-format representation.
-  arrow::Result<std::string> SerializeToString() const;
+  arrow::Status DoSerializeToString(std::string* out) const;
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<CloseSessionResult> Deserialize(std::string_view serialized);

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -635,7 +635,7 @@ struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
 /// \brief Staging data structure for messages about to be put on the wire
 ///
 /// This structure corresponds to FlightData in the protocol.
-struct ARROW_FLIGHT_EXPORT FlightPayload : public internal::BaseType<FlightPayload> {
+struct ARROW_FLIGHT_EXPORT FlightPayload {
   std::shared_ptr<Buffer> descriptor;
   std::shared_ptr<Buffer> app_metadata;
   ipc::IpcPayload ipc_message;

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -195,7 +195,7 @@ struct BaseType {
   /// \brief Serialize this message to its wire-format representation.
   inline arrow::Result<std::string> SerializeToString() const {
     std::string out;
-    ARROW_RETURN_NOT_OK(self().SerializeToString(&out));
+    ARROW_RETURN_NOT_OK(self().SelfT::SerializeToString(&out));
     return out;
   }
 
@@ -207,7 +207,7 @@ struct BaseType {
 
   inline arrow::Result<std::shared_ptr<Buffer>> SerializeToBuffer() const {
     std::string out;
-    ARROW_RETURN_NOT_OK(self().SerializeToString(&out));
+    ARROW_RETURN_NOT_OK(self().SelfT::SerializeToString(&out));
     return Buffer::FromString(std::move(out));
   }
 };

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -159,8 +159,24 @@ struct ARROW_FLIGHT_EXPORT CertKeyPair {
   std::string pem_key;
 };
 
+namespace internal {
+
+// Base CRTP type
+template <class T>
+struct BaseType {
+ protected:
+  const T& self() const { return static_cast<const T&>(*this); }
+  T& self() { return static_cast<T&>(*this); }
+
+ public:
+  friend bool operator==(const T& left, const T& right) { return left.Equals(right); }
+  friend bool operator!=(const T& left, const T& right) { return !left.Equals(right); }
+};
+
+}  // namespace internal
+
 /// \brief A type of action that can be performed with the DoAction RPC.
-struct ARROW_FLIGHT_EXPORT ActionType {
+struct ARROW_FLIGHT_EXPORT ActionType : public internal::BaseType<ActionType> {
   /// \brief The name of the action.
   std::string type;
 
@@ -169,13 +185,6 @@ struct ARROW_FLIGHT_EXPORT ActionType {
 
   std::string ToString() const;
   bool Equals(const ActionType& other) const;
-
-  friend bool operator==(const ActionType& left, const ActionType& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const ActionType& left, const ActionType& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -191,19 +200,12 @@ struct ARROW_FLIGHT_EXPORT ActionType {
 };
 
 /// \brief Opaque selection criteria for ListFlights RPC
-struct ARROW_FLIGHT_EXPORT Criteria {
+struct ARROW_FLIGHT_EXPORT Criteria : public internal::BaseType<Criteria> {
   /// Opaque criteria expression, dependent on server implementation
   std::string expression;
 
   std::string ToString() const;
   bool Equals(const Criteria& other) const;
-
-  friend bool operator==(const Criteria& left, const Criteria& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const Criteria& left, const Criteria& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -213,7 +215,7 @@ struct ARROW_FLIGHT_EXPORT Criteria {
 };
 
 /// \brief An action to perform with the DoAction RPC
-struct ARROW_FLIGHT_EXPORT Action {
+struct ARROW_FLIGHT_EXPORT Action : public internal::BaseType<Action> {
   /// The action type
   std::string type;
 
@@ -223,13 +225,6 @@ struct ARROW_FLIGHT_EXPORT Action {
   std::string ToString() const;
   bool Equals(const Action& other) const;
 
-  friend bool operator==(const Action& left, const Action& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const Action& left, const Action& right) {
-    return !(left == right);
-  }
-
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
@@ -238,18 +233,11 @@ struct ARROW_FLIGHT_EXPORT Action {
 };
 
 /// \brief Opaque result returned after executing an action
-struct ARROW_FLIGHT_EXPORT Result {
+struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   std::shared_ptr<Buffer> body;
 
   std::string ToString() const;
   bool Equals(const Result& other) const;
-
-  friend bool operator==(const Result& left, const Result& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const Result& left, const Result& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -275,20 +263,12 @@ enum class CancelStatus {
 };
 
 /// \brief The result of the CancelFlightInfo action.
-struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult {
+struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
+    : public internal::BaseType<CancelFlightInfoResult> {
   CancelStatus status;
 
   std::string ToString() const;
   bool Equals(const CancelFlightInfoResult& other) const;
-
-  friend bool operator==(const CancelFlightInfoResult& left,
-                         const CancelFlightInfoResult& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const CancelFlightInfoResult& left,
-                         const CancelFlightInfoResult& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -301,19 +281,12 @@ ARROW_FLIGHT_EXPORT
 std::ostream& operator<<(std::ostream& os, CancelStatus status);
 
 /// \brief message for simple auth
-struct ARROW_FLIGHT_EXPORT BasicAuth {
+struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
   std::string username;
   std::string password;
 
   std::string ToString() const;
   bool Equals(const BasicAuth& other) const;
-
-  friend bool operator==(const BasicAuth& left, const BasicAuth& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const BasicAuth& left, const BasicAuth& right) {
-    return !(left == right);
-  }
 
   /// \brief Deserialize this message from its wire-format representation.
   static arrow::Result<BasicAuth> Deserialize(std::string_view serialized);
@@ -322,7 +295,8 @@ struct ARROW_FLIGHT_EXPORT BasicAuth {
 };
 
 /// \brief A request to retrieve or generate a dataset
-struct ARROW_FLIGHT_EXPORT FlightDescriptor {
+struct ARROW_FLIGHT_EXPORT FlightDescriptor
+    : public internal::BaseType<FlightDescriptor> {
   enum DescriptorType {
     UNKNOWN = 0,  /// Unused
     PATH = 1,     /// Named path identifying a dataset
@@ -366,29 +340,15 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor {
   static FlightDescriptor Path(const std::vector<std::string>& p) {
     return FlightDescriptor{PATH, "", p};
   }
-
-  friend bool operator==(const FlightDescriptor& left, const FlightDescriptor& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const FlightDescriptor& left, const FlightDescriptor& right) {
-    return !(left == right);
-  }
 };
 
 /// \brief Data structure providing an opaque identifier or credential to use
 /// when requesting a data stream with the DoGet RPC
-struct ARROW_FLIGHT_EXPORT Ticket {
+struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   std::string ticket;
 
   std::string ToString() const;
   bool Equals(const Ticket& other) const;
-
-  friend bool operator==(const Ticket& left, const Ticket& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const Ticket& left, const Ticket& right) {
-    return !(left == right);
-  }
 
   /// \brief Get the wire-format representation of this type.
   ///
@@ -416,7 +376,7 @@ ARROW_FLIGHT_EXPORT
 extern const char* kSchemeGrpcTls;
 
 /// \brief A host location (a URI)
-struct ARROW_FLIGHT_EXPORT Location {
+struct ARROW_FLIGHT_EXPORT Location : public internal::BaseType<Location> {
  public:
   /// \brief Initialize a blank location.
   Location();
@@ -464,13 +424,6 @@ struct ARROW_FLIGHT_EXPORT Location {
 
   bool Equals(const Location& other) const;
 
-  friend bool operator==(const Location& left, const Location& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const Location& left, const Location& right) {
-    return !(left == right);
-  }
-
  private:
   friend class FlightClient;
   friend class FlightServerBase;
@@ -479,7 +432,7 @@ struct ARROW_FLIGHT_EXPORT Location {
 
 /// \brief A flight ticket and list of locations where the ticket can be
 /// redeemed
-struct ARROW_FLIGHT_EXPORT FlightEndpoint {
+struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndpoint> {
   /// Opaque ticket identify; use with DoGet RPC
   Ticket ticket;
 
@@ -499,13 +452,6 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint {
   std::string ToString() const;
   bool Equals(const FlightEndpoint& other) const;
 
-  friend bool operator==(const FlightEndpoint& left, const FlightEndpoint& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const FlightEndpoint& left, const FlightEndpoint& right) {
-    return !(left == right);
-  }
-
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
@@ -514,20 +460,12 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint {
 };
 
 /// \brief The request of the RenewFlightEndpoint action.
-struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest {
+struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
+    : public internal::BaseType<RenewFlightEndpointRequest> {
   FlightEndpoint endpoint;
 
   std::string ToString() const;
   bool Equals(const RenewFlightEndpointRequest& other) const;
-
-  friend bool operator==(const RenewFlightEndpointRequest& left,
-                         const RenewFlightEndpointRequest& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const RenewFlightEndpointRequest& left,
-                         const RenewFlightEndpointRequest& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -540,7 +478,7 @@ struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest {
 /// \brief Staging data structure for messages about to be put on the wire
 ///
 /// This structure corresponds to FlightData in the protocol.
-struct ARROW_FLIGHT_EXPORT FlightPayload {
+struct ARROW_FLIGHT_EXPORT FlightPayload : public internal::BaseType<FlightPayload> {
   std::shared_ptr<Buffer> descriptor;
   std::shared_ptr<Buffer> app_metadata;
   ipc::IpcPayload ipc_message;
@@ -550,7 +488,7 @@ struct ARROW_FLIGHT_EXPORT FlightPayload {
 };
 
 /// \brief Schema result returned after a schema request RPC
-struct ARROW_FLIGHT_EXPORT SchemaResult {
+struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult> {
  public:
   SchemaResult() = default;
   explicit SchemaResult(std::string schema) : raw_schema_(std::move(schema)) {}
@@ -570,13 +508,6 @@ struct ARROW_FLIGHT_EXPORT SchemaResult {
   std::string ToString() const;
   bool Equals(const SchemaResult& other) const;
 
-  friend bool operator==(const SchemaResult& left, const SchemaResult& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const SchemaResult& left, const SchemaResult& right) {
-    return !(left == right);
-  }
-
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
@@ -589,7 +520,7 @@ struct ARROW_FLIGHT_EXPORT SchemaResult {
 
 /// \brief The access coordinates for retrieval of a dataset, returned by
 /// GetFlightInfo
-class ARROW_FLIGHT_EXPORT FlightInfo {
+class ARROW_FLIGHT_EXPORT FlightInfo : public internal::BaseType<FlightInfo> {
  public:
   struct Data {
     std::string schema;
@@ -661,13 +592,6 @@ class ARROW_FLIGHT_EXPORT FlightInfo {
   /// the schemas.
   bool Equals(const FlightInfo& other) const;
 
-  friend bool operator==(const FlightInfo& left, const FlightInfo& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const FlightInfo& left, const FlightInfo& right) {
-    return !(left == right);
-  }
-
  private:
   Data data_;
   mutable std::shared_ptr<Schema> schema_;
@@ -675,7 +599,7 @@ class ARROW_FLIGHT_EXPORT FlightInfo {
 };
 
 /// \brief The information to process a long-running query.
-class ARROW_FLIGHT_EXPORT PollInfo {
+class ARROW_FLIGHT_EXPORT PollInfo : public internal::BaseType<PollInfo> {
  public:
   /// The currently available results so far.
   std::unique_ptr<FlightInfo> info = NULLPTR;
@@ -741,30 +665,15 @@ class ARROW_FLIGHT_EXPORT PollInfo {
   /// serialized schema representations, NOT the logical equality of
   /// the schemas.
   bool Equals(const PollInfo& other) const;
-
-  friend bool operator==(const PollInfo& left, const PollInfo& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const PollInfo& left, const PollInfo& right) {
-    return !(left == right);
-  }
 };
 
 /// \brief The request of the CancelFlightInfoRequest action.
-struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest {
+struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
+    : public internal::BaseType<CancelFlightInfoRequest> {
   std::unique_ptr<FlightInfo> info;
 
   std::string ToString() const;
   bool Equals(const CancelFlightInfoRequest& other) const;
-
-  friend bool operator==(const CancelFlightInfoRequest& left,
-                         const CancelFlightInfoRequest& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const CancelFlightInfoRequest& left,
-                         const CancelFlightInfoRequest& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -821,20 +730,12 @@ std::string ToString(const CloseSessionStatus& status);
 std::ostream& operator<<(std::ostream& os, const CloseSessionStatus& status);
 
 /// \brief A request to set a set of session options by name/value.
-struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest {
+struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
+    : public internal::BaseType<SetSessionOptionsRequest> {
   std::map<std::string, SessionOptionValue> session_options;
 
   std::string ToString() const;
   bool Equals(const SetSessionOptionsRequest& other) const;
-
-  friend bool operator==(const SetSessionOptionsRequest& left,
-                         const SetSessionOptionsRequest& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const SetSessionOptionsRequest& left,
-                         const SetSessionOptionsRequest& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -844,7 +745,8 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest {
 };
 
 /// \brief The result(s) of setting session option(s).
-struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult {
+struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
+    : public internal::BaseType<SetSessionOptionsResult> {
   struct Error {
     SetSessionOptionErrorValue value;
 
@@ -862,15 +764,6 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult {
   std::string ToString() const;
   bool Equals(const SetSessionOptionsResult& other) const;
 
-  friend bool operator==(const SetSessionOptionsResult& left,
-                         const SetSessionOptionsResult& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const SetSessionOptionsResult& left,
-                         const SetSessionOptionsResult& right) {
-    return !(left == right);
-  }
-
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
 
@@ -879,18 +772,10 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult {
 };
 
 /// \brief A request to get current session options.
-struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest {
+struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest
+    : public internal::BaseType<GetSessionOptionsRequest> {
   std::string ToString() const;
   bool Equals(const GetSessionOptionsRequest& other) const;
-
-  friend bool operator==(const GetSessionOptionsRequest& left,
-                         const GetSessionOptionsRequest& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const GetSessionOptionsRequest& left,
-                         const GetSessionOptionsRequest& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -900,20 +785,12 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsRequest {
 };
 
 /// \brief The current session options.
-struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult {
+struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult
+    : public internal::BaseType<GetSessionOptionsResult> {
   std::map<std::string, SessionOptionValue> session_options;
 
   std::string ToString() const;
   bool Equals(const GetSessionOptionsResult& other) const;
-
-  friend bool operator==(const GetSessionOptionsResult& left,
-                         const GetSessionOptionsResult& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const GetSessionOptionsResult& left,
-                         const GetSessionOptionsResult& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -923,18 +800,10 @@ struct ARROW_FLIGHT_EXPORT GetSessionOptionsResult {
 };
 
 /// \brief A request to close the open client session.
-struct ARROW_FLIGHT_EXPORT CloseSessionRequest {
+struct ARROW_FLIGHT_EXPORT CloseSessionRequest
+    : public internal::BaseType<CloseSessionRequest> {
   std::string ToString() const;
   bool Equals(const CloseSessionRequest& other) const;
-
-  friend bool operator==(const CloseSessionRequest& left,
-                         const CloseSessionRequest& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const CloseSessionRequest& left,
-                         const CloseSessionRequest& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;
@@ -944,20 +813,12 @@ struct ARROW_FLIGHT_EXPORT CloseSessionRequest {
 };
 
 /// \brief The result of attempting to close the client session.
-struct ARROW_FLIGHT_EXPORT CloseSessionResult {
+struct ARROW_FLIGHT_EXPORT CloseSessionResult
+    : public internal::BaseType<CloseSessionResult> {
   CloseSessionStatus status;
 
   std::string ToString() const;
   bool Equals(const CloseSessionResult& other) const;
-
-  friend bool operator==(const CloseSessionResult& left,
-                         const CloseSessionResult& right) {
-    return left.Equals(right);
-  }
-  friend bool operator!=(const CloseSessionResult& left,
-                         const CloseSessionResult& right) {
-    return !(left == right);
-  }
 
   /// \brief Serialize this message to its wire-format representation.
   arrow::Result<std::string> SerializeToString() const;


### PR DESCRIPTION
### Rationale for this change

Flight should eventually be buildable without a specific protobuf version. As such, all the protobuf types are wrapped in hand-written classes. Uniformity of the interface is not enforced even though it's desirable. Extending the interface requires adding functions to every struct. A common base class can mitigates risks and reduce the amount of hand-written code.

### What changes are included in this PR?

 - Definition of a BaseType<> template (a CRTP)
 - Add constructors that aren't implicitly defined anymore
 - Having a default value for some fields that would be undefined values otherwise
 - Leverage this structure to add `SerializeToBuffer` to all the types
 - ~30KiB in binary size reduction 
 
### Are these changes tested?

By existing tests.
* GitHub Issue: #43258