### PR TITLE
GH-42247: [C++] Support casting to and from utf8_view/binary_view

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -133,7 +133,8 @@ struct GetViewType<Type, enable_if_has_c_type<Type>> {
 
 template <typename Type>
 struct GetViewType<Type, enable_if_t<is_base_binary_type<Type>::value ||
-                                     is_fixed_size_binary_type<Type>::value>> {
+                                     is_fixed_size_binary_type<Type>::value ||
+                                     is_binary_view_like_type<Type>::value>> {
   using T = std::string_view;
   using PhysicalType = T;
 
@@ -1259,6 +1260,22 @@ ArrayKernelExec GenerateVarBinary(detail::GetTypeId get_id) {
       return Generator<Type0, LargeBinaryType, Args...>::Exec;
     case Type::LARGE_STRING:
       return Generator<Type0, LargeStringType, Args...>::Exec;
+    default:
+      DCHECK(false);
+      return nullptr;
+  }
+}
+
+// Generate a kernel given a templated functor for binary-view types. Generates a
+// single kernel for binary/string-view.
+//
+// See "Numeric" above for description of the generator functor
+template <template <typename...> class Generator, typename Type0, typename... Args>
+ArrayKernelExec GenerateVarBinaryViewBase(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::BINARY_VIEW:
+    case Type::STRING_VIEW:
+      return Generator<Type0, BinaryViewType, Args...>::Exec;
     default:
       DCHECK(false);
       return nullptr;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
@@ -63,6 +63,12 @@ std::vector<std::shared_ptr<CastFunction>> GetBooleanCasts() {
                                                  BooleanType, ParseBooleanString>(*ty);
     DCHECK_OK(func->AddKernel(ty->id(), {ty}, boolean(), exec));
   }
+  for (const auto& ty : BinaryViewTypes()) {
+    ArrayKernelExec exec =
+        GenerateVarBinaryViewBase<applicator::ScalarUnaryNotNull, BooleanType,
+                                  ParseBooleanString>(*ty);
+    DCHECK_OK(func->AddKernel(ty->id(), {ty}, boolean(), exec));
+  }
   return {func};
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -279,8 +279,10 @@ void AddZeroCopyCast(Type::type in_type_id, InputType in_type, OutputType out_ty
 }
 
 static bool CanCastFromDictionary(Type::type type_id) {
+  /// TODO(GH-43010): add is_binary_view_like() here once array_take
+  /// can handle string-views
   return (is_primitive(type_id) || is_base_binary_like(type_id) ||
-          is_fixed_size_binary(type_id) || is_binary_view_like(type_id));
+          is_fixed_size_binary(type_id));
 }
 
 void AddCommonCasts(Type::type out_type_id, OutputType out_ty, CastFunction* func) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -280,7 +280,7 @@ void AddZeroCopyCast(Type::type in_type_id, InputType in_type, OutputType out_ty
 
 static bool CanCastFromDictionary(Type::type type_id) {
   return (is_primitive(type_id) || is_base_binary_like(type_id) ||
-          is_fixed_size_binary(type_id));
+          is_fixed_size_binary(type_id) || is_binary_view_like(type_id));
 }
 
 void AddCommonCasts(Type::type out_type_id, OutputType out_ty, CastFunction* func) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -188,8 +188,6 @@ void CastNumberToNumberUnsafe(Type::type in_type, Type::type out_type,
 // ----------------------------------------------------------------------
 
 Status UnpackDictionary(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-  // TODO: is there an implementation more friendly to the "span" data structures?
-
   DictionaryArray dict_arr(batch[0].array.ToArrayData());
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
 
@@ -297,9 +295,6 @@ void AddCommonCasts(Type::type out_type_id, OutputType out_ty, CastFunction* fun
   // From dictionary to this type
   if (CanCastFromDictionary(out_type_id)) {
     // Dictionary unpacking not implemented for boolean or nested types.
-    //
-    // XXX: Uses Take and does its own memory allocation for the moment. We can
-    // fix this later.
     DCHECK_OK(func->AddKernel(Type::DICTIONARY, {InputType(Type::DICTIONARY)}, out_ty,
                               UnpackDictionary, NullHandling::COMPUTED_NO_PREALLOCATE,
                               MemAllocation::NO_PREALLOCATE));

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -313,7 +313,9 @@ struct ParseString {
 
 template <typename O, typename I>
 struct CastFunctor<
-    O, I, enable_if_t<(is_number_type<O>::value && is_base_binary_type<I>::value)>> {
+    O, I,
+    enable_if_t<(is_number_type<O>::value && (is_base_binary_type<I>::value ||
+                                              is_binary_view_like_type<I>::value))>> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     return applicator::ScalarUnaryNotNull<O, I, ParseString<O>>::Exec(ctx, batch, out);
   }
@@ -658,11 +660,15 @@ struct DecimalCastFunctor {
 };
 
 template <typename I>
-struct CastFunctor<Decimal128Type, I, enable_if_t<is_base_binary_type<I>::value>>
+struct CastFunctor<
+    Decimal128Type, I,
+    enable_if_t<is_base_binary_type<I>::value || is_binary_view_like_type<I>::value>>
     : public DecimalCastFunctor<Decimal128Type, I> {};
 
 template <typename I>
-struct CastFunctor<Decimal256Type, I, enable_if_t<is_base_binary_type<I>::value>>
+struct CastFunctor<
+    Decimal256Type, I,
+    enable_if_t<is_base_binary_type<I>::value || is_binary_view_like_type<I>::value>>
     : public DecimalCastFunctor<Decimal256Type, I> {};
 
 // ----------------------------------------------------------------------
@@ -706,6 +712,10 @@ void AddCommonNumberCasts(const std::shared_ptr<DataType>& out_ty, CastFunction*
   // Cast from other strings
   for (const std::shared_ptr<DataType>& in_ty : BaseBinaryTypes()) {
     auto exec = GenerateVarBinaryBase<CastFunctor, OutType>(*in_ty);
+    DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, out_ty, exec));
+  }
+  for (const std::shared_ptr<DataType>& in_ty : BinaryViewTypes()) {
+    auto exec = GenerateVarBinaryViewBase<CastFunctor, OutType>(*in_ty);
     DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, out_ty, exec));
   }
 }
@@ -793,6 +803,10 @@ std::shared_ptr<CastFunction> GetCastToDecimal128() {
     auto exec = GenerateVarBinaryBase<CastFunctor, Decimal128Type>(in_ty->id());
     DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, std::move(exec)));
   }
+  for (const std::shared_ptr<DataType>& in_ty : BinaryViewTypes()) {
+    auto exec = GenerateVarBinaryViewBase<CastFunctor, Decimal128Type>(in_ty->id());
+    DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, std::move(exec)));
+  }
 
   // Cast from other decimal
   auto exec = CastFunctor<Decimal128Type, Decimal128Type>::Exec;
