### PR TITLE
GH-43633: [R] Add tests for packages that might be tricky to roundtrip data to Tables + Parquet files

### DIFF
--- a/dev/tasks/r/github.linux.extra.packages.yml
+++ b/dev/tasks/r/github.linux.extra.packages.yml
@@ -38,9 +38,10 @@ jobs:
         with:
           working-directory: 'arrow/r'
           extra-packages: |
+            any::data.table
             any::rcmdcheck
             any::readr
-            any::data.table
+            any::unites
       - name: Build arrow package
         run: |
           R CMD build --no-build-vignettes arrow/r

--- a/dev/tasks/r/github.linux.extra.packages.yml
+++ b/dev/tasks/r/github.linux.extra.packages.yml
@@ -32,6 +32,8 @@ jobs:
       {{ macros.github_checkout_arrow()|indent }}
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/dev/tasks/r/github.linux.extra.packages.yml
+++ b/dev/tasks/r/github.linux.extra.packages.yml
@@ -22,12 +22,11 @@
 jobs:
   extra-packages:
     name: "extra package roundtrip tests"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     env:
       ARROW_R_DEV: "FALSE"
-      RSPM: "https://packagemanager.posit.co/cran/__linux__/noble/latest"
       ARROW_R_FORCE_EXTRA_PACKAGE_TESTS: TRUE
     steps:
       {{ macros.github_checkout_arrow()|indent }}

--- a/dev/tasks/r/github.linux.extra.packages.yml
+++ b/dev/tasks/r/github.linux.extra.packages.yml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{% import 'macros.jinja' as macros with context %}
+
+{{ macros.github_header() }}
+
+jobs:
+  extra-packages:
+    name: "extra package roundtrip tests"
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+    env:
+      ARROW_R_DEV: "FALSE"
+      RSPM: "https://packagemanager.posit.co/cran/__linux__/noble/latest"
+      ARROW_R_FORCE_EXTRA_PACKAGE_TESTS: TRUE
+    steps:
+      {{ macros.github_checkout_arrow()|indent }}
+
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: 'arrow/r'
+          extra-packages: |
+            any::rcmdcheck
+            any::readr
+            any::data.table
+      - name: Build arrow package
+        run: |
+          R CMD build --no-build-vignettes arrow/r
+          R CMD INSTALL --install-tests --no-test-load --no-byte-compile arrow_*.tar.gz
+      - name: run tests
+        run: |
+          testthat::test_package("arrow", filter = "extra-package-roundtrip")
+        shell: Rscript {0}

--- a/dev/tasks/r/github.linux.extra.packages.yml
+++ b/dev/tasks/r/github.linux.extra.packages.yml
@@ -41,7 +41,7 @@ jobs:
             any::data.table
             any::rcmdcheck
             any::readr
-            any::unites
+            any::units
       - name: Build arrow package
         run: |
           R CMD build --no-build-vignettes arrow/r

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1309,6 +1309,10 @@ tasks:
     ci: github
     template: r/github.linux.rchk.yml
 
+  test-r-extra-packages:
+    ci: github
+    template: r/github.linux.extra.packages.yml   
+
   test-r-linux-as-cran:
     ci: github
     template: r/github.linux.cran.yml

--- a/r/tests/testthat/test-extra-package-roundtrip.R
+++ b/r/tests/testthat/test-extra-package-roundtrip.R
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+skip_on_cran()
+
+# So that we can force these in CI
+load_or_skip <- function(pkg) {
+  if (identical(tolower(Sys.getenv("ARROW_R_FORCE_EXTRA_PACKAGE_TESTS")), "true")) {
+    # because of this indirection on the package name we also avoid a CHECK note and 
+    # we don't otherwise need to Suggest this
+    requireNamespace(pkg, quietly = TRUE)
+  } else {
+    skip_if(!requireNamespace(pkg, quietly = TRUE))
+  }
+  attachNamespace(pkg)
+}
+
+library(tibble)
+
+test_that("readr read csvs roundtrip", {
+  load_or_skip("readr")
+
+  tbl <- example_data[, c("dbl", "lgl", "false", "chr")]
+
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  write.csv(tbl, tf, row.names = FALSE)
+
+  # we should still be able to turn this into a table
+  new_df <- read_csv(tf, show_col_types = FALSE)
+  expect_equal(tbl, as_tibble(arrow_table(new_df)))    
+
+  # we should still be able to turn this into a table
+  new_df <- read_csv(tf, show_col_types = FALSE, lazy = TRUE)
+  expect_equal(tbl, as_tibble(arrow_table(new_df)))    
+})
+
+test_that("data.table objects roundtrip", {
+  # indirection to avoid CHECK note and we don't otherwise need to Suggest this
+  load_or_skip("data.table")
+
+  DT <- as.data.table(example_data)
+
+  # we should still be able to turn this into a table
+  expect_equal(example_data, as_tibble(arrow_table(DT)))    
+
+  # TODO: parquet write?  
+})

