### PR TITLE
GH-43578: [C++] Simplify arrow::ArrayStatistics::ValueType

### DIFF
--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -20,10 +20,8 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <variant>
 
-#include "arrow/util/float16.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -34,9 +32,7 @@ namespace arrow {
 /// as Apache Parquet may have statistics. Statistics associated with
 /// data source can be read unified API via this class.
 struct ARROW_EXPORT ArrayStatistics {
-  using ValueType =
-      std::variant<bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
-                   uint64_t, util::Float16, float, double, std::string, std::string_view>;
+  using ValueType = std::variant<bool, int64_t, uint64_t, double, std::string>;
 
   ArrayStatistics() = default;
   ~ArrayStatistics() = default;

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -41,11 +41,11 @@ TEST(ArrayStatisticsTest, TestMin) {
   ArrayStatistics statistics;
   ASSERT_FALSE(statistics.min.has_value());
   ASSERT_FALSE(statistics.is_min_exact.has_value());
-  statistics.min = static_cast<int32_t>(29);
+  statistics.min = static_cast<uint64_t>(29);
   statistics.is_min_exact = true;
   ASSERT_TRUE(statistics.min.has_value());
-  ASSERT_TRUE(std::holds_alternative<int32_t>(statistics.min.value()));
-  ASSERT_EQ(29, std::get<int32_t>(statistics.min.value()));
+  ASSERT_TRUE(std::holds_alternative<uint64_t>(statistics.min.value()));
+  ASSERT_EQ(29, std::get<uint64_t>(statistics.min.value()));
   ASSERT_TRUE(statistics.is_min_exact.has_value());
   ASSERT_TRUE(statistics.is_min_exact.value());
 }
@@ -79,9 +79,9 @@ TEST(ArrayStatisticsTest, TestEquality) {
   statistics2.distinct_count = 2929;
   ASSERT_EQ(statistics1, statistics2);
 
-  statistics1.min = std::string_view("world");
+  statistics1.min = std::string("world");
   ASSERT_NE(statistics1, statistics2);
-  statistics2.min = std::string_view("world");
+  statistics2.min = std::string("world");
   ASSERT_EQ(statistics1, statistics2);
 
   statistics1.is_min_exact = false;
@@ -89,9 +89,9 @@ TEST(ArrayStatisticsTest, TestEquality) {
   statistics2.is_min_exact = false;
   ASSERT_EQ(statistics1, statistics2);
 
-  statistics1.max = arrow::util::Float16(-29);
+  statistics1.max = -29;
   ASSERT_NE(statistics1, statistics2);
-  statistics2.max = arrow::util::Float16(-29);
+  statistics2.max = -29;
   ASSERT_EQ(statistics1, statistics2);
 
   statistics1.is_max_exact = true;

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -89,9 +89,9 @@ TEST(ArrayStatisticsTest, TestEquality) {
   statistics2.is_min_exact = false;
   ASSERT_EQ(statistics1, statistics2);
 
-  statistics1.max = -29;
+  statistics1.max = static_cast<int64_t>(-29);
   ASSERT_NE(statistics1, statistics2);
-  statistics2.max = -29;
+  statistics2.max = static_cast<int64_t>(-29);
   ASSERT_EQ(statistics1, statistics2);
 
   statistics1.is_max_exact = true;


### PR DESCRIPTION
### Rationale for this change

We can cover integer values by `int64_t` and `uint64_t` and float values by `double`.

We can remove `std::string_view` because we don't support out of `ArrayStatistics` string/binary data.

### What changes are included in this PR?

* Remove `uint_8_t`, `int8_t`, `uint16_t`, `int16_t`, `uint32_t` and `int32_t`
* Remove `arrow::util::Float16` and `float`
* Remove `std::string_view`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #43578