### PR TITLE
GH-43316: [C++] Implement cast suggestions for struct type

### DIFF
--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -703,7 +703,6 @@ class ConcatenateImpl {
           RETURN_NOT_OK(ConcatenateImpl(child_data, pool_)
                             .Concatenate(&out_->child_data[i], /*hints=*/nullptr));
         }
-
         break;
       }
       case UnionMode::DENSE: {

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -42,6 +42,7 @@
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/list_util.h"
 #include "arrow/util/unreachable.h"
 
@@ -763,7 +764,7 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
 
   auto struct_ty = struct_({field("a", int32()), field("b", list(utf8()))});
   auto fake_long_struct = ArrayFromJSON(struct_ty, "[[0, [\"Hello\"]]]");
-  std::dynamic_pointer_cast<StructArray>(fake_long_struct)
+  internal::checked_pointer_cast<StructArray>(fake_long_struct)
       ->field(1)
       ->data()
       ->GetMutableValues<int32_t>(1)[1] = std::numeric_limits<int32_t>::max();

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -760,6 +760,24 @@ TEST_F(ConcatenateTest, OffsetOverflow) {
                                                pool, &suggested_cast)
                              .status());
   ASSERT_TRUE(suggested_cast->Equals(LargeVersionOfType(list_view_ty)));
+
+  auto struct_ty = struct_({field("a", int32()), field("b", list(utf8()))});
+  auto fake_long_struct = ArrayFromJSON(struct_ty, "[[0, [\"Hello\"]]]");
+  std::dynamic_pointer_cast<StructArray>(fake_long_struct)
+      ->field(1)
+      ->data()
+      ->GetMutableValues<int32_t>(1)[1] = std::numeric_limits<int32_t>::max();
+  auto suggested_struct_ty =
+      struct_({field("a", int32()), field("b", large_list(utf8()))});
+  auto concatenate_status = Concatenate({fake_long_struct, fake_long_struct});
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid,
+      ::testing::StrEq("Invalid: offset overflow while concatenating arrays, "
+                       "consider casting input from `" +
+                       struct_ty->ToString() + "` to `" +
+                       suggested_struct_ty->ToString() + "` first."),
+      concatenate_status);
 }
 
 TEST_F(ConcatenateTest, DictionaryConcatenateWithEmptyUint16) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

We should give a cast suggestion if an overflow happens when concatenating struct type. eg. when concatenating a type like `struct<a: int8, b: list>` an overflow on the recursive concatenation of field b should lead to a cast suggestion to `struct<a: int8, b: large_list>`.
### What changes are included in this PR?

Suggest casts when concatenation of struct type fails due to overflow.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43316