### PR TITLE
GH-44052: [C++][Compute] Reduce the complexity of row segmenter

### DIFF
--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -915,8 +915,8 @@ static void CountScalarSegmentedByInts(benchmark::State& state, Args&&...) {
   // A trivial column to count from.
   auto arg = ConstantArrayGenerator::Zeroes(num_rows, int32());
 
-  BenchmarkSegmentedAggregate(state, num_rows, {{"count", ""}}, {arg}, {}, state.range(0),
-                              state.range(1));
+  BenchmarkSegmentedAggregate(state, num_rows, {{"count", ""}}, {arg}, /*keys=*/{},
+                              state.range(0), state.range(1));
 }
 BENCHMARK(CountScalarSegmentedByInts)
     ->ArgNames({"SegmentKeys", "Segments"})
@@ -936,8 +936,8 @@ static void CountGroupByIntsSegmentedByInts(benchmark::State& state, Args&&...) 
     key = rng.Int64(num_rows, /*min=*/0, /*max=*/64);
   }
 
-  BenchmarkSegmentedAggregate(state, num_rows, {{"hash_count", ""}}, {arg},
-                              std::move(keys), state.range(1), state.range(2));
+  BenchmarkSegmentedAggregate(state, num_rows, {{"hash_count", ""}}, {arg}, keys,
+                              state.range(1), state.range(2));
 }
 BENCHMARK(CountGroupByIntsSegmentedByInts)
     ->ArgNames({"Keys", "SegmentKeys", "Segments"})

--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -402,6 +402,7 @@ static void BenchmarkGroupBy(
     ABORT_NOT_OK(BatchGroupBy(batch, aggregates, key_refs, segment_key_refs));
   }
   state.SetBytesProcessed(total_bytes * state.iterations());
+  state.SetItemsProcessed(batch->num_rows() * state.iterations());
 }
 
 #define GROUP_BY_BENCHMARK(Name, Impl)                               \
@@ -920,8 +921,6 @@ static void BenchmarkRowSegmenter(benchmark::State& state, Args&&...) {
   ArrayVector segment_keys(num_segment_keys, segment_key);
 
   BenchmarkGroupBy(state, {{"count", ""}}, {arg}, /*keys=*/{}, segment_keys);
-
-  state.SetItemsProcessed(num_rows * state.iterations());
 }
 
 std::vector<std::string> row_segmenter_argnames = {"Rows", "Segments", "SegmentKeys"};

--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -921,7 +921,7 @@ static void BenchmarkRowSegmenter(benchmark::State& state, Args&&...) {
 
 std::vector<std::string> row_segmenter_argnames = {"Rows", "Segments", "SegmentKeys"};
 std::vector<std::vector<int64_t>> row_segmenter_args = {
-    {1 * 1024 * 1024}, benchmark::CreateRange(1, 1024, 8), {0, 1, 2}};
+    {1 * 1024 * 1024}, benchmark::CreateRange(1, 4096, 16), {0, 1, 2, 3}};
 
 BENCHMARK(BenchmarkRowSegmenter)
     ->ArgNames(row_segmenter_argnames)

