### PR TITLE
GH-43320: [Java] fix for SchemaChangeRuntimeException transferring empty FixedSizeListVector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -602,7 +602,9 @@ public class FixedSizeListVector extends BaseValueVector
 
     public TransferImpl(FixedSizeListVector to) {
       this.to = to;
-      to.addOrGetVector(vector.getField().getFieldType());
+      if (!(vector instanceof ZeroVector)) {
+        to.addOrGetVector(vector.getField().getFieldType());
+      }
       dataPair = vector.makeTransferPair(to.vector);
     }
 


### PR DESCRIPTION
### What changes are included in this PR?

When we create a FSLV through TransferImpl, we check to see if the source's element vector is a ZeroVector and, if not, we don't call addOrGetVector.

### Are these changes tested?

Yep - see TestFixedSizeListVector

### Are there any user-facing changes?

No
* GitHub Issue: #43320