### PR TITLE
GH-43693: [C++][Acero] Support AVX2 swiss join decoding

### DIFF
--- a/cpp/src/arrow/acero/hash_join_benchmark.cc
+++ b/cpp/src/arrow/acero/hash_join_benchmark.cc
@@ -686,9 +686,7 @@ void RowArrayDecodeBenchmark(benchmark::State& st, const std::shared_ptr<Schema>
     DCHECK_OK(rows.DecodeSelected(&column, column_to_decode,
                                   static_cast<int>(batch.length), row_ids_decode.data(),
                                   default_memory_pool()));
-    st.PauseTiming();
     total_rows += batch.length;
-    st.ResumeTiming();
   }
   st.counters["rows/sec"] = benchmark::Counter(total_rows, benchmark::Counter::kIsRate);
 }

--- a/cpp/src/arrow/acero/hash_join_benchmark.cc
+++ b/cpp/src/arrow/acero/hash_join_benchmark.cc
@@ -641,7 +641,7 @@ BENCHMARK_CAPTURE(BM_HashJoinBasic_ComplexResidualFilter, "Full Outer",
 
 BENCHMARK(BM_HashJoinBasic_HeavyBuildPayload)
     ->ArgNames({"HashTable krows"})
-    ->ArgsProduct({hashtable_krows});
+    ->ArgsProduct({benchmark::CreateRange(1, 512, 8)});
 #else
 
 BENCHMARK_CAPTURE(BM_HashJoinBasic_KeyTypes, "{int32}", {int32()})

--- a/cpp/src/arrow/acero/hash_join_benchmark.cc
+++ b/cpp/src/arrow/acero/hash_join_benchmark.cc
@@ -673,7 +673,12 @@ void RowArrayDecodeBenchmark(benchmark::State& st, const std::shared_ptr<Schema>
       static_cast<int>(batch.length), static_cast<int>(batch.length),
       row_ids_encode.data(), temp_column_arrays));
   std::vector<uint32_t> row_ids_decode(batch.length);
