### PR TITLE
GH-39789: [Go][Parquet] Close current row group when finished writing unbuffered batch

### DIFF
--- a/go/parquet/pqarrow/file_writer.go
+++ b/go/parquet/pqarrow/file_writer.go
@@ -246,7 +246,7 @@ func (fw *FileWriter) Write(rec arrow.Record) error {
 		}
 	}
 	fw.colIdx = 0
-	return nil
+	return fw.rgw.Close()
 }
 
 // WriteTable writes an arrow table to the underlying file using chunkSize to determine

--- a/go/parquet/pqarrow/file_writer_test.go
+++ b/go/parquet/pqarrow/file_writer_test.go
@@ -55,7 +55,11 @@ func TestFileWriterRowGroupNumRows(t *testing.T) {
 	numRows, err := writer.RowGroupNumRows()
 	require.NoError(t, err)
 	assert.Equal(t, 4, numRows)
+
+	// Make sure that row group stats are up-to-date immediately after writing
+	bytesWritten := writer.RowGroupTotalBytesWritten()
 	require.NoError(t, writer.Close())
+	require.Equal(t, bytesWritten, writer.RowGroupTotalBytesWritten())
 }
 
 func TestFileWriterNumRows(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Fixes: #39789

The number of bytes reported by `FileWriter.RowGroupTotalBytesWritten()` was consistently lower than the actual bytes in the output buffer, if it was read before closing the writer. The issue is that the last column's data page was not flushed until the entire writer was closed, causing it's bytes not to be included in the total. By closing the row group writer before returning from `Write()`, we can ensure all pages are flushed and the totalBytesWritten will be accurate.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Close row group writer before returning from `FileWriter.Write()`
- Test to ensure stats are up to date _before_ closing the writer

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

`FileWriter.RowGroupTotalBytesWritten()` will be accurate when read while still writing to the file.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #39789