### PR TITLE
MINOR: [Java] Bump ch.qos.logback:logback-classic from 1.3.14 to 1.4.14 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -280,7 +280,7 @@ under the License.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.14</version>
+      <version>1.5.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -280,7 +280,7 @@ under the License.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.6</version>
+      <version>1.4.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -59,6 +59,7 @@ under the License.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>1.5.6</version>
       <scope>test</scope>
     </dependency>
     <!--

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -59,7 +59,7 @@ under the License.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.6</version>
+      <version>1.4.14</version>
       <scope>test</scope>
     </dependency>
     <!--

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -59,7 +59,6 @@ under the License.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.14</version>
       <scope>test</scope>
     </dependency>
     <!--


### PR DESCRIPTION
### Rationale for this change

With Java 8 deprecated, we can bump logback to the next version which supports Java 11 at build and runtime. See https://github.com/apache/arrow/pull/40778/files

### What changes are included in this PR?

* Bump logback-classic to 1.4.14

### Are these changes tested?

CI

### Are there any user-facing changes?

No