### PR TITLE
GH-43429: [C++][FlightRPC] Fix Flight UCX build issues

### DIFF
--- a/cpp/src/arrow/flight/transport/ucx/ucx_client.cc
+++ b/cpp/src/arrow/flight/transport/ucx/ucx_client.cc
@@ -118,7 +118,7 @@ class ClientConnection {
       params.flags = UCP_EP_PARAMS_FLAGS_CLIENT_SERVER;
       params.name = "UcxClientImpl";
       params.sockaddr.addr = reinterpret_cast<const sockaddr*>(&connect_addr);
-      params.sockaddr.addrlen = addrlen;
+      params.sockaddr.addrlen = static_cast<socklen_t>(addrlen);
 
       auto status = ucp_ep_create(ucp_worker_->get(), &params, &remote_endpoint_);
       RETURN_NOT_OK(FromUcsStatus("ucp_ep_create", status));

--- a/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
+++ b/cpp/src/arrow/flight/transport/ucx/ucx_server.cc
@@ -258,7 +258,7 @@ class UcxServerImpl : public arrow::flight::internal::ServerTransport {
       params.field_mask =
           UCP_LISTENER_PARAM_FIELD_SOCK_ADDR | UCP_LISTENER_PARAM_FIELD_CONN_HANDLER;
       params.sockaddr.addr = reinterpret_cast<const sockaddr*>(&listen_addr);
-      params.sockaddr.addrlen = addrlen;
+      params.sockaddr.addrlen = static_cast<socklen_t>(addrlen);
       params.conn_handler.cb = HandleIncomingConnection;
       params.conn_handler.arg = this;
 
@@ -376,7 +376,7 @@ class UcxServerImpl : public arrow::flight::internal::ServerTransport {
     std::unique_ptr<FlightInfo> info;
     std::string response;
     SERVER_RETURN_NOT_OK(driver, base_->GetFlightInfo(context, descriptor, &info));
-    SERVER_RETURN_NOT_OK(driver, info->DoSerializeToString(&response));
+    SERVER_RETURN_NOT_OK(driver, info->SerializeToString(&response));
     RETURN_NOT_OK(driver->SendFrame(FrameType::kBuffer,
                                     reinterpret_cast<const uint8_t*>(response.data()),
                                     static_cast<int64_t>(response.size())));
@@ -397,7 +397,7 @@ class UcxServerImpl : public arrow::flight::internal::ServerTransport {
     std::unique_ptr<PollInfo> info;
     std::string response;
     SERVER_RETURN_NOT_OK(driver, base_->PollFlightInfo(context, descriptor, &info));
-    SERVER_RETURN_NOT_OK(driver, info->DoSerializeToString(&response));
+    SERVER_RETURN_NOT_OK(driver, info->SerializeToString(&response));
     RETURN_NOT_OK(driver->SendFrame(FrameType::kBuffer,
                                     reinterpret_cast<const uint8_t*>(response.data()),
                                     static_cast<int64_t>(response.size())));


### PR DESCRIPTION
### Rationale for this change

Fixing compilation errors.

### What changes are included in this PR?

 - Casts of integer types
 - Fixing the name of functions (these mistakes weren't caught because UCX is not built on CI)

### Are these changes tested?

Locally by building and running `arrow-flight-transport-ucx-test`.
* GitHub Issue: #43429