### PR TITLE
GH-41476: [C++][Python][Parquet] Add time_is_adjusted_to_utc to parquet prope…

### DIFF
--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -1183,6 +1183,76 @@ TEST_F(TestConvertArrowSchema, ParquetNestedComplianceEnabledNotNullable) {
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
 }
 
+TEST_F(TestConvertArrowSchema, ParquetTimeIsAdjustedToUTC) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  // // Time32 millis, Time64 micros, Time64 nanos
+
+  auto milli_logical = LogicalType::Time(true, LogicalType::TimeUnit::MILLIS);
+  auto milli_parquet = PrimitiveNode::Make("millis", Repetition::OPTIONAL, milli_logical,
+                                           ParquetType::INT32, -1);
+  parquet_fields.push_back(milli_parquet);
+  auto micro_logical = LogicalType::Time(true, LogicalType::TimeUnit::MICROS);
+  auto micro_parquet = PrimitiveNode::Make("micros", Repetition::OPTIONAL, micro_logical,
+                                           ParquetType::INT64, -1);
+  parquet_fields.push_back(milli_parquet);
+  auto nano_logical = LogicalType::Time(true, LogicalType::TimeUnit::NANOS);
+  auto nano_parquet = PrimitiveNode::Make("nanos", Repetition::OPTIONAL, nano_logical,
+                                          ParquetType::INT64, -1);
+  parquet_fields.push_back(nano_parquet);
+
+  auto milli_arrow = ::arrow::field("millis", ::arrow::time32(::arrow::TimeUnit::MILLI));
+  arrow_fields.push_back(milli_arrow);
+  auto micro_arrow = ::arrow::field("micros", ::arrow::time64(::arrow::TimeUnit::MICRO));
+  arrow_fields.push_back(milli_arrow);
+  auto nano_arrow = ::arrow::field("nanos", ::arrow::time64(::arrow::TimeUnit::NANO));
+  arrow_fields.push_back(nano_arrow);
+
+  ArrowWriterProperties::Builder builder;
+  builder.set_time_is_adjusted_to_utc();
+  auto arrow_properties = builder.build();
+
+  ASSERT_OK(ConvertSchema(arrow_fields, arrow_properties));
+
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
+}
+
+TEST_F(TestConvertArrowSchema, ParquetTimeIsAdjustedToUTCFalse) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  // // Time32 millis, Time64 micros, Time64 nanos
+
+  auto milli_logical = LogicalType::Time(false, LogicalType::TimeUnit::MILLIS);
+  auto milli_parquet = PrimitiveNode::Make("millis", Repetition::OPTIONAL, milli_logical,
+                                           ParquetType::INT32, -1);
+  parquet_fields.push_back(milli_parquet);
+  auto micro_logical = LogicalType::Time(false, LogicalType::TimeUnit::MICROS);
+  auto micro_parquet = PrimitiveNode::Make("micros", Repetition::OPTIONAL, micro_logical,
+                                           ParquetType::INT64, -1);
+  parquet_fields.push_back(milli_parquet);
+  auto nano_logical = LogicalType::Time(false, LogicalType::TimeUnit::NANOS);
+  auto nano_parquet = PrimitiveNode::Make("nanos", Repetition::OPTIONAL, nano_logical,
+                                          ParquetType::INT64, -1);
+  parquet_fields.push_back(nano_parquet);
+
+  auto milli_arrow = ::arrow::field("millis", ::arrow::time32(::arrow::TimeUnit::MILLI));
+  arrow_fields.push_back(milli_arrow);
+  auto micro_arrow = ::arrow::field("micros", ::arrow::time64(::arrow::TimeUnit::MICRO));
+  arrow_fields.push_back(milli_arrow);
+  auto nano_arrow = ::arrow::field("nanos", ::arrow::time64(::arrow::TimeUnit::NANO));
+  arrow_fields.push_back(nano_arrow);
+
+  ArrowWriterProperties::Builder builder;
+  builder.unset_time_is_adjusted_to_utc();
+  auto arrow_properties = builder.build();
+
+  ASSERT_OK(ConvertSchema(arrow_fields, arrow_properties));
+
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
+}
+
 TEST_F(TestConvertArrowSchema, ParquetFlatDecimals) {
   std::vector<NodePtr> parquet_fields;
   std::vector<std::shared_ptr<Field>> arrow_fields;

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -382,18 +382,18 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
       break;
     case ArrowTypeId::TIME32:
       type = ParquetType::INT32;
-      logical_type =
-          LogicalType::Time(/*is_adjusted_to_utc=*/true, LogicalType::TimeUnit::MILLIS);
+      logical_type = LogicalType::Time(arrow_properties.time_is_adjusted_to_utc(),
+                                       LogicalType::TimeUnit::MILLIS);
       break;
     case ArrowTypeId::TIME64: {
       type = ParquetType::INT64;
       auto time_type = static_cast<::arrow::Time64Type*>(field->type().get());
       if (time_type->unit() == ::arrow::TimeUnit::NANO) {
-        logical_type =
-            LogicalType::Time(/*is_adjusted_to_utc=*/true, LogicalType::TimeUnit::NANOS);
+        logical_type = LogicalType::Time(arrow_properties.time_is_adjusted_to_utc(),
+                                         LogicalType::TimeUnit::NANOS);
       } else {
-        logical_type =
-            LogicalType::Time(/*is_adjusted_to_utc=*/true, LogicalType::TimeUnit::MICROS);
+        logical_type = LogicalType::Time(arrow_properties.time_is_adjusted_to_utc(),
+                                         LogicalType::TimeUnit::MICROS);
       }
     } break;
     case ArrowTypeId::DURATION:

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -972,7 +972,8 @@ class PARQUET_EXPORT ArrowWriterProperties {
           compliant_nested_types_(true),
           engine_version_(V2),
           use_threads_(kArrowDefaultUseThreads),
-          executor_(NULLPTR) {}
+          executor_(NULLPTR),
+          time_is_adjusted_to_utc_(true) {}
     virtual ~Builder() = default;
 
     /// \brief Disable writing legacy int96 timestamps (default disabled).
@@ -1067,12 +1068,26 @@ class PARQUET_EXPORT ArrowWriterProperties {
       return this;
     }
 
+    /// \brief Set time columns as adjusted to utc (default)
+    Builder* set_time_is_adjusted_to_utc() {
+      time_is_adjusted_to_utc_ = true;
+      return this;
+    }
+
+    /// \brief Set time columns as not adjusted to utc
+    ///
+    /// This is true by default
+    Builder* unset_time_is_adjusted_to_utc() {
+      time_is_adjusted_to_utc_ = false;
+      return this;
+    }
+
     /// Create the final properties.
     std::shared_ptr<ArrowWriterProperties> build() {
       return std::shared_ptr<ArrowWriterProperties>(new ArrowWriterProperties(
           write_timestamps_as_int96_, coerce_timestamps_enabled_, coerce_timestamps_unit_,
           truncated_timestamps_allowed_, store_schema_, compliant_nested_types_,
-          engine_version_, use_threads_, executor_));
+          engine_version_, use_threads_, executor_, time_is_adjusted_to_utc_));
     }
 
    private:
