### PR TITLE
GH-43536: [Python] Declare support for free-threading in Cython

### DIFF
--- a/cpp/cmake_modules/UseCython.cmake
+++ b/cpp/cmake_modules/UseCython.cmake
@@ -184,13 +184,9 @@ function(cython_add_module _name pyx_target_name generated_files)
   add_dependencies(${_name} ${pyx_target_name})
 endfunction()
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -m cython --version
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from Cython.Compiler.Version import version; print(version)"
                 OUTPUT_VARIABLE CYTHON_VERSION_OUTPUT
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(CYTHON_VERSION_OUTPUT MATCHES "^Cython version (.+)")
-  set(CYTHON_VERSION "${CMAKE_MATCH_1}")
-else()
-  set(CYTHON_VERSION "")
-endif()
+set(CYTHON_VERSION "${CYTHON_VERSION_OUTPUT}")
 
 include(CMakeParseArguments)

--- a/cpp/cmake_modules/UseCython.cmake
+++ b/cpp/cmake_modules/UseCython.cmake
@@ -184,4 +184,24 @@ function(cython_add_module _name pyx_target_name generated_files)
   add_dependencies(${_name} ${pyx_target_name})
 endfunction()
 
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -m cython --version
+                OUTPUT_VARIABLE CYTHON_version_output
+                ERROR_VARIABLE CYTHON_version_error
+                RESULT_VARIABLE CYTHON_version_result
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_STRIP_TRAILING_WHITESPACE)
+if(NOT ${CYTHON_version_result} EQUAL 0)
+  set(_error_msg "Command \"${PYTHON_EXECUTABLE} -m cython --version\" failed with")
+  set(_error_msg "${_error_msg} output:\n${CYTHON_version_error}")
+  message(SEND_ERROR "${_error_msg}")
+else()
+  if("${CYTHON_version_output}" MATCHES "^[Cc]ython version ([^,]+)")
+    set(CYTHON_VERSION "${CMAKE_MATCH_1}")
+  else()
+    if("${CYTHON_version_error}" MATCHES "^[Cc]ython version ([^,]+)")
+      set(CYTHON_VERSION "${CMAKE_MATCH_1}")
+    endif()
+  endif()
+endif()
+
 include(CMakeParseArguments)

--- a/cpp/cmake_modules/UseCython.cmake
+++ b/cpp/cmake_modules/UseCython.cmake
@@ -185,23 +185,12 @@ function(cython_add_module _name pyx_target_name generated_files)
 endfunction()
 
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -m cython --version
-                OUTPUT_VARIABLE CYTHON_version_output
-                ERROR_VARIABLE CYTHON_version_error
-                RESULT_VARIABLE CYTHON_version_result
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE)
-if(NOT ${CYTHON_version_result} EQUAL 0)
-  set(_error_msg "Command \"${PYTHON_EXECUTABLE} -m cython --version\" failed with")
-  set(_error_msg "${_error_msg} output:\n${CYTHON_version_error}")
-  message(SEND_ERROR "${_error_msg}")
+                OUTPUT_VARIABLE CYTHON_VERSION_OUTPUT
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(CYTHON_VERSION_OUTPUT MATCHES "^Cython version (.+)")
+  set(CYTHON_VERSION "${CMAKE_MATCH_1}")
 else()
-  if("${CYTHON_version_output}" MATCHES "^[Cc]ython version ([^,]+)")
-    set(CYTHON_VERSION "${CMAKE_MATCH_1}")
-  else()
-    if("${CYTHON_version_error}" MATCHES "^[Cc]ython version ([^,]+)")
-      set(CYTHON_VERSION "${CMAKE_MATCH_1}")
-    endif()
-  endif()
+  set(CYTHON_VERSION "")
 endif()
 
 include(CMakeParseArguments)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -857,7 +857,7 @@ set(CYTHON_FLAGS "${CYTHON_FLAGS}" "--warning-errors")
 set(CYTHON_FLAGS "${CYTHON_FLAGS}" "--no-c-in-traceback")
 
 if(CYTHON_VERSION VERSION_GREATER_EQUAL "3.1.0a0")
-  set(CYTHON_FLAGS "${CYTHON_FLAGS}" "-Xfreethreading_compatible=True")
+  list(APPEND CYTHON_FLAGS "-Xfreethreading_compatible=True")
 endif()
 
 foreach(module ${CYTHON_EXTENSIONS})

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -260,6 +260,7 @@ message(STATUS "Found NumPy version: ${Python3_NumPy_VERSION}")
 message(STATUS "NumPy include dir: ${NUMPY_INCLUDE_DIRS}")
 
 include(UseCython)
+message(STATUS "Found Cython version: ${CYTHON_VERSION}")
 
 # Arrow C++ and set default PyArrow build options
 include(GNUInstallDirs)
@@ -854,6 +855,10 @@ set(CYTHON_FLAGS "${CYTHON_FLAGS}" "--warning-errors")
 # GH-40236: make generated C++ code easier to compile by disabling an
 # undocumented Cython feature.
 set(CYTHON_FLAGS "${CYTHON_FLAGS}" "--no-c-in-traceback")
+
+if(CYTHON_VERSION VERSION_GREATER_EQUAL "3.1.0a0")
+  set(CYTHON_FLAGS "${CYTHON_FLAGS}" "-Xfreethreading_compatible=True")
+endif()
 
 foreach(module ${CYTHON_EXTENSIONS})
   string(REPLACE "." ";" directories ${module})


### PR DESCRIPTION



<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This is done by passing an extra flag when building the Cython extension modules. It is needed so that the GIL is not dynamically reenabled when importing `pyarrow.lib`.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Changes to CMake so that the extra flag is passed when building Cython extension modules.


* GitHub Issue: #43536