### PR TITLE
GH-41951: [Java] Add @FormatMethod annotations

### DIFF
--- a/java/memory/memory-core/pom.xml
+++ b/java/memory/memory-core/pom.xml
@@ -47,6 +47,10 @@ under the License.
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/memory/memory-core/src/main/java/module-info.java
+++ b/java/memory/memory-core/src/main/java/module-info.java
@@ -27,5 +27,6 @@ module org.apache.arrow.memory.core {
   requires jsr305;
   requires static org.checkerframework.checker.qual;
   requires static org.immutables.value.annotations;
+  requires static com.google.errorprone.annotations;
   requires org.slf4j;
 }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.arrow.memory;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -539,9 +541,8 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
     return sb.toString();
   }
 
-  /* Remove @SuppressWarnings after fixing https://github.com/apache/arrow/issues/41951 */
-  @SuppressWarnings("FormatStringAnnotation")
-  private void hist(String noteFormat, Object... args) {
+  @FormatMethod
+  private void hist(@FormatString String noteFormat, Object... args) {
     if (historicalLog != null) {
       historicalLog.recordEvent(noteFormat, args);
     }

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/HistoricalLog.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/HistoricalLog.java
@@ -16,6 +16,8 @@
  */
 package org.apache.arrow.memory.util;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
@@ -42,9 +44,8 @@ public class HistoricalLog {
    *     object instance is best.
    * @param args for the format string, or nothing if none are required
    */
-  @SuppressWarnings("FormatStringAnnotation")
-  /* Remove @SuppressWarnings after fixing https://github.com/apache/arrow/issues/41951 */
-  public HistoricalLog(final String idStringFormat, Object... args) {
+  @FormatMethod
+  public HistoricalLog(@FormatString final String idStringFormat, Object... args) {
     this(Integer.MAX_VALUE, idStringFormat, args);
   }
 
@@ -65,9 +66,8 @@ public class HistoricalLog {
    *     object instance is best.
    * @param args for the format string, or nothing if none are required
    */
-  @SuppressWarnings("AnnotateFormatMethod")
-  public HistoricalLog(final int limit, final String idStringFormat, Object... args) {
-    // Remove @SuppressWarnings after fixing https://github.com/apache/arrow/issues/41951
+  @FormatMethod
+  public HistoricalLog(final int limit, @FormatString final String idStringFormat, Object... args) {
     this.limit = limit;
     this.idString = String.format(idStringFormat, args);
     this.firstEvent = null;
@@ -80,9 +80,8 @@ public class HistoricalLog {
    * @param noteFormat {@link String#format} format string that describes the event
    * @param args for the format string, or nothing if none are required
    */
-  @SuppressWarnings("AnnotateFormatMethod")
-  public synchronized void recordEvent(final String noteFormat, Object... args) {
-    // Remove @SuppressWarnings after fixing https://github.com/apache/arrow/issues/41951
+  @FormatMethod
+  public synchronized void recordEvent(@FormatString final String noteFormat, Object... args) {
     final String note = String.format(noteFormat, args);
     final Event event = new Event(note);
     if (firstEvent == null) {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -106,8 +106,7 @@ under the License.
     <arrow.vector.classifier></arrow.vector.classifier>
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
-    <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
-    <error_prone_core.version>2.28.0</error_prone_core.version>
+    <error_prone_core.version>2.29.2</error_prone_core.version>
     <mockito.core.version>5.11.0</mockito.core.version>
     <mockito.inline.version>5.2.0</mockito.inline.version>
     <checker.framework.version>3.45.0</checker.framework.version>
@@ -159,6 +158,12 @@ under the License.
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${error_prone_core.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What changes are included in this PR?

Annotate several methods using format-like string with error-prone `@FormatMethod` and `@FormatString` annotations.

Update error-prone version to 2.29.2 and remove unused error-prone javac version property.

### Are these changes tested?
 
CI/CD

### Are there any user-facing changes?

None


* GitHub Issue: #41951