### PR TITLE
GH-43790: [Go][Parquet] Add support for LZ4_RAW compression codec

### DIFF
--- a/go/parquet/compress/compress.go
+++ b/go/parquet/compress/compress.go
@@ -20,14 +20,11 @@ package compress
 
 import (
 	"compress/flate"
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/apache/arrow/go/v18/parquet/internal/gen-go/parquet"
 )
-
-var ErrUnsupportedCodec = errors.New("compress: unsupported codec")
 
 // Compression is an alias to the thrift compression codec enum type for easy use
 type Compression parquet.CompressionCodec
@@ -99,13 +96,7 @@ type StreamingCodec interface {
 	NewWriterLevel(io.Writer, int) (io.WriteCloser, error)
 }
 
-var (
-	codecs        = map[Compression]Codec{}
-	invalidCodecs = map[Compression]string{
-		Codecs.Lz4: "LZ4 (hadoop-format) is deprecated, consider using newer LZ4_RAW codec",
-		Codecs.Lzo: "LZO is unsupported in this library since LZO license is incompatible with Apache License",
-	}
-)
+var codecs = map[Compression]Codec{}
 
 // RegisterCodec adds or overrides a codec implementation for a given compression algorithm.
 // The intended use case is within the init() section of a package. For example,
@@ -182,10 +173,6 @@ func init() {
 
 // GetCodec returns a Codec interface for the requested Compression type
 func GetCodec(typ Compression) (Codec, error) {
-	msg, ok := invalidCodecs[typ]
-	if ok {
-		return nil, fmt.Errorf("%w: %s", ErrUnsupportedCodec, msg)
-	}
 	ret, ok := codecs[typ]
 	if !ok {
 		return nil, fmt.Errorf("compression for %s unimplemented", typ.String())

--- a/go/parquet/compress/compress_test.go
+++ b/go/parquet/compress/compress_test.go
@@ -66,8 +66,8 @@ func TestCompressDataOneShot(t *testing.T) {
 		{compress.Codecs.Gzip},
 		{compress.Codecs.Brotli},
 		{compress.Codecs.Zstd},
+		{compress.Codecs.Lz4Raw},
 		// {compress.Codecs.Lzo},
-		// {compress.Codecs.Lz4},
 	}
 
 	for _, tt := range tests {
@@ -107,9 +107,11 @@ func TestCompressReaderWriter(t *testing.T) {
 			var buf bytes.Buffer
 			codec, err := compress.GetCodec(tt.c)
 			assert.NoError(t, err)
+			streamingCodec, ok := codec.(compress.StreamingCodec)
+			assert.True(t, ok)
 			data := makeRandomData(RandomDataSize)
 
-			wr := codec.NewWriter(&buf)
+			wr := streamingCodec.NewWriter(&buf)
 
 			const chunkSize = 1111
 			input := data
@@ -129,7 +131,7 @@ func TestCompressReaderWriter(t *testing.T) {
 			}
 			wr.Close()
 
-			rdr := codec.NewReader(&buf)
+			rdr := streamingCodec.NewReader(&buf)
 			out, err := io.ReadAll(rdr)
 			assert.NoError(t, err)
 			assert.Exactly(t, data, out)

--- a/go/parquet/compress/compress_test.go
+++ b/go/parquet/compress/compress_test.go
@@ -138,30 +138,3 @@ func TestCompressReaderWriter(t *testing.T) {
 		})
 	}
 }
-
-func TestCompressGetSupportedCodecs(t *testing.T) {
-	tests := []struct {
-		c           compress.Compression
-		unsupported bool
-	}{
-		{c: compress.Codecs.Uncompressed},
-		{c: compress.Codecs.Snappy},
-		{c: compress.Codecs.Gzip},
-		{c: compress.Codecs.Brotli},
-		{c: compress.Codecs.Zstd},
-		{c: compress.Codecs.Lz4Raw},
-		{c: compress.Codecs.Lz4, unsupported: true},
-		{c: compress.Codecs.Lzo, unsupported: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.c.String(), func(t *testing.T) {
-			_, err := compress.GetCodec(tt.c)
-			if tt.unsupported {
-				assert.ErrorIs(t, err, compress.ErrUnsupportedCodec)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}

--- a/go/parquet/compress/compress_test.go
+++ b/go/parquet/compress/compress_test.go
@@ -138,3 +138,30 @@ func TestCompressReaderWriter(t *testing.T) {
 		})
 	}
 }
+
+func TestCompressGetSupportedCodecs(t *testing.T) {
+	tests := []struct {
+		c           compress.Compression
+		unsupported bool
+	}{
+		{c: compress.Codecs.Uncompressed},
+		{c: compress.Codecs.Snappy},
+		{c: compress.Codecs.Gzip},
+		{c: compress.Codecs.Brotli},
+		{c: compress.Codecs.Zstd},
+		{c: compress.Codecs.Lz4Raw},
+		{c: compress.Codecs.Lz4, unsupported: true},
+		{c: compress.Codecs.Lzo, unsupported: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.c.String(), func(t *testing.T) {
+			_, err := compress.GetCodec(tt.c)
+			if tt.unsupported {
+				assert.ErrorIs(t, err, compress.ErrUnsupportedCodec)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/go/parquet/compress/lz4_raw.go
+++ b/go/parquet/compress/lz4_raw.go
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compress
+
+import (
+	"sync"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+// lz4.Compressor is not goroutine-safe, so we use a pool to amortize the cost
+// of allocating a new one for each call to Encode().
+var compressorPool = sync.Pool{New: func() interface{} { return new(lz4.Compressor) }}
+
+func compressBlock(src, dst []byte) (int, error) {
+	c := compressorPool.Get().(*lz4.Compressor)
+	defer compressorPool.Put(c)
+	return c.CompressBlock(src, dst)
+}
+
+type lz4RawCodec struct{}
+
+func (c lz4RawCodec) Encode(dst, src []byte) []byte {
+	n, err := compressBlock(src, dst[:cap(dst)])
+	if err != nil {
+		panic(err)
+	}
+
+	return dst[:n]
+}
+
+func (c lz4RawCodec) EncodeLevel(dst, src []byte, _ int) []byte {
+	// the lz4 block implementation does not allow level to be set
+	return c.Encode(dst, src)
+}
+
+func (lz4RawCodec) Decode(dst, src []byte) []byte {
+	n, err := lz4.UncompressBlock(src, dst)
+	if err != nil {
+		panic(err)
+	}
+
+	return dst[:n]
+}
+
+func (c lz4RawCodec) CompressBound(len int64) int64 {
+	return int64(lz4.CompressBlockBound(int(len)))
+}
+
+func init() {
+	RegisterCodec(Codecs.Lz4Raw, lz4RawCodec{})
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Fixes: #43790

The LZ4 compression codec for Parquet is no longer ambiguous, as it has been superceded by the [LZ4_RAW](https://github.com/apache/parquet-format/blob/master/Compression.md#lz4_raw) spec.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

- Add `LZ4Raw` compression codec
- Split out `StreamingCodec` methods from core `Codec` interface
- Various conformance/roundtrip tests
- Set of benchmarks for reading/writing an Arrow table to/from Parquet, using each compression codec

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

- New codec `LZ4Raw` is available
- `Codec` interface no long provides the following methods, which are now part of `StreamingCodec`:
  - `NewReader`
  - `NewWriter`
  - `NewWriterLevel`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43790