### PR TITLE
GH-44016: [Java] Consider warnings as errors for Format Module

### DIFF
--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -61,6 +61,15 @@ under the License.
           </java>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration combine.children="append">
+          <compilerArgs>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/java/format/src/main/java/module-info.java
+++ b/java/format/src/main/java/module-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-// Remove warnings once criterion in https://github.com/apache/arrow/issues/44037 met.
+// TODO(https://github.com/apache/arrow/issues/44037): Google hasn't reviewed Flatbuffers fix
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.apache.arrow.format {
   exports org.apache.arrow.flatbuf;

--- a/java/format/src/main/java/module-info.java
+++ b/java/format/src/main/java/module-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-// TODO: PR to fix this under-review https://github.com/google/flatbuffers/pull/8367
+// Remove warnings once criterion in https://github.com/apache/arrow/issues/44037 met. 
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.apache.arrow.format {
   exports org.apache.arrow.flatbuf;

--- a/java/format/src/main/java/module-info.java
+++ b/java/format/src/main/java/module-info.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+@SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.apache.arrow.format {
   exports org.apache.arrow.flatbuf;
   requires transitive flatbuffers.java;

--- a/java/format/src/main/java/module-info.java
+++ b/java/format/src/main/java/module-info.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-// Remove warnings once criterion in https://github.com/apache/arrow/issues/44037 met. 
+// Remove warnings once criterion in https://github.com/apache/arrow/issues/44037 met.
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.apache.arrow.format {
   exports org.apache.arrow.flatbuf;

--- a/java/format/src/main/java/module-info.java
+++ b/java/format/src/main/java/module-info.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// TODO: PR to fix this under-review https://github.com/google/flatbuffers/pull/8367
 @SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.apache.arrow.format {
   exports org.apache.arrow.flatbuf;

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -34,4 +34,18 @@ under the License.
     <module>memory-netty-buffer-patch</module>
     <module>memory-netty</module>
   </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration combine.children="append">
+          <compilerArgs>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -34,18 +34,4 @@ under the License.
     <module>memory-netty-buffer-patch</module>
     <module>memory-netty</module>
   </modules>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.children="append">
-          <compilerArgs>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
### Rationale for this change

This PR configs the build such that warnings are considered errors in the Format module. And corresponding code changes have also been made.

### What changes are included in this PR?

Adding flags to consider warnings as errors in javac and fixing the corresponding errors.

### Are these changes tested?

Tested by existing test cases.

### Are there any user-facing changes?

N/A
* GitHub Issue: apache/arrow#44016
* GitHub Issue: #44016