### PR TITLE
GH-43463: [C++][Gandiva] Always use gdv_function_stubs.h in context_helper.cc

### DIFF
--- a/cpp/src/gandiva/context_helper.cc
+++ b/cpp/src/gandiva/context_helper.cc
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "gandiva/execution_context.h"
+#include "gandiva/gdv_function_stubs.h"
+
 // This file is also used in the pre-compiled unit tests, which do include
 // llvm/engine/..
 #ifndef GANDIVA_UNIT_TEST
 #include "gandiva/exported_funcs.h"
-#include "gandiva/gdv_function_stubs.h"
 
 #include "gandiva/engine.h"
 
@@ -55,8 +57,6 @@ arrow::Status ExportedContextFunctions::AddMappings(Engine* engine) const {
 
 }  // namespace gandiva
 #endif  // !GANDIVA_UNIT_TEST
-
-#include "gandiva/execution_context.h"
 
 extern "C" {
 


### PR DESCRIPTION
### Rationale for this change

`gdv_function_stubs.h` has declarations of functions in `context_helper.cc`.

If we don't include `gdv_function_stubs.h`, it causes attribution mismatch error with unity build.

### What changes are included in this PR?

Always include `gdv_function_stubs.h` in `context_helper.cc`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43463