### PR TITLE
MINOR: [Java] Bump com.puppycrawl.tools:checkstyle from 8.29 to 10.17.0 in /java

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -150,7 +150,6 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
-      - run: git config --global core.autocrlf false
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -150,6 +150,7 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
+      - run: git config --global core.autocrlf false
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:

--- a/java/.gitattributes
+++ b/java/.gitattributes
@@ -1,2 +1,3 @@
 .gitattributes export-ignore
 .gitignore export-ignore
+* text eol=lf

--- a/java/.gitattributes
+++ b/java/.gitattributes
@@ -1,3 +1,3 @@
 .gitattributes export-ignore
 .gitignore export-ignore
-* text eol=lf
+* text=auto eol=lf

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -180,7 +180,7 @@
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -48,7 +48,9 @@
       <property name="file" value="${checkstyle.suppressions.file}"/>
     </module>
 
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Google style modules -->
 

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -48,9 +48,7 @@
       <property name="file" value="${checkstyle.suppressions.file}"/>
     </module>
 
-    <module name="NewlineAtEndOfFile">
-        <property name="lineSeparator" value="lf" />
-    </module>
+    <module name="NewlineAtEndOfFile"/>
 
     <!-- Google style modules -->
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/VectorSchemaRootTransformer.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/VectorSchemaRootTransformer.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
@@ -44,6 +45,12 @@ public interface VectorSchemaRootTransformer {
     private final List<Field> newFields = new ArrayList<>();
     private final Collection<Task> tasks = new ArrayList<>();
 
+    /**
+     * Constructor for the VectorSchemaRootTransformer's Builder.
+     *
+     * @param schema The Arrow schema.
+     * @param bufferAllocator The BufferAllocator to use for allocating memory.
+     */
     public Builder(final Schema schema, final BufferAllocator bufferAllocator) {
       this.schema = schema;
       this.bufferAllocator =
@@ -127,6 +134,11 @@ public interface VectorSchemaRootTransformer {
       return this;
     }
 
+    /**
+     * Build the {@link VectorSchemaRoot} with applied transformation tasks.
+     *
+     * @return The built {@link VectorSchemaRoot}.
+     */
     public VectorSchemaRootTransformer build() {
       return (originalRoot, transformedRoot) -> {
         if (transformedRoot == null) {

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/VectorSchemaRootTransformer.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/VectorSchemaRootTransformer.java
@@ -17,7 +17,6 @@
 package org.apache.arrow.driver.jdbc.utils;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -719,7 +719,7 @@ under the License.
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.29</version>
+            <version>10.17.0</version>
           </dependency>
           <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -403,7 +403,7 @@ under the License.
                   <pluginExecutionFilter>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <versionRange>[0,)</versionRange>
                     <goals>
                       <goal>check</goal>
                     </goals>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -403,7 +403,7 @@ under the License.
                   <pluginExecutionFilter>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <versionRange>[0,)</versionRange>
+                    <version>3.4.0</version>
                     <goals>
                       <goal>check</goal>
                     </goals>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -719,7 +719,6 @@ under the License.
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.17.0</version>
           </dependency>
           <dependency>
             <groupId>org.slf4j</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -717,10 +717,6 @@ under the License.
         </configuration>
         <dependencies>
           <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-          </dependency>
-          <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>${dep.slf4j.version}</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -105,6 +105,7 @@ under the License.
     <dep.avro.version>1.11.3</dep.avro.version>
     <arrow.vector.classifier></arrow.vector.classifier>
     <forkCount>2</forkCount>
+    <checkstyle.version>10.17.0</checkstyle.version>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <error_prone_core.version>2.29.2</error_prone_core.version>
     <mockito.core.version>5.11.0</mockito.core.version>
@@ -716,6 +717,11 @@ under the License.
           <linkXRef>false</linkXRef>
         </configuration>
         <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+          </dependency>
           <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -453,9 +453,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -259,9 +259,9 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Override
   @Deprecated

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -275,9 +275,9 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthViewVector.java
@@ -315,9 +315,9 @@ public abstract class BaseVariableWidthViewVector extends BaseValueVector
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -233,9 +233,9 @@ public abstract class ExtensionTypeVector<T extends ValueVector & FieldVector>
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
@@ -111,9 +111,9 @@ public interface FieldVector extends ValueVector {
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   List<BufferBacked> getFieldInnerVectors();

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -224,9 +224,9 @@ public class NullVector implements FieldVector, ValueIterableVector<Object> {
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -142,9 +142,9 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector
   /**
    * Get the offset vector.
    *
+   * @return the underlying offset vector or null if none exists.
    * @deprecated This API will be removed, as the current implementations no longer hold inner
    *     offset vectors.
-   * @return the underlying offset vector or null if none exists.
    */
   @Override
   @Deprecated

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -319,9 +319,9 @@ public class LargeListVector extends BaseValueVector
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override
@@ -494,9 +494,9 @@ public class LargeListVector extends BaseValueVector
   /**
    * Get the offset vector.
    *
+   * @return the underlying offset vector or null if none exists.
    * @deprecated This API will be removed, as the current implementations no longer hold inner
    *     offset vectors.
-   * @return the underlying offset vector or null if none exists.
    */
   @Override
   @Deprecated

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -277,9 +277,9 @@ public class ListVector extends BaseRepeatedValueVector
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedValueVector.java
@@ -35,9 +35,9 @@ public interface RepeatedValueVector extends ValueVector, DensityAwareVector {
   /**
    * Get the offset vector.
    *
+   * @return the underlying offset vector or null if none exists.
    * @deprecated This API will be removed, as the current implementations no longer hold inner
    *     offset vectors.
-   * @return the underlying offset vector or null if none exists.
    */
   @Deprecated
   UInt4Vector getOffsetVector();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -188,9 +188,9 @@ public class StructVector extends NonNullableStructVector
   /**
    * Get the inner vectors.
    *
+   * @return the inner vectors for this field as defined by the TypeLayout
    * @deprecated This API will be removed as the current implementations no longer support inner
    *     vectors.
-   * @return the inner vectors for this field as defined by the TypeLayout
    */
   @Deprecated
   @Override


### PR DESCRIPTION
### Rationale for this change

Now that Java 8 is deprecated, we can bump checkstyle to latest version.

### What changes are included in this PR?

* Bump checkstyle to 10.17.0
* Update checkstyle.xml to fix backwards-breaking changes
* Fix new check errors

### Are these changes tested?

CI

### Are there any user-facing changes?

No