### PR TITLE
GH-43435: [Python] Support using list or tuple with from_pylist to create Table

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -6223,9 +6223,16 @@ def _from_pylist(cls, mapping, schema, metadata):
         return cls.from_arrays(arrays, names, metadata=metadata)
     else:
         if isinstance(schema, Schema):
-            for n in schema.names:
-                v = [row[n] if n in row else None for row in mapping]
-                arrays.append(v)
+            if any(isinstance(row, (list, tuple)) for row in mapping):
+                for i in range(len(schema)):
+                    v = [row[i] if i < len(row) else None for row in mapping]
+                    arrays.append(v)
+            else if any(isinstance(row, dict) for row in mapping):
+                for n in schema.names:
+                    v = [row[n] if n in row else None for row in mapping]
+                    arrays.append(v)
+            else:
+                raise TypeError("pylist elements should be the same type")
             # Will raise if metadata is not None
             return cls.from_arrays(arrays, schema=schema, metadata=metadata)
         else:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1950,7 +1950,7 @@ cdef class _Tabular(_PandasConvertible):
         >>> pylist = [{'n_legs': 2, 'animals': 'Flamingo'},
         ...           {'n_legs': 4, 'animals': 'Dog'}]
 
-        Construct a Table from a list of rows:
+        Construct a Table from a list of dict rows:
 
         >>> pa.Table.from_pylist(pylist)
         pyarrow.Table
@@ -1960,7 +1960,7 @@ cdef class _Tabular(_PandasConvertible):
         n_legs: [[2,4]]
         animals: [["Flamingo","Dog"]]
 
-        Construct a Table from a list of dict values with metadata:
+        Construct a Table from a list of dict rows with metadata:
 
         >>> my_metadata={"n_legs": "Number of legs per animal"}
         >>> pa.Table.from_pylist(pylist, metadata=my_metadata).schema
@@ -1969,7 +1969,7 @@ cdef class _Tabular(_PandasConvertible):
         -- schema metadata --
         n_legs: 'Number of legs per animal'
 
-        Construct a Table from a list of rows with pyarrow schema:
+        Construct a Table from a list of dict rows with pyarrow schema:
 
         >>> my_schema = pa.schema([
         ...     pa.field('n_legs', pa.int64()),
@@ -1981,7 +1981,7 @@ cdef class _Tabular(_PandasConvertible):
         -- schema metadata --
         n_legs: 'Number of legs per animal'
 
-        Construct a Table from a list of list value with schema
+        Construct a Table from a list of list rows with schema
         >>> pylist = [[ 2, 'Flamingo'], [4, 'Dog']]
         >>> pa.Table.from_pylist(pylist, schema=my_schema)
         pyarrow.Table

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2392,7 +2392,6 @@ def test_table_from_pylist(cls):
     assert table.num_rows == 3
     assert table.to_pylist() == data2
 
-
     # Pass list of list or tuple with explicit schema
     schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float64())])
     data = [['foo', 4.0], ['bar', 3]]

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2392,6 +2392,19 @@ def test_table_from_pylist(cls):
     assert table.num_rows == 3
     assert table.to_pylist() == data2
 
+    # Pass list of (list, tuple) with explicit schema
+    schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float64())])
+    data = [['foo', 4.0], ['bar', 3]]
+    table = cls.from_pylist(data, schema=schema)
+    assert table.num_columns == 2
+    assert table.num_rows == 2
+    assert table.to_pylist() == data
+
+    
+
+    # Elements in py list have different type
+    data = [{'strs': ''}, ['a string']]
+
 
 @pytest.mark.pandas
 def test_table_from_pandas_schema():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2392,18 +2392,24 @@ def test_table_from_pylist(cls):
     assert table.num_rows == 3
     assert table.to_pylist() == data2
 
-    # Pass list of (list, tuple) with explicit schema
+
+    # Pass list of list or tuple with explicit schema
     schema = pa.schema([('strs', pa.utf8()), ('floats', pa.float64())])
     data = [['foo', 4.0], ['bar', 3]]
     table = cls.from_pylist(data, schema=schema)
     assert table.num_columns == 2
     assert table.num_rows == 2
-    assert table.to_pylist() == data
+    assert table.to_pylist()[0]['strs'] == data[0][0]
 
-    
+    # The comma makes the second element a tuple
+    data = [('foo', 4.0), ('bar',)]
+    table = cls.from_pylist(data, schema=schema)
+    assert table.to_pylist()[1]['floats'] is None
 
     # Elements in py list have different type
-    data = [{'strs': ''}, ['a string']]
+    data = [{'strs': 'foo', 'floats': 1.0}, ['foo', 1.0]]
+    with pytest.raises(TypeError):
+        table = cls.from_pylist(data, schema=schema)
 
 
 @pytest.mark.pandas


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
For now, we can regard the from_pydict as a method for creating Table with column-like data, since its input is a mapping of field to array. We also have from_pylist which can create Table with row-like data. But from_pylist requires that data and field are bounded, because it takes a dict as a row. It's a little bit inflexible for use, because we may have list of list as row data and we need to construct list of dict with schema name to use from_pylist.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Expand the from_pylist method to support the list of list/tuple as input data
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes, add new test cases for it
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43435