### PR TITLE
GH-43329: [C++] Order classes in flight/types.h according to Flight.proto

### DIFF
--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -151,6 +151,26 @@ Status MakeFlightError(FlightStatusCode code, std::string message,
                        std::make_shared<FlightStatusDetail>(code, std::move(extra_info)));
 }
 
+//------------------------------------------------------------
+// Wrapper types for Flight RPC protobuf messages
+
+std::string BasicAuth::ToString() const {
+  return arrow::util::StringBuilder("<BasicAuth username='", username,
+                                    "' password=(redacted)>");
+}
+
+bool BasicAuth::Equals(const BasicAuth& other) const {
+  return (username == other.username) && (password == other.password);
+}
+
+arrow::Status BasicAuth::Deserialize(std::string_view serialized, BasicAuth* out) {
+  return DeserializeProtoString<pb::BasicAuth, BasicAuth>("BasicAuth", serialized, out);
+}
+
+arrow::Status BasicAuth::SerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::BasicAuth>("BasicAuth", *this, out);
+}
+
 std::string FlightDescriptor::ToString() const {
   std::stringstream ss;
   ss << "<FlightDescriptor ";
@@ -964,6 +984,8 @@ std::ostream& operator<<(std::ostream& os, CancelStatus status) {
   return os;
 }
 
+//------------------------------------------------------------
+
 Status ResultStream::Drain() {
   while (true) {
     ARROW_ASSIGN_OR_RAISE(auto result, Next());
@@ -1049,23 +1071,6 @@ arrow::Result<std::unique_ptr<Result>> SimpleResultStream::Next() {
     return nullptr;
   }
   return std::make_unique<Result>(std::move(results_[position_++]));
-}
-
-std::string BasicAuth::ToString() const {
-  return arrow::util::StringBuilder("<BasicAuth username='", username,
-                                    "' password=(redacted)>");
-}
-
-bool BasicAuth::Equals(const BasicAuth& other) const {
-  return (username == other.username) && (password == other.password);
-}
-
-arrow::Status BasicAuth::Deserialize(std::string_view serialized, BasicAuth* out) {
-  return DeserializeProtoString<pb::BasicAuth, BasicAuth>("BasicAuth", serialized, out);
-}
-
-arrow::Status BasicAuth::SerializeToString(std::string* out) const {
-  return SerializeToProtoString<pb::BasicAuth>("BasicAuth", *this, out);
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -212,20 +212,6 @@ bool FlightDescriptor::Equals(const FlightDescriptor& other) const {
   }
 }
 
-Status FlightPayload::Validate() const {
-  static constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
-  if (descriptor && descriptor->size() > kInt32Max) {
-    return Status::CapacityError("Descriptor size overflow (>= 2**31)");
-  }
-  if (app_metadata && app_metadata->size() > kInt32Max) {
-    return Status::CapacityError("app_metadata size overflow (>= 2**31)");
-  }
-  if (ipc_message.body_length > kInt32Max) {
-    return Status::Invalid("Cannot send record batches exceeding 2GiB yet");
-  }
-  return Status::OK();
-}
-
 arrow::Status FlightDescriptor::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::FlightDescriptor>("FlightDescriptor", *this, out);
 }
@@ -841,6 +827,20 @@ arrow::Status RenewFlightEndpointRequest::Deserialize(std::string_view serialize
   return DeserializeProtoString<pb::RenewFlightEndpointRequest,
                                 RenewFlightEndpointRequest>("RenewFlightEndpointRequest",
                                                             serialized, out);
+}
+
+Status FlightPayload::Validate() const {
+  static constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
+  if (descriptor && descriptor->size() > kInt32Max) {
+    return Status::CapacityError("Descriptor size overflow (>= 2**31)");
+  }
+  if (app_metadata && app_metadata->size() > kInt32Max) {
+    return Status::CapacityError("app_metadata size overflow (>= 2**31)");
+  }
+  if (ipc_message.body_length > kInt32Max) {
+    return Status::Invalid("Cannot send record batches exceeding 2GiB yet");
+  }
+  return Status::OK();
 }
 
 std::string ActionType::ToString() const {

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -268,22 +268,6 @@ arrow::Status FlightDescriptor::Deserialize(std::string_view serialized,
       "FlightDescriptor", serialized, out);
 }
 
-std::string Ticket::ToString() const {
-  std::stringstream ss;
-  ss << "<Ticket ticket='" << ticket << "'>";
-  return ss.str();
-}
-
-bool Ticket::Equals(const Ticket& other) const { return ticket == other.ticket; }
-
-arrow::Status Ticket::SerializeToString(std::string* out) const {
-  return SerializeToProtoString<pb::Ticket>("Ticket", *this, out);
-}
-
-arrow::Status Ticket::Deserialize(std::string_view serialized, Ticket* out) {
-  return DeserializeProtoString<pb::Ticket, Ticket>("Ticket", serialized, out);
-}
-
 arrow::Result<FlightInfo> FlightInfo::Make(const Schema& schema,
                                            const FlightDescriptor& descriptor,
                                            const std::vector<FlightEndpoint>& endpoints,
@@ -691,6 +675,22 @@ arrow::Status CloseSessionResult::Deserialize(std::string_view serialized,
                                               CloseSessionResult* out) {
   return DeserializeProtoString<pb::CloseSessionResult, CloseSessionResult>(
       "CloseSessionResult", serialized, out);
+}
+
+std::string Ticket::ToString() const {
+  std::stringstream ss;
+  ss << "<Ticket ticket='" << ticket << "'>";
+  return ss.str();
+}
+
+bool Ticket::Equals(const Ticket& other) const { return ticket == other.ticket; }
+
+arrow::Status Ticket::SerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::Ticket>("Ticket", *this, out);
+}
+
+arrow::Status Ticket::Deserialize(std::string_view serialized, Ticket* out) {
+  return DeserializeProtoString<pb::Ticket, Ticket>("Ticket", serialized, out);
 }
 
 Location::Location() { uri_ = std::make_shared<arrow::util::Uri>(); }

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -226,38 +226,6 @@ Status FlightPayload::Validate() const {
   return Status::OK();
 }
 
-arrow::Result<std::shared_ptr<Schema>> SchemaResult::GetSchema(
-    ipc::DictionaryMemo* dictionary_memo) const {
-  // Create a non-owned Buffer to avoid copying
-  io::BufferReader schema_reader(std::make_shared<Buffer>(raw_schema_));
-  return ipc::ReadSchema(&schema_reader, dictionary_memo);
-}
-
-arrow::Result<std::unique_ptr<SchemaResult>> SchemaResult::Make(const Schema& schema) {
-  std::string schema_in;
-  RETURN_NOT_OK(internal::SchemaToString(schema, &schema_in));
-  return std::make_unique<SchemaResult>(std::move(schema_in));
-}
-
-std::string SchemaResult::ToString() const {
-  return "<SchemaResult raw_schema=(serialized)>";
-}
-
-bool SchemaResult::Equals(const SchemaResult& other) const {
-  return raw_schema_ == other.raw_schema_;
-}
-
-arrow::Status SchemaResult::SerializeToString(std::string* out) const {
-  return SerializeToProtoString<pb::SchemaResult>("SchemaResult", *this, out);
-}
-
-arrow::Status SchemaResult::Deserialize(std::string_view serialized, SchemaResult* out) {
-  pb::SchemaResult pb_schema_result;
-  RETURN_NOT_OK(ParseFromString("SchemaResult", serialized, &pb_schema_result));
-  *out = SchemaResult{pb_schema_result.schema()};
-  return Status::OK();
-}
-
 arrow::Status FlightDescriptor::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::FlightDescriptor>("FlightDescriptor", *this, out);
 }
