### PR TITLE
GH-41551: [C++] Remove boost::filesystem in favor of std::filesystem

### DIFF
--- a/cpp/src/arrow/io/hdfs_test.cc
+++ b/cpp/src/arrow/io/hdfs_test.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <random>
@@ -36,12 +37,6 @@
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
-
-// boost/filesystem.hpp should be included after
-// arrow/util/windows_compatibility.h because boost/filesystem.hpp
-// includes windows.h implicitly.
-#include <filesystem>
-#include <string>
 
 namespace arrow {
 namespace io {

--- a/cpp/src/arrow/testing/process.cc
+++ b/cpp/src/arrow/testing/process.cc
@@ -74,10 +74,10 @@
 #endif
 
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <sstream>
 #include <thread>
-#include <filesystem>
 
 #ifdef BOOST_PROCESS_USE_V2
 namespace asio = BOOST_PROCESS_V2_ASIO_NAMESPACE;
@@ -89,18 +89,7 @@ namespace filesystem = boost::process::v1::filesystem;
 #else
 namespace process = boost::process;
 namespace filesystem = boost::filesystem;
-#endif
-
-#ifdef BOOST_PROCESS_USE_V2
-namespace asio = BOOST_PROCESS_V2_ASIO_NAMESPACE;
-namespace process = BOOST_PROCESS_V2_NAMESPACE;
-namespace filesystem = std::filesystem;
-#elif defined(BOOST_PROCESS_HAVE_V1)
-namespace process = boost::process::v1;
-namespace filesystem = boost::process::v1::filesystem;
-#else
-namespace process = boost::process;
-namespace filesystem = std::filesystem;
+//namespace filesystem = std::filesystem;
 #endif
 
 namespace arrow::util {

--- a/cpp/src/arrow/testing/process.cc
+++ b/cpp/src/arrow/testing/process.cc
@@ -77,6 +77,7 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+#include <filesystem>
 
 #ifdef BOOST_PROCESS_USE_V2
 namespace asio = BOOST_PROCESS_V2_ASIO_NAMESPACE;
@@ -88,6 +89,18 @@ namespace filesystem = boost::process::v1::filesystem;
 #else
 namespace process = boost::process;
 namespace filesystem = boost::filesystem;
+#endif
+
+#ifdef BOOST_PROCESS_USE_V2
+namespace asio = BOOST_PROCESS_V2_ASIO_NAMESPACE;
+namespace process = BOOST_PROCESS_V2_NAMESPACE;
+namespace filesystem = std::filesystem;
+#elif defined(BOOST_PROCESS_HAVE_V1)
+namespace process = boost::process::v1;
+namespace filesystem = boost::process::v1::filesystem;
+#else
+namespace process = boost::process;
+namespace filesystem = std::filesystem;
 #endif
 
 namespace arrow::util {

--- a/cpp/src/arrow/testing/process.cc
+++ b/cpp/src/arrow/testing/process.cc
@@ -74,7 +74,6 @@
 #endif
 
 #include <chrono>
-#include <filesystem>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -89,7 +88,6 @@ namespace filesystem = boost::process::v1::filesystem;
 #else
 namespace process = boost::process;
 namespace filesystem = boost::filesystem;
-//namespace filesystem = std::filesystem;
 #endif
 
 namespace arrow::util {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fixes #41551 

```
$ grep -Rnw "boost::filesystem" arrow/
./cpp/src/arrow/io/hdfs_test.cc:93:        boost::filesystem::unique_path(boost::filesystem::temp_directory_path() /
./cpp/src/arrow/testing/process.cc:90:namespace filesystem = boost::filesystem;
```
The latter file in this list required some other boost elements to be stripped away with the removal of `boost::filesystem`. For example there is some reliance on `boost::system::error_code`, `boost::process` methods that take in `boost::filesystem` type parameters, etc. Perhaps the rework in this file should be more generalized beyond just replacing instances of `boost::filesystem` in another PR?
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
- Replace instance of `boost::filesystem` with `std::filesystem`
- Adds helper function to generate random hex string for unique file paths used in hdfs_test.cc's `SetUp` function. Previously used was the `boost::filesystem::unique_path` method which does not exist in `std::filesystem`.  The helper function creates a random 4 digit hex string to append to the scratch directory similar to what `boost::filesystem::unique_path`:

```
boost scratch dir: /tmp/arrow-hdfs/scratch-8907
std scratch dir: /tmp/arrow-hdfs/scratch-f7a5
```

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes. Built with `--preset ninja-debug-filesystems` and tested with the `./arrow-io-hdfs-test` test suite

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41551