--- a/r/tests/testthat/test-extra-package-roundtrip.R
+++ b/r/tests/testthat/test-extra-package-roundtrip.R
@@ -17,7 +17,7 @@
 
 skip_on_cran()
 
-# Any additional pacakge that we test here that is not already in DESCRIPTION should be
+# Any additional package that we test here that is not already in DESCRIPTION should be
 # added to dev/tasks/r/github.linux.extra.packages.yml in the r-lib/actions/setup-r-dependencies@v2
 # step so that they are installed + available in that CI job.
 
@@ -59,13 +59,12 @@ test_that("readr read csvs roundtrip", {
 
   # we should still be able to turn this into a table
   expect_equal(new_df, new_df_read)
-
 })
 
 test_that("data.table objects roundtrip", {
   load_or_skip("data.table")
 
-  # https://rdatatable.gitlab.io/data.table/articles/datatable-importing.html#testing-using-testthat
+  # https://github.com/Rdatatable/data.table/blob/83fd2c05ce2d8555ceb8ba417833956b1b574f7e/R/cedta.R#L25-L27
   .datatable.aware=TRUE
 
   DT <- as.data.table(example_data)
@@ -76,10 +75,8 @@ test_that("data.table objects roundtrip", {
   DT_read <- read_parquet(pq_tmp_file)
 
   # we should still be able to turn this into a table
+  # the .internal.selfref attribute is automatically ignored by testthat/waldo
   expect_equal(DT, DT_read)
-
-  # attributes are the same, aside from the internal selfref pointer
-  expect_mapequal(attributes(DT_read), attributes(DT)[names(attributes(DT)) != ".internal.selfref"])
 
   # and we can set keys + indices + create new columns
   setkey(DT, chr)
@@ -93,7 +90,19 @@ test_that("data.table objects roundtrip", {
 
   # we should still be able to turn this into a table
   expect_equal(DT, DT_read)
+})
 
-  # and the attributes are the same, aside from the internal selfref pointer
-  expect_mapequal(attributes(DT_read), attributes(DT)[names(attributes(DT)) != ".internal.selfref"])
+test_that("units roundtrip", {
+  load_or_skip("units")
+
+  tbl <- example_data
+  units(tbl$dbl) <- "s"
+
+  # and can roundtrip to a parquet file
+  pq_tmp_file <- tempfile()
+  write_parquet(tbl, pq_tmp_file)
+  tbl_read <- read_parquet(pq_tmp_file)
+
+  # we should still be able to turn this into a table
+  expect_equal(tbl, tbl_read)
 })

--- a/r/tests/testthat/test-extra-package-roundtrip.R
+++ b/r/tests/testthat/test-extra-package-roundtrip.R
@@ -71,6 +71,21 @@ test_that("data.table objects roundtrip", {
   # we should still be able to turn this into a table
   expect_equal(DT, DT_read)
 
+  # attributes are the same, aside from the internal selfref pointer
+  expect_mapequal(attributes(DT_read), attributes(DT)[names(attributes(DT)) != ".internal.selfref"])
+
+  # and we can set keys + indices
+  setkey(DT, chr)
+  setindex(DT, dbl)
+
+  # write to parquet
+  pq_tmp_file <- tempfile()
+  write_parquet(DT, pq_tmp_file)
+  DT_read <- read_parquet(pq_tmp_file)
+
+  # we should still be able to turn this into a table
+  expect_equal(DT, DT_read)
+
   # and the attributes are the same, aside from the internal selfref pointer
   expect_mapequal(attributes(DT_read), attributes(DT)[names(attributes(DT)) != ".internal.selfref"])
 })

--- a/r/tests/testthat/test-extra-package-roundtrip.R
+++ b/r/tests/testthat/test-extra-package-roundtrip.R
@@ -59,7 +59,6 @@ test_that("readr read csvs roundtrip", {
 })
 
 test_that("data.table objects roundtrip", {
-  # indirection to avoid CHECK note and we don't otherwise need to Suggest this
   load_or_skip("data.table")
 
   DT <- as.data.table(example_data)

--- a/r/tests/testthat/test-extra-package-roundtrip.R
+++ b/r/tests/testthat/test-extra-package-roundtrip.R
@@ -33,7 +33,7 @@ load_or_skip <- function(pkg) {
   attachNamespace(pkg)
 }
 
-library(tibble)
+library(dplyr)
 
 test_that("readr read csvs roundtrip", {
   load_or_skip("readr")
@@ -69,10 +69,9 @@ test_that("data.table objects roundtrip", {
 
   DT <- as.data.table(example_data)
 
-  # write to parquet
-  pq_tmp_file <- tempfile()
-  write_parquet(DT, pq_tmp_file)
-  DT_read <- read_parquet(pq_tmp_file)
+  # Table -> collect which is what writing + reading to parquet uses under the hood to roundtrip
+  tab <- as_arrow_table(DT)
+  DT_read <- collect(tab)
 
   # we should still be able to turn this into a table
   # the .internal.selfref attribute is automatically ignored by testthat/waldo
@@ -83,10 +82,9 @@ test_that("data.table objects roundtrip", {
   setindex(DT, dbl)
   DT[, dblshift := data.table::shift(dbl, 1)]
 
-  # write to parquet
-  pq_tmp_file <- tempfile()
-  write_parquet(DT, pq_tmp_file)
-  DT_read <- read_parquet(pq_tmp_file)
+  # Table -> collect
+  tab <- as_arrow_table(DT)
+  DT_read <- collect(tab)
 
   # we should still be able to turn this into a table
   expect_equal(DT, DT_read)
@@ -98,10 +96,9 @@ test_that("units roundtrip", {
   tbl <- example_data
   units(tbl$dbl) <- "s"
 
-  # and can roundtrip to a parquet file
-  pq_tmp_file <- tempfile()
-  write_parquet(tbl, pq_tmp_file)
-  tbl_read <- read_parquet(pq_tmp_file)
+   # Table -> collect which is what writing + reading to parquet uses under the hood to roundtrip
+  tab <- as_arrow_table(tbl)
+  tbl_read <- collect(tab)
 
   # we should still be able to turn this into a table
   expect_equal(tbl, tbl_read)

--- a/r/tests/testthat/test-extra-package-roundtrip.R
+++ b/r/tests/testthat/test-extra-package-roundtrip.R
@@ -65,6 +65,9 @@ test_that("readr read csvs roundtrip", {
 test_that("data.table objects roundtrip", {
   load_or_skip("data.table")
 
+  # https://rdatatable.gitlab.io/data.table/articles/datatable-importing.html#testing-using-testthat
+  .datatable.aware=TRUE
+
   DT <- as.data.table(example_data)
 
   # write to parquet
@@ -78,9 +81,10 @@ test_that("data.table objects roundtrip", {
   # attributes are the same, aside from the internal selfref pointer
   expect_mapequal(attributes(DT_read), attributes(DT)[names(attributes(DT)) != ".internal.selfref"])
 
-  # and we can set keys + indices
+  # and we can set keys + indices + create new columns
   setkey(DT, chr)
   setindex(DT, dbl)
+  DT[, dblshift := data.table::shift(dbl, 1)]
 
   # write to parquet
   pq_tmp_file <- tempfile()

--- a/r/tests/testthat/test-extra-package-roundtrip.R
+++ b/r/tests/testthat/test-extra-package-roundtrip.R
@@ -17,6 +17,10 @@
 
 skip_on_cran()
 
+# Any additional pacakge that we test here that is not already in DESCRIPTION should be
+# added to dev/tasks/r/github.linux.extra.packages.yml in the r-lib/actions/setup-r-dependencies@v2
+# step so that they are installed + available in that CI job.
+
 # So that we can force these in CI
 load_or_skip <- function(pkg) {
   if (identical(tolower(Sys.getenv("ARROW_R_FORCE_EXTRA_PACKAGE_TESTS")), "true")) {


### PR DESCRIPTION
### Rationale for this change

Add coverage for objects that might have issues roundtripping to Arrow Tables or Parquet files 

### What changes are included in this PR?

A new test file + a crossbow job that ensures these other packages are installed so the tests run.

### Are these changes tested?

The changes are tests

### Are there any user-facing changes?

No
* GitHub Issue: #43633