### PR TITLE
GH-43377: [Java][CI] Java-Jars CI is Failing with a linking error on macOS

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -141,7 +141,10 @@ jobs:
 
           brew bundle --file=arrow/java/Brewfile
           
-          # We want to use the bundled googletest for linking.
+          # We want to use the bundled googletest for static linking. Since
+          # both BUNDLED and brew options are enabled, it could cause a conflict
+          # when there is a version mismatch.
+          # We uninstall googletest to ensure using the bundled googletest.
           brew uninstall googletest
       - name: Build C++ libraries
         env:

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -142,7 +142,7 @@ jobs:
           brew bundle --file=arrow/java/Brewfile
           
           # installing googletest older version
-          brew install googletest@1.14
+          brew install googletest@1.14.0
       - name: Build C++ libraries
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -83,7 +83,7 @@ jobs:
           - { runs_on: ["macos-13"], arch: "x86_64"}
           - { runs_on: ["macos-14"], arch: "aarch_64" }
     env:
-      MACOSX_DEPLOYMENT_TARGET: "13.10"
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       - name: Set up Python

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -140,6 +140,9 @@ jobs:
           brew uninstall protobuf
 
           brew bundle --file=arrow/java/Brewfile
+          
+          # installing googletest older version
+          brew install googletest@1.14
       - name: Build C++ libraries
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -141,8 +141,8 @@ jobs:
 
           brew bundle --file=arrow/java/Brewfile
           
-          # installing googletest older version
-          brew install googletest@1.14.0
+          # We want to use the bundled googletest for linking.
+          brew uninstall googletest
       - name: Build C++ libraries
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -83,7 +83,7 @@ jobs:
           - { runs_on: ["macos-13"], arch: "x86_64"}
           - { runs_on: ["macos-14"], arch: "aarch_64" }
     env:
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
+      MACOSX_DEPLOYMENT_TARGET: "13.10"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       - name: Set up Python


### PR DESCRIPTION
### Rationale for this change

For `googletest`, we have installation via BUNDLED and brew, a version mismatch from one of these options could cause conflicts and linking related issues. Preferring BUNDLED version, this PR uninstalls the brew installation of `googletest`. 

### What changes are included in this PR?

Removing brew installation of `googletest`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No

* GitHub Issue: #43377