### PR TITLE
MINOR: [Java] Bump org.apache.derby:derby from 10.14.2.0 to 10.15.2.0 in /java

### DIFF
--- a/java/flight/flight-sql/pom.xml
+++ b/java/flight/flight-sql/pom.xml
@@ -87,7 +87,7 @@ under the License.
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.14.2.0</version>
+      <version>10.15.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSql.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSql.java
@@ -123,10 +123,10 @@ public class TestFlightSql {
         Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_NAME_VALUE), "Apache Derby");
     GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
         Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_VERSION_VALUE),
-        "10.14.2.0 - (1828579)");
+        "10.15.2.0 - (1873585)");
     GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
         Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_ARROW_VERSION_VALUE),
-        "10.14.2.0 - (1828579)");
+        "10.15.2.0 - (1873585)");
     GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(
         Integer.toString(FlightSql.SqlInfo.FLIGHT_SQL_SERVER_READ_ONLY_VALUE), "false");
     GET_SQL_INFO_EXPECTED_RESULTS_MAP.put(


### PR DESCRIPTION
### Rationale for this change

Bump to latest version that supports Java 11. See Apache Derby support matrix here https://db.apache.org/derby/derby_downloads.html

### What changes are included in this PR?

* Bump derby to 10.15.2.0

### Are these changes tested?

CI

### Are there any user-facing changes?

No