### PR TITLE
GH-43907: [C#][FlightRPC] Add Grpc Call Options support on Flight Client

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
+++ b/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
@@ -32,35 +32,35 @@ namespace Apache.Arrow.Flight.Client
             _client = new FlightService.FlightServiceClient(grpcChannel);
         }
 
-        public AsyncServerStreamingCall<FlightInfo> ListFlights(FlightCriteria criteria = null, Metadata headers = null)
+        public AsyncServerStreamingCall<FlightInfo> ListFlights(FlightCriteria criteria = null, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
-            if(criteria == null)
+            if (criteria == null)
             {
                 criteria = FlightCriteria.Empty;
             }
-            
-            var response = _client.ListFlights(criteria.ToProtocol(), headers);
+
+            var response = _client.ListFlights(criteria.ToProtocol(), headers, deadline, cancellationToken);
             var convertStream = new StreamReader<Protocol.FlightInfo, FlightInfo>(response.ResponseStream, inFlight => new FlightInfo(inFlight));
 
             return new AsyncServerStreamingCall<FlightInfo>(convertStream, response.ResponseHeadersAsync, response.GetStatus, response.GetTrailers, response.Dispose);
         }
 
-        public AsyncServerStreamingCall<FlightActionType> ListActions(Metadata headers = null)
+        public AsyncServerStreamingCall<FlightActionType> ListActions(Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
-            var response = _client.ListActions(EmptyInstance, headers);
+            var response = _client.ListActions(EmptyInstance, headers, deadline, cancellationToken);
             var convertStream = new StreamReader<Protocol.ActionType, FlightActionType>(response.ResponseStream, actionType => new FlightActionType(actionType));
 
             return new AsyncServerStreamingCall<FlightActionType>(convertStream, response.ResponseHeadersAsync, response.GetStatus, response.GetTrailers, response.Dispose);
         }
 
-        public FlightRecordBatchStreamingCall GetStream(FlightTicket ticket, Metadata headers = null)
+        public FlightRecordBatchStreamingCall GetStream(FlightTicket ticket, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
-            var stream = _client.DoGet(ticket.ToProtocol(),  headers);
+            var stream = _client.DoGet(ticket.ToProtocol(), headers, deadline, cancellationToken);
             var responseStream = new FlightClientRecordBatchStreamReader(stream.ResponseStream);
             return new FlightRecordBatchStreamingCall(responseStream, stream.ResponseHeadersAsync, stream.GetStatus, stream.GetTrailers, stream.Dispose);
         }
 
-        public AsyncUnaryCall<FlightInfo> GetInfo(FlightDescriptor flightDescriptor, Metadata headers = null)
+        public AsyncUnaryCall<FlightInfo> GetInfo(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
             var flightInfoResult = _client.GetFlightInfoAsync(flightDescriptor.ToProtocol(), headers);
 
@@ -77,9 +77,9 @@ namespace Apache.Arrow.Flight.Client
                 flightInfoResult.Dispose);
         }
 
-        public FlightRecordBatchDuplexStreamingCall StartPut(FlightDescriptor flightDescriptor, Metadata headers = null)
+        public FlightRecordBatchDuplexStreamingCall StartPut(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
-            var channels = _client.DoPut(headers);
+            var channels = _client.DoPut(headers, deadline, cancellationToken);
             var requestStream = new FlightClientRecordBatchStreamWriter(channels.RequestStream, flightDescriptor);
             var readStream = new StreamReader<Protocol.PutResult, FlightPutResult>(channels.ResponseStream, putResult => new FlightPutResult(putResult));
             return new FlightRecordBatchDuplexStreamingCall(
@@ -91,9 +91,9 @@ namespace Apache.Arrow.Flight.Client
                 channels.Dispose);
         }
 
