### PR TITLE
GH-43359: [Go][Parquet] ReadRowGroups panics with canceled context

### DIFF
--- a/go/parquet/pqarrow/file_reader.go
+++ b/go/parquet/pqarrow/file_reader.go
@@ -375,6 +375,12 @@ func (fr *FileReader) ReadRowGroups(ctx context.Context, indices, rowGroups []in
 		data.data.Release()
 	}
 
+	if ctxErr := ctx.Err(); err == nil && ctxErr != nil {
+		// if the context is in error, but we haven't set an error yet, then it means that the parent context
+		// was cancelled. In this case, we should exit early as some columns may not have been read yet.
+		err = ctxErr
+	}
+
 	if err != nil {
 		// if we encountered an error, consume any waiting data on the channel
 		// so the goroutines don't leak and so memory can get cleaned up. we already

--- a/go/parquet/pqarrow/file_reader.go
+++ b/go/parquet/pqarrow/file_reader.go
@@ -18,6 +18,7 @@ package pqarrow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -375,11 +376,9 @@ func (fr *FileReader) ReadRowGroups(ctx context.Context, indices, rowGroups []in
 		data.data.Release()
 	}
 
-	if ctxErr := ctx.Err(); err == nil && ctxErr != nil {
-		// if the context is in error, but we haven't set an error yet, then it means that the parent context
-		// was cancelled. In this case, we should exit early as some columns may not have been read yet.
-		err = ctxErr
-	}
+	// if the context is in error, but we haven't set an error yet, then it means that the parent context
+	// was cancelled. In this case, we should exit early as some columns may not have been read yet.
+	err = errors.Join(err, ctx.Err())
 
 	if err != nil {
 		// if we encountered an error, consume any waiting data on the channel

--- a/go/parquet/pqarrow/helpers.go
+++ b/go/parquet/pqarrow/helpers.go
@@ -38,6 +38,8 @@ func releaseArrayData(data []arrow.ArrayData) {
 
 func releaseColumns(columns []arrow.Column) {
 	for _, col := range columns {
-		col.Release()
+		if col.Data() != nil { // data can be nil due to the way columns are constructed in ReadRowGroups
+			col.Release()
+		}
 	}
 }


### PR DESCRIPTION
### Rationale for this change

`ReadRowGroups` needs to support externally canceled contexts, e.g. for request-scoped contexts in servers like gRPC.

### What changes are included in this PR?

Additionnaly, `releaseColumns` needs to ignore columns with uninitialized data as it used in a `defer` statement.

### Are these changes tested?

Yes: a new test `TestArrowReaderCanceledContext` is included.

### Are there any user-facing changes?

None
* GitHub Issue: #43359