### PR TITLE
GH-43500: [R][CI] Bump dev docs CI job from ubuntu 20.04

### DIFF
--- a/dev/tasks/r/github.devdocs.yml
+++ b/dev/tasks/r/github.devdocs.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-20.04]
+        os: [macOS-latest, ubuntu-latest]
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}


### PR DESCRIPTION
### Rationale for this change
More modern ubuntu OS

### What changes are included in this PR?
Swap to ubuntu-latest for devdocs job

### Are these changes tested?
They are tests

### Are there any user-facing changes?
No.
* GitHub Issue: #43500