### PR TITLE
GH-43589: [Python] Add bindings for Buffer copy() method to other device

### DIFF
--- a/python/pyarrow/device.pxi
+++ b/python/pyarrow/device.pxi
@@ -158,6 +158,7 @@ cdef class MemoryManager(_Weakrefable):
         """
         return self.memory_manager.get().is_cpu()
 
+
 def default_cpu_memory_manager():
     """
     Return the default CPU MemoryManager instance.

--- a/python/pyarrow/device.pxi
+++ b/python/pyarrow/device.pxi
@@ -158,7 +158,6 @@ cdef class MemoryManager(_Weakrefable):
         """
         return self.memory_manager.get().is_cpu()
 
-
 def default_cpu_memory_manager():
     """
     Return the default CPU MemoryManager instance.

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -366,7 +366,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CDevice] device()
         const shared_ptr[CMemoryManager] memory_manager()
         CDeviceAllocationType device_type()
-        CResult[shared_ptr[CBuffer]] Copy(shared_ptr[CBuffer] source, const shared_ptr[CMemoryManager]& to) const
+
+        @staticmethod
+        CResult[shared_ptr[CBuffer]] Copy(shared_ptr[CBuffer] source, const shared_ptr[CMemoryManager]& to)
 
     CResult[shared_ptr[CBuffer]] SliceBufferSafe(
         const shared_ptr[CBuffer]& buffer, int64_t offset)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -366,6 +366,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CDevice] device()
         const shared_ptr[CMemoryManager] memory_manager()
         CDeviceAllocationType device_type()
+        CResult[shared_ptr[CBuffer]] Copy(shared_ptr[CBuffer] source, const shared_ptr[CMemoryManager]& to) const
 
     CResult[shared_ptr[CBuffer]] SliceBufferSafe(
         const shared_ptr[CBuffer]& buffer, int64_t offset)

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1446,6 +1446,27 @@ cdef class Buffer(_Weakrefable):
         """
         return _wrap_device_allocation_type(self.buffer.get().device_type())
 
+    def copy(self, MemoryManager mm):
+        """
+        The buffer contents will be copied into a new buffer allocated by the
+        given MemoryManager.  This function supports cross-device copies.
+
+        Parameters
+        ---------
+        MemoryManager
+            Memory manager used to allocate the new buffer.
+
+        Returns
+        -------
+        Buffer
+        """
+        cdef:
+            shared_ptr[CBuffer] c_buffer
+
+        c_buffer = GetResultValue(self.buffer.get().Copy(self.buffer, mm.unwrap()))
+        return pyarrow_wrap_buffer(c_buffer)
+
+
     @property
     def parent(self):
         cdef shared_ptr[CBuffer] parent_buf = self.buffer.get().parent()

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1453,9 +1453,9 @@ cdef class Buffer(_Weakrefable):
         This function supports cross-device copies.
 
         Parameters
-        ---------
-        dest
-            pyarrow.MemoryManager or pyarrow.Device used to allocate the new buffer.
+        ----------
+        dest : pyarrow.MemoryManager or pyarrow.Device
+            Used to allocate the new buffer.
 
         Returns
         -------

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1466,7 +1466,6 @@ cdef class Buffer(_Weakrefable):
         c_buffer = GetResultValue(self.buffer.get().Copy(self.buffer, mm.unwrap()))
         return pyarrow_wrap_buffer(c_buffer)
 
-
     @property
     def parent(self):
         cdef shared_ptr[CBuffer] parent_buf = self.buffer.get().parent()

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1446,15 +1446,17 @@ cdef class Buffer(_Weakrefable):
         """
         return _wrap_device_allocation_type(self.buffer.get().device_type())
 