@@ -982,6 +950,38 @@ arrow::Status Result::SerializeToString(std::string* out) const {
 
 arrow::Status Result::Deserialize(std::string_view serialized, Result* out) {
   return DeserializeProtoString<pb::Result, Result>("Result", serialized, out);
+}
+
+arrow::Result<std::shared_ptr<Schema>> SchemaResult::GetSchema(
+    ipc::DictionaryMemo* dictionary_memo) const {
+  // Create a non-owned Buffer to avoid copying
+  io::BufferReader schema_reader(std::make_shared<Buffer>(raw_schema_));
+  return ipc::ReadSchema(&schema_reader, dictionary_memo);
+}
+
+arrow::Result<std::unique_ptr<SchemaResult>> SchemaResult::Make(const Schema& schema) {
+  std::string schema_in;
+  RETURN_NOT_OK(internal::SchemaToString(schema, &schema_in));
+  return std::make_unique<SchemaResult>(std::move(schema_in));
+}
+
+std::string SchemaResult::ToString() const {
+  return "<SchemaResult raw_schema=(serialized)>";
+}
+
+bool SchemaResult::Equals(const SchemaResult& other) const {
+  return raw_schema_ == other.raw_schema_;
+}
+
+arrow::Status SchemaResult::SerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::SchemaResult>("SchemaResult", *this, out);
+}
+
+arrow::Status SchemaResult::Deserialize(std::string_view serialized, SchemaResult* out) {
+  pb::SchemaResult pb_schema_result;
+  RETURN_NOT_OK(ParseFromString("SchemaResult", serialized, &pb_schema_result));
+  *out = SchemaResult{pb_schema_result.schema()};
+  return Status::OK();
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -151,20 +151,6 @@ Status MakeFlightError(FlightStatusCode code, std::string message,
                        std::make_shared<FlightStatusDetail>(code, std::move(extra_info)));
 }
 
