### PR TITLE
GH-43514: [Python] Deprecate passing build flags to setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -92,9 +92,9 @@ MSG_DEPR_SETUP_BUILD_FLAGS = """
         The '{}' flag is being passed to setup.py, but this is
         deprecated.
 
-        If a certain component is available in Arrow C++, it will
-        automatically be enabled for the PyArrow build as well. If you want
-        to force build a certain component, you can still use the
+        If a certain component is available in Arrow C++, it will automatically
+        be enabled for the PyArrow build as well. If you want to force the
+        build of a certain component, you can still use the
         PYARROW_WITH_$COMPONENT environment variable.
         ***********************************************************************
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,6 +24,7 @@ from os.path import join as pjoin
 import re
 import shlex
 import sys
+import warnings
 
 if sys.version_info >= (3, 10):
     import sysconfig
@@ -82,6 +83,23 @@ def strtobool(val):
         return 0
     else:
         raise ValueError("invalid truth value %r" % (val,))
+
+
+MSG_DEPR_SETUP_BUILD_FLAGS = """
+  !!
+
+        ***********************************************************************
+        The '{}' flag is being passed to setup.py, but this is
+        deprecated.
+
+        In general, if a certain component is available in Arrow C++, it will
+        automatically be enabled for the PyArrow build as well. If you want
+        to force build a certain component, you can still use the
+        PYARROW_WITH_$COMPONENT environment variable.
+        ***********************************************************************
+
+  !!
+"""
 
 
 class build_ext(_build_ext):
@@ -258,9 +276,16 @@ class build_ext(_build_ext):
                     varname, 'on' if value else 'off'))
 
             def append_cmake_component(flag, varname):
-                # only pass this to cmake is the user pass the --with-component
+                # only pass this to cmake if the user pass the --with-component
                 # flag to setup.py build_ext
                 if flag is not None:
+                    flag_name = (
+                        "--with-"
+                        + varname.removeprefix("PYARROW_").lower().replace("_", "-"))
+                    warnings.warn(
+                        MSG_DEPR_SETUP_BUILD_FLAGS.format(flag_name),
+                        UserWarning, stacklevel=2
+                    )
                     append_cmake_bool(flag, varname)
 
             if self.cmake_generator:

--- a/python/setup.py
+++ b/python/setup.py
@@ -92,7 +92,7 @@ MSG_DEPR_SETUP_BUILD_FLAGS = """
         The '{}' flag is being passed to setup.py, but this is
         deprecated.
 
-        In general, if a certain component is available in Arrow C++, it will
+        If a certain component is available in Arrow C++, it will
         automatically be enabled for the PyArrow build as well. If you want
         to force build a certain component, you can still use the
         PYARROW_WITH_$COMPONENT environment variable.


### PR DESCRIPTION
### Rationale for this change

As mentioned in https://github.com/apache/arrow/pull/41494#issuecomment-2092829903 (while refactoring how to specify to the pyarrow build which components to build, i.e. to let it follow the Arrow C++ components by default), we do have a "feature" that you can specify which components to build directly to setup.py, like `python setup.py build_ext --with-parquet`. 

This is currently not used in our own codebase, and is also not documented anymore, but we did document it in the past.

In general calling setup.py directly is not recommended (although for development installs, it is still useful), furthermore there are alternatives to those flags (relying on Arrow C++ or setting an environment variable), and this would go away anyhow in case we would move away from setuptools at some point. 
So I think it is better to deprecate those options.

### What changes are included in this PR?

Whenever a user passes such a `--with-` flag, a warning is raised.

### Are these changes tested?

Tested it locally

### Are there any user-facing changes?

Only for developers building pyarrow from source, they have to potentially update their build instructions.
* GitHub Issue: #43514