-    def copy(self, dest):
+    def copy(self, destination):
         """
+        Copy the buffer to the destination device.
+
         The buffer contents will be copied into a new buffer allocated onto
         the destination MemoryManager or Device. It will return the new Buffer.
         This function supports cross-device copies.
 
         Parameters
         ----------
-        dest : pyarrow.MemoryManager or pyarrow.Device
+        destination : pyarrow.MemoryManager or pyarrow.Device
             Used to allocate the new buffer.
 
         Returns
@@ -1465,17 +1467,17 @@ cdef class Buffer(_Weakrefable):
             shared_ptr[CBuffer] c_buffer
             shared_ptr[CMemoryManager] c_memory_manager
 
-        if isinstance(dest, Device):
-            c_memory_manager = (<Device>dest).unwrap().get().default_memory_manager()
-        elif isinstance(dest, MemoryManager):
-            c_memory_manager = (<MemoryManager>dest).unwrap()
+        if isinstance(destination, Device):
+            c_memory_manager = (<Device>destination).unwrap().get().default_memory_manager()
+        elif isinstance(destination, MemoryManager):
+            c_memory_manager = (<MemoryManager>destination).unwrap()
         else:
             raise TypeError(
-                "Argument 'dest' is incorrect type (expected pyarrow.Device or "
-                f"pyarrow.MemoryManager, got {type(dest)})"
+                "Argument 'destination' is incorrect type (expected pyarrow.Device or "
+                f"pyarrow.MemoryManager, got {type(destination)})"
             )
 
-        c_buffer = GetResultValue(self.buffer.get().Copy(self.buffer, c_memory_manager))
+        c_buffer = GetResultValue(CBuffer.Copy(self.buffer, c_memory_manager))
         return pyarrow_wrap_buffer(c_buffer)
 
     @property

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1477,7 +1477,8 @@ cdef class Buffer(_Weakrefable):
                 f"pyarrow.MemoryManager, got {type(destination)})"
             )
 
-        c_buffer = GetResultValue(CBuffer.Copy(self.buffer, c_memory_manager))
+        with nogil:
+            c_buffer = GetResultValue(CBuffer.Copy(self.buffer, c_memory_manager))
         return pyarrow_wrap_buffer(c_buffer)
 
     @property

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -132,8 +132,7 @@ def test_copy_from_buffer():
         assert not cudabuf2.is_cpu
         assert cudabuf2.device_type == pa.DeviceAllocationType.CUDA
 
-        arr2 = np.frombuffer(cudabuf2.copy_to_host(), dtype=np.uint8)
-        np.testing.assert_equal(arr, arr2)
+        assert cudabuf2.copy_to_host().equals(buf)
 
         assert cudabuf2.device == mm2.device
 

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -118,6 +118,22 @@ def make_random_buffer(size, target='host'):
         return arr, dbuf
     raise ValueError('invalid target value')
 
+def test_copy_from_buffer():
+    arr, buf = make_random_buffer(128)
+    cudabuf = global_context.buffer_from_data(buf)
+
+    mm2 = global_context1.memory_manager
+    buf2 = cudabuf.copy(mm2)
+    cudabuf2 = cuda.CudaBuffer.from_buffer(buf2)
+    cudabuf2.size == cudabuf.size
+
+    arr2 = np.frombuffer(cudabuf2.copy_to_host(), dtype=np.uint8)
+    np.testing.assert_equal(arr, arr2)
+
+    assert cudabuf2.memory_manager.device == mm2.device
+
+
+
 
 @pytest.mark.parametrize("size", [0, 1, 1000])
 def test_context_device_buffer(size):

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -124,14 +124,17 @@ def test_copy_from_buffer():
     cudabuf = global_context.buffer_from_data(buf)
 
     mm2 = global_context1.memory_manager
-    buf2 = cudabuf.copy(mm2)
-    cudabuf2 = cuda.CudaBuffer.from_buffer(buf2)
-    cudabuf2.size == cudabuf.size
+    for dest in [mm2, mm2.device]:
+        buf2 = cudabuf.copy(dest)
+        cudabuf2 = cuda.CudaBuffer.from_buffer(buf2)
+        cudabuf2.size == cudabuf.size
+        assert not cudabuf2.is_cpu
+        assert cudabuf2.device_type == pa.DeviceAllocationType.CUDA
 
-    arr2 = np.frombuffer(cudabuf2.copy_to_host(), dtype=np.uint8)
-    np.testing.assert_equal(arr, arr2)
+        arr2 = np.frombuffer(cudabuf2.copy_to_host(), dtype=np.uint8)
+        np.testing.assert_equal(arr, arr2)
 
-    assert cudabuf2.memory_manager.device == mm2.device
+        assert cudabuf2.device == mm2.device
 
 
 @pytest.mark.parametrize("size", [0, 1, 1000])

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -126,6 +126,7 @@ def test_copy_from_buffer():
     mm2 = global_context1.memory_manager
     for dest in [mm2, mm2.device]:
         buf2 = cudabuf.copy(dest)
+        assert buf2.device_type == pa.DeviceAllocationType.CUDA
         cudabuf2 = cuda.CudaBuffer.from_buffer(buf2)
         cudabuf2.size == cudabuf.size
         assert not cudabuf2.is_cpu

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -118,6 +118,7 @@ def make_random_buffer(size, target='host'):
         return arr, dbuf
     raise ValueError('invalid target value')
 
+
 def test_copy_from_buffer():
     arr, buf = make_random_buffer(128)
     cudabuf = global_context.buffer_from_data(buf)
@@ -131,8 +132,6 @@ def test_copy_from_buffer():
     np.testing.assert_equal(arr, arr2)
 
     assert cudabuf2.memory_manager.device == mm2.device
-
-
 
 
 @pytest.mark.parametrize("size", [0, 1, 1000])

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -128,7 +128,7 @@ def test_copy_from_buffer():
         buf2 = cudabuf.copy(dest)
         assert buf2.device_type == pa.DeviceAllocationType.CUDA
         cudabuf2 = cuda.CudaBuffer.from_buffer(buf2)
-        cudabuf2.size == cudabuf.size
+        assert cudabuf2.size == cudabuf.size
         assert not cudabuf2.is_cpu
         assert cudabuf2.device_type == pa.DeviceAllocationType.CUDA
 

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -127,6 +127,7 @@ def test_copy_from_buffer():
     for dest in [mm2, mm2.device]:
         buf2 = cudabuf.copy(dest)
         assert buf2.device_type == pa.DeviceAllocationType.CUDA
+        assert buf2.copy(pa.default_cpu_memory_manager()).equals(buf)
         cudabuf2 = cuda.CudaBuffer.from_buffer(buf2)
         assert cudabuf2.size == cudabuf.size
         assert not cudabuf2.is_cpu

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -710,6 +710,13 @@ def test_non_cpu_buffer(pickle_module):
     # Sliced buffers with same address
     assert buf_on_gpu_sliced.equals(cuda_buf[2:4])
 
+    # Testing copying buffer
+    mm = ctx.memory_manager
+    buf2 = cuda_buf.copy(mm)
+    cuda_buf2 = cuda.CudaBuffer.from_buffer(buf2)
+    cuda_buf2.size == cuda_buf.size
+    cuda_buf2.copy_to_host()[:] == b'testing'
+
     # Buffers on different devices
     msg_device = "Device on which the data resides differs between buffers"
     with pytest.raises(ValueError, match=msg_device):

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -712,10 +712,12 @@ def test_non_cpu_buffer(pickle_module):
 
     # Testing copying buffer
     mm = ctx.memory_manager
-    buf2 = cuda_buf.copy(mm)
-    cuda_buf2 = cuda.CudaBuffer.from_buffer(buf2)
-    cuda_buf2.size == cuda_buf.size
-    cuda_buf2.copy_to_host()[:] == b'testing'
+    for dest in [mm, mm.device]:
+        buf2 = cuda_buf.copy(dest)
+        cuda_buf2 = cuda.CudaBuffer.from_buffer(buf2)
+        cuda_buf2.size == cuda_buf.size
+        cuda_buf2.copy_to_host()[:] == b'testing'
+        assert cuda_buf2.device == mm.device
 
     # Buffers on different devices
     msg_device = "Device on which the data resides differs between buffers"

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -715,8 +715,8 @@ def test_non_cpu_buffer(pickle_module):
     for dest in [mm, mm.device]:
         buf2 = cuda_buf.copy(dest)
         cuda_buf2 = cuda.CudaBuffer.from_buffer(buf2)
-        cuda_buf2.size == cuda_buf.size
-        cuda_buf2.copy_to_host()[:] == b'testing'
+        assert cuda_buf2.size == cuda_buf.size
+        assert cuda_buf2.copy_to_host()[:] == b'testing'
         assert cuda_buf2.device == mm.device
 
     # Buffers on different devices

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -713,11 +713,11 @@ def test_non_cpu_buffer(pickle_module):
     # Testing copying buffer
     mm = ctx.memory_manager
     for dest in [mm, mm.device]:
-        buf2 = cuda_buf.copy(dest)
+        buf2 = buf_on_gpu.copy(dest)
         cuda_buf2 = cuda.CudaBuffer.from_buffer(buf2)
         assert cuda_buf2.size == cuda_buf.size
-        assert cuda_buf2.copy_to_host()[:] == b'testing'
-        assert cuda_buf2.device == mm.device
+        assert cuda_buf2.to_pybytes() == b'testing'
+        assert buf2.device == mm.device
 
     # Buffers on different devices
     msg_device = "Device on which the data resides differs between buffers"


### PR DESCRIPTION
WIP. Feel free to make any comments while this is under active development!

- [x] Within Copy, in addition to accepting a MemoryManager as argument to the copy function, we could also accept a Device (see review comments here: https://github.com/apache/arrow/pull/42223)
- [x]  add a test in test_io.py where Buffer is being tested, so there is also coverage of this new function outside of the CUDA tests
- [x] What is the difference between Copy and CopyNonOwned? Do we need both or should they be in the same method? (We decided to not add bindings for it.)

<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43589