### PR TITLE
GH-43276: [Go][Parquet] Make DeltaBitPacking Encoders/Decoders Generic

### DIFF
--- a/go/parquet/file/file_reader_test.go
+++ b/go/parquet/file/file_reader_test.go
@@ -18,6 +18,7 @@ package file_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -26,6 +27,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/apache/arrow/go/v18/arrow"
+	"github.com/apache/arrow/go/v18/arrow/array"
 	"github.com/apache/arrow/go/v18/arrow/memory"
 	"github.com/apache/arrow/go/v18/internal/utils"
 	"github.com/apache/arrow/go/v18/parquet"
@@ -35,6 +38,7 @@ import (
 	format "github.com/apache/arrow/go/v18/parquet/internal/gen-go/parquet"
 	"github.com/apache/arrow/go/v18/parquet/internal/thrift"
 	"github.com/apache/arrow/go/v18/parquet/metadata"
+	"github.com/apache/arrow/go/v18/parquet/pqarrow"
 	"github.com/apache/arrow/go/v18/parquet/schema"
 	libthrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/stretchr/testify/assert"
@@ -581,4 +585,66 @@ func TestByteStreamSplitEncodingFileRead(t *testing.T) {
 			require.Equal(t, valuesPlain, valuesByteStreamSplit)
 		})
 	}
