### PR TITLE
GH-43594: [C++] Remove std::optional from arrow::ArrayStatistics::is_{min,max}_exact

### DIFF
--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -43,14 +43,14 @@ struct ARROW_EXPORT ArrayStatistics {
   /// \brief The minimum value, may not be set
   std::optional<ValueType> min = std::nullopt;
 
-  /// \brief Whether the minimum value is exact or not, may not be set
-  std::optional<bool> is_min_exact = std::nullopt;
+  /// \brief Whether the minimum value is exact or not
+  bool is_min_exact = false;
 
   /// \brief The maximum value, may not be set
   std::optional<ValueType> max = std::nullopt;
 
-  /// \brief Whether the maximum value is exact or not, may not be set
-  std::optional<bool> is_max_exact = std::nullopt;
+  /// \brief Whether the maximum value is exact or not
+  bool is_max_exact = false;
 
   /// \brief Check two statistics for equality
   bool Equals(const ArrayStatistics& other) const {

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -40,27 +40,25 @@ TEST(ArrayStatisticsTest, TestDistinctCount) {
 TEST(ArrayStatisticsTest, TestMin) {
   ArrayStatistics statistics;
   ASSERT_FALSE(statistics.min.has_value());
-  ASSERT_FALSE(statistics.is_min_exact.has_value());
+  ASSERT_FALSE(statistics.is_min_exact);
   statistics.min = static_cast<uint64_t>(29);
   statistics.is_min_exact = true;
   ASSERT_TRUE(statistics.min.has_value());
   ASSERT_TRUE(std::holds_alternative<uint64_t>(statistics.min.value()));
   ASSERT_EQ(29, std::get<uint64_t>(statistics.min.value()));
-  ASSERT_TRUE(statistics.is_min_exact.has_value());
-  ASSERT_TRUE(statistics.is_min_exact.value());
+  ASSERT_TRUE(statistics.is_min_exact);
 }
 
 TEST(ArrayStatisticsTest, TestMax) {
   ArrayStatistics statistics;
   ASSERT_FALSE(statistics.max.has_value());
-  ASSERT_FALSE(statistics.is_max_exact.has_value());
+  ASSERT_FALSE(statistics.is_max_exact);
   statistics.max = std::string("hello");
   statistics.is_max_exact = false;
   ASSERT_TRUE(statistics.max.has_value());
   ASSERT_TRUE(std::holds_alternative<std::string>(statistics.max.value()));
   ASSERT_EQ("hello", std::get<std::string>(statistics.max.value()));
-  ASSERT_TRUE(statistics.is_max_exact.has_value());
-  ASSERT_FALSE(statistics.is_max_exact.value());
+  ASSERT_FALSE(statistics.is_max_exact);
 }
 
 TEST(ArrayStatisticsTest, TestEquality) {
@@ -84,9 +82,9 @@ TEST(ArrayStatisticsTest, TestEquality) {
   statistics2.min = std::string("world");
   ASSERT_EQ(statistics1, statistics2);
 
-  statistics1.is_min_exact = false;
+  statistics1.is_min_exact = true;
   ASSERT_NE(statistics1, statistics2);
-  statistics2.is_min_exact = false;
+  statistics2.is_min_exact = true;
   ASSERT_EQ(statistics1, statistics2);
 
   statistics1.max = static_cast<int64_t>(-29);


### PR DESCRIPTION
### Rationale for this change

We don't need "unknown" state. If they aren't set, we can process they are not exact.

### What changes are included in this PR?

Remove `std::optional` from `arrow::ArrayStatistics::is_{min,max}_exact`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #43594