### PR TITLE
GH-43618: [Packaging][Python] Fix vcpkg version detection in macOS wheel build jobs

### DIFF
--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -64,7 +64,7 @@ jobs:
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 
       - name: Install Vcpkg
-        run: bash -x arrow/ci/scripts/install_vcpkg.sh $VCPKG_ROOT $VCPKG_VERSION
+        run: arrow/ci/scripts/install_vcpkg.sh $VCPKG_ROOT $VCPKG_VERSION
 
       - name: Add Vcpkg to PATH
         run: echo ${VCPKG_ROOT} >> $GITHUB_PATH

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Retrieve VCPKG version from arrow/.env
         run: |
-          vcpkg_version=$(. "arrow/.env" | echo "${VCPKG}")
+          vcpkg_version=$(. "arrow/.env" && echo "${VCPKG}")
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 
       - name: Install Vcpkg

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -64,7 +64,7 @@ jobs:
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 
       - name: Install Vcpkg
-        run: arrow/ci/scripts/install_vcpkg.sh $VCPKG_ROOT $VCPKG_VERSION
+        run: bash -x arrow/ci/scripts/install_vcpkg.sh $VCPKG_ROOT $VCPKG_VERSION
 
       - name: Add Vcpkg to PATH
         run: echo ${VCPKG_ROOT} >> $GITHUB_PATH

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Retrieve VCPKG version from arrow/.env
         run: |
-          vcpkg_version=$(cat "arrow/.env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
+          vcpkg_version=$(. "arrow/.env" | echo "${VCPKG}")
           echo "VCPKG_VERSION=$vcpkg_version" >> $GITHUB_ENV
 
       - name: Install Vcpkg


### PR DESCRIPTION
### Rationale for this change

`.env` is a shell script. We can use `VCPKG=... # comment` form in a shell script but our handmade `VCPKG` value in `.env` detection doesn't care about the case.

### What changes are included in this PR?

Use shell instead of handmade detection.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43618