### PR TITLE
MINOR: [R] switch on `R_VERSION`

### DIFF
--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -389,7 +389,7 @@ SEXP to_r6(const std::shared_ptr<T>& ptr, const char* r6_class_name) {
 
 // R_existsVarInFrame doesn't exist before R 4.2, so we need to fall back to
 // Rf_findVarInFrame3 if it is not defined.
-#ifdef R_existsVarInFrame
+#if (R_VERSION >= R_Version(4, 2, 0))
   if (!R_existsVarInFrame(arrow::r::ns::arrow, r6_class)) {
     cpp11::stop("No arrow R6 class named '%s'", r6_class_name);
   }

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -389,7 +389,7 @@ SEXP to_r6(const std::shared_ptr<T>& ptr, const char* r6_class_name) {
 
 // R_existsVarInFrame doesn't exist before R 4.2, so we need to fall back to
 // Rf_findVarInFrame3 if it is not defined.
-#if (R_VERSION >= R_Version(4, 2, 0))
+#if R_VERSION >= R_Version(4, 2, 0)
   if (!R_existsVarInFrame(arrow::r::ns::arrow, r6_class)) {
     cpp11::stop("No arrow R6 class named '%s'", r6_class_name);
   }


### PR DESCRIPTION
A follow on to #43243 `#ifdef function declaration` does not work, instead we must use the `#if (R_VERSION >= R_Version(4, 2, 0))` pattern to only include code for specific versions.