### PR TITLE
GH-43926: [C++] Compute: RowEncoder eliminates offsets when all columns are fixed-sized

### DIFF
--- a/cpp/src/arrow/acero/hash_join_dict.cc
+++ b/cpp/src/arrow/acero/hash_join_dict.cc
@@ -266,7 +266,7 @@ Status HashJoinDictBuild::Init(ExecContext* ctx, std::shared_ptr<Array> dictiona
 
     auto iter = hash_table_.find(str);
     if (iter == hash_table_.end()) {
-      hash_table_.insert(std::make_pair(str, num_entries));
+      hash_table_.insert(std::make_pair(std::move(str), num_entries));
       ids[i] = num_entries;
       entries_to_take.push_back(static_cast<int32_t>(i));
       ++num_entries;

--- a/cpp/src/arrow/compute/row/row_encoder_internal.cc
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.cc
@@ -331,12 +331,12 @@ void RowEncoder::Init(const std::vector<TypeHolder>& column_types, ExecContext* 
 void RowEncoder::Clear() {
   offsets_.clear();
   bytes_.clear();
-  fixed_with_row_count_ = 0;
+  fixed_width_row_count_ = 0;
 }
 
 Status RowEncoder::EncodeAndAppendForFixedWidth(const ExecSpan& batch) {
   size_t length_before =
-      static_cast<size_t>(this->fixed_width_length_) * this->fixed_with_row_count_;
+      static_cast<size_t>(this->fixed_width_length_) * this->fixed_width_row_count_;
   ARROW_CHECK_EQ(length_before, bytes_.size());
 #ifndef NDEBUG
   {
@@ -356,7 +356,7 @@ Status RowEncoder::EncodeAndAppendForFixedWidth(const ExecSpan& batch) {
   for (int64_t i = 0; i < batch.length; ++i) {
     buf_ptrs[i] = bytes_.data() + length_before + i * fixed_width_length_;
   }
-  fixed_with_row_count_ += batch.length;
+  fixed_width_row_count_ += batch.length;
   for (int i = 0; i < batch.num_values(); ++i) {
     RETURN_NOT_OK(encoders_[i]->Encode(batch[i], batch.length, buf_ptrs.data()));
   }

--- a/cpp/src/arrow/compute/row/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.h
@@ -377,7 +377,7 @@ class ARROW_EXPORT RowEncoder {
     int32_t row_offset = 0;
     if (fixed_width_length_ != kInvalidFixedWidthOffset) {
       row_length = fixed_width_length_;
-      row_offset = fixed_with_row_count_ * i;
+      row_offset = fixed_with_row_count_ * i * fixed_width_length_;
     } else {
       row_length = offsets_[i + 1] - offsets_[i];
       row_offset = offsets_[i];

--- a/cpp/src/arrow/compute/row/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.h
@@ -390,7 +390,7 @@ class ARROW_EXPORT RowEncoder {
     if (IsFixedWidth()) {
       return fixed_with_row_count_;
     }
-    return offsets_.empty() ? 0 : offsets_[0];
+    return offsets_.empty() ? 0 : static_cast<int32_t>(offsets_.size() - 1);
   }
 
  private:
@@ -413,6 +413,9 @@ class ARROW_EXPORT RowEncoder {
   //
   // The size would be num_rows + 1 if not empty, the last element is the total
   // length of the bytes_ vector.
+  //
+  // When all columns in a row are Fixed-width or NA, the offsets_ can be
+  // eliminated, and the encoded row can be accessed by fixed_width_length_.
   std::vector<int32_t> offsets_;
   // The encoded bytes of all non "kRowIdForNulls" rows.
   std::vector<uint8_t> bytes_;

--- a/cpp/src/arrow/compute/row/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.h
@@ -375,9 +375,9 @@ class ARROW_EXPORT RowEncoder {
     }
     int32_t row_length = 0;
     int32_t row_offset = 0;
-    if (fixed_width_length_ != kInvalidFixedWidthOffset) {
+    if (IsFixedWidth()) {
       row_length = fixed_width_length_;
-      row_offset = fixed_with_row_count_ * i * fixed_width_length_;
+      row_offset = i * fixed_width_length_;
     } else {
       row_length = offsets_[i + 1] - offsets_[i];
       row_offset = offsets_[i];
@@ -387,7 +387,7 @@ class ARROW_EXPORT RowEncoder {
   }
 
   int32_t num_rows() const {
-    if (kInvalidFixedWidthOffset == fixed_width_length_) {
+    if (IsFixedWidth()) {
       return fixed_with_row_count_;
     }
     return offsets_.empty() ? 0 : offsets_[0];
@@ -395,6 +395,9 @@ class ARROW_EXPORT RowEncoder {
 
  private:
   Status EncodeAndAppendForFixedWidth(const ExecSpan& batch);
+  bool IsFixedWidth() const noexcept {
+    return fixed_width_length_ != kInvalidFixedWidthOffset;
+  }
 
  private:
   static constexpr int32_t kInvalidFixedWidthOffset = 1;

--- a/cpp/src/arrow/compute/row/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.h
@@ -388,7 +388,7 @@ class ARROW_EXPORT RowEncoder {
 
   int32_t num_rows() const {
     if (IsFixedWidth()) {
-      return fixed_with_row_count_;
+      return fixed_width_row_count_;
     }
     return offsets_.empty() ? 0 : static_cast<int32_t>(offsets_.size() - 1);
   }
@@ -407,7 +407,7 @@ class ARROW_EXPORT RowEncoder {
   // doesn't need to maintain the row offsets. In this case, the
   // offsets_.size() would be also empty.
   int32_t fixed_width_length_{kInvalidFixedWidthOffset};
-  int32_t fixed_with_row_count_{0};
+  int32_t fixed_width_row_count_{0};
   // offsets_ vector stores the starting position (offset) of each encoded row
   // within the bytes_ vector. This allows for quick access to individual rows.
   //

--- a/cpp/src/arrow/compute/row/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.h
@@ -403,9 +403,9 @@ class ARROW_EXPORT RowEncoder {
   static constexpr int32_t kInvalidFixedWidthOffset = 1;
   ExecContext* ctx_{nullptr};
   std::vector<std::shared_ptr<KeyEncoder>> encoders_;
-  // When all columns in a row are Fixed-width or NA, the encoded row
-  // doesn't need to maintain the column offsets. In this case, the
-  // offsets_.size() would be also be empty.
+  // When all columns in a row are fixed-width or NA, the encoded row
+  // doesn't need to maintain the row offsets. In this case, the
+  // offsets_.size() would be also empty.
   int32_t fixed_width_length_{kInvalidFixedWidthOffset};
   int32_t fixed_with_row_count_{0};
   // offsets_ vector stores the starting position (offset) of each encoded row
@@ -414,7 +414,7 @@ class ARROW_EXPORT RowEncoder {
   // The size would be num_rows + 1 if not empty, the last element is the total
   // length of the bytes_ vector.
   //
-  // When all columns in a row are Fixed-width or NA, the offsets_ can be
+  // When all columns in a row are fixed-width or NA, the offsets_ can be
   // eliminated, and the encoded row can be accessed by fixed_width_length_.
   std::vector<int32_t> offsets_;
   // The encoded bytes of all non "kRowIdForNulls" rows.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Not use `offsets_` vector when all columns in RowEncoder is fixed-width.

This:
1. Reducing the memory usage
2. Reducing calling to AddLength

This might enlarge 8-byte memory in RowEncoder.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Not use `offsets_` vector when all columns in RowEncoder is fixed-width.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered by existing

### Are there any user-facing changes?

no

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43926