### PR TITLE
GH-43412: [Java][Benchmarking] Use JDK_JAVA_OPTIONS for JVM arguments

### DIFF
--- a/dev/archery/archery/lang/java.py
+++ b/dev/archery/archery/lang/java.py
@@ -73,7 +73,7 @@ class JavaConfiguration:
             env["JAVA_HOME"] = self.java_home
 
         if self.java_options:
-            env["JAVA_OPTIONS"] = self.java_options
+            env["JDK_JAVA_OPTIONS"] = self.java_options
 
         return env
 

--- a/docs/source/java/install.rst
+++ b/docs/source/java/install.rst
@@ -40,7 +40,7 @@ adding ``--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
    # Directly on the command line
    $ java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -jar ...
    # Indirectly via environment variables
-   $ env _JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
+   $ env JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
 
 Otherwise, you may see errors like ``module java.base does not "opens
 java.nio" to unnamed module`` or ``module java.base does not "opens
@@ -58,7 +58,7 @@ Modifying the command above for Flight:
    # Directly on the command line
    $ java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -jar ...
    # Indirectly via environment variables
-   $ env _JAVA_OPTIONS="--add-reads=org.apache.arrow.flight.core=ALL-UNNAMED --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
+   $ env JDK_JAVA_OPTIONS="--add-reads=org.apache.arrow.flight.core=ALL-UNNAMED --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
 
 Otherwise, you may see errors like ``java.lang.IllegalAccessError: superclass access check failed: class
 org.apache.arrow.flight.ArrowMessage$ArrowBufRetainingCompositeByteBuf (in module org.apache.arrow.flight.core)
@@ -73,7 +73,7 @@ Modifying the command above for arrow-memory:
    # Directly on the command line
    $ java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -jar ...
    # Indirectly via environment variables
-   $ env _JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.dataset,org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
+   $ env JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=org.apache.arrow.dataset,org.apache.arrow.memory.core,ALL-UNNAMED" java -jar ...
 
 Otherwise you may see errors such as ``java.lang.RuntimeException: java.lang.reflect.InaccessibleObjectException:
 Unable to make static void java.nio.Bits.reserveMemory(long,long) accessible: module
@@ -216,7 +216,7 @@ Or they can be added via environment variable, for example when executing your c
 
 .. code-block::
 
-    _JAVA_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED" mvn exec:java -Dexec.mainClass="YourMainCode"
+    JDK_JAVA_OPTIONS="--add-opens=java.base/java.nio=ALL-UNNAMED" mvn exec:java -Dexec.mainClass="YourMainCode"
 
 Installing from Source
 ======================


### PR DESCRIPTION
### Rationale for this change

Java options are not getting picked up properly in archery.

### What changes are included in this PR?

* Use JDK_JAVA_OPTIONS instead of _JAVA_OPTIONS env var.

### Are these changes tested?

Test via benchmark bot (ursabot)

### Are there any user-facing changes?

No
* GitHub Issue: #43412