### PR TITLE
GH-43282: [Release][Docs][Packaging] Upload correct docs job when uploading binaries

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1895,7 +1895,7 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                               :docs,
                               "#{rc_dir}/docs/#{full_version}",
                               "#{release_dir}/docs/#{full_version}",
-                              "test-ubuntu-22.04-docs/**/*")
+                              "test-debian-12-docs/**/*")
   end
 
   def define_nuget_tasks


### PR DESCRIPTION
### Rationale for this change

We are currently missing to upload binaries

### What changes are included in this PR?

Update task name to correct one.

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #43282