@@ -826,6 +840,10 @@ std::shared_ptr<CastFunction> GetCastToDecimal256() {
   // Cast from other strings
   for (const std::shared_ptr<DataType>& in_ty : BaseBinaryTypes()) {
     auto exec = GenerateVarBinaryBase<CastFunctor, Decimal256Type>(in_ty->id());
+    DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, std::move(exec)));
+  }
+  for (const std::shared_ptr<DataType>& in_ty : BinaryViewTypes()) {
+    auto exec = GenerateVarBinaryViewBase<CastFunctor, Decimal256Type>(in_ty->id());
     DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, sig_out_ty, std::move(exec)));
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -520,14 +520,23 @@ void AddBinaryToFixedSizeBinaryCast(CastFunction* func) {
 }  // namespace
 
 std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
+  // cast_binary / cast_binary_view / cast_large_binary
+
   auto cast_binary = std::make_shared<CastFunction>("cast_binary", Type::BINARY);
   AddCommonCasts(Type::BINARY, binary(), cast_binary.get());
   AddBinaryToBinaryCast<BinaryType>(cast_binary.get());
+
+  // auto cast_binary_view =
+  //     std::make_shared<CastFunction>("cast_binary_view", Type::BINARY_VIEW);
+  // AddCommonCasts(Type::BINARY_VIEW, binary_view(), cast_binary_view.get());
+  // AddBinaryToBinaryCast<BinaryViewType>(cast_binary_view.get());
 
   auto cast_large_binary =
       std::make_shared<CastFunction>("cast_large_binary", Type::LARGE_BINARY);
   AddCommonCasts(Type::LARGE_BINARY, large_binary(), cast_large_binary.get());
   AddBinaryToBinaryCast<LargeBinaryType>(cast_large_binary.get());
+
+  // cast_string / cast_string_view / cast_large_string
 
   auto cast_string = std::make_shared<CastFunction>("cast_string", Type::STRING);
   AddCommonCasts(Type::STRING, utf8(), cast_string.get());
@@ -535,6 +544,14 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   AddDecimalToStringCasts<StringType>(cast_string.get());
   AddTemporalToStringCasts<StringType>(cast_string.get());
   AddBinaryToBinaryCast<StringType>(cast_string.get());
+
+  // auto cast_string_view =
+  //     std::make_shared<CastFunction>("cast_string_view", Type::STRING_VIEW);
+  // AddCommonCasts(Type::STRING_VIEW, utf8_view(), cast_string_view.get());
+  // AddNumberToStringCasts<StringViewType>(cast_string_view.get());
+  // AddDecimalToStringCasts<StringViewType>(cast_string_view.get());
+  // AddTemporalToStringCasts<StringViewType>(cast_string_view.get());
+  // AddBinaryToBinaryCast<StringViewType>(cast_string_view.get());
 
   auto cast_large_string =
       std::make_shared<CastFunction>("cast_large_string", Type::LARGE_STRING);