--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -899,6 +899,7 @@ static void BenchmarkRowSegmenter(benchmark::State& state, Args&&...) {
   int64_t num_rows = state.range(0);
   int64_t num_segments = state.range(1);
   ASSERT_NE(num_segments, 0);
+  ASSERT_GE(num_rows, num_segments);
   int64_t num_segment_keys = state.range(2);
   // Adjust num_rows to be a multiple of num_segments.
   num_rows = num_rows / num_segments * num_segments;

--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -22,7 +22,6 @@
 #include "arrow/acero/exec_plan.h"
 #include "arrow/acero/options.h"
 #include "arrow/array/array_primitive.h"
-#include "arrow/array/concatenate.h"
 #include "arrow/compute/api.h"
 #include "arrow/table.h"
 #include "arrow/testing/generator.h"
@@ -36,9 +35,6 @@
 
 namespace arrow {
 
-using arrow::Concatenate;
-using arrow::ConstantArrayGenerator;
-using arrow::gen::Constant;
 using compute::Count;
 using compute::MinMax;
 using compute::Mode;
@@ -377,7 +373,7 @@ Result<std::shared_ptr<Table>> BatchGroupBy(
   return DeclarationToTable(std::move(plan), use_threads, memory_pool);
 }
 
-static void BenchmarkGroupBy(
+static void BenchmarkAggregate(
     benchmark::State& state, std::vector<Aggregate> aggregates,
     const std::vector<std::shared_ptr<Array>>& arguments,
     const std::vector<std::shared_ptr<Array>>& keys,
@@ -429,7 +425,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedByTinyStringSet, [&] {
                                    /*min_length=*/3,
                                    /*max_length=*/32);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedBySmallStringSet, [&] {
@@ -444,7 +440,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedBySmallStringSet, [&] {
                                    /*min_length=*/3,
                                    /*max_length=*/32);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedByMediumStringSet, [&] {
@@ -459,7 +455,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedByMediumStringSet, [&] {
                                    /*min_length=*/3,
                                    /*max_length=*/32);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedByTinyIntegerSet, [&] {
@@ -473,7 +469,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedByTinyIntegerSet, [&] {
                        /*min=*/0,
                        /*max=*/15);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedBySmallIntegerSet, [&] {
@@ -487,7 +483,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedBySmallIntegerSet, [&] {
                        /*min=*/0,
                        /*max=*/255);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedByMediumIntegerSet, [&] {
@@ -501,7 +497,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedByMediumIntegerSet, [&] {
                        /*min=*/0,
                        /*max=*/4095);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedByTinyIntStringPairSet, [&] {
@@ -519,7 +515,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedByTinyIntStringPairSet, [&] {
                                        /*min_length=*/3,
                                        /*max_length=*/32);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {int_key, str_key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {int_key, str_key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedBySmallIntStringPairSet, [&] {
@@ -537,7 +533,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedBySmallIntStringPairSet, [&] {
                                        /*min_length=*/3,
                                        /*max_length=*/32);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {int_key, str_key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {int_key, str_key});
 });
 
 GROUP_BY_BENCHMARK(SumDoublesGroupedByMediumIntStringPairSet, [&] {
@@ -555,7 +551,7 @@ GROUP_BY_BENCHMARK(SumDoublesGroupedByMediumIntStringPairSet, [&] {
                                        /*min_length=*/3,
                                        /*max_length=*/32);
 
-  BenchmarkGroupBy(state, {{"hash_sum", ""}}, {summand}, {int_key, str_key});
+  BenchmarkAggregate(state, {{"hash_sum", ""}}, {summand}, {int_key, str_key});
 });
 
 // Grouped MinMax
@@ -568,7 +564,7 @@ GROUP_BY_BENCHMARK(MinMaxDoublesGroupedByMediumInt, [&] {
                            /*nan_probability=*/args.null_proportion / 10);
   auto int_key = rng.Int64(args.size, /*min=*/0, /*max=*/63);
 
-  BenchmarkGroupBy(state, {{"hash_min_max", ""}}, {input}, {int_key});
+  BenchmarkAggregate(state, {{"hash_min_max", ""}}, {input}, {int_key});
 });
 
 GROUP_BY_BENCHMARK(MinMaxShortStringsGroupedByMediumInt, [&] {
@@ -578,7 +574,7 @@ GROUP_BY_BENCHMARK(MinMaxShortStringsGroupedByMediumInt, [&] {
                           /*null_probability=*/args.null_proportion);
   auto int_key = rng.Int64(args.size, /*min=*/0, /*max=*/63);
 
-  BenchmarkGroupBy(state, {{"hash_min_max", ""}}, {input}, {int_key});
+  BenchmarkAggregate(state, {{"hash_min_max", ""}}, {input}, {int_key});
 });
 
 GROUP_BY_BENCHMARK(MinMaxLongStringsGroupedByMediumInt, [&] {
@@ -588,7 +584,7 @@ GROUP_BY_BENCHMARK(MinMaxLongStringsGroupedByMediumInt, [&] {
                           /*null_probability=*/args.null_proportion);
   auto int_key = rng.Int64(args.size, /*min=*/0, /*max=*/63);
 
-  BenchmarkGroupBy(state, {{"hash_min_max", ""}}, {input}, {int_key});
+  BenchmarkAggregate(state, {{"hash_min_max", ""}}, {input}, {int_key});
 });
 
 //
@@ -892,44 +888,60 @@ BENCHMARK(TDigestKernelDoubleDeciles)->Apply(QuantileKernelArgs);
 BENCHMARK(TDigestKernelDoubleCentiles)->Apply(QuantileKernelArgs);
 
 //
-// RowSegmenter
+// Segmented Aggregate
 //
 
-template <typename... Args>
-static void BenchmarkRowSegmenter(benchmark::State& state, Args&&...) {
-  int64_t num_rows = state.range(0);
-  int64_t num_segments = state.range(1);
-  ASSERT_NE(num_segments, 0);
-  ASSERT_GE(num_rows, num_segments);
-  int64_t num_segment_keys = state.range(2);
-  // Adjust num_rows to be a multiple of num_segments.
-  num_rows = num_rows / num_segments * num_segments;
+static void BenchmarkSegmentedAggregate(
+    benchmark::State& state, int64_t num_rows, std::vector<Aggregate> aggregates,
+    const std::vector<std::shared_ptr<Array>>& arguments,
+    const std::vector<std::shared_ptr<Array>>& keys, int64_t num_segment_keys,
+    int64_t num_segments) {
+  ASSERT_GT(num_segments, 0);
 
-  // A trivial column to count from.
-  auto arg = ConstantArrayGenerator::Zeroes(num_rows, int64());
-  // num_segments segments, each having identical num_rows / num_segments rows of the
-  // associated segment id.
-  ArrayVector segments(num_segments);
-  for (int i = 0; i < num_segments; ++i) {
-    ASSERT_OK_AND_ASSIGN(
-        segments[i],
-        Constant(std::make_shared<Int64Scalar>(i))->Generate(num_rows / num_segments));
-  }
-  // Concat all segments to form the segment key.
-  ASSERT_OK_AND_ASSIGN(auto segment_key, Concatenate(segments));
+  auto rng = random::RandomArrayGenerator(42);
+  auto segment_key = rng.Int64(num_rows, /*min=*/0, /*max=*/num_segments - 1);
+  int64_t* values = segment_key->data()->GetMutableValues<int64_t>(1);
+  std::sort(values, values + num_rows);
   // num_segment_keys copies of the segment key.
   ArrayVector segment_keys(num_segment_keys, segment_key);
 
-  BenchmarkGroupBy(state, {{"count", ""}}, {arg}, /*keys=*/{}, segment_keys);
+  BenchmarkAggregate(state, std::move(aggregates), arguments, keys, segment_keys);
 }
 
-std::vector<std::string> row_segmenter_argnames = {"Rows", "Segments", "SegmentKeys"};
-std::vector<std::vector<int64_t>> row_segmenter_args = {
-    {32 * 1024}, benchmark::CreateRange(1, 256, 4), benchmark::CreateDenseRange(0, 3, 1)};
+template <typename... Args>
+static void CountScalarSegmentedByInts(benchmark::State& state, Args&&...) {
+  constexpr int64_t num_rows = 32 * 1024;
 
-BENCHMARK(BenchmarkRowSegmenter)
-    ->ArgNames(row_segmenter_argnames)
-    ->ArgsProduct(row_segmenter_args);
+  // A trivial column to count from.
+  auto arg = ConstantArrayGenerator::Zeroes(num_rows, int32());
+
+  BenchmarkSegmentedAggregate(state, num_rows, {{"count", ""}}, {arg}, {}, state.range(0),
+                              state.range(1));
+}
+BENCHMARK(CountScalarSegmentedByInts)
+    ->ArgNames({"SegmentKeys", "Segments"})
+    ->ArgsProduct({{0, 1, 2}, benchmark::CreateRange(1, 256, 8)});
+
+template <typename... Args>
+static void CountGroupByIntsSegmentedByInts(benchmark::State& state, Args&&...) {
+  constexpr int64_t num_rows = 32 * 1024;
+
+  // A trivial column to count from.
+  auto arg = ConstantArrayGenerator::Zeroes(num_rows, int32());
+
+  auto rng = random::RandomArrayGenerator(42);
+  int64_t num_keys = state.range(0);
+  ArrayVector keys(num_keys);
+  for (auto& key : keys) {
+    key = rng.Int64(num_rows, /*min=*/0, /*max=*/64);
+  }
+
+  BenchmarkSegmentedAggregate(state, num_rows, {{"hash_count", ""}}, {arg},
+                              std::move(keys), state.range(1), state.range(2));
+}
+BENCHMARK(CountGroupByIntsSegmentedByInts)
+    ->ArgNames({"Keys", "SegmentKeys", "Segments"})
+    ->ArgsProduct({{1, 2}, {0, 1, 2}, benchmark::CreateRange(1, 256, 8)});
 
 }  // namespace acero
 }  // namespace arrow

--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -926,7 +926,7 @@ static void BenchmarkRowSegmenter(benchmark::State& state, Args&&...) {
 
 std::vector<std::string> row_segmenter_argnames = {"Rows", "Segments", "SegmentKeys"};
 std::vector<std::vector<int64_t>> row_segmenter_args = {
-    {1 * 1024 * 1024}, benchmark::CreateRange(1, 4096, 16), {0, 1, 2, 3}};
+    {32 * 1024}, benchmark::CreateRange(1, 256, 4), benchmark::CreateDenseRange(0, 3, 1)};
 
 BENCHMARK(BenchmarkRowSegmenter)
     ->ArgNames(row_segmenter_argnames)

--- a/cpp/src/arrow/acero/aggregate_internal.h
+++ b/cpp/src/arrow/acero/aggregate_internal.h
@@ -145,6 +145,20 @@ Status HandleSegments(RowSegmenter* segmenter, const ExecBatch& batch,
   return Status::OK();
 }
 
+// template <typename BatchHandler>
+// Status HandleSegments(RowSegmenter* segmenter, const ExecBatch& batch,
+//                       const std::vector<int>& ids, const BatchHandler& handle_batch) {
+//   ARROW_ASSIGN_OR_RAISE(auto segment_exec_batch, batch.SelectValues(ids));
+//   ExecSpan segment_batch(segment_exec_batch);
+
+//   ARROW_ASSIGN_OR_RAISE(auto segments, segmenter->GetSegments(segment_batch));
+//   for (const auto& segment : segments) {
+//     ARROW_RETURN_NOT_OK(handle_batch(batch, segment));
+//   }
+
+//   return Status::OK();
+// }
+
 /// @brief Extract values of segment keys from a segment batch
 /// @param[out] values_ptr Vector to store the extracted segment key values
 /// @param[in] input_batch Segment batch. Must have the a constant value for segment key

--- a/cpp/src/arrow/acero/aggregate_internal.h
+++ b/cpp/src/arrow/acero/aggregate_internal.h
@@ -128,23 +128,6 @@ void AggregatesToString(std::stringstream* ss, const Schema& input_schema,
 // Extract segments from a batch and run the given handler on them.  Note that the
 // handle may be called on open segments which are not yet finished.  Typically a
 // handler should accumulate those open segments until a closed segment is reached.
-// template <typename BatchHandler>
-// Status HandleSegments(RowSegmenter* segmenter, const ExecBatch& batch,
-//                       const std::vector<int>& ids, const BatchHandler& handle_batch) {
-//   int64_t offset = 0;
-//   ARROW_ASSIGN_OR_RAISE(auto segment_exec_batch, batch.SelectValues(ids));
-//   ExecSpan segment_batch(segment_exec_batch);
-
-//   while (true) {
-//     ARROW_ASSIGN_OR_RAISE(compute::Segment segment,
-//                           segmenter->GetNextSegment(segment_batch, offset));
-//     if (segment.offset >= segment_batch.length) break;  // condition of no-next-segment
-//     ARROW_RETURN_NOT_OK(handle_batch(batch, segment));
-//     offset = segment.offset + segment.length;
-//   }
-//   return Status::OK();
-// }
-
 template <typename BatchHandler>
 Status HandleSegments(RowSegmenter* segmenter, const ExecBatch& batch,
                       const std::vector<int>& ids, const BatchHandler& handle_batch) {

--- a/cpp/src/arrow/acero/aggregate_internal.h
+++ b/cpp/src/arrow/acero/aggregate_internal.h
@@ -128,36 +128,36 @@ void AggregatesToString(std::stringstream* ss, const Schema& input_schema,
 // Extract segments from a batch and run the given handler on them.  Note that the
 // handle may be called on open segments which are not yet finished.  Typically a
 // handler should accumulate those open segments until a closed segment is reached.
-template <typename BatchHandler>
-Status HandleSegments(RowSegmenter* segmenter, const ExecBatch& batch,
-                      const std::vector<int>& ids, const BatchHandler& handle_batch) {
-  int64_t offset = 0;
-  ARROW_ASSIGN_OR_RAISE(auto segment_exec_batch, batch.SelectValues(ids));
-  ExecSpan segment_batch(segment_exec_batch);
-
-  while (true) {
-    ARROW_ASSIGN_OR_RAISE(compute::Segment segment,
-                          segmenter->GetNextSegment(segment_batch, offset));
-    if (segment.offset >= segment_batch.length) break;  // condition of no-next-segment
-    ARROW_RETURN_NOT_OK(handle_batch(batch, segment));
-    offset = segment.offset + segment.length;
-  }
-  return Status::OK();
-}
-
 // template <typename BatchHandler>
 // Status HandleSegments(RowSegmenter* segmenter, const ExecBatch& batch,
 //                       const std::vector<int>& ids, const BatchHandler& handle_batch) {
+//   int64_t offset = 0;
 //   ARROW_ASSIGN_OR_RAISE(auto segment_exec_batch, batch.SelectValues(ids));
 //   ExecSpan segment_batch(segment_exec_batch);
 
-//   ARROW_ASSIGN_OR_RAISE(auto segments, segmenter->GetSegments(segment_batch));
-//   for (const auto& segment : segments) {
+//   while (true) {
+//     ARROW_ASSIGN_OR_RAISE(compute::Segment segment,
+//                           segmenter->GetNextSegment(segment_batch, offset));
+//     if (segment.offset >= segment_batch.length) break;  // condition of no-next-segment
 //     ARROW_RETURN_NOT_OK(handle_batch(batch, segment));
+//     offset = segment.offset + segment.length;
 //   }
-
 //   return Status::OK();
 // }
+
+template <typename BatchHandler>
+Status HandleSegments(RowSegmenter* segmenter, const ExecBatch& batch,
+                      const std::vector<int>& ids, const BatchHandler& handle_batch) {
+  ARROW_ASSIGN_OR_RAISE(auto segment_exec_batch, batch.SelectValues(ids));
+  ExecSpan segment_batch(segment_exec_batch);
+
+  ARROW_ASSIGN_OR_RAISE(auto segments, segmenter->GetSegments(segment_batch));
+  for (const auto& segment : segments) {
+    ARROW_RETURN_NOT_OK(handle_batch(batch, segment));
+  }
+
+  return Status::OK();
+}
 
 /// @brief Extract values of segment keys from a segment batch
 /// @param[out] values_ptr Vector to store the extracted segment key values

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -199,7 +199,6 @@ struct SimpleKeySegmenter : public BaseRowSegmenter {
     ARROW_UNSUPPRESS_DEPRECATION_WARNING
   }
 
-  ARROW_DEPRECATED("Deprecated in 18.0.0. Use GetSegments instead.")
   Result<Segment> GetNextSegment(const ExecSpan& batch, int64_t offset) override {
     ARROW_SUPPRESS_DEPRECATION_WARNING
     ARROW_RETURN_NOT_OK(CheckForGetNextSegment(batch, offset, {key_type_}));

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -387,7 +387,7 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
     bool extends = kDefaultExtends;
     // the group id must be computed prior to resetting the grouper, since it is compared
     // to save_group_id_, and after resetting the grouper produces incomparable group ids
-    ARROW_ASSIGN_OR_RAISE(auto group_id, MapGroupIdAt(batch, 0));
+    ARROW_ASSIGN_OR_RAISE(auto group_id, MapGroupIdAt(batch));
     // it "extends" unless the group id differs from the last group id
     if (save_group_id_ != kNoGroupId && group_id != save_group_id_) {
       extends = false;
@@ -397,7 +397,7 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
     RETURN_NOT_OK(grouper_->Reset());
 
     std::vector<Segment> segments;
-    ARROW_ASSIGN_OR_RAISE(auto datum, grouper_->Consume(batch, 0));
+    ARROW_ASSIGN_OR_RAISE(auto datum, grouper_->Consume(batch));
     DCHECK(datum.is_array());
     // `data` is an array whose index-0 corresponds to index `offset` of `batch`
     const std::shared_ptr<ArrayData>& data = datum.array();
@@ -429,7 +429,7 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
   // Runs the grouper on a single row.  This is used to determine the group id of the
   // first row of a new segment to see if it extends the previous segment.
   template <typename Batch>
-  Result<group_id_t> MapGroupIdAt(const Batch& batch, int64_t offset) {
+  Result<group_id_t> MapGroupIdAt(const Batch& batch, int64_t offset = 0) {
     ARROW_ASSIGN_OR_RAISE(auto datum, grouper_->Consume(batch, offset,
                                                         /*length=*/1));
     if (!datum.is_array()) {

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -385,12 +385,12 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
     // determine if the first segment in this batch extends the last segment in the
     // previous batch
     bool extends = kDefaultExtends;
-    // the group id must be computed prior to resetting the grouper, since it is compared
-    // to save_group_id_, and after resetting the grouper produces incomparable group ids
-    ARROW_ASSIGN_OR_RAISE(auto group_id, MapGroupIdAt(batch));
-    // it "extends" unless the group id differs from the last group id
-    if (save_group_id_ != kNoGroupId && group_id != save_group_id_) {
-      extends = false;
+    if (save_group_id_ != kNoGroupId) {
+      // the group id must be computed prior to resetting the grouper, since it is compared
+      // to save_group_id_, and after resetting the grouper produces incomparable group ids
+      ARROW_ASSIGN_OR_RAISE(auto group_id, MapGroupIdAt(batch));
+      // it "extends" unless the group id differs from the last group id
+      extends = (group_id == save_group_id_);
     }
 
     // resetting drops grouper's group-ids, freeing-up memory for the next segment

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -124,8 +124,10 @@ struct NoKeysSegmenter : public BaseRowSegmenter {
 
   ARROW_DEPRECATED("Deprecated in 18.0.0. Use GetSegments instead.")
   Result<Segment> GetNextSegment(const ExecSpan& batch, int64_t offset) override {
+    ARROW_SUPPRESS_DEPRECATION_WARNING
     ARROW_RETURN_NOT_OK(CheckForGetNextSegment(batch, offset, {}));
     return MakeSegment(batch.length, offset, batch.length - offset, kDefaultExtends);
+    ARROW_UNSUPPRESS_DEPRECATION_WARNING
   }
 
   Result<std::vector<Segment>> GetSegments(const ExecSpan& batch) override {

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -291,7 +291,7 @@ struct SimpleKeySegmenter : public BaseRowSegmenter {
   }
 
   bool Extend(const void* data) {
-    if ARROW_PREDICT_FALSE (!extend_was_called_) {
+    if (ARROW_PREDICT_FALSE(!extend_was_called_)) {
       extend_was_called_ = true;
       return kDefaultExtends;
     }

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -385,8 +385,9 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
     // previous batch
     bool extends = kDefaultExtends;
     if (save_group_id_ != kNoGroupId) {
-      // the group id must be computed prior to resetting the grouper, since it is compared
-      // to save_group_id_, and after resetting the grouper produces incomparable group ids
+      // the group id must be computed prior to resetting the grouper, since it is
+      // compared to save_group_id_, and after resetting the grouper produces incomparable
+      // group ids
       ARROW_ASSIGN_OR_RAISE(auto group_id, MapGroupIdAt(batch));
       // it "extends" unless the group id differs from the last group id
       extends = (group_id == save_group_id_);

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -56,7 +56,7 @@ using GroupIdType = CTypeTraits<group_id_t>::ArrowType;
 auto g_group_id_type = std::make_shared<GroupIdType>();
 
 template <typename Value>
-ARROW_DEPRECATED("Deprecated in 18.0.0.")
+ARROW_DEPRECATED("Deprecated in 18.0.0 along with GetSegments.")
 Status CheckForGetNextSegment(const std::vector<Value>& values, int64_t length,
                               int64_t offset, const std::vector<TypeHolder>& key_types) {
   if (offset < 0 || offset > length) {
@@ -78,7 +78,7 @@ Status CheckForGetNextSegment(const std::vector<Value>& values, int64_t length,
 }
 
 template <typename Batch>
-ARROW_DEPRECATED("Deprecated in 18.0.0.")
+ARROW_DEPRECATED("Deprecated in 18.0.0 along with GetSegments.")
 enable_if_t<std::is_same<Batch, ExecSpan>::value || std::is_same<Batch, ExecBatch>::value,
             Status> CheckForGetNextSegment(const Batch& batch, int64_t offset,
                                            const std::vector<TypeHolder>& key_types) {
@@ -153,7 +153,7 @@ struct SimpleKeySegmenter : public BaseRowSegmenter {
 
   // Checks whether the given grouping data extends the current segment, i.e., is equal to
   // previously seen grouping data, which is updated with each invocation.
-  ARROW_DEPRECATED("Deprecated in 18.0.0.")
+  ARROW_DEPRECATED("Deprecated in 18.0.0 along with GetSegments.")
   bool ExtendDeprecated(const void* data) {
     bool extends = !extend_was_called_
                        ? kDefaultExtends
@@ -163,7 +163,7 @@ struct SimpleKeySegmenter : public BaseRowSegmenter {
     return extends;
   }
 
-  ARROW_DEPRECATED("Deprecated in 18.0.0.")
+  ARROW_DEPRECATED("Deprecated in 18.0.0 along with GetSegments.")
   Result<Segment> GetNextSegmentDeprecated(const Scalar& scalar, int64_t offset,
                                            int64_t length) {
     ARROW_RETURN_NOT_OK(CheckType(*scalar.type));
@@ -175,7 +175,7 @@ struct SimpleKeySegmenter : public BaseRowSegmenter {
     return MakeSegment(length, offset, length, extends);
   }
 
-  ARROW_DEPRECATED("Deprecated in 18.0.0.")
+  ARROW_DEPRECATED("Deprecated in 18.0.0 along with GetSegments.")
   Result<Segment> GetNextSegmentDeprecated(const DataType& array_type,
                                            const uint8_t* array_bytes, int64_t offset,
                                            int64_t length) {
@@ -256,7 +256,7 @@ struct SimpleKeySegmenter : public BaseRowSegmenter {
     return Status::OK();
   }
 
-  inline const uint8_t* GetValuesAsBytes(const ArraySpan& data, int64_t offset = 0) {
+  static const uint8_t* GetValuesAsBytes(const ArraySpan& data, int64_t offset = 0) {
     DCHECK_GT(data.type->byte_width(), 0);
     int64_t absolute_byte_offset = (data.offset + offset) * data.type->byte_width();
     return data.GetValues<uint8_t>(1, absolute_byte_offset);
@@ -314,7 +314,7 @@ struct AnyKeysSegmenter : public BaseRowSegmenter {
     return Status::OK();
   }
 
-  ARROW_DEPRECATED("Deprecated in 18.0.0.")
+  ARROW_DEPRECATED("Deprecated in 18.0.0 along with GetSegments.")
   bool Extend(const void* data) {
     auto group_id = *static_cast<const group_id_t*>(data);
     bool extends =

--- a/cpp/src/arrow/compute/row/grouper.h
+++ b/cpp/src/arrow/compute/row/grouper.h
@@ -98,6 +98,9 @@ class ARROW_EXPORT RowSegmenter {
 
   /// \brief Get the next segment for the given batch starting from the given offset
   virtual Result<Segment> GetNextSegment(const ExecSpan& batch, int64_t offset) = 0;
+
+  /// \brief Get all segments for the given batch
+  virtual Result<std::vector<Segment>> GetSegments(const ExecSpan& batch) = 0;
 };
 
 /// Consumes batches of keys and yields batches of the group ids.

--- a/cpp/src/arrow/compute/row/grouper.h
+++ b/cpp/src/arrow/compute/row/grouper.h
@@ -97,6 +97,8 @@ class ARROW_EXPORT RowSegmenter {
   virtual Status Reset() = 0;
 
   /// \brief Get the next segment for the given batch starting from the given offset
+  /// DEPRECATED: Due to its inefficiency, use GetSegments instead.
+  ARROW_DEPRECATED("Deprecated in 18.0.0. Use GetSegments instead.")
   virtual Result<Segment> GetNextSegment(const ExecSpan& batch, int64_t offset) = 0;
 
   /// \brief Get all segments for the given batch


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

As described in #44052, currently `AnyKeysSegmenter::GetNextSegment` has `O(n*m)` complexity, where `n` is the number of rows in a batch, and `m` is the number of segments in this batch (a "segment" is the group of contiguous rows who have the same segment key). This is because in each invocation of the method, it computes all the group ids of the remaining rows in this batch, where it's only interested in the first group, making the rest of the computation a waste.

In this PR I introduced a new API `GetSegments` (and subsequently deprecated the old `GetNextSegment`) to compute the group ids only once and iterate all the segments outside to avoid the duplicated computation. This reduces the complexity from `O(n*m)` to `O(n)`.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Because `grouper.h` is a [public header](https://github.com/apache/arrow/blob/8556001e6a8b4c7f35d4e18c28704d7811005904/cpp/src/arrow/compute/api.h#L47), so I assume `RowSegmenter::GetNextSegment` is a public API and only deprecate it instead of removing it.
2. Implement new API `RowSegmenter::GetSegments` and update the call-sites.
3. Some code reorg of the segmenter code (mostly moving to inside a class).
4. A new benchmark for the segmented aggregation. (The benchmark result is listed in the comments below, which shows up to `50x` speedup, nearly `O(n*m)` to `O(n)` complexity reduction.)

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Legacy tests are sufficient.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**This PR includes breaking changes to public APIs.**

The API `RowSegmenter::GetNextSegment` is deprecated due to its inefficiency and replaced with a more efficient one `RowSegmenter::GetSegments`.

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44052