### PR TITLE
GH-43167: [C++] Add workaround for missing Boost dependency of Thrift

### DIFF
--- a/cpp/cmake_modules/FindThriftAlt.cmake
+++ b/cpp/cmake_modules/FindThriftAlt.cmake
@@ -191,6 +191,10 @@ if(ThriftAlt_FOUND)
     # thrift/windows/config.h for Visual C++.
     set_target_properties(thrift::thrift PROPERTIES INTERFACE_LINK_LIBRARIES "ws2_32")
   endif()
+  # Workaround: thrift.pc doesn't have Boost dependency.
+  if(TARGET Boost::headers)
+    target_link_libraries(thrift::thrift INTERFACE Boost::headers)
+  endif()
 
   if(Thrift_COMPILER_FOUND)
     add_executable(thrift::compiler IMPORTED)


### PR DESCRIPTION
### Rationale for this change

Apache Thrift uses Boost but `thrift.pc` doesn't have `-I${BOOST_INCLUDE_DIR}`. 

### What changes are included in this PR?

Add Boost dependency in our side as a workaround.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #43167