### PR TITLE
GH-44034:  [Go][Format][FlightRPC] Update go_package in Flight.proto and FlightSql.proto

### DIFF
--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 import "google/protobuf/timestamp.proto";
 
 option java_package = "org.apache.arrow.flight.impl";
-option go_package = "github.com/apache/arrow/go/arrow/flight/gen/flight";
+option go_package = "github.com/apache/arrow-go/arrow/flight/gen/flight";
 option csharp_namespace = "Apache.Arrow.Flight.Protocol";
 
 package arrow.flight.protocol;

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -20,7 +20,7 @@ syntax = "proto3";
 import "google/protobuf/descriptor.proto";
 
 option java_package = "org.apache.arrow.flight.sql.impl";
-option go_package = "github.com/apache/arrow/go/arrow/flight/gen/flight";
+option go_package = "github.com/apache/arrow-go/arrow/flight/gen/flight";
 package arrow.flight.protocol.sql;
 
 /*


### PR DESCRIPTION
### Rationale for this change

We're migrating `go/` to apache/arrow-go.

### What changes are included in this PR?

Update Go package name to .../apache/arrow-go/... from .../apache/arrow/go/...

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #44034