### PR TITLE
GH-43576: [Java] Gandiva Tests are failing due to linking issues

### DIFF
--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -473,6 +473,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     eval.close();
   }
 
+  @Disabled("Enable after fixing: https://github.com/apache/arrow/issues/43981")
   @Test
   public void testStringFields() throws GandivaException {
     /*
@@ -546,6 +547,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     eval.close();
   }
 
+  @Disabled("Enable after fixing: https://github.com/apache/arrow/issues/43981")
   @Test
   public void testStringOutput() throws GandivaException {
     /*
@@ -1234,6 +1236,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     eval.close();
   }
 
+  @Disabled("Enable after fixing: https://github.com/apache/arrow/issues/43981")
   @Test
   public void testTimeEquals() throws GandivaException, Exception {
     /*

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -148,6 +148,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     executors.awaitTermination(100, java.util.concurrent.TimeUnit.SECONDS);
   }
 
+  @Disabled
   @Test
   public void testMakeProjectorParallel() throws Exception {
     testMakeProjectorParallel(null);

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -62,6 +62,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Disabled("Disabled until GH-43981 is solved")
 public class ProjectorTest extends BaseEvaluatorTest {
 
   private Charset utf8Charset = Charset.forName("UTF-8");
@@ -148,7 +149,6 @@ public class ProjectorTest extends BaseEvaluatorTest {
     executors.awaitTermination(100, java.util.concurrent.TimeUnit.SECONDS);
   }
 
-  @Disabled
   @Test
   public void testMakeProjectorParallel() throws Exception {
     testMakeProjectorParallel(null);
@@ -473,7 +473,6 @@ public class ProjectorTest extends BaseEvaluatorTest {
     eval.close();
   }
 
-  @Disabled("Enable after fixing: https://github.com/apache/arrow/issues/43981")
   @Test
   public void testStringFields() throws GandivaException {
     /*
@@ -547,7 +546,6 @@ public class ProjectorTest extends BaseEvaluatorTest {
     eval.close();
   }
 
-  @Disabled("Enable after fixing: https://github.com/apache/arrow/issues/43981")
   @Test
   public void testStringOutput() throws GandivaException {
     /*
@@ -1236,7 +1234,6 @@ public class ProjectorTest extends BaseEvaluatorTest {
     eval.close();
   }
 
-  @Disabled("Enable after fixing: https://github.com/apache/arrow/issues/43981")
   @Test
   public void testTimeEquals() throws GandivaException, Exception {
     /*


### PR DESCRIPTION
### Rationale for this change

Gandiva tests are failing due to a linking issue and it is failing the Java CIs. But for most of the made PRs, we cannot verify the overall workflow given that those PRs are independent of the Gandiva component. 

### What changes are included in this PR?

This PR disables such failing tests temporarily such that once the Gandiva issue is fixed, re-enabling the tests. 
Re-enabling task will be tracked using https://github.com/apache/arrow/issues/43981

### Are these changes tested?

Yes, by existing CIs and tests.

### Are there any user-facing changes?

No
* GitHub Issue: apache/arrow-java#63
* GitHub Issue: #63