### PR TITLE
GH-43541: [C++] Check accepted device allocation types before executing kernel

### DIFF
--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -68,6 +68,15 @@ static inline void AdjustNonNullable(Type::type type_id, int64_t length,
 
 namespace internal {
 
+void AdjustNonNullable(ArrayData* array_data) {
+  int64_t null_count = kUnknownNullCount;
+  AdjustNonNullable(array_data->type->id(), array_data->length, &array_data->buffers,
+                    &null_count);
+  if (null_count != kUnknownNullCount) {
+    array_data->null_count.store(null_count, std::memory_order_release);
+  }
+}
+
 bool IsNullSparseUnion(const ArrayData& data, int64_t i) {
   auto* union_type = checked_cast<const SparseUnionType*>(data.type.get());
   const auto* types = reinterpret_cast<const int8_t*>(data.buffers[1]->data());

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -996,7 +996,6 @@ cdef class Array(_PandasConvertible):
         -------
         cast : Array
         """
-        self._assert_cpu()
         return _pc().cast(self, target_type, safe=safe,
                           options=options, memory_pool=memory_pool)
 
@@ -1354,7 +1353,6 @@ cdef class Array(_PandasConvertible):
         -------
         array : boolean Array
         """
-        self._assert_cpu()
         options = _pc().NullOptions(nan_is_null=nan_is_null)
         return _pc().call_function('is_null', [self], options)
 
@@ -1366,14 +1364,12 @@ cdef class Array(_PandasConvertible):
         -------
         array : boolean Array
         """
-        self._assert_cpu()
         return _pc().call_function('is_nan', [self])
 
     def is_valid(self):
         """
         Return BooleanArray indicating the non-null values.
         """
-        self._assert_cpu()
         return _pc().is_valid(self)
 
     def fill_null(self, fill_value):
@@ -1390,7 +1386,6 @@ cdef class Array(_PandasConvertible):
         result : Array
             A new array with nulls replaced by the given value.
         """
-        self._assert_cpu()
         return _pc().fill_null(self, fill_value)
 
     def __getitem__(self, key):
@@ -1517,7 +1512,6 @@ cdef class Array(_PandasConvertible):
         index : Int64Scalar
             The index of the value in the array (-1 if not found).
         """
-        self._assert_cpu()
         return _pc().index(self, value, start, end, memory_pool=memory_pool)
 
     def sort(self, order="ascending", **kwargs):
@@ -1537,7 +1531,6 @@ cdef class Array(_PandasConvertible):
         -------
         result : Array
         """
-        self._assert_cpu()
         indices = _pc().sort_indices(
             self,
             options=_pc().SortOptions(sort_keys=[("", order)], **kwargs)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1464,7 +1464,6 @@ cdef class Array(_PandasConvertible):
         taken : Array
             An array with the same datatype, containing the taken values.
         """
-        self._assert_cpu()
         return _pc().take(self, indices)
 
     def drop_null(self):
@@ -1493,7 +1492,6 @@ cdef class Array(_PandasConvertible):
             An array of the same type, with only the elements selected by
             the boolean mask.
         """
-        self._assert_cpu()
         return _pc().filter(self, mask,
                             null_selection_behavior=null_selection_behavior)
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1644,7 +1644,6 @@ cdef class Array(_PandasConvertible):
         -------
         lst : list
         """
-        self._assert_cpu()
         return [x.as_py() for x in self]
 
     def tolist(self):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1555,8 +1555,6 @@ cdef class Array(_PandasConvertible):
         return _array_like_to_pandas(self, options, types_mapper=types_mapper)
 
     def __array__(self, dtype=None, copy=None):
-        self._assert_cpu()
-
         if copy is False:
             try:
                 values = self.to_numpy(zero_copy_only=True)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1038,7 +1038,6 @@ cdef class Array(_PandasConvertible):
         sum : Scalar
             A scalar containing the sum value.
         """
-        self._assert_cpu()
         options = _pc().ScalarAggregateOptions(**kwargs)
         return _pc().call_function('sum', [self], options)
 
@@ -1051,7 +1050,6 @@ cdef class Array(_PandasConvertible):
         unique : Array
             An array of the same data type, with deduplicated elements.
         """
-        self._assert_cpu()
         return _pc().call_function('unique', [self])
 
     def dictionary_encode(self, null_encoding='mask'):
@@ -1070,7 +1068,6 @@ cdef class Array(_PandasConvertible):
         encoded : DictionaryArray
             A dictionary-encoded version of this array.
         """
-        self._assert_cpu()
         options = _pc().DictionaryEncodeOptions(null_encoding)
         return _pc().call_function('dictionary_encode', [self], options)
 
@@ -1083,7 +1080,6 @@ cdef class Array(_PandasConvertible):
         StructArray
             An array of  <input type "Values", int64 "Counts"> structs
         """
-        self._assert_cpu()
         return _pc().call_function('value_counts', [self])
 
     @staticmethod

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1465,7 +1465,6 @@ cdef class Array(_PandasConvertible):
         """
         Remove missing values from an array.
         """
-        self._assert_cpu()
         return _pc().drop_null(self)
 
     def filter(self, object mask, *, null_selection_behavior='drop'):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4113,6 +4113,8 @@ def test_non_cpu_array():
     with pytest.raises(NotImplementedError):
         arr[0]
     with pytest.raises(NotImplementedError):
+        arr[1:2]
+    with pytest.raises(NotImplementedError):
         arr.take([0])
     with pytest.raises(NotImplementedError):
         arr.drop_null()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4060,6 +4060,7 @@ def test_non_cpu_array():
     arr2 = pa.Array.from_buffers(pa.int32(), 4, [None, cuda_data_buf])
     arr_with_nulls = pa.Array.from_buffers(
         pa.int32(), 4, [cuda_validity_buf, cuda_data_buf])
+    arr_bool = pa.Array.from_buffers(pa.bool_(), 4, [None, cuda_validity_buf])
 
     # Supported
     arr.validate()
@@ -4130,12 +4131,16 @@ def test_non_cpu_array():
         arr[0]
     with pytest.raises(NotImplementedError):
         arr[1:2]
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=bad_device_msg("take", 0)):
         arr.take([0])
+    with pytest.raises(NotImplementedError, match=bad_device_msg("take", 1)):
+        pa.array([0, 1]).take(arr)
     with pytest.raises(NotImplementedError):
         arr.drop_null()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=bad_device_msg("filter", 0)):
         arr.filter([True, True, False, False])
+    with pytest.raises(NotImplementedError, match=bad_device_msg("filter", 1)):
+        pa.array([0, 1]).filter(arr_bool)
     with pytest.raises(NotImplementedError):
         arr.index(0)
     with pytest.raises(NotImplementedError):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4135,8 +4135,8 @@ def test_non_cpu_array():
         arr.take([0])
     with pytest.raises(NotImplementedError, match=bad_device_msg("take", 1)):
         pa.array([0, 1]).take(arr)
-    with pytest.raises(NotImplementedError):
-        arr.drop_null()
+    with pytest.raises(NotImplementedError, match=bad_device_msg("filter", 0)):
+        arr_with_nulls.drop_null()
     with pytest.raises(NotImplementedError, match=bad_device_msg("filter", 0)):
         arr.filter([True, True, False, False])
     with pytest.raises(NotImplementedError, match=bad_device_msg("filter", 1)):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4096,7 +4096,7 @@ def test_non_cpu_array():
     # Not Supported
     with pytest.raises(NotImplementedError):
         arr.diff(arr2)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=bad_device_msg("cast")):
         arr.cast(pa.int64())
     with pytest.raises(NotImplementedError):
         arr.view(pa.int64())
@@ -4119,13 +4119,13 @@ def test_non_cpu_array():
         [i for i in iter(arr)]
     with pytest.raises(NotImplementedError):
         arr == arr2
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=bad_device_msg("is_null", 0)):
         arr.is_null()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=bad_device_msg("is_nan", 0)):
         arr.is_nan()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=bad_device_msg("is_valid", 0)):
         arr.is_valid()
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match=bad_device_msg("coalesce", 0)):
         arr.fill_null(0)
     with pytest.raises(NotImplementedError):
         arr[0]
@@ -4141,9 +4141,10 @@ def test_non_cpu_array():
         arr.filter([True, True, False, False])
     with pytest.raises(NotImplementedError, match=bad_device_msg("filter", 1)):
         pa.array([0, 1]).filter(arr_bool)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="index"):
         arr.index(0)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError,
+                       match=bad_device_msg("sort_indices", 0)):
         arr.sort()
     with pytest.raises(NotImplementedError):
         arr.__array__()


### PR DESCRIPTION
### Rationale for this change

Kernels shouldn't segfault when executing against GPU-allocated (or any other non-CPU device) Arrays.

### What changes are included in this PR?

 - A way of declaring which device allocation types a kernel can handle per parameter
 - Removal of some of the checks from the Python code
 - Making `drop_null` callable when array is CUDA-allocated

### Are these changes tested?

Tested from the Python tests.

### Are there any user-facing changes?

New member functions to some classes.
* GitHub Issue: #43541