-bool FlightDescriptor::Equals(const FlightDescriptor& other) const {
-  if (type != other.type) {
-    return false;
-  }
-  switch (type) {
-    case PATH:
-      return path == other.path;
-    case CMD:
-      return cmd == other.cmd;
-    default:
-      return false;
-  }
-}
-
 std::string FlightDescriptor::ToString() const {
   std::stringstream ss;
   ss << "<FlightDescriptor ";
@@ -190,6 +176,20 @@ std::string FlightDescriptor::ToString() const {
   }
   ss << ">";
   return ss.str();
+}
+
+bool FlightDescriptor::Equals(const FlightDescriptor& other) const {
+  if (type != other.type) {
+    return false;
+  }
+  switch (type) {
+    case PATH:
+      return path == other.path;
+    case CMD:
+      return cmd == other.cmd;
+    default:
+      return false;
+  }
 }
 
 Status FlightPayload::Validate() const {
@@ -712,7 +712,6 @@ arrow::Result<Location> Location::ForScheme(const std::string& scheme,
   return Location::Parse(uri_string.str());
 }
 
-std::string Location::ToString() const { return uri_->ToString(); }
 std::string Location::scheme() const {
   std::string scheme = uri_->scheme();
   if (scheme.empty()) {
@@ -721,6 +720,8 @@ std::string Location::scheme() const {
   }
   return scheme;
 }
+
+std::string Location::ToString() const { return uri_->ToString(); }
 
 bool Location::Equals(const Location& other) const {
   return ToString() == other.ToString();

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -435,6 +435,45 @@ arrow::Status CancelFlightInfoRequest::Deserialize(std::string_view serialized,
       "CancelFlightInfoRequest", serialized, out);
 }
 
+std::string CancelFlightInfoResult::ToString() const {
+  std::stringstream ss;
+  ss << "<CancelFlightInfoResult status=" << status << ">";
+  return ss.str();
+}
+
+bool CancelFlightInfoResult::Equals(const CancelFlightInfoResult& other) const {
+  return status == other.status;
+}
+
+arrow::Status CancelFlightInfoResult::SerializeToString(std::string* out) const {
+  return SerializeToProtoString<pb::CancelFlightInfoResult>("CancelFlightInfoResult",
+                                                            *this, out);
+}
+
+arrow::Status CancelFlightInfoResult::Deserialize(std::string_view serialized,
+                                                  CancelFlightInfoResult* out) {
+  return DeserializeProtoString<pb::CancelFlightInfoResult, CancelFlightInfoResult>(
+      "CancelFlightInfoResult", serialized, out);
+}
+
+std::ostream& operator<<(std::ostream& os, CancelStatus status) {
+  switch (status) {
+    case CancelStatus::kUnspecified:
+      os << "Unspecified";
+      break;
+    case CancelStatus::kCancelled:
+      os << "Cancelled";
+      break;
+    case CancelStatus::kCancelling:
+      os << "Cancelling";
+      break;
+    case CancelStatus::kNotCancellable:
+      os << "NotCancellable";
+      break;
+  }
+  return os;
+}
+
 static const char* const SetSessionOptionStatusNames[] = {"Unspecified", "InvalidName",
                                                           "InvalidValue", "Error"};
 static const char* const CloseSessionStatusNames[] = {"Unspecified", "Closed", "Closing",
@@ -943,45 +982,6 @@ arrow::Status Result::SerializeToString(std::string* out) const {
 
 arrow::Status Result::Deserialize(std::string_view serialized, Result* out) {
   return DeserializeProtoString<pb::Result, Result>("Result", serialized, out);
-}
-
-std::string CancelFlightInfoResult::ToString() const {
-  std::stringstream ss;
-  ss << "<CancelFlightInfoResult status=" << status << ">";
-  return ss.str();
-}
-
-bool CancelFlightInfoResult::Equals(const CancelFlightInfoResult& other) const {
-  return status == other.status;
-}
-
-arrow::Status CancelFlightInfoResult::SerializeToString(std::string* out) const {
-  return SerializeToProtoString<pb::CancelFlightInfoResult>("CancelFlightInfoResult",
-                                                            *this, out);
-}
-
-arrow::Status CancelFlightInfoResult::Deserialize(std::string_view serialized,
-                                                  CancelFlightInfoResult* out) {
-  return DeserializeProtoString<pb::CancelFlightInfoResult, CancelFlightInfoResult>(
-      "CancelFlightInfoResult", serialized, out);
-}
-
-std::ostream& operator<<(std::ostream& os, CancelStatus status) {
-  switch (status) {
-    case CancelStatus::kUnspecified:
-      os << "Unspecified";
-      break;
-    case CancelStatus::kCancelled:
-      os << "Cancelled";
-      break;
-    case CancelStatus::kCancelling:
-      os << "Cancelling";
-      break;
-    case CancelStatus::kNotCancellable:
-      os << "NotCancellable";
-      break;
-  }
-  return os;
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -61,6 +61,18 @@ class Uri;
 
 namespace flight {
 
+ARROW_FLIGHT_EXPORT
+extern const char* kSchemeGrpc;
+ARROW_FLIGHT_EXPORT
+extern const char* kSchemeGrpcTcp;
+ARROW_FLIGHT_EXPORT
+extern const char* kSchemeGrpcUnix;
+ARROW_FLIGHT_EXPORT
+extern const char* kSchemeGrpcTls;
+
+class FlightClient;
+class FlightServerBase;
+
 /// \brief A timestamp compatible with Protocol Buffer's
 /// google.protobuf.Timestamp:
 ///
@@ -500,18 +512,6 @@ struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
   /// Use `Deserialize(serialized)` if you want a Result-returning version.
   static arrow::Status Deserialize(std::string_view serialized, Ticket* out);
 };
-
-class FlightClient;
-class FlightServerBase;
-
-ARROW_FLIGHT_EXPORT
-extern const char* kSchemeGrpc;
-ARROW_FLIGHT_EXPORT
-extern const char* kSchemeGrpcTcp;
-ARROW_FLIGHT_EXPORT
-extern const char* kSchemeGrpcUnix;
-ARROW_FLIGHT_EXPORT
-extern const char* kSchemeGrpcTls;
 
 /// \brief A host location (a URI)
 struct ARROW_FLIGHT_EXPORT Location : public internal::BaseType<Location> {

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -473,195 +473,6 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   }
 };
 
-/// \brief Data structure providing an opaque identifier or credential to use
-/// when requesting a data stream with the DoGet RPC
-struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
-  std::string ticket;
-
-  Ticket() = default;
-  Ticket(std::string ticket)  // NOLINT runtime/explicit
-      : ticket(std::move(ticket)) {}
-
-  std::string ToString() const;
-  bool Equals(const Ticket& other) const;
-
-  using SuperT::Deserialize;
-  using SuperT::SerializeToString;
-
-  /// \brief Get the wire-format representation of this type.
-  ///
-  /// Useful when interoperating with non-Flight systems (e.g. REST
-  /// services) that may want to return Flight types.
-  ///
-  /// Use `SerializeToString()` if you want a Result-returning version.
-  arrow::Status SerializeToString(std::string* out) const;
-
-  /// \brief Parse the wire-format representation of this type.
-  ///
-  /// Useful when interoperating with non-Flight systems (e.g. REST
-  /// services) that may want to return Flight types.
-  ///
-  /// Use `Deserialize(serialized)` if you want a Result-returning version.
-  static arrow::Status Deserialize(std::string_view serialized, Ticket* out);
-};
-
-/// \brief A host location (a URI)
-struct ARROW_FLIGHT_EXPORT Location : public internal::BaseType<Location> {
- public:
-  /// \brief Initialize a blank location.
-  Location();
-
-  /// \brief Initialize a location by parsing a URI string
-  static arrow::Result<Location> Parse(const std::string& uri_string);
-
-  /// \brief Get the fallback URI.
-  ///
-  /// arrow-flight-reuse-connection://? means that a client may attempt to
-  /// reuse an existing connection to a Flight service to fetch data instead
-  /// of creating a new connection to one of the other locations listed in a
-  /// FlightEndpoint response.
-  static const Location& ReuseConnection();
-
-  /// \brief Initialize a location for a non-TLS, gRPC-based Flight
-  /// service from a host and port
-  /// \param[in] host The hostname to connect to
-  /// \param[in] port The port
-  /// \return Arrow result with the resulting location
-  static arrow::Result<Location> ForGrpcTcp(const std::string& host, const int port);
-
-  /// \brief Initialize a location for a TLS-enabled, gRPC-based Flight
-  /// service from a host and port
-  /// \param[in] host The hostname to connect to
-  /// \param[in] port The port
-  /// \return Arrow result with the resulting location
-  static arrow::Result<Location> ForGrpcTls(const std::string& host, const int port);
-
-  /// \brief Initialize a location for a domain socket-based Flight
-  /// service
-  /// \param[in] path The path to the domain socket
-  /// \return Arrow result with the resulting location
-  static arrow::Result<Location> ForGrpcUnix(const std::string& path);
-
-  /// \brief Initialize a location based on a URI scheme
-  static arrow::Result<Location> ForScheme(const std::string& scheme,
-                                           const std::string& host, const int port);
-
-  /// \brief Get the scheme of this URI.
-  std::string scheme() const;
-
-  /// \brief Get a representation of this URI as a string.
-  std::string ToString() const;
-  bool Equals(const Location& other) const;
-
-  using SuperT::Deserialize;
-  using SuperT::SerializeToString;
-
-  /// \brief Serialize this message to its wire-format representation.
-  ///
-  /// Use `SerializeToString()` if you want a Result-returning version.
-  arrow::Status SerializeToString(std::string* out) const;
-
-  /// \brief Deserialize this message from its wire-format representation.
-  ///
-  /// Use `Deserialize(serialized)` if you want a Result-returning version.
-  static arrow::Status Deserialize(std::string_view serialized, Location* out);
-
- private:
-  friend class FlightClient;
-  friend class FlightServerBase;
-  std::shared_ptr<arrow::util::Uri> uri_;
-};
-
-/// \brief A flight ticket and list of locations where the ticket can be
-/// redeemed
-struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndpoint> {
-  /// Opaque ticket identify; use with DoGet RPC
-  Ticket ticket;
-
-  /// List of locations where ticket can be redeemed. If the list is empty, the
-  /// ticket can only be redeemed on the current service where the ticket was
-  /// generated
-  std::vector<Location> locations;
-
-  /// Expiration time of this stream. If present, clients may assume
-  /// they can retry DoGet requests. Otherwise, clients should avoid
-  /// retrying DoGet requests.
-  std::optional<Timestamp> expiration_time;
-
-  /// Opaque Application-defined metadata
-  std::string app_metadata;
-
-  FlightEndpoint() = default;
-  FlightEndpoint(Ticket ticket, std::vector<Location> locations,
-                 std::optional<Timestamp> expiration_time, std::string app_metadata)
-      : ticket(std::move(ticket)),
-        locations(std::move(locations)),
-        expiration_time(expiration_time),
-        app_metadata(std::move(app_metadata)) {}
-
-  std::string ToString() const;
-  bool Equals(const FlightEndpoint& other) const;
-
-  using SuperT::Deserialize;
-  using SuperT::SerializeToString;
-
-  /// \brief Serialize this message to its wire-format representation.
-  ///
-  /// Use `SerializeToString()` if you want a Result-returning version.
-  arrow::Status SerializeToString(std::string* out) const;
-
-  /// \brief Deserialize this message from its wire-format representation.
-  ///
-  /// Use `Deserialize(serialized)` if you want a Result-returning version.
-  static arrow::Status Deserialize(std::string_view serialized, FlightEndpoint* out);
-};
-
-/// \brief The request of the RenewFlightEndpoint action.
-struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
-    : public internal::BaseType<RenewFlightEndpointRequest> {
-  FlightEndpoint endpoint;
-
-  RenewFlightEndpointRequest() = default;
-  explicit RenewFlightEndpointRequest(FlightEndpoint endpoint)
-      : endpoint(std::move(endpoint)) {}
-
-  std::string ToString() const;
-  bool Equals(const RenewFlightEndpointRequest& other) const;
-
-  using SuperT::Deserialize;
-  using SuperT::SerializeToString;
-
-  /// \brief Serialize this message to its wire-format representation.
-  ///
-  /// Use `SerializeToString()` if you want a Result-returning version.
-  arrow::Status SerializeToString(std::string* out) const;
-
-  /// \brief Deserialize this message from its wire-format representation.
-  ///
-  /// Use `Deserialize(serialized)` if you want a Result-returning version.
-  static arrow::Status Deserialize(std::string_view serialized,
-                                   RenewFlightEndpointRequest* out);
-};
-
-/// \brief Staging data structure for messages about to be put on the wire
-///
-/// This structure corresponds to FlightData in the protocol.
-struct ARROW_FLIGHT_EXPORT FlightPayload {
-  std::shared_ptr<Buffer> descriptor;
-  std::shared_ptr<Buffer> app_metadata;
-  ipc::IpcPayload ipc_message;
-
-  FlightPayload() = default;
-  FlightPayload(std::shared_ptr<Buffer> descriptor, std::shared_ptr<Buffer> app_metadata,
-                ipc::IpcPayload ipc_message)
-      : descriptor(std::move(descriptor)),
-        app_metadata(std::move(app_metadata)),
-        ipc_message(std::move(ipc_message)) {}
-
-  /// \brief Check that the payload can be written to the wire.
-  Status Validate() const;
-};
-
 /// \brief The access coordinates for retrieval of a dataset, returned by
 /// GetFlightInfo
 class ARROW_FLIGHT_EXPORT FlightInfo
@@ -896,6 +707,197 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
 
 ARROW_FLIGHT_EXPORT
 std::ostream& operator<<(std::ostream& os, CancelStatus status);
+
+/// \brief Data structure providing an opaque identifier or credential to use
+/// when requesting a data stream with the DoGet RPC
+struct ARROW_FLIGHT_EXPORT Ticket : public internal::BaseType<Ticket> {
+  std::string ticket;
+
+  Ticket() = default;
+  Ticket(std::string ticket)  // NOLINT runtime/explicit
+      : ticket(std::move(ticket)) {}
+
+  std::string ToString() const;
+  bool Equals(const Ticket& other) const;
+
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
+  /// \brief Get the wire-format representation of this type.
+  ///
+  /// Useful when interoperating with non-Flight systems (e.g. REST
+  /// services) that may want to return Flight types.
+  ///
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
+
+  /// \brief Parse the wire-format representation of this type.
+  ///
+  /// Useful when interoperating with non-Flight systems (e.g. REST
+  /// services) that may want to return Flight types.
+  ///
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, Ticket* out);
+};
+
+/// \brief A host location (a URI)
+struct ARROW_FLIGHT_EXPORT Location : public internal::BaseType<Location> {
+ public:
+  /// \brief Initialize a blank location.
+  Location();
+
+  /// \brief Initialize a location by parsing a URI string
+  static arrow::Result<Location> Parse(const std::string& uri_string);
+
+  /// \brief Get the fallback URI.
+  ///
+  /// arrow-flight-reuse-connection://? means that a client may attempt to
+  /// reuse an existing connection to a Flight service to fetch data instead
+  /// of creating a new connection to one of the other locations listed in a
+  /// FlightEndpoint response.
+  static const Location& ReuseConnection();
+
+  /// \brief Initialize a location for a non-TLS, gRPC-based Flight
+  /// service from a host and port
+  /// \param[in] host The hostname to connect to
+  /// \param[in] port The port
+  /// \return Arrow result with the resulting location
+  static arrow::Result<Location> ForGrpcTcp(const std::string& host, const int port);
+
+  /// \brief Initialize a location for a TLS-enabled, gRPC-based Flight
+  /// service from a host and port
+  /// \param[in] host The hostname to connect to
+  /// \param[in] port The port
+  /// \return Arrow result with the resulting location
+  static arrow::Result<Location> ForGrpcTls(const std::string& host, const int port);
+
+  /// \brief Initialize a location for a domain socket-based Flight
+  /// service
+  /// \param[in] path The path to the domain socket
+  /// \return Arrow result with the resulting location
+  static arrow::Result<Location> ForGrpcUnix(const std::string& path);
+
+  /// \brief Initialize a location based on a URI scheme
+  static arrow::Result<Location> ForScheme(const std::string& scheme,
+                                           const std::string& host, const int port);
+
+  /// \brief Get the scheme of this URI.
+  std::string scheme() const;
+
+  /// \brief Get a representation of this URI as a string.
+  std::string ToString() const;
+  bool Equals(const Location& other) const;
+
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
+  /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, Location* out);
+
+ private:
+  friend class FlightClient;
+  friend class FlightServerBase;
+  std::shared_ptr<arrow::util::Uri> uri_;
+};
+
+/// \brief A flight ticket and list of locations where the ticket can be
+/// redeemed
+struct ARROW_FLIGHT_EXPORT FlightEndpoint : public internal::BaseType<FlightEndpoint> {
+  /// Opaque ticket identify; use with DoGet RPC
+  Ticket ticket;
+
+  /// List of locations where ticket can be redeemed. If the list is empty, the
+  /// ticket can only be redeemed on the current service where the ticket was
+  /// generated
+  std::vector<Location> locations;
+
+  /// Expiration time of this stream. If present, clients may assume
+  /// they can retry DoGet requests. Otherwise, clients should avoid
+  /// retrying DoGet requests.
+  std::optional<Timestamp> expiration_time;
+
+  /// Opaque Application-defined metadata
+  std::string app_metadata;
+
+  FlightEndpoint() = default;
+  FlightEndpoint(Ticket ticket, std::vector<Location> locations,
+                 std::optional<Timestamp> expiration_time, std::string app_metadata)
+      : ticket(std::move(ticket)),
+        locations(std::move(locations)),
+        expiration_time(expiration_time),
+        app_metadata(std::move(app_metadata)) {}
+
+  std::string ToString() const;
+  bool Equals(const FlightEndpoint& other) const;
+
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
+  /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, FlightEndpoint* out);
+};
+
+/// \brief The request of the RenewFlightEndpoint action.
+struct ARROW_FLIGHT_EXPORT RenewFlightEndpointRequest
+    : public internal::BaseType<RenewFlightEndpointRequest> {
+  FlightEndpoint endpoint;
+
+  RenewFlightEndpointRequest() = default;
+  explicit RenewFlightEndpointRequest(FlightEndpoint endpoint)
+      : endpoint(std::move(endpoint)) {}
+
+  std::string ToString() const;
+  bool Equals(const RenewFlightEndpointRequest& other) const;
+
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
+  /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   RenewFlightEndpointRequest* out);
+};
+
+// FlightData in Flight.proto maps to FlightPayload here.
+
+/// \brief Staging data structure for messages about to be put on the wire
+///
+/// This structure corresponds to FlightData in the protocol.
+struct ARROW_FLIGHT_EXPORT FlightPayload {
+  std::shared_ptr<Buffer> descriptor;
+  std::shared_ptr<Buffer> app_metadata;
+  ipc::IpcPayload ipc_message;
+
+  FlightPayload() = default;
+  FlightPayload(std::shared_ptr<Buffer> descriptor, std::shared_ptr<Buffer> app_metadata,
+                ipc::IpcPayload ipc_message)
+      : descriptor(std::move(descriptor)),
+        app_metadata(std::move(app_metadata)),
+        ipc_message(std::move(ipc_message)) {}
+
+  /// \brief Check that the payload can be written to the wire.
+  Status Validate() const;
+};
 
 /// \brief Variant supporting all possible value types for {Set,Get}SessionOptions
 ///

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -376,6 +376,44 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   static arrow::Status Deserialize(std::string_view serialized, Result* out);
 };
 
