### PR TITLE
GH-43284: [Release] Fix version detection timing for bump deb package names on post-12-bump-versions.sh script

### DIFF
--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -358,8 +358,15 @@ class PostBumpVersionsTest < Test::Unit::TestCase
   def test_deb_package_names
     omit_on_release_branch unless bump_type.nil?
     current_commit = git_current_commit
-    stdout = bump_versions("DEB_PACKAGE_NAMES")
-    changes = parse_patch(git("log", "-p", "#{current_commit}.."))
+    stdout = bump_versions("VERSION_POST_TAG", "DEB_PACKAGE_NAMES")
+    log = git("log", "-p", "#{current_commit}..")
+    # Remove a commit for VERSION_POST_TAG
+    if log.scan(/^commit/).size == 1
+      log = ""
+    else
+      log.gsub!(/\A(commit.*?)^commit .*\z/um, "\\1")
+    end
+    changes = parse_patch(log)
     sampled_changes = changes.collect do |change|
       first_hunk = change[:hunks][0]
       first_removed_line = first_hunk.find { |line| line.start_with?("-") }

--- a/dev/release/post-12-bump-versions.sh
+++ b/dev/release/post-12-bump-versions.sh
@@ -64,7 +64,7 @@ if [ ${BUMP_VERSION_POST_TAG} -gt 0 ]; then
 fi
 
 if [ ${BUMP_DEB_PACKAGE_NAMES} -gt 0 ] && \
-     [ "${next_version}" != "$(current_version)" ]; then
+     [ "${next_version}" != "${version}" ]; then
   update_deb_package_names "${version}" "${next_version}"
 fi
 

--- a/dev/release/post-12-bump-versions.sh
+++ b/dev/release/post-12-bump-versions.sh
@@ -40,6 +40,7 @@ fi
 version=$1
 next_version=$2
 next_version_snapshot="${next_version}-SNAPSHOT"
+current_version_before_bump="$(current_version)"
 
 case "${version}" in
   *.0.0)
@@ -64,7 +65,7 @@ if [ ${BUMP_VERSION_POST_TAG} -gt 0 ]; then
 fi
 
 if [ ${BUMP_DEB_PACKAGE_NAMES} -gt 0 ] && \
-     [ "${next_version}" != "${version}" ]; then
+     [ "${next_version}" != "${current_version_before_bump}" ]; then
   update_deb_package_names "${version}" "${next_version}"
 fi
 


### PR DESCRIPTION
### Rationale for this change

The script fails to bump deb package names at the moment due to an unmatching if.

### What changes are included in this PR?

Use current_version before bumping the versions in order to match debian packages to be updated.

### Are these changes tested?

It has been tested locally to bump the versions for the debian package names on main for 17.0.0

### Are there any user-facing changes?

No
* GitHub Issue: #43284