### PR TITLE
GH-43291: [C++] Expand the 'take' function tests to cover more chunked-array cases

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1130,6 +1130,7 @@ TEST(TestFilterMetaFunction, ArityChecking) {
 //
 //   TakeXA = {TakeAAA, TakeCAC},
 //   TakeXX = {TakeAAA, TakeACC, TakeCAC, TakeCCC}
+namespace {
 
 Result<std::shared_ptr<Array>> TakeAAA(const Array& values, const Array& indices) {
   ARROW_ASSIGN_OR_RAISE(Datum out, Take(Datum(values), Datum(indices)));
@@ -1142,10 +1143,7 @@ Result<std::shared_ptr<Array>> TakeAAA(
   return TakeAAA(*ArrayFromJSON(type, values), *ArrayFromJSON(index_type, indices));
 }
 
-Result<Datum> TakeACC(std::shared_ptr<Array> values,
-                      std::shared_ptr<ChunkedArray> indices) {
-  return Take(Datum{std::move(values)}, Datum{std::move(indices)});
-}
+// TakeACC is never tested directly, so it is not defined here
 
 Result<Datum> TakeCAC(std::shared_ptr<ChunkedArray> values,
                       std::shared_ptr<Array> indices) {
@@ -1445,6 +1443,8 @@ template <>
 uint64_t GetMaxIndex(int64_t values_length) {
   return static_cast<uint64_t>(values_length - 1);
 }
+
+}  // namespace
 
 class TestTakeKernel : public ::testing::Test {
  private:

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1954,7 +1954,6 @@ class TestTakeKernelWithUnion : public TestTakeKernelTyped<ArrowUnionType> {
 };
 TYPED_TEST_SUITE(TestTakeKernelWithUnion, UnionArrowTypes);
 TYPED_TEST(TestTakeKernelWithUnion, TakeUnion) {
-  auto union_type = this->value_type();
   {
     auto union_json = R"([
       [2, 222],
@@ -1965,22 +1964,22 @@ TYPED_TEST(TestTakeKernelWithUnion, TakeUnion) {
       [2, 111],
       [5, null]
     ])";
-    CheckTakeXA(union_type, union_json, "[]", "[]");
-    CheckTakeXA(union_type, union_json, "[3, 0, 3, 0, 3]", R"([
+    this->CheckTakeXA(union_json, "[]", "[]");
+    this->CheckTakeXA(union_json, "[3, 0, 3, 0, 3]", R"([
       [5, "eh"],
       [2, 222],
       [5, "eh"],
       [2, 222],
       [5, "eh"]
     ])");
-    CheckTakeXA(union_type, union_json, "[4, 2, 0, 6]", R"([
+    this->CheckTakeXA(union_json, "[4, 2, 0, 6]", R"([
       [2, null],
       [5, "hello"],
       [2, 222],
       [5, null]
     ])");
-    CheckTakeXA(union_type, union_json, "[0, 1, 2, 3, 4, 5, 6]", union_json);
-    CheckTakeXA(union_type, union_json, "[1, 2, 2, 2, 2, 2, 2]", R"([
+    this->CheckTakeXA(union_json, "[0, 1, 2, 3, 4, 5, 6]", union_json);
+    this->CheckTakeXA(union_json, "[1, 2, 2, 2, 2, 2, 2]", R"([
       [2, null],
       [5, "hello"],
       [5, "hello"],
@@ -1989,7 +1988,7 @@ TYPED_TEST(TestTakeKernelWithUnion, TakeUnion) {
       [5, "hello"],
       [5, "hello"]
     ])");
-    CheckTakeXA(union_type, union_json, "[0, null, 1, null, 2, 2, 2]", R"([
+    this->CheckTakeXA(union_json, "[0, null, 1, null, 2, 2, 2]", R"([
       [2, 222],
       [2, null],
       [2, null],

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1519,7 +1519,7 @@ class TestTakeKernelTyped : public TestTakeKernel {
   }
 };
 
-static const std::string kNull3 = "[null, null, null]";
+static const char kNull3[] = "[null, null, null]";
 
 TEST_F(TestTakeKernel, TakeNull) {
   CheckTakeXA(null(), kNull3, "[0, 1, 0]", "[null, null, null]");

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1948,26 +1948,37 @@ class TestTakeKernelWithChunkedArray : public TestTakeKernelTyped<ChunkedArray> 
 };
 
 TEST_F(TestTakeKernelWithChunkedArray, TakeChunkedArray) {
-  this->AssertTake(int8(), {"[]"}, "[]", {"[]"});
-  this->AssertChunkedTake(int8(), {}, {}, {});
-  this->AssertChunkedTake(int8(), {}, {"[]"}, {"[]"});
-  this->AssertChunkedTake(int8(), {}, {"[null]"}, {"[null]"});
-  this->AssertChunkedTake(int8(), {"[]"}, {}, {});
-  this->AssertChunkedTake(int8(), {"[]"}, {"[]"}, {"[]"});
-  this->AssertChunkedTake(int8(), {"[]"}, {"[null]"}, {"[null]"});
+  for (auto& ty : {boolean(), int8(), uint64()}) {
+    this->AssertTake(ty, {"[]"}, "[]", {"[]"});
+    this->AssertChunkedTake(ty, {}, {}, {});
+    this->AssertChunkedTake(ty, {}, {"[]"}, {"[]"});
+    this->AssertChunkedTake(ty, {}, {"[null]"}, {"[null]"});
+    this->AssertChunkedTake(ty, {"[]"}, {}, {});
+    this->AssertChunkedTake(ty, {"[]"}, {"[]"}, {"[]"});
+    this->AssertChunkedTake(ty, {"[]"}, {"[null]"}, {"[null]"});
+  }
 
-  this->AssertTake(int8(), {"[7]", "[8, 9]"}, "[0, 1, 0, 2]", {"[7, 8, 7, 9]"});
-  this->AssertChunkedTake(int8(), {"[7]", "[8, 9]"}, {"[0, 1, 0]", "[]", "[2]"},
-                          {"[7, 8, 7]", "[]", "[9]"});
-  this->AssertTake(int8(), {"[7]", "[8, 9]"}, "[2, 1]", {"[9, 8]"});
+  this->AssertTake(boolean(), {"[true]", "[false, true]"}, "[0, 1, 0, 2]",
+                   {"[true, false, true, true]"});
+  this->AssertChunkedTake(boolean(), {"[false]", "[true, false]"},
+                          {"[0, 1, 0]", "[]", "[2]"},
+                          {"[false, true, false]", "[]", "[false]"});
+  this->AssertTake(boolean(), {"[true]", "[false, true]"}, "[2, 1]", {"[true, false]"});
 
   std::shared_ptr<ChunkedArray> arr;
-  ASSERT_RAISES(IndexError,
-                this->TakeWithArray(int8(), {"[7]", "[8, 9]"}, "[0, 5]", &arr));
-  ASSERT_RAISES(IndexError, this->TakeWithChunkedArray(int8(), {"[7]", "[8, 9]"},
-                                                       {"[0, 1, 0]", "[5, 1]"}, &arr));
-  ASSERT_RAISES(IndexError, this->TakeWithChunkedArray(int8(), {}, {"[0]"}, &arr));
-  ASSERT_RAISES(IndexError, this->TakeWithChunkedArray(int8(), {"[]"}, {"[0]"}, &arr));
+  for (auto& int_ty : SignedIntTypes()) {
+    this->AssertTake(int_ty, {"[7]", "[8, 9]"}, "[0, 1, 0, 2]", {"[7, 8, 7, 9]"});
+    this->AssertChunkedTake(int_ty, {"[7]", "[8, 9]"}, {"[0, 1, 0]", "[]", "[2]"},
+                            {"[7, 8, 7]", "[]", "[9]"});
+    this->AssertTake(int_ty, {"[7]", "[8, 9]"}, "[2, 1]", {"[9, 8]"});
+
+    ASSERT_RAISES(IndexError,
+                  this->TakeWithArray(int_ty, {"[7]", "[8, 9]"}, "[0, 5]", &arr));
+    ASSERT_RAISES(IndexError, this->TakeWithChunkedArray(int_ty, {"[7]", "[8, 9]"},
+                                                         {"[0, 1, 0]", "[5, 1]"}, &arr));
+    ASSERT_RAISES(IndexError, this->TakeWithChunkedArray(int_ty, {}, {"[0]"}, &arr));
+    ASSERT_RAISES(IndexError, this->TakeWithChunkedArray(int_ty, {"[]"}, {"[0]"}, &arr));
+  }
 }
 
 class TestTakeKernelWithTable : public TestTakeKernelTyped<Table> {

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2080,8 +2080,7 @@ TEST_F(TestPermutationsWithTake, InvertPermutation) {
       if (inverse == nullptr) {
         break;
       }
-      ASSERT_OK_AND_ASSIGN(auto result, DoTakeAAA(inverse, permutation));
-      AssertArraysEqual(*result, *identity);
+      DoAssertTakeAAA(inverse, permutation, identity);
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2120,7 +2120,7 @@ TEST(TestTakeKernelWithRecordBatch, TakeRecordBatch) {
   ])");
 }
 
-TEST(TestTakeKernelWithChunkedArray, TakeChunkedArray) {
+TEST(TestTakeKernelWithChunkedIndices, TakeChunkedArray) {
   for (auto& ty : {boolean(), int8(), uint64()}) {
     AssertTakeCAC(ty, {"[]"}, "[]", {"[]"});
     AssertTakeCCC(ty, {}, {}, {});

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1268,12 +1268,13 @@ void CheckTakeXA(const std::shared_ptr<Array>& values,
   auto chunked_values3 = std::make_shared<ChunkedArray>(values3);
   std::shared_ptr<Array> concat_indices3;
   {
-    Int32Scalar double_length(static_cast<int32_t>(2 * values->length()));
-    Int32Scalar zero(static_cast<int32_t>(values->length()));
-    Int32Scalar length(static_cast<int32_t>(values->length()));
-    ASSERT_OK_AND_ASSIGN(auto indices_prefix, Add(indices, double_length));
-    ASSERT_OK_AND_ASSIGN(auto indices_middle, Add(indices, zero));
-    ASSERT_OK_AND_ASSIGN(auto indices_suffix, Add(indices, length));
+    auto double_length =
+        MakeScalar(indices->type(), static_cast<int>(2 * values->length()));
+    auto zero = MakeScalar(indices->type(), 0);
+    auto length = MakeScalar(indices->type(), static_cast<int>(values->length()));
+    ASSERT_OK_AND_ASSIGN(auto indices_prefix, Add(indices, *double_length));
+    ASSERT_OK_AND_ASSIGN(auto indices_middle, Add(indices, *zero));
+    ASSERT_OK_AND_ASSIGN(auto indices_suffix, Add(indices, *length));
     auto indices3 = ArrayVector{
         indices_prefix.make_array(),
         indices_middle.make_array(),

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1274,14 +1274,16 @@ void DoCheckTakeCACWithArrays(const std::shared_ptr<Array>& values,
   //   I = indices
   const int64_t n = values->length();
   const int64_t k = n / 4;
-  auto value_slices = ArrayVector{values->Slice(0, k), values->Slice(k, 2 * k),
-                                  values->Slice(3 * k, n - k)};
-  auto chunked_values = std::make_shared<ChunkedArray>(value_slices);
-  ASSERT_OK_AND_ASSIGN(chunked_actual, TakeCAC(chunked_values, indices));
-  ValidateOutput(chunked_actual);
-  ASSERT_OK_AND_ASSIGN(concat_actual,
-                       Concatenate(chunked_actual.chunked_array()->chunks()));
-  AssertArraysEqual(*concat_actual, *expected, /*verbose=*/true);
+  if (k > 0) {
+    auto value_slices = ArrayVector{values->Slice(0, k), values->Slice(k, 2 * k),
+                                    values->Slice(3 * k, n - k)};
+    auto chunked_values = std::make_shared<ChunkedArray>(value_slices);
+    ASSERT_OK_AND_ASSIGN(chunked_actual, TakeCAC(chunked_values, indices));
+    ValidateOutput(chunked_actual);
+    ASSERT_OK_AND_ASSIGN(concat_actual,
+                         Concatenate(chunked_actual.chunked_array()->chunks()));
+    AssertArraysEqual(*concat_actual, *expected, /*verbose=*/true);
+  }
 }
 
 // TakeXA = {TakeAAA, TakeCAC}

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1234,14 +1234,12 @@ void CheckTakeAAA(const std::shared_ptr<DataType>& type, const std::string& valu
 }
 
 // TakeXA = {TakeAAA, TakeCAC}
-void CheckTakeXA(const std::shared_ptr<Array>& values,
-                 const std::shared_ptr<Array>& indices,
-                 const std::shared_ptr<Array>& expected) {
+void DoCheckTakeXA(const std::shared_ptr<Array>& values,
+                   const std::shared_ptr<Array>& indices,
+                   const std::shared_ptr<Array>& expected) {
   auto pool = default_memory_pool();
 
-  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Array> actual, TakeAAA(*values, *indices));
-  ValidateOutput(actual);
-  AssertArraysEqual(*expected, *actual, /*verbose=*/true);
+  DoCheckTakeAAA(values, indices, expected);
 
   // We check TakeCAC by checking this equality:
   //
@@ -1292,7 +1290,7 @@ void CheckTakeXADictionary(std::shared_ptr<DataType> value_type,
       auto expected,
       DictionaryArray::FromArrays(type, ArrayFromJSON(int8(), expected_indices), dict));
   auto take_indices = ArrayFromJSON(int8(), indices);
-  CheckTakeXA(values, take_indices, expected);
+  DoCheckTakeXA(values, take_indices, expected);
 }
 
 void AssertTakeCAC(const std::shared_ptr<DataType>& type,

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -2080,7 +2080,7 @@ TEST_F(TestPermutationsWithTake, InvertPermutation) {
       if (inverse == nullptr) {
         break;
       }
-      DoAssertTakeAAA(inverse, permutation, identity);
+      DoCheckTakeXA(inverse, permutation, identity);
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1230,14 +1230,11 @@ void CheckTakeAAA(const std::shared_ptr<DataType>& type, const std::string& valu
   }
 }
 
-// TakeXA = {TakeAAA, TakeCAC}
-void DoCheckTakeXA(const std::shared_ptr<Array>& values,
-                   const std::shared_ptr<Array>& indices,
-                   const std::shared_ptr<Array>& expected) {
+void DoCheckTakeCACWithArrays(const std::shared_ptr<Array>& values,
+                              const std::shared_ptr<Array>& indices,
+                              const std::shared_ptr<Array>& expected) {
   auto pool = default_memory_pool();
   const bool indices_null_count_is_known = indices->null_count() != kUnknownNullCount;
-
-  DoCheckTakeAAA(values, indices, expected);
 
   // We check TakeCAC by checking this equality:
   //
@@ -1276,6 +1273,14 @@ void DoCheckTakeXA(const std::shared_ptr<Array>& values,
   ASSERT_OK_AND_ASSIGN(auto concat_actual,
                        Concatenate(chunked_actual.chunked_array()->chunks()));
   AssertArraysEqual(*concat_expected3, *concat_actual, /*verbose=*/true);
+}
+
+// TakeXA = {TakeAAA, TakeCAC}
+void DoCheckTakeXA(const std::shared_ptr<Array>& values,
+                   const std::shared_ptr<Array>& indices,
+                   const std::shared_ptr<Array>& expected) {
+  DoCheckTakeAAA(values, indices, expected);
+  DoCheckTakeCACWithArrays(values, indices, expected);
 }
 
 // TakeXA = {TakeAAA, TakeCAC}

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1505,6 +1505,10 @@ TEST_F(TestTakeKernel, InvalidIndexType) {
   std::shared_ptr<Array> arr;
   ASSERT_RAISES(NotImplemented,
                 TakeAAA(null(), kNull3, "[0.0, 1.0, 0.1]", float32()).Value(&arr));
+  Datum chunked_arr;
+  ASSERT_RAISES(NotImplemented,
+                TakeCAC(null(), {kNull3, kNull3}, "[0.0, 1.0, 0.1]", float32())
+                    .Value(&chunked_arr));
 }
 
 TEST_F(TestTakeKernel, TakeXCCEmptyIndices) {

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -1696,7 +1696,7 @@ TEST_F(TestTakeKernelFSB, TakeFixedSizeBinary) {
   this->TestNoValidityBitmapButUnknownNullCount(kABC, "[0, 1, 0]");
 
   std::shared_ptr<DataType> type = this->value_type();
-  const std::string kABNullDE = R"(["aaa", "bbb", "ccc", null, "eee"])";
+  const std::string kABNullDE = R"(["aaa", "bbb", null, "ddd", "eee"])";
   std::shared_ptr<Array> arr;
   ASSERT_RAISES(IndexError, TakeAAA(type, kABC, "[0, 9, 0]").Value(&arr));
   ASSERT_RAISES(IndexError, TakeAAA(type, kABNullDE, "[2, 5]").Value(&arr));
@@ -1973,7 +1973,9 @@ class TestTakeKernelWithUnion : public TestTakeKernelTyped<ArrowUnionType> {
         });
   }
 };
+
 TYPED_TEST_SUITE(TestTakeKernelWithUnion, UnionArrowTypes);
+
 TYPED_TEST(TestTakeKernelWithUnion, TakeUnion) {
   {
     auto union_json = R"([


### PR DESCRIPTION

### Rationale for this change

#41700 (as it is currently) passes all the C++ tests even though it contains a few bugs (caught by manual repro steps and tests of of the Ruby bindings). The C++ tests should be able to catch these kinds of bugs and exercise code beyond the TakeAAA cases.

### What changes are included in this PR?

 - Explicitly calling out which TakeXX variation is being checked in tests and assert helpers
 - Using `AssertChunkedEqual` instead of `AssertChunkedEquivalent` (via `AssertDatumsEqual`)
 - 

### Are these changes tested?

Yes. The improved tests catch bugs now.
* GitHub Issue: #43291