### PR TITLE
MINOR: [CI][C++][Python] Fix Cuda builds on git main

### DIFF
--- a/dev/tasks/docker-tests/github.cuda.yml
+++ b/dev/tasks/docker-tests/github.cuda.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ['self-hosted', 'cuda']
 {{ macros.github_set_env(env) }}
     timeout-minutes: {{ timeout|default(60) }}
+    env:
+      ARCHERY_USE_LEGACY_DOCKER_COMPOSE: 1
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=fetch_depth|default(1))|indent }}
       # python 3.8 is installed on the runner, no need to install
@@ -33,8 +35,6 @@ jobs:
         run: python -m pip install -e arrow/dev/archery[docker]
       - name: Execute Docker Build
         shell: bash
-        env:
-          ARCHERY_USE_LEGACY_DOCKER_COMPOSE: 1
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: |
           archery docker run \

--- a/dev/tasks/docker-tests/github.cuda.yml
+++ b/dev/tasks/docker-tests/github.cuda.yml
@@ -35,6 +35,7 @@ jobs:
         run: python -m pip install -e arrow/dev/archery[docker]
       - name: Execute Docker Build
         shell: bash
+        env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: |
           archery docker run \


### PR DESCRIPTION
On the Cuda self-hosted runners, we need to use legacy `docker-compose` on all Archery Docker invocations, including the "image push" step. This is because the Docker client version on those runners is too old to accept the `--file` option to the `compose` subcommand.

This is a followup to https://github.com/apache/arrow/pull/43586 . The image push step cannot easily be verified in a PR, hence this second PR.