### PR TITLE
GH-43340: [JS] Fix build on node v22 and fix `arrow2csv` bin extension

### DIFF
--- a/js/gulp/closure-task.js
+++ b/js/gulp/closure-task.js
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { targetDir, mainExport, esmRequire, gCCLanguageNames, publicModulePaths, observableFromStreams, shouldRunInChildProcess, spawnGulpCommandInChildProcess } from "./util.js";
+import { targetDir, mainExport, gCCLanguageNames, publicModulePaths, observableFromStreams, shouldRunInChildProcess, spawnGulpCommandInChildProcess } from "./util.js";
 
 import fs from 'node:fs';
 import gulp from 'gulp';
@@ -48,12 +48,13 @@ export const closureTask = ((cache) => memoizeTask(cache, async function closure
     const externs = Path.join(`${out}/${mainExport}.externs.js`);
     const entry_point = Path.join(`${src}/${mainExport}.dom.cls.js`);
 
-    const exportedImports = publicModulePaths(srcAbsolute).reduce((entries, publicModulePath) => [
-        ...entries, {
+    const exportedImports = [];
+    for (const publicModulePath of publicModulePaths(srcAbsolute)) {
+        exportedImports.push({
             publicModulePath,
-            exports_: getPublicExportedNames(esmRequire(publicModulePath))
-        }
-    ], []);
+            exports_: getPublicExportedNames(await import(publicModulePath))
+        });
+    }
 
     await mkdirp(out);
 

--- a/js/gulp/closure-task.js
+++ b/js/gulp/closure-task.js
@@ -52,7 +52,7 @@ export const closureTask = ((cache) => memoizeTask(cache, async function closure
     for (const publicModulePath of publicModulePaths(srcAbsolute)) {
         exportedImports.push({
             publicModulePath,
-            exports_: getPublicExportedNames(await import(publicModulePath))
+            exports_: getPublicExportedNames(await import(`file://${publicModulePath}`))
         });
     }
 

--- a/js/gulp/package-task.js
+++ b/js/gulp/package-task.js
@@ -40,7 +40,6 @@ export default packageTask;
 
 const createMainPackageJson = (target, format) => (orig) => ({
     ...createTypeScriptPackageJson(target, format)(orig),
-    bin: orig.bin,
     name: npmPkgName,
     type: 'commonjs',
     main: `${mainExport}.node.js`,
@@ -90,7 +89,6 @@ const createMainPackageJson = (target, format) => (orig) => ({
 
 const createTypeScriptPackageJson = (target, format) => (orig) => ({
     ...createScopedPackageJSON(target, format)(orig),
-    bin: undefined,
     main: `${mainExport}.node.ts`,
     module: `${mainExport}.node.ts`,
     types: `${mainExport}.node.ts`,
@@ -108,6 +106,9 @@ const createScopedPackageJSON = (target, format) => (({ name, ...orig }) =>
     packageJSONFields.reduce(
         (xs, key) => ({ ...xs, [key]: xs[key] || orig[key] }),
         {
+            bin: Object.entries(orig.bin).reduce((xs, [key, val]) => ({
+                ...xs, [key]: val.replace('.cjs', '.js')
+            }), {}),
             // un-set version, since it's automatically applied during the release process
             version: undefined,
             // set the scoped package name (e.g. "@apache-arrow/esnext-esm")

--- a/js/gulp/package-task.js
+++ b/js/gulp/package-task.js
@@ -120,11 +120,11 @@ const createScopedPackageJSON = (target, format) => (({ name, ...orig }) =>
             // set "main" to "Arrow" if building scoped UMD target, otherwise "Arrow.node"
             main:     format === 'umd' ? `${mainExport}.js` : `${mainExport}.node.js`,
             // set "type" to `module` or `commonjs` (https://nodejs.org/api/packages.html#packages_type)
-            type:     format === 'esm' ? `module` : `commonjs`,
+            type:     format === 'esm' || format === 'cls' ? `module` : `commonjs`,
             // set "module" if building scoped ESM target
-            module:   format === 'esm' ? `${mainExport}.node.js` : undefined,
+            module:   format === 'esm' || format === 'cls' ? `${mainExport}.node.js` : undefined,
             // set "sideEffects" to false as a hint to Webpack that it's safe to tree-shake the ESM target
-            sideEffects: format === 'esm' ? false : undefined,
+            sideEffects: format === 'esm' || format === 'cls' ? false : undefined,
             // include "esm" settings for https://www.npmjs.com/package/esm if building scoped ESM target
             esm:      format === `esm` ? { mode: `auto`, sourceMap: true } : undefined,
             // set "types" to "Arrow.dom" if building scoped UMD target, otherwise "Arrow.node"

--- a/js/gulp/util.js
+++ b/js/gulp/util.js
@@ -27,7 +27,6 @@ import { ReplaySubject, empty as ObservableEmpty, throwError as ObservableThrow,
 import { share, flatMap, takeUntil, defaultIfEmpty, mergeWith } from 'rxjs/operators';
 const asyncDone = util.promisify(asyncDoneSync);
 import { createRequire } from 'node:module';
-import esmRequire from './esm-require.cjs'
 
 const require = createRequire(import.meta.url);
 
@@ -177,7 +176,7 @@ export {
     knownTargets, knownModules, tasksToSkipPerTargetOrFormat, gCCLanguageNames,
 
     taskName, packageName, tsconfigName, targetDir, combinations, observableFromStreams,
-    publicModulePaths, esmRequire, shouldRunInChildProcess, spawnGulpCommandInChildProcess,
+    publicModulePaths, shouldRunInChildProcess, spawnGulpCommandInChildProcess,
 };
 
 export const targetAndModuleCombinations = [...combinations(targets, modules)];

--- a/js/package.json
+++ b/js/package.json
@@ -84,7 +84,6 @@
     "eslint": "8.57.0",
     "eslint-plugin-jest": "28.5.0",
     "eslint-plugin-unicorn": "54.0.0",
-    "esm": "https://github.com/jsg2021/esm/releases/download/v3.x.x-pr883/esm-3.x.x-pr883.tgz",
     "gulp": "4.0.2",
     "glob": "10.4.1",
     "google-closure-compiler": "20240317.0.0",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -3140,10 +3140,6 @@ eslint@8.57.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-"esm@https://github.com/jsg2021/esm/releases/download/v3.x.x-pr883/esm-3.x.x-pr883.tgz":
-  version "3.2.25"
-  resolved "https://github.com/jsg2021/esm/releases/download/v3.x.x-pr883/esm-3.x.x-pr883.tgz#c463cfa4e14aceea6b7cd7e669ef90de072ea60a"
-
 esniff@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/esniff/-/esniff-2.0.1.tgz#a4d4b43a5c71c7ec51c51098c1d8a29081f9b308"


### PR DESCRIPTION
Fixes #42229
Fixes #43340
Fixes #43341

* GitHub Issue: #43340