### PR TITLE
MINOR: [Python] Remove extra import from PyCapsule Interface Doc

### DIFF
--- a/docs/source/format/CDataInterface/PyCapsuleInterface.rst
+++ b/docs/source/format/CDataInterface/PyCapsuleInterface.rst
@@ -303,7 +303,6 @@ function accepts an object implementing one of these protocols.
 .. code-block:: python
 
     from typing import Tuple, Protocol
-    from typing_extensions import Self
 
     class ArrowSchemaExportable(Protocol):
         def __arrow_c_schema__(self) -> object: ...


### PR DESCRIPTION
### Rationale for this change

The PyCapsule Interface doc includes the line

```py
from typing_extensions import Self
```

but `Self` is not used anywhere in the typing declarations, so that line can be removed.

### What changes are included in this PR?



### Are these changes tested?



### Are there any user-facing changes?

No