@@ -544,13 +561,23 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   AddTemporalToStringCasts<LargeStringType>(cast_large_string.get());
   AddBinaryToBinaryCast<LargeStringType>(cast_large_string.get());
 
+  // cast_fixed_size_binary
+
   auto cast_fsb =
       std::make_shared<CastFunction>("cast_fixed_size_binary", Type::FIXED_SIZE_BINARY);
   AddCommonCasts(Type::FIXED_SIZE_BINARY, OutputType(ResolveOutputFromOptions),
                  cast_fsb.get());
   AddBinaryToFixedSizeBinaryCast(cast_fsb.get());
 
-  return {cast_binary, cast_large_binary, cast_string, cast_large_string, cast_fsb};
+  return {
+      std::move(cast_binary),
+      // std::move(cast_binary_view),
+      std::move(cast_large_binary),
+      std::move(cast_string),
+      // std::move(cast_string_view),
+      std::move(cast_large_string),
+      std::move(cast_fsb),
+  };
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -400,9 +400,10 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
   return ZeroCopyCastExec(ctx, batch, out);
 }
 
-// Span -> Fixed
+// Span | View -> Fixed
 template <typename O, typename I>
-enable_if_t<is_base_binary_type<I>::value && std::is_same<O, FixedSizeBinaryType>::value,
+enable_if_t<(is_base_binary_type<I>::value || is_binary_view_like_type<I>::value) &&
+                std::is_same<O, FixedSizeBinaryType>::value,
             Status>
 BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
@@ -511,7 +512,9 @@ void AddBinaryToFixedSizeBinaryCast(CastFunction* func) {
 
 void AddBinaryToFixedSizeBinaryCast(CastFunction* func) {
   AddBinaryToFixedSizeBinaryCast<StringType>(func);
+  AddBinaryToFixedSizeBinaryCast<StringViewType>(func);
   AddBinaryToFixedSizeBinaryCast<BinaryType>(func);
+  AddBinaryToFixedSizeBinaryCast<BinaryViewType>(func);
   AddBinaryToFixedSizeBinaryCast<LargeStringType>(func);
   AddBinaryToFixedSizeBinaryCast<LargeBinaryType>(func);
   AddBinaryToFixedSizeBinaryCast<FixedSizeBinaryType>(func);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -288,7 +288,7 @@ Status CastBinaryToBinaryOffsets<int64_t, int32_t>(KernelContext* ctx,
   }
 }
 
-// Span -> Span
+// Offset String -> Offset String
 template <typename O, typename I>
 enable_if_t<is_base_binary_type<I>::value && is_base_binary_type<O>::value, Status>
 BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -310,7 +310,7 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
       ctx, input, out->array_data().get());
 }
 
-// View -> Span
+// String View -> Offset String
 template <typename O, typename I>
 enable_if_t<is_binary_view_like_type<I>::value && is_base_binary_type<O>::value, Status>
 BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -346,7 +346,7 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
   return Status::OK();
 }
 
-// Span -> View
+// Offset String -> String View
 template <typename O, typename I>
 enable_if_t<is_base_binary_type<I>::value && is_binary_view_like_type<O>::value, Status>
 BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -408,7 +408,7 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
   return Status::OK();
 }
 
-// View -> View
+// String View -> String View
 template <typename O, typename I>
 enable_if_t<is_binary_view_like_type<I>::value && is_binary_view_like_type<O>::value,
             Status>
@@ -428,7 +428,7 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
   return ZeroCopyCastExec(ctx, batch, out);
 }
 
-// Fixed -> View
+// Fixed -> String View
 template <typename O, typename I>
 enable_if_t<std::is_same<I, FixedSizeBinaryType>::value &&
                 is_binary_view_like_type<O>::value,
@@ -487,7 +487,7 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
   return Status::OK();
 }
 
-// Fixed -> Span
+// Fixed -> Offset String
 template <typename O, typename I>
 enable_if_t<std::is_same<I, FixedSizeBinaryType>::value && is_base_binary_type<O>::value,
             Status>
@@ -579,7 +579,7 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
   return ZeroCopyCastExec(ctx, batch, out);
 }
 
-// Span | View -> Fixed
+// Offset String | String View -> Fixed
 template <typename O, typename I>
 enable_if_t<(is_base_binary_type<I>::value || is_binary_view_like_type<I>::value) &&
                 std::is_same<O, FixedSizeBinaryType>::value,

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -732,9 +732,9 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   auto cast_string_view =
       std::make_shared<CastFunction>("cast_string_view", Type::STRING_VIEW);
   AddCommonCasts(Type::STRING_VIEW, utf8_view(), cast_string_view.get());
-  // AddNumberToStringCasts<StringViewType>(cast_string_view.get());
-  // AddDecimalToStringCasts<StringViewType>(cast_string_view.get());
-  // AddTemporalToStringCasts<StringViewType>(cast_string_view.get());
+  AddNumberToStringCasts<StringViewType>(cast_string_view.get());
+  AddDecimalToStringCasts<StringViewType>(cast_string_view.get());
+  AddTemporalToStringCasts<StringViewType>(cast_string_view.get());
   AddBinaryToBinaryCast<StringViewType>(cast_string_view.get());
 
   auto cast_large_string =

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -327,11 +327,15 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
     }
   }
 