@@ -1088,6 +1103,7 @@ class PARQUET_EXPORT ArrowWriterProperties {
 
     bool use_threads_;
     ::arrow::internal::Executor* executor_;
+    bool time_is_adjusted_to_utc_;
   };
 
   bool support_deprecated_int96_timestamps() const { return write_timestamps_as_int96_; }
@@ -1121,6 +1137,9 @@ class PARQUET_EXPORT ArrowWriterProperties {
   /// \brief Returns the executor used to write columns in parallel.
   ::arrow::internal::Executor* executor() const;
 
+  /// \brief Returns whether time types are adjusted to utc
+  bool time_is_adjusted_to_utc() const { return time_is_adjusted_to_utc_; }
+
  private:
   explicit ArrowWriterProperties(bool write_nanos_as_int96,
                                  bool coerce_timestamps_enabled,
@@ -1128,7 +1147,8 @@ class PARQUET_EXPORT ArrowWriterProperties {
                                  bool truncated_timestamps_allowed, bool store_schema,
                                  bool compliant_nested_types,
                                  EngineVersion engine_version, bool use_threads,
-                                 ::arrow::internal::Executor* executor)
+                                 ::arrow::internal::Executor* executor,
+                                 bool time_is_adjusted_to_utc)
       : write_timestamps_as_int96_(write_nanos_as_int96),
         coerce_timestamps_enabled_(coerce_timestamps_enabled),
         coerce_timestamps_unit_(coerce_timestamps_unit),
@@ -1137,7 +1157,8 @@ class PARQUET_EXPORT ArrowWriterProperties {
         compliant_nested_types_(compliant_nested_types),
         engine_version_(engine_version),
         use_threads_(use_threads),
-        executor_(executor) {}
+        executor_(executor),
+        time_is_adjusted_to_utc_(time_is_adjusted_to_utc) {}
 
   const bool write_timestamps_as_int96_;
   const bool coerce_timestamps_enabled_;
@@ -1148,6 +1169,7 @@ class PARQUET_EXPORT ArrowWriterProperties {
   const EngineVersion engine_version_;
   const bool use_threads_;
   ::arrow::internal::Executor* executor_;
+  const bool time_is_adjusted_to_utc_;
 };
 
 /// \brief State object used for writing Arrow data directly to a Parquet

--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -575,6 +575,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             "coerce_timestamps",
             "allow_truncated_timestamps",
             "use_compliant_nested_type",
+            "time_is_adjusted_to_utc",
         }
 
         setters = set()
@@ -630,6 +631,9 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             writer_engine_version="V2",
             use_compliant_nested_type=(
                 self._properties["use_compliant_nested_type"]
+            ),
+            time_is_adjusted_to_utc=(
+                self._properties["time_is_adjusted_to_utc"]
             )
         )
 
