### PR TITLE
GH-43592: [C++] Remove redundant default constructor/deconstructor in arrow::ArrayStatistics

### DIFF
--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -38,9 +38,6 @@ struct ARROW_EXPORT ArrayStatistics {
       std::variant<bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
                    uint64_t, util::Float16, float, double, std::string, std::string_view>;
 
-  ArrayStatistics() = default;
-  ~ArrayStatistics() = default;
-
   /// \brief The number of null values, may not be set
   std::optional<int64_t> null_count = std::nullopt;
 


### PR DESCRIPTION
### Rationale for this change

`= default` constructor/deconstructor are needless in `arrow::ArrayStatistics`.

### What changes are included in this PR?

Remove them.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43592