### PR TITLE
GH-43357: [R] Fix some lints

### DIFF
--- a/r/R/arrow-tabular.R
+++ b/r/R/arrow-tabular.R
@@ -48,13 +48,13 @@ ArrowTabular <- R6Class("ArrowTabular",
     SortIndices = function(names, descending = FALSE) {
       assert_that(is.character(names))
       assert_that(length(names) > 0)
-      assert_that(!any(is.na(names)))
+      assert_that(!anyNA(names))
       if (length(descending) == 1L) {
         descending <- rep_len(descending, length(names))
       }
       assert_that(is.logical(descending))
       assert_that(identical(length(names), length(descending)))
-      assert_that(!any(is.na(descending)))
+      assert_that(!anyNA(descending))
       call_function(
         "sort_indices",
         self,
@@ -113,13 +113,13 @@ as.data.frame.ArrowTabular <- function(x, row.names = NULL, optional = FALSE, ..
     # That way, if we're filtering too, we have fewer arrays to filter/slice/take
     if (is.character(j)) {
       j_new <- match(j, names(x))
-      if (any(is.na(j_new))) {
+      if (anyNA(j_new)) {
         stop("Column not found: ", oxford_paste(j[is.na(j_new)]), call. = FALSE)
       }
       j <- j_new
     }
     if (is_integerish(j)) {
-      if (any(is.na(j))) {
+      if (anyNA(j)) {
         stop("Column indices cannot be NA", call. = FALSE)
       }
       if (length(j) && all(j < 0)) {

--- a/r/R/dplyr-datetime-helpers.R
+++ b/r/R/dplyr-datetime-helpers.R
@@ -55,7 +55,7 @@ duration_from_chunks <- function(chunks) {
   accepted_chunks <- c("second", "minute", "hour", "day", "week")
   matched_chunks <- accepted_chunks[pmatch(names(chunks), accepted_chunks, duplicates.ok = TRUE)]
 
-  if (any(is.na(matched_chunks))) {
+  if (anyNA(matched_chunks)) {
     arrow_not_supported(
       paste(
         "named `difftime` units other than:",
@@ -442,7 +442,7 @@ parse_period_unit <- function(x) {
   str_unit_start <- substr(str_unit, 1, 3)
   unit <- as.integer(pmatch(str_unit_start, known_units)) - 1L
 
-  if (any(is.na(unit))) {
+  if (anyNA(unit)) {
     validation_error(
       sprintf(
         "Invalid period name: '%s'",

--- a/r/R/dplyr-funcs-datetime.R
+++ b/r/R/dplyr-funcs-datetime.R
@@ -814,7 +814,7 @@ register_bindings_datetime_rounding <- function() {
              week_start = getOption("lubridate.week.start", 7)) {
       opts <- parse_period_unit(unit)
       if (is.null(change_on_boundary)) {
-        change_on_boundary <- ifelse(call_binding("is.Date", x), TRUE, FALSE)
+        change_on_boundary <- call_binding("is.Date", x)
       }
       opts$ceil_is_strictly_greater <- change_on_boundary
 

--- a/r/R/dplyr-slice.R
+++ b/r/R/dplyr-slice.R
@@ -101,7 +101,7 @@ slice_sample.arrow_dplyr_query <- function(.data,
   # just to make sure we get enough, then head(n)
   sampling_n <- missing(prop)
   if (sampling_n) {
-    prop <- min(n_to_prop(.data, n) + .05, 1)
+    prop <- min(n_to_prop(.data, n) + 0.05, 1)
   }
   validate_prop(prop)
 

--- a/r/tests/testthat/helper-data.R
+++ b/r/tests/testthat/helper-data.R
@@ -17,7 +17,7 @@
 
 example_data <- tibble::tibble(
   int = c(1:3, NA_integer_, 5:10),
-  dbl = c(1:8, NA, 10) + .1,
+  dbl = c(1:8, NA, 10) + 0.1,
   dbl2 = rep(5, 10),
   lgl = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
   false = logical(10),

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -539,14 +539,14 @@ test_that("StructArray methods", {
   expect_equal(a$x, arrow_array(df$x))
   expect_equal(a[["x"]], arrow_array(df$x))
   expect_equal(a[[1]], arrow_array(df$x))
-  expect_identical(names(a), c("x", "y", "z"))
+  expect_named(a, c("x", "y", "z"))
   expect_identical(dim(a), c(10L, 3L))
 })
 
 test_that("StructArray creation", {
   # from data.frame
   a <- StructArray$create(example_data)
-  expect_identical(names(a), c("int", "dbl", "dbl2", "lgl", "false", "chr", "fct"))
+  expect_named(a, c("int", "dbl", "dbl2", "lgl", "false", "chr", "fct"))
   expect_identical(dim(a), c(10L, 7L))
   expect_r6_class(a, "StructArray")
 

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -42,7 +42,7 @@ test_that("RecordBatch", {
   expect_equal(batch$column_name(2), "lgl")
   expect_equal(batch$column_name(3), "chr")
   expect_equal(batch$column_name(4), "fct")
-  expect_equal(names(batch), c("int", "dbl", "lgl", "chr", "fct"))
+  expect_named(batch, c("int", "dbl", "lgl", "chr", "fct"))
 
   # input validation
   expect_error(batch$column_name(NA), "'i' cannot be NA")
@@ -497,9 +497,9 @@ test_that("RecordBatch$Equals(check_metadata)", {
 
 test_that("RecordBatch name assignment", {
   rb <- record_batch(x = 1:10, y = 1:10)
-  expect_identical(names(rb), c("x", "y"))
+  expect_named(rb, c("x", "y"))
   names(rb) <- c("a", "b")
-  expect_identical(names(rb), c("a", "b"))
+  expect_named(rb, c("a", "b"))
   expect_error(names(rb) <- "f")
   expect_error(names(rb) <- letters)
   expect_error(names(rb) <- character(0))

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -66,7 +66,7 @@ tbl <- tibble::tibble(
 tab <- Table$create(tbl)
 
 test_that("[, [[, $ for Table", {
-  expect_identical(names(tab), names(tbl))
+  expect_named(tab, names(tbl))
 
   expect_equal_data_frame(tab[6:7, ], tbl[6:7, ])
   expect_equal_data_frame(tab[6:7, 2:4], tbl[6:7, 2:4])
@@ -393,9 +393,9 @@ test_that("Table$SelectColumns()", {
 
 test_that("Table name assignment", {
   tab <- Table$create(x = 1:10, y = 1:10)
-  expect_identical(names(tab), c("x", "y"))
+  expect_named(tab, c("x", "y"))
   names(tab) <- c("a", "b")
-  expect_identical(names(tab), c("a", "b"))
+  expect_named(tab, c("a", "b"))
   expect_error(names(tab) <- "f")
   expect_error(names(tab) <- letters)
   expect_error(names(tab) <- character(0))

--- a/r/tests/testthat/test-compute-aggregate.R
+++ b/r/tests/testthat/test-compute-aggregate.R
@@ -286,7 +286,7 @@ test_that("median passes ... args to quantile", {
     Scalar$create(2)
   )
   expect_error(
-    median(Array$create(c(1, 2)), probs = c(.25, .75))
+    median(Array$create(c(1, 2)), probs = c(0.25, 0.75))
   )
 })
 

--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -108,22 +108,22 @@ test_that("Power", {
   expect_equal(a^0, Array$create(c(1, 1, 1, 1, NA_real_)))
   expect_equal(a^2, Array$create(c(1, 4, 9, 16, NA_real_)))
   expect_equal(a^(-1), Array$create(c(1, 1 / 2, 1 / 3, 1 / 4, NA_real_)))
-  expect_equal(a^(.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
+  expect_equal(a^(0.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
 
   expect_equal(b^0, Array$create(c(1, 1, 1, 1, NA_real_)))
   expect_equal(b^2, Array$create(c(1, 4, 9, 16, NA_real_)))
   expect_equal(b^(-1), Array$create(c(1, 1 / 2, 1 / 3, 1 / 4, NA_real_)))
-  expect_equal(b^(.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
+  expect_equal(b^(0.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
 
   expect_equal(c^0, Array$create(c(1, 1, 1, 1, NA_real_)))
   expect_equal(c^2, Array$create(c(1, 4, 9, 16, NA_real_)))
   expect_equal(c^(-1), Array$create(c(1, 1 / 2, 1 / 3, 1 / 4, NA_real_)))
-  expect_equal(c^(.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
+  expect_equal(c^(0.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
 
   expect_equal(d^0, Array$create(c(1, 1, 1, 1, NA_real_)))
   expect_equal(d^2, Array$create(c(1, 4, 9, 16, NA_real_)))
   expect_equal(d^(-1), Array$create(c(1, 1 / 2, 1 / 3, 1 / 4, NA_real_)))
-  expect_equal(d^(.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
+  expect_equal(d^(0.5), Array$create(c(1, sqrt(2), sqrt(3), sqrt(4), NA_real_)))
 })
 
 test_that("Dates casting", {

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -90,7 +90,7 @@ test_that("read_csv_arrow parsing options: col_names", {
 
   tab1 <- read_csv_arrow(tf, col_names = names(tbl))
 
-  expect_identical(names(tab1), names(tbl))
+  expect_named(tab1, names(tbl))
   expect_equal(tbl, tab1)
 
   # This errors (correctly) because I haven't given enough names
@@ -114,7 +114,7 @@ test_that("read_csv_arrow parsing options: skip", {
 
   tab1 <- read_csv_arrow(tf, skip = 2)
 
-  expect_identical(names(tab1), names(tbl))
+  expect_named(tab1, names(tbl))
   expect_equal(tbl, tab1)
 })
 

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -49,7 +49,7 @@ test_that("CSV dataset", {
   ds <- open_dataset(csv_dir, partitioning = "part", format = "csv")
   expect_r6_class(ds$format, "CsvFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
-  expect_identical(names(ds), c(names(df1), "part"))
+  expect_named(ds, c(names(df1), "part"))
   expect_identical(dim(ds), c(20L, 7L))
 
   expect_equal(
@@ -349,7 +349,7 @@ test_that("Can use col_names readr parameter", {
     format = "csv",
     col_names = expected_names
   )
-  expect_equal(names(ds), expected_names)
+  expect_named(ds, expected_names)
   expect_equal(ds %>% collect(), set_names(tbl, expected_names))
 
   # WITHOUT header, makes up names
@@ -358,7 +358,7 @@ test_that("Can use col_names readr parameter", {
     format = "csv",
     col_names = FALSE
   )
-  expect_equal(names(ds), c("f0", "f1"))
+  expect_named(ds, c("f0", "f1"))
   expect_equal(ds %>% collect(), set_names(tbl, c("f0", "f1")))
 
   # WITH header, gets names
@@ -367,7 +367,7 @@ test_that("Can use col_names readr parameter", {
     format = "csv",
     col_names = TRUE
   )
-  expect_equal(names(ds), c("int", "dbl"))
+  expect_named(ds, c("int", "dbl"))
   expect_equal(ds %>% collect(), tbl)
 
   ds <- open_dataset(
@@ -376,7 +376,7 @@ test_that("Can use col_names readr parameter", {
     col_names = FALSE,
     skip = 1
   )
-  expect_equal(names(ds), c("f0", "f1"))
+  expect_named(ds, c("f0", "f1"))
   expect_equal(ds %>% collect(), set_names(tbl, c("f0", "f1")))
 
   expect_error(
@@ -481,7 +481,7 @@ test_that("open_delim_dataset params passed through to open_dataset", {
   ds <- open_delim_dataset(csv_dir, delim = ",", partitioning = "part")
   expect_r6_class(ds$format, "CsvFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
-  expect_identical(names(ds), c(names(df1), "part"))
+  expect_named(ds, c(names(df1), "part"))
   expect_identical(dim(ds), c(20L, 7L))
 
   # quote
@@ -629,8 +629,8 @@ test_that("GH-34640 - CSV datasets are read in correctly when both schema and pa
   )
   expect_r6_class(ds$format, "CsvFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
-  expect_identical(names(ds), c(names(df1), "part"))
-  expect_identical(names(collect(ds)), c(names(df1), "part"))
+  expect_named(ds, c(names(df1), "part"))
+  expect_named(collect(ds), c(names(df1), "part"))
 
   expect_identical(dim(ds), c(20L, 7L))
   expect_equal(schema(ds), target_schema)

--- a/r/tests/testthat/test-dataset-json.R
+++ b/r/tests/testthat/test-dataset-json.R
@@ -40,7 +40,7 @@ test_that("JSON dataset", {
 
   expect_r6_class(ds$format, "JsonFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
-  expect_identical(names(ds), c(names(df1), "part"))
+  expect_named(ds, c(names(df1), "part"))
   expect_identical(dim(ds), c(20L, 7L))
 
   expect_equal(

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -50,7 +50,7 @@ test_that("IPC/Feather format data", {
   ds <- open_dataset(ipc_dir, partitioning = "part", format = "feather")
   expect_r6_class(ds$format, "IpcFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
-  expect_identical(names(ds), c(names(df1), "part"))
+  expect_named(ds, c(names(df1), "part"))
   expect_identical(dim(ds), c(20L, 7L))
 
   expect_equal(
@@ -396,7 +396,7 @@ test_that("input validation", {
 test_that("Partitioning inference", {
   # These are the same tests as above, just using the *PartitioningFactory
   ds1 <- open_dataset(dataset_dir, partitioning = "part")
-  expect_identical(names(ds1), c(names(df1), "part"))
+  expect_named(ds1, c(names(df1), "part"))
   expect_equal(
     ds1 %>%
       select(string = chr, integer = int, part) %>%
@@ -410,7 +410,7 @@ test_that("Partitioning inference", {
   )
 
   ds2 <- open_dataset(hive_dir)
-  expect_identical(names(ds2), c(names(df1), "group", "other"))
+  expect_named(ds2, c(names(df1), "group", "other"))
   expect_equal(
     ds2 %>%
       filter(group == 2) %>%
@@ -511,7 +511,7 @@ test_that("Including partition columns in schema and partitioning, hive style CS
 
 test_that("partitioning = NULL to ignore partition information (but why?)", {
   ds <- open_dataset(hive_dir, partitioning = NULL)
-  expect_identical(names(ds), names(df1)) # i.e. not c(names(df1), "group", "other")
+  expect_named(ds, names(df1)) # i.e. not c(names(df1), "group", "other")
 })
 
 test_that("Dataset with multiple file formats", {
@@ -520,7 +520,7 @@ test_that("Dataset with multiple file formats", {
     open_dataset(dataset_dir, format = "parquet", partitioning = "part"),
     open_dataset(ipc_dir, format = "arrow", partitioning = "part")
   ))
-  expect_identical(names(ds), c(names(df1), "part"))
+  expect_named(ds, c(names(df1), "part"))
   expect_equal(
     ds %>%
       filter(int > 6 & part %in% c(1, 3)) %>%
@@ -1085,14 +1085,14 @@ test_that("Assembling a Dataset manually and getting a Table", {
   expect_r6_class(schm, "Schema")
 
   phys_schm <- ParquetFileReader$create(files[1])$GetSchema()
-  expect_equal(names(phys_schm), names(df1))
-  expect_equal(names(schm), c(names(phys_schm), "part"))
+  expect_named(phys_schm, names(df1))
+  expect_named(schm, c(names(phys_schm), "part"))
 
   child <- factory$Finish(schm)
   expect_r6_class(child, "FileSystemDataset")
   expect_r6_class(child$schema, "Schema")
   expect_r6_class(child$format, "ParquetFileFormat")
-  expect_equal(names(schm), names(child$schema))
+  expect_named(schm, names(child$schema))
   expect_equal(child$files, files)
 
   ds <- Dataset$create(list(child), schm)
@@ -1112,12 +1112,12 @@ test_that("Assembling multiple DatasetFactories with DatasetFactory", {
   expect_r6_class(schm, "Schema")
 
   phys_schm <- ParquetFileReader$create(files[1])$GetSchema()
-  expect_equal(names(phys_schm), names(df1))
+  expect_named(phys_schm, names(df1))
 
   ds <- factory$Finish(schm)
   expect_r6_class(ds, "UnionDataset")
   expect_r6_class(ds$schema, "Schema")
-  expect_equal(names(schm), names(ds$schema))
+  expect_named(schm, names(ds$schema))
   expect_equal(unlist(map(ds$children, ~ .$files)), files)
 
   expect_scan_result(ds, schm)

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -26,7 +26,7 @@ tbl$verses <- verses[[1]]
 # c(" a ", "  b  ", "   c   ", ...) increasing padding
 # nchar =   3  5  7  9 11 13 15 17 19 21
 tbl$padded_strings <- stringr::str_pad(letters[1:10], width = 2 * (1:10) + 1, side = "both")
-tbl$some_negative <- tbl$int * (-1)^(1:nrow(tbl)) # nolint
+tbl$some_negative <- tbl$int * (-1)^(seq_len(nrow(tbl))) # nolint
 
 test_that("filter() on is.na()", {
   compare_dplyr_binding(
@@ -314,7 +314,7 @@ test_that("Filtering on a column that doesn't exist errors correctly", {
 test_that("Filtering with unsupported functions", {
   compare_dplyr_binding(
     .input %>%
-      filter(int > 2, pnorm(dbl) > .99) %>%
+      filter(int > 2, pnorm(dbl) > 0.99) %>%
       collect(),
     tbl,
     warning = paste(
@@ -329,7 +329,7 @@ test_that("Filtering with unsupported functions", {
       filter(
         nchar(chr, type = "bytes", allowNA = TRUE) == 1, # bad, Arrow msg
         int > 2, # good
-        pnorm(dbl) > .99 # bad, opaque, but we'll error on the first one before we get here
+        pnorm(dbl) > 0.99 # bad, opaque, but we'll error on the first one before we get here
       ) %>%
       collect(),
     tbl,
@@ -472,7 +472,7 @@ test_that(".by argument", {
   # filter should pulling not grouped data into R when using the .by argument
   compare_dplyr_binding(
     .input %>%
-      filter(int > 2, pnorm(dbl) > .99, .by = chr) %>%
+      filter(int > 2, pnorm(dbl) > 0.99, .by = chr) %>%
       collect(),
     tbl,
     warning = paste(

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -26,7 +26,7 @@ tbl$verses <- verses[[1]]
 # c(" a ", "  b  ", "   c   ", ...) increasing padding
 # nchar =   3  5  7  9 11 13 15 17 19 21
 tbl$padded_strings <- stringr::str_pad(letters[1:10], width = 2 * (1:10) + 1, side = "both")
-tbl$some_negative <- tbl$int * (-1)^(seq_len(nrow(tbl))) # nolint
+tbl$some_negative <- tbl$int * (-1)^(1:nrow(tbl)) # nolint
 
 test_that("filter() on is.na()", {
   compare_dplyr_binding(

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -30,7 +30,7 @@ test_that("if_else and ifelse", {
   compare_dplyr_binding(
     .input %>%
       mutate(
-        y = as.integer(int > 5),
+        y = if_else(int > 5, 1, 0),
         y2 = dplyr::if_else(int > 6, 1, 0)
       ) %>%
       collect(),
@@ -67,7 +67,7 @@ test_that("if_else and ifelse", {
   compare_dplyr_binding(
     .input %>%
       mutate(
-        y = as.integer(int > 5),
+        y = ifelse(int > 5, 1, 0),
         y2 = base::ifelse(int > 6, 1, 0)
       ) %>%
       collect(),
@@ -77,7 +77,7 @@ test_that("if_else and ifelse", {
   compare_dplyr_binding(
     .input %>%
       mutate(
-        y = dbl > 5
+        y = if_else(dbl > 5, TRUE, FALSE)
       ) %>%
       collect(),
     tbl

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -30,7 +30,7 @@ test_that("if_else and ifelse", {
   compare_dplyr_binding(
     .input %>%
       mutate(
-        y = if_else(int > 5, 1, 0),
+        y = as.integer(int > 5),
         y2 = dplyr::if_else(int > 6, 1, 0)
       ) %>%
       collect(),
@@ -67,7 +67,7 @@ test_that("if_else and ifelse", {
   compare_dplyr_binding(
     .input %>%
       mutate(
-        y = ifelse(int > 5, 1, 0),
+        y = as.integer(int > 5),
         y2 = base::ifelse(int > 6, 1, 0)
       ) %>%
       collect(),
@@ -77,7 +77,7 @@ test_that("if_else and ifelse", {
   compare_dplyr_binding(
     .input %>%
       mutate(
-        y = if_else(dbl > 5, TRUE, FALSE)
+        y = dbl > 5
       ) %>%
       collect(),
     tbl

--- a/r/tests/testthat/test-dplyr-funcs-datetime.R
+++ b/r/tests/testthat/test-dplyr-funcs-datetime.R
@@ -3411,7 +3411,7 @@ check_boundary_with_unit <- function(unit, ...) {
 test_that("ceiling_date() applies change_on_boundary correctly", {
   check_boundary_with_unit(".001 second")
   check_boundary_with_unit("second")
-  check_boundary_with_unit("minute", tolerance = .001) # floating point issue?
+  check_boundary_with_unit("minute", tolerance = 0.001) # floating point issue?
   check_boundary_with_unit("hour")
   check_boundary_with_unit("day")
 })

--- a/r/tests/testthat/test-dplyr-join.R
+++ b/r/tests/testthat/test-dplyr-join.R
@@ -353,7 +353,7 @@ test_that("suffix and implicit schema", {
   join_op <- inner_join(left_suf, right_suf, by = "key", suffix = c("_left", "_right"))
   output <- collect(join_op)
   impl_schema <- implicit_schema(join_op)
-  expect_equal(names(output), names(implicit_schema(join_op)))
+  expect_named(output, names(implicit_schema(join_op)))
 })
 
 test_that("summarize and join", {

--- a/r/tests/testthat/test-dplyr-slice.R
+++ b/r/tests/testthat/test-dplyr-slice.R
@@ -40,13 +40,13 @@ test_that("slice_head/tail, ungrouped", {
 
   expect_equal(
     tab %>%
-      slice_head(prop = .25) %>%
+      slice_head(prop = 0.25) %>%
       nrow(),
     2
   )
   expect_equal(
     tab %>%
-      slice_tail(prop = .25) %>%
+      slice_tail(prop = 0.25) %>%
       nrow(),
     2
   )
@@ -78,13 +78,13 @@ test_that("slice_min/max, ungrouped", {
 
   compare_dplyr_binding(
     .input %>%
-      slice_max(int, prop = .25, with_ties = FALSE) %>%
+      slice_max(int, prop = 0.25, with_ties = FALSE) %>%
       collect(),
     tbl
   )
   compare_dplyr_binding(
     .input %>%
-      slice_min(int, prop = .25, with_ties = FALSE) %>%
+      slice_min(int, prop = 0.25, with_ties = FALSE) %>%
       collect(),
     tbl
   )
@@ -108,7 +108,7 @@ test_that("slice_sample, ungrouped", {
   # Because this is random (and we only have 10 rows), try several times
   for (i in 1:50) {
     sampled_prop <- tab %>%
-      slice_sample(prop = .2) %>%
+      slice_sample(prop = 0.2) %>%
       collect() %>%
       nrow()
     if (sampled_prop == 2) break
@@ -184,7 +184,7 @@ test_that("slice_* not supported with groups", {
 
 test_that("input validation", {
   tab <- arrow_table(tbl)
-  for (p in list("a", -1, 2, c(.01, .02), NA_real_)) {
+  for (p in list("a", -1, 2, c(0.01, 0.02), NA_real_)) {
     expect_error(
       slice_head(tab, prop = !!p),
       "`prop` must be a single numeric value between 0 and 1",
@@ -206,7 +206,7 @@ test_that("n <-> prop conversion when nrow is not known", {
 
   expect_error(
     joined %>%
-      slice_min(int, prop = .25, with_ties = FALSE),
+      slice_min(int, prop = 0.25, with_ties = FALSE),
     "Slicing with `prop` when"
   )
 

--- a/r/tests/testthat/test-json.R
+++ b/r/tests/testthat/test-json.R
@@ -80,10 +80,10 @@ test_that("read_json_arrow() supports col_select=", {
   ', tf)
 
   tab1 <- read_json_arrow(tf, col_select = c(hello, world))
-  expect_equal(names(tab1), c("hello", "world"))
+  expect_named(tab1, c("hello", "world"))
 
   tab2 <- read_json_arrow(tf, col_select = 1:2)
-  expect_equal(names(tab2), c("hello", "world"))
+  expect_named(tab2, c("hello", "world"))
 })
 
 test_that("read_json_arrow(schema=) with empty schema", {

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -42,10 +42,10 @@ test_that("simple int column roundtrip", {
 test_that("read_parquet() supports col_select", {
   skip_if_not_available("snappy")
   df <- read_parquet(pq_file, col_select = c(x, y, z))
-  expect_equal(names(df), c("x", "y", "z"))
+  expect_named(df, c("x", "y", "z"))
 
   df <- read_parquet(pq_file, col_select = starts_with("c"))
-  expect_equal(names(df), c("carat", "cut", "color", "clarity"))
+  expect_named(df, c("carat", "cut", "color", "clarity"))
 })
 
 test_that("read_parquet() with raw data", {

--- a/r/tests/testthat/test-record-batch-reader.R
+++ b/r/tests/testthat/test-record-batch-reader.R
@@ -183,7 +183,7 @@ test_that("RBR methods", {
 x: int32
 y: string"
   )
-  expect_equal(names(reader), c("x", "y"))
+  expect_named(reader, c("x", "y"))
   expect_identical(dim(reader), c(NA_integer_, 2L))
 
   expect_equal(

--- a/r/tests/testthat/test-schema.R
+++ b/r/tests/testthat/test-schema.R
@@ -21,7 +21,7 @@ test_that("Alternate type names are supported", {
     schema(b = double(), c = bool(), d = string(), e = float(), f = halffloat()),
     schema(b = float64(), c = boolean(), d = utf8(), e = float32(), f = float16())
   )
-  expect_equal(names(schema(b = double(), c = bool(), d = string())), c("b", "c", "d"))
+  expect_named(schema(b = double(), c = bool(), d = string()), c("b", "c", "d"))
 })
 
 test_that("Schema print method", {
@@ -279,9 +279,9 @@ test_that("as_schema() works for StructType objects", {
 
 test_that("schema name assignment", {
   schm <- schema(x = int8(), y = string(), z = double())
-  expect_identical(names(schm), c("x", "y", "z"))
+  expect_named(schm, c("x", "y", "z"))
   names(schm) <- c("a", "b", "c")
-  expect_identical(names(schm), c("a", "b", "c"))
+  expect_named(schm, c("a", "b", "c"))
   expect_error(names(schm) <- "f", regexp = "Replacement names must contain same number of items as current names")
   expect_error(names(schm) <- NULL, regexp = "Replacement names must be character vector, not NULL")
 
@@ -289,8 +289,8 @@ test_that("schema name assignment", {
   df <- data.frame(x = 1:3, y = c("a", "b", "c"))
   schm2 <- arrow_table(df)$schema
   names(schm2) <- c("col1", "col2")
-  expect_identical(names(schm2), c("col1", "col2"))
-  expect_identical(names(schm2$r_metadata$columns), c("col1", "col2"))
+  expect_named(schm2, c("col1", "col2"))
+  expect_named(schm2$r_metadata$columns, c("col1", "col2"))
 })
 
 test_that("schema extraction", {

--- a/r/tests/testthat/test-utf.R
+++ b/r/tests/testthat/test-utf.R
@@ -54,7 +54,7 @@ test_that("We handle non-UTF strings", {
 
   # Schema field name
   df_schema <- schema(raw_schema)
-  expect_identical(names(df_schema), names(df))
+  expect_named(df_schema, names(df))
 
   df_struct_schema <- schema(a = do.call(struct, raw_schema))
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

I'm building a new package to find and automatically fix lints in R code: [`flint`](https://flint.etiennebacher.com/).

I'm using real-life, large packages to check its performance and `arrow` is one of them. Since I already test on this, there's no additional cost for me in proposing those changes.

FYI, those changes were generated with `flint::fix_package(exclude_linters = "outer_negation")` (I excluded this linter because of https://github.com/etiennebacher/flint/issues/23).

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

There are many changes but most of them are trivial:
- replace `any(is.na())` by `anyNA()`
- add a leading 0 to decimal (e.g `.1` -> `0.1`)
- use `expect_named()` in tests
etc.

`flint` is quite new and linter rules are necessarily a bit opinionated, so some of those changes might not be to your taste.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

They don't change any functionality.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43357