### PR TITLE
GH-37756: [Format][Docs] Document IPC Compression

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1385,6 +1385,36 @@ have two entries in each RecordBatch. For a RecordBatch of this schema with
     buffer 13: col2    data
 
 
+Compression
+-----------
+
+There are three different options for record batch body
+buffers compression: buffers can be uncompressed, can use
+``lz4`` or ``zstd`` compression codec. All buffers in the flat
+sequence of the message body are compressed separately with the
+same codec.
+
+The difference between compressed and uncompressed buffers in the
+serialized form is as follows:
+
+* If the buffers in the ``RecordBatch`` message are **compressed**
+
+  - the ``data header`` includes the length and memory offset
+    of each **compressed buffer** in the record batch's body
+
+  - the ``body`` includes a flat sequence of **compressed memory
+    buffers** together with the **length of uncompressed buffer**
+    stored in the first 8 bytes for each buffer in the sequence
+
+* If the buffers in the ``RecordBatch`` message are **uncompressed**
+
+  - the ``data header`` includes the length and memory offset
+    of each **uncompressed buffer** in the record batch's body
+
+  - the ``body`` includes a flat sequence of **uncompressed memory
+    buffers** with the first 8 bytes empty or equal to ``-1`` to
+    indicate that the buffer is uncompressed
+
 Byte Order (`Endianness`_)
 ---------------------------
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1404,8 +1404,9 @@ serialized form is as follows:
     of each **compressed buffer** in the record batch's body
 
   - the ``body`` includes a flat sequence of **compressed buffers**
-    together with the **length of uncompressed buffer** stored in
-    the first 8 bytes for each buffer in the sequence
+    together with the **length of uncompressed buffer** as a 64-bit
+    little-endian signed integer stored in the first 8 bytes for each
+    buffer in the sequence
 
 * If the buffers in the ``RecordBatch`` message are **uncompressed**
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1390,7 +1390,7 @@ Compression
 
 There are three different options for compression of record batch
 body buffers: Buffers can be uncompressed, buffers can be
-compressed with the``lz4`` compression codec, or buffers can
+compressed with the ``lz4`` compression codec, or buffers can
 be compressed with the ``zstd`` compression codec. Buffers in
 the flat sequence of a message body must be either all
 uncompressed or all compressed separately using the same codec.

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1403,18 +1403,18 @@ serialized form is as follows:
   - the ``data header`` includes the length and memory offset
     of each **compressed buffer** in the record batch's body
 
-  - the ``body`` includes a flat sequence of **compressed memory
-    buffers** together with the **length of uncompressed buffer**
-    stored in the first 8 bytes for each buffer in the sequence
+  - the ``body`` includes a flat sequence of **compressed buffers**
+    together with the **length of uncompressed buffer** stored in
+    the first 8 bytes for each buffer in the sequence
 
 * If the buffers in the ``RecordBatch`` message are **uncompressed**
 
   - the ``data header`` includes the length and memory offset
     of each **uncompressed buffer** in the record batch's body
 
-  - the ``body`` includes a flat sequence of **uncompressed memory
-    buffers** with the first 8 bytes empty or equal to ``-1`` to
-    indicate that the buffer is uncompressed
+  - the ``body`` includes a flat sequence of **uncompressed buffers**
+    with the first 8 bytes empty or equal to ``-1`` to indicate that
+    the buffer is uncompressed
 
 Byte Order (`Endianness`_)
 ---------------------------

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1284,6 +1284,8 @@ We additionally provide both schema-level and field-level
 ``custom_metadata`` attributes allowing for systems to insert their
 own application defined metadata to customize behavior.
 
+.. _ipc-recordbatch-message:
+
 RecordBatch message
 -------------------
 
@@ -1395,10 +1397,17 @@ be compressed with the ``zstd`` compression codec. Buffers in
 the flat sequence of a message body must be either all
 uncompressed or all compressed separately using the same codec.
 
+.. note::
+
+  ``lz4`` compression codec means the
+  `LZ4 frame format <https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md>`_
+  and should not to be confused with
+  `"raw" (also called "block") format <https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md>`_.
+
 The difference between compressed and uncompressed buffers in the
 serialized form is as follows:
 
-* If the buffers in the ``RecordBatch`` message are **compressed**
+* If the buffers in the :ref:`ipc-recordbatch-message` are **compressed**
 
   - the ``data header`` includes the length and memory offset
     of each **compressed buffer** in the record batch's body
@@ -1408,7 +1417,7 @@ serialized form is as follows:
     little-endian signed integer stored in the first 8 bytes for each
     buffer in the sequence
 
-* If the buffers in the ``RecordBatch`` message are **uncompressed**
+* If the buffers in the :ref:`ipc-recordbatch-message` are **uncompressed**
 
   - the ``data header`` includes the length and memory offset
     of each **uncompressed buffer** in the record batch's body

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1388,11 +1388,12 @@ have two entries in each RecordBatch. For a RecordBatch of this schema with
 Compression
 -----------
 