+/// \brief Schema result returned after a schema request RPC
+struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult> {
+ public:
+  SchemaResult() = default;
+  explicit SchemaResult(std::string schema) : raw_schema_(std::move(schema)) {}
+
+  /// \brief Factory method to construct a SchemaResult.
+  static arrow::Result<std::unique_ptr<SchemaResult>> Make(const Schema& schema);
+
+  /// \brief return schema
+  /// \param[in,out] dictionary_memo for dictionary bookkeeping, will
+  /// be modified
+  /// \return Arrow result with the reconstructed Schema
+  arrow::Result<std::shared_ptr<Schema>> GetSchema(
+      ipc::DictionaryMemo* dictionary_memo) const;
+
+  const std::string& serialized_schema() const { return raw_schema_; }
+
+  std::string ToString() const;
+  bool Equals(const SchemaResult& other) const;
+
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
+  /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, SchemaResult* out);
+
+ private:
+  std::string raw_schema_;
+};
+
 /// \brief A request to retrieve or generate a dataset
 struct ARROW_FLIGHT_EXPORT FlightDescriptor
     : public internal::BaseType<FlightDescriptor> {
@@ -622,44 +660,6 @@ struct ARROW_FLIGHT_EXPORT FlightPayload {
 
   /// \brief Check that the payload can be written to the wire.
   Status Validate() const;
-};
-
-/// \brief Schema result returned after a schema request RPC
-struct ARROW_FLIGHT_EXPORT SchemaResult : public internal::BaseType<SchemaResult> {
- public:
-  SchemaResult() = default;
-  explicit SchemaResult(std::string schema) : raw_schema_(std::move(schema)) {}
-
-  /// \brief Factory method to construct a SchemaResult.
-  static arrow::Result<std::unique_ptr<SchemaResult>> Make(const Schema& schema);
-
-  /// \brief return schema
-  /// \param[in,out] dictionary_memo for dictionary bookkeeping, will
-  /// be modified
-  /// \return Arrow result with the reconstructed Schema
-  arrow::Result<std::shared_ptr<Schema>> GetSchema(
-      ipc::DictionaryMemo* dictionary_memo) const;
-
-  const std::string& serialized_schema() const { return raw_schema_; }
-
-  std::string ToString() const;
-  bool Equals(const SchemaResult& other) const;
-
-  using SuperT::Deserialize;
-  using SuperT::SerializeToString;
-
-  /// \brief Serialize this message to its wire-format representation.
-  ///
-  /// Use `SerializeToString()` if you want a Result-returning version.
-  arrow::Status SerializeToString(std::string* out) const;
-
-  /// \brief Deserialize this message from its wire-format representation.
-  ///
-  /// Use `Deserialize(serialized)` if you want a Result-returning version.
-  static arrow::Status Deserialize(std::string_view serialized, SchemaResult* out);
-
- private:
-  std::string raw_schema_;
 };
 
 /// \brief The access coordinates for retrieval of a dataset, returned by

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -376,52 +376,6 @@ struct ARROW_FLIGHT_EXPORT Result : public internal::BaseType<Result> {
   static arrow::Status Deserialize(std::string_view serialized, Result* out);
 };
 
-enum class CancelStatus {
-  /// The cancellation status is unknown. Servers should avoid using
-  /// this value (send a kNotCancellable if the requested FlightInfo
-  /// is not known). Clients can retry the request.
-  kUnspecified = 0,
-  /// The cancellation request is complete. Subsequent requests with
-  /// the same payload may return kCancelled or a kNotCancellable error.
-  kCancelled = 1,
-  /// The cancellation request is in progress. The client may retry
-  /// the cancellation request.
-  kCancelling = 2,
-  // The FlightInfo is not cancellable. The client should not retry the
-  // cancellation request.
-  kNotCancellable = 3,
-};
-
-/// \brief The result of the CancelFlightInfo action.
-struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
-    : public internal::BaseType<CancelFlightInfoResult> {
-  CancelStatus status = CancelStatus::kUnspecified;
-
-  CancelFlightInfoResult() = default;
-  CancelFlightInfoResult(CancelStatus status)  // NOLINT runtime/explicit
-      : status(status) {}
-
-  std::string ToString() const;
-  bool Equals(const CancelFlightInfoResult& other) const;
-
-  using SuperT::Deserialize;
-  using SuperT::SerializeToString;
-
-  /// \brief Serialize this message to its wire-format representation.
-  ///
-  /// Use `SerializeToString()` if you want a Result-returning version.
-  arrow::Status SerializeToString(std::string* out) const;
-
-  /// \brief Deserialize this message from its wire-format representation.
-  ///
-  /// Use `Deserialize(serialized)` if you want a Result-returning version.
-  static arrow::Status Deserialize(std::string_view serialized,
-                                   CancelFlightInfoResult* out);
-};
-
-ARROW_FLIGHT_EXPORT
-std::ostream& operator<<(std::ostream& os, CancelStatus status);
-
 /// \brief A request to retrieve or generate a dataset
 struct ARROW_FLIGHT_EXPORT FlightDescriptor
     : public internal::BaseType<FlightDescriptor> {
@@ -896,6 +850,52 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoRequest
   static arrow::Status Deserialize(std::string_view serialized,
                                    CancelFlightInfoRequest* out);
 };
+
+enum class CancelStatus {
+  /// The cancellation status is unknown. Servers should avoid using
+  /// this value (send a kNotCancellable if the requested FlightInfo
+  /// is not known). Clients can retry the request.
+  kUnspecified = 0,
+  /// The cancellation request is complete. Subsequent requests with
+  /// the same payload may return kCancelled or a kNotCancellable error.
+  kCancelled = 1,
+  /// The cancellation request is in progress. The client may retry
+  /// the cancellation request.
+  kCancelling = 2,
+  // The FlightInfo is not cancellable. The client should not retry the
+  // cancellation request.
+  kNotCancellable = 3,
+};
+
+/// \brief The result of the CancelFlightInfo action.
+struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
+    : public internal::BaseType<CancelFlightInfoResult> {
+  CancelStatus status = CancelStatus::kUnspecified;
+
+  CancelFlightInfoResult() = default;
+  CancelFlightInfoResult(CancelStatus status)  // NOLINT runtime/explicit
+      : status(status) {}
+
+  std::string ToString() const;
+  bool Equals(const CancelFlightInfoResult& other) const;
+
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
+  /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized,
+                                   CancelFlightInfoResult* out);
+};
+
+ARROW_FLIGHT_EXPORT
+std::ostream& operator<<(std::ostream& os, CancelStatus status);
 
 /// \brief Variant supporting all possible value types for {Set,Get}SessionOptions
 ///

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -427,10 +427,9 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   FlightDescriptor(DescriptorType type, std::string cmd, std::vector<std::string> path)
       : type(type), cmd(std::move(cmd)), path(std::move(path)) {}
 
