### PR TITLE
GH-40216: [Python][CI][Packaging] Upload nightly wheels to main label of scientific-python-nightly-wheels channel

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -189,7 +189,7 @@ env:
     shell: bash
     run: |
       python3 -m pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@1.12.3
-      anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label dev {{ pattern }}
+      anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label main {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}
   {% endif %}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,6 +184,7 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
+  {%- if arrow.is_default_branch() -%}
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |
@@ -191,6 +192,7 @@ env:
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label main {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}
+  {% endif %}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -184,7 +184,6 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
-  {%- if arrow.is_default_branch() -%}
   - name: Upload wheel to Anaconda scientific-python
     shell: bash
     run: |
@@ -192,7 +191,6 @@ env:
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label main {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}
-  {% endif %}
 {% endmacro %}
 
 {%- macro azure_checkout_arrow() -%}


### PR DESCRIPTION
### Rationale for this change

Small follow-up on https://github.com/apache/arrow/pull/43862, correcting the `label` being used to upload the wheels. See https://github.com/apache/arrow/issues/40216#issuecomment-2325937999 for context.

* GitHub Issue: #40216