### PR TITLE
GH-43187 [C++] Support is_in predicates for SimplifyWithGuarantee

### DIFF
--- a/cpp/src/arrow/compute/kernels/set_lookup_internal.h
+++ b/cpp/src/arrow/compute/kernels/set_lookup_internal.h
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/compute/kernel.h"
+
+namespace arrow::compute::internal {
+
+/// Base class for `is_in` and `index_in` kernel states.
+struct SetLookupStateBase : public KernelState {
+  /// Enables non-templated access to the value set type.
+  std::shared_ptr<DataType> value_set_type;
+  /// Enables fast simplification for `is_in` expressions.
+  ///
+  /// This field may be null.
+  ///
+  /// \invariant sorted and contains no null or duplicate values
+  std::shared_ptr<Array> sorted_and_unique_value_set;
+};
+
+}  // namespace arrow::compute::internal


### PR DESCRIPTION
### Rationale for this change

We would like to enable parquet predicate pushdown on `is_in` predicates. The first step is to add support for `is_in` predicates in `SimplifyWithGuarantee`.

### What changes are included in this PR?

We add a option to `SimplifyWithGuarantee` that users can set if they can ensure that all `is_in` value sets in the expression are sorted and contain no duplicates. When this option is set, `SimplifyWithGuarantee` will attempt to simplify any `is_in` predicates that it finds in the expression.

### Are these changes tested?

A new unit test was added to `arrow-compute-expression-test` testing this change.

### Are there any user-facing changes?

No. 
* GitHub Issue: #43187