### PR TITLE
GH-40860: [GLib][Parquet] Add `gparquet_arrow_file_writer_write_record_batch()`

### DIFF
--- a/c_glib/parquet-glib/arrow-file-writer.h
+++ b/c_glib/parquet-glib/arrow-file-writer.h
@@ -116,6 +116,16 @@ gparquet_arrow_file_writer_new_path(GArrowSchema *schema,
                                     GParquetWriterProperties *writer_properties,
                                     GError **error);
 
+GPARQUET_AVAILABLE_IN_18_0
+GArrowSchema *
+gparquet_arrow_file_writer_get_schema(GParquetArrowFileWriter *writer);
+
+GPARQUET_AVAILABLE_IN_18_0
+gboolean
+gparquet_arrow_file_writer_write_record_batch(GParquetArrowFileWriter *writer,
+                                              GArrowRecordBatch *record_batch,
+                                              GError **error);
+
 GPARQUET_AVAILABLE_IN_0_11
 gboolean
 gparquet_arrow_file_writer_write_table(GParquetArrowFileWriter *writer,

--- a/ruby/red-parquet/lib/parquet/arrow-file-writer.rb
+++ b/ruby/red-parquet/lib/parquet/arrow-file-writer.rb
@@ -1,0 +1,98 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Parquet
+  class ArrowFileWriter
+    # Write data to Apache Parquet.
+    #
+    # @return [void]
+    #
+    # @overload write(record_batch)
+    #
+    #   @param record_batch [Arrow::RecordBatch] The record batch to
+    #     be written.
+    #
+    #   @example Write a record batch
+    #     record_batch = Arrow::RecordBatch.new(enabled: [true, false])
+    #     schema = record_batch.schema
+    #     Parquet::ArrowFileWriter.open(schema, "data.parquet") do |writer|
+    #       writer.write(record_batch)
+    #     end
+    #
+    # @overload write(table, chunk_size: nil)
+    #
+    #   @param table [Arrow::Table] The table to be written.
+    #
+    #   @param chunk_size [nil, Integer] (nil) The maximum number of
+    #     rows to write per row group.
+    #
+    #     If this is `nil`, the default value (`1024 * 1024`) is used.
+    #
+    #   @example Write a record batch with the default chunk size
+    #     table = Arrow::Table.new(enabled: [true, false])
+    #     schema = table.schema
+    #     Parquet::ArrowFileWriter.open(schema, "data.parquet") do |writer|
+    #       writer.write(table)
+    #     end
+    #
+    #   @example Write a record batch with the specified chunk size
+    #     table = Arrow::Table.new(enabled: [true, false])
+    #     schema = table.schema
+    #     Parquet::ArrowFileWriter.open(schema, "data.parquet") do |writer|
+    #       writer.write(table, chunk_size: 1)
+    #     end
+    #
+    # @overload write(raw_records)
+    #
+    #   @param data [Array<Hash>, Array<Array>] The data to be written
+    #     as primitive Ruby objects.
+    #
+    #   @example Write a record batch with Array<Array> based data
+    #     schema = Arrow::Schema.new(enabled: :boolean)
+    #     raw_records = [
+    #       [true],
+    #       [false],
+    #     ]
+    #     Parquet::ArrowFileWriter.open(schema, "data.parquet") do |writer|
+    #       writer.write(raw_records)
+    #     end
+    #
+    #   @example Write a record batch with Array<Hash> based data
+    #     schema = Arrow::Schema.new(enabled: :boolean)
+    #     raw_columns = [
+    #       enabled: [true, false],
+    #     ]
+    #     Parquet::ArrowFileWriter.open(schema, "data.parquet") do |writer|
+    #       writer.write(raw_columns)
+    #     end
+    #
+    # @since 18.0.0
+    def write(target, chunk_size: nil)
+      case target
+      when Arrow::RecordBatch
+        write_record_batch(target)
+      when Arrow::Table
+        # Same as parquet::DEFAULT_MAX_ROW_GROUP_LENGTH in C++
+        chunk_size ||= 1024 * 1024
+        write_table(target, chunk_size)
+      else
+        record_batch = Arrow::RecordBatch.new(schema, target)
+        write_record_batch(record_batch)
+      end
+    end
+  end
+end

--- a/ruby/red-parquet/lib/parquet/loader.rb
+++ b/ruby/red-parquet/lib/parquet/loader.rb
@@ -30,6 +30,7 @@ module Parquet
 
     def require_libraries
       require "parquet/arrow-file-reader"
+      require "parquet/arrow-file-writer"
       require "parquet/arrow-table-loadable"
       require "parquet/arrow-table-savable"
       require "parquet/writer-properties"

--- a/ruby/red-parquet/test/test-arrow-file-writer.rb
+++ b/ruby/red-parquet/test/test-arrow-file-writer.rb
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestArrowFileWriter < Test::Unit::TestCase
+  sub_test_case("#write") do
+    test("RecordBatch") do
+      schema = Arrow::Schema.new(visible: :boolean)
+      record_batch = Arrow::RecordBatch.new(schema, [[true], [false]])
+      Tempfile.create(["red-parquet", ".parquet"]) do |file|
+        Parquet::ArrowFileWriter.open(record_batch.schema, file.path) do |writer|
+          writer.write(record_batch)
+        end
+        assert_equal(record_batch.to_table,
+                     Arrow::Table.load(file.path))
+      end
+    end
+
+    test("Table") do
+      schema = Arrow::Schema.new(visible: :boolean)
+      table = Arrow::Table.new(schema, [[true], [false]])
+      Tempfile.create(["red-parquet", ".parquet"]) do |file|
+        Parquet::ArrowFileWriter.open(table.schema, file.path) do |writer|
+          writer.write(table)
+        end
+        assert_equal(table,
+                     Arrow::Table.load(file.path))
+      end
+    end
+
+    test("[[]]") do
+      schema = Arrow::Schema.new(visible: :boolean)
+      raw_records = [[true], [false]]
+      Tempfile.create(["red-parquet", ".parquet"]) do |file|
+        Parquet::ArrowFileWriter.open(schema, file.path) do |writer|
+          writer.write(raw_records)
+        end
+        assert_equal(Arrow::RecordBatch.new(schema, raw_records).to_table,
+                     Arrow::Table.load(file.path))
+      end
+    end
+
+    test("[{}]") do
+      schema = Arrow::Schema.new(visible: :boolean)
+      raw_columns = [visible: [true, false]]
+      Tempfile.create(["red-parquet", ".parquet"]) do |file|
+        Parquet::ArrowFileWriter.open(schema, file.path) do |writer|
+          writer.write(raw_columns)
+        end
+        assert_equal(Arrow::RecordBatch.new(schema, raw_columns).to_table,
+                     Arrow::Table.load(file.path))
+      end
+    end
+  end
+end

--- a/ruby/red-parquet/test/test-arrow-file-writer.rb
+++ b/ruby/red-parquet/test/test-arrow-file-writer.rb
@@ -16,53 +16,61 @@
 # under the License.
 
 class TestArrowFileWriter < Test::Unit::TestCase
+  def open_buffer_output_stream
+    buffer = Arrow::ResizableBuffer.new(4096)
+    Arrow::BufferOutputStream.open(buffer) do |output|
+      yield(output)
+    end
+    buffer
+  end
+
   sub_test_case("#write") do
     test("RecordBatch") do
       schema = Arrow::Schema.new(visible: :boolean)
       record_batch = Arrow::RecordBatch.new(schema, [[true], [false]])
-      Tempfile.create(["red-parquet", ".parquet"]) do |file|
-        Parquet::ArrowFileWriter.open(record_batch.schema, file.path) do |writer|
+      buffer = open_buffer_output_stream do |output|
+        Parquet::ArrowFileWriter.open(record_batch.schema, output) do |writer|
           writer.write(record_batch)
         end
-        assert_equal(record_batch.to_table,
-                     Arrow::Table.load(file.path))
       end
+      assert_equal(record_batch.to_table,
+                   Arrow::Table.load(buffer, format: :parquet))
     end
 
     test("Table") do
       schema = Arrow::Schema.new(visible: :boolean)
       table = Arrow::Table.new(schema, [[true], [false]])
-      Tempfile.create(["red-parquet", ".parquet"]) do |file|
-        Parquet::ArrowFileWriter.open(table.schema, file.path) do |writer|
+      buffer = open_buffer_output_stream do |output|
+        Parquet::ArrowFileWriter.open(table.schema, output) do |writer|
           writer.write(table)
         end
-        assert_equal(table,
-                     Arrow::Table.load(file.path))
       end
+      assert_equal(table,
+                   Arrow::Table.load(buffer, format: :parquet))
     end
 
     test("[[]]") do
       schema = Arrow::Schema.new(visible: :boolean)
       raw_records = [[true], [false]]
-      Tempfile.create(["red-parquet", ".parquet"]) do |file|
-        Parquet::ArrowFileWriter.open(schema, file.path) do |writer|
+      buffer = open_buffer_output_stream do |output|
+        Parquet::ArrowFileWriter.open(schema, output) do |writer|
           writer.write(raw_records)
         end
-        assert_equal(Arrow::RecordBatch.new(schema, raw_records).to_table,
-                     Arrow::Table.load(file.path))
       end
+      assert_equal(Arrow::RecordBatch.new(schema, raw_records).to_table,
+                   Arrow::Table.load(buffer, format: :parquet))
     end
 
     test("[{}]") do
       schema = Arrow::Schema.new(visible: :boolean)
       raw_columns = [visible: [true, false]]
-      Tempfile.create(["red-parquet", ".parquet"]) do |file|
-        Parquet::ArrowFileWriter.open(schema, file.path) do |writer|
+      buffer = open_buffer_output_stream do |output|
+        Parquet::ArrowFileWriter.open(schema, output) do |writer|
           writer.write(raw_columns)
         end
-        assert_equal(Arrow::RecordBatch.new(schema, raw_columns).to_table,
-                     Arrow::Table.load(file.path))
       end
+      assert_equal(Arrow::RecordBatch.new(schema, raw_columns).to_table,
+                   Arrow::Table.load(buffer, format: :parquet))
     end
   end
 end


### PR DESCRIPTION
### Rationale for this change

We don't need to create a `GArrowTable` only for writing a `GArrowRecordBatch`.

### What changes are included in this PR?

The following APIs are also added:
* `gparquet_arrow_file_writer_get_schema()`
* Parquet::ArrowFileWriter#write` in Ruby

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40860