### PR TITLE
GH-44008: [C++][Parquet] Add support for arrow::ArrayStatistics: boolean

### DIFF
--- a/cpp/src/parquet/arrow/arrow_statistics_test.cc
+++ b/cpp/src/parquet/arrow/arrow_statistics_test.cc
@@ -248,6 +248,10 @@ void TestStatisticsReadArray(std::shared_ptr<::arrow::DataType> arrow_type) {
 }
 }  // namespace
 
+TEST(TestStatisticsRead, Boolean) {
+  TestStatisticsReadArray<::arrow::BooleanType, bool>(::arrow::boolean());
+}
+
 TEST(TestStatisticsRead, Int8) {
   TestStatisticsReadArray<::arrow::Int8Type, int64_t>(::arrow::int8());
 }


### PR DESCRIPTION
### Rationale for this change

Statistics is useful for fast processing.

Target types:

* `Boolean`

### What changes are included in this PR?

Map `ColumnChunkMetaData` information to `arrow::ArrayStatistics`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44008