### PR TITLE
GH-43605: [Go][Parquet] unpack32Avx2 returns 0 if its buffer is empty

### DIFF
--- a/ci/scripts/go_test.sh
+++ b/ci/scripts/go_test.sh
@@ -78,6 +78,7 @@ go test $testargs -tags $TAGS,noasm ./...
 popd
 
 export PARQUET_TEST_DATA=${1}/cpp/submodules/parquet-testing/data
+export PARQUET_TEST_BAD_DATA=${1}/cpp/submodules/parquet-testing/bad_data
 export ARROW_TEST_DATA=${1}/testing/data
 pushd ${source_dir}/parquet
 

--- a/go/parquet/internal/utils/bit_packing_avx2_amd64.go
+++ b/go/parquet/internal/utils/bit_packing_avx2_amd64.go
@@ -39,6 +39,10 @@ func unpack32Avx2(in io.Reader, out []uint32, nbits int) int {
 
 	n := batch * nbits / 8
 
+	if n == 0 {
+		return 0
+	}
+
 	buffer := bufferPool.Get().(*bytes.Buffer)
 	defer bufferPool.Put(buffer)
 	buffer.Reset()

--- a/go/parquet/pqarrow/file_reader_test.go
+++ b/go/parquet/pqarrow/file_reader_test.go
@@ -381,7 +381,7 @@ func TestReadParquetFile(t *testing.T) {
 		t.Skip("no path supplied with PARQUET_TEST_BAD_DATA")
 	}
 	assert.DirExists(t, dir)
-	filename := path.Join(dir, "GH_43605.parquet")
+	filename := path.Join(dir, "ARROW-GH-43605.parquet")
 	ctx := context.TODO()
 
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In case a uint16 column of a parquet file is fully filled with 0, it may happen in some cases that arrow fails to open the file.
Issue is described in GH-43605 and related PR: https://github.com/apache/arrow/pull/43607

I created a new PR to be able to differenciate the 2 changes:
- https://github.com/apache/arrow/pull/43607 deals with unexpected crashes in goroutines while reading parquet files
- This one deals with the crash I faced while reading empty uint16 column in parquet file.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

In case the buffer of `unpack32Avx2` is empty, this function returns 0.

### Are these changes tested?

Yes, I need this branch to be merged to be able to run the test in your CI/CD:
https://github.com/apache/parquet-testing/pull/57

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

I would say the API is not broken and no changes are expected from users, plus unit tests are passing on my setup with `./ci/scripts/go_test.sh`. I would like to see the results of the jobs in your GH workflows.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
**This PR contains a "Critical Fix".**
* GitHub Issue: #43605