### PR TITLE
MINOR: [CI] Fix ubuntu-lint to not install into system Python

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1889,6 +1889,9 @@ services:
     command: >
       /bin/bash -c "
         git config --global --add safe.directory /arrow &&
+        python3 -m venv /build/pyvenv &&
+        source /build/pyvenv/bin/activate &&
+        pip install -U pip setuptools &&
         pip install arrow/dev/archery[lint] &&
         archery lint --all --no-clang-tidy --no-iwyu --no-numpydoc --src /arrow"
 


### PR DESCRIPTION
### Rationale for this change

Currently, the `ubuntu-lint` Docker build would install its Python dependencies directly into the system Python, which can fail depending on existing system Python packages.

See example here:
https://github.com/apache/arrow/actions/runs/10400929007/job/28802420047?pr=43539 where pip's dependency resolution fails with the following error message:
```
packaging.version.InvalidVersion: Invalid version: '2013-02-16'
```

### What changes are included in this PR?

This PR switches to use a virtual environment, guaranteeing that we're not interfering with the system Python and that we're not bound by already installed Python packages.

### Are these changes tested?

By CI.

### Are there any user-facing changes?

No.