-There are three different options for record batch body
-buffers compression: buffers can be uncompressed, can use
-``lz4`` or ``zstd`` compression codec. All buffers in the flat
-sequence of the message body are compressed separately with the
-same codec.
+There are three different options for compression of record batch
+body buffers: Buffers can be uncompressed, buffers can be
+compressed with the``lz4`` compression codec, or buffers can
+be compressed with the ``zstd`` compression codec. Buffers in
+the flat sequence of a message body must be either all
+uncompressed or all compressed separately using the same codec.
 
 The difference between compressed and uncompressed buffers in the
 serialized form is as follows:

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1397,6 +1397,10 @@ be compressed with the ``zstd`` compression codec. Buffers in
 the flat sequence of a message body must be either all
 uncompressed or all compressed separately using the same codec.
 
+The codec or the compression type used is defined in the ``data header```
+of the :ref:`ipc-recordbatch-message` in the optional ``compression``
+field.
+
 .. note::
 
    ``lz4`` compression codec means the
@@ -1410,7 +1414,8 @@ serialized form is as follows:
 * If the buffers in the :ref:`ipc-recordbatch-message` are **compressed**
 
   - the ``data header`` includes the length and memory offset
-    of each **compressed buffer** in the record batch's body
+    of each **compressed buffer** in the record batch's body together
+    with the compression type
 
   - the ``body`` includes a flat sequence of **compressed buffers**
     together with the **length of the uncompressed buffer** as a 64-bit

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1426,6 +1426,19 @@ serialized form is as follows:
     with the first 8 bytes empty or equal to ``-1`` to indicate that
     the buffer is uncompressed
 
+.. note::
+
+  Some Arrow implementations lack support for producing and consuming
+  IPC data with compressed buffers using one or either of the codecs
+  listed above. See :doc:`../status` for details.
+
+  Some applications might apply compression in the protocol they use
+  to store or transport Arrow IPC data. (For example, an HTTP server
+  might serve gzip-compressed Arrow IPC streams.) Applications that
+  already use compression in their storage or transport protocols
+  should avoid using buffer compression. Double compression typically
+  worsens performance and does not substantially improve compression
+  ratios.
 Byte Order (`Endianness`_)
 ---------------------------
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1399,7 +1399,7 @@ the same codec. Specific buffer in the sequence of compressed
 buffers can be left uncompressed in case compression does not yield
 appreciable savings.
 
-The codec or the compression type used is defined in the ``data header```
+The compression type used is defined in the ``data header```
 of the :ref:`ipc-recordbatch-message` in the optional ``compression``
 field.
 
@@ -1421,8 +1421,8 @@ serialized form is as follows:
 
   - the ``body`` includes a flat sequence of **compressed buffers**
     together with the **length of the uncompressed buffer** as a 64-bit
-    little-endian signed integer stored in the first 8 bytes for each
-    buffer in the sequence. The first 8 bytes can equal ``-1`` to indicate
+    little-endian signed integer stored in the first 8 bytes of each
+    buffer in the sequence. This uncompressed length can be set to ``-1`` to indicate
     that that specific buffer is left uncompressed.
 
 * If the buffers in the :ref:`ipc-recordbatch-message` are **uncompressed**

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1399,7 +1399,7 @@ the same codec. Specific buffers in the sequence of compressed
 buffers may be left uncompressed (for example if compressing those
 specific buffers would not appreciably reduce their size).
 
-The compression type used is defined in the ``data header```
+The compression type used is defined in the ``data header``
 of the :ref:`ipc-recordbatch-message` in the optional ``compression``
 field with the default being uncompressed.
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1395,9 +1395,9 @@ body buffers: Buffers can be uncompressed, buffers can be
 compressed with the ``lz4`` compression codec, or buffers can be
 compressed with the ``zstd`` compression codec. Buffers in the
 flat sequence of a message body must be compressed separately using
-the same codec. Specific buffer in the sequence of compressed
-buffers can be left uncompressed in case compression does not yield
-appreciable savings.
+the same codec. Specific buffers in the sequence of compressed
+buffers may be left uncompressed (for example if compressing those
+specific buffers would not appreciably reduce their size).
 
 The compression type used is defined in the ``data header```
 of the :ref:`ipc-recordbatch-message` in the optional ``compression``

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1439,6 +1439,7 @@ serialized form is as follows:
   should avoid using buffer compression. Double compression typically
   worsens performance and does not substantially improve compression
   ratios.
+  
 Byte Order (`Endianness`_)
 ---------------------------
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1392,10 +1392,12 @@ Compression
 
 There are three different options for compression of record batch
 body buffers: Buffers can be uncompressed, buffers can be
-compressed with the ``lz4`` compression codec, or buffers can
-be compressed with the ``zstd`` compression codec. Buffers in
-the flat sequence of a message body must be either all
-uncompressed or all compressed separately using the same codec.
+compressed with the ``lz4`` compression codec, or buffers can be
+compressed with the ``zstd`` compression codec. Buffers in the
+flat sequence of a message body must be compressed separately using
+the same codec. Specific buffer in the sequence of compressed
+buffers can be left uncompressed in case compression does not yield
+appreciable savings.
 
 The codec or the compression type used is defined in the ``data header```
 of the :ref:`ipc-recordbatch-message` in the optional ``compression``