-  bool Equals(const FlightDescriptor& other) const;
-
   /// \brief Get a human-readable form of this descriptor.
   std::string ToString() const;
+  bool Equals(const FlightDescriptor& other) const;
 
   using SuperT::Deserialize;
   using SuperT::SerializeToString;
@@ -547,12 +546,11 @@ struct ARROW_FLIGHT_EXPORT Location : public internal::BaseType<Location> {
   static arrow::Result<Location> ForScheme(const std::string& scheme,
                                            const std::string& host, const int port);
 
-  /// \brief Get a representation of this URI as a string.
-  std::string ToString() const;
-
   /// \brief Get the scheme of this URI.
   std::string scheme() const;
 
+  /// \brief Get a representation of this URI as a string.
+  std::string ToString() const;
   bool Equals(const Location& other) const;
 
   using SuperT::Deserialize;

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -899,52 +899,17 @@ struct ARROW_FLIGHT_EXPORT FlightPayload {
   Status Validate() const;
 };
 
+// A wrapper around arrow.flight.protocol.PutResult is not defined
+
+// Session management messages
+
 /// \brief Variant supporting all possible value types for {Set,Get}SessionOptions
 ///
 /// By convention, an attempt to set a valueless (std::monostate) SessionOptionValue
 /// should attempt to unset or clear the named option value on the server.
 using SessionOptionValue = std::variant<std::monostate, std::string, bool, int64_t,
                                         double, std::vector<std::string>>;
-
-/// \brief The result of setting a session option.
-enum class SetSessionOptionErrorValue : int8_t {
-  /// \brief The status of setting the option is unknown.
-  ///
-  /// Servers should avoid using this value (send a NOT_FOUND error if the requested
-  /// session is not known). Clients can retry the request.
-  kUnspecified,
-  /// \brief The given session option name is invalid.
-  kInvalidName,
-  /// \brief The session option value or type is invalid.
-  kInvalidValue,
-  /// \brief The session option cannot be set.
-  kError
-};
-std::string ToString(const SetSessionOptionErrorValue& error_value);
-std::ostream& operator<<(std::ostream& os, const SetSessionOptionErrorValue& error_value);
-
-/// \brief The result of closing a session.
-enum class CloseSessionStatus : int8_t {
-  // \brief The session close status is unknown.
-  //
-  // Servers should avoid using this value (send a NOT_FOUND error if the requested
-  // session is not known). Clients can retry the request.
-  kUnspecified,
-  // \brief The session close request is complete.
-  //
-  // Subsequent requests with the same session produce a NOT_FOUND error.
-  kClosed,
-  // \brief The session close request is in progress.
-  //
-  // The client may retry the request.
-  kClosing,
-  // \brief The session is not closeable.
-  //
-  // The client should not retry the request.
-  kNotClosable
-};
-std::string ToString(const CloseSessionStatus& status);
-std::ostream& operator<<(std::ostream& os, const CloseSessionStatus& status);
+std::ostream& operator<<(std::ostream& os, const SessionOptionValue& v);
 
 /// \brief A request to set a set of session options by name/value.
 struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
@@ -973,6 +938,23 @@ struct ARROW_FLIGHT_EXPORT SetSessionOptionsRequest
   static arrow::Status Deserialize(std::string_view serialized,
                                    SetSessionOptionsRequest* out);
 };
