### PR TITLE
GH-43437: [Java] Update protobuf from 3.25.1 to 3.25.4

### DIFF
--- a/java/flight/flight-core/src/main/java/module-info.java
+++ b/java/flight/flight-core/src/main/java/module-info.java
@@ -26,6 +26,8 @@ module org.apache.arrow.flight.core {
   requires com.fasterxml.jackson.databind;
   requires com.google.common;
   requires com.google.errorprone.annotations;
+  requires com.google.protobuf;
+  requires com.google.protobuf.util;
   requires io.grpc;
   requires io.grpc.internal;
   requires io.grpc.netty;
@@ -38,7 +40,5 @@ module org.apache.arrow.flight.core {
   requires org.apache.arrow.format;
   requires org.apache.arrow.memory.core;
   requires org.apache.arrow.vector;
-  requires protobuf.java;
-  requires protobuf.java.util;
   requires org.slf4j;
 }

--- a/java/flight/flight-sql/src/main/java/module-info.java
+++ b/java/flight/flight-sql/src/main/java/module-info.java
@@ -21,10 +21,10 @@ module org.apache.arrow.flight.sql {
   exports org.apache.arrow.flight.sql.util;
 
   requires com.google.common;
+  requires com.google.protobuf;
   requires java.sql;
   requires org.apache.arrow.flight.core;
   requires org.apache.arrow.memory.core;
   requires org.apache.arrow.vector;
   requires org.apache.commons.cli;
-  requires protobuf.java;
 }

--- a/java/gandiva/src/main/java/module-info.java
+++ b/java/gandiva/src/main/java/module-info.java
@@ -21,9 +21,9 @@ open module org.apache.arrow.gandiva {
   exports org.apache.arrow.gandiva.ipc;
 
   requires com.google.common;
+  requires com.google.protobuf;
   requires org.apache.arrow.format;
   requires org.apache.arrow.memory.core;
   requires org.apache.arrow.vector;
   requires org.slf4j;
-  requires protobuf.java;
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -98,7 +98,7 @@ under the License.
     <dep.guava-bom.version>33.2.1-jre</dep.guava-bom.version>
     <dep.netty-bom.version>4.1.112.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.65.0</dep.grpc-bom.version>
-    <dep.protobuf-bom.version>3.25.1</dep.protobuf-bom.version>
+    <dep.protobuf-bom.version>3.25.4</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.17.2</dep.jackson-bom.version>
     <dep.hadoop.version>3.4.0</dep.hadoop.version>
     <dep.fbs.version>24.3.25</dep.fbs.version>


### PR DESCRIPTION
### Rationale for this change

Update Java protobuf minor version. 3.25.4 includes the `Automatic-Module-Name`. 

### What changes are included in this PR?

* Update java protobuf to 3.25.4 

### Are these changes tested?

CI

### Are there any user-facing changes?

No.
* GitHub Issue: #43437