### PR TITLE
GH-43394: [Java][Benchmarking] Fix Java benchmarks for Java 17+

### DIFF
--- a/dev/archery/archery/lang/java.py
+++ b/dev/archery/archery/lang/java.py
@@ -34,14 +34,22 @@ class Jar(CommandStackMixin, Java):
 
 
 class JavaConfiguration:
-    def __init__(self,
+    REQUIRED_JAVA_OPTIONS = [
+        "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED",
+    ]
 
+    def __init__(self,
                  # toolchain
                  java_home=None, java_options=None,
                  # build & benchmark
                  build_extras=None, benchmark_extras=None):
         self.java_home = java_home
-        self.java_options = java_options
+
+        required_options = " ".join(self.REQUIRED_JAVA_OPTIONS)
+        if java_options:
+            self.java_options = java_options + " " + required_options
+        else:
+            self.java_options = required_options
 
         self.build_extras = list(build_extras) if build_extras else []
         self.benchmark_extras = list(

--- a/dev/archery/archery/lang/java.py
+++ b/dev/archery/archery/lang/java.py
@@ -44,12 +44,14 @@ class JavaConfiguration:
                  # build & benchmark
                  build_extras=None, benchmark_extras=None):
         self.java_home = java_home
+        self.java_options = java_options
 
-        required_options = " ".join(self.REQUIRED_JAVA_OPTIONS)
-        if java_options:
-            self.java_options = java_options + " " + required_options
+        if self.java_options is None:
+            self.java_options = " ".join(self.REQUIRED_JAVA_OPTIONS)
         else:
-            self.java_options = required_options
+            for option in self.REQUIRED_JAVA_OPTIONS:
+                if option not in self.java_options:
+                    self.java_options += " " + option
 
         self.build_extras = list(build_extras) if build_extras else []
         self.benchmark_extras = list(


### PR DESCRIPTION
### Rationale for this change

Now that Arrow Java has moved from Java 8 -> Java 11, we need to add `--add-opens` when running Java.

### What changes are included in this PR?

* Add `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED` to `_JAVA_OPTIONS` in archery.
* Clean up test code only used for Java 8

### Are these changes tested?

To be verified via CI and ursabot.

### Are there any user-facing changes?

No
* GitHub Issue: #43394