+  const int64_t sum_of_binary_view_sizes = util::SumOfBinaryViewSizes(
+      input.GetValues<BinaryViewType::c_type>(1), input.length);
+
   // TODO(GH-43573): A more efficient implementation that copies the validity
   // bitmap all at once is possible, but would mean we don't delegate all the
   // building logic to the ArrayBuilder implementation for the output type.
   OutputBuilderType builder(options.to_type.GetSharedPtr(), ctx->memory_pool());
   RETURN_NOT_OK(builder.Resize(input.length));
+  RETURN_NOT_OK(builder.ReserveData(sum_of_binary_view_sizes));
   arrow::internal::ArraySpanInlineVisitor<I> visitor;
   RETURN_NOT_OK(visitor.VisitStatus(
       input,

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -526,9 +526,9 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   AddCommonCasts(Type::BINARY, binary(), cast_binary.get());
   AddBinaryToBinaryCast<BinaryType>(cast_binary.get());
 
-  // auto cast_binary_view =
-  //     std::make_shared<CastFunction>("cast_binary_view", Type::BINARY_VIEW);
-  // AddCommonCasts(Type::BINARY_VIEW, binary_view(), cast_binary_view.get());
+  auto cast_binary_view =
+      std::make_shared<CastFunction>("cast_binary_view", Type::BINARY_VIEW);
+  AddCommonCasts(Type::BINARY_VIEW, binary_view(), cast_binary_view.get());
   // AddBinaryToBinaryCast<BinaryViewType>(cast_binary_view.get());
 
   auto cast_large_binary =
@@ -545,9 +545,9 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   AddTemporalToStringCasts<StringType>(cast_string.get());
   AddBinaryToBinaryCast<StringType>(cast_string.get());
 
-  // auto cast_string_view =
-  //     std::make_shared<CastFunction>("cast_string_view", Type::STRING_VIEW);
-  // AddCommonCasts(Type::STRING_VIEW, utf8_view(), cast_string_view.get());
+  auto cast_string_view =
+      std::make_shared<CastFunction>("cast_string_view", Type::STRING_VIEW);
+  AddCommonCasts(Type::STRING_VIEW, utf8_view(), cast_string_view.get());
   // AddNumberToStringCasts<StringViewType>(cast_string_view.get());
   // AddDecimalToStringCasts<StringViewType>(cast_string_view.get());
   // AddTemporalToStringCasts<StringViewType>(cast_string_view.get());
@@ -570,12 +570,8 @@ std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   AddBinaryToFixedSizeBinaryCast(cast_fsb.get());
 
   return {
-      std::move(cast_binary),
-      // std::move(cast_binary_view),
-      std::move(cast_large_binary),
-      std::move(cast_string),
-      // std::move(cast_string_view),
-      std::move(cast_large_string),
+      std::move(cast_binary), std::move(cast_binary_view), std::move(cast_large_binary),
+      std::move(cast_string), std::move(cast_string_view), std::move(cast_large_string),
       std::move(cast_fsb),
   };
 }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -396,9 +396,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
         // A more complicated loop could work by slicing the data buffer into
         // more than one variadic buffer, but this is probably overkill for now
         // before someone hits this problem in practice.
-        return Status::Invalid("Failed casting from ", input.type->ToString(), " to ",
-                               output->type->ToString(),
-                               ": input array too large for efficient conversion.");
+        return Status::CapacityError("Failed casting from ", input.type->ToString(),
+                                     " to ", output->type->ToString(),
+                                     ": input array too large for efficient conversion.");
       }
     }
   }
@@ -499,9 +499,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
       // A more complicated loop could work by slicing the data buffer into
       // more than one variadic buffer, but this is probably overkill for now
       // before someone hits this problem in practice.