@@ -666,6 +670,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             write_page_checksum=False,
             sorting_columns=None,
             store_decimal_as_integer=False,
+            time_is_adjusted_to_utc=True,
         )
 
         self._set_properties()

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -459,6 +459,8 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* enable_compliant_nested_types()
             Builder* disable_compliant_nested_types()
             Builder* set_engine_version(ArrowWriterEngineVersion version)
+            Builder* set_time_is_adjusted_to_utc()
+            Builder* unset_time_is_adjusted_to_utc()
             shared_ptr[ArrowWriterProperties] build()
         c_bool support_deprecated_int96_timestamps()
 
@@ -607,6 +609,7 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
     allow_truncated_timestamps=*,
     writer_engine_version=*,
     use_compliant_nested_type=*,
+    time_is_adjusted_to_utc=*,
     store_schema=*,
 ) except *
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -2023,6 +2023,7 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
         allow_truncated_timestamps=False,
         writer_engine_version=None,
         use_compliant_nested_type=True,
+        time_is_adjusted_to_utc=True,
         store_schema=True) except *:
     """Arrow writer properties"""
     cdef:
@@ -2073,6 +2074,13 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
     elif writer_engine_version != "V2":
         raise ValueError("Unsupported Writer Engine Version: {0}"
                          .format(writer_engine_version))
+
+    # time_is_adjusted_to_utc
+
+    if time_is_adjusted_to_utc:
+        arrow_props.set_time_is_adjusted_to_utc()
+    else:
+        arrow_props.unset_time_is_adjusted_to_utc()
 
     arrow_properties = arrow_props.build()
 
@@ -2134,6 +2142,7 @@ cdef class ParquetWriter(_Weakrefable):
         int64_t dictionary_pagesize_limit
         object store_schema
         object store_decimal_as_integer
+        object time_is_adjusted_to_utc
 
     def __cinit__(self, where, Schema schema not None, use_dictionary=None,
                   compression=None, version=None,
@@ -2156,7 +2165,8 @@ cdef class ParquetWriter(_Weakrefable):
                   write_page_index=False,
                   write_page_checksum=False,
                   sorting_columns=None,
-                  store_decimal_as_integer=False):
+                  store_decimal_as_integer=False,
+                  time_is_adjusted_to_utc=True):
         cdef:
             shared_ptr[WriterProperties] properties
             shared_ptr[ArrowWriterProperties] arrow_properties
@@ -2198,7 +2208,7 @@ cdef class ParquetWriter(_Weakrefable):
             allow_truncated_timestamps=allow_truncated_timestamps,
             writer_engine_version=writer_engine_version,
             use_compliant_nested_type=use_compliant_nested_type,
-            store_schema=store_schema,
+            store_schema=store_schema, time_is_adjusted_to_utc=time_is_adjusted_to_utc
         )
 
         pool = maybe_unbox_memory_pool(memory_pool)

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -986,6 +986,7 @@ Examples
                  write_page_checksum=False,
                  sorting_columns=None,
                  store_decimal_as_integer=False,
+                 time_is_adjusted_to_utc=True,
                  **options):
         if use_deprecated_int96_timestamps is None:
             # Use int96 timestamps for Spark
@@ -1039,6 +1040,7 @@ Examples
             write_page_checksum=write_page_checksum,
             sorting_columns=sorting_columns,
             store_decimal_as_integer=store_decimal_as_integer,
+            time_is_adjusted_to_utc=time_is_adjusted_to_utc,
             **options)
         self.is_open = True
 


### PR DESCRIPTION
This is my first contribution to Arrow.  I've tried to follow all the development and testing guidelines [here](https://arrow.apache.org/docs/developers/), but please do let me know if I've missed anything.
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Explained in issue, it is currently impossible to specify `is_adjusted_to_utc` for time types because it is hardcoded in `cpp/src/parquet/arrow/schema.cc` to `True`.  I'd like to make it possible to specify `False` for this parquet schema property.

### What changes are included in this PR?
* Change `parquet::ArrowWriterProperties` to include a new `time_is_adjusted_to_utc` field and corresponding builder functions for setting this field to True/False.
* Change the `FieldToNode` function in `schema.cc` to use the new field when setting `is_adjusted_to_utc` for time types.
* Change various python/cython classes to add support for setting the new field from `write_table` and `write_to_dataset`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, I've added unit tests for c++ schema conversion, c++ dataset writes, pyarrow writes through write_table, and pyarrow writes through write_to_dataset.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes, to `parquet::ArrowWriterProperties`, which users can pass into various write functions.  Additionally, users can now pass `time_is_adjusted_to_utc=True/False` to `pq.write_table` and `pq.write_to_dataset`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41476