### PR TITLE
GH-40216: [Python][CI][Packaging] Don't upload sdist to scientific-python nightly channel (only wheels)

### DIFF
--- a/dev/tasks/python-sdist/github.yml
+++ b/dev/tasks/python-sdist/github.yml
@@ -43,4 +43,3 @@ jobs:
 
       {{ macros.github_upload_releases("arrow/python/dist/*.tar.gz")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/dist/*.tar.gz")|indent }}
-      {{ macros.github_upload_wheel_scientific_python("arrow/python/dist/*.tar.gz")|indent }}


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/issues/40216#issuecomment-2325960675 for context. It might be expected that the channel only holds wheels, to users (downstream projects' CI) would accidentally try build from the sdist (e.g. when a wheel is missing).

* GitHub Issue: #40216