### PR TITLE
GH-36275: [C++] Add `create_missing_dirs_on_delete` option

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -3078,7 +3078,6 @@ Status S3FileSystem::Move(const std::string& src, const std::string& dest) {
   }
   RETURN_NOT_OK(impl_->CopyObject(src_path, dest_path));
   RETURN_NOT_OK(impl_->DeleteObject(src_path.bucket, src_path.key));
-
   if (options().create_missing_dirs_on_delete) {
     // Source parent may be implicitly deleted if it became empty, recreate it
     return impl_->EnsureParentExists(src_path);

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -2995,8 +2995,11 @@ Status S3FileSystem::DeleteDir(const std::string& s) {
   } else {
     // Delete "directory"
     RETURN_NOT_OK(impl_->DeleteObject(path.bucket, path.key + kSep));
-    // Parent may be implicitly deleted if it became empty, recreate it
-    return impl_->EnsureParentExists(path);
+    if (options().create_missing_dirs_on_delete) {
+      // Parent may be implicitly deleted if it became empty, recreate it
+      return impl_->EnsureParentExists(path);
+    }
+    return Status::OK();
   }
 }
 
@@ -3053,8 +3056,11 @@ Status S3FileSystem::DeleteFile(const std::string& s) {
   }
   // Object found, delete it
   RETURN_NOT_OK(impl_->DeleteObject(path.bucket, path.key));
-  // Parent may be implicitly deleted if it became empty, recreate it
-  return impl_->EnsureParentExists(path);
+  if (options().create_missing_dirs_on_delete) {
+    // Parent may be implicitly deleted if it became empty, recreate it
+    return impl_->EnsureParentExists(path);
+  }
+  return Status::OK();
 }
 
 Status S3FileSystem::Move(const std::string& src, const std::string& dest) {
@@ -3072,8 +3078,12 @@ Status S3FileSystem::Move(const std::string& src, const std::string& dest) {
   }
   RETURN_NOT_OK(impl_->CopyObject(src_path, dest_path));
   RETURN_NOT_OK(impl_->DeleteObject(src_path.bucket, src_path.key));
-  // Source parent may be implicitly deleted if it became empty, recreate it
-  return impl_->EnsureParentExists(src_path);
+
+  if (options().create_missing_dirs_on_delete) {
+    // Source parent may be implicitly deleted if it became empty, recreate it
+    return impl_->EnsureParentExists(src_path);
+  }
+  return Status::OK();
 }
 
 Status S3FileSystem::CopyFile(const std::string& src, const std::string& dest) {

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -177,7 +177,6 @@ struct ARROW_EXPORT S3Options {
   /// to be true to address these scenarios.
   bool check_directory_existence_before_creation = false;
 
-
   /// Whether to create missing directories when deleting files
   ///
   /// Creates 0-byte files to maintain file system semantics during deletion of files and

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -177,6 +177,13 @@ struct ARROW_EXPORT S3Options {
   /// to be true to address these scenarios.
   bool check_directory_existence_before_creation = false;
 
+
+  /// Whether to create missing directories when deleting files
+  ///
+  /// Creates 0-byte files to maintain file system semantics during deletion of files and
+  /// directories.
+  bool create_missing_dirs_on_delete = true;
+
   /// \brief Default metadata for OpenOutputStream.
   ///
   /// This will be ignored if non-empty metadata is passed to OpenOutputStream.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The option handles missing directories during delete operations, allowing the file systems to either maintain the directory structure or operate with object storage semantics based on user preference.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Added `create_missing_dirs_on_delete` option to S3 file system.
- Added unit tests to cover the new feature.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes, I ran the test locally with MinIO (`minio.RELEASE.2022-05-26T05-48-41Z`).

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #36275