### PR TITLE
GH-43432: [Java][Packaging] Clean up java-jars job

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -256,7 +256,6 @@ jobs:
           pushd arrow/java
           mvn versions:set -DnewVersion={{ arrow.no_rc_snapshot_version }}
           mvn versions:set -DnewVersion={{ arrow.no_rc_snapshot_version }} -f bom
-          mvn versions:set -DnewVersion={{ arrow.no_rc_snapshot_version }} -f maven
           popd
           arrow/ci/scripts/java_full_build.sh \
             $GITHUB_WORKSPACE/arrow \

--- a/java/bom/pom.xml
+++ b/java/bom/pom.xml
@@ -24,6 +24,7 @@ under the License.
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>33</version>
+    <relativePath></relativePath>
   </parent>
 
   <groupId>org.apache.arrow</groupId>


### PR DESCRIPTION
### Rationale for this change
1) Remove maven module references
2) Fix warning in java-jars job:

```
Warning:  Some problems were encountered while building the effective model for org.apache.arrow:arrow-bom:pom:18.0.0-SNAPSHOT
Warning:  'parent.relativePath' of POM org.apache.arrow:arrow-bom:18.0.0-SNAPSHOT (/Users/runner/work/crossbow/crossbow/arrow/java/bom/pom.xml) points at org.apache.arrow:arrow-java-root instead of org.apache:apache, please verify your project structure @ line 23, column 11
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
```

### What changes are included in this PR?

* Delete `mvn versions:set` for removed maven module
* Add empty relativePath to Arrow BOM, so it doesn't use arrow-java-root

### Are these changes tested?

java-jars CI job

### Are there any user-facing changes?

No
* GitHub Issue: #43432