### PR TITLE
MINOR: [Java][CI] Update the order of commands in Java-Jars CI

### DIFF
--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -138,14 +138,13 @@ jobs:
           # used on test  We uninstall Homebrew's Protobuf to ensure using
           # bundled Protobuf.
           brew uninstall protobuf
-
-          brew bundle --file=arrow/java/Brewfile
-          
           # We want to use the bundled googletest for static linking. Since
           # both BUNDLED and brew options are enabled, it could cause a conflict
           # when there is a version mismatch.
           # We uninstall googletest to ensure using the bundled googletest.
           brew uninstall googletest
+
+          brew bundle --file=arrow/java/Brewfile
       - name: Build C++ libraries
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}


### PR DESCRIPTION
### Rationale for this change

`googletest` is installed by the `Brewfile` associated with cpp not Java. So move the order of uninstalling in that order. 

### What changes are included in this PR?

Change the order of commands to suit the installation objectives. 

### Are these changes tested?

Existing tests. 

### Are there any user-facing changes?

No