-  std::iota(row_ids_decode.begin(), row_ids_decode.end(), 0);
+  // Create a random access pattern to simulate hash join.
+  std::default_random_engine gen(42);
+  std::uniform_int_distribution<uint32_t> dist(0,
+                                               static_cast<uint32_t>(batch.length - 1));
+  std::transform(row_ids_decode.begin(), row_ids_decode.end(), row_ids_decode.begin(),
+                 [&](uint32_t) { return dist(gen); });
 
   uint64_t total_rows = 0;
   for (auto _ : st) {

--- a/cpp/src/arrow/acero/hash_join_benchmark.cc
+++ b/cpp/src/arrow/acero/hash_join_benchmark.cc
@@ -681,7 +681,8 @@ void RowArrayDecodeBenchmark(benchmark::State& st, const std::shared_ptr<Schema>
     ResizableArrayData column;
     // Allocate at least 8 rows for the convenience of SIMD decoding.
     int log_num_rows_min = std::max(3, bit_util::Log2(batch.length));
-    column.Init(batch[column_to_decode].type(), default_memory_pool(), log_num_rows_min);
+    DCHECK_OK(column.Init(batch[column_to_decode].type(), default_memory_pool(),
+                          log_num_rows_min));
     st.ResumeTiming();
     DCHECK_OK(rows.DecodeSelected(&column, column_to_decode,
                                   static_cast<int>(batch.length), row_ids_decode.data(),

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -318,7 +318,7 @@ void RowArray::DecodeFixedLength(ResizableArrayData* output, int output_start_ro
       RowArrayAccessor::Visit(
           rows_, column_id, num_rows_to_append, row_ids,
           [&](int i, const uint8_t* ptr, uint32_t num_bytes) {
-            output->mutable_data_as<uint64_t>(i)[output_start_row + i] =
+            output->mutable_data_as<uint64_t>(1)[output_start_row + i] =
                 *reinterpret_cast<const uint64_t*>(ptr);
           });
       break;

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -302,7 +302,7 @@ void RowArray::DecodeFixedLength(ResizableArrayData* output, int output_start_ro
       RowArrayAccessor::Visit(
           rows_, column_id, num_rows_to_append, row_ids,
           [&](int i, const uint8_t* ptr, uint32_t num_bytes) {
-            reinterpret_cast<uint16_t*>(output->mutable_data(1))[output_start_row + i] =
+            output->mutable_data_as<uint16_t>(1)[output_start_row + i] =
                 *reinterpret_cast<const uint16_t*>(ptr);
           });
       break;

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -310,7 +310,7 @@ void RowArray::DecodeFixedLength(ResizableArrayData* output, int output_start_ro
       RowArrayAccessor::Visit(
           rows_, column_id, num_rows_to_append, row_ids,
           [&](int i, const uint8_t* ptr, uint32_t num_bytes) {
-            reinterpret_cast<uint32_t*>(output->mutable_data(1))[output_start_row + i] =
+            output->mutable_data_as<uint32_t>(1)[output_start_row + i] =
                 *reinterpret_cast<const uint32_t*>(ptr);
           });
       break;
@@ -318,7 +318,7 @@ void RowArray::DecodeFixedLength(ResizableArrayData* output, int output_start_ro
       RowArrayAccessor::Visit(
           rows_, column_id, num_rows_to_append, row_ids,
           [&](int i, const uint8_t* ptr, uint32_t num_bytes) {
-            reinterpret_cast<uint64_t*>(output->mutable_data(1))[output_start_row + i] =
+            output->mutable_data_as<uint64_t>(i)[output_start_row + i] =
                 *reinterpret_cast<const uint64_t*>(ptr);
           });
       break;
@@ -342,8 +342,7 @@ void RowArray::DecodeFixedLength(ResizableArrayData* output, int output_start_ro
 void RowArray::DecodeOffsets(ResizableArrayData* output, int output_start_row,
                              int column_id, int num_rows_to_append,
                              const uint32_t* row_ids) const {
-  uint32_t* offsets =
-      reinterpret_cast<uint32_t*>(output->mutable_data(1)) + output_start_row;
+  uint32_t* offsets = output->mutable_data_as<uint32_t>(1) + output_start_row;
   uint32_t sum = (output_start_row == 0) ? 0 : offsets[0];
   RowArrayAccessor::Visit(
       rows_, column_id, num_rows_to_append, row_ids,
@@ -363,8 +362,8 @@ void RowArray::DecodeVarLength(ResizableArrayData* output, int output_start_row,
       rows_, column_id, num_rows_to_append, row_ids,
       [&](int i, const uint8_t* ptr, uint32_t num_bytes) {
         uint64_t* dst = reinterpret_cast<uint64_t*>(
-            output->mutable_data(2) + reinterpret_cast<const uint32_t*>(
-                                          output->mutable_data(1))[output_start_row + i]);
+            output->mutable_data(2) +
+            output->mutable_data_as<uint32_t>(1)[output_start_row + i]);
         const uint64_t* src = reinterpret_cast<const uint64_t*>(ptr);
         for (uint32_t word_id = 0;
              word_id < bit_util::CeilDiv(num_bytes, sizeof(uint64_t)); ++word_id) {

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -1812,9 +1812,9 @@ bool JoinMatchIterator::GetNextBatch(int num_rows_max, int* out_num_rows,
 
 namespace {
 
-// Given match_bitvector identifies that there is a match for row[batch_start_row + i]
-// in given input batch if bit match_bitvector[i] == passing_bit. Collect all the
-// passing row ids according to the given match_bitvector.
+// Given match_bitvector identifies that there is a match for row[batch_start_row + i] in
+// given input batch if bit match_bitvector[i] == passing_bit. Collect all the passing row
+// ids according to the given match_bitvector.
 //
 void CollectPassingBatchIds(int passing_bit, int64_t hardware_flags, int batch_start_row,
                             int num_batch_rows, const uint8_t* match_bitvector,
@@ -1941,8 +1941,8 @@ Status JoinResidualFilter::FilterLeftSemi(const ExecBatch& keypayload_batch,
   auto match_payload_ids_buf =
       arrow::util::TempVectorHolder<uint32_t>(temp_stack, minibatch_size_);
 
-  // Inner matching is necessary for non-trivial filter. Only until evaluating filter
-  // for all matches of the same row can we be sure that it's not passing (it could pass
+  // Inner matching is necessary for non-trivial filter. Only until evaluating filter for
+  // all matches of the same row can we be sure that it's not passing (it could pass
   // earlier though).
   //
   JoinMatchIterator match_iterator;

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -57,145 +57,149 @@ int RowArrayAccessor::VarbinaryColumnId(const RowTableMetadata& row_metadata,
   return varbinary_column_id;
 }
 
-int RowArrayAccessor::NumRowsToSkip(const RowTableImpl& rows, int column_id, int num_rows,
-                                    const uint32_t* row_ids, int num_tail_bytes_to_skip) {
-  uint32_t num_bytes_skipped = 0;
-  int num_rows_left = num_rows;
+// int RowArrayAccessor::NumRowsToSkip(const RowTableImpl& rows, int column_id, int
+// num_rows,
+//                                     const uint32_t* row_ids, int
+//                                     num_tail_bytes_to_skip) {
+//   uint32_t num_bytes_skipped = 0;
+//   int num_rows_left = num_rows;
 
-  bool is_fixed_length_column =
-      rows.metadata().column_metadatas[column_id].is_fixed_length;
+//   bool is_fixed_length_column =
+//       rows.metadata().column_metadatas[column_id].is_fixed_length;
 
-  if (!is_fixed_length_column) {
-    // Varying length column
-    //
-    int varbinary_column_id = VarbinaryColumnId(rows.metadata(), column_id);
+//   if (!is_fixed_length_column) {
+//     // Varying length column
+//     //
+//     int varbinary_column_id = VarbinaryColumnId(rows.metadata(), column_id);
 
-    while (num_rows_left > 0 &&
-           num_bytes_skipped < static_cast<uint32_t>(num_tail_bytes_to_skip)) {
-      // Find the pointer to the last requested row
-      //
-      uint32_t last_row_id = row_ids[num_rows_left - 1];
-      const uint8_t* row_ptr = rows.data(2) + rows.offsets()[last_row_id];
+//     while (num_rows_left > 0 &&
+//            num_bytes_skipped < static_cast<uint32_t>(num_tail_bytes_to_skip)) {
+//       // Find the pointer to the last requested row
+//       //
+//       uint32_t last_row_id = row_ids[num_rows_left - 1];
+//       const uint8_t* row_ptr = rows.data(2) + rows.offsets()[last_row_id];
 
-      // Find the length of the requested varying length field in that row
-      //
-      uint32_t field_offset_within_row, field_length;
-      if (varbinary_column_id == 0) {
-        rows.metadata().first_varbinary_offset_and_length(
-            row_ptr, &field_offset_within_row, &field_length);
-      } else {
-        rows.metadata().nth_varbinary_offset_and_length(
-            row_ptr, varbinary_column_id, &field_offset_within_row, &field_length);
-      }
+//       // Find the length of the requested varying length field in that row
+//       //
+//       uint32_t field_offset_within_row, field_length;
+//       if (varbinary_column_id == 0) {
+//         rows.metadata().first_varbinary_offset_and_length(
+//             row_ptr, &field_offset_within_row, &field_length);
+//       } else {
+//         rows.metadata().nth_varbinary_offset_and_length(
+//             row_ptr, varbinary_column_id, &field_offset_within_row, &field_length);
+//       }
 
-      num_bytes_skipped += field_length;
-      --num_rows_left;
-    }
-  } else {
-    // Fixed length column
-    //
-    uint32_t field_length = rows.metadata().column_metadatas[column_id].fixed_length;
-    uint32_t num_bytes_skipped = 0;
-    while (num_rows_left > 0 &&
-           num_bytes_skipped < static_cast<uint32_t>(num_tail_bytes_to_skip)) {
-      num_bytes_skipped += field_length;
-      --num_rows_left;
-    }
-  }
+//       num_bytes_skipped += field_length;
+//       --num_rows_left;
+//     }
+//   } else {
+//     // Fixed length column
+//     //
+//     uint32_t field_length = rows.metadata().column_metadatas[column_id].fixed_length;
+//     uint32_t num_bytes_skipped = 0;
+//     while (num_rows_left > 0 &&
+//            num_bytes_skipped < static_cast<uint32_t>(num_tail_bytes_to_skip)) {
+//       num_bytes_skipped += field_length;
+//       --num_rows_left;
+//     }
+//   }
 
-  return num_rows - num_rows_left;
-}
+//   return num_rows - num_rows_left;
+// }
 
-template <class PROCESS_VALUE_FN>
-void RowArrayAccessor::Visit(const RowTableImpl& rows, int column_id, int num_rows,
-                             const uint32_t* row_ids, PROCESS_VALUE_FN process_value_fn) {
-  bool is_fixed_length_column =
-      rows.metadata().column_metadatas[column_id].is_fixed_length;
+// template <class PROCESS_VALUE_FN>
+// void RowArrayAccessor::Visit(const RowTableImpl& rows, int column_id, int num_rows,
+//                              const uint32_t* row_ids, PROCESS_VALUE_FN
+//                              process_value_fn) {
+//   bool is_fixed_length_column =
+//       rows.metadata().column_metadatas[column_id].is_fixed_length;
 
-  // There are 4 cases, each requiring different steps:
-  // 1. Varying length column that is the first varying length column in a row
-  // 2. Varying length column that is not the first varying length column in a
-  // row
-  // 3. Fixed length column in a fixed length row
-  // 4. Fixed length column in a varying length row
+//   // There are 4 cases, each requiring different steps:
+//   // 1. Varying length column that is the first varying length column in a row
+//   // 2. Varying length column that is not the first varying length column in a
+//   // row
+//   // 3. Fixed length column in a fixed length row
+//   // 4. Fixed length column in a varying length row
 
-  if (!is_fixed_length_column) {
-    int varbinary_column_id = VarbinaryColumnId(rows.metadata(), column_id);
-    const uint8_t* row_ptr_base = rows.data(2);
-    const RowTableImpl::offset_type* row_offsets = rows.offsets();
-    uint32_t field_offset_within_row, field_length;
+//   if (!is_fixed_length_column) {
+//     int varbinary_column_id = VarbinaryColumnId(rows.metadata(), column_id);
+//     const uint8_t* row_ptr_base = rows.data(2);
+//     const RowTableImpl::offset_type* row_offsets = rows.offsets();
+//     uint32_t field_offset_within_row, field_length;
 
-    if (varbinary_column_id == 0) {
-      // Case 1: This is the first varbinary column
-      //
-      for (int i = 0; i < num_rows; ++i) {
-        uint32_t row_id = row_ids[i];
-        const uint8_t* row_ptr = row_ptr_base + row_offsets[row_id];
-        rows.metadata().first_varbinary_offset_and_length(
-            row_ptr, &field_offset_within_row, &field_length);
-        process_value_fn(i, row_ptr + field_offset_within_row, field_length);
-      }
-    } else {
-      // Case 2: This is second or later varbinary column
-      //
-      for (int i = 0; i < num_rows; ++i) {
-        uint32_t row_id = row_ids[i];
-        const uint8_t* row_ptr = row_ptr_base + row_offsets[row_id];
-        rows.metadata().nth_varbinary_offset_and_length(
-            row_ptr, varbinary_column_id, &field_offset_within_row, &field_length);
-        process_value_fn(i, row_ptr + field_offset_within_row, field_length);
-      }
-    }
-  }
+//     if (varbinary_column_id == 0) {
+//       // Case 1: This is the first varbinary column
+//       //
+//       for (int i = 0; i < num_rows; ++i) {
+//         uint32_t row_id = row_ids[i];
+//         const uint8_t* row_ptr = row_ptr_base + row_offsets[row_id];
+//         rows.metadata().first_varbinary_offset_and_length(
+//             row_ptr, &field_offset_within_row, &field_length);
+//         process_value_fn(i, row_ptr + field_offset_within_row, field_length);
+//       }
+//     } else {
+//       // Case 2: This is second or later varbinary column
+//       //
+//       for (int i = 0; i < num_rows; ++i) {
+//         uint32_t row_id = row_ids[i];
+//         const uint8_t* row_ptr = row_ptr_base + row_offsets[row_id];
+//         rows.metadata().nth_varbinary_offset_and_length(
+//             row_ptr, varbinary_column_id, &field_offset_within_row, &field_length);
+//         process_value_fn(i, row_ptr + field_offset_within_row, field_length);
+//       }
+//     }
+//   }
 
-  if (is_fixed_length_column) {
-    uint32_t field_offset_within_row = rows.metadata().encoded_field_offset(
-        rows.metadata().pos_after_encoding(column_id));
-    uint32_t field_length = rows.metadata().column_metadatas[column_id].fixed_length;
-    // Bit column is encoded as a single byte
-    //
-    if (field_length == 0) {
-      field_length = 1;
-    }
-    uint32_t row_length = rows.metadata().fixed_length;
+//   if (is_fixed_length_column) {
+//     uint32_t field_offset_within_row = rows.metadata().encoded_field_offset(
+//         rows.metadata().pos_after_encoding(column_id));
+//     uint32_t field_length = rows.metadata().column_metadatas[column_id].fixed_length;
+//     // Bit column is encoded as a single byte
+//     //
+//     if (field_length == 0) {
+//       field_length = 1;
+//     }
+//     uint32_t row_length = rows.metadata().fixed_length;
 
-    bool is_fixed_length_row = rows.metadata().is_fixed_length;
-    if (is_fixed_length_row) {
-      // Case 3: This is a fixed length column in a fixed length row
-      //
-      const uint8_t* row_ptr_base = rows.data(1) + field_offset_within_row;
-      for (int i = 0; i < num_rows; ++i) {
-        uint32_t row_id = row_ids[i];
-        const uint8_t* row_ptr = row_ptr_base + row_length * row_id;
-        process_value_fn(i, row_ptr, field_length);
-      }
-    } else {
-      // Case 4: This is a fixed length column in a varying length row
-      //
-      const uint8_t* row_ptr_base = rows.data(2) + field_offset_within_row;
-      const RowTableImpl::offset_type* row_offsets = rows.offsets();
-      for (int i = 0; i < num_rows; ++i) {
-        uint32_t row_id = row_ids[i];
-        const uint8_t* row_ptr = row_ptr_base + row_offsets[row_id];
-        process_value_fn(i, row_ptr, field_length);
-      }
-    }
-  }
-}
+//     bool is_fixed_length_row = rows.metadata().is_fixed_length;
+//     if (is_fixed_length_row) {
+//       // Case 3: This is a fixed length column in a fixed length row
+//       //
+//       const uint8_t* row_ptr_base = rows.data(1) + field_offset_within_row;
+//       for (int i = 0; i < num_rows; ++i) {
+//         uint32_t row_id = row_ids[i];
+//         const uint8_t* row_ptr = row_ptr_base + row_length * row_id;
+//         process_value_fn(i, row_ptr, field_length);
+//       }
+//     } else {
+//       // Case 4: This is a fixed length column in a varying length row
+//       //
+//       const uint8_t* row_ptr_base = rows.data(2) + field_offset_within_row;
+//       const RowTableImpl::offset_type* row_offsets = rows.offsets();
+//       for (int i = 0; i < num_rows; ++i) {
+//         uint32_t row_id = row_ids[i];
+//         const uint8_t* row_ptr = row_ptr_base + row_offsets[row_id];
+//         process_value_fn(i, row_ptr, field_length);
+//       }
+//     }
+//   }
+// }
 
-template <class PROCESS_VALUE_FN>
-void RowArrayAccessor::VisitNulls(const RowTableImpl& rows, int column_id, int num_rows,
-                                  const uint32_t* row_ids,
-                                  PROCESS_VALUE_FN process_value_fn) {
-  const uint8_t* null_masks = rows.null_masks();
-  uint32_t null_mask_num_bytes = rows.metadata().null_masks_bytes_per_row;
-  uint32_t pos_after_encoding = rows.metadata().pos_after_encoding(column_id);
-  for (int i = 0; i < num_rows; ++i) {
-    uint32_t row_id = row_ids[i];
-    int64_t bit_id = row_id * null_mask_num_bytes * 8 + pos_after_encoding;
-    process_value_fn(i, bit_util::GetBit(null_masks, bit_id) ? 0xff : 0);
-  }
-}
+// template <class PROCESS_VALUE_FN>
+// void RowArrayAccessor::VisitNulls(const RowTableImpl& rows, int column_id, int
+// num_rows,
+//                                   const uint32_t* row_ids,
+//                                   PROCESS_VALUE_FN process_value_fn) {
+//   const uint8_t* null_masks = rows.null_masks();
+//   uint32_t null_mask_num_bytes = rows.metadata().null_masks_bytes_per_row;
+//   uint32_t pos_after_encoding = rows.metadata().pos_after_encoding(column_id);
+//   for (int i = 0; i < num_rows; ++i) {
+//     uint32_t row_id = row_ids[i];
+//     int64_t bit_id = row_id * null_mask_num_bytes * 8 + pos_after_encoding;
+//     process_value_fn(i, bit_util::GetBit(null_masks, bit_id) ? 0xff : 0);
+//   }
+// }
 
 Status RowArray::InitIfNeeded(MemoryPool* pool, int64_t hardware_flags,
                               const RowTableMetadata& row_metadata) {
@@ -263,6 +267,21 @@ Status RowArray::DecodeSelected(ResizableArrayData* output, int column_id,
                                 int num_rows_to_append, const uint32_t* row_ids,
                                 MemoryPool* pool) const {
   int num_rows_before = output->num_rows();
+#ifdef ARROW_HAVE_RUNTIME_AVX2
+  // Preprocess some rows if necessary to assure that AVX2 version sees 8-row aligned
+  // output address.
+  if ((hardware_flags_ & arrow::internal::CpuInfo::AVX2) && (num_rows_before % 8 != 0)) {
+    int num_rows_to_preprocess = std::min(8 - num_rows_before % 8, num_rows_to_append);
+    RETURN_NOT_OK(
+        DecodeSelected(output, column_id, num_rows_to_preprocess, row_ids, pool));
+    return DecodeSelected(output, column_id, num_rows_to_append - num_rows_to_preprocess,
+                          row_ids + num_rows_to_preprocess, pool);
+  }
+
+  bool use_avx2 =
+      (hardware_flags_ & arrow::internal::CpuInfo::AVX2) && (num_rows_before % 8 == 0);
+#endif
+
   RETURN_NOT_OK(output->ResizeFixedLengthBuffers(num_rows_before + num_rows_to_append));
 
   // Both input (KeyRowArray) and output (ResizableArrayData) have buffers with
@@ -271,26 +290,17 @@ Status RowArray::DecodeSelected(ResizableArrayData* output, int column_id,
   //
 
   ARROW_ASSIGN_OR_RAISE(KeyColumnMetadata column_metadata, output->column_metadata());
-  int num_rows_processed = 0;
 
   if (column_metadata.is_fixed_length) {
     uint32_t fixed_length = column_metadata.fixed_length;
 
-#ifdef ARROW_HAVE_RUNTIME_AVX2
     // Process fixed length columns
     //
-    if (hardware_flags_ & arrow::internal::CpuInfo::AVX2) {
-      // Process some beginning rows to assure AVX2 version see 8-row aligned output
-      // address.
-      int num_rows_to_append_head = std::min(num_rows_to_append, 8 - num_rows_before % 8);
-      DecodeFixedLength(output, num_rows_before, column_id, fixed_length,
-                        num_rows_to_append_head, row_ids);
-      num_rows_processed =
-          num_rows_to_append_head +
-          DecodeFixedLength_avx2(output, num_rows_before + num_rows_to_append_head,
-                                 column_id, fixed_length,
-                                 num_rows_to_append - num_rows_to_append_head,
-                                 row_ids + num_rows_to_append_head);
+    int num_rows_processed = 0;
+#ifdef ARROW_HAVE_RUNTIME_AVX2
+    if (use_avx2) {
+      num_rows_processed = DecodeFixedLength_avx2(
+          output, num_rows_before, column_id, fixed_length, num_rows_to_append, row_ids);
     }
 #endif
     DecodeFixedLength(output, num_rows_before + num_rows_processed, column_id,
@@ -299,8 +309,9 @@ Status RowArray::DecodeSelected(ResizableArrayData* output, int column_id,
   } else {
     // Process offsets for varying length columns
     //
+    int num_rows_processed = 0;
 #ifdef ARROW_HAVE_RUNTIME_AVX2
-    if (hardware_flags_ & arrow::internal::CpuInfo::AVX2) {
+    if (use_avx2) {
       num_rows_processed = DecodeOffsets_avx2(output, num_rows_before, column_id,
                                               num_rows_to_append, row_ids);
     }
@@ -313,10 +324,9 @@ Status RowArray::DecodeSelected(ResizableArrayData* output, int column_id,
     // Process data for varying length columns
     //
 #ifdef ARROW_HAVE_RUNTIME_AVX2
-    if (hardware_flags_ & arrow::internal::CpuInfo::AVX2) {
-      int num_var_length_rows_processed = DecodeVarLength_avx2(
-          output, num_rows_before, column_id, num_rows_to_append, row_ids);
-      DCHECK_EQ(num_var_length_rows_processed, num_rows_processed);
+    if (use_avx2) {
+      num_rows_processed = DecodeVarLength_avx2(output, num_rows_before, column_id,
+                                                num_rows_to_append, row_ids);
     }
 #endif
     DecodeVarLength(output, num_rows_before + num_rows_processed, column_id,
@@ -324,13 +334,13 @@ Status RowArray::DecodeSelected(ResizableArrayData* output, int column_id,
                     row_ids + num_rows_processed);
   }
 
-// Process nulls
-//
+  // Process nulls
+  //
+  int num_rows_processed = 0;
 #ifdef ARROW_HAVE_RUNTIME_AVX2
-  if (hardware_flags_ & arrow::internal::CpuInfo::AVX2) {
-    int num_null_rows_processed =
+  if (use_avx2) {
+    num_rows_processed =
         DecodeNulls_avx2(output, num_rows_before, column_id, num_rows_to_append, row_ids);
-    DCHECK_EQ(num_null_rows_processed, num_rows_processed);
   }
 #endif
   DecodeNulls(output, num_rows_before + num_rows_processed, column_id,
@@ -1749,7 +1759,9 @@ Result<std::shared_ptr<ArrayData>> JoinResultMaterialize::FlushBuildColumn(
     const std::shared_ptr<DataType>& data_type, const RowArray* row_array, int column_id,
     uint32_t* row_ids) {
   ResizableArrayData output;
-  RETURN_NOT_OK(output.Init(data_type, pool_, bit_util::Log2(num_rows_)));
+  // Allocate at least 8 rows for the convenience of SIMD decoding.
+  int log_num_rows_min = std::max(3, bit_util::Log2(num_rows_));
+  RETURN_NOT_OK(output.Init(data_type, pool_, log_num_rows_min));
 
   for (size_t i = 0; i <= null_ranges_.size(); ++i) {
     int row_id_begin =
@@ -2329,9 +2341,11 @@ Result<ExecBatch> JoinResidualFilter::MaterializeFilterInput(
         build_schemas_->map(HashJoinProjection::FILTER, HashJoinProjection::PAYLOAD);
     for (int i = 0; i < num_build_cols; ++i) {
       ResizableArrayData column_data;
+      // Allocate at least 8 rows for the convenience of SIMD decoding.
+      int log_num_rows_min = std::max(3, bit_util::Log2(num_batch_rows));
       RETURN_NOT_OK(
           column_data.Init(build_schemas_->data_type(HashJoinProjection::FILTER, i),
-                           pool_, bit_util::Log2(num_batch_rows)));
+                           pool_, log_num_rows_min));
       if (auto idx = to_key.get(i); idx != SchemaProjectionMap::kMissingField) {
         RETURN_NOT_OK(build_keys_->DecodeSelected(&column_data, idx, num_batch_rows,
                                                   key_ids_maybe_null, pool_));

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -128,7 +128,10 @@ Status RowArray::DecodeSelected(ResizableArrayData* output, int column_id,
   // output address.
   if ((hardware_flags_ & arrow::internal::CpuInfo::AVX2) && (num_rows_before % 8 != 0) &&
       (num_rows_to_append >= 8)) {
-    int num_rows_to_preprocess = std::min(8 - num_rows_before % 8, num_rows_to_append);
+    int num_rows_to_preprocess = 8 - num_rows_before % 8;
+    // The output must have allocated enough rows to store this few number of preprocessed
+    // rows without costly resizing the internal buffers.
+    DCHECK_GE(output->num_rows_allocated(), num_rows_before + num_rows_to_preprocess);
     RETURN_NOT_OK(
         DecodeSelected(output, column_id, num_rows_to_preprocess, row_ids, pool));
     return DecodeSelected(output, column_id, num_rows_to_append - num_rows_to_preprocess,

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -329,6 +329,10 @@ void RowArray::DecodeFixedLength(ResizableArrayData* output, int output_start_ro
             uint64_t* dst = reinterpret_cast<uint64_t*>(
                 output->mutable_data(1) + num_bytes * (output_start_row + i));
             const uint64_t* src = reinterpret_cast<const uint64_t*>(ptr);
+            // Note that both `output` and `ptr` have been allocated with enough padding
+            // to accommodate the memory overshoot. See the allocations for
+            // `ResizableArrayData` in `JoinResultMaterialize` and `JoinResidualFilter`
+            // for `output`, and `RowTableImpl::kPaddingForVectors` for `ptr`.
             for (uint32_t word_id = 0;
                  word_id < bit_util::CeilDiv(num_bytes, sizeof(uint64_t)); ++word_id) {
               arrow::util::SafeStore<uint64_t>(dst + word_id,
@@ -365,6 +369,10 @@ void RowArray::DecodeVarLength(ResizableArrayData* output, int output_start_row,
             output->mutable_data(2) +
             output->mutable_data_as<uint32_t>(1)[output_start_row + i]);
         const uint64_t* src = reinterpret_cast<const uint64_t*>(ptr);
+        // Note that both `output` and `ptr` have been allocated with enough padding to
+        // accommodate the memory overshoot. See the allocations for `ResizableArrayData`
+        // in `JoinResultMaterialize` and `JoinResidualFilter` for `output`, and
+        // `RowTableImpl::kPaddingForVectors` for `ptr`.
         for (uint32_t word_id = 0;
              word_id < bit_util::CeilDiv(num_bytes, sizeof(uint64_t)); ++word_id) {
           arrow::util::SafeStore<uint64_t>(dst + word_id,

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -282,7 +282,8 @@ inline void Decode8FixedLength0_avx2(uint8_t* output, const uint8_t* row_ptr_bas
   // Extend to 64-bit.
   __m256i row_lo_64 = _mm256_cvtepi32_epi64(row_lo);
   __m256i row_hi_64 = _mm256_cvtepi32_epi64(row_hi);
-  // Keep the first 8 bits in each 64-bit row.
+  // Keep the first 8 bits in each 64-bit value, as the other bits belong
+  // to other columns.
   row_lo_64 = _mm256_and_si256(row_lo_64, _mm256_set1_epi64x(0xFF));
   row_hi_64 = _mm256_and_si256(row_hi_64, _mm256_set1_epi64x(0xFF));
   // If the 64-bit is zero, then we get 64 set bits.

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -286,10 +286,10 @@ inline void Decode8FixedLength0_avx2(uint8_t* output, const uint8_t* row_ptr_bas
   // to other columns.
   row_lo_64 = _mm256_and_si256(row_lo_64, _mm256_set1_epi64x(0xFF));
   row_hi_64 = _mm256_and_si256(row_hi_64, _mm256_set1_epi64x(0xFF));
-  // If the 64-bit is zero, then we get 64 set bits.
+  // If a 64-bit value is zero, then we get 64 set bits.
   __m256i is_zero_lo_64 = _mm256_cmpeq_epi64(row_lo_64, _mm256_setzero_si256());
   __m256i is_zero_hi_64 = _mm256_cmpeq_epi64(row_hi_64, _mm256_setzero_si256());
-  // 64 set bits to 8 set bits.
+  // 64 set bits per value to 8 set bits (one byte) per value.
   int is_zero_lo_8 = _mm256_movemask_epi8(is_zero_lo_64);
   int is_zero_hi_8 = _mm256_movemask_epi8(is_zero_hi_64);
   // 8 set bits to 1 set bit.

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -252,6 +252,8 @@ int RowArrayAccessor::VisitNulls_avx2(const RowTableImpl& rows, int column_id,
                                            _mm256_srli_epi32(bit_id, 3), 1);
     __m256i bit_in_word = _mm256_sllv_epi32(
         _mm256_set1_epi32(1), _mm256_and_si256(bit_id, _mm256_set1_epi32(7)));
+    // `result` will contain one 32-bit word per tested null bit,
+    // either 0xffffffff if the null bit was set or 0 if it was unset.
     __m256i result =
         _mm256_cmpeq_epi32(_mm256_and_si256(bytes, bit_in_word), bit_in_word);
     // NB: Be careful about sign-extension when casting the return value of

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -311,7 +311,7 @@ inline void Decode8FixedLength1_avx2(uint8_t* output, const uint8_t* row_ptr_bas
   const __m256i shuffle_const =
       _mm256_setr_epi64x(kByteSequence_0_4_8_12, -1, kByteSequence_0_4_8_12, -1);
   row = _mm256_shuffle_epi8(row, shuffle_const);
-  // Get the lower 32-bits (4 8-bit rows) from each 128-bit lane.
+  // Get the lower 32-bits (4 8-bit values) from each 128-bit lane.
   // NB: Be careful about sign-extension when casting the return value of
   // _mm256_extract_epi32 (signed 32-bit) to unsigned 64-bit, which will pollute the
   // higher bits of the following OR.

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -300,12 +300,12 @@ inline void Decode8FixedLength0_avx2(uint8_t* output, const uint8_t* row_ptr_bas
 
 inline void Decode8FixedLength1_avx2(uint8_t* output, const uint8_t* row_ptr_base,
                                      __m256i offset_lo, __m256i offset_hi) {
-  // Gather the lower/higher 4 32-bit (only lower 8 bits interesting) rows based on the
+  // Gather the lower/higher 4 32-bit (only lower 8 bits interesting) values based on the
   // lower/higher 4 64-bit row offsets.
   __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
   __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);
   __m256i row = _mm256_set_m128i(row_hi, row_lo);
-  // Shuffle the lower 8 bits of each 32-bit rows to the lower 32 bits of each 128-bit
+  // Shuffle the lower 8 bits of each 32-bit values to the lower 32 bits of each 128-bit
   // lane.
   constexpr uint64_t kByteSequence_0_4_8_12 = 0x0c080400ULL;
   const __m256i shuffle_const =
@@ -322,12 +322,12 @@ inline void Decode8FixedLength1_avx2(uint8_t* output, const uint8_t* row_ptr_bas
 
 inline void Decode8FixedLength2_avx2(uint16_t* output, const uint8_t* row_ptr_base,
                                      __m256i offset_lo, __m256i offset_hi) {
-  // Gather the lower/higher 4 32-bit (only lower 16 bits interesting) rows based on the
+  // Gather the lower/higher 4 32-bit (only lower 16 bits interesting) values based on the
   // lower/higher 4 64-bit row offsets.
   __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
   __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);
   __m256i row = _mm256_set_m128i(row_hi, row_lo);
-  // Shuffle the lower 16 bits of each 32-bit rows to the lower 64 bits of each 128-bit
+  // Shuffle the lower 16 bits of each 32-bit values to the lower 64 bits of each 128-bit
   // lane.
   constexpr uint64_t kByteSequence_0_1_4_5_8_9_12_13 = 0x0d0c090805040100ULL;
   const __m256i shuffle_const = _mm256_setr_epi64x(kByteSequence_0_1_4_5_8_9_12_13, -1,
@@ -340,7 +340,8 @@ inline void Decode8FixedLength2_avx2(uint16_t* output, const uint8_t* row_ptr_ba
 
 inline void Decode8FixedLength4_avx2(uint32_t* output, const uint8_t* row_ptr_base,
                                      __m256i offset_lo, __m256i offset_hi) {
-  // Gather the lower/higher 4 32-bit rows based on the lower/higher 4 64-bit row offsets.
+  // Gather the lower/higher 4 32-bit values based on the lower/higher 4 64-bit row
+  // offsets.
   __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
   __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);
   __m256i row = _mm256_set_m128i(row_hi, row_lo);
@@ -351,7 +352,8 @@ inline void Decode8FixedLength8_avx2(uint64_t* output, const uint8_t* row_ptr_ba
                                      __m256i offset_lo, __m256i offset_hi) {
   auto row_ptr_base_i64 =
       reinterpret_cast<const arrow::util::int64_for_gather_t*>(row_ptr_base);
-  // Gather the lower/higher 4 64-bit rows based on the lower/higher 4 64-bit row offsets.
+  // Gather the lower/higher 4 64-bit values based on the lower/higher 4 64-bit row
+  // offsets.
   __m256i row_lo = _mm256_i64gather_epi64(row_ptr_base_i64, offset_lo, 1);
   __m256i row_hi = _mm256_i64gather_epi64(row_ptr_base_i64, offset_hi, 1);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(output), row_lo);

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -445,9 +445,8 @@ int RowArray::DecodeFixedLength_avx2(ResizableArrayData* output, int output_star
           [&](int i, const uint8_t* row_ptr_base, __m256i offset_lo, __m256i offset_hi,
               __m256i num_bytes) {
             Decode8FixedLength2_avx2(
-                reinterpret_cast<uint16_t*>(output->mutable_data(1)) + output_start_row +
-                    i,
-                row_ptr_base, offset_lo, offset_hi);
+                output->mutable_data_as<uint16_t>(1) + output_start_row + i, row_ptr_base,
+                offset_lo, offset_hi);
           });
       break;
     case 4:
@@ -456,9 +455,8 @@ int RowArray::DecodeFixedLength_avx2(ResizableArrayData* output, int output_star
           [&](int i, const uint8_t* row_ptr_base, __m256i offset_lo, __m256i offset_hi,
               __m256i num_bytes) {
             Decode8FixedLength4_avx2(
-                reinterpret_cast<uint32_t*>(output->mutable_data(1)) + output_start_row +
-                    i,
-                row_ptr_base, offset_lo, offset_hi);
+                output->mutable_data_as<uint32_t>(1) + output_start_row + i, row_ptr_base,
+                offset_lo, offset_hi);
           });
       break;
     case 8:
@@ -467,9 +465,8 @@ int RowArray::DecodeFixedLength_avx2(ResizableArrayData* output, int output_star
           [&](int i, const uint8_t* row_ptr_base, __m256i offset_lo, __m256i offset_hi,
               __m256i num_bytes) {
             Decode8FixedLength8_avx2(
-                reinterpret_cast<uint64_t*>(output->mutable_data(1)) + output_start_row +
-                    i,
-                row_ptr_base, offset_lo, offset_hi);
+                output->mutable_data_as<uint64_t>(1) + output_start_row + i, row_ptr_base,
+                offset_lo, offset_hi);
           });
       break;
     default:
@@ -489,8 +486,7 @@ int RowArray::DecodeFixedLength_avx2(ResizableArrayData* output, int output_star
 int RowArray::DecodeOffsets_avx2(ResizableArrayData* output, int output_start_row,
                                  int column_id, int num_rows_to_append,
                                  const uint32_t* row_ids) const {
-  uint32_t* offsets =
-      reinterpret_cast<uint32_t*>(output->mutable_data(1)) + output_start_row;
+  uint32_t* offsets = output->mutable_data_as<uint32_t>(1) + output_start_row;
   uint32_t current_length = (output_start_row == 0) ? 0 : offsets[0];
   int num_rows_processed = RowArrayAccessor::Visit_avx2(
       rows_, column_id, num_rows_to_append, row_ids,
@@ -505,14 +501,13 @@ int RowArray::DecodeOffsets_avx2(ResizableArrayData* output, int output_start_ro
 int RowArray::DecodeVarLength_avx2(ResizableArrayData* output, int output_start_row,
                                    int column_id, int num_rows_to_append,
                                    const uint32_t* row_ids) const {
-  RowArrayAccessor::Visit(rows_, column_id, num_rows_to_append, row_ids,
-                          [&](int i, const uint8_t* row_ptr, uint32_t num_bytes) {
-                            uint8_t* dst =
-                                output->mutable_data(2) +
-                                reinterpret_cast<const uint32_t*>(
-                                    output->mutable_data(1))[output_start_row + i];
-                            Decode1_avx2(dst, row_ptr, num_bytes);
-                          });
+  RowArrayAccessor::Visit(
+      rows_, column_id, num_rows_to_append, row_ids,
+      [&](int i, const uint8_t* row_ptr, uint32_t num_bytes) {
+        uint8_t* dst = output->mutable_data(2) +
+                       output->mutable_data_as<uint32_t>(1)[output_start_row + i];
+        Decode1_avx2(dst, row_ptr, num_bytes);
+      });
   return num_rows_to_append;
 }
 

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -252,8 +252,8 @@ int RowArrayAccessor::VisitNulls_avx2(const RowTableImpl& rows, int column_id,
                                            _mm256_srli_epi32(bit_id, 3), 1);
     __m256i bit_in_word = _mm256_sllv_epi32(
         _mm256_set1_epi32(1), _mm256_and_si256(bit_id, _mm256_set1_epi32(7)));
-    // `result` will contain one 32-bit word per tested null bit,
-    // either 0xffffffff if the null bit was set or 0 if it was unset.
+    // `result` will contain one 32-bit word per tested null bit, either 0xffffffff if the
+    // null bit was set or 0 if it was unset.
     __m256i result =
         _mm256_cmpeq_epi32(_mm256_and_si256(bytes, bit_in_word), bit_in_word);
     // NB: Be careful about sign-extension when casting the return value of
@@ -282,8 +282,8 @@ inline void Decode8FixedLength0_avx2(uint8_t* output, const uint8_t* row_ptr_bas
   // Extend to 64-bit.
   __m256i row_lo_64 = _mm256_cvtepi32_epi64(row_lo);
   __m256i row_hi_64 = _mm256_cvtepi32_epi64(row_hi);
-  // Keep the first 8 bits in each 64-bit value, as the other bits belong
-  // to other columns.
+  // Keep the first 8 bits in each 64-bit value, as the other bits belong to other
+  // columns.
   row_lo_64 = _mm256_and_si256(row_lo_64, _mm256_set1_epi64x(0xFF));
   row_hi_64 = _mm256_and_si256(row_hi_64, _mm256_set1_epi64x(0xFF));
   // If a 64-bit value is zero, then we get 64 set bits.

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -377,7 +377,7 @@ inline uint32_t Decode8Offset_avx2(uint32_t* output, uint32_t current_length,
   uint32_t num_bytes_last = static_cast<uint32_t>(_mm256_extract_epi32(num_bytes, 7));
   // Init every offset with the current length.
   __m256i offsets = _mm256_set1_epi32(current_length);
-  // We keep right-shifting the length and accumulate the offset by adding the length.
+  // We keep left-shifting the length and accumulate the offset by adding the length.
   __m256i length =
       _mm256_permutevar8x32_epi32(num_bytes, _mm256_setr_epi32(7, 0, 1, 2, 3, 4, 5, 6));
   length = _mm256_insert_epi32(length, 0, 0);

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -426,6 +426,7 @@ int RowArray::DecodeFixedLength_avx2(ResizableArrayData* output, int output_star
           rows_, column_id, num_rows_to_append, row_ids,
           [&](int i, const uint8_t* row_ptr_base, __m256i offset_lo, __m256i offset_hi,
               __m256i num_bytes) {
+            DCHECK_EQ(i % 8, 0);
             Decode8FixedLength0_avx2(output->mutable_data(1) + (output_start_row + i) / 8,
                                      row_ptr_base, offset_lo, offset_hi);
           });
@@ -518,6 +519,7 @@ int RowArray::DecodeNulls_avx2(ResizableArrayData* output, int output_start_row,
 
   return RowArrayAccessor::VisitNulls_avx2(
       rows_, column_id, num_rows_to_append, row_ids, [&](int i, uint64_t null_bytes) {
+        DCHECK_EQ(i % 8, 0);
         Decode8Null_avx2(output->mutable_data(0) + (output_start_row + i) / 8,
                          null_bytes);
       });

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -36,8 +36,6 @@ int RowArrayAccessor::Visit_avx2(const RowTableImpl& rows, int column_id, int nu
 
   bool is_fixed_length_column =
       rows.metadata().column_metadatas[column_id].is_fixed_length;
-  auto offsets_right_i64 =
-      reinterpret_cast<const arrow::util::int64_for_gather_t*>(offsets_right);
 
   // There are 4 cases, each requiring different steps:
   // 1. Varying length column that is the first varying length column in a row
@@ -50,6 +48,8 @@ int RowArrayAccessor::Visit_avx2(const RowTableImpl& rows, int column_id, int nu
     int varbinary_column_id = VarbinaryColumnId(rows.metadata(), column_id);
     const uint8_t* row_ptr_base = rows.data(2);
     const RowTableImpl::offset_type* row_offsets = rows.offsets();
+    auto row_offsets_i64 =
+        reinterpret_cast<const arrow::util::int64_for_gather_t*>(row_offsets);
     static_assert(
         sizeof(RowTableImpl::offset_type) == sizeof(int64_t),
         "RowArrayAccessor::Visit_avx2 only supports 64-bit RowTableImpl::offset_type");
@@ -201,6 +201,8 @@ int RowArrayAccessor::Visit_avx2(const RowTableImpl& rows, int column_id, int nu
       //
       const uint8_t* row_ptr_base = rows.data(2);
       const RowTableImpl::offset_type* row_offsets = rows.offsets();
+      auto row_offsets_i64 =
+          reinterpret_cast<const arrow::util::int64_for_gather_t*>(row_offsets);
       for (int i = 0; i < num_rows / unroll; ++i) {
         // Load 8 32-bit row ids.
         __m256i row_id =

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -279,7 +279,7 @@ inline void Decode8FixedLength0_avx2(uint8_t* output, const uint8_t* row_ptr_bas
   // Keep the first 8 bits in each 64-bit row.
   row_lo_64 = _mm256_and_si256(row_lo_64, _mm256_set1_epi64x(0xFF));
   row_hi_64 = _mm256_and_si256(row_hi_64, _mm256_set1_epi64x(0xFF));
-  // If the 64-bit is zero, then we get 64 st bits.
+  // If the 64-bit is zero, then we get 64 set bits.
   __m256i is_zero_lo_64 = _mm256_cmpeq_epi64(row_lo_64, _mm256_setzero_si256());
   __m256i is_zero_hi_64 = _mm256_cmpeq_epi64(row_hi_64, _mm256_setzero_si256());
   // 64 set bits to 8 set bits.

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -381,6 +381,12 @@ inline uint32_t Decode8Offset_avx2(uint32_t* output, uint32_t current_length,
   __m256i length =
       _mm256_permutevar8x32_epi32(num_bytes, _mm256_setr_epi32(7, 0, 1, 2, 3, 4, 5, 6));
   length = _mm256_insert_epi32(length, 0, 0);
+  // `length` is now a sequence of 32-bit words such as:
+  //   - length[0] = 0
+  //   - length[1] = num_bytes[0]
+  //   ...
+  //   - length[7] = num_bytes[6]
+  // (note that num_bytes[7] is kept in `num_bytes_last`)
   for (int i = 0; i < 7; ++i) {
     offsets = _mm256_add_epi32(offsets, length);
     length =

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -277,8 +277,10 @@ inline void Decode8FixedLength0_avx2(uint8_t* output, const uint8_t* row_ptr_bas
                                      __m256i offset_lo, __m256i offset_hi) {
   // Gather the lower/higher 4 32-bit (only lower 1 bit interesting) values based on the
   // lower/higher 4 64-bit row offsets.
-  __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
-  __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);
+  __m128i row_lo =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_lo, 1);
+  __m128i row_hi =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_hi, 1);
   // Extend to 64-bit.
   __m256i row_lo_64 = _mm256_cvtepi32_epi64(row_lo);
   __m256i row_hi_64 = _mm256_cvtepi32_epi64(row_hi);
@@ -302,8 +304,10 @@ inline void Decode8FixedLength1_avx2(uint8_t* output, const uint8_t* row_ptr_bas
                                      __m256i offset_lo, __m256i offset_hi) {
   // Gather the lower/higher 4 32-bit (only lower 8 bits interesting) values based on the
   // lower/higher 4 64-bit row offsets.
-  __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
-  __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);
+  __m128i row_lo =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_lo, 1);
+  __m128i row_hi =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_hi, 1);
   __m256i row = _mm256_set_m128i(row_hi, row_lo);
   // Shuffle the lower 8 bits of each 32-bit values to the lower 32 bits of each 128-bit
   // lane.
@@ -324,8 +328,10 @@ inline void Decode8FixedLength2_avx2(uint16_t* output, const uint8_t* row_ptr_ba
                                      __m256i offset_lo, __m256i offset_hi) {
   // Gather the lower/higher 4 32-bit (only lower 16 bits interesting) values based on the
   // lower/higher 4 64-bit row offsets.
-  __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
-  __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);
+  __m128i row_lo =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_lo, 1);
+  __m128i row_hi =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_hi, 1);
   __m256i row = _mm256_set_m128i(row_hi, row_lo);
   // Shuffle the lower 16 bits of each 32-bit values to the lower 64 bits of each 128-bit
   // lane.
@@ -344,8 +350,10 @@ inline void Decode8FixedLength4_avx2(uint32_t* output, const uint8_t* row_ptr_ba
                                      __m256i offset_lo, __m256i offset_hi) {
   // Gather the lower/higher 4 32-bit values based on the lower/higher 4 64-bit row
   // offsets.
-  __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
-  __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);
+  __m128i row_lo =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_lo, 1);
+  __m128i row_hi =
+      _mm256_i64gather_epi32(reinterpret_cast<const int*>(row_ptr_base), offset_hi, 1);
   __m256i row = _mm256_set_m128i(row_hi, row_lo);
   _mm256_storeu_si256(reinterpret_cast<__m256i*>(output), row);
 }

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -333,8 +333,8 @@ inline void Decode8FixedLength2_avx2(uint16_t* output, const uint8_t* row_ptr_ba
   const __m256i shuffle_const = _mm256_setr_epi64x(kByteSequence_0_1_4_5_8_9_12_13, -1,
                                                    kByteSequence_0_1_4_5_8_9_12_13, -1);
   row = _mm256_shuffle_epi8(row, shuffle_const);
-  // Swap the second and the third 64-bit lane, so that all
-  // 16-bit values end up in the lower half of `row`.
+  // Swap the second and the third 64-bit lane, so that all 16-bit values end up in the
+  // lower half of `row`.
   // (0xd8 = 0b 11 01 10 00)
   row = _mm256_permute4x64_epi64(row, 0xd8);
   _mm_storeu_si128(reinterpret_cast<__m128i*>(output), _mm256_castsi256_si128(row));

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -275,7 +275,7 @@ namespace {
 
 inline void Decode8FixedLength0_avx2(uint8_t* output, const uint8_t* row_ptr_base,
                                      __m256i offset_lo, __m256i offset_hi) {
-  // Gather the lower/higher 4 32-bit (only lower 8 bits interesting) rows based on the
+  // Gather the lower/higher 4 32-bit (only lower 1 bit interesting) values based on the
   // lower/higher 4 64-bit row offsets.
   __m128i row_lo = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_lo, 1);
   __m128i row_hi = _mm256_i64gather_epi32((const int*)row_ptr_base, offset_hi, 1);

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -333,7 +333,9 @@ inline void Decode8FixedLength2_avx2(uint16_t* output, const uint8_t* row_ptr_ba
   const __m256i shuffle_const = _mm256_setr_epi64x(kByteSequence_0_1_4_5_8_9_12_13, -1,
                                                    kByteSequence_0_1_4_5_8_9_12_13, -1);
   row = _mm256_shuffle_epi8(row, shuffle_const);
-  // Swap the second and the third 64-bit lane.
+  // Swap the second and the third 64-bit lane, so that all
+  // 16-bit values end up in the lower half of `row`.
+  // (0xd8 = 0b 11 01 10 00)
   row = _mm256_permute4x64_epi64(row, 0xd8);
   _mm_storeu_si128(reinterpret_cast<__m128i*>(output), _mm256_castsi256_si128(row));
 }

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -396,20 +396,6 @@ int RowArray::DecodeFixedLength_avx2(ResizableArrayData* output, int output_star
                                      int column_id, uint32_t fixed_length,
                                      int num_rows_to_append,
                                      const uint32_t* row_ids) const {
-  // Benchmarking shows that when the data element width is <= 8, the scalar code almost
-  // always outperforms the vectorized code - about 2X~3X faster when the whole data set
-  // falls into L1~LLC, and the ratio goes down to about 1:1 as the data size increases
-  // when most of the accesses hit the main memory. This is possibly because that decoding
-  // is mostly copying scattered pieces of data and there is not enough computation to pay
-  // off the cost of the heavy gather instructions.
-  // For fixed length 0 (boolean column), the vectorized code wins by batching 8 bits into
-  // a single byte instead of modifying the same byte 8 times in the scalar code.
-  if (!(fixed_length == 0 || fixed_length > 8)) {
-    DecodeFixedLength(output, output_start_row, column_id, fixed_length,
-                      num_rows_to_append, row_ids);
-    return num_rows_to_append;
-  }
-
   DCHECK_EQ(output_start_row % 8, 0);
 
   int num_rows_processed = 0;
@@ -482,10 +468,6 @@ int RowArray::DecodeFixedLength_avx2(ResizableArrayData* output, int output_star
 int RowArray::DecodeOffsets_avx2(ResizableArrayData* output, int output_start_row,
                                  int column_id, int num_rows_to_append,
                                  const uint32_t* row_ids) const {
-  // Same reason as DecodeFixedLength_avx2.
-  DecodeOffsets(output, output_start_row, column_id, num_rows_to_append, row_ids);
-  return num_rows_to_append;
-
   uint32_t* offsets =
       reinterpret_cast<uint32_t*>(output->mutable_data(1)) + output_start_row;
   uint32_t current_length = (output_start_row == 0) ? 0 : offsets[0];

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -372,6 +372,10 @@ inline void Decode8FixedLength8_avx2(uint64_t* output, const uint8_t* row_ptr_ba
 
 inline void Decode1_avx2(uint8_t* output, const uint8_t* row_ptr, uint32_t num_bytes) {
   // Copy 32 bytes at a time.
+  // Note that both `output` and `row_ptr` have been allocated with enough padding to
+  // accommodate the memory overshoot. See the allocations for `ResizableArrayData` in
+  // `JoinResultMaterialize` and `JoinResidualFilter` for `output`, and
+  // `RowTableImpl::kPaddingForVectors` for `row_ptr`.
   __m256i* output_i256 = reinterpret_cast<__m256i*>(output);
   const __m256i* row_ptr_i256 = reinterpret_cast<const __m256i*>(row_ptr);
   for (int istripe = 0; istripe < bit_util::CeilDiv(num_bytes, 32); ++istripe) {

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -80,7 +80,6 @@ class RowArrayAccessor {
   static void VisitNulls(const RowTableImpl& rows, int column_id, int num_rows,
                          const uint32_t* row_ids, PROCESS_VALUE_FN process_value_fn);
 
- private:
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
   // This is equivalent to Visit method, but processing 8 rows at a time in a
   // loop.
@@ -149,15 +148,16 @@ struct RowArray {
   RowTableImpl rows_temp_;
 
  private:
-  int DecodeFixedLength(ResizableArrayData* output, int output_start_row, int column_id,
+  void DecodeFixedLength(ResizableArrayData* output, int output_start_row, int column_id,
                         uint32_t fixed_length, int num_rows_to_append,
                         const uint32_t* row_ids) const;
-  int DecodeOffsets(ResizableArrayData* output, int output_start_row, int column_id,
+  void DecodeOffsets(ResizableArrayData* output, int output_start_row, int column_id,
                     int num_rows_to_append, const uint32_t* row_ids) const;
-  int DecodeVarLength(ResizableArrayData* output, int output_start_row, int column_id,
+  void DecodeVarLength(ResizableArrayData* output, int output_start_row, int column_id,
                       int num_rows_to_append, const uint32_t* row_ids) const;
-  int DecodeNulls(ResizableArrayData* output, int output_start_row, int column_id,
+  void DecodeNulls(ResizableArrayData* output, int output_start_row, int column_id,
                   int num_rows_to_append, const uint32_t* row_ids) const;
+
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
   int DecodeFixedLength_avx2(ResizableArrayData* output, int output_start_row,
                              int column_id, uint32_t fixed_length, int num_rows_to_append,

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -149,19 +149,26 @@ struct RowArray {
   RowTableImpl rows_temp_;
 
  private:
+  int DecodeFixedLength(ResizableArrayData* output, int output_start_row, int column_id,
+                        uint32_t fixed_length, int num_rows_to_append,
+                        const uint32_t* row_ids) const;
+  int DecodeOffsets(ResizableArrayData* output, int output_start_row, int column_id,
+                    int num_rows_to_append, const uint32_t* row_ids) const;
+  int DecodeVarLength(ResizableArrayData* output, int output_start_row, int column_id,
+                      int num_rows_to_append, const uint32_t* row_ids) const;
+  int DecodeNulls(ResizableArrayData* output, int output_start_row, int column_id,
+                  int num_rows_to_append, const uint32_t* row_ids) const;
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-  int DecodeFixedLength_avx2(ResizableArrayData* target, int column_id,
-                             int num_rows_to_append, const uint32_t* row_ids,
-                             MemoryPool* pool) const;
-  int DecodeOffsets_avx2(ResizableArrayData* target, int column_id,
-                         int num_rows_to_append, const uint32_t* row_ids,
-                         MemoryPool* pool) const;
-  Status DecodeVarLength_avx2(ResizableArrayData* target, int column_id,
-                              int num_rows_to_append, const uint32_t* row_ids,
-                              MemoryPool* pool) const;
-  Status DecodeNulls_avx2(ResizableArrayData* target, int column_id,
-                          int num_rows_to_append, const uint32_t* row_ids,
-                          MemoryPool* pool) const;
+  int DecodeFixedLength_avx2(ResizableArrayData* output, int output_start_row,
+                             int column_id, uint32_t fixed_length, int num_rows_to_append,
+                             const uint32_t* row_ids) const;
+  int DecodeOffsets_avx2(ResizableArrayData* output, int output_start_row, int column_id,
+                         int num_rows_to_append, const uint32_t* row_ids) const;
+  int DecodeVarLength_avx2(ResizableArrayData* output, int output_start_row,
+                           int column_id, int num_rows_to_append,
+                           const uint32_t* row_ids) const;
+  int DecodeNulls_avx2(ResizableArrayData* output, int output_start_row, int column_id,
+                       int num_rows_to_append, const uint32_t* row_ids) const;
 #endif
 
   friend class RowArrayMerge;

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -48,16 +48,6 @@ class RowArrayAccessor {
   //
   static int VarbinaryColumnId(const RowTableMetadata& row_metadata, int column_id);
 
-  // Calculate how many rows to skip from the tail of the
-  // sequence of selected rows, such that the total size of skipped rows is at
-  // least equal to the size specified by the caller. Skipping of the tail rows
-  // is used to allow for faster processing by the caller of remaining rows
-  // without checking buffer bounds (useful with SIMD or fixed size memory loads
-  // and stores).
-  //
-  // static int NumRowsToSkip(const RowTableImpl& rows, int column_id, int num_rows,
-  //                          const uint32_t* row_ids, int num_tail_bytes_to_skip);
-
   // The supplied lambda will be called for each row in the given list of rows.
   // The arguments given to it will be:
   // - index of a row (within the set of selected rows),

--- a/cpp/src/arrow/compute/light_array_internal.h
+++ b/cpp/src/arrow/compute/light_array_internal.h
@@ -350,6 +350,11 @@ class ARROW_EXPORT ResizableArrayData {
   /// length binary data
   uint8_t* mutable_data(int i) { return buffers_[i]->mutable_data(); }
 
+  template <typename T>
+  T* mutable_data_as(int i) {
+    return reinterpret_cast<T*>(mutable_data(i));
+  }
+
  private:
   static constexpr int64_t kNumPaddingBytes = 64;
   int log_num_rows_min_;

--- a/cpp/src/arrow/compute/light_array_internal.h
+++ b/cpp/src/arrow/compute/light_array_internal.h
@@ -319,6 +319,9 @@ class ARROW_EXPORT ResizableArrayData {
   /// \brief The current length (in rows) of the array
   int num_rows() const { return num_rows_; }
 
+  /// \brief The current allocated length (in rows) of the array
+  int num_rows_allocated() const { return num_rows_allocated_; }
+
   /// \brief A non-owning view into this array
   KeyColumnArray column_array() const;
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

You can find the background in #43693.

By looking at how `Visit_avx2/VisitNulls_avx2`'s non-simd counterparts (`Visit/VisitNulls`) are used, I found they are solely for decoding rows from the build side of the join. So I added AVX2 versions for those decoding methods and wired `Visit_avx2/VisitNulls_avx2`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Split the decoding methods into smaller pieces to make each of them able to cooperate with the AVX2 version.
2. Concrete AVX2 specialized functions utilizing the `Visit*_avx2` functions to decode fixed-length/offsets/var-length/nulls of the row table.
3. Fix some bugs in the original `Visit*_avx2` functions.
4. Related benchmarks.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

No new tests needed.

The benchmarking result is a bit complicated, I put them in comment https://github.com/apache/arrow/pull/43832#issuecomment-2328206421.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No changes other than positive performance improvement. Users can expect such improvement for hash joins related workload. Nevertheless the improvement degree highly depends on not only the workload, but also the CPU models. For Intel CPUs from Skylake to Icelake/Tigerlake, which suffer the performance degradation of AVX2 gather because of an vulnerability mitigation of Intel's (detailed in https://github.com/apache/arrow/pull/43832#issuecomment-2326646353), the improvement is less significant - single digit percent. Other models, e.g. AMD, and the most recent Intel, can achieve better improvement up to 30%.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43693