### PR TITLE
GH-43543: [FlightRPC][C++] Reduce the number of references to protobuf::Any

### DIFF
--- a/cpp/src/arrow/flight/flight_internals_test.cc
+++ b/cpp/src/arrow/flight/flight_internals_test.cc
@@ -83,9 +83,8 @@ void TestRoundtrip(const std::vector<FlightType>& values,
       ASSERT_OK(internal::FromProto(pb_value, &info_data));
       EXPECT_EQ(values[i], FlightInfo{std::move(info_data)});
     } else if constexpr (std::is_same_v<FlightType, SchemaResult>) {
-      std::string data;
-      ASSERT_OK(internal::FromProto(pb_value, &data));
-      SchemaResult value(std::move(data));
+      SchemaResult value;
+      ASSERT_OK(internal::FromProto(pb_value, &value));
       EXPECT_EQ(values[i], value);
     } else {
       FlightType value;

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -82,6 +82,17 @@ Status PackProtoAction(std::string action_type, const google::protobuf::Message&
   return Status::OK();
 }
 
+Status UnpackProtoAction(const Action& action, google::protobuf::Message* out) {
+  google::protobuf::Any any;
+  if (!any.ParseFromArray(action.body->data(), static_cast<int>(action.body->size()))) {
+    return Status::Invalid("Unable to parse action ", action.type);
+  }
+  if (!any.UnpackTo(out)) {
+    return Status::Invalid("Unable to unpack ", out->GetTypeName());
+  }
+  return Status::OK();
+}
+
 // Timestamp
 
 Status FromProto(const google::protobuf::Timestamp& pb_timestamp, Timestamp* timestamp) {

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -73,6 +73,15 @@ Status PackProtoCommand(const google::protobuf::Message& command, FlightDescript
   return Status::OK();
 }
 
+Status PackProtoAction(std::string action_type, const google::protobuf::Message& action,
+                       Action* out) {
+  std::string buf;
+  RETURN_NOT_OK(PackToAnyAndSerialize(action, &buf));
+  out->type = std::move(action_type);
+  out->body = Buffer::FromString(std::move(buf));
+  return Status::OK();
+}
+
 // Timestamp
 
 Status FromProto(const google::protobuf::Timestamp& pb_timestamp, Timestamp* timestamp) {

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "arrow/buffer.h"
+#include "arrow/flight/protocol_internal.h"
 #include "arrow/io/memory.h"
 #include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -283,8 +283,8 @@ Status FromProto(const pb::BasicAuth& pb_basic_auth, BasicAuth* basic_auth) {
   return Status::OK();
 }
 
-Status FromProto(const pb::SchemaResult& pb_result, std::string* result) {
-  *result = pb_result.schema();
+Status FromProto(const pb::SchemaResult& pb_result, SchemaResult* result) {
+  *result = SchemaResult{pb_result.schema()};
   return Status::OK();
 }
 

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -91,6 +91,9 @@ Status PackProtoCommand(const google::protobuf::Message& command, FlightDescript
 Status PackProtoAction(std::string action_type, const google::protobuf::Message& action,
                        Action* out);
 
+/// \brief Unpacks a protobuf message packed by PackProtoAction.
+Status UnpackProtoAction(const Action& action, google::protobuf::Message* out);
+
 // These functions depend on protobuf types which are not exported in the Flight DLL.
 
 Status FromProto(const google::protobuf::Timestamp& pb_timestamp, Timestamp* timestamp);

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -80,6 +80,7 @@ Status SchemaToString(const Schema& schema, std::string* out);
 /// format the implementation desires. A common pattern in Flight implementations
 /// is to wrap a message in a `protobuf::Any` message, which is then serialized
 /// into the string of the `FlightDescriptor.`
+ARROW_FLIGHT_EXPORT
 Status PackProtoCommand(const google::protobuf::Message& command, FlightDescriptor* out);
 
 /// \brief Wraps a protobuf message representing a Flight action.
@@ -88,10 +89,12 @@ Status PackProtoCommand(const google::protobuf::Message& command, FlightDescript
 /// implementation desires. A common pattern in Flight implementations is to
 /// wrap a message in a `protobuf::Any` message, which is then serialized into
 /// the string of the `Action.`
+ARROW_FLIGHT_EXPORT
 Status PackProtoAction(std::string action_type, const google::protobuf::Message& action,
                        Action* out);
 
 /// \brief Unpacks a protobuf message packed by PackProtoAction.
+ARROW_FLIGHT_EXPORT
 Status UnpackProtoAction(const Action& action, google::protobuf::Message* out);
 
 // These functions depend on protobuf types which are not exported in the Flight DLL.

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -82,6 +82,15 @@ Status SchemaToString(const Schema& schema, std::string* out);
 /// into the string of the `FlightDescriptor.`
 Status PackProtoCommand(const google::protobuf::Message& command, FlightDescriptor* out);
 
+/// \brief Wraps a protobuf message representing a Flight action.
+///
+/// A Flight action can carry a string representing an action in any format the
+/// implementation desires. A common pattern in Flight implementations is to
+/// wrap a message in a `protobuf::Any` message, which is then serialized into
+/// the string of the `Action.`
+Status PackProtoAction(std::string action_type, const google::protobuf::Message& action,
+                       Action* out);
+
 // These functions depend on protobuf types which are not exported in the Flight DLL.
 
 Status FromProto(const google::protobuf::Timestamp& pb_timestamp, Timestamp* timestamp);

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -96,7 +96,7 @@ Status FromProto(const pb::PollInfo& pb_info, PollInfo* info);
 Status FromProto(const pb::PollInfo& pb_info, std::unique_ptr<PollInfo>* info);
 Status FromProto(const pb::CancelFlightInfoRequest& pb_request,
                  CancelFlightInfoRequest* request);
-Status FromProto(const pb::SchemaResult& pb_result, std::string* result);
+Status FromProto(const pb::SchemaResult& pb_result, SchemaResult* result);
 Status FromProto(const pb::BasicAuth& pb_basic_auth, BasicAuth* info);
 Status FromProto(const pb::SetSessionOptionsRequest& pb_request,
                  SetSessionOptionsRequest* request);

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -19,10 +19,14 @@
 
 #pragma once
 
-#include "arrow/flight/protocol_internal.h"  // IWYU pragma: keep
 #include "arrow/flight/transport.h"
+#include "arrow/flight/type_fwd.h"
 #include "arrow/flight/types.h"
-#include "arrow/util/macros.h"
+#include "arrow/flight/visibility.h"
+
+namespace google::protobuf {
+class Timestamp;
+}  // namespace google::protobuf
 
 namespace arrow {
 
@@ -34,6 +38,32 @@ class Message;
 }  // namespace ipc
 
 namespace flight {
+// Protobuf types from Flight.proto
+namespace protocol {
+class Action;
+class ActionType;
+class BasicAuth;
+class CancelFlightInfoRequest;
+class CancelFlightInfoResult;
+class Criteria;
+class FlightData;
+class FlightDescriptor;
+class FlightEndpoint;
+class FlightInfo;
+class GetSessionOptionsRequest;
+class Location;
+class PollInfo;
+class RenewFlightEndpointRequest;
+class Result;
+class SchemaResult;
+class SetSessionOptionsRequest;
+class SetSessionOptionsResult;
+class Ticket;
+class GetSessionOptionsRequest;
+class GetSessionOptionsResult;
+class CloseSessionRequest;
+class CloseSessionResult;
+}  // namespace protocol
 namespace pb = arrow::flight::protocol;
 namespace internal {
 

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -25,6 +25,7 @@
 #include "arrow/flight/visibility.h"
 
 namespace google::protobuf {
+class Message;
 class Timestamp;
 }  // namespace google::protobuf
 
@@ -72,6 +73,14 @@ static constexpr char kAuthHeader[] = "authorization";
 
 ARROW_FLIGHT_EXPORT
 Status SchemaToString(const Schema& schema, std::string* out);
+
+/// \brief Wraps a protobuf message representing a Flight command in a FlightDescriptor.
+///
+/// A `FlightDescriptor` can carry a string representing a command in any
+/// format the implementation desires. A common pattern in Flight implementations
+/// is to wrap a message in a `protobuf::Any` message, which is then serialized
+/// into the string of the `FlightDescriptor.`
+Status PackProtoCommand(const google::protobuf::Message& command, FlightDescriptor* out);
 
 // These functions depend on protobuf types which are not exported in the Flight DLL.
 

--- a/cpp/src/arrow/flight/sql/client.h
+++ b/cpp/src/arrow/flight/sql/client.h
@@ -408,12 +408,22 @@ class ARROW_FLIGHT_SQL_EXPORT FlightSqlClient {
   /// \brief Explicitly shut down and clean up the client.
   Status Close();
 
+  /// \brief Wrapper around FlightClient::DoGet.
+  ///
+  /// \internal
+  /// Don't call this directly.
+  /// \endinternal
   virtual ::arrow::Result<FlightClient::DoPutResult> DoPut(
       const FlightCallOptions& options, const FlightDescriptor& descriptor,
       const std::shared_ptr<Schema>& schema) {
     return impl_->DoPut(options, descriptor, schema);
   }
 
+  /// \brief Wrapper around FlightClient::DoPut. Don't call this directly.
+  ///
+  /// \internal
+  /// Don't call this directly.
+  /// \endinternal
   virtual ::arrow::Result<std::unique_ptr<ResultStream>> DoAction(
       const FlightCallOptions& options, const Action& action) {
     return impl_->DoAction(options, action);

--- a/cpp/src/arrow/flight/sql/client.h
+++ b/cpp/src/arrow/flight/sql/client.h
@@ -408,7 +408,6 @@ class ARROW_FLIGHT_SQL_EXPORT FlightSqlClient {
   /// \brief Explicitly shut down and clean up the client.
   Status Close();
 
- protected:
   virtual ::arrow::Result<FlightClient::DoPutResult> DoPut(
       const FlightCallOptions& options, const FlightDescriptor& descriptor,
       const std::shared_ptr<Schema>& schema) {

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -978,9 +978,9 @@ class GrpcClientImpl : public internal::ClientTransport {
                               &rpc.context);
     RETURN_NOT_OK(s);
 
-    std::string str;
-    RETURN_NOT_OK(internal::FromProto(pb_response, &str));
-    return std::make_unique<SchemaResult>(std::move(str));
+    auto schema_result = std::make_unique<SchemaResult>();
+    RETURN_NOT_OK(internal::FromProto(pb_response, schema_result.get()));
+    return schema_result;
   }
 
   Status DoGet(const FlightCallOptions& options, const Ticket& ticket,

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "arrow/buffer.h"
+#include "arrow/flight/protocol_internal.h"
 #include "arrow/flight/serialization_internal.h"
 #include "arrow/flight/types_async.h"
 #include "arrow/io/memory.h"
@@ -696,6 +697,8 @@ arrow::Status Ticket::Deserialize(std::string_view serialized, Ticket* out) {
 
 Location::Location() { uri_ = std::make_shared<arrow::util::Uri>(); }
 
+Location::~Location() = default;
+
 arrow::Result<Location> Location::Parse(const std::string& uri_string) {
   Location location;
   RETURN_NOT_OK(location.uri_->Parse(uri_string));
@@ -1001,6 +1004,9 @@ Status ResultStream::Drain() {
   }
   return Status::OK();
 }
+
+FlightStreamChunk::FlightStreamChunk() noexcept = default;
+FlightStreamChunk::~FlightStreamChunk() = default;
 
 arrow::Result<std::vector<std::shared_ptr<RecordBatch>>>
 MetadataRecordBatchReader::ToRecordBatches() {

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -989,10 +989,8 @@ arrow::Status SchemaResult::SerializeToString(std::string* out) const {
 }
 
 arrow::Status SchemaResult::Deserialize(std::string_view serialized, SchemaResult* out) {
-  pb::SchemaResult pb_schema_result;
-  RETURN_NOT_OK(ParseFromString("SchemaResult", serialized, &pb_schema_result));
-  *out = SchemaResult{pb_schema_result.schema()};
-  return Status::OK();
+  return DeserializeProtoString<pb::SchemaResult, SchemaResult>("SchemaResult",
+                                                                serialized, out);
 }
 
 //------------------------------------------------------------

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -205,6 +205,14 @@ arrow::Status BasicAuth::SerializeToString(std::string* out) const {
   return SerializeToProtoString<pb::BasicAuth>("BasicAuth", *this, out);
 }
 
+FlightDescriptor::FlightDescriptor() = default;
+
+FlightDescriptor::FlightDescriptor(DescriptorType type, std::string cmd,
+                                   std::vector<std::string> path) noexcept
+    : type(type), cmd(std::move(cmd)), path(std::move(path)) {}
+
+FlightDescriptor::~FlightDescriptor() = default;
+
 std::string FlightDescriptor::ToString() const {
   std::stringstream ss;
   ss << "<FlightDescriptor ";

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -41,22 +41,16 @@
 
 namespace arrow {
 
-class Buffer;
 class RecordBatch;
 class Schema;
-class Status;
 class Table;
 
 namespace ipc {
-
 class DictionaryMemo;
-
 }  // namespace ipc
 
 namespace util {
-
 class Uri;
-
 }  // namespace util
 
 namespace flight {
@@ -746,6 +740,8 @@ struct ARROW_FLIGHT_EXPORT Location : public internal::BaseType<Location> {
   /// \brief Initialize a blank location.
   Location();
 
+  ~Location();
+
   /// \brief Initialize a location by parsing a URI string
   static arrow::Result<Location> Parse(const std::string& uri_string);
 
@@ -1148,6 +1144,9 @@ class ARROW_FLIGHT_EXPORT ResultStream {
 /// \brief A holder for a RecordBatch with associated Flight metadata.
 struct ARROW_FLIGHT_EXPORT FlightStreamChunk {
  public:
+  FlightStreamChunk() noexcept;
+  ~FlightStreamChunk();
+
   std::shared_ptr<RecordBatch> data;
   std::shared_ptr<Buffer> app_metadata;
 };

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -458,8 +458,8 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
 
   // Convenience factory functions
 
-  static FlightDescriptor Command(const std::string& c) {
-    return FlightDescriptor{CMD, c, {}};
+  static FlightDescriptor Command(std::string cmd) {
+    return FlightDescriptor{CMD, std::move(cmd), {}};
   }
 
   static FlightDescriptor Path(const std::vector<std::string>& p) {

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -428,10 +428,10 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
   /// when type is PATH
   std::vector<std::string> path;
 
-  FlightDescriptor() = default;
-
-  FlightDescriptor(DescriptorType type, std::string cmd, std::vector<std::string> path)
-      : type(type), cmd(std::move(cmd)), path(std::move(path)) {}
+  FlightDescriptor();
+  FlightDescriptor(DescriptorType type, std::string cmd,
+                   std::vector<std::string> path) noexcept;
+  ~FlightDescriptor();
 
   /// \brief Get a human-readable form of this descriptor.
   std::string ToString() const;
@@ -462,8 +462,8 @@ struct ARROW_FLIGHT_EXPORT FlightDescriptor
     return FlightDescriptor{CMD, std::move(cmd), {}};
   }
 
-  static FlightDescriptor Path(const std::vector<std::string>& p) {
-    return FlightDescriptor{PATH, "", p};
+  static FlightDescriptor Path(std::vector<std::string> path) {
+    return FlightDescriptor{PATH, "", std::move(path)};
   }
 };
 


### PR DESCRIPTION
### Rationale for this change

The less code depends on `protobuf::Any`, the easier it is to separate the parts that need to link against pb libraries from the ones that can be built without it.

### What changes are included in this PR?

 - Internal forward declarations (plus making some dtor/ctor non-inline)
 - Add missing `SchemaResult::FromProto`
 - Extract a few proto-related functions
 - Move more generic code from `flight/sql` to `sql`

### Are these changes tested?

By existing tests.
* GitHub Issue: #43543