### PR TITLE
GH-43425: [Java] Upgrade JNI to version 10

### DIFF
--- a/docs/source/java/cdata.rst
+++ b/docs/source/java/cdata.rst
@@ -366,7 +366,7 @@ This application uses JNI to call Java code, but transfers data (zero-copy) via 
        JavaVMOption options[2];
        options[0].optionString = "-Djava.class.path=cpptojava.jar";
        options[1].optionString = "-DXcheck:jni:pedantic";
-       vm_args.version = JNI_VERSION_1_8;
+       vm_args.version = JNI_VERSION_10;
        vm_args.nOptions = 2;
        vm_args.options = options;
        int status = JNI_CreateJavaVM(jvm, (void **) &env, &vm_args);

--- a/java/adapter/orc/src/main/cpp/jni_wrapper.cpp
+++ b/java/adapter/orc/src/main/cpp/jni_wrapper.cpp
@@ -49,7 +49,7 @@ static jmethodID orc_memory_constructor;
 static jclass record_batch_class;
 static jmethodID record_batch_constructor;
 
-static jint JNI_VERSION = JNI_VERSION_1_6;
+static jint JNI_VERSION = JNI_VERSION_10;
 
 using arrow::internal::checked_cast;
 using arrow::jni::ConcurrentMap;

--- a/java/c/src/main/cpp/jni_wrapper.cc
+++ b/java/c/src/main/cpp/jni_wrapper.cc
@@ -43,7 +43,7 @@ jmethodID kPrivateDataGetNextMethod;
 jmethodID kPrivateDataGetSchemaMethod;
 jmethodID kCDataExceptionConstructor;
 
-jint JNI_VERSION = JNI_VERSION_1_6;
+jint JNI_VERSION = JNI_VERSION_10;
 
 class JniPendingException : public std::runtime_error {
  public:

--- a/java/dataset/src/main/cpp/jni_util.cc
+++ b/java/dataset/src/main/cpp/jni_util.cc
@@ -28,7 +28,7 @@ namespace arrow {
 namespace dataset {
 namespace jni {
 
-jint JNI_VERSION = JNI_VERSION_1_6;
+jint JNI_VERSION = JNI_VERSION_10;
 
 class ReservationListenableMemoryPool::Impl {
  public:

--- a/java/dataset/src/main/cpp/jni_wrapper.cc
+++ b/java/dataset/src/main/cpp/jni_wrapper.cc
@@ -51,7 +51,7 @@ jmethodID unreserve_memory_method;
 
 jlong default_memory_pool_id = -1L;
 
-jint JNI_VERSION = JNI_VERSION_1_6;
+jint JNI_VERSION = JNI_VERSION_10;
 
 class JniPendingException : public std::runtime_error {
  public:

--- a/java/gandiva/src/main/cpp/jni_common.cc
+++ b/java/gandiva/src/main/cpp/jni_common.cc
@@ -67,7 +67,7 @@ using gandiva::ProjectorHolder;
 // forward declarations
 NodePtr ProtoTypeToNode(const gandiva::types::TreeNode& node);
 
-static jint JNI_VERSION = JNI_VERSION_1_6;
+static jint JNI_VERSION = JNI_VERSION_10;
 
 // extern refs - initialized for other modules.
 jclass configuration_builder_class_;


### PR DESCRIPTION
### Rationale for this change

Java 11 is the supported min version, which means we can use JNI version 10. See Version info here: https://docs.oracle.com/en/java/javase/21/docs/specs/jni/functions.html#version-information

### What changes are included in this PR?

* JNI Version upgraded to 10 from 1.6 and 1.8 

### Are these changes tested?

CI/CD

### Are there any user-facing changes?

No
* GitHub Issue: #43425