### PR TITLE
GH-43577: [Java] getBuffers method needs correction on clear flag usage

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -382,6 +382,17 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
     return new VectorWithOrdinal(vector, ordinal);
   }
 
+  /**
+   * Return the underlying buffers associated with this vector. Note that this doesn't impact the
+   * reference counts for this buffer, so it only should be used for in-context access. Also note
+   * that this buffer changes regularly, thus external classes shouldn't hold a reference to it
+   * (unless they change it).
+   *
+   * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
+   * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
+   */
   @Override
   public ArrowBuf[] getBuffers(boolean clear) {
     final List<ArrowBuf> buffers = new ArrayList<>();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -398,7 +398,7 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
     final List<ArrowBuf> buffers = new ArrayList<>();
 
     for (final ValueVector vector : vectors.values()) {
-      for (final ArrowBuf buf : vector.getBuffers(clear)) {
+      for (final ArrowBuf buf : vector.getBuffers(false)) {
         buffers.add(buf);
         if (clear) {
           buf.getReferenceManager().retain(1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -387,7 +387,7 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
     final List<ArrowBuf> buffers = new ArrayList<>();
 
     for (final ValueVector vector : vectors.values()) {
-      for (final ArrowBuf buf : vector.getBuffers(false)) {
+      for (final ArrowBuf buf : vector.getBuffers(clear)) {
         buffers.add(buf);
         if (clear) {
           buf.getReferenceManager().retain(1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -279,7 +279,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector
     } else {
       List<ArrowBuf> list = new ArrayList<>();
       list.add(offsetBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
+      list.addAll(Arrays.asList(vector.getBuffers(clear)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -271,6 +271,17 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector
     valueCount = 0;
   }
 
+  /**
+   * Return the underlying buffers associated with this vector. Note that this doesn't impact the
+   * reference counts for this buffer, so it only should be used for in-context access. Also note
+   * that this buffer changes regularly, thus external classes shouldn't hold a reference to it
+   * (unless they change it).
+   *
+   * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
+   * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
+   */
   @Override
   public ArrowBuf[] getBuffers(boolean clear) {
     final ArrowBuf[] buffers;
@@ -279,7 +290,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector
     } else {
       List<ArrowBuf> list = new ArrayList<>();
       list.add(offsetBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(clear)));
+      list.addAll(Arrays.asList(vector.getBuffers(false)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -360,6 +360,17 @@ public class FixedSizeListVector extends BaseValueVector
     valueCount = 0;
   }
 
+  /**
+   * Return the underlying buffers associated with this vector. Note that this doesn't impact the
+   * reference counts for this buffer, so it only should be used for in-context access. Also note
+   * that this buffer changes regularly, thus external classes shouldn't hold a reference to it
+   * (unless they change it).
+   *
+   * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
+   * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
+   */
   @Override
   public ArrowBuf[] getBuffers(boolean clear) {
     setReaderAndWriterIndex();
@@ -369,7 +380,7 @@ public class FixedSizeListVector extends BaseValueVector
     } else {
       List<ArrowBuf> list = new ArrayList<>();
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(clear)));
+      list.addAll(Arrays.asList(vector.getBuffers(false)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -369,7 +369,7 @@ public class FixedSizeListVector extends BaseValueVector
     } else {
       List<ArrowBuf> list = new ArrayList<>();
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
+      list.addAll(Arrays.asList(vector.getBuffers(clear)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -882,12 +882,13 @@ public class LargeListVector extends BaseValueVector
 
   /**
    * Return the underlying buffers associated with this vector. Note that this doesn't impact the
-   * reference counts for this buffer so it only should be used for in-context access. Also note
-   * that this buffer changes regularly thus external classes shouldn't hold a reference to it
+   * reference counts for this buffer, so it only should be used for in-context access. Also note
+   * that this buffer changes regularly, thus external classes shouldn't hold a reference to it
    * (unless they change it).
    *
-   * @param clear Whether to clear vector before returning; the buffers will still be refcounted but
-   *     the returned array will be the only reference to them
+   * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
    * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
    */
   @Override
@@ -900,7 +901,7 @@ public class LargeListVector extends BaseValueVector
       List<ArrowBuf> list = new ArrayList<>();
       list.add(offsetBuffer);
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(clear)));
+      list.addAll(Arrays.asList(vector.getBuffers(false)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -900,7 +900,7 @@ public class LargeListVector extends BaseValueVector
       List<ArrowBuf> list = new ArrayList<>();
       list.add(offsetBuffer);
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
+      list.addAll(Arrays.asList(vector.getBuffers(clear)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
@@ -546,7 +546,8 @@ public class LargeListViewVector extends BaseLargeRepeatedValueViewVector
    * (unless they change it).
    *
    * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
-   *     the returned array will be the only reference to them
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
    * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
    */
   @Override
@@ -561,7 +562,7 @@ public class LargeListViewVector extends BaseLargeRepeatedValueViewVector
       list.add(validityBuffer);
       list.add(offsetBuffer);
       list.add(sizeBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(clear)));
+      list.addAll(Arrays.asList(vector.getBuffers(false)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -726,12 +726,13 @@ public class ListVector extends BaseRepeatedValueVector
 
   /**
    * Return the underlying buffers associated with this vector. Note that this doesn't impact the
-   * reference counts for this buffer so it only should be used for in-context access. Also note
-   * that this buffer changes regularly thus external classes shouldn't hold a reference to it
+   * reference counts for this buffer, so it only should be used for in-context access. Also note
+   * that this buffer changes regularly, thus external classes shouldn't hold a reference to it
    * (unless they change it).
    *
-   * @param clear Whether to clear vector before returning; the buffers will still be refcounted but
-   *     the returned array will be the only reference to them
+   * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
    * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
    */
   @Override
@@ -744,7 +745,7 @@ public class ListVector extends BaseRepeatedValueVector
       List<ArrowBuf> list = new ArrayList<>();
       list.add(offsetBuffer);
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(clear)));
+      list.addAll(Arrays.asList(vector.getBuffers(false)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -744,7 +744,7 @@ public class ListVector extends BaseRepeatedValueVector
       List<ArrowBuf> list = new ArrayList<>();
       list.add(offsetBuffer);
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
+      list.addAll(Arrays.asList(vector.getBuffers(clear)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
@@ -719,7 +719,7 @@ public class ListViewVector extends BaseRepeatedValueViewVector
       list.add(validityBuffer);
       list.add(offsetBuffer);
       list.add(sizeBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
+      list.addAll(Arrays.asList(vector.getBuffers(clear)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
@@ -704,7 +704,8 @@ public class ListViewVector extends BaseRepeatedValueViewVector
    * (unless they change it).
    *
    * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
-   *     the returned array will be the only reference to them
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
    * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
    */
   @Override
@@ -719,7 +720,7 @@ public class ListViewVector extends BaseRepeatedValueViewVector
       list.add(validityBuffer);
       list.add(offsetBuffer);
       list.add(sizeBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(clear)));
+      list.addAll(Arrays.asList(vector.getBuffers(false)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -396,12 +396,13 @@ public class StructVector extends NonNullableStructVector
 
   /**
    * Return the underlying buffers associated with this vector. Note that this doesn't impact the
-   * reference counts for this buffer so it only should be used for in-context access. Also note
-   * that this buffer changes regularly thus external classes shouldn't hold a reference to it
+   * reference counts for this buffer, so it only should be used for in-context access. Also note
+   * that this buffer changes regularly, thus external classes shouldn't hold a reference to it
    * (unless they change it).
    *
-   * @param clear Whether to clear vector before returning; the buffers will still be refcounted but
-   *     the returned array will be the only reference to them
+   * @param clear Whether to clear vector before returning, the buffers will still be refcounted but
+   *     the returned array will be the only reference to them. Also, this won't clear the child
+   *     buffers.
    * @return The underlying {@link ArrowBuf buffers} that is used by this vector instance.
    */
   @Override
@@ -413,7 +414,7 @@ public class StructVector extends NonNullableStructVector
     } else {
       List<ArrowBuf> list = new ArrayList<>();
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(super.getBuffers(clear)));
+      list.addAll(Arrays.asList(super.getBuffers(false)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -413,7 +413,7 @@ public class StructVector extends NonNullableStructVector
     } else {
       List<ArrowBuf> list = new ArrayList<>();
       list.add(validityBuffer);
-      list.addAll(Arrays.asList(super.getBuffers(false)));
+      list.addAll(Arrays.asList(super.getBuffers(clear)));
       buffers = list.toArray(new ArrowBuf[list.size()]);
     }
     if (clear) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
@@ -64,25 +64,6 @@ public class TestVectorReset {
     assertEquals(0, vector.getValueCount());
   }
 
-  private void resetClearVectorAndVerify(ValueVector vector, ArrowBuf[] bufs) {
-    long[] sizeBefore = new long[bufs.length];
-    for (int i = 0; i < bufs.length; i++) {
-      sizeBefore[i] = bufs[i].capacity();
-    }
-    vector.reset();
-    for (int i = 0; i < bufs.length; i++) {
-      assertEquals(sizeBefore[i], bufs[i].capacity());
-    }
-    assertEquals(0, vector.getValueCount());
-    // clear the retrieved buffers
-    for (ArrowBuf buf : bufs) {
-      // clear the buffer to release the memory
-      while (buf.refCnt() > 0) {
-        buf.close();
-      }
-    }
-  }
-
   private void verifyBufferZeroed(ArrowBuf buf) {
     for (int i = 0; i < buf.capacity(); i++) {
       assertTrue((byte) 0 == buf.getByte(i));
@@ -100,16 +81,6 @@ public class TestVectorReset {
   }
 
   @Test
-  public void testFixedTypeResetAndClear() {
-    try (final UInt4Vector vector = new UInt4Vector("UInt4", allocator)) {
-      vector.allocateNewSafe();
-      vector.setNull(0);
-      vector.setValueCount(1);
-      resetClearVectorAndVerify(vector, vector.getBuffers(true));
-    }
-  }
-
-  @Test
   public void testVariableTypeReset() {
     try (final VarCharVector vector = new VarCharVector("VarChar", allocator)) {
       vector.allocateNewSafe();
@@ -117,18 +88,6 @@ public class TestVectorReset {
       vector.setLastSet(0);
       vector.setValueCount(1);
       resetVectorAndVerify(vector, vector.getBuffers(false));
-      assertEquals(-1, vector.getLastSet());
-    }
-  }
-
-  @Test
-  public void testVariableTypeResetAndClear() {
-    try (final VarCharVector vector = new VarCharVector("VarChar", allocator)) {
-      vector.allocateNewSafe();
-      vector.set(0, "a".getBytes(StandardCharsets.UTF_8));
-      vector.setLastSet(0);
-      vector.setValueCount(1);
-      resetClearVectorAndVerify(vector, vector.getBuffers(true));
       assertEquals(-1, vector.getLastSet());
     }
   }
@@ -146,18 +105,6 @@ public class TestVectorReset {
   }
 
   @Test
-  public void testVariableViewTypeResetAndClear() {
-    try (final ViewVarCharVector vector = new ViewVarCharVector("ViewVarChar", allocator)) {
-      vector.allocateNewSafe();
-      vector.set(0, "a".getBytes(StandardCharsets.UTF_8));
-      vector.setLastSet(0);
-      vector.setValueCount(1);
-      resetClearVectorAndVerify(vector, vector.getBuffers(true));
-      assertEquals(-1, vector.getLastSet());
-    }
-  }
-
-  @Test
   public void testLargeVariableTypeReset() {
     try (final LargeVarCharVector vector = new LargeVarCharVector("LargeVarChar", allocator)) {
       vector.allocateNewSafe();
@@ -165,18 +112,6 @@ public class TestVectorReset {
       vector.setLastSet(0);
       vector.setValueCount(1);
       resetVectorAndVerify(vector, vector.getBuffers(false));
-      assertEquals(-1, vector.getLastSet());
-    }
-  }
-
-  @Test
-  public void testLargeVariableTypeResetAndClear() {
-    try (final LargeVarCharVector vector = new LargeVarCharVector("LargeVarChar", allocator)) {
-      vector.allocateNewSafe();
-      vector.set(0, "a".getBytes(StandardCharsets.UTF_8));
-      vector.setLastSet(0);
-      vector.setValueCount(1);
-      resetClearVectorAndVerify(vector, vector.getBuffers(true));
       assertEquals(-1, vector.getLastSet());
     }
   }
@@ -216,40 +151,6 @@ public class TestVectorReset {
   }
 
   @Test
-  public void testListTypeResetAndClear() {
-    try (final ListVector variableList =
-            new ListVector(
-                "VarList", allocator, FieldType.nullable(MinorType.INT.getType()), null);
-        final FixedSizeListVector fixedList =
-            new FixedSizeListVector(
-                "FixedList", allocator, FieldType.nullable(new FixedSizeList(2)), null);
-        final ListViewVector variableViewList =
-            new ListViewVector(
-                "VarListView", allocator, FieldType.nullable(MinorType.INT.getType()), null)) {
-      // ListVector
-      variableList.allocateNewSafe();
-      variableList.startNewValue(0);
-      variableList.endValue(0, 0);
-      variableList.setValueCount(1);
-      resetClearVectorAndVerify(variableList, variableList.getBuffers(true));
-      assertEquals(-1, variableList.getLastSet());
-
-      // FixedSizeListVector
-      fixedList.allocateNewSafe();
-      fixedList.setNull(0);
-      fixedList.setValueCount(1);
-      resetClearVectorAndVerify(fixedList, fixedList.getBuffers(true));
-
-      // ListViewVector
-      variableViewList.allocateNewSafe();
-      variableViewList.startNewValue(0);
-      variableViewList.endValue(0, 0);
-      variableViewList.setValueCount(1);
-      resetClearVectorAndVerify(variableViewList, variableViewList.getBuffers(true));
-    }
-  }
-
-  @Test
   public void testStructTypeReset() {
     try (final NonNullableStructVector nonNullableStructVector =
             new NonNullableStructVector(
@@ -275,31 +176,6 @@ public class TestVectorReset {
   }
 
   @Test
-  public void testStructTypeResetAndClear() {
-    try (final NonNullableStructVector nonNullableStructVector =
-            new NonNullableStructVector(
-                "Struct", allocator, FieldType.nullable(MinorType.INT.getType()), null);
-        final StructVector structVector =
-            new StructVector(
-                "NullableStruct", allocator, FieldType.nullable(MinorType.INT.getType()), null)) {
-      // NonNullableStructVector
-      nonNullableStructVector.allocateNewSafe();
-      IntVector structChild =
-          nonNullableStructVector.addOrGet(
-              "child", FieldType.nullable(new Int(32, true)), IntVector.class);
-      structChild.setNull(0);
-      nonNullableStructVector.setValueCount(1);
-      resetClearVectorAndVerify(nonNullableStructVector, nonNullableStructVector.getBuffers(true));
-
-      // StructVector
-      structVector.allocateNewSafe();
-      structVector.setNull(0);
-      structVector.setValueCount(1);
-      resetClearVectorAndVerify(structVector, structVector.getBuffers(true));
-    }
-  }
-
-  @Test
   public void testUnionTypeReset() {
     try (final UnionVector vector =
             new UnionVector("Union", allocator, /* field type */ null, /* call-back */ null);
@@ -311,21 +187,6 @@ public class TestVectorReset {
       dataVector.setNull(0);
       vector.setValueCount(1);
       resetVectorAndVerify(vector, vector.getBuffers(false));
-    }
-  }
-
-  @Test
-  public void testUnionTypeResetAndClear() {
-    try (final UnionVector vector =
-            new UnionVector("Union", allocator, /* field type */ null, /* call-back */ null);
-        final IntVector dataVector = new IntVector("Int", allocator)) {
-      vector.getBufferSize();
-      vector.allocateNewSafe();
-      dataVector.allocateNewSafe();
-      vector.addVector(dataVector);
-      dataVector.setNull(0);
-      vector.setValueCount(1);
-      resetClearVectorAndVerify(vector, vector.getBuffers(true));
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
@@ -25,6 +25,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.ListViewVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -187,7 +188,10 @@ public class TestVectorReset {
                 "VarList", allocator, FieldType.nullable(MinorType.INT.getType()), null);
         final FixedSizeListVector fixedList =
             new FixedSizeListVector(
-                "FixedList", allocator, FieldType.nullable(new FixedSizeList(2)), null)) {
+                "FixedList", allocator, FieldType.nullable(new FixedSizeList(2)), null);
+        final ListViewVector variableViewList =
+            new ListViewVector(
+                "VarListView", allocator, FieldType.nullable(MinorType.INT.getType()), null)) {
       // ListVector
       variableList.allocateNewSafe();
       variableList.startNewValue(0);
@@ -201,6 +205,13 @@ public class TestVectorReset {
       fixedList.setNull(0);
       fixedList.setValueCount(1);
       resetVectorAndVerify(fixedList, fixedList.getBuffers(false));
+
+      // ListViewVector
+      variableViewList.allocateNewSafe();
+      variableViewList.startNewValue(0);
+      variableViewList.endValue(0, 0);
+      variableViewList.setValueCount(1);
+      resetVectorAndVerify(variableViewList, variableViewList.getBuffers(false));
     }
   }
 
@@ -211,7 +222,10 @@ public class TestVectorReset {
                 "VarList", allocator, FieldType.nullable(MinorType.INT.getType()), null);
         final FixedSizeListVector fixedList =
             new FixedSizeListVector(
-                "FixedList", allocator, FieldType.nullable(new FixedSizeList(2)), null)) {
+                "FixedList", allocator, FieldType.nullable(new FixedSizeList(2)), null);
+        final ListViewVector variableViewList =
+            new ListViewVector(
+                "VarListView", allocator, FieldType.nullable(MinorType.INT.getType()), null)) {
       // ListVector
       variableList.allocateNewSafe();
       variableList.startNewValue(0);
@@ -225,6 +239,13 @@ public class TestVectorReset {
       fixedList.setNull(0);
       fixedList.setValueCount(1);
       resetClearVectorAndVerify(fixedList, fixedList.getBuffers(true));
+
+      // ListViewVector
+      variableViewList.allocateNewSafe();
+      variableViewList.startNewValue(0);
+      variableViewList.endValue(0, 0);
+      variableViewList.setValueCount(1);
+      resetClearVectorAndVerify(variableViewList, variableViewList.getBuffers(true));
     }
   }
 


### PR DESCRIPTION
### Rationale for this change

`getBuffers` method provides the capability to clear the buffers in the vector, this has not been properly tested while clear flag is not properly used in the implementation across various types of vectors. 

### What changes are included in this PR?

Updating the vector `getBuffers` method to use `clear` flag as expected and adding corresponding test cases. 

### Are these changes tested?

Yes, via existing test cases and new test cases. 

### Are there any user-facing changes?

Yes
* GitHub Issue: #43577