### PR TITLE
GH-43390: [C++] Add support for building on Android porting patch from vcpkg

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -166,7 +166,9 @@ if(WIN32)
   list(APPEND ARROW_SYSTEM_LINK_LIBS "ws2_32")
 endif()
 
-if(NOT WIN32 AND NOT APPLE AND NOT ANDROID)
+if(NOT WIN32
+   AND NOT APPLE
+   AND NOT ANDROID)
   # Pass -lrt on Linux only
   list(APPEND ARROW_SYSTEM_LINK_LIBS rt)
 endif()

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -166,7 +166,7 @@ if(WIN32)
   list(APPEND ARROW_SYSTEM_LINK_LIBS "ws2_32")
 endif()
 
-if(NOT WIN32 AND NOT APPLE)
+if(NOT WIN32 AND NOT APPLE AND NOT ANDROID)
   # Pass -lrt on Linux only
   list(APPEND ARROW_SYSTEM_LINK_LIBS rt)
 endif()

--- a/cpp/src/arrow/vendored/musl/strptime.c
+++ b/cpp/src/arrow/vendored/musl/strptime.c
@@ -18,7 +18,9 @@
 #undef HAVE_LANGINFO
 
 #ifndef _WIN32
+# if !(defined(__ANDROID__) && __ANDROID_API__ < 26)
 #define HAVE_LANGINFO 1
+#endif
 #endif
 
 #ifdef HAVE_LANGINFO


### PR DESCRIPTION
### Rationale for this change

We had to apply a patch on vcpkg in order to build on Android. Adding this patch to the main arrow repo to remove upstream patch.
The upstream patch: https://github.com/microsoft/vcpkg/blob/43586b1aa054ba3e453c5cce2c13cae64b61e5e1/ports/arrow/android.patch

### What changes are included in this PR?

Some minor changes to allow build on Android

### Are these changes tested?

On CI, build for Android must be tested upstream but the patch has been tested on vcpkg.

### Are there any user-facing changes?

No
* GitHub Issue: #43390