### PR TITLE
GH-38183: [CI][Python] Use pipx to install GCS testbench

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -471,9 +471,9 @@ jobs:
         shell: bash
         run: |
           ci/scripts/install_gcs_testbench.sh default
-          echo "PYTHON_BIN_DIR=$(cygpath --windows $(dirname $(which python3.exe)))" >> $GITHUB_ENV
+          echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench)))" >> $GITHUB_ENV
       - name: Test
         shell: msys2 {0}
         run: |
-          PATH="$(cygpath --unix ${PYTHON_BIN_DIR}):${PATH}"
+          PATH="$(cygpath --unix ${TESTBENCH_BIN_DIR}):${PATH}"
           ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -471,6 +471,7 @@ jobs:
         shell: bash
         run: |
           ci/scripts/install_gcs_testbench.sh default
+          pipx ensurepath
           echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench.exe)))" >> $GITHUB_ENV
       - name: Test
         shell: msys2 {0}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -465,17 +465,16 @@ jobs:
           chmod +x /usr/local/bin/minio.exe
       - name: Set up Python
         uses: actions/setup-python@v5.1.1
+        id: python-install
         with:
           python-version: 3.9
       - name: Install Google Cloud Storage Testbench
-        shell: bash
+        shell: msys2 {0}
+        env:
+          PIPX_BIN_DIR: /usr/local/bin
         run: |
           ci/scripts/install_gcs_testbench.sh default
-          pipx ensurepath
-          echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench.exe)))"
-          echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench.exe)))" >> $GITHUB_ENV
       - name: Test
         shell: msys2 {0}
         run: |
-          PATH="$(cygpath --unix ${TESTBENCH_BIN_DIR}):${PATH}"
           ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -472,6 +472,7 @@ jobs:
         run: |
           ci/scripts/install_gcs_testbench.sh default
           pipx ensurepath
+          echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench.exe)))"
           echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench.exe)))" >> $GITHUB_ENV
       - name: Test
         shell: msys2 {0}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -472,6 +472,7 @@ jobs:
         shell: msys2 {0}
         env:
           PIPX_BIN_DIR: /usr/local/bin
+          PIPX_PYTHON: ${{ steps.python-install.outputs.python-path }}
         run: |
           ci/scripts/install_gcs_testbench.sh default
       - name: Test

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -471,7 +471,7 @@ jobs:
         shell: bash
         run: |
           ci/scripts/install_gcs_testbench.sh default
-          echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench)))" >> $GITHUB_ENV
+          echo "TESTBENCH_BIN_DIR=$(cygpath --windows $(dirname $(which storage-testbench.exe)))" >> $GITHUB_ENV
       - name: Test
         shell: msys2 {0}
         run: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ only_commits:
     - appveyor.yml
     - ci/appveyor*
     - ci/conda*