-      return Status::Invalid("Failed casting from ", input.type->ToString(), " to ",
-                             output->type->ToString(),
-                             ": input array too large for efficient conversion.");
+      return Status::CapacityError("Failed casting from ", input.type->ToString(), " to ",
+                                   output->type->ToString(),
+                                   ": input array too large for efficient conversion.");
     }
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2084,7 +2084,11 @@ static void AssertBinaryZeroCopy(std::shared_ptr<Array> lhs, std::shared_ptr<Arr
 
 TEST(Cast, BinaryToString) {
   for (auto bin_type : {binary(), binary_view(), large_binary()}) {
-    for (auto string_type : {utf8(), large_utf8()}) {
+    for (auto string_type : {utf8(), utf8_view(), large_utf8()}) {
+      if (is_binary_view_like(*bin_type) && is_binary_view_like(*string_type)) {
+        // XXX: implement BinaryToStringCast<View, View>
+        continue;
+      }
       // empty -> empty always works
       CheckCast(ArrayFromJSON(bin_type, "[]"), ArrayFromJSON(string_type, "[]"));
 
@@ -2102,7 +2106,7 @@ TEST(Cast, BinaryToString) {
       options.allow_invalid_utf8 = true;
       ASSERT_OK_AND_ASSIGN(auto strings, Cast(*invalid_utf8, string_type, options));
       ASSERT_RAISES(Invalid, strings->ValidateFull());
-      if (!is_binary_view_like(*bin_type)) {
+      if (!is_binary_view_like(*bin_type) && !is_binary_view_like(*string_type)) {
         AssertBinaryZeroCopy(invalid_utf8, strings);
       }
     }
@@ -2138,7 +2142,11 @@ TEST(Cast, BinaryToString) {
 TEST(Cast, BinaryOrStringToBinary) {
   for (auto from_type :
        {utf8(), utf8_view(), large_utf8(), binary(), binary_view(), large_binary()}) {
-    for (auto to_type : {binary(), large_binary()}) {
+    for (auto to_type : {binary(), binary_view(), large_binary()}) {
+      if (is_binary_view_like(*from_type) && is_binary_view_like(*to_type)) {
+        // XXX: implement BinaryToBinaryCast<View, View>
+        continue;
+      }
       // empty -> empty always works
       CheckCast(ArrayFromJSON(from_type, "[]"), ArrayFromJSON(to_type, "[]"));
 
@@ -2147,7 +2155,7 @@ TEST(Cast, BinaryOrStringToBinary) {
       // invalid utf-8 is not an error for binary
       ASSERT_OK_AND_ASSIGN(auto strings, Cast(*invalid_utf8, to_type));
       ValidateOutput(*strings);
-      if (!is_binary_view_like(*from_type)) {
+      if (!is_binary_view_like(*from_type) && !is_binary_view_like(*to_type)) {
         AssertBinaryZeroCopy(invalid_utf8, strings);
       }
 
@@ -2181,7 +2189,11 @@ TEST(Cast, BinaryOrStringToBinary) {
 
 TEST(Cast, StringToString) {
   for (auto from_type : {utf8(), utf8_view(), large_utf8()}) {
-    for (auto to_type : {utf8(), large_utf8()}) {
+    for (auto to_type : {utf8(), utf8_view(), large_utf8()}) {
+      if (is_binary_view_like(*from_type) && is_binary_view_like(*to_type)) {
+        // XXX: implemenet BinarytoBinaryCast<View, View>
+        continue;
+      }
       // empty -> empty always works
       CheckCast(ArrayFromJSON(from_type, "[]"), ArrayFromJSON(to_type, "[]"));
 
@@ -2197,7 +2209,7 @@ TEST(Cast, StringToString) {
       // utf-8 is not checked by Cast when the origin guarantees utf-8
       ASSERT_OK_AND_ASSIGN(auto strings, Cast(*invalid_utf8, to_type, options));
       ASSERT_RAISES(Invalid, strings->ValidateFull());
-      if (!is_binary_view_like(*from_type)) {
+      if (!is_binary_view_like(*from_type) && !is_binary_view_like(*to_type)) {
         AssertBinaryZeroCopy(invalid_utf8, strings);
       }
     }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -205,8 +205,8 @@ TEST(Cast, CanCast) {
     ExpectCanCast(from_base_binary, {boolean()});
     ExpectCanCast(from_base_binary, kNumericTypes);
     ExpectCanCast(from_base_binary, kBaseBinaryTypes);
-    /// TODO(GH-43010): include is_binary_view_like() types here once array_take
-    /// can handle string-views
+    // TODO(GH-43010): include is_binary_view_like() types here once array_take
+    // can handle string-views
     if (!is_binary_view_like(*from_base_binary)) {
       ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
     }
@@ -223,15 +223,9 @@ TEST(Cast, CanCast) {
   ExpectCannotCast(timestamp(TimeUnit::MICRO),
                    {binary(), large_binary()});  // no formatting supported
 
-  ExpectCanCast(fixed_size_binary(3), {
-                                          utf8(),
-                                          large_utf8(),
-                                          utf8_view(),
-                                          binary(),
-                                          large_binary(),
-                                          binary_view(),
-                                          fixed_size_binary(3),
-                                      });
+  ExpectCanCast(fixed_size_binary(3), kBaseBinaryAndViewTypes);
+  // Identity cast
+  ExpectCanCast(fixed_size_binary(3), {fixed_size_binary(3)});
   // Doesn't fail since a kernel exists (but it will return an error when executed)
   // ExpectCannotCast(fixed_size_binary(3), {fixed_size_binary(5)});
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -205,8 +205,6 @@ TEST(Cast, CanCast) {
     ExpectCanCast(from_base_binary, {boolean()});
     ExpectCanCast(from_base_binary, kNumericTypes);
     ExpectCanCast(from_base_binary, kBaseBinaryTypes);
-    // XXX: add float16 to kNumericTypes
-    ExpectCanCast(from_base_binary, {float16()});
     ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
 
     // any cast which is valid for the dictionary is valid for the DictionaryArray

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -201,10 +201,12 @@ TEST(Cast, CanCast) {
     ExpectCannotCast(from_numeric, {null()});
   }
 
-  for (auto from_base_binary : kBaseBinaryTypes) {
+  for (auto from_base_binary : kBaseBinaryAndViewTypes) {
     ExpectCanCast(from_base_binary, {boolean()});
     ExpectCanCast(from_base_binary, kNumericTypes);
     ExpectCanCast(from_base_binary, kBaseBinaryTypes);
+    // XXX: add float16 to kNumericTypes
+    ExpectCanCast(from_base_binary, {float16()});
     ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
 
     // any cast which is valid for the dictionary is valid for the DictionaryArray
@@ -212,21 +214,6 @@ TEST(Cast, CanCast) {
     ExpectCanCast(dictionary(int16(), from_base_binary), kNumericTypes);
 
     ExpectCannotCast(from_base_binary, {null()});
-  }
-  // XXX: include utf8_view() on the list above once all of these pass
-  for (auto view_ty : {utf8_view(), binary_view()}) {
-    ExpectCanCast(view_ty, {boolean()});
-    ExpectCanCast(view_ty, kNumericTypes);
-    ExpectCanCast(view_ty, kBaseBinaryTypes);
-    // XXX: add float16 to kNumericTypes
-    ExpectCanCast(view_ty, {float16()});
-    ExpectCanCast(dictionary(int64(), view_ty), {view_ty});
-
-    // any cast which is valid for the dictionary is valid for the DictionaryArray
-    ExpectCanCast(dictionary(uint32(), view_ty), kBaseBinaryTypes);
-    ExpectCanCast(dictionary(int16(), view_ty), kNumericTypes);
-
-    ExpectCannotCast(view_ty, {null()});
   }
 
   ExpectCanCast(utf8(), {timestamp(TimeUnit::MILLI), date32(), date64()});

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2215,6 +2215,17 @@ TEST(Cast, StringToString) {
       if (is_binary_view_like(*from_type) == is_binary_view_like(*to_type)) {
         AssertBinaryZeroCopy(invalid_utf8, strings);
       }
+
+      auto short_input = R"(["foo", null, "bar", "baz", "quu"])";
+      auto long_input = R"(["foofoofoofoofoo", null, "barbarbarbarbarbarbar",
+          "bazbazbazbazbazbazbaz", "quuquuquuquuquuquuquuquuquu"])";
+      auto combine_input = R"(["foo", null, "barbarbarbarbarbarbar", "baz", "quu"])";
+
+      CheckCast(ArrayFromJSON(from_type, short_input),
+                ArrayFromJSON(to_type, short_input));
+      CheckCast(ArrayFromJSON(from_type, long_input), ArrayFromJSON(to_type, long_input));
+      CheckCast(ArrayFromJSON(from_type, combine_input),
+                ArrayFromJSON(to_type, combine_input));
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -215,7 +215,7 @@ TEST(Cast, CanCast) {
   }
   // XXX: include utf8_view() on the list above once all of these pass
   for (auto view_ty : {utf8_view(), binary_view()}) {
-    // ExpectCanCast(view_ty, {boolean()});
+    ExpectCanCast(view_ty, {boolean()});
     // ExpectCanCast(view_ty, kNumericTypes);
     ExpectCanCast(view_ty, kBaseBinaryTypes);
     ExpectCanCast(dictionary(int64(), view_ty), {view_ty});

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -205,7 +205,11 @@ TEST(Cast, CanCast) {
     ExpectCanCast(from_base_binary, {boolean()});
     ExpectCanCast(from_base_binary, kNumericTypes);
     ExpectCanCast(from_base_binary, kBaseBinaryTypes);
-    ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
+    /// TODO(GH-43010): include is_binary_view_like() types here once array_take
+    /// can handle string-views
+    if (!is_binary_view_like(*from_base_binary)) {
+      ExpectCanCast(dictionary(int64(), from_base_binary), {from_base_binary});
+    }
 
     // any cast which is valid for the dictionary is valid for the DictionaryArray
     ExpectCanCast(dictionary(uint32(), from_base_binary), kBaseBinaryTypes);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -210,6 +210,19 @@ TEST(Cast, CanCast) {
 
     ExpectCannotCast(from_base_binary, {null()});
   }
+  // XXX: include utf8_view() on the list above once all of these pass
+  for (auto view_ty : {utf8_view(), binary_view()}) {
+    // ExpectCanCast(view_ty, {boolean()});
+    // ExpectCanCast(view_ty, kNumericTypes);
+    // ExpectCanCast(view_ty, kBaseBinaryTypes);
+    ExpectCanCast(dictionary(int64(), view_ty), {view_ty});
+
+    // any cast which is valid for the dictionary is valid for the DictionaryArray
+    ExpectCanCast(dictionary(uint32(), view_ty), kBaseBinaryTypes);
+    ExpectCanCast(dictionary(int16(), view_ty), kNumericTypes);
+
+    ExpectCannotCast(view_ty, {null()});
+  }
 
   ExpectCanCast(utf8(), {timestamp(TimeUnit::MILLI), date32(), date64()});
   ExpectCanCast(large_utf8(), {timestamp(TimeUnit::NANO), date32(), date64()});
@@ -2913,9 +2926,12 @@ TEST(Cast, IdentityCasts) {
   for (auto type : kNumericTypes) {
     CheckIdentityCast(type, "[1, 2, null, 4]");
   }
-  CheckIdentityCast(binary(), R"(["foo", "bar"])");
-  CheckIdentityCast(utf8(), R"(["foo", "bar"])");
-  CheckIdentityCast(fixed_size_binary(3), R"(["foo", "bar"])");
+  const std::string json = R"(["foo", "bar"])";
+  CheckIdentityCast(utf8(), json);
+  CheckIdentityCast(binary(), json);
+  CheckIdentityCast(utf8_view(), json);
+  CheckIdentityCast(binary_view(), json);
+  CheckIdentityCast(fixed_size_binary(3), json);
 
   CheckIdentityCast(list(int8()), "[[1, 2], [null], [], [3]]");
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -216,8 +216,10 @@ TEST(Cast, CanCast) {
   // XXX: include utf8_view() on the list above once all of these pass
   for (auto view_ty : {utf8_view(), binary_view()}) {
     ExpectCanCast(view_ty, {boolean()});
-    // ExpectCanCast(view_ty, kNumericTypes);
+    ExpectCanCast(view_ty, kNumericTypes);
     ExpectCanCast(view_ty, kBaseBinaryTypes);
+    // XXX: add float16 to kNumericTypes
+    ExpectCanCast(view_ty, {float16()});
     ExpectCanCast(dictionary(int64(), view_ty), {view_ty});
 
     // any cast which is valid for the dictionary is valid for the DictionaryArray

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2198,7 +2198,8 @@ TEST(Cast, StringToString) {
 }
 
 TEST(Cast, BinaryOrStringToFixedSizeBinary) {
-  for (auto in_type : {utf8(), large_utf8(), binary(), large_binary()}) {
+  for (auto in_type :
+       {utf8(), large_utf8(), utf8_view(), binary(), binary_view(), large_binary()}) {
     auto valid_input = ArrayFromJSON(in_type, R"(["foo", null, "bar", "baz", "quu"])");
     auto invalid_input = ArrayFromJSON(in_type, R"(["foo", null, "bar", "baz", "quux"])");
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -3333,6 +3333,7 @@ std::vector<std::shared_ptr<DataType>> g_int_types;
 std::vector<std::shared_ptr<DataType>> g_floating_types;
 std::vector<std::shared_ptr<DataType>> g_numeric_types;
 std::vector<std::shared_ptr<DataType>> g_base_binary_types;
+std::vector<std::shared_ptr<DataType>> g_binary_view_types;
 std::vector<std::shared_ptr<DataType>> g_temporal_types;
 std::vector<std::shared_ptr<DataType>> g_interval_types;
 std::vector<std::shared_ptr<DataType>> g_duration_types;
@@ -3384,6 +3385,9 @@ void InitStaticData() {
   // Base binary types (without FixedSizeBinary)
   g_base_binary_types = {binary(), utf8(), large_binary(), large_utf8()};
 
+  // Binary view types
+  g_binary_view_types = {utf8_view(), binary_view()};
+
   // Non-parametric, non-nested types. This also DOES NOT include
   //
   // * Decimal
@@ -3391,9 +3395,10 @@ void InitStaticData() {
   // * Time32
   // * Time64
   // * Timestamp
-  g_primitive_types = {null(), boolean(), date32(), date64(), binary_view(), utf8_view()};
+  g_primitive_types = {null(), boolean(), date32(), date64()};
   Extend(g_numeric_types, &g_primitive_types);
   Extend(g_base_binary_types, &g_primitive_types);
+  Extend(g_binary_view_types, &g_primitive_types);
 }
 
 }  // namespace
@@ -3411,6 +3416,11 @@ const std::vector<std::shared_ptr<DataType>>& BinaryTypes() {
 const std::vector<std::shared_ptr<DataType>>& StringTypes() {
   static DataTypeVector types = {utf8(), large_utf8()};
   return types;
+}
+
+const std::vector<std::shared_ptr<DataType>>& BinaryViewTypes() {
+  std::call_once(static_data_initialized, InitStaticData);
+  return g_binary_view_types;
 }
 
 const std::vector<std::shared_ptr<DataType>>& SignedIntTypes() {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -2540,6 +2540,9 @@ const std::vector<std::shared_ptr<DataType>>& BinaryTypes();
 /// \brief String and large-string types
 ARROW_EXPORT
 const std::vector<std::shared_ptr<DataType>>& StringTypes();
+/// \brief String-view and Binary-view
+ARROW_EXPORT
+const std::vector<std::shared_ptr<DataType>>& BinaryViewTypes();
 /// \brief Temporal types including date, time and timestamps for each unit
 ARROW_EXPORT
 const std::vector<std::shared_ptr<DataType>>& TemporalTypes();

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1307,6 +1307,7 @@ TEST_F(TestUnifySchemas, Binary) {
   options.promote_binary = false;
   CheckUnifyFailsTypeError({utf8(), binary()}, {large_utf8(), large_binary()});
   CheckUnifyFailsTypeError(fixed_size_binary(2), BaseBinaryTypes());
+  CheckUnifyFailsTypeError(fixed_size_binary(2), BinaryViewTypes());
   CheckUnifyFailsTypeError(utf8(), {binary(), large_binary(), fixed_size_binary(2)});
 }
 

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -2430,6 +2430,7 @@ TEST(TypesTest, TestMembership) {
   TEST_PREDICATE(all_types, is_large_binary_like);
   TEST_PREDICATE(all_types, is_binary);
   TEST_PREDICATE(all_types, is_string);
+  TEST_PREDICATE(all_types, is_binary_view_like);
   TEST_PREDICATE(all_types, is_temporal);
   TEST_PREDICATE(all_types, is_interval);
   TEST_PREDICATE(all_types, is_dictionary);

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1201,6 +1201,21 @@ constexpr bool is_string(Type::type type_id) {
   return false;
 }
 
+/// \brief Check for a binary-view-like type (i.e. string view and binary view)
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id is a binary-view-like type one
+constexpr bool is_binary_view_like(Type::type type_id) {
+  switch (type_id) {
+    case Type::STRING_VIEW:
+    case Type::BINARY_VIEW:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
 /// \brief Check for a temporal type
 ///
 /// \param[in] type_id the type-id to check
@@ -1623,6 +1638,16 @@ static inline bool is_binary(const DataType& type) { return is_binary(type.id())
 ///
 /// Convenience for checking using the type's id
 static inline bool is_string(const DataType& type) { return is_string(type.id()); }
+
+/// \brief Check for a binary-view-like type
+///
+/// \param[in] type the type to check
+/// \return whether type is a binary-view-like type
+///
+/// Convenience for checking using the type's id
+static inline bool is_binary_view_like(const DataType& type) {
+  return is_binary_view_like(type.id());
+}
 
 /// \brief Check for a temporal type, including time and timestamps for each unit
 ///

--- a/cpp/src/arrow/util/binary_view_util.h
+++ b/cpp/src/arrow/util/binary_view_util.h
@@ -99,4 +99,17 @@ bool EqualBinaryView(BinaryViewType::c_type l, BinaryViewType::c_type r,
                 l.size() - BinaryViewType::kPrefixSize) == 0;
 }
 
+/// \brief Compute the total size of a list of binary views including null
+/// views.
+///
+/// This is useful when calculating the necessary memory to store all the string
+/// data from the views.
+inline int64_t SumOfBinaryViewSizes(const BinaryViewType::c_type* views, int64_t length) {
+  int64_t total = 0;
+  for (int64_t i = 0; i < length; ++i) {
+    total += views[i].size();
+  }
+  return total;
+}
+
 }  // namespace arrow::util

--- a/cpp/src/arrow/visit_data_inline.h
+++ b/cpp/src/arrow/visit_data_inline.h
@@ -249,7 +249,8 @@ VisitArraySpanInline(const ArraySpan& arr, ValidFunc&& valid_func, NullFunc&& nu
 // The scalar value's type depends on the array data type:
 // - the type's `c_type`, if any
 // - for boolean arrays, a `bool`
-// - for binary, string[-view] and fixed-size binary arrays, a `std::string_view`
+// - for binary, string, large binary and string, binary and string view, and fixed-size
+//   binary arrays, a `std::string_view`
 
 template <typename T>
 struct ArraySpanVisitor {

--- a/cpp/src/arrow/visit_data_inline.h
+++ b/cpp/src/arrow/visit_data_inline.h
@@ -249,7 +249,7 @@ VisitArraySpanInline(const ArraySpan& arr, ValidFunc&& valid_func, NullFunc&& nu
 // The scalar value's type depends on the array data type:
 // - the type's `c_type`, if any
 // - for boolean arrays, a `bool`
-// - for binary, string and fixed-size binary arrays, a `std::string_view`
+// - for binary, string[-view] and fixed-size binary arrays, a `std::string_view`
 
 template <typename T>
 struct ArraySpanVisitor {


### PR DESCRIPTION
### Rationale for this change

We need casts between string (binary) and string-view (binary-view) types since they are semantically equivalent.

### What changes are included in this PR?

 - Add `is_binary_view_like()` type predicate
 - Add `BinaryViewTypes()` list including `STRING_VIEW/BINARY_VIEW`
 - New cast kernels

### Are these changes tested?

Yes, but test coverage might be improved.

### Are there any user-facing changes?

More casts are available.
* GitHub Issue: #42247