### PR TITLE
GH-41396: [Ruby] Add workaround for re2.pc on Ubuntu 20.04

### DIFF
--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -66,6 +66,13 @@ unless required_pkg_config_package([
   exit(false)
 end
 
+# Old re2.pc (e.g. re2.pc on Ubuntu 20.04) may add -std=c++11. It
+# causes a build error because Apache Arrow C++ requires C++17 or
+# later.
+#
+# We can remove this when we drop support for Ubuntu 20.04.
+$CXXFLAGS.gsub!("-std=c++11", "")
+
 [
   ["glib2", "ext/glib2"],
 ].each do |name, relative_source_dir|


### PR DESCRIPTION
### Rationale for this change

Old re2.pc add "-std=c++11" but it causes a build error. Because Apache Arrow C++ requires C++17.

### What changes are included in this PR?

Remove "-std=c++11" as workaround. We can remove this workaround when we drop support for Ubuntu 20.04.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #41396