+
+/// \brief The result of setting a session option.
+enum class SetSessionOptionErrorValue : int8_t {
+  /// \brief The status of setting the option is unknown.
+  ///
+  /// Servers should avoid using this value (send a NOT_FOUND error if the requested
+  /// session is not known). Clients can retry the request.
+  kUnspecified,
+  /// \brief The given session option name is invalid.
+  kInvalidName,
+  /// \brief The session option value or type is invalid.
+  kInvalidValue,
+  /// \brief The session option cannot be set.
+  kError
+};
+std::string ToString(const SetSessionOptionErrorValue& error_value);
+std::ostream& operator<<(std::ostream& os, const SetSessionOptionErrorValue& error_value);
 
 /// \brief The result(s) of setting session option(s).
 struct ARROW_FLIGHT_EXPORT SetSessionOptionsResult
@@ -1085,6 +1067,29 @@ struct ARROW_FLIGHT_EXPORT CloseSessionRequest
   /// Use `Deserialize(serialized)` if you want a Result-returning version.
   static arrow::Status Deserialize(std::string_view serialized, CloseSessionRequest* out);
 };
+
+/// \brief The result of closing a session.
+enum class CloseSessionStatus : int8_t {
+  // \brief The session close status is unknown.
+  //
+  // Servers should avoid using this value (send a NOT_FOUND error if the requested
+  // session is not known). Clients can retry the request.
+  kUnspecified,
+  // \brief The session close request is complete.
+  //
+  // Subsequent requests with the same session produce a NOT_FOUND error.
+  kClosed,
+  // \brief The session close request is in progress.
+  //
+  // The client may retry the request.
+  kClosing,
+  // \brief The session is not closeable.
+  //
+  // The client should not retry the request.
+  kNotClosable
+};
+std::string ToString(const CloseSessionStatus& status);
+std::ostream& operator<<(std::ostream& os, const CloseSessionStatus& status);
 
 /// \brief The result of attempting to close the client session.
 struct ARROW_FLIGHT_EXPORT CloseSessionResult

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -214,6 +214,40 @@ struct BaseType {
 
 }  // namespace internal
 
