### PR TITLE
GH-43624: [Go] Interval support for pqarrow

### DIFF
--- a/go/arrow/array/interval.go
+++ b/go/arrow/array/interval.go
@@ -652,6 +652,7 @@ func NewMonthDayNanoIntervalData(data arrow.ArrayData) *MonthDayNanoInterval {
 	return a
 }
 
+func (a *MonthDayNanoInterval) Values() []arrow.MonthDayNanoInterval { return a.values }
 func (a *MonthDayNanoInterval) Value(i int) arrow.MonthDayNanoInterval { return a.values[i] }
 func (a *MonthDayNanoInterval) ValueStr(i int) string {
 	if a.IsNull(i) {

--- a/go/parquet/pqarrow/encode_dictionary_test.go
+++ b/go/parquet/pqarrow/encode_dictionary_test.go
@@ -41,8 +41,8 @@ import (
 
 func (ps *ParquetIOTestSuite) TestSingleColumnOptionalDictionaryWrite() {
 	for _, dt := range fullTypeList {
-		// skip tests for bool as we don't do dictionaries for it
-		if dt.ID() == arrow.BOOL {
+		// skip tests for bool and interval as we don't do dictionaries for them
+		if dt.ID() == arrow.BOOL || dt.ID() == arrow.INTERVAL_MONTH_DAY_NANO {
 			continue
 		}
 

--- a/go/parquet/pqarrow/schema.go
+++ b/go/parquet/pqarrow/schema.go
@@ -348,6 +348,10 @@ func fieldToNode(name string, field arrow.Field, props *parquet.WriterProperties
 		typ = parquet.Types.FixedLenByteArray
 		length = arrow.Float16SizeBytes
 		logicalType = schema.Float16LogicalType{}
+	case arrow.INTERVAL_MONTH_DAY_NANO:
+		typ = parquet.Types.FixedLenByteArray
+		length = 12
+		logicalType = schema.IntervalLogicalType{}
 	case arrow.STRUCT:
 		return structToNode(field.Type.(*arrow.StructType), field.Name, field.Nullable, props, arrprops)
 	case arrow.FIXED_SIZE_LIST, arrow.LIST:
@@ -602,10 +606,12 @@ func arrowFromFLBA(logical schema.LogicalType, length int) (arrow.DataType, erro
 	switch logtype := logical.(type) {
 	case *schema.DecimalLogicalType:
 		return arrowDecimal(logtype), nil
-	case schema.NoLogicalType, schema.IntervalLogicalType, schema.UUIDLogicalType:
+	case schema.NoLogicalType, schema.UUIDLogicalType:
 		return &arrow.FixedSizeBinaryType{ByteWidth: int(length)}, nil
 	case schema.Float16LogicalType:
 		return &arrow.Float16Type{}, nil
+	case schema.IntervalLogicalType:
+		return &arrow.MonthDayNanoIntervalType{}, nil
 	default:
 		return nil, xerrors.New("unhandled logical type " + logical.String() + " for fixed-length byte array")
 	}

--- a/go/parquet/pqarrow/schema_test.go
+++ b/go/parquet/pqarrow/schema_test.go
@@ -207,6 +207,10 @@ func TestConvertArrowFlatPrimitives(t *testing.T) {
 	parquetFields = append(parquetFields, schema.NewFloat64Node("double", parquet.Repetitions.Optional, -1))
 	arrowFields = append(arrowFields, arrow.Field{Name: "double", Type: arrow.PrimitiveTypes.Float64, Nullable: true})
 
+	parquetFields = append(parquetFields, schema.Must(schema.NewPrimitiveNodeLogical("interval", parquet.Repetitions.Optional,
+		schema.IntervalLogicalType{}, parquet.Types.FixedLenByteArray, 12, -1)))
+	arrowFields = append(arrowFields, arrow.Field{Name: "interval", Type: arrow.FixedWidthTypes.MonthDayNanoInterval, Nullable: true})
+
 	parquetFields = append(parquetFields, schema.NewByteArrayNode("binary", parquet.Repetitions.Optional, -1))
 	arrowFields = append(arrowFields, arrow.Field{Name: "binary", Type: arrow.BinaryTypes.Binary, Nullable: true})
 
@@ -440,7 +444,6 @@ func TestUnsupportedTypes(t *testing.T) {
 		{typ: &arrow.DurationType{}},
 		{typ: &arrow.DayTimeIntervalType{}},
 		{typ: &arrow.MonthIntervalType{}},
-		{typ: &arrow.MonthDayNanoIntervalType{}},
 		{typ: &arrow.DenseUnionType{}},
 		{typ: &arrow.SparseUnionType{}},
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
#43624 

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
* Main functional changes:
  * Writer:
    * `pqarrow.schema.fieldToNode`: convert `arrow.INTERVAL_MONTH_DAY_NANO` type to parquet `schema.IntervalLogicalType`
    * `pqarrow.encode_arrow.writeDenseArrow`: write each `arrow.MonthDayNanoInterval` as a 12-byte array (following [Parquet Interval format](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#interval))
  * Reader:
    * `pqarrow.schema.arrayFromFLBA`: convert `schema.IntervalLogicalType` to `arrow.MonthDayNanoIntervalType`
    * `pqarrows.column_readers.transferColumnData`: convert data from parquet Interval to data for `arrow.MonthDayNanoInterval`
* Others:
  * `arrow.MonthDayNanoInterval`: expose `Values()` function

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43624