### PR TITLE
GH-43416: [CI] Upgrade our vcpkg version on .env

### DIFF
--- a/.env
+++ b/.env
@@ -89,7 +89,7 @@ TZ=UTC
 # Used through docker-compose.yml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the
 # docker tags more readable.
-VCPKG="943c5ef1c8f6b5e6ced092b242c8299caae2ff01"    # 2024.04.26 Release
+VCPKG="1de2026f28ead93ff1773e6e680387643e914ea1"    # 2024.07.12 Release
 
 # This must be updated when we update
 # ci/docker/python-wheel-windows-vs2019.dockerfile.

--- a/ci/vcpkg/ports.patch
+++ b/ci/vcpkg/ports.patch
@@ -29,17 +29,19 @@ index a79c72a59..6b7fa6a66 100644
  
  vcpkg_cmake_install(ADD_BIN_TO_PATH)
 diff --git a/ports/snappy/portfile.cmake b/ports/snappy/portfile.cmake
-index c33046b..14d2ae3 100644
+index c33046b..baf2c5e 100644
 --- a/ports/snappy/portfile.cmake
 +++ b/ports/snappy/portfile.cmake
-@@ -8,6 +8,7 @@ vcpkg_from_github(
+@@ -8,7 +8,9 @@ vcpkg_from_github(
          fix_clang-cl_build.patch
          no-werror.patch
          pkgconfig.diff
 +        "snappy-disable-bmi.patch"
  )
++
  file(COPY "${CURRENT_PORT_DIR}/snappy.pc.in" DESTINATION "${SOURCE_PATH}")
-
+ 
+ vcpkg_cmake_configure(
 diff --git a/ports/snappy/snappy-disable-bmi.patch b/ports/snappy/snappy-disable-bmi.patch
 new file mode 100644
 index 000000000..e839c93a4

--- a/ci/vcpkg/ports.patch
+++ b/ci/vcpkg/ports.patch
@@ -29,17 +29,17 @@ index a79c72a59..6b7fa6a66 100644
  
  vcpkg_cmake_install(ADD_BIN_TO_PATH)
 diff --git a/ports/snappy/portfile.cmake b/ports/snappy/portfile.cmake
-index 0c7098082..c603c3653 100644
+index c33046b..14d2ae3 100644
 --- a/ports/snappy/portfile.cmake
 +++ b/ports/snappy/portfile.cmake
-@@ -10,6 +10,7 @@ vcpkg_from_github(
-     PATCHES
+@@ -8,6 +8,7 @@ vcpkg_from_github(
          fix_clang-cl_build.patch
          no-werror.patch
+         pkgconfig.diff
 +        "snappy-disable-bmi.patch"
  )
- 
- vcpkg_cmake_configure(
+ file(COPY "${CURRENT_PORT_DIR}/snappy.pc.in" DESTINATION "${SOURCE_PATH}")
+
 diff --git a/ports/snappy/snappy-disable-bmi.patch b/ports/snappy/snappy-disable-bmi.patch
 new file mode 100644
 index 000000000..e839c93a4
@@ -65,56 +65,3 @@ index 000000000..e839c93a4
 + }
 + 
 + static inline bool LeftShiftOverflows(uint8_t value, uint32_t shift) {
-diff --git a/ports/thrift/portfile.cmake b/ports/thrift/portfile.cmake
-index 1501782..71d2147 100644
---- a/ports/thrift/portfile.cmake
-+++ b/ports/thrift/portfile.cmake
-@@ -12,7 +12,7 @@ vcpkg_find_acquire_program(BISON)
- vcpkg_from_github(
-     OUT_SOURCE_PATH SOURCE_PATH
-     REPO apache/thrift
--    REF "${VERSION}"
-+    REF "v${VERSION}"
-     SHA512 5e4ee9870b30fe5ba484d39781c435716f7f3903793dc8aae96594ca813b1a5a73363b84719038ca8fa3ab8ef0a419a28410d936ff7b3bbadf36fc085a6883ae
-     HEAD_REF master
-     PATCHES
-diff --git a/ports/thrift/vcpkg.json b/ports/thrift/vcpkg.json
-index 2d5a854..9ff49ec 100644
---- a/ports/thrift/vcpkg.json
-+++ b/ports/thrift/vcpkg.json
-@@ -1,6 +1,7 @@
- {
-   "name": "thrift",
-   "version": "0.20.0",
-+  "port-version": 1,
-   "description": "Apache Thrift is a software project spanning a variety of programming languages and use cases. Our goal is to make reliable, performant communication and data serialization across languages as efficient and seamless as possible.",
-   "homepage": "https://github.com/apache/thrift",
-   "license": "Apache-2.0",
-diff --git a/versions/baseline.json b/versions/baseline.json
-index c6ce736..9ad1d63 100644
---- a/versions/baseline.json
-+++ b/versions/baseline.json
-@@ -8622,7 +8622,7 @@
-     },
-     "thrift": {
-       "baseline": "0.20.0",
--      "port-version": 0
-+      "port-version": 1
-     },
-     "tidy-html5": {
-       "baseline": "5.8.0",
-diff --git a/versions/t-/thrift.json b/versions/t-/thrift.json
-index 3db38c5..7464bde 100644
---- a/versions/t-/thrift.json
-+++ b/versions/t-/thrift.json
-@@ -1,5 +1,10 @@
- {
-   "versions": [
-+    {
-+      "git-tree": "13757a6b05741cf3c9c39e3a1dcc5e5cd685e025",
-+      "version": "0.20.0",
-+      "port-version": 1
-+    },
-     {
-       "git-tree": "6855be1ce96497811d4eb0a9879baf6cf1b3610c",
-       "version": "0.20.0",

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4512,9 +4512,12 @@ function(build_orc)
   message(STATUS "Building Apache ORC from source")
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
+    find_program(PATCH patch REQUIRED)
+    set(ORC_PATCH_COMMAND ${PATCH} -p1 -i ${CMAKE_CURRENT_LIST_DIR}/orc.diff)
     fetchcontent_declare(orc
                          ${FC_DECLARE_COMMON_OPTIONS}
                          URL ${ORC_SOURCE_URL}
+                         PATCH_COMMAND ${ORC_PATCH_COMMAND}
                          URL_HASH "SHA256=${ARROW_ORC_BUILD_SHA256_CHECKSUM}")
     prepare_fetchcontent()
 

--- a/cpp/cmake_modules/orc.diff
+++ b/cpp/cmake_modules/orc.diff
@@ -24,7 +24,7 @@ index aa520ff..01ab294 100644
  if (ORC_PACKAGE_KIND STREQUAL "conan")
    target_link_libraries (orc_protobuf INTERFACE ${protobuf_LIBRARIES})
 -elseif (ORC_PREFER_STATIC_PROTOBUF AND ${PROTOBUF_STATIC_LIB})
-+elseif (ORC_PREFER_STATIC_PROTOBUF AND DEFINED PROTOBUF_STATIC_LIB)
++elseif (ORC_PREFER_STATIC_PROTOBUF AND PROTOBUF_STATIC_LIB)
    target_link_libraries (orc_protobuf INTERFACE ${PROTOBUF_STATIC_LIB})
  else ()
    target_link_libraries (orc_protobuf INTERFACE ${PROTOBUF_LIBRARY})
@@ -33,7 +33,7 @@ index aa520ff..01ab294 100644
  
  if (NOT ORC_PACKAGE_KIND STREQUAL "conan")
 -  if (ORC_PREFER_STATIC_PROTOBUF AND ${PROTOC_STATIC_LIB})
-+  if (ORC_PREFER_STATIC_PROTOBUF AND DEFINED PROTOC_STATIC_LIB)
++  if (ORC_PREFER_STATIC_PROTOBUF AND PROTOC_STATIC_LIB)
      target_link_libraries (orc_protoc INTERFACE ${PROTOC_STATIC_LIB})
    else ()
      target_link_libraries (orc_protoc INTERFACE ${PROTOC_LIBRARY})

--- a/cpp/cmake_modules/orc.diff
+++ b/cpp/cmake_modules/orc.diff
@@ -16,24 +16,25 @@
 # under the License.
 
 diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
-index aa520ff..01ab294 100644
+index aa520ff..7bd75d1 100644
 --- a/cmake_modules/ThirdpartyToolchain.cmake
 +++ b/cmake_modules/ThirdpartyToolchain.cmake
-@@ -464,7 +464,7 @@ add_library (orc::protoc ALIAS orc_protoc)
- 
- if (ORC_PACKAGE_KIND STREQUAL "conan")
-   target_link_libraries (orc_protobuf INTERFACE ${protobuf_LIBRARIES})
--elseif (ORC_PREFER_STATIC_PROTOBUF AND ${PROTOBUF_STATIC_LIB})
-+elseif (ORC_PREFER_STATIC_PROTOBUF AND PROTOBUF_STATIC_LIB)
-   target_link_libraries (orc_protobuf INTERFACE ${PROTOBUF_STATIC_LIB})
+@@ -416,6 +416,18 @@ endif ()
+ if (NOT "${PROTOBUF_HOME}" STREQUAL "" OR ORC_PACKAGE_KIND STREQUAL "conan")
+   find_package (Protobuf REQUIRED)
+   set(PROTOBUF_VENDORED FALSE)
++  if (Protobuf_FOUND AND NOT PROTOBUF_STATIC_LIB)
++    get_target_property (target_type protobuf::libprotobuf TYPE)
++    if (target_type STREQUAL "STATIC_LIBRARY")
++        set(PROTOBUF_STATIC_LIB protobuf::libprotobuf)
++    endif ()
++  endif()
++  if (Protobuf_FOUND AND NOT PROTOC_STATIC_LIB)
++    get_target_property (target_type protobuf::libprotoc TYPE)
++    if (target_type STREQUAL "STATIC_LIBRARY")
++        set (PROTOC_STATIC_LIB protobuf::libprotoc)
++    endif ()
++  endif()
  else ()
-   target_link_libraries (orc_protobuf INTERFACE ${PROTOBUF_LIBRARY})
-@@ -476,7 +476,7 @@ else ()
- endif ()
- 
- if (NOT ORC_PACKAGE_KIND STREQUAL "conan")
--  if (ORC_PREFER_STATIC_PROTOBUF AND ${PROTOC_STATIC_LIB})
-+  if (ORC_PREFER_STATIC_PROTOBUF AND PROTOC_STATIC_LIB)
-     target_link_libraries (orc_protoc INTERFACE ${PROTOC_STATIC_LIB})
-   else ()
-     target_link_libraries (orc_protoc INTERFACE ${PROTOC_LIBRARY})
+   set(PROTOBUF_PREFIX "${THIRDPARTY_DIR}/protobuf_ep-install")
+   set(PROTOBUF_INCLUDE_DIR "${PROTOBUF_PREFIX}/include")

--- a/cpp/cmake_modules/orc.diff
+++ b/cpp/cmake_modules/orc.diff
@@ -1,0 +1,22 @@
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+index aa520ff..01ab294 100644
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -464,7 +464,7 @@ add_library (orc::protoc ALIAS orc_protoc)
+ 
+ if (ORC_PACKAGE_KIND STREQUAL "conan")
+   target_link_libraries (orc_protobuf INTERFACE ${protobuf_LIBRARIES})
+-elseif (ORC_PREFER_STATIC_PROTOBUF AND ${PROTOBUF_STATIC_LIB})
++elseif (ORC_PREFER_STATIC_PROTOBUF AND DEFINED PROTOBUF_STATIC_LIB)
+   target_link_libraries (orc_protobuf INTERFACE ${PROTOBUF_STATIC_LIB})
+ else ()
+   target_link_libraries (orc_protobuf INTERFACE ${PROTOBUF_LIBRARY})
+@@ -476,7 +476,7 @@ else ()
+ endif ()
+ 
+ if (NOT ORC_PACKAGE_KIND STREQUAL "conan")
+-  if (ORC_PREFER_STATIC_PROTOBUF AND ${PROTOC_STATIC_LIB})
++  if (ORC_PREFER_STATIC_PROTOBUF AND DEFINED PROTOC_STATIC_LIB)
+     target_link_libraries (orc_protoc INTERFACE ${PROTOC_STATIC_LIB})
+   else ()
+     target_link_libraries (orc_protoc INTERFACE ${PROTOC_LIBRARY})

--- a/cpp/cmake_modules/orc.diff
+++ b/cpp/cmake_modules/orc.diff
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
 index aa520ff..01ab294 100644
 --- a/cmake_modules/ThirdpartyToolchain.cmake


### PR DESCRIPTION
### Rationale for this change

We are using a pretty old version and we are seeing some CI jobs.

### What changes are included in this PR?

Upgrade vcpkg version

### Are these changes tested?

on CI

### Are there any user-facing changes?

No
* GitHub Issue: #43416