+//------------------------------------------------------------
+// Wrapper types for Flight RPC protobuf messages
+
+// A wrapper around arrow.flight.protocol.HandshakeRequest is not defined
+// A wrapper around arrow.flight.protocol.HandshakeResponse is not defined
+
+/// \brief message for simple auth
+struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
+  std::string username;
+  std::string password;
+
+  BasicAuth() = default;
+  BasicAuth(std::string username, std::string password)
+      : username(std::move(username)), password(std::move(password)) {}
+
+  std::string ToString() const;
+  bool Equals(const BasicAuth& other) const;
+
+  using SuperT::Deserialize;
+  using SuperT::SerializeToString;
+
+  /// \brief Serialize this message to its wire-format representation.
+  ///
+  /// Use `SerializeToString()` if you want a Result-returning version.
+  arrow::Status SerializeToString(std::string* out) const;
+
+  /// \brief Deserialize this message from its wire-format representation.
+  ///
+  /// Use `Deserialize(serialized)` if you want a Result-returning version.
+  static arrow::Status Deserialize(std::string_view serialized, BasicAuth* out);
+};
+
+// A wrapper around arrow.flight.protocol.Empty is not defined
+
 /// \brief A type of action that can be performed with the DoAction RPC.
 struct ARROW_FLIGHT_EXPORT ActionType : public internal::BaseType<ActionType> {
   /// \brief The name of the action.
@@ -375,32 +409,6 @@ struct ARROW_FLIGHT_EXPORT CancelFlightInfoResult
 
 ARROW_FLIGHT_EXPORT
 std::ostream& operator<<(std::ostream& os, CancelStatus status);
-
-/// \brief message for simple auth
-struct ARROW_FLIGHT_EXPORT BasicAuth : public internal::BaseType<BasicAuth> {
-  std::string username;
-  std::string password;
-
-  BasicAuth() = default;
-  BasicAuth(std::string username, std::string password)
-      : username(std::move(username)), password(std::move(password)) {}
-
-  std::string ToString() const;
-  bool Equals(const BasicAuth& other) const;
-
-  using SuperT::Deserialize;
-  using SuperT::SerializeToString;
-
-  /// \brief Serialize this message to its wire-format representation.
-  ///
-  /// Use `SerializeToString()` if you want a Result-returning version.
-  arrow::Status SerializeToString(std::string* out) const;
-
-  /// \brief Deserialize this message from its wire-format representation.
-  ///
-  /// Use `Deserialize(serialized)` if you want a Result-returning version.
-  static arrow::Status Deserialize(std::string_view serialized, BasicAuth* out);
-};
 
 /// \brief A request to retrieve or generate a dataset
 struct ARROW_FLIGHT_EXPORT FlightDescriptor
@@ -1101,6 +1109,8 @@ struct ARROW_FLIGHT_EXPORT CloseSessionResult
   /// Use `Deserialize(serialized)` if you want a Result-returning version.
   static arrow::Status Deserialize(std::string_view serialized, CloseSessionResult* out);
 };
