### PR TITLE
GH-43548: [R][CI] Use grep -F to simplify matching or rchk output

### DIFF
--- a/dev/tasks/r/github.linux.rchk.yml
+++ b/dev/tasks/r/github.linux.rchk.yml
@@ -54,7 +54,7 @@ jobs:
         # ERROR: too many states (abstraction error?))
         # https://github.com/kalibera/rchk
         run: |
-          if [ $(grep -c "Suspicious call" rchk.out) -gt 0 ] || [ $(grep -c "\[UP\]" rchk.out) -gt 0 ] || [ $(grep -c "\[PB\]" rchk.out) -gt 0 ]; then
+          if [ $(grep -Fc "Suspicious call" rchk.out) -gt 0 ] || [ $(grep -Fc "[UP]" rchk.out) -gt 0 ] || [ $(grep -Fc "[PB]" rchk.out) -gt 0 ]; then
             echo "Found rchk errors"
             cat rchk.out
             exit 1


### PR DESCRIPTION
Passing along a minor change we made in our own mimeo of this GHA.

Resolves #43548
* GitHub Issue: #43548