+}
+
+func TestDeltaSomething(t *testing.T) {
+	size := 10
+	buf := new(bytes.Buffer)
+	mem := memory.NewGoAllocator()
+
+	// Define the schema for the test data
+	fields := []arrow.Field{
+		{Name: "int64", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+	}
+	schema := arrow.NewSchema(fields, nil)
+
+	// Create a record batch with the test data
+	b := array.NewRecordBuilder(mem, schema)
+	defer b.Release()
+
+	for i := 0; i < size; i++ {
+		b.Field(0).(*array.Int64Builder).Append(int64(i))
+	}
+	rec := b.NewRecord()
+	defer rec.Release()
+
+	// Write the data to Parquet using the file writer
+	props := parquet.NewWriterProperties(
+		parquet.WithCompression(compress.Codecs.Zstd),
+		parquet.WithCompressionLevel(3),
+		parquet.WithDictionaryDefault(false),
+		parquet.WithEncoding(parquet.Encodings.DeltaBinaryPacked))
+	writerProps := pqarrow.DefaultWriterProps()
+	pw, err := pqarrow.NewFileWriter(schema, buf, props, writerProps)
+	assert.NoError(t, err)
+	pw.Write(rec)
+	pw.Close()
+
+	// Read the data back from the Parquet file
+	reader, err := file.NewParquetReader(bytes.NewReader(buf.Bytes()))
+	assert.NoError(t, err)
+	defer reader.Close()
+
+	pr, err := pqarrow.NewFileReader(reader, pqarrow.ArrowReadProperties{BatchSize: 5}, memory.DefaultAllocator)
+	assert.NoError(t, err)
+
+	rr, err := pr.GetRecordReader(context.Background(), nil, nil)
+	assert.NoError(t, err)
+
+	totalRows := 0
+	for rr.Next() {
+		rec := rr.Record()
+		for i := 0; i < int(rec.NumRows()); i++ {
+			col := rec.Column(0).(*array.Int64)
+
+			val := col.Value(i)
+			assert.Equal(t, val, int64(totalRows+i))
+		}
+		totalRows += int(rec.NumRows())
+	}
+
+	if totalRows != size {
+		t.Fatalf("Expected %d rows, but got %d rows", size, totalRows)
+	}
+
 }

--- a/go/parquet/internal/encoding/delta_bit_packing.go
+++ b/go/parquet/internal/encoding/delta_bit_packing.go
@@ -153,7 +153,7 @@ func (d *deltaBitPackDecoder[T]) unpackNextMini() error {
 // Decode retrieves min(remaining values, len(out)) values from the data and returns the number
 // of values actually decoded and any errors encountered.
 func (d *deltaBitPackDecoder[T]) Decode(out []T) (int, error) {
-	max := shared_utils.Min(len(out), int(d.totalValues))
+	max := shared_utils.Min(len(out), int(d.nvals))
 	if max == 0 {
 		return 0, nil
 	}

--- a/go/parquet/internal/encoding/delta_bit_packing.go
+++ b/go/parquet/internal/encoding/delta_bit_packing.go
@@ -206,6 +206,7 @@ func (d *deltaBitPackDecoder[T]) DecodeSpaced(out []T, nullCount int, validBits 
 	return spacedExpand(out, nullCount, validBits, validBitsOffset), nil
 }
 
+// Type returns the underlying physical type this decoder works with
 func (dec *deltaBitPackDecoder[T]) Type() parquet.Type {
 	switch v := any(dec).(type) {
 	case *deltaBitPackDecoder[int32]:
@@ -217,7 +218,10 @@ func (dec *deltaBitPackDecoder[T]) Type() parquet.Type {
 	}
 }
 
+// DeltaBitPackInt32Decoder decodes Int32 values which are packed using the Delta BitPacking algorithm.
 type DeltaBitPackInt32Decoder = deltaBitPackDecoder[int32]
+
+// DeltaBitPackInt64Decoder decodes Int64 values which are packed using the Delta BitPacking algorithm.
 type DeltaBitPackInt64Decoder = deltaBitPackDecoder[int64]
 
 const (
@@ -385,7 +389,7 @@ func (enc *deltaBitPackEncoder[T]) EstimatedDataEncodedSize() int64 {
 	return int64(enc.bitWriter.Written())
 }
 
-// PutSpaced takes a slice of int32 along with a bitmap that describes the nulls and an offset into the bitmap
+// PutSpaced takes a slice of values along with a bitmap that describes the nulls and an offset into the bitmap
 // in order to write spaced data to the encoder.
 func (enc *deltaBitPackEncoder[T]) PutSpaced(in []T, validBits []byte, validBitsOffset int64) {
 	buffer := memory.NewResizableBuffer(enc.mem)
@@ -398,7 +402,7 @@ func (enc *deltaBitPackEncoder[T]) PutSpaced(in []T, validBits []byte, validBits
 	enc.Put(data[:nvalid])
 }
 
-// Type returns the underlying physical type this encoder works with, in this case Int32
+// Type returns the underlying physical type this encoder works with
 func (dec *deltaBitPackEncoder[T]) Type() parquet.Type {
 	switch v := any(dec).(type) {
 	case *deltaBitPackEncoder[int32]:
@@ -410,5 +414,8 @@ func (dec *deltaBitPackEncoder[T]) Type() parquet.Type {
 	}
 }
 
+// DeltaBitPackInt32Encoder is an encoder for the delta bitpacking encoding for Int32 data.
 type DeltaBitPackInt32Encoder = deltaBitPackEncoder[int32]
+
+// DeltaBitPackInt64Encoder is an encoder for the delta bitpacking encoding for Int64 data.
 type DeltaBitPackInt64Encoder = deltaBitPackEncoder[int64]

--- a/go/parquet/internal/encoding/delta_byte_array.go
+++ b/go/parquet/internal/encoding/delta_byte_array.go
@@ -53,11 +53,14 @@ func (enc *DeltaByteArrayEncoder) EstimatedDataEncodedSize() int64 {
 
 func (enc *DeltaByteArrayEncoder) initEncoders() {
 	enc.prefixEncoder = &DeltaBitPackInt32Encoder{
-		deltaBitPackEncoder: &deltaBitPackEncoder{encoder: newEncoderBase(enc.encoding, nil, enc.mem)}}
+		encoder: newEncoderBase(enc.encoding, nil, enc.mem),
+	}
 	enc.suffixEncoder = &DeltaLengthByteArrayEncoder{
 		newEncoderBase(enc.encoding, nil, enc.mem),
 		&DeltaBitPackInt32Encoder{
-			deltaBitPackEncoder: &deltaBitPackEncoder{encoder: newEncoderBase(enc.encoding, nil, enc.mem)}}}
+			encoder: newEncoderBase(enc.encoding, nil, enc.mem),
+		},
+	}
 }
 
 // Type returns the underlying physical type this operates on, in this case ByteArrays only

--- a/go/parquet/internal/encoding/delta_byte_array.go
+++ b/go/parquet/internal/encoding/delta_byte_array.go
@@ -160,9 +160,9 @@ func (d *DeltaByteArrayDecoder) Allocator() memory.Allocator { return d.mem }
 // blocks of suffix data in order to initialize the decoder.
 func (d *DeltaByteArrayDecoder) SetData(nvalues int, data []byte) error {
 	prefixLenDec := DeltaBitPackInt32Decoder{
-		deltaBitPackDecoder: &deltaBitPackDecoder{
-			decoder: newDecoderBase(d.encoding, d.descr),
-			mem:     d.mem}}
+		decoder: newDecoderBase(d.encoding, d.descr),
+		mem:     d.mem,
+	}
 
 	if err := prefixLenDec.SetData(nvalues, data); err != nil {
 		return err

--- a/go/parquet/internal/encoding/delta_length_byte_array.go
+++ b/go/parquet/internal/encoding/delta_length_byte_array.go
@@ -110,9 +110,9 @@ func (d *DeltaLengthByteArrayDecoder) Allocator() memory.Allocator { return d.me
 // followed by the rest of the byte array data immediately after.
 func (d *DeltaLengthByteArrayDecoder) SetData(nvalues int, data []byte) error {
 	dec := DeltaBitPackInt32Decoder{
-		deltaBitPackDecoder: &deltaBitPackDecoder{
-			decoder: newDecoderBase(d.encoding, d.descr),
-			mem:     d.mem}}
+		decoder: newDecoderBase(d.encoding, d.descr),
+		mem:     d.mem,
+	}
 
 	if err := dec.SetData(nvalues, data); err != nil {
 		return err

--- a/go/parquet/internal/encoding/typed_encoder.gen.go
+++ b/go/parquet/internal/encoding/typed_encoder.gen.go
@@ -86,8 +86,9 @@ func (int32EncoderTraits) Encoder(e format.Encoding, useDict bool, descr *schema
 	case format.Encoding_PLAIN:
 		return &PlainInt32Encoder{encoder: newEncoderBase(e, descr, mem)}
 	case format.Encoding_DELTA_BINARY_PACKED:
-		return DeltaBitPackInt32Encoder{&deltaBitPackEncoder{
-			encoder: newEncoderBase(e, descr, mem)}}
+		return &DeltaBitPackInt32Encoder{
+			encoder: newEncoderBase(e, descr, mem),
+		}
 	case format.Encoding_BYTE_STREAM_SPLIT:
 		return &ByteStreamSplitInt32Encoder{PlainInt32Encoder: PlainInt32Encoder{encoder: newEncoderBase(e, descr, mem)}}
 	default:
@@ -326,8 +327,9 @@ func (int64EncoderTraits) Encoder(e format.Encoding, useDict bool, descr *schema
 	case format.Encoding_PLAIN:
 		return &PlainInt64Encoder{encoder: newEncoderBase(e, descr, mem)}
 	case format.Encoding_DELTA_BINARY_PACKED:
-		return DeltaBitPackInt64Encoder{&deltaBitPackEncoder{
-			encoder: newEncoderBase(e, descr, mem)}}
+		return &DeltaBitPackInt64Encoder{
+			encoder: newEncoderBase(e, descr, mem),
+		}
 	case format.Encoding_BYTE_STREAM_SPLIT:
 		return &ByteStreamSplitInt64Encoder{PlainInt64Encoder: PlainInt64Encoder{encoder: newEncoderBase(e, descr, mem)}}
 	default:
@@ -1304,7 +1306,8 @@ func (byteArrayEncoderTraits) Encoder(e format.Encoding, useDict bool, descr *sc
 		return &DeltaLengthByteArrayEncoder{
 			encoder: newEncoderBase(e, descr, mem),
 			lengthEncoder: &DeltaBitPackInt32Encoder{
-				&deltaBitPackEncoder{encoder: newEncoderBase(e, descr, mem)}},
+				encoder: newEncoderBase(e, descr, mem),
+			},
 		}
 	case format.Encoding_DELTA_BYTE_ARRAY:
 		return &DeltaByteArrayEncoder{

--- a/go/parquet/internal/encoding/typed_encoder.gen.go
+++ b/go/parquet/internal/encoding/typed_encoder.gen.go
@@ -118,10 +118,9 @@ func (int32DecoderTraits) Decoder(e parquet.Encoding, descr *schema.Column, useD
 			mem = memory.DefaultAllocator
 		}
 		return &DeltaBitPackInt32Decoder{
-			deltaBitPackDecoder: &deltaBitPackDecoder{
-				decoder: newDecoderBase(format.Encoding(e), descr),
-				mem:     mem,
-			}}
+			decoder: newDecoderBase(format.Encoding(e), descr),
+			mem:     mem,
+		}
 	case parquet.Encodings.ByteStreamSplit:
 		return &ByteStreamSplitInt32Decoder{decoder: newDecoderBase(format.Encoding(e), descr)}
 	default:
@@ -359,10 +358,9 @@ func (int64DecoderTraits) Decoder(e parquet.Encoding, descr *schema.Column, useD
 			mem = memory.DefaultAllocator
 		}
 		return &DeltaBitPackInt64Decoder{
-			deltaBitPackDecoder: &deltaBitPackDecoder{
-				decoder: newDecoderBase(format.Encoding(e), descr),
-				mem:     mem,
-			}}
+			decoder: newDecoderBase(format.Encoding(e), descr),
+			mem:     mem,
+		}
 	case parquet.Encodings.ByteStreamSplit:
 		return &ByteStreamSplitInt64Decoder{decoder: newDecoderBase(format.Encoding(e), descr)}
 	default:

--- a/go/parquet/internal/encoding/typed_encoder.gen.go.tmpl
+++ b/go/parquet/internal/encoding/typed_encoder.gen.go.tmpl
@@ -79,15 +79,17 @@ func ({{.lower}}EncoderTraits) Encoder(e format.Encoding, useDict bool, descr *s
 {{- end}}
 {{- if or (eq .Name "Int32") (eq .Name "Int64")}}
   case format.Encoding_DELTA_BINARY_PACKED:
-    return DeltaBitPack{{.Name}}Encoder{&deltaBitPackEncoder{
-      encoder: newEncoderBase(e, descr, mem)}}
+    return &DeltaBitPack{{.Name}}Encoder{
+      encoder: newEncoderBase(e, descr, mem),
+    }
 {{- end}}
 {{- if eq .Name "ByteArray"}}
   case format.Encoding_DELTA_LENGTH_BYTE_ARRAY:
     return &DeltaLengthByteArrayEncoder{
       encoder: newEncoderBase(e, descr, mem),
       lengthEncoder: &DeltaBitPackInt32Encoder{
-        &deltaBitPackEncoder{encoder: newEncoderBase(e, descr, mem)}},
+        encoder: newEncoderBase(e, descr, mem),
+      },
     }
   case format.Encoding_DELTA_BYTE_ARRAY:
     return &DeltaByteArrayEncoder{

--- a/go/parquet/internal/encoding/typed_encoder.gen.go.tmpl
+++ b/go/parquet/internal/encoding/typed_encoder.gen.go.tmpl
@@ -135,10 +135,9 @@ func ({{.lower}}DecoderTraits) Decoder(e parquet.Encoding, descr *schema.Column,
       mem = memory.DefaultAllocator
     }
     return &DeltaBitPack{{.Name}}Decoder{
-      deltaBitPackDecoder: &deltaBitPackDecoder{
-        decoder: newDecoderBase(format.Encoding(e), descr),
-        mem:     mem,
-      }}
+      decoder: newDecoderBase(format.Encoding(e), descr),
+      mem:     mem,
+    }
 {{- end}}
 {{- if eq .Name "ByteArray"}}
   case parquet.Encodings.DeltaLengthByteArray:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Fixes: #43276

The slice of `miniBlockValues` in the decoder was getting reset between calls to `Decode`, while the remaining internal state of the decoder was persisted. By making the decoder generic, it became possible to bring `miniBlockValues` into the base decoder.

The encoder was also made generic for consistency. By avoiding reflection, encoding performance is improved (from around `700 MB/s` before to about `1100 MB/s` after on my machine).

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Passing test case reproducing the reported bug.
- Benchmarks for `DeltaBinaryPacked`
- Refactor of `deltaBitPackDecoder` and `deltaBitPackEncoder` to make them generic.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

The DeltaBitPackDecoders should no longer panic when decoding multiple batches from a single page.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43276