### PR TITLE
GH-43285: [Python] Add module level `__getattr__` to `pyarrow.compute` for typing

### DIFF
--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -98,10 +98,16 @@ from collections import namedtuple
 import inspect
 from textwrap import dedent
 import warnings
+from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
 from pyarrow import _compute_docstrings
 from pyarrow.vendored import docscrape
+
+if TYPE_CHECKING:
+    # prevents missing attribute errors in type checker
+    # See https://github.com/apache/arrow/issues/43285
+    def __getattr__(name: str) -> Any: ...
 
 
 def _get_arg_names(func):


### PR DESCRIPTION
Fixes #43285

### Are these changes tested?

I tested them locally in a different project. `pyright` should no longer raise `reportAttributeAccessIssue` on `pyarrow.compute` members.

### Are there any user-facing changes?

IDEs will no longer mark compute functions as missing attributes (however, due to lack of `__all__`, they will also not mark any misspelled methods)
* GitHub Issue: #43285