### PR TITLE
GH-43669: [Docs][Dev] Document archery --debug flag in section about docker

### DIFF
--- a/docs/source/developers/continuous_integration/docker.rst
+++ b/docs/source/developers/continuous_integration/docker.rst
@@ -156,6 +156,17 @@ The following example starts an interactive ``bash`` session in the container
 
     archery docker run ubuntu-cpp bash
 
+**Build the image with increased debugging output:**
+
+To enable additional logging output for debugging, pass the ``--debug`` flag
+to ``archery``.
+
+.. code:: bash
+
+    archery --debug docker run ubuntu-cpp
+
+which translates to passing ``--progress=plain`` to docker(-compose) build command.
+
 Docker Volume Caches
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developers/continuous_integration/docker.rst
+++ b/docs/source/developers/continuous_integration/docker.rst
@@ -165,7 +165,8 @@ to ``archery``.
 
     archery --debug docker run ubuntu-cpp
 
-which translates to passing ``--progress=plain`` to docker(-compose) build command.
+In addition to enabling ``DEBUG``-level logging, this also translates to
+passing ``--progress=plain`` to docker(-compose) build command.
 
 Docker Volume Caches
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
### Rationale for this change

This feature was added in https://github.com/apache/arrow/pull/40129, but adding it to the docker page in the developer docs for better visibility.

* GitHub Issue: #43669