### PR TITLE
MINOR: [Go] Fix typo in documentation in go/arrow/table.go

### DIFF
--- a/go/arrow/table.go
+++ b/go/arrow/table.go
@@ -49,7 +49,7 @@ type Table interface {
 // To get strongly typed data from a Column, you need to iterate the
 // chunks and type assert each individual Array. For example:
 //
-//	switch column.DataType().ID {
+//	switch column.DataType().ID() {
 //	case arrow.INT32:
 //		for _, c := range column.Data().Chunks() {
 //			arr := c.(*array.Int32)


### PR DESCRIPTION
### Rationale for this change

I found a small typo in the documentation

### Are there any user-facing changes?

No
