### PR TITLE
GH-40216: [CI][Packaging][Python] Upload pyarrow nightly wheels to scientific python channel on Anaconda

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -185,11 +185,10 @@ env:
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
   - name: Upload wheel to Anaconda scientific-python
-    uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
-    with:
-      artifacts_path: {{ pattern }}
-      anaconda_nightly_upload_token: {{ '${{secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN}}' }}
-      anaconda_nightly_upload_labels: dev
+    bash: |
+      conda create -y -n upload_wheel_scientific_python -c conda-forge anaconda-client
+      source activate upload_wheel_scientific_python
+      anaconda -t $(CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN) upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,13 +184,15 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
-  - uses: conda-incubator/setup-miniconda@v3
-    with:
-      activate-environment: upload_wheel_scientific_python
+    - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822
+      with:
+        init-shell: bash
+        environment-name: upload_wheel_scientific_python
+        create-args: >-
+          anaconda-client
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |
-      conda install -y -c conda-forge anaconda-client
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -183,6 +183,17 @@ env:
   {% endif %}
 {% endmacro %}
 
+{%- macro github_upload_wheel_scientific_python(pattern) -%}
+  {%- if arrow.is_default_branch() -%}
+  - name: Upload wheel to Anaconda scientific-python
+    uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
+    with:
+      artifacts_path: {{ pattern }}
+      anaconda_nightly_upload_token: {{ '${{secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN}}' }}
+      anaconda_nightly_upload_labels: dev
+  {% endif %}
+{% endmacro %}
+
 {%- macro azure_checkout_arrow() -%}
   - script: |
       git clone --no-checkout --branch {{ arrow.branch }} {{ arrow.remote }} arrow

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,14 +184,12 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
-  {%- if arrow.is_default_branch() -%}
   - name: Upload wheel to Anaconda scientific-python
     uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
     with:
       artifacts_path: {{ pattern }}
       anaconda_nightly_upload_token: {{ '${{secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN}}' }}
       anaconda_nightly_upload_labels: dev
-  {% endif %}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -187,7 +187,7 @@ env:
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |
-      python3 -m pip install anaconda-client
+      python3 -m pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@1.12.3
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,6 +184,10 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
+  - name: Install conda to upload wheel to scientific-python
+    shell: bash
+    run: |
+      arrow/ci/scripts/install_conda.sh mambaforge latest /opt/conda
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,6 +184,7 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
+  {%- if arrow.is_default_branch() -%}
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |
@@ -191,6 +192,7 @@ env:
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}
+  {% endif %}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,10 +184,7 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
-  - name: Install conda to upload wheel to scientific-python
-    shell: bash
-    run: |
-      arrow/ci/scripts/install_conda.sh mambaforge latest /opt/conda
+  - uses: conda-incubator/setup-miniconda@v3
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,15 +184,10 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
-  - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822
-    with:
-      init-shell: bash
-      environment-name: upload_wheel_scientific_python
-      create-args: >-
-        anaconda-client
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |
+      python3 -m pip install anaconda-client
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,12 +184,12 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
-    - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822
-      with:
-        init-shell: bash
-        environment-name: upload_wheel_scientific_python
-        create-args: >-
-          anaconda-client
+  - uses: mamba-org/setup-micromamba@f8b8a1e23a26f60a44c853292711bacfd3eac822
+    with:
+      init-shell: bash
+      environment-name: upload_wheel_scientific_python
+      create-args: >-
+        anaconda-client
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -185,7 +185,8 @@ env:
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
   - name: Upload wheel to Anaconda scientific-python
-    bash: |
+    shell: bash
+    run: |
       conda create -y -n upload_wheel_scientific_python -c conda-forge anaconda-client
       source activate upload_wheel_scientific_python
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -189,7 +189,7 @@ env:
     shell: bash
     run: |
       conda create -y -n upload_wheel_scientific_python -c conda-forge anaconda-client
-      source activate upload_wheel_scientific_python
+      conda activate upload_wheel_scientific_python
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -185,11 +185,12 @@ env:
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
   - uses: conda-incubator/setup-miniconda@v3
+    with:
+      activate-environment: upload_wheel_scientific_python
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |
-      conda create -y -n upload_wheel_scientific_python -c conda-forge anaconda-client
-      conda activate upload_wheel_scientific_python
+      conda install -y -c conda-forge anaconda-client
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -188,7 +188,9 @@ env:
     bash: |
       conda create -y -n upload_wheel_scientific_python -c conda-forge anaconda-client
       source activate upload_wheel_scientific_python
-      anaconda -t $(CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN) upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
+      anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
+    env:
+      CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/python-sdist/github.yml
+++ b/dev/tasks/python-sdist/github.yml
@@ -43,3 +43,4 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/dist/*.tar.gz")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/dist/*.tar.gz")|indent }}
+      {{ macros.github_upload_wheel_scientific_python("arrow/python/dist/*.tar.gz")|indent }}

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -110,6 +110,7 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
+      {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}
       - name: Push Docker Image

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -126,4 +126,4 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
-      {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/")|indent }}
+      {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/*.whl")|indent }}

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -126,3 +126,4 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
+      {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/")|indent }}

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -71,6 +71,7 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/dist/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/dist/*.whl")|indent }}
+      {{ macros.github_upload_wheel_scientific_python("arrow/python/dist/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}
       - name: Push Docker Image

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -29,6 +29,7 @@ groups:
 
   wheel:
     - wheel-*
+    - python-sdist
 
   linux:
     - almalinux-*


### PR DESCRIPTION
### Rationale for this change

As discussed on the main issue is interesting for discoverability to have the wheels uploaded to the nightly channel.

### What changes are included in this PR?

Added macro to upload wheel to scientific python channel

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No but nightly wheels will be available on scientific python channel
* GitHub Issue: #40216