### PR TITLE
GH-43396: [Java] Remove/replace jsr305

### DIFF
--- a/java/flight/flight-core/src/main/java/module-info.java
+++ b/java/flight/flight-core/src/main/java/module-info.java
@@ -35,7 +35,6 @@ module org.apache.arrow.flight.core {
   requires io.netty.common;
   requires io.netty.handler;
   requires io.netty.transport;
-  requires jsr305;
   requires org.apache.arrow.format;
   requires org.apache.arrow.memory.core;
   requires org.apache.arrow.vector;

--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -132,10 +132,8 @@ under the License.
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>compile</scope>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
     </dependency>
   </dependencies>
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/client/ArrowFlightSqlClientHandler.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.arrow.driver.jdbc.client.utils.ClientAuthenticationUtils;
 import org.apache.arrow.flight.CallOption;
 import org.apache.arrow.flight.CallStatus;
@@ -61,6 +60,7 @@ import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.calcite.avatica.Meta.StatementType;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/memory/memory-core/pom.xml
+++ b/java/memory/memory-core/pom.xml
@@ -32,10 +32,6 @@ under the License.
 
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/java/memory/memory-core/src/main/java/module-info.java
+++ b/java/memory/memory-core/src/main/java/module-info.java
@@ -24,7 +24,6 @@ module org.apache.arrow.memory.core {
 
   requires java.compiler;
   requires transitive jdk.unsupported;
-  requires jsr305;
   requires static org.checkerframework.checker.qual;
   requires static org.immutables.value.annotations;
   requires static com.google.errorprone.annotations;

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/Accountant.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/Accountant.java
@@ -17,7 +17,6 @@
 package org.apache.arrow.memory;
 
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.concurrent.ThreadSafe;
 import org.apache.arrow.util.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -25,7 +24,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Provides a concurrent way to manage account for memory usage without locking. Used as basis for
  * Allocators. All operations are threadsafe (except for close).
  */
-@ThreadSafe
 class Accountant implements AutoCloseable {
 
   /** The parent allocator. */

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -155,11 +155,6 @@ under the License.
         <version>${dep.fbs.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>3.0.2</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>${error_prone_core.version}</version>


### PR DESCRIPTION
### Rationale for this change

jsr305 is not maintained anymore and is unlikely to support JPMS. The classes are also in the javax. namespace which is known to cause issues as well.

### What changes are included in this PR?

Replace most uses of jsr305 with the equivalent checker framework annotations, and remove usage of `@ThreadSafe.`

### Are these changes tested?

CI/CD

### Are there any user-facing changes?

None


* GitHub Issue: #43396