### PR TITLE
MINOR: [Docs][Release] Clarification on when to run the new Update Release Notes on GH Release

### DIFF
--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -406,7 +406,7 @@ Be sure to go through on the following checklist:
    .. code-block:: Bash
 
       # dev/release/post-05-update-gh-release-notes.sh 17.0.0
-      dev/release/post-05-update-gh-release-notes.sh apache-arrow-X.Y.Z
+      dev/release/post-05-update-gh-release-notes.sh <version>
 
 .. dropdown:: Update Homebrew packages
    :animate: fade-in-slide-down

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -400,7 +400,8 @@ Be sure to go through on the following checklist:
    :class-title: sd-fs-5
    :class-container: sd-shadow-md
 
-   A committer must run the following script:
+   A committer must run the following script. This has to be done once the
+   Pull Request from the Update Website script has been merged:
 
    .. code-block:: Bash
 


### PR DESCRIPTION
### Rationale for this change

Minor docs clarification on when to run the script. We could potentially search for the PR and validate it has been merged on the script to avoid issues but this change on the docs still applies.

### What changes are included in this PR?

Just a minor clarification on the docs.

### Are these changes tested?

No

### Are there any user-facing changes?

No