### PR TITLE
MINOR: [Java] Bump org.mockito:mockito-junit-jupiter from 2.25.1 to 5.12.0 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -274,7 +274,7 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>2.25.1</version>
+      <version>5.12.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Rationale for this change

Bump version now that Java 8 is deprecated. Follow up PR from https://github.com/apache/arrow/pull/39408.

### What changes are included in this PR?

* Bump mockito to 5.12.0

### Are these changes tested?

CI

### Are there any user-facing changes?

No