### PR TITLE
GH-43953: [C++] Add tests based on random data and benchmarks to ChunkResolver::ResolveMany

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -1218,6 +1218,7 @@ add_arrow_test(sparse_tensor_test)
 add_arrow_test(stl_test SOURCES stl_iterator_test.cc stl_test.cc)
 
 add_arrow_benchmark(builder_benchmark)
+add_arrow_benchmark(chunk_resolver_benchmark)
 add_arrow_benchmark(compare_benchmark)
 add_arrow_benchmark(memory_pool_benchmark)
 add_arrow_benchmark(type_benchmark)

--- a/cpp/src/arrow/chunk_resolver.cc
+++ b/cpp/src/arrow/chunk_resolver.cc
@@ -146,15 +146,15 @@ void ChunkResolver::ResolveManyImpl(int64_t n_indices, const uint8_t* logical_in
                     logical_index_vec, out_chunk_location_vec, chunk_hint);
 }
 
-void ChunkResolver::ResolveManyImpl(int64_t n_indices, const uint32_t* logical_index_vec,
-                                    TypedChunkLocation<uint32_t>* out_chunk_location_vec,
+void ChunkResolver::ResolveManyImpl(int64_t n_indices, const uint16_t* logical_index_vec,
+                                    TypedChunkLocation<uint16_t>* out_chunk_location_vec,
                                     int32_t chunk_hint) const {
   ResolveManyInline(static_cast<uint32_t>(offsets_.size()), offsets_.data(), n_indices,
                     logical_index_vec, out_chunk_location_vec, chunk_hint);
 }
 
-void ChunkResolver::ResolveManyImpl(int64_t n_indices, const uint16_t* logical_index_vec,
-                                    TypedChunkLocation<uint16_t>* out_chunk_location_vec,
+void ChunkResolver::ResolveManyImpl(int64_t n_indices, const uint32_t* logical_index_vec,
+                                    TypedChunkLocation<uint32_t>* out_chunk_location_vec,
                                     int32_t chunk_hint) const {
   ResolveManyInline(static_cast<uint32_t>(offsets_.size()), offsets_.data(), n_indices,
                     logical_index_vec, out_chunk_location_vec, chunk_hint);

--- a/cpp/src/arrow/chunk_resolver.h
+++ b/cpp/src/arrow/chunk_resolver.h
@@ -92,7 +92,8 @@ struct ARROW_EXPORT ChunkResolver {
     for (size_t i = 1; i < offsets_.size(); i++) {
       assert(offsets_[i] >= offsets_[i - 1]);
     }
-    assert(offsets_.size() - 1 <= std::numeric_limits<int32_t>::max());
+    assert(offsets_.size() - 1 <=
+           static_cast<size_t>(std::numeric_limits<int32_t>::max()));
 #endif
   }
 

--- a/cpp/src/arrow/chunk_resolver_benchmark.cc
+++ b/cpp/src/arrow/chunk_resolver_benchmark.cc
@@ -95,8 +95,6 @@ struct ResolveManyBenchmark {
       all_succeeded &= success;
     }
     ARROW_CHECK(all_succeeded);
-    state.counters["logical_len"] = static_cast<double>(chunked_array_length);
-    state.counters["num_chunks"] = static_cast<double>(num_chunks);
     state.SetItemsProcessed(state.iterations() * num_logical_indices);
   }
 };
@@ -106,6 +104,8 @@ void ResolveManySetArgs(benchmark::internal::Benchmark* bench) {
   constexpr int32_t kNonAligned = 3;
   const int64_t kNumIndicesFew = (kChunkedArrayLength >> 7) - kNonAligned;
   const int64_t kNumIndicesMany = (kChunkedArrayLength >> 1) - kNonAligned;
+
+  bench->ArgNames({"chunked_array_length", "num_chunks", "num_indices"});
 
   switch (sizeof(IndexType)) {
     case 1:

--- a/cpp/src/arrow/chunk_resolver_benchmark.cc
+++ b/cpp/src/arrow/chunk_resolver_benchmark.cc
@@ -1,0 +1,166 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "arrow/chunk_resolver.h"
+#include "arrow/util/benchmark_util.h"
+#include "arrow/util/pcg_random.h"
+
+namespace arrow {
+
+using internal::ChunkResolver;
+using internal::TypedChunkLocation;
+
+namespace {
+
+int64_t constexpr kChunkedArrayLength = std::numeric_limits<uint16_t>::max();
+
+struct ResolveManyBenchmark {
+  benchmark::State& state;
+  random::pcg64 rng;
+  // Values from the state.range(i)
+  int64_t chunked_array_length;
+  int32_t num_chunks;
+  int64_t num_logical_indices;
+
+  explicit ResolveManyBenchmark(benchmark::State& state)
+      : state(state),
+        rng(42),
+        chunked_array_length(state.range(0)),
+        num_chunks(static_cast<int32_t>(state.range(1))),
+        num_logical_indices(state.range(2)) {}
+
+  std::vector<int64_t> GenChunkedArrayOffsets() {
+    std::uniform_int_distribution<int64_t> offset_gen(1, chunked_array_length);
+    std::vector<int64_t> offsets;
+    offsets.reserve(num_chunks + 1);
+    offsets.push_back(0);
+    while (offsets.size() < static_cast<size_t>(num_chunks)) {
+      offsets.push_back(offset_gen(rng));
+    }
+    offsets.push_back(chunked_array_length);
+    std::sort(offsets.begin() + 1, offsets.end());
+    return offsets;
+  }
+
+  template <typename IndexType>
+  std::vector<IndexType> GenRandomIndices(IndexType max_index, bool sorted) {
+    std::uniform_int_distribution<IndexType> index_gen(0, max_index);
+    std::vector<IndexType> indices;
+    indices.reserve(num_logical_indices);
+    while (indices.size() < static_cast<size_t>(num_logical_indices)) {
+      indices.push_back(index_gen(rng));
+    }
+    if (sorted) {
+      std::sort(indices.begin(), indices.end());
+    }
+    return indices;
+  }
+
+  template <typename IndexType>
+  void Bench(bool sorted) {
+    if constexpr (sizeof(IndexType) < 8) {
+      constexpr uint64_t kLimitIndex = std::numeric_limits<IndexType>::max();
+      ARROW_CHECK_LE(static_cast<uint64_t>(chunked_array_length), kLimitIndex);
+    }
+    const auto max_random_index = static_cast<IndexType>(chunked_array_length);
+    auto offsets = GenChunkedArrayOffsets();
+    auto logical_indices = GenRandomIndices<IndexType>(max_random_index, sorted);
+    ChunkResolver resolver(std::move(offsets));
+    std::vector<TypedChunkLocation<IndexType>> chunk_location_vec(num_logical_indices);
+    BENCHMARK_UNUSED bool all_succeeded = true;
+    for (auto _ : state) {
+      const bool success = resolver.ResolveMany<IndexType>(
+          num_logical_indices, logical_indices.data(), chunk_location_vec.data());
+      all_succeeded &= success;
+    }
+    ARROW_CHECK(all_succeeded);
+    state.counters["logical_len"] = static_cast<double>(chunked_array_length);
+    state.counters["num_chunks"] = static_cast<double>(num_chunks);
+    state.SetItemsProcessed(state.iterations() * num_logical_indices);
+  }
+};
+
+template <typename IndexType>
+void ResolveManySetArgs(benchmark::internal::Benchmark* bench) {
+  constexpr int32_t kNonAligned = 3;
+  const int64_t kNumIndicesFew = (kChunkedArrayLength >> 7) - kNonAligned;
+  const int64_t kNumIndicesMany = (kChunkedArrayLength >> 1) - kNonAligned;
+
+  switch (sizeof(IndexType)) {
+    case 1:
+      // Unexpected. See comments below.
+    case 2:
+    case 4:
+    case 8:
+      bench->Args({kChunkedArrayLength, /*num_chunks*/ 10000, kNumIndicesFew});
+      bench->Args({kChunkedArrayLength, /*num_chunks*/ 100, kNumIndicesFew});
+      bench->Args({kChunkedArrayLength, /*num_chunks*/ 10000, kNumIndicesMany});
+      bench->Args({kChunkedArrayLength, /*num_chunks*/ 100, kNumIndicesMany});
+      break;
+  }
+}
+
+template <typename IndexType>
+void ResolveManyBench(benchmark::State& state, bool sorted) {
+  ResolveManyBenchmark{state}.Bench<IndexType>(sorted);
+}
+
+void ResolveManyUInt16Random(benchmark::State& state) {
+  ResolveManyBench<uint16_t>(state, false);
+}
+
+void ResolveManyUInt32Random(benchmark::State& state) {
+  ResolveManyBench<uint32_t>(state, false);
+}
+
+void ResolveManyUInt64Random(benchmark::State& state) {
+  ResolveManyBench<uint64_t>(state, false);
+}
+
+void ResolveManyUInt16Sorted(benchmark::State& state) {
+  ResolveManyBench<uint16_t>(state, true);
+}
+
+void ResolveManyUInt32Sorted(benchmark::State& state) {
+  ResolveManyBench<uint32_t>(state, true);
+}
+
+void ResolveManyUInt64Sorted(benchmark::State& state) {
+  ResolveManyBench<uint64_t>(state, true);
+}
+
+}  // namespace
+
+// We don't benchmark with uint8_t because it's too fast -- any meaningful
+// array of logical indices will contain all the possible values.
+
+BENCHMARK(ResolveManyUInt16Random)->Apply(ResolveManySetArgs<uint16_t>);
+BENCHMARK(ResolveManyUInt32Random)->Apply(ResolveManySetArgs<uint32_t>);
+BENCHMARK(ResolveManyUInt64Random)->Apply(ResolveManySetArgs<uint64_t>);
+
+BENCHMARK(ResolveManyUInt16Sorted)->Apply(ResolveManySetArgs<uint16_t>);
+BENCHMARK(ResolveManyUInt32Sorted)->Apply(ResolveManySetArgs<uint32_t>);
+BENCHMARK(ResolveManyUInt64Sorted)->Apply(ResolveManySetArgs<uint64_t>);
+
+}  // namespace arrow

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -51,7 +51,7 @@ ChunkedArray::ChunkedArray(ArrayVector chunks, std::shared_ptr<DataType> type)
       null_count_(0),
       chunk_resolver_{chunks_} {
   if (type_ == nullptr) {
-    ARROW_CHECK_GT(chunks_.size(), 0)
+    ARROW_CHECK_GT(chunks_.size(), static_cast<size_t>(0))
         << "cannot construct ChunkedArray from empty vector and omitted type";
     type_ = chunks_[0]->type();
   }

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -55,7 +55,7 @@ ChunkedArray::ChunkedArray(ArrayVector chunks, std::shared_ptr<DataType> type)
         << "cannot construct ChunkedArray from empty vector and omitted type";
     type_ = chunks_[0]->type();
   }
-
+  ARROW_CHECK_LE(chunks.size(), std::numeric_limits<int>::max());
   for (const auto& chunk : chunks_) {
     length_ += chunk->length();
     null_count_ += chunk->null_count();

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -55,7 +55,7 @@ ChunkedArray::ChunkedArray(ArrayVector chunks, std::shared_ptr<DataType> type)
         << "cannot construct ChunkedArray from empty vector and omitted type";
     type_ = chunks_[0]->type();
   }
-  ARROW_CHECK_LE(chunks.size(), std::numeric_limits<int>::max());
+  ARROW_CHECK_LE(chunks.size(), static_cast<size_t>(std::numeric_limits<int>::max()));
   for (const auto& chunk : chunks_) {
     length_ += chunk->length();
     null_count_ += chunk->null_count();

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -32,6 +32,7 @@
 #include "arrow/type.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/key_value_metadata.h"
+#include "arrow/util/pcg_random.h"
 
 namespace arrow {
 
@@ -373,10 +374,27 @@ TEST(TestChunkResolver, Resolve) {
   ASSERT_EQ(resolver.Resolve(10).chunk_index, 3);
 }
 
+template <class RNG>
+std::vector<int64_t> GenChunkedArrayOffsets(RNG& rng, int32_t num_chunks,
+                                            int64_t chunked_array_len) {
+  std::uniform_int_distribution<int64_t> offset_gen(1, chunked_array_len - 1);
+  std::vector<int64_t> offsets;
+  offsets.reserve(num_chunks + 1);
+  offsets.push_back(0);
+  while (offsets.size() < static_cast<size_t>(num_chunks)) {
+    offsets.push_back(offset_gen(rng));
+  }
+  offsets.push_back(chunked_array_len);
+  std::sort(offsets.begin() + 1, offsets.end());
+  return offsets;
+}
+
 template <typename T>
 class TestChunkResolverMany : public ::testing::Test {
  public:
   using IndexType = T;
+  static constexpr int32_t kMaxInt32 = std::numeric_limits<int32_t>::max();
+  static constexpr size_t kMaxValidIndex = std::numeric_limits<IndexType>::max();
 
   Result<std::vector<ChunkLocation>> ResolveMany(
       const ChunkResolver& resolver, const std::vector<IndexType>& logical_index_vec) {
@@ -510,6 +528,54 @@ class TestChunkResolverMany : public ::testing::Test {
       ASSERT_OK(ResolveMany(resolver_with_empty, logical_index_vec));
     }
   }
+
+  void TestRandomInput(int32_t num_chunks, int64_t chunked_array_len) {
+    random::pcg64 rng(42);
+
+    // Generate random chunk offsets...
+    auto offsets = GenChunkedArrayOffsets(rng, num_chunks, chunked_array_len);
+    ASSERT_EQ(offsets.size(), static_cast<size_t>(num_chunks) + 1);
+    // ...and ensure there is at least one empty chunk.
+    std::uniform_int_distribution<int32_t> chunk_index_gen(
+        1, static_cast<int32_t>(num_chunks - 1));
+    auto chunk_index = chunk_index_gen(rng);
+    offsets[chunk_index] = offsets[chunk_index - 1];
+
+    // Generate random query array of logical indices...
+    const auto num_logical_indices = 3 * static_cast<int64_t>(num_chunks) / 2;
+    std::vector<IndexType> logical_index_vec;
+    logical_index_vec.reserve(num_logical_indices);
+    std::uniform_int_distribution<IndexType> logical_index_gen(1, kMaxValidIndex);
+    for (int64_t i = 0; i < num_logical_indices; i++) {
+      logical_index_vec.push_back(logical_index_gen(rng));
+    }
+    // ...and sprinkle some extreme logical index values.
+    std::uniform_int_distribution<size_t> position_gen(0, logical_index_vec.size() - 1);
+    for (int i = 0; i < 2; i++) {
+      auto max_valid_index =
+          std::min(kMaxValidIndex, static_cast<size_t>(chunked_array_len));
+      // zero and last valid logical index
+      logical_index_vec[position_gen(rng)] = 0;
+      logical_index_vec[position_gen(rng)] = static_cast<IndexType>(max_valid_index - 1);
+      // out of  bounds indices
+      logical_index_vec[position_gen(rng)] = static_cast<IndexType>(max_valid_index);
+      if (max_valid_index < kMaxValidIndex) {
+        logical_index_vec[position_gen(rng)] =
+            static_cast<IndexType>(max_valid_index + 1);
+      }
+    }
+
+    ChunkResolver resolver(std::move(offsets));
+    CheckResolveMany(resolver, logical_index_vec);
+  }
+
+  void TestRandomInput() {
+    const int64_t num_chunks =
+        static_cast<int64_t>(std::min(kMaxValidIndex - 1, static_cast<size_t>(1) << 16));
+    const int64_t avg_chunk_length = 20;
+    const int64_t chunked_array_len = num_chunks * 2 * avg_chunk_length;
+    TestRandomInput(num_chunks, chunked_array_len);
+  }
 };
 
 TYPED_TEST_SUITE(TestChunkResolverMany, IndexTypes);
@@ -517,5 +583,6 @@ TYPED_TEST_SUITE(TestChunkResolverMany, IndexTypes);
 TYPED_TEST(TestChunkResolverMany, Basics) { this->TestBasics(); }
 TYPED_TEST(TestChunkResolverMany, OutOfBounds) { this->TestOutOfBounds(); }
 TYPED_TEST(TestChunkResolverMany, Overflow) { this->TestOverflow(); }
+TYPED_TEST(TestChunkResolverMany, RandomInput) { this->TestRandomInput(); }
 
 }  // namespace arrow

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -551,7 +551,7 @@ class TestChunkResolverMany : public ::testing::Test {
       logical_index_vec.push_back(index);
     }
     // ...and sprinkle some extreme logical index values.
-    std::uniform_int_distribution<size_t> position_gen(0, logical_index_vec.size() - 1);
+    std::uniform_int_distribution<int64_t> position_gen(0, logical_index_vec.size() - 1);
     for (int i = 0; i < 2; i++) {
       auto max_valid_index =
           std::min(kMaxValidIndex, static_cast<uint64_t>(chunked_array_len));

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -394,7 +394,7 @@ class TestChunkResolverMany : public ::testing::Test {
  public:
   using IndexType = T;
   static constexpr int32_t kMaxInt32 = std::numeric_limits<int32_t>::max();
-  static constexpr size_t kMaxValidIndex = std::numeric_limits<IndexType>::max();
+  static constexpr uint64_t kMaxValidIndex = std::numeric_limits<IndexType>::max();
 
   Result<std::vector<ChunkLocation>> ResolveMany(
       const ChunkResolver& resolver, const std::vector<IndexType>& logical_index_vec) {

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -545,9 +545,9 @@ class TestChunkResolverMany : public ::testing::Test {
     const auto num_logical_indices = 3 * static_cast<int64_t>(num_chunks) / 2;
     std::vector<IndexType> logical_index_vec;
     logical_index_vec.reserve(num_logical_indices);
-    std::uniform_int_distribution<IndexType> logical_index_gen(1, kMaxValidIndex);
+    std::uniform_int_distribution<uint64_t> logical_index_gen(1, kMaxValidIndex);
     for (int64_t i = 0; i < num_logical_indices; i++) {
-      logical_index_vec.push_back(logical_index_gen(rng));
+      logical_index_vec.push_back(static_cast<IndexType>(logical_index_gen(rng)));
     }
     // ...and sprinkle some extreme logical index values.
     std::uniform_int_distribution<size_t> position_gen(0, logical_index_vec.size() - 1);

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -547,7 +547,8 @@ class TestChunkResolverMany : public ::testing::Test {
     logical_index_vec.reserve(num_logical_indices);
     std::uniform_int_distribution<uint64_t> logical_index_gen(1, kMaxValidIndex);
     for (int64_t i = 0; i < num_logical_indices; i++) {
-      logical_index_vec.push_back(static_cast<IndexType>(logical_index_gen(rng)));
+      const auto index = static_cast<IndexType>(logical_index_gen(rng));
+      logical_index_vec.push_back(index);
     }
     // ...and sprinkle some extreme logical index values.
     std::uniform_int_distribution<size_t> position_gen(0, logical_index_vec.size() - 1);

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -553,7 +553,7 @@ class TestChunkResolverMany : public ::testing::Test {
     std::uniform_int_distribution<size_t> position_gen(0, logical_index_vec.size() - 1);
     for (int i = 0; i < 2; i++) {
       auto max_valid_index =
-          std::min(kMaxValidIndex, static_cast<size_t>(chunked_array_len));
+          std::min(kMaxValidIndex, static_cast<uint64_t>(chunked_array_len));
       // zero and last valid logical index
       logical_index_vec[position_gen(rng)] = 0;
       logical_index_vec[position_gen(rng)] = static_cast<IndexType>(max_valid_index - 1);
@@ -570,8 +570,8 @@ class TestChunkResolverMany : public ::testing::Test {
   }
 
   void TestRandomInput() {
-    const int64_t num_chunks =
-        static_cast<int64_t>(std::min(kMaxValidIndex - 1, static_cast<size_t>(1) << 16));
+    const int64_t num_chunks = static_cast<int64_t>(
+        std::min(kMaxValidIndex - 1, static_cast<uint64_t>(1) << 16));
     const int64_t avg_chunk_length = 20;
     const int64_t chunked_array_len = num_chunks * 2 * avg_chunk_length;
     TestRandomInput(num_chunks, chunked_array_len);


### PR DESCRIPTION
### Rationale for this change

Improve tests and add benchmarks. I wrote the tests and benchmarks while trying to improve the performance of `ResolveMany` and failing at it.

### What changes are included in this PR?

Tests, benchmarks, and changes that don't really affect performance but might unlock more optimization opportunities in the future.

### Are these changes tested?

Yes.

* GitHub Issue: #43953