### PR TITLE
MINOR: [CI][C++] Add C++ example builds to "cpp" Crossbow task group

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -75,6 +75,7 @@ groups:
 
   cpp:
     - test-*cpp*
+    - example-*cpp*
 
   c-glib:
     - test-*c-glib*


### PR DESCRIPTION
### Rationale for this change

The `python` task group already includes the Python example builds. This PR does the same for the `cpp` task group.

### Are these changes tested?

By CI itself.

### Are there any user-facing changes?

No.

<!-- **This PR contains a "Critical Fix".** -->