### PR TITLE
GH-44044: [Java] Consider warnings as errors for Vector Module

### DIFF
--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -119,6 +119,15 @@ under the License.
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration combine.children="append">
+          <compilerArgs>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <!-- generate sources from fmpp -->
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -125,6 +125,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     /**
      * @deprecated use {@link #listOfStruct()} instead.
      */
+    @Deprecated
     StructOrListWriter listoftstruct(String name);
     StructOrListWriter listOfStruct(String name);
     StructOrListWriter list(String name);


### PR DESCRIPTION
### Rationale for this change

This PR configs the build such that warnings are considered errors in the Vector module. And corresponding code changes have also been made.

### What changes are included in this PR?

Adding flags to consider warnings as errors in javac and fixing the corresponding errors.

### Are these changes tested?

Tested by existing test cases.

### Are there any user-facing changes?

N/A
* GitHub Issue: #44044