+
+//------------------------------------------------------------
 
 /// \brief An iterator to FlightInfo instances returned by ListFlights.
 class ARROW_FLIGHT_EXPORT FlightListing {

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -415,6 +415,25 @@ message PollInfo {
 }
 
 /*
+ * An opaque identifier that the service can use to retrieve a particular
+ * portion of a stream.
+ *
+ * Tickets are meant to be single use. It is an error/application-defined
+ * behavior to reuse a ticket.
+ */
+message Ticket {
+  bytes ticket = 1;
+}
+
+/*
+ * A location where a Flight service will accept retrieval of a particular
+ * stream given a ticket.
+ */
+message Location {
+  string uri = 1;
+}
+
+/*
  * A particular stream or split associated with a flight.
  */
 message FlightEndpoint {
@@ -472,25 +491,6 @@ message FlightEndpoint {
  */
 message RenewFlightEndpointRequest {
   FlightEndpoint endpoint = 1;
-}
-
-/*
- * A location where a Flight service will accept retrieval of a particular
- * stream given a ticket.
- */
-message Location {
-  string uri = 1;
-}
-
-/*
- * An opaque identifier that the service can use to retrieve a particular
- * portion of a stream.
- *
- * Tickets are meant to be single use. It is an error/application-defined
- * behavior to reuse a ticket.
- */
-message Ticket {
-  bytes ticket = 1;
 }
 
 /*

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -209,49 +209,10 @@ message Action {
 }
 
 /*
- * The request of the CancelFlightInfo action.
- *
- * The request should be stored in Action.body.
- */
-message CancelFlightInfoRequest {
-  FlightInfo info = 1;
-}
-
-/*
  * An opaque result returned after executing an action.
  */
 message Result {
   bytes body = 1;
-}
-
-/*
- * The result of a cancel operation.
- *
- * This is used by CancelFlightInfoResult.status.
- */
-enum CancelStatus {
-  // The cancellation status is unknown. Servers should avoid using
-  // this value (send a NOT_FOUND error if the requested query is
-  // not known). Clients can retry the request.
-  CANCEL_STATUS_UNSPECIFIED = 0;
-  // The cancellation request is complete. Subsequent requests with
-  // the same payload may return CANCELLED or a NOT_FOUND error.
-  CANCEL_STATUS_CANCELLED = 1;
-  // The cancellation request is in progress. The client may retry
-  // the cancellation request.
-  CANCEL_STATUS_CANCELLING = 2;
-  // The query is not cancellable. The client should not retry the
-  // cancellation request.
-  CANCEL_STATUS_NOT_CANCELLABLE = 3;
-}
-
-/*
- * The result of the CancelFlightInfo action.
- *
- * The result should be stored in Result.body.
- */
-message CancelFlightInfoResult {
-  CancelStatus status = 1;
 }
 
 /*
@@ -412,6 +373,45 @@ message PollInfo {
    * be cancelled). This may be updated on a call to PollFlightInfo.
    */
   google.protobuf.Timestamp expiration_time = 4;
+}
+
+/*
+ * The request of the CancelFlightInfo action.
+ *
+ * The request should be stored in Action.body.
+ */
+message CancelFlightInfoRequest {
+  FlightInfo info = 1;
+}
+
+/*
+ * The result of a cancel operation.
+ *
+ * This is used by CancelFlightInfoResult.status.
+ */
+enum CancelStatus {
+  // The cancellation status is unknown. Servers should avoid using
+  // this value (send a NOT_FOUND error if the requested query is
+  // not known). Clients can retry the request.
+  CANCEL_STATUS_UNSPECIFIED = 0;
+  // The cancellation request is complete. Subsequent requests with
+  // the same payload may return CANCELLED or a NOT_FOUND error.
+  CANCEL_STATUS_CANCELLED = 1;
+  // The cancellation request is in progress. The client may retry
+  // the cancellation request.
+  CANCEL_STATUS_CANCELLING = 2;
+  // The query is not cancellable. The client should not retry the
+  // cancellation request.
+  CANCEL_STATUS_NOT_CANCELLABLE = 3;
+}
+
+/*
+ * The result of the CancelFlightInfo action.
+ *
+ * The result should be stored in Result.body.
+ */
+message CancelFlightInfoResult {
+  CancelStatus status = 1;
 }
 
 /*

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -218,15 +218,6 @@ message CancelFlightInfoRequest {
 }
 
 /*
- * The request of the RenewFlightEndpoint action.
- *
- * The request should be stored in Action.body.
- */
-message RenewFlightEndpointRequest {
-  FlightEndpoint endpoint = 1;
-}
-
-/*
  * An opaque result returned after executing an action.
  */
 message Result {
@@ -472,6 +463,15 @@ message FlightEndpoint {
    * but there is none required by the spec.
    */
   bytes app_metadata = 4;
+}
+
+/*
+ * The request of the RenewFlightEndpoint action.
+ *
+ * The request should be stored in Action.body.
+ */
+message RenewFlightEndpointRequest {
+  FlightEndpoint endpoint = 1;
 }
 
 /*


### PR DESCRIPTION
### Rationale for this change

Identify the differences between Flight.proto and the hand-written types.h,.cc files.

### What changes are included in this PR?

 - Re-ordering of the classes

### Are these changes tested?

By existing tests.
* GitHub Issue: #43329