### PR TITLE
GH-43666: [C++] Attach `arrow::ArrayStatistics` to `arrow::Array`

### DIFF
--- a/cpp/src/arrow/array/array_binary.cc
+++ b/cpp/src/arrow/array/array_binary.cc
@@ -32,36 +32,19 @@ namespace arrow {
 
 using internal::checked_cast;
 
-BinaryArray::BinaryArray(const std::shared_ptr<ArrayData>& data) {
+void BinaryArray::SetData(const std::shared_ptr<ArrayData>& data) {
   ARROW_CHECK(is_binary_like(data->type->id()));
-  SetData(data);
+  BaseBinaryArray<BinaryType>::SetData(data);
 }
 
-BinaryArray::BinaryArray(int64_t length, const std::shared_ptr<Buffer>& value_offsets,
-                         const std::shared_ptr<Buffer>& data,
-                         const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count,
-                         int64_t offset) {
-  SetData(ArrayData::Make(binary(), length, {null_bitmap, value_offsets, data},
-                          null_count, offset));
-}
-
-LargeBinaryArray::LargeBinaryArray(const std::shared_ptr<ArrayData>& data) {
+void LargeBinaryArray::SetData(const std::shared_ptr<ArrayData>& data) {
   ARROW_CHECK(is_large_binary_like(data->type->id()));
-  SetData(data);
+  BaseBinaryArray<LargeBinaryType>::SetData(data);
 }
 
-LargeBinaryArray::LargeBinaryArray(int64_t length,
-                                   const std::shared_ptr<Buffer>& value_offsets,
-                                   const std::shared_ptr<Buffer>& data,
-                                   const std::shared_ptr<Buffer>& null_bitmap,
-                                   int64_t null_count, int64_t offset) {
-  SetData(ArrayData::Make(large_binary(), length, {null_bitmap, value_offsets, data},
-                          null_count, offset));
-}
-
-StringArray::StringArray(const std::shared_ptr<ArrayData>& data) {
+void StringArray::SetData(const std::shared_ptr<ArrayData>& data) {
   ARROW_CHECK_EQ(data->type->id(), Type::STRING);
-  SetData(data);
+  BinaryArray::SetData(data);
 }
 
 StringArray::StringArray(int64_t length, const std::shared_ptr<Buffer>& value_offsets,
@@ -74,9 +57,9 @@ StringArray::StringArray(int64_t length, const std::shared_ptr<Buffer>& value_of
 
 Status StringArray::ValidateUTF8() const { return internal::ValidateUTF8(*data_); }
 
-LargeStringArray::LargeStringArray(const std::shared_ptr<ArrayData>& data) {
+void LargeStringArray::SetData(const std::shared_ptr<ArrayData>& data) {
   ARROW_CHECK_EQ(data->type->id(), Type::LARGE_STRING);
-  SetData(data);
+  LargeBinaryArray::SetData(data);
 }
 
 LargeStringArray::LargeStringArray(int64_t length,
@@ -90,19 +73,27 @@ LargeStringArray::LargeStringArray(int64_t length,
 
 Status LargeStringArray::ValidateUTF8() const { return internal::ValidateUTF8(*data_); }
 
-BinaryViewArray::BinaryViewArray(std::shared_ptr<ArrayData> data) {
-  ARROW_CHECK_EQ(data->type->id(), Type::BINARY_VIEW);
-  SetData(std::move(data));
+void BinaryViewArray::SetData(const std::shared_ptr<ArrayData>& data) {
+  ARROW_CHECK_EQ(data->type->id(), expected_type_id());
+  FlatArray::SetData(data);
+  raw_values_ = data_->GetValuesSafe<c_type>(1);
 }
+
+namespace {
+void InitViewArrayBuffers(BufferVector& buffers, std::shared_ptr<Buffer> views,
+                          std::shared_ptr<Buffer> null_bitmap) {
+  buffers.insert(buffers.begin(), std::move(views));
+  buffers.insert(buffers.begin(), std::move(null_bitmap));
+}
+};  // namespace
 
 BinaryViewArray::BinaryViewArray(std::shared_ptr<DataType> type, int64_t length,
                                  std::shared_ptr<Buffer> views, BufferVector buffers,
                                  std::shared_ptr<Buffer> null_bitmap, int64_t null_count,
                                  int64_t offset) {
-  buffers.insert(buffers.begin(), std::move(views));
-  buffers.insert(buffers.begin(), std::move(null_bitmap));
-  SetData(
-      ArrayData::Make(std::move(type), length, std::move(buffers), null_count, offset));
+  InitViewArrayBuffers(buffers, std::move(views), std::move(null_bitmap));
+  Init(ArrayData::Make(std::move(type), length, std::move(buffers), null_count, offset),
+       nullptr);
 }
 
 std::string_view BinaryViewArray::GetView(int64_t i) const {
@@ -110,24 +101,21 @@ std::string_view BinaryViewArray::GetView(int64_t i) const {
   return util::FromBinaryView(raw_values_[i], data_buffers);
 }
 
-StringViewArray::StringViewArray(std::shared_ptr<ArrayData> data) {
-  ARROW_CHECK_EQ(data->type->id(), Type::STRING_VIEW);
-  SetData(std::move(data));
+StringViewArray::StringViewArray(std::shared_ptr<DataType> type, int64_t length,
+                                 std::shared_ptr<Buffer> views, BufferVector buffers,
+                                 std::shared_ptr<Buffer> null_bitmap, int64_t null_count,
+                                 int64_t offset) {
+  InitViewArrayBuffers(buffers, std::move(views), std::move(null_bitmap));
+  Init(ArrayData::Make(std::move(type), length, std::move(buffers), null_count, offset),
+       nullptr);
 }
 
 Status StringViewArray::ValidateUTF8() const { return internal::ValidateUTF8(*data_); }
 
-FixedSizeBinaryArray::FixedSizeBinaryArray(const std::shared_ptr<ArrayData>& data) {
-  SetData(data);
+void FixedSizeBinaryArray::SetData(const std::shared_ptr<ArrayData>& data) {
+  PrimitiveArray::SetData(data);
+  byte_width_ = internal::checked_cast<const FixedSizeBinaryType&>(*type()).byte_width();
 }
-
-FixedSizeBinaryArray::FixedSizeBinaryArray(const std::shared_ptr<DataType>& type,
-                                           int64_t length,
-                                           const std::shared_ptr<Buffer>& data,
-                                           const std::shared_ptr<Buffer>& null_bitmap,
-                                           int64_t null_count, int64_t offset)
-    : PrimitiveArray(type, length, data, null_bitmap, null_count, offset),
-      byte_width_(checked_cast<const FixedSizeBinaryType&>(*type).byte_width()) {}
 
 const uint8_t* FixedSizeBinaryArray::GetValue(int64_t i) const {
   return raw_values_ + (i + data_->offset) * byte_width_;

--- a/cpp/src/arrow/array/array_decimal.cc
+++ b/cpp/src/arrow/array/array_decimal.cc
@@ -35,9 +35,10 @@ using internal::checked_cast;
 // ----------------------------------------------------------------------
 // Decimal128
 
-Decimal128Array::Decimal128Array(const std::shared_ptr<ArrayData>& data)
-    : FixedSizeBinaryArray(data) {
+Decimal128Array::Decimal128Array(const std::shared_ptr<ArrayData>& data,
+                                 const std::shared_ptr<ArrayStatistics>& statistics) {
   ARROW_CHECK_EQ(data->type->id(), Type::DECIMAL128);
+  Init(data, statistics);
 }
 
 std::string Decimal128Array::FormatValue(int64_t i) const {
@@ -49,9 +50,10 @@ std::string Decimal128Array::FormatValue(int64_t i) const {
 // ----------------------------------------------------------------------
 // Decimal256
 
-Decimal256Array::Decimal256Array(const std::shared_ptr<ArrayData>& data)
-    : FixedSizeBinaryArray(data) {
+Decimal256Array::Decimal256Array(const std::shared_ptr<ArrayData>& data,
+                                 const std::shared_ptr<ArrayStatistics>& statistics) {
   ARROW_CHECK_EQ(data->type->id(), Type::DECIMAL256);
+  Init(data, statistics);
 }
 
 std::string Decimal256Array::FormatValue(int64_t i) const {

--- a/cpp/src/arrow/array/array_decimal.h
+++ b/cpp/src/arrow/array/array_decimal.h
@@ -43,7 +43,8 @@ class ARROW_EXPORT Decimal128Array : public FixedSizeBinaryArray {
   using FixedSizeBinaryArray::FixedSizeBinaryArray;
 
   /// \brief Construct Decimal128Array from ArrayData instance
-  explicit Decimal128Array(const std::shared_ptr<ArrayData>& data);
+  explicit Decimal128Array(const std::shared_ptr<ArrayData>& data,
+                           const std::shared_ptr<ArrayStatistics>& statistics = NULLPTR);
 
   std::string FormatValue(int64_t i) const;
 };
@@ -62,7 +63,8 @@ class ARROW_EXPORT Decimal256Array : public FixedSizeBinaryArray {
   using FixedSizeBinaryArray::FixedSizeBinaryArray;
 
   /// \brief Construct Decimal256Array from ArrayData instance
-  explicit Decimal256Array(const std::shared_ptr<ArrayData>& data);
+  explicit Decimal256Array(const std::shared_ptr<ArrayData>& data,
+                           const std::shared_ptr<ArrayStatistics>& statistics = NULLPTR);
 
   std::string FormatValue(int64_t i) const;
 };

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -78,15 +78,16 @@ int64_t DictionaryArray::GetValueIndex(int64_t i) const {
   }
 }
 
-DictionaryArray::DictionaryArray(const std::shared_ptr<ArrayData>& data)
+DictionaryArray::DictionaryArray(const std::shared_ptr<ArrayData>& data,
+                                 const std::shared_ptr<ArrayStatistics>& statistics)
     : dict_type_(checked_cast<const DictionaryType*>(data->type.get())) {
   ARROW_CHECK_EQ(data->type->id(), Type::DICTIONARY);
   ARROW_CHECK_NE(data->dictionary, nullptr);
-  SetData(data);
+  Init(data, statistics);
 }
 
 void DictionaryArray::SetData(const std::shared_ptr<ArrayData>& data) {
-  this->Array::SetData(data);
+  Array::SetData(data);
   auto indices_data = data_->Copy();
   indices_data->type = dict_type_->index_type();
   indices_data->dictionary = nullptr;
@@ -104,7 +105,7 @@ DictionaryArray::DictionaryArray(const std::shared_ptr<DataType>& type,
   auto data = indices->data()->Copy();
   data->type = type;
   data->dictionary = dictionary->data();
-  SetData(data);
+  Init(data, nullptr);
 }
 
 const std::shared_ptr<Array>& DictionaryArray::dictionary() const {

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -54,7 +54,8 @@ class ARROW_EXPORT DictionaryArray : public Array {
  public:
   using TypeClass = DictionaryType;
 
-  explicit DictionaryArray(const std::shared_ptr<ArrayData>& data);
+  explicit DictionaryArray(const std::shared_ptr<ArrayData>& data,
+                           const std::shared_ptr<ArrayStatistics>& statistics = NULLPTR);
 
   DictionaryArray(const std::shared_ptr<DataType>& type,
                   const std::shared_ptr<Array>& indices,
@@ -114,7 +115,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
   const DictionaryType* dict_type() const { return dict_type_; }
 
  private:
-  void SetData(const std::shared_ptr<ArrayData>& data);
+  void SetData(const std::shared_ptr<ArrayData>& data) override;
   const DictionaryType* dict_type_;
   std::shared_ptr<Array> indices_;
 

--- a/cpp/src/arrow/array/array_primitive.cc
+++ b/cpp/src/arrow/array/array_primitive.cc
@@ -29,27 +29,13 @@
 namespace arrow {
 
 // ----------------------------------------------------------------------
-// Primitive array base
-
-PrimitiveArray::PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t length,
-                               const std::shared_ptr<Buffer>& data,
-                               const std::shared_ptr<Buffer>& null_bitmap,
-                               int64_t null_count, int64_t offset) {
-  SetData(ArrayData::Make(type, length, {null_bitmap, data}, null_count, offset));
-}
-
-// ----------------------------------------------------------------------
 // BooleanArray
 
-BooleanArray::BooleanArray(const std::shared_ptr<ArrayData>& data)
-    : PrimitiveArray(data) {
+BooleanArray::BooleanArray(const std::shared_ptr<ArrayData>& data,
+                           const std::shared_ptr<ArrayStatistics>& statistics) {
   ARROW_CHECK_EQ(data->type->id(), Type::BOOL);
+  Init(data, statistics);
 }
-
-BooleanArray::BooleanArray(int64_t length, const std::shared_ptr<Buffer>& data,
-                           const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count,
-                           int64_t offset)
-    : PrimitiveArray(boolean(), length, data, null_bitmap, null_count, offset) {}
 
 int64_t BooleanArray::false_count() const {
   return this->length() - this->null_count() - this->true_count();
@@ -70,24 +56,6 @@ int64_t BooleanArray::true_count() const {
 // ----------------------------------------------------------------------
 // Day time interval
 
-DayTimeIntervalArray::DayTimeIntervalArray(const std::shared_ptr<ArrayData>& data) {
-  SetData(data);
-}
-
-DayTimeIntervalArray::DayTimeIntervalArray(const std::shared_ptr<DataType>& type,
-                                           int64_t length,
-                                           const std::shared_ptr<Buffer>& data,
-                                           const std::shared_ptr<Buffer>& null_bitmap,
-                                           int64_t null_count, int64_t offset)
-    : PrimitiveArray(type, length, data, null_bitmap, null_count, offset) {}
-
-DayTimeIntervalArray::DayTimeIntervalArray(int64_t length,
-                                           const std::shared_ptr<Buffer>& data,
-                                           const std::shared_ptr<Buffer>& null_bitmap,
-                                           int64_t null_count, int64_t offset)
-    : PrimitiveArray(day_time_interval(), length, data, null_bitmap, null_count, offset) {
-}
-
 DayTimeIntervalType::DayMilliseconds DayTimeIntervalArray::GetValue(int64_t i) const {
   DCHECK(i < length());
   return *reinterpret_cast<const DayTimeIntervalType::DayMilliseconds*>(
@@ -96,23 +64,6 @@ DayTimeIntervalType::DayMilliseconds DayTimeIntervalArray::GetValue(int64_t i) c
 
 // ----------------------------------------------------------------------
 // Month, day and Nanos interval
-
-MonthDayNanoIntervalArray::MonthDayNanoIntervalArray(
-    const std::shared_ptr<ArrayData>& data) {
-  SetData(data);
-}
-
-MonthDayNanoIntervalArray::MonthDayNanoIntervalArray(
-    const std::shared_ptr<DataType>& type, int64_t length,
-    const std::shared_ptr<Buffer>& data, const std::shared_ptr<Buffer>& null_bitmap,
-    int64_t null_count, int64_t offset)
-    : PrimitiveArray(type, length, data, null_bitmap, null_count, offset) {}
-
-MonthDayNanoIntervalArray::MonthDayNanoIntervalArray(
-    int64_t length, const std::shared_ptr<Buffer>& data,
-    const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count, int64_t offset)
-    : PrimitiveArray(month_day_nano_interval(), length, data, null_bitmap, null_count,
-                     offset) {}
 
 MonthDayNanoIntervalType::MonthDayNanos MonthDayNanoIntervalArray::GetValue(
     int64_t i) const {

--- a/cpp/src/arrow/array/array_run_end.cc
+++ b/cpp/src/arrow/array/array_run_end.cc
@@ -26,21 +26,6 @@ namespace arrow {
 // ----------------------------------------------------------------------
 // RunEndEncodedArray
 
-RunEndEncodedArray::RunEndEncodedArray(const std::shared_ptr<ArrayData>& data) {
-  this->SetData(data);
-}
-
-RunEndEncodedArray::RunEndEncodedArray(const std::shared_ptr<DataType>& type,
-                                       int64_t length,
-                                       const std::shared_ptr<Array>& run_ends,
-                                       const std::shared_ptr<Array>& values,
-                                       int64_t offset) {
-  this->SetData(ArrayData::Make(type, length,
-                                /*buffers=*/{NULLPTR},
-                                /*child_data=*/{run_ends->data(), values->data()},
-                                /*null_count=*/0, offset));
-}
-
 Result<std::shared_ptr<RunEndEncodedArray>> RunEndEncodedArray::Make(
     const std::shared_ptr<DataType>& type, int64_t logical_length,
     const std::shared_ptr<Array>& run_ends, const std::shared_ptr<Array>& values,

--- a/cpp/src/arrow/array/array_run_end.h
+++ b/cpp/src/arrow/array/array_run_end.h
@@ -53,7 +53,11 @@ class ARROW_EXPORT RunEndEncodedArray : public Array {
  public:
   using TypeClass = RunEndEncodedType;
 
-  explicit RunEndEncodedArray(const std::shared_ptr<ArrayData>& data);
+  explicit RunEndEncodedArray(
+      const std::shared_ptr<ArrayData>& data,
+      const std::shared_ptr<ArrayStatistics>& statistics = NULLPTR) {
+    Init(data, statistics);
+  }
 
   /// \brief Construct a RunEndEncodedArray from all parameters
   ///
@@ -63,7 +67,12 @@ class ARROW_EXPORT RunEndEncodedArray : public Array {
   /// the child run_ends and values arrays.
   RunEndEncodedArray(const std::shared_ptr<DataType>& type, int64_t length,
                      const std::shared_ptr<Array>& run_ends,
-                     const std::shared_ptr<Array>& values, int64_t offset = 0);
+                     const std::shared_ptr<Array>& values, int64_t offset = 0)
+      : RunEndEncodedArray(
+            ArrayData::Make(type, length,
+                            /*buffers=*/{NULLPTR},
+                            /*child_data=*/{run_ends->data(), values->data()},
+                            /*null_count=*/0, offset)) {}
 
   /// \brief Construct a RunEndEncodedArray from all parameters
   ///
@@ -85,7 +94,7 @@ class ARROW_EXPORT RunEndEncodedArray : public Array {
       const std::shared_ptr<Array>& values, int64_t logical_offset = 0);
 
  protected:
-  void SetData(const std::shared_ptr<ArrayData>& data);
+  void SetData(const std::shared_ptr<ArrayData>& data) override;
 
  public:
   /// \brief Returns an array holding the logical indexes of each run-end


### PR DESCRIPTION
### Rationale for this change

If we can attach associated statistics to an array, we can use it in later processes such as query planning. 

### What changes are included in this PR?

New public APIs:

* `arrow::Array::statistics()`: It returns the associated statistics. It can't be changed after an array is created. A sliced array doesn't have parent array's statistics because parent array's statistics isn't valid for sliced array.
* Add new optional `arrow::ArrayStatistics` argument to all `arrow::*Array(ArrayData)` constructors: `arrow::*Array(ArrayData, ArrayStatistics = NULLPTR)`

New internal APIs:

* `arrow::Array::Init()`: All array constructors must call this to attach `arrow::ArrayData` and `arrow::ArrayStatistics`. Note that calling this via parent's constructor isn't allowed. Array constructors don't need to call `arrow::Array::SetData()` directly. It's called in `arrow::Array::Init()`.
* `arrow::Array::SetStatitics()`: It attaches `arrow::ArrayStatistics` to `arrow::Array`. In general, this is not called directly. This is called from `arrow::Array::Init()` internally.

Changed internal APIs:

* `arrow::Array::SetData()`: It becomes a virtual method. So `arrow::Array::Init()` must be called by each array's constructor.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**

APIs are compatible but ABIs are incompatible.
* GitHub Issue: #43666