-        public AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> Handshake(Metadata headers = null)
+        public AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> Handshake(Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
-            var channel = _client.Handshake(headers);
+            var channel = _client.Handshake(headers, deadline, cancellationToken);
             var readStream = new StreamReader<HandshakeResponse, FlightHandshakeResponse>(channel.ResponseStream, response => new FlightHandshakeResponse(response));
             var writeStream = new FlightHandshakeStreamWriterAdapter(channel.RequestStream);
             var call = new AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse>(
@@ -107,9 +107,9 @@ namespace Apache.Arrow.Flight.Client
             return call;
         }
 
-        public FlightRecordBatchExchangeCall DoExchange(FlightDescriptor flightDescriptor, Metadata headers = null)
+        public FlightRecordBatchExchangeCall DoExchange(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
-            var channel = _client.DoExchange(headers);
+            var channel = _client.DoExchange(headers, deadline, cancellationToken);
             var requestStream = new FlightClientRecordBatchStreamWriter(channel.RequestStream, flightDescriptor);
             var responseStream = new FlightClientRecordBatchStreamReader(channel.ResponseStream);
             var call = new FlightRecordBatchExchangeCall(
@@ -123,16 +123,16 @@ namespace Apache.Arrow.Flight.Client
             return call;
         }
 
-        public AsyncServerStreamingCall<FlightResult> DoAction(FlightAction action, Metadata headers = null)
+        public AsyncServerStreamingCall<FlightResult> DoAction(FlightAction action, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
             var stream = _client.DoAction(action.ToProtocol(), headers);
             var streamReader = new StreamReader<Protocol.Result, FlightResult>(stream.ResponseStream, result => new FlightResult(result));
             return new AsyncServerStreamingCall<FlightResult>(streamReader, stream.ResponseHeadersAsync, stream.GetStatus, stream.GetTrailers, stream.Dispose);
         }
 
-        public AsyncUnaryCall<Schema> GetSchema(FlightDescriptor flightDescriptor, Metadata headers = null)
+        public AsyncUnaryCall<Schema> GetSchema(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
         {
-            var schemaResult = _client.GetSchemaAsync(flightDescriptor.ToProtocol(), headers);
+            var schemaResult = _client.GetSchemaAsync(flightDescriptor.ToProtocol(), headers, deadline, cancellationToken);
 
             var schema = schemaResult
                 .ResponseAsync

--- a/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
+++ b/csharp/src/Apache.Arrow.Flight/Client/FlightClient.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Flight.Internal;
 using Apache.Arrow.Flight.Protocol;
@@ -32,7 +33,12 @@ namespace Apache.Arrow.Flight.Client
             _client = new FlightService.FlightServiceClient(grpcChannel);
         }
 
-        public AsyncServerStreamingCall<FlightInfo> ListFlights(FlightCriteria criteria = null, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public AsyncServerStreamingCall<FlightInfo> ListFlights(FlightCriteria criteria = null, Metadata headers = null)
+        {
+            return ListFlights(criteria, headers, null, CancellationToken.None);
+        }
+
+        public AsyncServerStreamingCall<FlightInfo> ListFlights(FlightCriteria criteria, Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
         {
             if (criteria == null)
             {
@@ -45,7 +51,12 @@ namespace Apache.Arrow.Flight.Client
             return new AsyncServerStreamingCall<FlightInfo>(convertStream, response.ResponseHeadersAsync, response.GetStatus, response.GetTrailers, response.Dispose);
         }
 
-        public AsyncServerStreamingCall<FlightActionType> ListActions(Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public AsyncServerStreamingCall<FlightActionType> ListActions(Metadata headers = null)
+        {
+            return ListActions(headers, null, CancellationToken.None);
+        }
+
+        public AsyncServerStreamingCall<FlightActionType> ListActions(Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
         {
             var response = _client.ListActions(EmptyInstance, headers, deadline, cancellationToken);
             var convertStream = new StreamReader<Protocol.ActionType, FlightActionType>(response.ResponseStream, actionType => new FlightActionType(actionType));
@@ -53,16 +64,26 @@ namespace Apache.Arrow.Flight.Client
             return new AsyncServerStreamingCall<FlightActionType>(convertStream, response.ResponseHeadersAsync, response.GetStatus, response.GetTrailers, response.Dispose);
         }
 
-        public FlightRecordBatchStreamingCall GetStream(FlightTicket ticket, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public FlightRecordBatchStreamingCall GetStream(FlightTicket ticket, Metadata headers = null)
+        {
+            return GetStream(ticket, headers, null, CancellationToken.None);
+        }
+
+        public FlightRecordBatchStreamingCall GetStream(FlightTicket ticket, Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
         {
             var stream = _client.DoGet(ticket.ToProtocol(), headers, deadline, cancellationToken);
             var responseStream = new FlightClientRecordBatchStreamReader(stream.ResponseStream);
             return new FlightRecordBatchStreamingCall(responseStream, stream.ResponseHeadersAsync, stream.GetStatus, stream.GetTrailers, stream.Dispose);
         }
 
-        public AsyncUnaryCall<FlightInfo> GetInfo(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public AsyncUnaryCall<FlightInfo> GetInfo(FlightDescriptor flightDescriptor, Metadata headers = null)
         {
-            var flightInfoResult = _client.GetFlightInfoAsync(flightDescriptor.ToProtocol(), headers);
+            return GetInfo(flightDescriptor, headers, null, CancellationToken.None);
+        }
+
+        public AsyncUnaryCall<FlightInfo> GetInfo(FlightDescriptor flightDescriptor, Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
+        {
+            var flightInfoResult = _client.GetFlightInfoAsync(flightDescriptor.ToProtocol(), headers, deadline, cancellationToken);
 
             var flightInfo = flightInfoResult
                 .ResponseAsync
@@ -77,7 +98,12 @@ namespace Apache.Arrow.Flight.Client
                 flightInfoResult.Dispose);
         }
 
-        public FlightRecordBatchDuplexStreamingCall StartPut(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public FlightRecordBatchDuplexStreamingCall StartPut(FlightDescriptor flightDescriptor, Metadata headers = null)
+        {
+            return StartPut(flightDescriptor, headers, null, CancellationToken.None);
+        }
+
+        public FlightRecordBatchDuplexStreamingCall StartPut(FlightDescriptor flightDescriptor, Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
         {
             var channels = _client.DoPut(headers, deadline, cancellationToken);
             var requestStream = new FlightClientRecordBatchStreamWriter(channels.RequestStream, flightDescriptor);
@@ -91,7 +117,13 @@ namespace Apache.Arrow.Flight.Client
                 channels.Dispose);
         }
 
-        public AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> Handshake(Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> Handshake(Metadata headers = null)
+        {
+            return Handshake(headers, null, CancellationToken.None);
+
+        }
+
+        public AsyncDuplexStreamingCall<FlightHandshakeRequest, FlightHandshakeResponse> Handshake(Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
         {
             var channel = _client.Handshake(headers, deadline, cancellationToken);
             var readStream = new StreamReader<HandshakeResponse, FlightHandshakeResponse>(channel.ResponseStream, response => new FlightHandshakeResponse(response));
@@ -107,7 +139,12 @@ namespace Apache.Arrow.Flight.Client
             return call;
         }
 
-        public FlightRecordBatchExchangeCall DoExchange(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public FlightRecordBatchExchangeCall DoExchange(FlightDescriptor flightDescriptor, Metadata headers = null)
+        {
+            return DoExchange(flightDescriptor, headers, null, CancellationToken.None);
+        }
+
+        public FlightRecordBatchExchangeCall DoExchange(FlightDescriptor flightDescriptor, Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
         {
             var channel = _client.DoExchange(headers, deadline, cancellationToken);
             var requestStream = new FlightClientRecordBatchStreamWriter(channel.RequestStream, flightDescriptor);
@@ -123,14 +160,24 @@ namespace Apache.Arrow.Flight.Client
             return call;
         }
 
-        public AsyncServerStreamingCall<FlightResult> DoAction(FlightAction action, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public AsyncServerStreamingCall<FlightResult> DoAction(FlightAction action, Metadata headers = null)
         {
-            var stream = _client.DoAction(action.ToProtocol(), headers);
+            return DoAction(action, headers, null, CancellationToken.None);
+        }
+
+        public AsyncServerStreamingCall<FlightResult> DoAction(FlightAction action, Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
+        {
+            var stream = _client.DoAction(action.ToProtocol(), headers, deadline, cancellationToken);
             var streamReader = new StreamReader<Protocol.Result, FlightResult>(stream.ResponseStream, result => new FlightResult(result));
             return new AsyncServerStreamingCall<FlightResult>(streamReader, stream.ResponseHeadersAsync, stream.GetStatus, stream.GetTrailers, stream.Dispose);
         }
 
-        public AsyncUnaryCall<Schema> GetSchema(FlightDescriptor flightDescriptor, Metadata headers = null, System.DateTime? deadline = null, System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+        public AsyncUnaryCall<Schema> GetSchema(FlightDescriptor flightDescriptor, Metadata headers = null)
+        {
+            return GetSchema(flightDescriptor, headers, null, CancellationToken.None);
+        }
+
+        public AsyncUnaryCall<Schema> GetSchema(FlightDescriptor flightDescriptor, Metadata headers, System.DateTime? deadline, CancellationToken cancellationToken = default)
         {
             var schemaResult = _client.GetSchemaAsync(flightDescriptor.ToProtocol(), headers, deadline, cancellationToken);
 

--- a/csharp/test/Apache.Arrow.Flight.Tests/FlightTests.cs
+++ b/csharp/test/Apache.Arrow.Flight.Tests/FlightTests.cs
@@ -24,6 +24,7 @@ using Apache.Arrow.Tests;
 using Google.Protobuf;
 using Grpc.Core;
 using Grpc.Core.Utils;
+using Python.Runtime;
 using Xunit;
 
 namespace Apache.Arrow.Flight.Tests
@@ -419,7 +420,7 @@ namespace Apache.Arrow.Flight.Tests
         }
 
         [Fact]
-        public async Task TestExchangeRaiseDeadlineExceeded()
+        public async Task EnsureCallRaiseDeadlineExceeded()
         {
             var flightDescriptor = FlightDescriptor.CreatePathDescriptor("raise_deadline");
             var deadline = DateTime.UtcNow;
@@ -447,14 +448,14 @@ namespace Apache.Arrow.Flight.Tests
         }
 
         [Fact]
-        public async Task TestExchangeRaiseRequestCancelled()
+        public async Task EnsureCallRaiseRequestCancelled()
         {
-            var flightDescriptor = FlightDescriptor.CreatePathDescriptor("raise_cancelled");
-            var batch = CreateTestBatch(0, 100);
             var cts = new CancellationTokenSource();
-            
             cts.CancelAfter(1);
-
+            
+            var batch = CreateTestBatch(0, 100);
+            var flightDescriptor = FlightDescriptor.CreatePathDescriptor("raise_cancelled");
+            await Task.Delay(5);
             RpcException exception = null;
 
             var duplexStreamingCall = _flightClient.DoExchange(flightDescriptor, null, null, cts.Token);


### PR DESCRIPTION
### Rationale for this change

This implementation add default grpc call options on the csharp implementation FlightClient

### What changes are included in this PR?

- FlightClient.cs with updated signature for all the methods accepting grpc call options
- FlightTest.cs update test to verify the raise of the right exception

### Are these changes tested?

Yes, tests are added in FlightTest.cs
I've tested locally with the C++ implementation.

### Are there any user-facing changes?

No is transparent for the user, following the already present documentation should be sufficient.

### References

* GitHub Issue: #43907