### PR TITLE
MINOR: [Docs][Java] Add Apache Staging url to docs

### DIFF
--- a/docs/source/developers/java/building.rst
+++ b/docs/source/developers/java/building.rst
@@ -335,7 +335,6 @@ Arrow repository, and update the following settings:
   right click the directory, and select Mark Directory as > Generated Sources
   Root. There is no need to mark other generated sources directories, as only
   the ``vector`` module generates sources.
-* For JDK 8, disable the ``error-prone`` profile to build the project successfully.
 * For JDK 11, due to an `IntelliJ bug
   <https://youtrack.jetbrains.com/issue/IDEA-201168>`__, you must go into
   Settings > Build, Execution, Deployment > Compiler > Java Compiler and disable
@@ -538,3 +537,40 @@ Installing Manually
 
 .. _builds@arrow.apache.org: https://lists.apache.org/list.html?builds@arrow.apache.org
 .. _GitHub Nightly: https://github.com/ursacomputing/crossbow/releases/tag/nightly-packaging-2022-07-30-0-github-java-jars
+
+Installing Staging Packages
+===========================
+
+.. warning::
+    These packages are not official releases. Use them at your own risk.
+
+Arrow staging builds are created when a Release Candidate (RC) is being prepared. This allows users to test the RC in their applications before voting on the release.
+
+
+Installing from Apache Staging
+--------------------------------
+1. Look up the next version number for the Arrow libraries used.
+
+2. Add Apache Staging Repository to the Maven/Gradle project.
+
+   .. code-block:: xml
+
+      <properties>
+         <arrow.version>9.0.0</arrow.version>
+      </properties>
+      ...
+      <repositories>
+         <repository>
+               <id>arrow-apache-staging</id>
+               <url>https://repository.apache.org/content/repositories/staging</url>
+         </repository>
+      </repositories>
+      ...
+      <dependencies>
+         <dependency>
+               <groupId>org.apache.arrow</groupId>
+               <artifactId>arrow-vector</artifactId>
+               <version>${arrow.version}</version>
+         </dependency>
+      </dependencies>
+      ...

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -29,8 +29,8 @@ Java modules are regularly built and tested on macOS and Linux distributions.
 Java Compatibility
 ==================
 
-Java modules are compatible with JDK 8 and above. Currently, JDK versions
-11, 17, and 21 are tested in CI. The latest JDK is also tested in CI.
+Java modules are compatible with JDK 11 and above. Currently, JDK versions
+11, 17, 21, and latest are tested in CI.
 
 Note that some JDK internals must be exposed by
 adding ``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`` to the ``java`` command:


### PR DESCRIPTION
### Rationale for this change

* The JAR staging location is not documented, let's fix that.

### What changes are included in this PR?

* Add Arrow Java Apache Staging URL to docs.
* Remove lingering JDK 8 references.

### Are these changes tested?

Yes - screenshot shared below

### Are there any user-facing changes?

Yes, improved documentation on the Arrow website.