### PR TITLE
GH-43391: [Python] Add bindings for memory manager and device to Context class

### DIFF
--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -201,7 +201,6 @@ cdef class Context(_Weakrefable):
         """
         The device instance associated with this context.
 
-
         Returns
         -------
         Device

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -185,10 +185,27 @@ cdef class Context(_Weakrefable):
             cudabuf = GetResultValue(self.context.get().Allocate(nbytes))
         return pyarrow_wrap_cudabuffer(cudabuf)
 
+    @property
     def memory_manager(self):
+        """
+        The default memory manager tied to this context's device.
+
+        Returns
+        -------
+        MemoryManager
+        """
         return MemoryManager.wrap(self.context.get().memory_manager())
 
+    @property
     def device(self):
+        """
+        The device instance associated with this context.
+
+
+        Returns
+        -------
+        Device
+        """
         return Device.wrap(self.context.get().device())
 
     def foreign_buffer(self, address, size, base=None):

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -185,6 +185,12 @@ cdef class Context(_Weakrefable):
             cudabuf = GetResultValue(self.context.get().Allocate(nbytes))
         return pyarrow_wrap_cudabuffer(cudabuf)
 
+    def memory_manager(self):
+        return MemoryManager.wrap(self.context.get().memory_manager())
+
+    def device(self):
+        return Device.wrap(self.context.get().device())
+
     def foreign_buffer(self, address, size, base=None):
         """
         Create device buffer from address and size as a view.

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -41,6 +41,8 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::cuda" nogil:
         const void* handle() const
         int device_number() const
         CResult[uintptr_t] GetDeviceAddress(uintptr_t addr)
+        shared_ptr[CDevice] device() const
+        shared_ptr[CMemoryManager] memory_manager() const
 
     cdef cppclass CCudaIpcMemHandle" arrow::cuda::CudaIpcMemHandle":
         @staticmethod

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -57,6 +57,18 @@ def test_Context():
     assert global_context.device_number == 0
     assert global_context1.device_number == cuda.Context.get_num_devices() - 1
 
+    mm = global_context.memory_manager()
+    assert not mm.is_cpu
+    assert "<pyarrow.MemoryManager device: CudaDevice" in repr(mm)
+
+    dev = global_context.device()
+    assert dev == mm.device
+
+    assert not dev.is_cpu
+    assert dev.device_id == 0
+    assert dev.device_type == pa.DeviceAllocationType.CUDA
+    assert "<pyarrow.Device: CudaDevice" in repr(dev)
+
     with pytest.raises(ValueError,
                        match=("device_number argument must "
                               "be non-negative less than")):

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -57,17 +57,16 @@ def test_Context():
     assert global_context.device_number == 0
     assert global_context1.device_number == cuda.Context.get_num_devices() - 1
 
-    mm = global_context.memory_manager()
+    mm = global_context.memory_manager
     assert not mm.is_cpu
     assert "<pyarrow.MemoryManager device: CudaDevice" in repr(mm)
 
-    dev = global_context.device()
+    dev = global_context.device
     assert dev == mm.device
 
     assert not dev.is_cpu
     assert dev.device_id == 0
     assert dev.device_type == pa.DeviceAllocationType.CUDA
-    assert "<pyarrow.Device: CudaDevice" in repr(dev)
 
     with pytest.raises(ValueError,
                        match=("device_number argument must "


### PR DESCRIPTION
### What changes are included in this PR?

Added bindings for `device` and `memory_manager` to `pyarrow.cuda.Context class`.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes
* GitHub Issue: #43391