### PR TITLE
GH-43690: [Python][CI] Simplify python/requirements-wheel-test.txt file

### DIFF
--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -5,8 +5,8 @@ pytest
 pytz
 tzdata; sys_platform == 'win32'
 
-numpy==1.21.3; python_version < "3.11"
-numpy==1.23.5; python_version == "3.11"
-numpy==1.26.4; python_version == "3.12"
+numpy~=1.21.3; python_version < "3.11"
+numpy~=1.23.2; python_version == "3.11"
+numpy~=1.26.0; python_version == "3.12"
 
 pandas

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -5,6 +5,10 @@ pytest
 pytz
 tzdata; sys_platform == 'win32'
 
+# We generally test with the oldest numpy version that supports a given Python
+# version. However, there is no need to make this strictly the oldest version,
+# so it can be broadened to have a single version specification across platforms.
+# (`~=x.y.z` specifies a compatible release as `>=x.y.z, == x.y.*`)
 numpy~=1.21.3; python_version < "3.11"
 numpy~=1.23.2; python_version == "3.11"
 numpy~=1.26.0; python_version == "3.12"

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -5,22 +5,10 @@ pytest
 pytz
 tzdata; sys_platform == 'win32'
 
-numpy==1.21.3; platform_system == "Linux"   and platform_machine == "aarch64" and python_version < "3.11"
-numpy==1.23.4;                                                                    python_version == "3.11"
-numpy==1.26.0;                                                                    python_version >= "3.12"
-numpy==1.19.5; platform_system == "Linux"   and platform_machine != "aarch64" and python_version <  "3.9"
-numpy==1.21.3; platform_system == "Linux"   and platform_machine != "aarch64" and python_version >= "3.9" and python_version < "3.11"
-numpy==1.21.3; platform_system == "Darwin"  and platform_machine == "arm64"   and python_version <  "3.11"
-numpy==1.19.5; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version <  "3.9"
-numpy==1.21.3; platform_system == "Darwin"  and platform_machine != "arm64"   and python_version >= "3.9" and python_version < "3.11"
-numpy==1.19.5; platform_system == "Windows"                                   and python_version <  "3.9"
-numpy==1.21.3; platform_system == "Windows"                                   and python_version >= "3.9" and python_version < "3.11"
+numpy==1.21.3; python_version < "3.11"
+numpy==1.23.5; python_version == "3.11"
+numpy==1.26.4; python_version == "3.12"
+numpy>=2; python_version == "3.13"
 
-pandas<1.1.0;  platform_system == "Linux"   and platform_machine != "aarch64" and python_version <  "3.8"
-pandas;        platform_system == "Linux"   and platform_machine != "aarch64" and python_version >= "3.8"
-pandas;        platform_system == "Linux"   and platform_machine == "aarch64"
-pandas<1.1.0;  platform_system == "Darwin"  and platform_machine != "arm64"   and python_version <  "3.8"
-pandas;        platform_system == "Darwin"  and platform_machine != "arm64"   and python_version >= "3.8"
-pandas;        platform_system == "Darwin"  and platform_machine == "arm64"
-pandas<1.1.0;  platform_system == "Windows"                                   and python_version <  "3.8"
-pandas;        platform_system == "Windows"                                   and python_version >= "3.8"
+pandas; python_version < "3.13"
+pandas>=3.0.0.dev0; python_version == "3.13"

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -8,7 +8,5 @@ tzdata; sys_platform == 'win32'
 numpy==1.21.3; python_version < "3.11"
 numpy==1.23.5; python_version == "3.11"
 numpy==1.26.4; python_version == "3.12"
-numpy>=2; python_version == "3.13"
 
-pandas; python_version < "3.13"
-pandas>=3.0.0.dev0; python_version == "3.13"
+pandas


### PR DESCRIPTION
### Rationale for this change

The current [requirements-wheel-test.txt](https://github.com/apache/arrow/blob/7c8909a144f2e8d593dc8ad363ac95b2865b04ca/python/requirements-wheel-test.txt) file has quite complex and detailed version pinning, varying per architecture. I think this can be simplified because we just want to test with some older version of numpy and pandas (and the exact version isn't that important).

* GitHub Issue: #43690