### PR TITLE
GH-43769: [Java] Pin Java JNI CI build to llvm 16

### DIFF
--- a/ci/docker/java-jni-manylinux-201x.dockerfile
+++ b/ci/docker/java-jni-manylinux-201x.dockerfile
@@ -18,6 +18,8 @@
 ARG base
 FROM ${base}
 
+ARG llvm=16
+
 # Install the libraries required by the Gandiva to run
 # Use enable llvm[enable-rtti] in the vcpkg.json to avoid link problems in Gandiva
 RUN vcpkg install \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1204,6 +1204,7 @@ services:
       args:
         base: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
         java: 11
+        llvm: 16
       context: .
       dockerfile: ci/docker/java-jni-manylinux-201x.dockerfile
       cache_from:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1204,6 +1204,7 @@ services:
       args:
         base: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
         java: 11
+        # GH-XXX: Gandiva throws error with LLVM 17+
         llvm: 16
       context: .
       dockerfile: ci/docker/java-jni-manylinux-201x.dockerfile


### PR DESCRIPTION
### Rationale for this change

ORC does not support LLVM 17+ yet.

### What changes are included in this PR?

* Pin llvm to v16 for the java-jni-manylinux_build job

### Are these changes tested?

CI

### Are there any user-facing changes?

No
* GitHub Issue: apache/arrow-java#61
* GitHub Issue: #61