### PR TITLE
GH-43638: [Java] LargeListViewVector RangeEqualVisitor and TypeEqualVisitor integration

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
@@ -28,6 +28,7 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.LargeListVector;
+import org.apache.arrow.vector.complex.LargeListViewVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.ListViewVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
@@ -127,6 +128,11 @@ public class TypeEqualsVisitor implements VectorVisitor<Boolean, Void> {
 
   @Override
   public Boolean visit(ListViewVector left, Void value) {
+    return compareField(left.getField(), right.getField());
+  }
+
+  @Override
+  public Boolean visit(LargeListViewVector left, Void value) {
     return compareField(left.getField(), right.getField());
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
@@ -25,6 +25,7 @@ import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.LargeListVector;
+import org.apache.arrow.vector.complex.LargeListViewVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.ListViewVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
@@ -64,5 +65,10 @@ public interface VectorVisitor<OUT, IN> {
 
   default OUT visit(ListViewVector left, IN value) {
     throw new UnsupportedOperationException("VectorVisitor for ListViewVector is not supported.");
+  }
+
+  default OUT visit(LargeListViewVector left, IN value) {
+    throw new UnsupportedOperationException(
+        "VectorVisitor for LargeListViewVector is not supported.");
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
@@ -449,7 +449,7 @@ public class LargeListViewVector extends BaseLargeRepeatedValueViewVector
 
   @Override
   public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
-    throw new UnsupportedOperationException();
+    return visitor.visit(this, value);
   }
 
   @Override

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestTypeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestTypeEqualsVisitor.java
@@ -32,6 +32,7 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.ViewVarBinaryVector;
 import org.apache.arrow.vector.ViewVarCharVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.LargeListViewVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.ListViewVector;
 import org.apache.arrow.vector.complex.StructVector;
@@ -110,6 +111,22 @@ public class TestTypeEqualsVisitor {
     try (final ListViewVector right = ListViewVector.empty("listview", allocator);
         final ListViewVector left1 = ListViewVector.empty("listview", allocator);
         final ListViewVector left2 = ListViewVector.empty("listview", allocator)) {
+
+      right.addOrGetVector(FieldType.nullable(new ArrowType.Utf8()));
+      left1.addOrGetVector(FieldType.nullable(new ArrowType.Utf8()));
+      left2.addOrGetVector(FieldType.nullable(new ArrowType.FixedSizeBinary(2)));
+
+      TypeEqualsVisitor visitor = new TypeEqualsVisitor(right);
+      assertTrue(visitor.equals(left1));
+      assertFalse(visitor.equals(left2));
+    }
+  }
+
+  @Test
+  public void testLargeListViewTypeEquals() {
+    try (final LargeListViewVector right = LargeListViewVector.empty("largelistview", allocator);
+        final LargeListViewVector left1 = LargeListViewVector.empty("largelistview", allocator);
+        final LargeListViewVector left2 = LargeListViewVector.empty("largelistview", allocator)) {
 
       right.addOrGetVector(FieldType.nullable(new ArrowType.Utf8()));
       left1.addOrGetVector(FieldType.nullable(new ArrowType.Utf8()));


### PR DESCRIPTION
### Rationale for this change

LargeListViewVector requires `RangeEqualVisitor` and `TypeEqualVisitor` to support the C Data interface. 

### What changes are included in this PR?

Adding `RangeEqualVisitor`, `TypeEqualVisitor` and the corresponding test cases. 

### Are these changes tested?

Yes. 

### Are there any user-facing changes?

No
* GitHub Issue: #43638