### PR TITLE
GH-38837: [Format] Add the specification to pass statistics through the Arrow C data interface

### DIFF
--- a/cpp/tools/parquet/parquet_dump_arrow_statistics.cc
+++ b/cpp/tools/parquet/parquet_dump_arrow_statistics.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 namespace {
+// doc: start: print-arrow-statistics
 arrow::Status PrintArrowStatistics(const char* path) {
   ARROW_ASSIGN_OR_RAISE(
       auto input, arrow::io::MemoryMappedFile::Open(path, arrow::io::FileMode::READ));
@@ -39,6 +40,7 @@ arrow::Status PrintArrowStatistics(const char* path) {
   }
   return arrow::Status::OK();
 }
+// doc: end: print-arrow-statistics
 };  // namespace
 
 int main(int argc, char** argv) {

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -85,7 +85,7 @@ Here is the outline of the schema for statistics::
 
     struct<
       column: int32,
-      values: map<
+      statistics: map<
         key: dictionary<
           indices: int32,
           dictionary: utf8
@@ -108,13 +108,13 @@ Here is the details of top-level ``struct``:
      - ``true``
      - The zero-based column index, or null if the statistics
        describe the whole table or record batch.
-   * - ``values``
+   * - ``statistics``
      - ``map``
      - ``false``
      - Statistics for the target column, table or record batch. See
        the separate table below for details.
 
-Here is the details of the ``map`` of the ``values``:
+Here is the details of the ``map`` of the ``statistics``:
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -57,8 +57,9 @@ Non-goals
 * Provide a common way to pass statistics that can be used for
   other interfaces such Arrow Flight too.
 
-For example, ADBC has the statistics related APIs. This specification
-doesn't replace them.
+For example, ADBC has `the statistics related APIs
+<https://arrow.apache.org/adbc/current/format/specification.html#statistics>`__.
+This specification doesn't replace them.
 
 .. _c-data-interface-statistics-schema:
 

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -69,7 +69,20 @@ This specification provides only the schema for statistics. The
 producer passes statistics through the Arrow C data interface as an
 Arrow map array that uses this schema.
 
-Here is the schema for a statistics Arrow map array:
+Here is the outline of the schema for statistics::
+
+    map<
+      key: int32,
+      items: map<
+        key: dictionary<
+          indices: int32,
+          dictionary: utf8
+        >,
+        items: dense_union<...all needed types...>,
+      >
+    >
+
+Here is the details of the top-level ``map``:
 
 .. list-table::
    :header-rows: 1
@@ -89,7 +102,8 @@ Here is the schema for a statistics Arrow map array:
      - Statistics for the target column, table or record batch. See
        the separate table below for details.
 
-Here is the schema for the statistics map:
+Here is the details of the nested ``map`` as the items part of the
+above ``map``:
 
 .. list-table::
    :header-rows: 1
@@ -99,7 +113,7 @@ Here is the schema for the statistics map:
      - Nullable
      - Notes
    * - key
-     - ``dictionary<int32, utf8>``
+     - ``dictionary<indices: int32, dictionary: utf8>``
      - ``false``
      - Statistics key is string. Dictionary is used for
        efficiency. Different keys are assigned for exact value and

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -21,6 +21,8 @@
 Passing statistics through the Arrow C data interface
 =====================================================
 
+.. warning:: This specification should be considered experimental.
+
 Rationale
 =========
 

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -154,7 +154,7 @@ Statistics key
 Statistics key is string. ``dictionary<int32, utf8>`` is used for
 efficiency.
 
-We assign different statistics keys for variants instead of using
+We assign different statistics keys for individual statistics instead of using
 flags. For example, we assign different statistics keys for exact
 value and approximate value.
 

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -32,7 +32,7 @@ be read as Apache Arrow data may have statistics. For example, the
 Apache Parquet C++ implementation can read an Apache Parquet file as
 Apache Arrow data and the Apache Parquet file may have statistics.
 
-One of the Arrow C data interface use cases is the following:
+One of :ref:`c-data-interface` use cases is the following:
 
 1. Module A reads Apache Parquet file as Apache Arrow data.
 2. Module A passes the read Apache Arrow data to module B through the
@@ -60,6 +60,17 @@ Non-goals
 For example, ADBC has `the statistics related APIs
 <https://arrow.apache.org/adbc/current/format/specification.html#statistics>`__.
 This specification doesn't replace them.
+
+This specification may fit some use cases of :ref:`format-ipc` not the
+Arrow data interface. But we don't recommend this specification for
+the Arrow IPC format for now. Because we may be able to define better
+specification for the Arrow IPC format. The Arrow IPC format has some
+different features compared with the Arrow C data interface. For
+example, the Arrow IPC format can have :ref:`ipc-message-format
+metadata for each message`. If you're interested in the specification
+for passing statistics through the Arrow IPC format, please start a
+discussion on the `Arrow development mailing-list
+<https://arrow.apache.org/community/>`__.
 
 .. _c-data-interface-statistics-schema:
 

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -83,39 +83,36 @@ Arrow map array that uses this schema.
 
 Here is the outline of the schema for statistics::
 
-    map<
-      key: int32,
-      items: map<
-        key: dictionary<
-          indices: int32,
-          dictionary: utf8
-        >,
-        items: dense_union<...all needed types...>,
-      >
+    column: int32,
+    values: map<
+      key: dictionary<
+        indices: int32,
+        dictionary: utf8
+      >,
+      items: dense_union<...all needed types...>,
     >
 
-Here is the details of the top-level ``map``:
+Here is the details of top-level columns:
 
 .. list-table::
    :header-rows: 1
 
-   * - Key or items
+   * - Name
      - Data type
      - Nullable
      - Notes
-   * - key
+   * - ``column``
      - ``int32``
      - ``true``
      - The zero-based column index, or null if the statistics
        describe the whole table or record batch.
-   * - items
+   * - ``values``
      - ``map``
      - ``false``
      - Statistics for the target column, table or record batch. See
        the separate table below for details.
 
-Here is the details of the nested ``map`` as the items part of the
-above ``map``:
+Here is the details of the ``map`` of the ``values``:
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -66,9 +66,9 @@ Arrow data interface. But we don't recommend this specification for
 the Arrow IPC format for now. Because we may be able to define better
 specification for the Arrow IPC format. The Arrow IPC format has some
 different features compared with the Arrow C data interface. For
-example, the Arrow IPC format can have :ref:`ipc-message-format
-metadata for each message`. If you're interested in the specification
-for passing statistics through the Arrow IPC format, please start a
+example, the Arrow IPC format can have :ref:`metadata for each message
+<ipc-message-format>`. If you're interested in the specification for
+passing statistics through the Arrow IPC format, please start a
 discussion on the `Arrow development mailing-list
 <https://arrow.apache.org/community/>`__.
 
@@ -219,6 +219,51 @@ systems, please propose it on the `Arrow development mailing-list
 <https://arrow.apache.org/community/>`__.
 
 Examples
---------
+========
 
-TODO: Add at least C++ example.
+Here are some examples to help you understand.
+
+C++
+---
+
+The C++ implementation provides convenience features to create a
+statistics array.
+
+You can attach statistics to an :cpp:class:`arrow::Array`. Statistics
+of an array is represented as :cpp:class:`arrow::ArrayStatistics`.
+
+If you build :cpp:class:`arrow::Array` s from a Parquet file, you
+don't need to attach statistics in a Parquet file
+explicitly. :cpp:class:`parquet::arrow::FileReader` attaches
+statistics in a Parquet file automatically.
+
+If you have a :cpp:class:`arrow::RecordBatch` that has
+:cpp:class:`arrow::Array` that has statistics, you can use
+:cpp:func:`arrow::RecordBatch::MakeStatisticsArray()`. It builds an
+:cpp:class:`arrow::Array` for statistics from attached statistics. The
+built statistics array uses the statistics schema defined in this
+documentation.
+
+Here is an example that reads record batches from a Parquet file and
+prints statistics array for each record batch. Each record batch has
+associated statistics when the Parquet file has statistics. The
+important part of this example is
+:cpp:func:`arrow::RecordBatch::MakeStatisticsArray` call. You can
+build a statistics :cpp:class:`arrow::Array` easily by it.
+
+.. literalinclude:: ../../../cpp/tools/parquet/parquet_dump_arrow_statistics.cc
+   :language: cpp
+   :start-after: doc: start: print-arrow-statistics
+   :end-before: doc: end: print-arrow-statistics
+
+You can pass a statistics :cpp:class:`arrow::Array` created by
+:cpp:func:`arrow::RecordBatch::MakeStatisticsArray` to another system
+in the same process with the normal C data interface. For example, you
+can use :cpp:func:`arrow::ExportArray` to export a statistics
+:cpp:class:`arrow::Array`:
+
+.. code-block:: cpp
+
+   ArrowArray exported_statistics_array;
+   arrow::Status status = arrow::ExportArray(*statistics_array, &exported_statistics_array);
+   // Pass exported_statistics_array to other system.

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -83,16 +83,18 @@ Arrow map array that uses this schema.
 
 Here is the outline of the schema for statistics::
 
-    column: int32,
-    values: map<
-      key: dictionary<
-        indices: int32,
-        dictionary: utf8
-      >,
-      items: dense_union<...all needed types...>,
+    struct<
+      column: int32,
+      values: map<
+        key: dictionary<
+          indices: int32,
+          dictionary: utf8
+        >,
+        items: dense_union<...all needed types...>,
+      >
     >
 
-Here is the details of top-level columns:
+Here is the details of top-level ``struct``:
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -79,6 +79,9 @@ For example, ADBC has `the statistics related APIs
 <https://arrow.apache.org/adbc/current/format/specification.html#statistics>`__.
 This specification doesn't replace them.
 
+TODO: Should we deprecate the current ADBC's statistics API and
+redesign with this specification?
+
 This specification may fit some use cases of :ref:`format-ipc` not the
 Arrow data interface. But we don't recommend this specification for
 the Arrow IPC format for now. Because we may be able to define better

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -143,7 +143,7 @@ Here is the details of the ``map`` of the ``statistics``:
        for statistics key.
 
        We don't standardize field names for the dense union because
-       consumers can access to proper field by index not name. So
+       consumers can access to proper field by type code not name. So
        producers can use any valid name for fields.
 
 .. _c-data-interface-statistics-key:

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -163,6 +163,8 @@ The colon symbol ``:`` is to be used as a namespace separator like
 
 The ``ARROW`` pattern is a reserved namespace for pre-defined
 statistics keys. User-defined statistics must not use it.
+For example, you can use your product name as namespace
+such as `MY_PRODUCT:my_statistics:exact`.
 
 Here are pre-defined statistics keys:
 

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -200,6 +200,12 @@ Here are pre-defined statistics keys:
    * - ``ARROW:min_value:approximate``
      - Target dependent
      - The minimum value in the target. (approximate)
+   * - ``ARROW:null_count:exact``
+     - ``int64``
+     - The number of nulls in the target. (exact)
+   * - ``ARROW:null_count:approximate``
+     - ``float64``
+     - The number of nulls in the target. (approximate)
    * - ``ARROW:row_count:exact``
      - ``int64``
      - The number of rows in the target table or record batch. (exact)

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -175,7 +175,7 @@ Here are pre-defined statistics keys:
      - Data type
      - Notes
    * - ``ARROW:average_byte_width:exact``
-     - ``float``
+     - ``float64``
      - The average size in bytes of a row in the target. (exact)
    * - ``ARROW:average_byte_width:approximate``
      - ``float64``

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -1,0 +1,192 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+.. _c-data-interface-statistics:
+
+=====================================================
+Passing statistics through the Arrow C data interface
+=====================================================
+
+Rationale
+=========
+
+Statistics are useful for fast query processing. Many query engines
+use statistics to optimize their query plan.
+
+Apache Arrow format doesn't have statistics but other formats that can
+be read as Apache Arrow data may have statistics. For example, Apache
+Parquet C++ can read Apache Parquet file as Apache Arrow data and
+Apache Parquet file may have statistics.
+
+One of the Arrow C data interface use cases is the following:
+
+1. Module A reads Apache Parquet file as Apache Arrow data
+2. Module A passes the read Apache Arrow data to module B through the
+   Arrow C data interface
+3. Module B processes the passed Apache Arrow data
+
+If module A can pass the statistics associated with the Apache Parquet
+file to module B through the Arrow C data interface, module B can use
+the statistics to optimize its query plan.
+
+Goals
+-----
+
+* Provide the standard way to pass statistics through the Arrow C data
+  interface to avoid reinventing the wheel.
+* The standard way must be easy to use with the Arrow C data interface.
+
+Non-goals
+---------
+
+* Provide a common way to pass statistics that can be used for
+  other interfaces such Arrow Flight too.
+
+For example, ADBC has the statistics related APIs. This specification
+doesn't replace them.
+
+.. _c-data-interface-statistics-schema:
+
+Schema
+======
+
+This specification provides only the schema for statistics. Producers
+passes statistics as a map Arrow array that uses the schema through
+the Arrow C data interface.
+
+Here is the schema for a statistics map Arrow Array:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Key or items
+     - Data type
+     - Nullable
+     - Notes
+   * - key
+     - ``int32``
+     - ``true``
+     - The column index or null if the statistics refer to whole table
+       or record batch.
+   * - items
+     - ``map``
+     - ``false``
+     - Statistics for the target column, table or record batch. See
+       the separated table for details.
+
+Here is the schema for the statistics map:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Key or items
+     - Data type
+     - Nullable
+     - Notes
+   * - key
+     - ``dictionary<int32, utf8>``
+     - ``false``
+     - Statistics key is string. Dictionary is used for
+       efficiency. Different keys are assigned for exact value and
+       approximate value. See also the separated description for
+       statistics key.
+   * - items
+     - ``dense_union``
+     - ``false``
+     - Statistics value is dense union. It has at least all needed
+       types based on statistics kinds in the keys. For example, you
+       need at least ``int64`` and ``float64`` types when you have a
+       ``int64`` distinct count statistic and a ``float64`` average
+       byte width statistic. See also the separated description for
+       statistics key.
+
+       We don't standardize field names for the dense union because
+       consumers can access to proper field by index not name. So
+       producers can use any valid name for fields.
+
+.. _c-data-interface-statistics-key:
+
+Statistics key
+--------------
+
+Statistics key is string. ``dictionary<int32, utf8>`` is used for
+efficiency.
+
+We assign different statistics keys for variants instead of using
+flags. For example, we assign different statistics keys for exact
+value and approximate value.
+
+The colon symbol ``:`` is to be used as a namespace separator like
+:ref:`format_metadata`. It can be used multiple times in a key.
+
+The ``ARROW`` pattern is a reserved namespace for pre-defined
+statistics keys. User-defined statistics must not use it.
+
+Here are pre-defined statistics keys:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Key
+     - Data type
+     - Notes
+   * - ``ARROW:average_byte_width:exact``
+     - ``float``
+     - The average size in bytes of a row in the target. (exact)
+   * - ``ARROW:average_byte_width:approximate``
+     - ``float64``
+     - The average size in bytes of a row in the target. (approximate)
+   * - ``ARROW:distinct_count:exact``
+     - ``int64``
+     - The number of distinct values in the target. (exact)
+   * - ``ARROW:distinct_count:approximate``
+     - ``float64``
+     - The number of distinct values in the target. (approximate)
+   * - ``ARROW:max_byte_width:exact``
+     - ``int64``
+     - The maximum size in bytes of a row in the target. (exact)
+   * - ``ARROW:max_byte_width:approximate``
+     - ``float64``
+     - The maximum size in bytes of a row in the target. (approximate)
+   * - ``ARROW:max_value:exact``
+     - Target dependent
+     - The maximum value in the target. (exact)
+   * - ``ARROW:max_value:approximate``
+     - Target dependent
+     - The maximum value in the target. (approximate)
+   * - ``ARROW:min_value:exact``
+     - Target dependent
+     - The minimum value in the target. (exact)
+   * - ``ARROW:min_value:approximate``
+     - Target dependent
+     - The minimum value in the target. (approximate)
+   * - ``ARROW:row_count:exact``
+     - ``int64``
+     - The number of rows in the target table or record batch. (exact)
+   * - ``ARROW:row_count:approximate``
+     - ``float64``
+     - The number of rows in the target table or record
+       batch. (approximate)
+
+If you find a missing statistics key that is usable for multiple
+systems, please propose it on the `Arrow development mailing-list
+<https://arrow.apache.org/community/>`__.
+
+Examples
+--------
+
+TODO: Add at least C++ example.

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -188,7 +188,7 @@ The colon symbol ``:`` is to be used as a namespace separator like
 The ``ARROW`` pattern is a reserved namespace for pre-defined
 statistics keys. User-defined statistics must not use it.
 For example, you can use your product name as namespace
-such as `MY_PRODUCT:my_statistics:exact`.
+such as ``MY_PRODUCT:my_statistics:exact``.
 
 Here are pre-defined statistics keys:
 

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -28,16 +28,16 @@ Statistics are useful for fast query processing. Many query engines
 use statistics to optimize their query plan.
 
 Apache Arrow format doesn't have statistics but other formats that can
-be read as Apache Arrow data may have statistics. For example, Apache
-Parquet C++ can read Apache Parquet file as Apache Arrow data and
-Apache Parquet file may have statistics.
+be read as Apache Arrow data may have statistics. For example, the
+Apache Parquet C++ implementation can read an Apache Parquet file as
+Apache Arrow data and the Apache Parquet file may have statistics.
 
 One of the Arrow C data interface use cases is the following:
 
-1. Module A reads Apache Parquet file as Apache Arrow data
+1. Module A reads Apache Parquet file as Apache Arrow data.
 2. Module A passes the read Apache Arrow data to module B through the
-   Arrow C data interface
-3. Module B processes the passed Apache Arrow data
+   Arrow C data interface.
+3. Module B processes the passed Apache Arrow data.
 
 If module A can pass the statistics associated with the Apache Parquet
 file to module B through the Arrow C data interface, module B can use
@@ -46,9 +46,10 @@ the statistics to optimize its query plan.
 Goals
 -----
 
-* Provide the standard way to pass statistics through the Arrow C data
-  interface to avoid reinventing the wheel.
-* The standard way must be easy to use with the Arrow C data interface.
+* Establish a standard way to pass statistics through the Arrow C data
+  interface.
+* Provide this in a manner that enables compatibility and ease of
+  implementation for existing users of the Arrow C data interface.
 
 Non-goals
 ---------
@@ -64,11 +65,11 @@ doesn't replace them.
 Schema
 ======
 
-This specification provides only the schema for statistics. Producers
-passes statistics as a map Arrow array that uses the schema through
-the Arrow C data interface.
+This specification provides only the schema for statistics. The
+producer passes statistics through the Arrow C data interface as an
+Arrow map array that uses this schema.
 
-Here is the schema for a statistics map Arrow Array:
+Here is the schema for a statistics Arrow map array:
 
 .. list-table::
    :header-rows: 1
@@ -80,13 +81,13 @@ Here is the schema for a statistics map Arrow Array:
    * - key
      - ``int32``
      - ``true``
-     - The column index or null if the statistics refer to whole table
-       or record batch.
+     - The zero-based column index, or null if the statistics
+       describe the whole table or record batch.
    * - items
      - ``map``
      - ``false``
      - Statistics for the target column, table or record batch. See
-       the separated table for details.
+       the separate table below for details.
 
 Here is the schema for the statistics map:
 
@@ -102,7 +103,7 @@ Here is the schema for the statistics map:
      - ``false``
      - Statistics key is string. Dictionary is used for
        efficiency. Different keys are assigned for exact value and
-       approximate value. See also the separated description for
+       approximate value. Also see the separate description below for
        statistics key.
    * - items
      - ``dense_union``
@@ -111,8 +112,8 @@ Here is the schema for the statistics map:
        types based on statistics kinds in the keys. For example, you
        need at least ``int64`` and ``float64`` types when you have a
        ``int64`` distinct count statistic and a ``float64`` average
-       byte width statistic. See also the separated description for
-       statistics key.
+       byte width statistic. Also see the separate description below
+       for statistics key.
 
        We don't standardize field names for the dense union because
        consumers can access to proper field by index not name. So

--- a/docs/source/format/CDataInterfaceStatistics.rst
+++ b/docs/source/format/CDataInterfaceStatistics.rst
@@ -165,6 +165,8 @@ Here is the details of the ``map`` of the ``statistics``:
        consumers can access to proper field by type code not name. So
        producers can use any valid name for fields.
 
+       TODO: Should we standardize field names?
+
 .. _c-data-interface-statistics-key:
 
 Statistics key

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1619,6 +1619,7 @@ example as above, an alternate encoding could be: ::
     0
     EOS
 
+.. _format_metadata:
 
 Custom Application Metadata
 ---------------------------

--- a/docs/source/format/index.rst
+++ b/docs/source/format/index.rst
@@ -30,6 +30,7 @@ Specifications
    CanonicalExtensions
    Other
    CDataInterface
+   CDataInterfaceStatistics
    CStreamInterface
    CDeviceDataInterface
    DissociatedIPC


### PR DESCRIPTION
### Rationale for this change

Statistics are useful for fast query processing. Many query engines
use statistics to optimize their query plan.

Apache Arrow format doesn't have statistics but other formats that can
be read as Apache Arrow data may have statistics. For example, Apache
Parquet C++ can read Apache Parquet file as Apache Arrow data and
Apache Parquet file may have statistics.

One of the Arrow C data interface use cases is the following:

1. Module A reads Apache Parquet file as Apache Arrow data
2. Module A passes the read Apache Arrow data to module B through the
   Arrow C data interface
3. Module B processes the passed Apache Arrow data

If module A can pass the statistics associated with the Apache Parquet
file to module B through the Arrow C data interface, module B can use
the statistics to optimize its query plan.

### What changes are included in this PR?

Add the specification to pass statistics through the Arrow C data interface based on the discussion on the `dev@` mailing list: https://lists.apache.org/thread/z0jz2bnv61j7c6lbk7lympdrs49f69cx

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #38837