### PR TITLE
GH-43349: [R] Fix altrep string columns from readr

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -62,6 +62,7 @@ Suggests:
     lubridate,
     pillar,
     pkgload,
+    readr,
     reticulate,
     rmarkdown,
     stringi,

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -62,7 +62,6 @@ Suggests:
     lubridate,
     pillar,
     pkgload,
-    readr,
     reticulate,
     rmarkdown,
     stringi,

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -148,7 +148,7 @@ inline SEXP utf8_strings(SEXP x) {
 
     for (R_xlen_t i = 0; i < n; i++, ++p_x) {
       SEXP s = *p_x;
-      if (s != NA_STRING) {
+      if (s != NA_STRING && ALTREP(s)) {
         SET_STRING_ELT(x, i, Rf_mkCharCE(Rf_translateCharUTF8(s), CE_UTF8));
       }
     }

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -138,6 +138,11 @@ inline R_xlen_t r_string_size(SEXP s) {
 }  // namespace unsafe
 
 inline SEXP utf8_strings(SEXP x) {
+  // ensure that x is not actually altrep first
+  if (ALTREP(x)) {
+    x = PROTECT(Rf_duplicate(x));
+    UNPROTECT(1);
+  }
   return cpp11::unwind_protect([x] {
     R_xlen_t n = XLENGTH(x);
 
@@ -148,7 +153,7 @@ inline SEXP utf8_strings(SEXP x) {
 
     for (R_xlen_t i = 0; i < n; i++, ++p_x) {
       SEXP s = *p_x;
-      if (s != NA_STRING && ALTREP(s)) {
+      if (s != NA_STRING) {
         SET_STRING_ELT(x, i, Rf_mkCharCE(Rf_translateCharUTF8(s), CE_UTF8));
       }
     }

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -139,7 +139,8 @@ inline R_xlen_t r_string_size(SEXP s) {
 
 inline SEXP utf8_strings(SEXP x) {
   return cpp11::unwind_protect([&] {
-    // ensure that x is not actually altrep first
+    // ensure that x is not actually altrep first this also ensures that
+    // x is not altrep even after it is materialized
     bool was_altrep = ALTREP(x);
     if (was_altrep) {
       x = PROTECT(Rf_duplicate(x));

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -738,5 +738,14 @@ test_that("read_csv2_arrow correctly parses comma decimals", {
   tf <- tempfile()
   writeLines("x;y\n1,2;c", con = tf)
   expect_equal(read_csv2_arrow(tf), tibble(x = 1.2, y = "c"))
+})
 
+test_that("lazy readr can roundtrip to table", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+
+  write.csv(tbl, tf, row.names = FALSE)
+  tab <- arrow::as_arrow_table(readr::read_csv(tf, lazy = TRUE, show_col_types = FALSE))
+
+  expect_equal(tbl, as_tibble(tab))
 })

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -740,12 +740,21 @@ test_that("read_csv2_arrow correctly parses comma decimals", {
   expect_equal(read_csv2_arrow(tf), tibble(x = 1.2, y = "c"))
 })
 
-test_that("lazy readr can roundtrip to table", {
+test_that("altrep columns can roundtrip to table", {
   tf <- tempfile()
   on.exit(unlink(tf))
-
   write.csv(tbl, tf, row.names = FALSE)
-  tab <- arrow::as_arrow_table(readr::read_csv(tf, lazy = TRUE, show_col_types = FALSE))
 
-  expect_equal(tbl, as_tibble(tab))
+  # read in, some columns will be altrep by default
+  new_df <- read_csv_arrow(tf)
+  expect_equal(tbl, as_tibble(arrow_table(new_df)))
+
+  # but also if we materialize the vector
+  # this could also be accomplished with printing, 
+  # though with that the error goes from 
+  new_df <- read_csv_arrow(tf)
+  test_arrow_altrep_force_materialize(new_df$chr)
+
+  # we should still be able to turn this into a table
+  expect_equal(tbl, as_tibble(arrow_table(new_df)))
 })

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -750,8 +750,7 @@ test_that("altrep columns can roundtrip to table", {
   expect_equal(tbl, as_tibble(arrow_table(new_df)))
 
   # but also if we materialize the vector
-  # this could also be accomplished with printing, 
-  # though with that the error goes from 
+  # this could also be accomplished with printing
   new_df <- read_csv_arrow(tf)
   test_arrow_altrep_force_materialize(new_df$chr)
 


### PR DESCRIPTION
### Rationale for this change

To resolve the reverse dependency issue with `parquetize`

### What changes are included in this PR?

One step towards resolving the issue

### Are these changes tested?

yes

### Are there any user-facing changes?

no
* GitHub Issue: #43349