### PR TITLE
MINOR: [CI] Replace docker-compose with `docker compose`

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run minimal example
         run: |
           cd cpp/examples/minimal_build
-          docker-compose run --rm minimal
+          docker compose run --rm minimal
 
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++

--- a/dev/tasks/cpp-examples/github.linux.yml
+++ b/dev/tasks/cpp-examples/github.linux.yml
@@ -30,4 +30,4 @@ jobs:
         shell: bash
         run: |
           cd arrow/cpp/examples/{{ type }}
-          docker-compose run --rm {{ run }}
+          docker compose run --rm {{ run }}

--- a/dev/tasks/python-minimal-build/github.linux.yml
+++ b/dev/tasks/python-minimal-build/github.linux.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run minimal build example
         run: |
           cd arrow/python/examples/{{ type }}
-          docker-compose run --rm {{ image }}
+          docker compose run --rm {{ image }}

--- a/dev/tasks/r/azure.linux.yml
+++ b/dev/tasks/r/azure.linux.yml
@@ -33,14 +33,14 @@ jobs:
   - script: |
       set -ex
       docker -v
-      docker-compose -v
+      docker compose version
       cd arrow
       export R_ORG={{ r_org }}
       export R_IMAGE={{ r_image }}
       export R_TAG={{ r_tag }}
       export R_CUSTOM_CCACHE={{ r_custom_ccache|default("false") }}
-      docker-compose pull --ignore-pull-failures r
-      docker-compose build r
+      docker compose pull --ignore-pull-failures r
+      docker compose build r
     displayName: Docker build
     env:
     {{ macros.azure_set_sccache_envvars()|indent(4) }}
@@ -54,7 +54,7 @@ jobs:
       export ARROW_R_DEV={{ not_cran|default("TRUE") }}
       # Note that by default, ci/scripts/r_test.sh sets NOT_CRAN=true
       # if ARROW_R_DEV=TRUE. Pass `-e NOT_CRAN=false` to turn that off.
-      docker-compose run {{ flags|default("") }} r
+      docker compose run {{ flags|default("") }} r
     displayName: Docker run
     env:
     {{ macros.azure_set_sccache_envvars()|indent(4) }}


### PR DESCRIPTION
"docker-compose" is not available on some CI images anymore, switch to the Docker built-in "compose" command.
