### PR TITLE
GH-43403: [Go] Handle LargeString and LargeBinary in the flightsql driver

### DIFF
--- a/go/arrow/flight/flightsql/driver/utils.go
+++ b/go/arrow/flight/flightsql/driver/utils.go
@@ -88,7 +88,11 @@ func fromArrowType(arr arrow.Array, idx int) (interface{}, error) {
 		return c.Value(idx), nil
 	case *array.Binary:
 		return c.Value(idx), nil
+	case *array.LargeBinary:
+		return c.Value(idx), nil
 	case *array.String:
+		return c.Value(idx), nil
+	case *array.LargeString:
 		return c.Value(idx), nil
 	case *array.Time32:
 		d32 := arr.DataType().(*arrow.Time32Type)

--- a/go/arrow/flight/flightsql/driver/utils_test.go
+++ b/go/arrow/flight/flightsql/driver/utils_test.go
@@ -54,6 +54,8 @@ func Test_fromArrowType(t *testing.T) {
 		{Name: "f19-duration_ms", Type: arrow.FixedWidthTypes.Duration_ms},
 		{Name: "f20-duration_us", Type: arrow.FixedWidthTypes.Duration_us},
 		{Name: "f21-duration_ns", Type: arrow.FixedWidthTypes.Duration_ns},
+		{Name: "f22-large-string", Type: arrow.BinaryTypes.LargeString},
+		{Name: "f23-large-binary", Type: arrow.BinaryTypes.LargeBinary},
 	}
 
 	schema := arrow.NewSchema(fields, nil)
@@ -98,6 +100,9 @@ func Test_fromArrowType(t *testing.T) {
 	b.Field(18).(*array.DurationBuilder).Append(1)
 	b.Field(19).(*array.DurationBuilder).Append(1)
 	b.Field(20).(*array.DurationBuilder).Append(1)
+	b.Field(21).(*array.LargeStringBuilder).Append("a")
+	// BinaryBuilder is also used for building a LargeBinary array
+	b.Field(22).(*array.BinaryBuilder).Append([]byte("a"))
 
 	rec := b.NewRecord()
 	defer rec.Release()
@@ -135,4 +140,6 @@ func Test_fromArrowType(t *testing.T) {
 	tf(t, 18, time.Duration(1000000))                        // "f19-duration_ms"
 	tf(t, 19, time.Duration(1000))                           // "f20-duration_us"
 	tf(t, 20, time.Duration(1))                              // "f21-duration_ns"
+	tf(t, 21, "a")                                           // "f22-large-string"
+	tf(t, 22, []byte("a"))                                   // "f23-large-binary"
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Closes #43403

The Go flightsql database driver currently does not handle scanning string or byte values where the Arrow type is LargeString or LargeBinary.

### What changes are included in this PR?

Adds those types to the `fromArrowType` utility method.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No


* GitHub Issue: #43403