### PR TITLE
GH-43305: [FlightRPC][Java] Invocation of close method from ArrowFlightConnection throws a SQLException when using catalog as parameter

### DIFF
--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightConnection.java
@@ -178,7 +178,6 @@ public final class ArrowFlightConnection extends AvaticaConnection {
     }
 
     try {
-      AutoCloseables.close(clientHandler);
       allocator.getChildAllocators().forEach(AutoCloseables::closeNoChecked);
       AutoCloseables.close(allocator);
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -220,9 +220,7 @@ public final class ArrowFlightSqlClientHandler implements AutoCloseable {
 
   @Override
   public void close() throws SQLException {
-    if (catalog.isPresent()) {
-      sqlClient.closeSession(new CloseSessionRequest(), getOptions());
-    }
+    sqlClient.closeSession(new CloseSessionRequest(), getOptions());
     try {
       AutoCloseables.close(sqlClient);
     } catch (final Exception e) {


### PR DESCRIPTION
### Rationale for this change

Changes for solving issue https://github.com/apache/arrow-java/issues/66. See that issue for details of the problem.

### What changes are included in this PR?

Do not close the `clientHandler` twice at `org.apache.arrow.driver.jdbc.ArrowFlightConnection#close`. Second call should be removed because it `clientHandler` is already closed and the executor is shutdown. 

Also, I changed the condition for calling to `org.apache.arrow.flight.sql.FlightSqlClient#closeSession` method. I do not see a reason why it has to be done only with the `catalog` was set. 

### Are these changes tested?

Still TODO. PR marked as draft for this reason.

### Are there any user-facing changes?

Users can start to receive a SQLException when calling `org.apache.arrow.driver.jdbc.ArrowFlightConnection#close`.


* GitHub Issue: apache/arrow-java#66
* GitHub Issue: #66