### PR TITLE
GH-43418: [CI] Add wheels and java-jars to vcpkg group for tasks

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -98,6 +98,8 @@ groups:
 
   vcpkg:
     - test-*vcpkg*
+    - wheel-*
+    - java-jars
 
   integration:
     - test-*dask*


### PR DESCRIPTION
### Rationale for this change

Grouping the vcpkg related tasks for CI purposes.

### What changes are included in this PR?

Adding missing vcpkg jobs to the vcpkg group

### Are these changes tested?

I will trigger CI to validate those are run

### Are there any user-facing changes?

No
* GitHub Issue: #43418