### PR TITLE
GH-43393: [C++][Parquet] parquet-dump-footer: Remove redundant link and fix --debug processing

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -1053,8 +1053,8 @@ std::shared_ptr<FileMetaData> FileMetaData::Subset(
   return impl_->Subset(row_groups);
 }
 
-std::string FileMetaData::SerializeUnencrypted(bool scrub, bool json) const {
-  return impl_->SerializeUnencrypted(scrub, json);
+std::string FileMetaData::SerializeUnencrypted(bool scrub, bool debug) const {
+  return impl_->SerializeUnencrypted(scrub, debug);
 }
 
 void FileMetaData::WriteTo(::arrow::io::OutputStream* dst,

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,7 +31,7 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  target_link_libraries(parquet-dump-footer ${ARROW_LIBRARIES})
+  # target_link_libraries(parquet-dump-footer ${ARROW_LIBRARIES})
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -31,7 +31,6 @@ if(PARQUET_BUILD_EXECUTABLES)
     install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
-  # target_link_libraries(parquet-dump-footer ${ARROW_LIBRARIES})
 
   add_dependencies(parquet ${PARQUET_TOOLS})
 endif()

--- a/cpp/tools/parquet/parquet_dump_footer.cc
+++ b/cpp/tools/parquet/parquet_dump_footer.cc
@@ -38,7 +38,7 @@ void AppendLE32(uint32_t v, std::string* out) {
   out->append(reinterpret_cast<const char*>(&v), sizeof(v));
 }
 
-int DoIt(std::string in, bool scrub, bool json, std::string out) {
+int DoIt(std::string in, bool scrub, bool debug, std::string out) {
   std::string path;
   auto fs = ::arrow::fs::FileSystemFromUriOrPath(in, &path).ValueOrDie();
   auto file = fs->OpenInputFile(path).ValueOrDie();
@@ -73,8 +73,8 @@ int DoIt(std::string in, bool scrub, bool json, std::string out) {
     file->ReadAt(file_len - tail_len, tail_len, data).ValueOrDie();
   }
   auto md = FileMetaData::Make(tail.data(), &metadata_len);
-  std::string ser = md->SerializeUnencrypted(scrub, json);
-  if (!json) {
+  std::string ser = md->SerializeUnencrypted(scrub, debug);
+  if (!debug) {
     AppendLE32(static_cast<uint32_t>(ser.size()), &ser);
     ser.append("PAR1", 4);
   }
@@ -107,7 +107,7 @@ static int PrintHelp() {
 
 int main(int argc, char** argv) {
   bool scrub = true;
-  bool json = false;
+  bool debug = false;
   std::string in;
   std::string out;
   for (int i = 1; i < argc; i++) {
@@ -116,8 +116,8 @@ int main(int argc, char** argv) {
       return PrintHelp();
     } else if (!std::strcmp(arg, "--no-scrub")) {
       scrub = false;
-    } else if (!std::strcmp(arg, "--json")) {
-      json = true;
+    } else if (!std::strcmp(arg, "--debug")) {
+      debug = true;
     } else if (!std::strcmp(arg, "--in")) {
       if (i + 1 >= argc) return PrintHelp();
       in = argv[++i];
@@ -131,5 +131,5 @@ int main(int argc, char** argv) {
   }
   if (in.empty()) return PrintHelp();
 
-  return parquet::DoIt(in, scrub, json, out);
+  return parquet::DoIt(in, scrub, debug, out);
 }


### PR DESCRIPTION
### Rationale for this change

* We don't need to link to `libarrow` explicitly because `parquet_shared`/`parquet_static` does it automatically
* `--help` shows `--debug` but the implementation accepts `--json` not `--debug`

### What changes are included in this PR?

* Remove the redundant `libarrow` link
* Accept `--debug` not `--json`

### Are these changes tested?

Manually.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #43393