### PR TITLE
GH-43605: [Go][Parquet] Recover from panic in file reader

### DIFF
--- a/ci/scripts/go_test.sh
+++ b/ci/scripts/go_test.sh
@@ -78,6 +78,7 @@ go test $testargs -tags $TAGS,noasm ./...
 popd
 
 export PARQUET_TEST_DATA=${1}/cpp/submodules/parquet-testing/data
+export PARQUET_TEST_BAD_DATA=${1}/cpp/submodules/parquet-testing/bad_data
 export ARROW_TEST_DATA=${1}/testing/data
 pushd ${source_dir}/parquet
 

--- a/go/parquet/internal/utils/bit_packing_avx2_amd64.go
+++ b/go/parquet/internal/utils/bit_packing_avx2_amd64.go
@@ -33,11 +33,10 @@ func _unpack32_avx2(in, out unsafe.Pointer, batchSize, nbits int) (num int)
 
 func unpack32Avx2(in io.Reader, out []uint32, nbits int) int {
 	batch := len(out) / 32 * 32
-	if batch <= 0 {
+	n := batch * nbits / 8
+	if n <= 0 {
 		return 0
 	}
-
-	n := batch * nbits / 8
 
 	buffer := bufferPool.Get().(*bytes.Buffer)
 	defer bufferPool.Put(buffer)

--- a/go/parquet/internal/utils/bit_packing_neon_arm64.go
+++ b/go/parquet/internal/utils/bit_packing_neon_arm64.go
@@ -33,11 +33,10 @@ func _unpack32_neon(in, out unsafe.Pointer, batchSize, nbits int) (num int)
 
 func unpack32NEON(in io.Reader, out []uint32, nbits int) int {
 	batch := len(out) / 32 * 32
-	if batch <= 0 {
+	n := batch * nbits / 8
+	if n <= 0 {
 		return 0
 	}
-
-	n := batch * nbits / 8
 
 	buffer := bufferPool.Get().(*bytes.Buffer)
 	defer bufferPool.Put(buffer)

--- a/go/parquet/pqarrow/file_reader.go
+++ b/go/parquet/pqarrow/file_reader.go
@@ -332,13 +332,13 @@ func (fr *FileReader) ReadRowGroups(ctx context.Context, indices, rowGroups []in
 	wg.Add(np) // fan-out to np readers
 	for i := 0; i < np; i++ {
 		go func() {
+			defer wg.Done()
 			defer func() {
 				if pErr := recover(); pErr != nil {
 					err := utils.FormatRecoveredError("panic while reading", pErr)
 					results <- resultPair{err: err}
 				}
 			}()
-			defer wg.Done()
 			for {
 				select {
 				case r, ok := <-ch:

--- a/go/parquet/pqarrow/file_reader_test.go
+++ b/go/parquet/pqarrow/file_reader_test.go
@@ -391,9 +391,7 @@ func TestReadParquetFile(t *testing.T) {
 		false,
 		file.WithReadProps(parquet.NewReaderProperties(mem)),
 	)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	defer func() {
 		if err2 := rdr.Close(); err2 != nil {
 			t.Errorf("unexpected error: %v", err2)
@@ -404,13 +402,9 @@ func TestReadParquetFile(t *testing.T) {
 		Parallel:  false,
 		BatchSize: 0,
 	}, mem)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	_, err = arrowRdr.ReadTable(ctx)
 
-	if err == nil {
-		t.Errorf("expected error: %v", err)
-	}
+	assert.Error(t, err)
 }

--- a/go/parquet/pqarrow/file_reader_test.go
+++ b/go/parquet/pqarrow/file_reader_test.go
@@ -381,7 +381,7 @@ func TestReadParquetFile(t *testing.T) {
 		t.Skip("no path supplied with PARQUET_TEST_BAD_DATA")
 	}
 	assert.DirExists(t, dir)
-	filename := path.Join(dir, "GH_43605.parquet")
+	filename := path.Join(dir, "ARROW-GH-43605.parquet")
 	ctx := context.TODO()
 
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)

--- a/go/parquet/pqarrow/file_reader_test.go
+++ b/go/parquet/pqarrow/file_reader_test.go
@@ -405,6 +405,5 @@ func TestReadParquetFile(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = arrowRdr.ReadTable(ctx)
-
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The Parquet file reader should handle panics within its internal goroutines to ensure graceful failure and prevent client-side crashes.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`ReadRowGroups` now defers a panic recover from its goroutines and return an error to gracefully fail file reading.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No more tests were added because I cannot reproduce such a corrupted file with dummy data.

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
**This PR contains a "Critical Fix".**

* GitHub Issue: #43605