### PR TITLE
GH-43280: [Python] Prune examples and benchmarks folders from release

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -6,6 +6,11 @@ global-include CMakeLists.txt
 graft pyarrow
 graft cmake_modules
 
+prune benchmarks
+prune cmake_modules
+prune examples
+prune scripts
+
 global-exclude *.so
 global-exclude *.pyc
 global-exclude *~


### PR DESCRIPTION
### Rationale for this change

Currently `examples` and `benchmarks` folders are installed into the top level install directory, alongside `pyarrow`. As these names are very generic, they should either be subfolders inside `pyarrow` e.g. `pyarrow/examples`, or otherwise pruned. 

### What changes are included in this PR?
Remove during disting

### Are these changes tested?
Locally

### Are there any user-facing changes?
Yes, those folders will no longer be installed.

fixes #43280
* GitHub Issue: #43280

fixes #43299