@@ -1420,16 +1422,15 @@ serialized form is as follows:
   - the ``body`` includes a flat sequence of **compressed buffers**
     together with the **length of the uncompressed buffer** as a 64-bit
     little-endian signed integer stored in the first 8 bytes for each
-    buffer in the sequence
+    buffer in the sequence. The first 8 bytes can be left empty or equal
+    to ``-1`` to indicate that that specific buffer is left uncompressed.
 
 * If the buffers in the :ref:`ipc-recordbatch-message` are **uncompressed**
 
   - the ``data header`` includes the length and memory offset
     of each **uncompressed buffer** in the record batch's body
 
-  - the ``body`` includes a flat sequence of **uncompressed buffers**
-    with the first 8 bytes empty or equal to ``-1`` to indicate that
-    the buffer is uncompressed
+  - the ``body`` includes a flat sequence of **uncompressed buffers**.
 
 .. note::
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1413,7 +1413,7 @@ serialized form is as follows:
     of each **compressed buffer** in the record batch's body
 
   - the ``body`` includes a flat sequence of **compressed buffers**
-    together with the **length of uncompressed buffer** as a 64-bit
+    together with the **length of the uncompressed buffer** as a 64-bit
     little-endian signed integer stored in the first 8 bytes for each
     buffer in the sequence
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1401,7 +1401,7 @@ appreciable savings.
 
 The compression type used is defined in the ``data header```
 of the :ref:`ipc-recordbatch-message` in the optional ``compression``
-field.
+field with the default being uncompressed.
 
 .. note::
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1422,8 +1422,8 @@ serialized form is as follows:
   - the ``body`` includes a flat sequence of **compressed buffers**
     together with the **length of the uncompressed buffer** as a 64-bit
     little-endian signed integer stored in the first 8 bytes for each
-    buffer in the sequence. The first 8 bytes can be left empty or equal
-    to ``-1`` to indicate that that specific buffer is left uncompressed.
+    buffer in the sequence. The first 8 bytes can equal ``-1`` to indicate
+    that that specific buffer is left uncompressed.
 
 * If the buffers in the :ref:`ipc-recordbatch-message` are **uncompressed**
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1439,7 +1439,8 @@ serialized form is as follows:
   should avoid using buffer compression. Double compression typically
   worsens performance and does not substantially improve compression
   ratios.
-  
+
+
 Byte Order (`Endianness`_)
 ---------------------------
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1399,10 +1399,10 @@ uncompressed or all compressed separately using the same codec.
 
 .. note::
 
-  ``lz4`` compression codec means the
-  `LZ4 frame format <https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md>`_
-  and should not to be confused with
-  `"raw" (also called "block") format <https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md>`_.
+   ``lz4`` compression codec means the
+   `LZ4 frame format <https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md>`_
+   and should not to be confused with
+   `"raw" (also called "block") format <https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md>`_.
 
 The difference between compressed and uncompressed buffers in the
 serialized form is as follows:
@@ -1428,18 +1428,17 @@ serialized form is as follows:
 
 .. note::
 
-  Some Arrow implementations lack support for producing and consuming
-  IPC data with compressed buffers using one or either of the codecs
-  listed above. See :doc:`../status` for details.
+   Some Arrow implementations lack support for producing and consuming
+   IPC data with compressed buffers using one or either of the codecs
+   listed above. See :doc:`../status` for details.
 
-  Some applications might apply compression in the protocol they use
-  to store or transport Arrow IPC data. (For example, an HTTP server
-  might serve gzip-compressed Arrow IPC streams.) Applications that
-  already use compression in their storage or transport protocols
-  should avoid using buffer compression. Double compression typically
-  worsens performance and does not substantially improve compression
-  ratios.
-
+   Some applications might apply compression in the protocol they use
+   to store or transport Arrow IPC data. (For example, an HTTP server
+   might serve gzip-compressed Arrow IPC streams.) Applications that
+   already use compression in their storage or transport protocols
+   should avoid using buffer compression. Double compression typically
+   worsens performance and does not substantially improve compression
+   ratios.
 
 Byte Order (`Endianness`_)
 ---------------------------


### PR DESCRIPTION
### Rationale for this change

There is no information about buffer compression of the record batch IPC message in the format docs (https://arrow.apache.org/docs/format/Columnar.html).

### What changes are included in this PR?

New paragraph is added with basic information about buffer compression in IPC.

### Are these changes tested?

No, it is only documentation update.

### Are there any user-facing changes?

No, only documentation update.
* GitHub Issue: #37756