### PR TITLE
GH-43635: [R][CI] Don't install Quarto

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -91,13 +91,13 @@ jobs:
         use-public-rspm: true
         install-r: false
 
-    - uses: r-lib/actions/setup-r-dependencies@v2
+    - uses: r-lib/actions/setup-r-dependencies@732fb28088814627972f1ccbacc02561178cf391
       with:
         extra-packages: any::rcmdcheck
         needs: check
         working-directory: src/r
 
-    - uses: r-lib/actions/check-r-package@v2
+    - uses: r-lib/actions/check-r-package@732fb28088814627972f1ccbacc02561178cf391
       with:
         working-directory: src/r
       env:
@@ -337,11 +337,11 @@ jobs:
           cd r/windows
           ls *.zip | xargs -n 1 unzip -uo
           rm -rf *.zip
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@732fb28088814627972f1ccbacc02561178cf391
         with:
           r-version: ${{ matrix.config.rversion }}
           Ncpus: 2
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@732fb28088814627972f1ccbacc02561178cf391
         env:
           GITHUB_PAT: "${{ github.token }}"
         with:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -86,6 +86,7 @@ jobs:
       run: |
         sudo apt-get install devscripts
 
+    # replace the SHA with v2 once INFRA-26031 is resolved
     - uses: r-lib/actions/setup-r@732fb28088814627972f1ccbacc02561178cf391
       with:
         use-public-rspm: true

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -86,11 +86,10 @@ jobs:
       run: |
         sudo apt-get install devscripts
 
-    - uses: r-lib/actions/setup-r@v2
+    - uses: r-lib/actions/setup-r@732fb28088814627972f1ccbacc02561178cf391
       with:
         use-public-rspm: true
         install-r: false
-        install-quarto: false
 
     - uses: r-lib/actions/setup-r-dependencies@v2
       with:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -90,6 +90,7 @@ jobs:
       with:
         use-public-rspm: true
         install-r: false
+        install-quarto: false
 
     - uses: r-lib/actions/setup-r-dependencies@v2
       with:


### PR DESCRIPTION
Pin to an old version of r-lib/actions that does not reference quarto-dev/quarto-actions. Though we still want to ask INFRA to add quarto-dev to the approved list.

* GitHub Issue: #43635