### PR TITLE
GH-43187: [C++] Support basic is_in predicate simplification

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -1746,12 +1746,8 @@ TEST(Expression, SimplifyIsInThenExecute) {
     ExpectExecute(filter, input, &evaluated);
     ExpectExecute(simplified, input, &simplified_evaluated);
     if (simplified_evaluated.is_scalar()) {
-      ASSERT_EQ(evaluated.kind(), Datum::ARRAY);
-      ASSERT_EQ(simplified_evaluated.type()->id(), Type::BOOL);
-      BooleanBuilder builder;
-      ASSERT_OK(builder.AppendValues(
-          evaluated.length(), simplified_evaluated.scalar_as<BooleanScalar>().value));
-      ASSERT_OK_AND_ASSIGN(simplified_evaluated, builder.Finish());
+      ASSERT_OK_AND_ASSIGN(simplified_evaluated,
+          MakeArrayFromScalar(*simplified_evaluated.scalar(), expected->length()));
     }
     AssertDatumsEqual(evaluated, simplified_evaluated, /*verbose=*/true);
   }


### PR DESCRIPTION
### Rationale for this change

Prior to https://github.com/apache/arrow/pull/43256, this PR adds a basic implementation that does a linear scan filter over the value set on each guarantee. This isolates the correctness/semantics of `is_in` predicate simplification from the binary search performance optimization.

### What changes are included in this PR?

`SimplifyWithGuarantee` now handles `is_in` expressions.

### Are these changes tested?

A new unit test was added to arrow-compute-expression-test testing this change.

### Are there any user-facing changes?

No.
* GitHub Issue: #43187