### PR TITLE
GH-43547: [R][CI] Add recheck workflow for checking reverse dependencies on GHA

### DIFF
--- a/dev/tasks/r/github.recheck.yml
+++ b/dev/tasks/r/github.recheck.yml
@@ -22,7 +22,7 @@
 jobs:
   recheck:
     name: Reverse check {{ which }} dependents
-    uses: r-devel/recheck/.github/workflows/recheck.yml@v1
+    uses: r-devel/recheck/.github/workflows/recheck.yml@9fe04de60ebeadd505b8d76223a346617ccca836
     with:
       which: {{ which }}
       subdirectory: r

--- a/dev/tasks/r/github.recheck.yml
+++ b/dev/tasks/r/github.recheck.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{% import 'macros.jinja' as macros with context %}
+
+{{ macros.github_header() }}
+
+jobs:
+  recheck:
+    name: Reverse check {{ which }} dependents
+    uses: amoeba/recheck/.github/workflows/recheck.yml@v1 # TODO: Point at recheck not amoeba before merging and pin to SHA
+    with:
+      which: {{ which }}
+      subdirectory: r
+      repository: {{ arrow.github_repo }}
+      ref: {{ arrow.branch }}

--- a/dev/tasks/r/github.recheck.yml
+++ b/dev/tasks/r/github.recheck.yml
@@ -22,7 +22,7 @@
 jobs:
   recheck:
     name: Reverse check {{ which }} dependents
-    uses: amoeba/recheck/.github/workflows/recheck.yml@v1 # TODO: Point at recheck not amoeba before merging and pin to SHA
+    uses: r-devel/recheck/.github/workflows/recheck.yml@v1
     with:
       which: {{ which }}
       subdirectory: r

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -89,6 +89,7 @@ groups:
   r:
     - test*-r-*
     - r-binary-packages
+    - r-recheck-most
 
   ruby:
     - test-*ruby*

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -897,6 +897,13 @@ tasks:
       - r-pkg__src__contrib__arrow_{no_rc_r_version}\.tar\.gz
 
 {% for which in ["strong", "most"] %}
+  # strong and most used here are defined by ?tools::package_dependencies as:
+  #
+  # strong: Depends, Imports, LinkingTo
+  # most: Depends, Imports, LinkingTo, Suggests
+  #
+  # So the key difference between strong and most is whether you want to expand
+  # the reverse dependency checking to Suggests (most) or not.
   r-recheck-{{which}}:
     ci: github
     template: r/github.recheck.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -895,6 +895,13 @@ tasks:
       - r-pkg__bin__macosx__big-sur-arm64__contrib__4.3__arrow_{no_rc_r_version}\.tgz
       - r-pkg__src__contrib__arrow_{no_rc_r_version}\.tar\.gz
 
+{% for which in ["strong", "most"] %}
+  r-recheck-{{which}}:
+    ci: github
+    template: r/github.recheck.yml
+    params:
+      which: {{which}}
+{% endfor %}
 
   ########################### Release verification ############################
 


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/issues/43547.

### What changes are included in this PR?

Adds two new new crossbow tasks for performing reverse dependency checking using https://github.com/r-devel/recheck: 

- `r-recheck-most` 
- `r-recheck-strong`

### Are these changes tested?

Yes. https://github.com/apache/arrow/pull/44523#issuecomment-2434122461.

### Are there any user-facing changes?

No.
* GitHub Issue: #43547

Fixes https://github.com/apache/arrow/issues/43547.