+    - ci/scripts/*.bat
     - cpp/
     - format/
     - python/

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -46,6 +46,7 @@ set ARROW_CMAKE_ARGS=-DARROW_DEPENDENCY_SOURCE=CONDA -DARROW_WITH_BZ2=ON
 set ARROW_CXXFLAGS=/WX /MP
 
 @rem Install GCS testbench
+set PIPX_BIN_DIR=C:\Windows\
 call %CD%\ci\scripts\install_gcs_testbench.bat
 storage-testbench -h || exit /B
 

--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -47,6 +47,7 @@ set ARROW_CXXFLAGS=/WX /MP
 
 @rem Install GCS testbench
 call %CD%\ci\scripts\install_gcs_testbench.bat
+storage-testbench -h || exit /B
 
 @rem
 @rem Build and test Arrow C++ libraries (including Parquet)

--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -42,16 +42,18 @@ RUN mamba install -q -y \
         valgrind && \
     mamba clean --all
 
+# We want to install the GCS testbench using the Conda base environment's Python,
+# because the test environment's Python may later change.
+ENV PIPX_PYTHON=/opt/conda/bin/python3
+COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts
+RUN /arrow/ci/scripts/install_gcs_testbench.sh default
+
 # Ensure npm, node and azurite are on path. npm and node are required to install azurite, which will then need to 
-# be on the path for the tests to run.  
+# be on the path for the tests to run.
 ENV PATH=/opt/conda/envs/arrow/bin:$PATH
 
 COPY ci/scripts/install_azurite.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_azurite.sh
-
-# We want to install the GCS testbench using the same Python binary that the Conda code will use.
-COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
 
 COPY ci/scripts/install_sccache.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -32,11 +32,6 @@ RUN mamba install -q -y \
         nomkl && \
     mamba clean --all
 
-# XXX The GCS testbench was already installed in conda-cpp.dockerfile,
-# but we changed the installed Python version above, so we need to reinstall it.
-COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts
-RUN /arrow/ci/scripts/install_gcs_testbench.sh default
-
 ENV ARROW_ACERO=ON \
     ARROW_BUILD_STATIC=OFF \
     ARROW_BUILD_TESTS=OFF \

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -46,15 +46,16 @@ RUN call "C:\arrow\ci\scripts\install_gcs_testbench.bat" && \
     storage-testbench -h
 
 # Define the full version number otherwise choco falls back to patch number 0 (3.8 => 3.8.0)
-# Also make sure the newly installed Python is first in PATH.
 ARG python=3.8
-RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10" && setx PATH "C:\Python38;C:\Python38\Scripts;%PATH%") & \
-    (if "%python%"=="3.9" setx PYTHON_VERSION "3.9.13" && setx PATH "C:\Python39;C:\Python39\Scripts;%PATH%") & \
-    (if "%python%"=="3.10" setx PYTHON_VERSION "3.10.11" && setx PATH "C:\Python310;C:\Python310\Scripts;%PATH%") & \
-    (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.9" && setx PATH "C:\Python311;C:\Python311\Scripts;%PATH%") & \
-    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.4" && setx PATH "C:\Python312;C:\Python312\Scripts;%PATH%") & \
-    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc1" && setx PATH "C:\Python313;C:\Python313\Scripts;%PATH%")
+RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10") & \
+    (if "%python%"=="3.9" setx PYTHON_VERSION "3.9.13") & \
+    (if "%python%"=="3.10" setx PYTHON_VERSION "3.10.11") & \
+    (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.9") & \
+    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.4") & \
+    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc1")
 
 # Install archiver to extract xz archives
 RUN choco install -r -y --pre --no-progress --force python --version=%PYTHON_VERSION% && \
     choco install --no-progress -r -y archiver
+
+ENV PYTHON=$python

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -41,7 +41,7 @@ RUN wmic product where "name like 'python%%'" call uninstall /nointeractive && \
 RUN choco install -r -y --pre --no-progress python --version=3.11.9
 ENV PIPX_BIN_DIR=C:\\Windows\\
 ENV PIPX_PYTHON="C:\Python311\python.exe"
-COPY ci/scripts/install_gcs_testbench.bat arrow/ci/scripts/
+COPY ci/scripts/install_gcs_testbench.bat C:/arrow/ci/scripts/
 RUN call "C:\arrow\ci\scripts\install_gcs_testbench.bat" && \
     storage-testbench -h
 

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -56,6 +56,6 @@ RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10" && setx PATH "C:\Python38
     (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc1" && setx PATH "C:\Python313;C:\Python313\Scripts;%PATH%")
 
 # Install archiver to extract xz archives
-RUN choco install -r -y --pre --no-progress python --version=%PYTHON_VERSION% && \
+RUN choco install -r -y --pre --no-progress --force python --version=%PYTHON_VERSION% && \
     python -m pip install --no-cache-dir -U pip setuptools && \
     choco install --no-progress -r -y archiver

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -41,7 +41,7 @@ RUN wmic product where "name like 'python%%'" call uninstall /nointeractive && \
 RUN choco install -r -y --pre --no-progress python --version=3.11.9
 ENV PIPX_BIN_DIR=C:\\Windows\\
 ENV PIPX_PYTHON="C:\Python311\python.exe"
-RUN call "C:\arrow\ci\scripts\install_gcs_testbench.bat" & \
+RUN call "C:\arrow\ci\scripts\install_gcs_testbench.bat" && \
     storage-testbench -h
 
 # Define the full version number otherwise choco falls back to patch number 0 (3.8 => 3.8.0)

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -46,15 +46,16 @@ RUN call "C:\arrow\ci\scripts\install_gcs_testbench.bat" && \
     storage-testbench -h
 
 # Define the full version number otherwise choco falls back to patch number 0 (3.8 => 3.8.0)
+# Also make sure the newly installed Python is first in PATH.
 ARG python=3.8
-RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10" && setx PATH "%PATH%;C:\Python38;C:\Python38\Scripts") & \
-    (if "%python%"=="3.9" setx PYTHON_VERSION "3.9.13" && setx PATH "%PATH%;C:\Python39;C:\Python39\Scripts") & \
-    (if "%python%"=="3.10" setx PYTHON_VERSION "3.10.11" && setx PATH "%PATH%;C:\Python310;C:\Python310\Scripts") & \
-    (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.9" && setx PATH "%PATH%;C:\Python311;C:\Python311\Scripts") & \
-    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.4" && setx PATH "%PATH%;C:\Python312;C:\Python312\Scripts") & \
-    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc1" && setx PATH "%PATH%;C:\Python313;C:\Python313\Scripts")
+RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10" && setx PATH "C:\Python38;C:\Python38\Scripts;%PATH%") & \
+    (if "%python%"=="3.9" setx PYTHON_VERSION "3.9.13" && setx PATH "C:\Python39;C:\Python39\Scripts;%PATH%") & \
+    (if "%python%"=="3.10" setx PYTHON_VERSION "3.10.11" && setx PATH "C:\Python310;C:\Python310\Scripts;%PATH%") & \
+    (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.9" && setx PATH "C:\Python311;C:\Python311\Scripts;%PATH%") & \
+    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.4" && setx PATH "C:\Python312;C:\Python312\Scripts;%PATH%") & \
+    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc1" && setx PATH "C:\Python313;C:\Python313\Scripts;%PATH%")
 
 # Install archiver to extract xz archives
-RUN choco install -r -y --pre --no-progress python --version=%PYTHON_VERSION% & \
-    python -m pip install --no-cache-dir -U pip setuptools & \
+RUN choco install -r -y --pre --no-progress python --version=%PYTHON_VERSION% && \
+    python -m pip install --no-cache-dir -U pip setuptools && \
     choco install --no-progress -r -y archiver

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -57,5 +57,4 @@ RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10" && setx PATH "C:\Python38
 
 # Install archiver to extract xz archives
 RUN choco install -r -y --pre --no-progress --force python --version=%PYTHON_VERSION% && \
-    python -m pip install --no-cache-dir -U pip setuptools && \
     choco install --no-progress -r -y archiver

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -41,6 +41,7 @@ RUN wmic product where "name like 'python%%'" call uninstall /nointeractive && \
 RUN choco install -r -y --pre --no-progress python --version=3.11.9
 ENV PIPX_BIN_DIR=C:\\Windows\\
 ENV PIPX_PYTHON="C:\Python311\python.exe"
+COPY ci/scripts/install_gcs_testbench.bat arrow/ci/scripts/
 RUN call "C:\arrow\ci\scripts\install_gcs_testbench.bat" && \
     storage-testbench -h
 

--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -35,6 +35,15 @@ RUN setx path "%path%;C:\Program Files\Git\usr\bin"
 RUN wmic product where "name like 'python%%'" call uninstall /nointeractive && \
     rm -rf Python*
 
+# Install the GCS testbench using a well-known Python version.
+# NOTE: cannot use pipx's `--fetch-missing-python` because of
+# https://github.com/pypa/pipx/issues/1521, therefore download Python ourselves.
+RUN choco install -r -y --pre --no-progress python --version=3.11.9
+ENV PIPX_BIN_DIR=C:\\Windows\\
+ENV PIPX_PYTHON="C:\Python311\python.exe"
+RUN call "C:\arrow\ci\scripts\install_gcs_testbench.bat" & \
+    storage-testbench -h
+
 # Define the full version number otherwise choco falls back to patch number 0 (3.8 => 3.8.0)
 ARG python=3.8
 RUN (if "%python%"=="3.8" setx PYTHON_VERSION "3.8.10" && setx PATH "%PATH%;C:\Python38;C:\Python38\Scripts") & \

--- a/ci/docker/ubuntu-20.04-cpp-minimal.dockerfile
+++ b/ci/docker/ubuntu-20.04-cpp-minimal.dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update -y -q && \
         libssl-dev \
         libcurl4-openssl-dev \
         python3-pip \
+        python3-venv \
         tzdata \
         wget && \
     apt-get clean && \

--- a/ci/docker/ubuntu-22.04-cpp-minimal.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp-minimal.dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update -y -q && \
         libssl-dev \
         libcurl4-openssl-dev \
         python3-pip \
+        python3-venv \
         tzdata \
         wget && \
     apt-get clean && \

--- a/ci/docker/ubuntu-24.04-cpp-minimal.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp-minimal.dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update -y -q && \
         libssl-dev \
         libcurl4-openssl-dev \
         python3-pip \
+        python3-venv \
         tzdata \
         tzdata-legacy \
         wget && \

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -19,7 +19,7 @@
 
 set GCS_TESTBENCH_VERSION="v0.40.0"
 
-python3 -m pip install pipx || exit /B 1
+python -m pip install pipx || exit /B 1
 
 pipx ensurepath || exit /B 1
 

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -21,7 +21,7 @@ set GCS_TESTBENCH_VERSION="v0.40.0"
 
 set PIPX_FLAGS=--verbose
 if NOT "%PIPX_PYTHON%"=="" (
-  set PIPX_FLAGS=--python %PIPX_PYTHON% --fetch-missing-python %PIPX_FLAGS%
+  set PIPX_FLAGS=--python %PIPX_PYTHON% %PIPX_FLAGS%
 )
 
 python -m pip install -U pipx || exit /B 1

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -19,11 +19,11 @@
 
 set GCS_TESTBENCH_VERSION="v0.40.0"
 
-python -m pip install pipx || exit /B 1
+python -m pip install -U pipx || exit /B 1
 
 @REM Install GCS testbench %GCS_TESTBENCH_VERSION%
-pipx install --global --verbose ^
+pipx install --verbose ^
         "https://github.com/googleapis/storage-testbench/archive/%GCS_TESTBENCH_VERSION%.tar.gz" ^
         || exit /B 1
 
-pipx list --global --verbose
+pipx list --verbose

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -19,9 +19,9 @@
 
 set GCS_TESTBENCH_VERSION="v0.40.0"
 
-set PIPX_FLAGS="--verbose"
+set PIPX_FLAGS=--verbose
 if NOT "%PIPX_PYTHON%"=="" (
-  set PIPX_FLAGS="--python %PIPX_PYTHON% --fetch-missing-python %PIPX_FLAGS%"
+  set PIPX_FLAGS=--python %PIPX_PYTHON% --fetch-missing-python %PIPX_FLAGS%
 )
 
 python -m pip install -U pipx || exit /B 1

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -17,9 +17,11 @@
 
 @echo on
 
-set GCS_TESTBENCH_VERSION="v0.36.0"
+set GCS_TESTBENCH_VERSION="v0.40.0"
+
+python -m pip install pipx || exit /B 1
 
 @REM Install GCS testbench %GCS_TESTBENCH_VERSION%
-python -m pip install  ^
+pipx install ^
         "https://github.com/googleapis/storage-testbench/archive/%GCS_TESTBENCH_VERSION%.tar.gz" ^
         || exit /B 1

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -21,9 +21,9 @@ set GCS_TESTBENCH_VERSION="v0.40.0"
 
 python -m pip install pipx || exit /B 1
 
-pipx ensurepath || exit /B 1
-
 @REM Install GCS testbench %GCS_TESTBENCH_VERSION%
-pipx install ^
+pipx install --global --verbose ^
         "https://github.com/googleapis/storage-testbench/archive/%GCS_TESTBENCH_VERSION%.tar.gz" ^
         || exit /B 1
+
+pipx list --global --verbose

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -19,10 +19,15 @@
 
 set GCS_TESTBENCH_VERSION="v0.40.0"
 
+set PIPX_FLAGS="--verbose"
+if NOT "%PIPX_PYTHON%"=="" (
+  set PIPX_FLAGS="--python %PIPX_PYTHON% --fetch-missing-python %PIPX_FLAGS%"
+)
+
 python -m pip install -U pipx || exit /B 1
 
 @REM Install GCS testbench %GCS_TESTBENCH_VERSION%
-pipx install --verbose ^
+pipx install %PIPX_FLAGS% ^
         "https://github.com/googleapis/storage-testbench/archive/%GCS_TESTBENCH_VERSION%.tar.gz" ^
         || exit /B 1
 

--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -19,7 +19,9 @@
 
 set GCS_TESTBENCH_VERSION="v0.40.0"
 
-python -m pip install pipx || exit /B 1
+python3 -m pip install pipx || exit /B 1
+
+pipx ensurepath || exit /B 1
 
 @REM Install GCS testbench %GCS_TESTBENCH_VERSION%
 pipx install ^

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
+set -ex
 
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <storage-testbench version>"
@@ -39,8 +39,10 @@ if [[ "${version}" -eq "default" ]]; then
   version="v0.39.0"
 fi
 
+: ${PIPX_PYTHON:=$(which python3)}
+
 export PIP_BREAK_SYSTEM_PACKAGES=1
-python3 -m pip install pipx
+${PIPX_PYTHON} -m pip install -U pipx
 
 # This script is run with PYTHON undefined in some places,
 # but those only use older pythons.
@@ -53,5 +55,5 @@ if [[ -z "${PYTHON_VERSION}" ]] || [[ "${PYTHON_VERSION}" != "3.13" ]]; then
   if [[ ! -z "${PIPX_PYTHON}" ]]; then
     pipx_flags="${pipx_flags} --python ${PIPX_PYTHON}"
   fi
-  pipx install ${pipx_flags} "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"
+  ${PIPX_PYTHON} -m pipx install ${pipx_flags} "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"
 fi

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -52,8 +52,5 @@ if [[ -z "${PYTHON_VERSION}" ]] || [[ "${PYTHON_VERSION}" != "3.13" ]]; then
     # Install globally as /root/.local/bin is typically not in $PATH
     pipx_flags="${pipx_flags} --global"
   fi
-  if [[ ! -z "${PIPX_PYTHON}" ]]; then
-    pipx_flags="${pipx_flags} --python ${PIPX_PYTHON}"
-  fi
   ${PIPX_PYTHON} -m pipx install ${pipx_flags} "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"
 fi

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -34,19 +34,24 @@ case "$(uname -m)" in
     ;;
 esac
 
-# On newer pythons install into the system will fail, so override that
-export PIP_BREAK_SYSTEM_PACKAGES=1
-
 version=$1
 if [[ "${version}" -eq "default" ]]; then
   version="v0.39.0"
-  # Latests versions of Testbench require newer setuptools
-  python3 -m pip install --upgrade setuptools
 fi
+
+export PIP_BREAK_SYSTEM_PACKAGES=1
+python3 -m pip install pipx
 
 # This script is run with PYTHON undefined in some places,
 # but those only use older pythons.
 if [[ -z "${PYTHON_VERSION}" ]] || [[ "${PYTHON_VERSION}" != "3.13" ]]; then
-  python3 -m pip install \
-    "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"
+  pipx_flags=--verbose
+  if [[ $(id -un) == "root" ]]; then
+    # Install globally as /root/.local/bin is typically not in $PATH
+    pipx_flags="${pipx_flags} --global"
+  fi
+  if [[ ! -z "${PIPX_PYTHON}" ]]; then
+    pipx_flags="${pipx_flags} --python ${PIPX_PYTHON}"
+  fi
+  pipx install ${pipx_flags} "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"
 fi

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -42,6 +42,7 @@ pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
 @REM Install GCS testbench
 call "C:\arrow\ci\scripts\install_gcs_testbench.bat"
+storage-testbench -h || exit /B 1
 
 @REM Install the built wheels
 python -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B 1 

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -37,8 +37,10 @@ set PYARROW_TEST_TENSORFLOW=ON
 set ARROW_TEST_DATA=C:\arrow\testing\data
 set PARQUET_TEST_DATA=C:\arrow\cpp\submodules\parquet-testing\data
 
+python -m pip install -U pip setuptools
+
 @REM Install testing dependencies
-pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
+python -m pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
 @REM Install the built wheels
 python -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B 1 
@@ -64,4 +66,4 @@ arc unarchive tzdata.tar.xz %USERPROFILE%\Downloads\test\tzdata
 set TZDIR=%USERPROFILE%\Downloads\test\tzdata\usr\share\zoneinfo
 
 @REM Execute unittest
-pytest -r s --pyargs pyarrow || exit /B 1
+python -m pytest -r s --pyargs pyarrow || exit /B 1

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -37,27 +37,32 @@ set PYARROW_TEST_TENSORFLOW=ON
 set ARROW_TEST_DATA=C:\arrow\testing\data
 set PARQUET_TEST_DATA=C:\arrow\cpp\submodules\parquet-testing\data
 
-python -m pip install -U pip setuptools
+@REM List installed Pythons
+py -0p
+
+set PYTHON_CMD=py -%PYTHON%
+
+%PYTHON_CMD% -m pip install -U pip setuptools || exit /B 1
 
 @REM Install testing dependencies
-python -m pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
+%PYTHON_CMD% -m pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
 @REM Install the built wheels
-python -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B 1 
+%PYTHON_CMD% -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B 1
 
 @REM Test that the modules are importable
-python -c "import pyarrow" || exit /B 1
-python -c "import pyarrow._gcsfs" || exit /B 1
-python -c "import pyarrow._hdfs" || exit /B 1 
-python -c "import pyarrow._s3fs" || exit /B 1
-python -c "import pyarrow.csv" || exit /B 1
-python -c "import pyarrow.dataset" || exit /B 1
-python -c "import pyarrow.flight" || exit /B 1
-python -c "import pyarrow.fs" || exit /B 1
-python -c "import pyarrow.json" || exit /B 1
-python -c "import pyarrow.orc" || exit /B 1
-python -c "import pyarrow.parquet" || exit /B 1
-python -c "import pyarrow.substrait" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow._gcsfs" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow._hdfs" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow._s3fs" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.csv" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.dataset" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.flight" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.fs" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.json" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.orc" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.parquet" || exit /B 1
+%PYTHON_CMD% -c "import pyarrow.substrait" || exit /B 1
 
 @rem Download IANA Timezone Database for ORC C++
 curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B
@@ -66,4 +71,4 @@ arc unarchive tzdata.tar.xz %USERPROFILE%\Downloads\test\tzdata
 set TZDIR=%USERPROFILE%\Downloads\test\tzdata\usr\share\zoneinfo
 
 @REM Execute unittest
-python -m pytest -r s --pyargs pyarrow || exit /B 1
+%PYTHON_CMD% -m pytest -r s --pyargs pyarrow || exit /B 1

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -40,12 +40,6 @@ set PARQUET_TEST_DATA=C:\arrow\cpp\submodules\parquet-testing\data
 @REM Install testing dependencies
 pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
-@REM Install GCS testbench using a well-known version of Python
-set PIPX_BIN_DIR=C:\Windows\
-set PIPX_PYTHON=3.11
-call "C:\arrow\ci\scripts\install_gcs_testbench.bat"
-storage-testbench -h || exit /B 1
-
 @REM Install the built wheels
 python -m pip install --no-index --find-links=C:\arrow\python\dist\ pyarrow || exit /B 1 
 

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -40,8 +40,9 @@ set PARQUET_TEST_DATA=C:\arrow\cpp\submodules\parquet-testing\data
 @REM Install testing dependencies
 pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
-@REM Install GCS testbench
+@REM Install GCS testbench using a well-known version of Python
 set PIPX_BIN_DIR=C:\Windows\
+set PIPX_PYTHON=3.11
 call "C:\arrow\ci\scripts\install_gcs_testbench.bat"
 storage-testbench -h || exit /B 1
 

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -41,6 +41,7 @@ set PARQUET_TEST_DATA=C:\arrow\cpp\submodules\parquet-testing\data
 pip install -r C:\arrow\python\requirements-wheel-test.txt || exit /B 1
 
 @REM Install GCS testbench
+set PIPX_BIN_DIR=C:\Windows\
 call "C:\arrow\ci\scripts\install_gcs_testbench.bat"
 storage-testbench -h || exit /B 1
 

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -41,6 +41,12 @@ jobs:
       {{ macros.github_login_ghcr()|indent }}
       {{ macros.github_install_archery()|indent }}
 
+      - name: Build test image
+        shell: cmd
+        run: |
+          cd arrow
+          archery docker build python-wheel-windows-test
+
       - name: Build wheel
         shell: cmd
         run: |

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -41,12 +41,6 @@ jobs:
       {{ macros.github_login_ghcr()|indent }}
       {{ macros.github_install_archery()|indent }}
 
-      - name: Build test image
-        shell: cmd
-        run: |
-          cd arrow
-          archery docker build python-wheel-windows-test
-
       - name: Build wheel
         shell: cmd
         run: |

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -233,17 +233,16 @@ def s3_server(s3_connection, tmpdir_factory):
 def gcs_server():
     port = find_free_port()
     env = os.environ.copy()
-    args = [sys.executable, '-m', 'testbench', '--port', str(port)]
+    exe = 'storage-testbench'
+    args = [exe, '--port', str(port)]
     proc = None
     try:
-        # check first if testbench module is available
-        import testbench  # noqa:F401
         # start server
         proc = subprocess.Popen(args, env=env)
         # Make sure the server is alive.
         if proc.poll() is not None:
             pytest.skip(f"Command {args} did not start server successfully!")
-    except (ModuleNotFoundError, OSError) as e:
+    except OSError as e:
         pytest.skip(f"Command {args} failed to execute: {e}")
     else:
         yield {

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -335,7 +335,7 @@ with launch_server(dist_dir) as (hostname, port):
         """
 import pyarrow,pathlib
 pyarrow_dir = pathlib.Path(pyarrow.__file__).parent
-pytest.main([pyarrow_dir, '-v'])
+pytest.main([pyarrow_dir, '-r', 's'])
 """,
         wait_for_terminate=False,
     )

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -116,7 +116,7 @@ test_that("GcsFileSystem$create() can read json_credentials", {
 })
 
 skip_on_cran()
-skip_if_not(system('storage-testbench -h') == 0, message = "googleapis-storage-testbench is not installed.")
+skip_if_not(system("storage-testbench -h") == 0, message = "googleapis-storage-testbench is not installed.")
 library(dplyr)
 
 testbench_port <- Sys.getenv("TESTBENCH_PORT", "9001")

--- a/r/tests/testthat/test-gcs.R
+++ b/r/tests/testthat/test-gcs.R
@@ -116,12 +116,12 @@ test_that("GcsFileSystem$create() can read json_credentials", {
 })
 
 skip_on_cran()
-skip_if_not(system('python -c "import testbench"') == 0, message = "googleapis-storage-testbench is not installed.")
+skip_if_not(system('storage-testbench -h') == 0, message = "googleapis-storage-testbench is not installed.")
 library(dplyr)
 
 testbench_port <- Sys.getenv("TESTBENCH_PORT", "9001")
 
-pid_minio <- sys::exec_background("python", c("-m", "testbench", "--port", testbench_port),
+pid_minio <- sys::exec_background("storage-testbench", c("--port", testbench_port),
   std_out = FALSE,
   std_err = FALSE # TODO: is there a good place to send output?
 )


### PR DESCRIPTION
### Rationale for this change

Installing the GCS testbench using the same Python that's being used to test PyArrow is fragile: some testbench versions may not be compatible, or there could be conflicts among the dependencies of the respective libraries.

### What changes are included in this PR?

Use `pipx` to install the GCS testbench in a separate, controlled environment, using an appropriate Python version.

### Are these changes tested?

Yes, by CI.

### Are there any user-facing changes?

No.

* GitHub Issue: #38183