### PR TITLE
GH-44055: [Java] Finalize ErrorProne Warnings to be considered as Errors

### DIFF
--- a/java/adapter/avro/pom.xml
+++ b/java/adapter/avro/pom.xml
@@ -57,17 +57,4 @@ under the License.
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.children="append">
-          <compilerArgs>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -87,6 +87,7 @@ under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang3.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -116,15 +116,6 @@ under the License.
           <argLine>--add-reads=org.apache.arrow.adapter.jdbc=com.fasterxml.jackson.dataformat.yaml --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED -Duser.timezone=UTC</argLine>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.children="append">
-          <compilerArgs>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -85,6 +85,12 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
@@ -58,6 +58,7 @@ import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
 import org.apache.arrow.vector.util.ObjectMapperFactory;
 import org.apache.arrow.vector.util.Text;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This is a Helper class which has functionalities to read and assert the values from the given
@@ -447,16 +448,15 @@ public class JdbcToArrowTestHelper {
     return valueArr;
   }
 
-  @SuppressWarnings("StringSplitter")
   public static String[] getValues(String[] values, String dataType) {
     String value = "";
     for (String val : values) {
       if (val.startsWith(dataType)) {
-        value = val.split("=")[1];
+        value = StringUtils.split(val, "=")[1];
         break;
       }
     }
-    return value.split(",");
+    return StringUtils.split(value, ",");
   }
 
   public static Integer[][] getListValues(String[] values, String dataType) {
@@ -464,7 +464,6 @@ public class JdbcToArrowTestHelper {
     return getListValues(dataArr);
   }
 
-  @SuppressWarnings("StringSplitter")
   public static Integer[][] getListValues(String[] dataArr) {
     Integer[][] valueArr = new Integer[dataArr.length][];
     int i = 0;
@@ -474,7 +473,7 @@ public class JdbcToArrowTestHelper {
       } else if ("()".equals(data.trim())) {
         valueArr[i++] = new Integer[0];
       } else {
-        String[] row = data.replace("(", "").replace(")", "").split(";");
+        String[] row = StringUtils.split(data.replace("(", "").replace(")", ""), ";");
         Integer[] arr = new Integer[row.length];
         for (int j = 0; j < arr.length; j++) {
           arr[j] = "null".equals(row[j]) ? null : Integer.parseInt(row[j]);

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -27,10 +27,10 @@ import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getListValues;
 import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getLongValues;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -146,10 +146,10 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
 
         if (reuseVectorSchemaRoot) {
           // when reuse is enabled, different iterations are based on the same vector schema root.
-          assertTrue(prev == cur);
+          assertSame(prev, cur);
         } else {
           // when reuse is enabled, a new vector schema root is created in each iteration.
-          assertFalse(prev == cur);
+          assertNotEquals(prev, cur);
           if (batchCount < 3) {
             cur.close();
           }

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -160,15 +160,6 @@ under the License.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.children="append">
-          <compilerArgs>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/java/c/pom.xml
+++ b/java/c/pom.xml
@@ -91,16 +91,5 @@ under the License.
         </includes>
       </resource>
     </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.children="append">
-          <compilerArgs>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
+++ b/java/c/src/test/java/org/apache/arrow/c/RoundtripTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.c;
 
+import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.DATA_VECTOR_NAME;
 import static org.apache.arrow.vector.testing.ValueVectorDataPopulator.setVector;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -965,7 +966,9 @@ public class RoundtripTest {
       try (ArrowSchema arrowSchema = ArrowSchema.wrap(consumerArrowSchema.memoryAddress());
           ArrowArray arrowArray = ArrowArray.wrap(consumerArrowArray.memoryAddress())) {
         // Producer exports vector into the C Data Interface structures
-        try (final NullVector vector = new NullVector()) {
+        try (final NullVector vector =
+            new NullVector(
+                new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null))) {
           Data.exportVector(allocator, vector, null, arrowArray, arrowSchema);
         }
       }

--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -202,15 +202,6 @@ under the License.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.children="append">
-          <compilerArgs>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CloseSessionResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CloseSessionResult.java
@@ -41,6 +41,7 @@ public class CloseSessionResult {
       return values()[proto.getNumber()];
     }
 
+    @SuppressWarnings("EnumOrdinal")
     public Flight.CloseSessionResult.Status toProtocol() {
       return Flight.CloseSessionResult.Status.values()[ordinal()];
     }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/DictionaryUtils.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/DictionaryUtils.java
@@ -79,7 +79,7 @@ final class DictionaryUtils {
               count);
       final VectorUnloader unloader = new VectorUnloader(dictRoot);
       try (final ArrowDictionaryBatch dictionaryBatch =
-              new ArrowDictionaryBatch(id, unloader.getRecordBatch());
+              new ArrowDictionaryBatch(id, unloader.getRecordBatch(), false);
           final ArrowMessage message = new ArrowMessage(dictionaryBatch, option)) {
         messageCallback.accept(message);
       }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
@@ -37,6 +37,11 @@ public class FlightRuntimeException extends RuntimeException {
 
   @Override
   public String toString() {
+    return getMessage();
+  }
+
+  @Override
+  public String getMessage() {
     String s = getClass().getName();
     return String.format("%s: %s: %s", s, status.code(), status.description());
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpSessionOptionValueVisitor.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/NoOpSessionOptionValueVisitor.java
@@ -25,26 +25,31 @@ package org.apache.arrow.flight;
  */
 public class NoOpSessionOptionValueVisitor<T> implements SessionOptionValueVisitor<T> {
   /** A callback to handle SessionOptionValue containing a String. */
+  @Override
   public T visit(String value) {
     return null;
   }
 
   /** A callback to handle SessionOptionValue containing a boolean. */
+  @Override
   public T visit(boolean value) {
     return null;
   }
 
   /** A callback to handle SessionOptionValue containing a long. */
+  @Override
   public T visit(long value) {
     return null;
   }
 
   /** A callback to handle SessionOptionValue containing a double. */
+  @Override
   public T visit(double value) {
     return null;
   }
 
   /** A callback to handle SessionOptionValue containing an array of String. */
+  @Override
   public T visit(String[] value) {
     return null;
   }
@@ -55,6 +60,7 @@ public class NoOpSessionOptionValueVisitor<T> implements SessionOptionValueVisit
    * <p>By convention, an attempt to set a valueless SessionOptionValue should attempt to unset or
    * clear the named option value on the server.
    */
+  @Override
   public T visit(Void value) {
     return null;
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
@@ -16,10 +16,8 @@
  */
 package org.apache.arrow.flight;
 
-import com.google.common.base.Splitter;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,6 +75,7 @@ public class ServerSessionMiddleware implements FlightServerMiddleware {
     }
 
     @Override
+    @SuppressWarnings("StringSplitter")
     public ServerSessionMiddleware onCallStarted(
         CallInfo callInfo, CallHeaders incomingHeaders, RequestContext context) {
       String sessionId = null;
@@ -85,15 +84,15 @@ public class ServerSessionMiddleware implements FlightServerMiddleware {
       if (it != null) {
         findIdCookie:
         for (final String headerValue : it) {
-          for (final String cookie : Splitter.on(" ;").split(headerValue)) {
-            final List<String> cookiePair = Splitter.on('=').splitToList(cookie);
-            if (cookiePair.size() != 2) {
+          for (final String cookie : headerValue.split(" ;")) {
+            final String[] cookiePair = cookie.split("=");
+            if (cookiePair.length != 2) {
               // Soft failure:  Ignore invalid cookie list field
               break;
             }
 
-            if (sessionCookieName.equals(cookiePair.get(0)) && !cookiePair.get(1).isEmpty()) {
-              sessionId = cookiePair.get(1);
+            if (sessionCookieName.equals(cookiePair[0]) && !cookiePair[1].isEmpty()) {
+              sessionId = cookiePair[1];
               break findIdCookie;
             }
           }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
@@ -16,8 +16,10 @@
  */
 package org.apache.arrow.flight;
 
+import com.google.common.base.Splitter;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,15 +85,15 @@ public class ServerSessionMiddleware implements FlightServerMiddleware {
       if (it != null) {
         findIdCookie:
         for (final String headerValue : it) {
-          for (final String cookie : headerValue.split(" ;")) {
-            final String[] cookiePair = cookie.split("=");
-            if (cookiePair.length != 2) {
+          for (final String cookie : Splitter.on(" ;").split(headerValue)) {
+            final List<String> cookiePair = Splitter.on('=').splitToList(cookie);
+            if (cookiePair.size() != 2) {
               // Soft failure:  Ignore invalid cookie list field
               break;
             }
 
-            if (sessionCookieName.equals(cookiePair[0]) && cookiePair[1].length() > 0) {
-              sessionId = cookiePair[1];
+            if (sessionCookieName.equals(cookiePair.get(0)) && !cookiePair.get(1).isEmpty()) {
+              sessionId = cookiePair.get(1);
               break findIdCookie;
             }
           }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValue.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValue.java
@@ -38,7 +38,8 @@ public abstract class SessionOptionValue {
     return false;
   }
 
-  private class SessionOptionValueToProtocolVisitor implements SessionOptionValueVisitor<Void> {
+  private static class SessionOptionValueToProtocolVisitor
+      implements SessionOptionValueVisitor<Void> {
     final Flight.SessionOptionValue.Builder b;
 
     SessionOptionValueToProtocolVisitor(Flight.SessionOptionValue.Builder b) {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValueFactory.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SessionOptionValueFactory.java
@@ -89,7 +89,7 @@ public class SessionOptionValueFactory {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SessionOptionValueString)) {
         return false;
       }
       SessionOptionValueString that = (SessionOptionValueString) o;
@@ -124,7 +124,7 @@ public class SessionOptionValueFactory {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SessionOptionValueBoolean)) {
         return false;
       }
       SessionOptionValueBoolean that = (SessionOptionValueBoolean) o;
@@ -159,7 +159,7 @@ public class SessionOptionValueFactory {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SessionOptionValueLong)) {
         return false;
       }
       SessionOptionValueLong that = (SessionOptionValueLong) o;
@@ -194,7 +194,7 @@ public class SessionOptionValueFactory {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SessionOptionValueDouble)) {
         return false;
       }
       SessionOptionValueDouble that = (SessionOptionValueDouble) o;
@@ -229,7 +229,7 @@ public class SessionOptionValueFactory {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SessionOptionValueStringList)) {
         return false;
       }
       SessionOptionValueStringList that = (SessionOptionValueStringList) o;
@@ -266,7 +266,7 @@ public class SessionOptionValueFactory {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof SessionOptionValueEmpty)) {
         return false;
       }
       return true;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SetSessionOptionsResult.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/SetSessionOptionsResult.java
@@ -45,12 +45,14 @@ public class SetSessionOptionsResult {
       return values()[s.getNumber()];
     }
 
+    @SuppressWarnings("EnumOrdinal")
     Flight.SetSessionOptionsResult.ErrorValue toProtocol() {
       return Flight.SetSessionOptionsResult.ErrorValue.values()[ordinal()];
     }
   }
 
   /** Per-option extensible error response container. */
+  @SuppressWarnings("JavaLangClash")
   public static class Error {
     public ErrorValue value;
 
@@ -74,7 +76,7 @@ public class SetSessionOptionsResult {
       if (this == o) {
         return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(o instanceof Error)) {
         return false;
       }
       Error that = (Error) o;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/AddWritableBuffer.java
@@ -70,8 +70,8 @@ public class AddWritableBuffer {
       tmpBufChainOut = tmpBufChainOut2;
 
     } catch (Exception ex) {
-      new RuntimeException("Failed to initialize AddWritableBuffer, falling back to slow path", ex)
-          .printStackTrace();
+      throw new RuntimeException(
+          "Failed to initialize AddWritableBuffer, falling back to slow path", ex);
     }
 
     bufConstruct = tmpConstruct;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
@@ -47,8 +47,8 @@ public class GetReadableBuffer {
       tmpField = f;
       tmpClazz = clazz;
     } catch (Exception e) {
-      new RuntimeException("Failed to initialize GetReadableBuffer, falling back to slow path", e)
-          .printStackTrace();
+      throw new RuntimeException(
+          "Failed to initialize GetReadableBuffer, falling back to slow path", e);
     }
     READABLE_BUFFER = tmpField;
     BUFFER_INPUT_STREAM = tmpClazz;

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
@@ -150,7 +150,9 @@ public class TestFlightService {
       Exception e =
           assertThrows(
               FlightRuntimeException.class, () -> client.getSchema(FlightDescriptor.path("test")));
-      assertEquals("No schema is present in FlightInfo", e.getMessage());
+      assertEquals(
+          "org.apache.arrow.flight.FlightRuntimeException: INVALID_ARGUMENT: No schema is present in FlightInfo",
+          e.getMessage());
     }
   }
 
@@ -211,7 +213,9 @@ public class TestFlightService {
               FlightRuntimeException.class,
               () ->
                   client.getInfo(FlightDescriptor.path("test"), new HeaderCallOption(callHeaders)));
-      assertEquals("http2 exception", e.getMessage());
+      assertEquals(
+          "org.apache.arrow.flight.FlightRuntimeException: INTERNAL: http2 exception",
+          e.getMessage());
     }
   }
 

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestServer.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/IntegrationTestServer.java
@@ -71,7 +71,7 @@ class IntegrationTestServer {
                     System.out.println("\nExiting...");
                     AutoCloseables.close(server, allocator);
                   } catch (Exception e) {
-                    e.printStackTrace();
+                    LOGGER.error("Error during shutdown", e);
                   }
                 }));
 

--- a/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/TestBufferAllocationListener.java
+++ b/java/flight/flight-integration-tests/src/main/java/org/apache/arrow/flight/integration/tests/TestBufferAllocationListener.java
@@ -35,10 +35,12 @@ class TestBufferAllocationListener implements AllocationListener {
 
   List<Entry> trail = new ArrayList<>();
 
+  @Override
   public void onAllocation(long size) {
     trail.add(new Entry(Thread.currentThread().getStackTrace(), size, true));
   }
 
+  @Override
   public void onRelease(long size) {
     trail.add(new Entry(Thread.currentThread().getStackTrace(), size, false));
   }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -277,7 +278,8 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
 
   static Properties lowerCasePropertyKeys(final Properties properties) {
     final Properties resultProperty = new Properties();
-    properties.forEach((k, v) -> resultProperty.put(k.toString().toLowerCase(), v));
+    properties.forEach(
+        (k, v) -> resultProperty.put(k.toString().toLowerCase(Locale.getDefault()), v));
     return resultProperty;
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessor.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessor.java
@@ -71,6 +71,7 @@ public class ArrowFlightJdbcDecimalVectorAccessor extends ArrowFlightJdbcAccesso
   }
 
   @Override
+  @SuppressWarnings("BigDecimalEquals")
   public boolean getBoolean() {
     final BigDecimal value = this.getBigDecimal();
 

--- a/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
+++ b/java/flight/flight-sql-jdbc-core/src/main/java/org/apache/arrow/driver/jdbc/utils/ArrowFlightConnectionConfigImpl.java
@@ -18,6 +18,7 @@ package org.apache.arrow.driver.jdbc.utils;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -196,6 +197,7 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
   }
 
   /** Custom {@link ConnectionProperty} for the {@link ArrowFlightConnectionConfigImpl}. */
+  @SuppressWarnings("Immutable")
   public enum ArrowFlightConnectionProperty implements ConnectionProperty {
     HOST("host", null, Type.STRING, true),
     PORT("port", null, Type.NUMBER, true),
@@ -241,7 +243,7 @@ public final class ArrowFlightConnectionConfigImpl extends ConnectionConfigImpl 
       Preconditions.checkNotNull(properties, "Properties cannot be null.");
       Object value = properties.get(camelName);
       if (value == null) {
-        value = properties.get(camelName.toLowerCase());
+        value = properties.get(camelName.toLowerCase(Locale.getDefault()));
       }
       if (required) {
         if (value == null) {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightStatementExecuteUpdateTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ArrowFlightStatementExecuteUpdateTest.java
@@ -220,7 +220,10 @@ public class ArrowFlightStatementExecuteUpdateTest {
        */
       assertThat(
           e.getMessage(),
-          is(format("Error while executing SQL \"%s\": Query not found", badQuery)));
+          is(
+              format(
+                  "Error while executing SQL \"%s\": org.apache.arrow.flight.FlightRuntimeException: INVALID_ARGUMENT: Query not found",
+                  badQuery)));
     }
     assertThat(count, is(1));
   }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/ResultSetTest.java
@@ -156,8 +156,6 @@ public class ResultSetTest {
 
   /**
    * Tests whether the {@link ArrowFlightJdbcDriver} fails upon attempting to run an invalid query.
-   *
-   * @throws Exception If the connection fails to be established.
    */
   @Test
   public void testShouldThrowExceptionUponAttemptingToExecuteAnInvalidSelectQuery() {
@@ -336,6 +334,7 @@ public class ResultSetTest {
   }
 
   @Test
+  @SuppressWarnings("ThreadPriorityCheck")
   public void
       testShouldInterruptFlightStreamsIfQueryIsCancelledMidProcessingForTimeConsumingQueries()
           throws SQLException, InterruptedException {

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/complex/AbstractArrowFlightJdbcUnionVectorAccessorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.driver.jdbc.accessor.impl.complex;
 
+import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.DATA_VECTOR_NAME;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,9 @@ import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
 import org.apache.arrow.driver.jdbc.accessor.impl.ArrowFlightJdbcNullVectorAccessor;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -253,7 +257,8 @@ public class AbstractArrowFlightJdbcUnionVectorAccessorTest {
 
     @Override
     protected ValueVector getVectorByTypeId(byte typeId) {
-      return new NullVector();
+      return new NullVector(
+          new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null));
     }
   }
 }

--- a/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessorTest.java
+++ b/java/flight/flight-sql-jdbc-core/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/numeric/ArrowFlightJdbcDecimalVectorAccessorTest.java
@@ -176,6 +176,7 @@ public class ArrowFlightJdbcDecimalVectorAccessorTest {
 
   @ParameterizedTest
   @MethodSource("data")
+  @SuppressWarnings("BigDecimalEquals")
   public void testShouldGetBooleanMethodFromDecimalVector(Supplier<ValueVector> vectorSupplier)
       throws Exception {
     setup(vectorSupplier);

--- a/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlClient.java
+++ b/java/flight/flight-sql/src/main/java/org/apache/arrow/flight/sql/FlightSqlClient.java
@@ -1240,7 +1240,7 @@ public class FlightSqlClient implements AutoCloseable {
      *     used in the {@code PreparedStatement} setters.
      */
     public void setParameters(final VectorSchemaRoot parameterBindingRoot) {
-      if (parameterBindingRoot == this.parameterBindingRoot) {
+      if (parameterBindingRoot.equals(this.parameterBindingRoot)) {
         // Nothing to do if we're attempting to set the same parameters again.
         return;
       }

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSqlStreams.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/test/TestFlightSqlStreams.java
@@ -144,6 +144,7 @@ public class TestFlightSqlStreams {
     }
 
     @Override
+    @SuppressWarnings("EnumOrdinal")
     public void getStreamTypeInfo(
         FlightSql.CommandGetXdbcTypeInfo request,
         CallContext context,

--- a/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/AdhocTestOption.java
+++ b/java/flight/flight-sql/src/test/java/org/apache/arrow/flight/sql/util/AdhocTestOption.java
@@ -26,6 +26,7 @@ enum AdhocTestOption implements ProtocolMessageEnum {
   OPTION_C;
 
   @Override
+  @SuppressWarnings("EnumOrdinal")
   public int getNumber() {
     return ordinal();
   }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Filter.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Filter.java
@@ -42,7 +42,10 @@ public class Filter {
 
   private final JniWrapper wrapper;
   private final long moduleId;
+
+  @SuppressWarnings("UnusedVariable")
   private final Schema schema;
+
   private boolean closed;
 
   private Filter(JniWrapper wrapper, long moduleId, Schema schema) {
@@ -98,7 +101,7 @@ public class Filter {
         schema,
         condition,
         JniLoader.getConfiguration(
-            (new ConfigurationBuilder.ConfigOptions()).withOptimize(optimize)));
+            new ConfigurationBuilder.ConfigOptions().withOptimize(optimize)));
   }
 
   /**

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/FunctionSignature.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/FunctionSignature.java
@@ -19,6 +19,7 @@ package org.apache.arrow.gandiva.evaluator;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import java.util.List;
+import java.util.Locale;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
 /** POJO to define a function signature. */
@@ -58,11 +59,12 @@ public class FunctionSignature {
    * @param signature - signature to compare
    * @return true if equal and false if not.
    */
+  @Override
   public boolean equals(Object signature) {
     if (signature == null) {
       return false;
     }
-    if (getClass() != signature.getClass()) {
+    if (!(signature instanceof FunctionSignature)) {
       return false;
     }
     final FunctionSignature other = (FunctionSignature) signature;
@@ -73,7 +75,8 @@ public class FunctionSignature {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.name.toLowerCase(), this.returnType, this.paramTypes);
+    return Objects.hashCode(
+        this.name.toLowerCase(Locale.getDefault()), this.returnType, this.paramTypes);
   }
 
   @Override

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniLoader.java
@@ -127,7 +127,7 @@ class JniLoader {
   static long getConfiguration(ConfigurationBuilder.ConfigOptions configOptions)
       throws GandivaException {
     if (!configurationMap.containsKey(configOptions)) {
-      synchronized (ConfigurationBuilder.class) {
+      synchronized (JniLoader.class) {
         if (!configurationMap.containsKey(configOptions)) {
           JniLoader.getInstance(); // setup
           long configInstance = new ConfigurationBuilder().buildConfigInstance(configOptions);
@@ -150,7 +150,7 @@ class JniLoader {
    */
   static long getDefaultConfiguration() throws GandivaException {
     if (defaultConfiguration == 0L) {
-      synchronized (ConfigurationBuilder.class) {
+      synchronized (JniLoader.class) {
         if (defaultConfiguration == 0L) {
           JniLoader.getInstance(); // setup
           ConfigurationBuilder.ConfigOptions defaultConfigOptions =
@@ -167,10 +167,9 @@ class JniLoader {
   /** Remove the configuration. */
   static void removeConfiguration(ConfigurationBuilder.ConfigOptions configOptions) {
     if (configurationMap.containsKey(configOptions)) {
-      synchronized (ConfigurationBuilder.class) {
+      synchronized (JniLoader.class) {
         if (configurationMap.containsKey(configOptions)) {
-          (new ConfigurationBuilder())
-              .releaseConfigInstance(configurationMap.remove(configOptions));
+          new ConfigurationBuilder().releaseConfigInstance(configurationMap.remove(configOptions));
           if (configOptions.equals(ConfigurationBuilder.ConfigOptions.getDefault())) {
             defaultConfiguration = 0;
           }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
@@ -45,7 +45,10 @@ public class Projector {
 
   private JniWrapper wrapper;
   private final long moduleId;
+
+  @SuppressWarnings("UnusedVariable")
   private final Schema schema;
+
   private final int numExprs;
   private boolean closed;
 
@@ -108,7 +111,7 @@ public class Projector {
         exprs,
         SelectionVectorType.SV_NONE,
         JniLoader.getConfiguration(
-            (new ConfigurationBuilder.ConfigOptions()).withOptimize(optimize)));
+            new ConfigurationBuilder.ConfigOptions().withOptimize(optimize)));
   }
 
   /**
@@ -173,7 +176,7 @@ public class Projector {
         exprs,
         selectionVectorType,
         JniLoader.getConfiguration(
-            (new ConfigurationBuilder.ConfigOptions()).withOptimize(optimize)));
+            new ConfigurationBuilder.ConfigOptions().withOptimize(optimize)));
   }
 
   /**

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVector.java
@@ -55,7 +55,7 @@ public abstract class SelectionVector {
    * Set the number of records in the selection vector.
    */
   final void setRecordCount(int recordCount) {
-    if (recordCount * getRecordSize() > buffer.capacity()) {
+    if ((long) recordCount * getRecordSize() > buffer.capacity()) {
       throw new IllegalArgumentException(
           "recordCount "
               + recordCount

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt16.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt16.java
@@ -40,7 +40,6 @@ public class SelectionVectorInt16 extends SelectionVector {
   public int getIndex(int index) {
     checkReadBounds(index);
 
-    char value = getBuffer().getChar(index * getRecordSize());
-    return (int) value;
+    return getBuffer().getChar((long) index * getRecordSize());
   }
 }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt32.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt32.java
@@ -40,6 +40,6 @@ public class SelectionVectorInt32 extends SelectionVector {
   public int getIndex(int index) {
     checkReadBounds(index);
 
-    return getBuffer().getInt(index * getRecordSize());
+    return getBuffer().getInt((long) index * getRecordSize());
   }
 }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/exceptions/GandivaException.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/exceptions/GandivaException.java
@@ -29,6 +29,11 @@ public class GandivaException extends Exception {
 
   @Override
   public String toString() {
-    return getMessage();
+    return this.getMessage();
+  }
+
+  @Override
+  public String getMessage() {
+    return super.getMessage();
   }
 }

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/FilterTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/FilterTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -47,12 +48,11 @@ public class FilterTest extends BaseEvaluatorTest {
     return actual;
   }
 
-  private Charset utf8Charset = Charset.forName("UTF-8");
-  private Charset utf16Charset = Charset.forName("UTF-16");
+  private final Charset utf8Charset = StandardCharsets.UTF_8;
 
   List<ArrowBuf> varBufs(String[] strings, Charset charset) {
-    ArrowBuf offsetsBuffer = allocator.buffer((strings.length + 1) * 4);
-    ArrowBuf dataBuffer = allocator.buffer(strings.length * 8);
+    ArrowBuf offsetsBuffer = allocator.buffer((strings.length + 1) * 4L);
+    ArrowBuf dataBuffer = allocator.buffer(strings.length * 8L);
 
     int startOffset = 0;
     for (int i = 0; i < strings.length; i++) {

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
@@ -69,7 +69,6 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
     Projector eval = Projector.make(schema, exprs);
 
     int numRows = 4;
-    byte[] validity = new byte[] {(byte) 255};
     String[] aValues = new String[] {"1.12345678", "2.12345678", "3.12345678", "4.12345678"};
     String[] bValues = new String[] {"2.12345678", "3.12345678", "4.12345678", "5.12345678"};
 
@@ -199,7 +198,6 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
     Projector eval = Projector.make(schema, exprs);
 
     int numRows = 4;
-    byte[] validity = new byte[] {(byte) 255};
     String[] aValues =
         new String[] {"1.12345678", "2.12345678", "3.12345678", "999999999999.99999999"};
     String[] bValues =
@@ -786,7 +784,6 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
   @Disabled("GH-43576 - Fix and enable this test")
   public void testCastStringToDecimal() throws GandivaException {
     Decimal decimalType = new Decimal(4, 2, 128);
-    Field dec = Field.nullable("dec", decimalType);
 
     Field str = Field.nullable("str", new ArrowType.Utf8());
     TreeNode field = TreeBuilder.makeField(str);
@@ -860,7 +857,7 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
         assertThrows(
             IllegalArgumentException.class,
             () -> {
-              Projector eval =
+              Projector unused =
                   Projector.make(
                       schema,
                       Lists.newArrayList(
@@ -884,7 +881,7 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
         assertThrows(
             IllegalArgumentException.class,
             () -> {
-              Projector eval =
+              Projector unused =
                   Projector.make(
                       schema,
                       Lists.newArrayList(

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/expression/TreeBuilderTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/expression/TreeBuilderTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,20 +40,20 @@ public class TreeBuilderTest {
 
     assertEquals(true, node.getBooleanNode().getValue());
 
-    n = TreeBuilder.makeLiteral(new Integer(10));
+    n = TreeBuilder.makeLiteral(10);
     node = n.toProtobuf();
     assertEquals(10, node.getIntNode().getValue());
 
-    n = TreeBuilder.makeLiteral(new Long(50));
+    n = TreeBuilder.makeLiteral(Long.valueOf(50));
     node = n.toProtobuf();
     assertEquals(50, node.getLongNode().getValue());
 
-    Float f = new Float(2.5);
+    Float f = (float) 2.5;
     n = TreeBuilder.makeLiteral(f);
     node = n.toProtobuf();
     assertEquals(f.floatValue(), node.getFloatNode().getValue(), 0.1);
 
-    Double d = new Double(3.3);
+    Double d = 3.3;
     n = TreeBuilder.makeLiteral(d);
     node = n.toProtobuf();
     assertEquals(d.doubleValue(), node.getDoubleNode().getValue(), 0.1);
@@ -60,9 +61,10 @@ public class TreeBuilderTest {
     String s = new String("hello");
     n = TreeBuilder.makeStringLiteral(s);
     node = n.toProtobuf();
-    assertArrayEquals(s.getBytes(), node.getStringNode().getValue().toByteArray());
+    assertArrayEquals(
+        s.getBytes(StandardCharsets.UTF_8), node.getStringNode().getValue().toByteArray());
 
-    byte[] b = new String("hello").getBytes();
+    byte[] b = new String("hello").getBytes(StandardCharsets.UTF_8);
     n = TreeBuilder.makeBinaryLiteral(b);
     node = n.toProtobuf();
     assertArrayEquals(b, node.getBinaryNode().getValue().toByteArray());

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -34,4 +34,21 @@ under the License.
     <module>memory-netty-buffer-patch</module>
     <module>memory-netty</module>
   </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+          <compilerArgs combine.children="override">
+            <arg>-XDcompilePolicy=simple</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -40,12 +40,20 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
           <compilerArgs combine.children="override">
             <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/(target/generated-source|target/generated-sources|format/src/main/java/org/apache/arrow/flatbuf)/.*</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+            <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+            <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/java/performance/src/main/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
+++ b/java/performance/src/main/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
@@ -154,13 +154,13 @@ public class JdbcAdapterBenchmarks {
 
     private JdbcConsumer<BitVector> bitConsumer;
 
-    private JdbcToArrowConfig config;
+    // private JdbcToArrowConfig config;
 
     @Setup(Level.Trial)
     public void prepare() throws Exception {
       allocator = new RootAllocator(Integer.MAX_VALUE);
-      config =
-          new JdbcToArrowConfigBuilder().setAllocator(allocator).setTargetBatchSize(1024).build();
+      // config =
+      //    new JdbcToArrowConfigBuilder().setAllocator(allocator).setTargetBatchSize(1024).build();
 
       Class.forName(DRIVER);
       conn = DriverManager.getConnection(URL);

--- a/java/performance/src/main/java/org/apache/arrow/vector/BaseValueVectorBenchmarks.java
+++ b/java/performance/src/main/java/org/apache/arrow/vector/BaseValueVectorBenchmarks.java
@@ -70,7 +70,7 @@ public class BaseValueVectorBenchmarks {
   public int testComputeCombinedBufferSize() {
     int totalSize = 0;
     for (int i = 0; i < VECTOR_LENGTH; i++) {
-      totalSize += vector.computeCombinedBufferSize(i, 4);
+      totalSize = (int) (totalSize + vector.computeCombinedBufferSize(i, 4));
     }
     return totalSize;
   }

--- a/java/performance/src/main/java/org/apache/arrow/vector/VarCharBenchmarks.java
+++ b/java/performance/src/main/java/org/apache/arrow/vector/VarCharBenchmarks.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -61,7 +62,7 @@ public class VarCharBenchmarks {
       if (i % 3 == 0) {
         fromVector.setNull(i);
       } else {
-        fromVector.set(i, String.valueOf(i * 1000).getBytes());
+        fromVector.set(i, String.valueOf(i * 1000).getBytes(StandardCharsets.UTF_8));
       }
     }
     fromVector.setValueCount(VECTOR_LENGTH);

--- a/java/performance/src/main/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
+++ b/java/performance/src/main/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
@@ -45,7 +46,8 @@ public class VariableWidthVectorBenchmarks {
 
   private static final int ALLOCATOR_CAPACITY = 1024 * 1024;
 
-  private static byte[] bytes = VariableWidthVectorBenchmarks.class.getName().getBytes();
+  private static byte[] bytes =
+      VariableWidthVectorBenchmarks.class.getName().getBytes(StandardCharsets.UTF_8);
   private ArrowBuf arrowBuff;
 
   private BufferAllocator allocator;

--- a/java/performance/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoderBenchmarks.java
+++ b/java/performance/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoderBenchmarks.java
@@ -117,7 +117,7 @@ public class DictionaryEncoderBenchmarks {
   private String generateUniqueKey(int length) {
     String str = "abcdefghijklmnopqrstuvwxyz";
     Random random = new Random();
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     for (int i = 0; i < length; i++) {
       int number = random.nextInt(26);
       sb.append(str.charAt(number));

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -923,7 +923,7 @@ under the License.
             <configuration>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/(target/generated-source|format/src/main/java/org/apache/arrow/flatbuf)/.*</arg>
+                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/(target/generated-source|target/generated-sources|format/src/main/java/org/apache/arrow/flatbuf)/.*</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -233,11 +233,6 @@ under the License.
         <artifactId>logback-core</artifactId>
         <version>${logback.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons.lang3.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -126,6 +126,7 @@ under the License.
       is addressed
     -->
     <version.maven-jar-plugin>3.2.2</version.maven-jar-plugin>
+    <commons.lang3.version>3.12.0</commons.lang3.version>
   </properties>
 
   <dependencyManagement>
@@ -231,6 +232,11 @@ under the License.
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
         <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons.lang3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -923,7 +923,7 @@ under the License.
             <configuration>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/(target/generated-source|target/generated-sources|format/src/main/java/org/apache/arrow/flatbuf)/.*</arg>
+                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/(target/generated-source|target/generated-sources|target/generated-test-sources|format/src/main/java/org/apache/arrow/flatbuf)/.*</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -934,6 +934,7 @@ under the License.
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                <arg>-Werror</arg>
               </compilerArgs>
               <annotationProcessorPaths combine.children="append">
                 <path>

--- a/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
+++ b/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -77,7 +78,7 @@ public class EchoServerTest {
             try {
               server.run();
             } catch (IOException e) {
-              e.printStackTrace();
+              throw new UncheckedIOException(e);
             }
           }
         };

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -86,6 +86,11 @@ under the License.
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -117,15 +122,6 @@ under the License.
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration combine.children="append">
-          <compilerArgs>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <!-- generate sources from fmpp -->

--- a/java/vector/src/main/codegen/templates/ArrowType.java
+++ b/java/vector/src/main/codegen/templates/ArrowType.java
@@ -21,6 +21,7 @@
 
 package org.apache.arrow.vector.types.pojo;
 
+import com.google.errorprone.annotations.Immutable;
 import com.google.flatbuffers.FlatBufferBuilder;
 
 import java.util.Objects;
@@ -49,6 +50,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
   @JsonSubTypes.Type(value = ArrowType.${type.name?remove_ending("_")}.class, name = "${type.name?remove_ending("_")?lower_case}"),
 </#list>
 })
+
+@Immutable
 public abstract class ArrowType {
 
   public static abstract class PrimitiveType extends ArrowType {

--- a/java/vector/src/main/java/module-info.java
+++ b/java/vector/src/main/java/module-info.java
@@ -48,6 +48,7 @@ module org.apache.arrow.vector {
   requires org.apache.arrow.memory.core;
   requires org.apache.commons.codec;
   requires org.slf4j;
+  requires com.google.errorprone.annotations;
 
   uses org.apache.arrow.vector.compression.CompressionCodec.Factory;
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
@@ -50,7 +50,7 @@ public class AllocationHelper {
     if (v instanceof FixedWidthVector) {
       ((FixedWidthVector) v).allocateNew(valueCount);
     } else if (v instanceof VariableWidthVector) {
-      ((VariableWidthVector) v).allocateNew(valueCount * bytesPerValue, valueCount);
+      ((VariableWidthVector) v).allocateNew(valueCount * ((long) bytesPerValue), valueCount);
     } else if (v instanceof RepeatedFixedWidthVectorLike) {
       ((RepeatedFixedWidthVectorLike) v).allocateNew(valueCount, childValCount);
     } else if (v instanceof RepeatedVariableWidthVectorLike) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -1006,6 +1006,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    * @param index position of the element to set
    * @param length length of the element
    */
+  @Override
   public void setValueLengthSafe(int index, int length) {
     assert index >= 0;
     handleSafe(index, length);
@@ -1091,6 +1092,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    * @param start start index in array of bytes
    * @param length length of data in array of bytes
    */
+  @Override
   public void setSafe(int index, byte[] value, int start, int length) {
     assert index >= 0;
     handleSafe(index, length);
@@ -1128,6 +1130,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    * @param start start index in ByteBuffer
    * @param length length of data in ByteBuffer
    */
+  @Override
   public void setSafe(int index, ByteBuffer value, int start, int length) {
     assert index >= 0;
     handleSafe(index, length);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -1129,6 +1129,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @param start start index in array of bytes
    * @param length length of data in array of bytes
    */
+  @Override
   public void set(int index, byte[] value, int start, int length) {
     assert index >= 0;
     fillHoles(index);
@@ -1146,6 +1147,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @param start start index in array of bytes
    * @param length length of data in array of bytes
    */
+  @Override
   public void setSafe(int index, byte[] value, int start, int length) {
     assert index >= 0;
     handleSafe(index, length);
@@ -1183,6 +1185,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @param start start index in ByteBuffer
    * @param length length of data in ByteBuffer
    */
+  @Override
   public void setSafe(int index, ByteBuffer value, int start, int length) {
     assert index >= 0;
     handleSafe(index, length);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -296,7 +296,7 @@ public class BitVectorHelper {
 
   /** Returns the byte at <code>index</code> from left-shifted by (8 - <code>offset</code>). */
   public static byte getBitsFromNextByte(ArrowBuf data, int index, int offset) {
-    return (byte) ((data.getByte(index) << (8 - offset)));
+    return (byte) (data.getByte(index) << (8 - offset));
   }
 
   /**
@@ -385,7 +385,7 @@ public class BitVectorHelper {
     }
 
     // copy the first bit set
-    if (input1 != output) {
+    if (!input1.equals(output)) {
       MemoryUtil.copyMemory(input1.memoryAddress(), output.memoryAddress(), numBytes1);
     }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Decimal256Vector.java
@@ -412,7 +412,7 @@ public final class Decimal256Vector extends BaseFixedWidthVector
   }
 
   /**
-   * Same as {@link #set(int, int, ArrowBuf)} except that it handles the case when index is greater
+   * Same as {@link #set(int, long, ArrowBuf)} except that it handles the case when index is greater
    * than or equal to existing value capacity {@link #getValueCapacity()}.
    *
    * @param index position of element
@@ -449,7 +449,7 @@ public final class Decimal256Vector extends BaseFixedWidthVector
   }
 
   /**
-   * Same as {@link #set(int, NullableDecimalHolder)} except that it handles the case when index is
+   * Same as {@link #set(int, Decimal256Holder)} except that it handles the case when index is
    * greater than or equal to existing value capacity {@link #getValueCapacity()}.
    *
    * @param index position of element
@@ -490,8 +490,8 @@ public final class Decimal256Vector extends BaseFixedWidthVector
   }
 
   /**
-   * Same as {@link #setSafe(int, int, int, ArrowBuf)} except that it handles the case when the
-   * position of new value is beyond the current value capacity of the vector.
+   * Same as {@link #setSafe(int, long, ArrowBuf)} except that it handles the case when the position
+   * of new value is beyond the current value capacity of the vector.
    *
    * @param index position of the new value
    * @param isSet 0 for NULL value, 1 otherwise

--- a/java/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/LargeVarBinaryVector.java
@@ -93,6 +93,7 @@ public final class LargeVarBinaryVector extends BaseLargeVariableWidthVector
    * @param index position of element to get
    * @return array of bytes for non-null element, null otherwise
    */
+  @Override
   public byte[] get(int index) {
     assert index >= 0;
     if (isSet(index) == 0) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -18,6 +18,7 @@ package org.apache.arrow.vector;
 
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.DATA_VECTOR_NAME;
 
+import com.google.errorprone.annotations.InlineMe;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -94,6 +95,15 @@ public class NullVector implements FieldVector, ValueIterableVector<Object> {
   }
 
   @Deprecated
+  @InlineMe(
+      replacement =
+          "this(new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null))",
+      imports = {
+        "DATA_VECTOR_NAME",
+        "org.apache.arrow.vector.types.pojo.ArrowType",
+        "org.apache.arrow.vector.types.pojo.Field",
+        "org.apache.arrow.vector.types.pojo.FieldType"
+      })
   public NullVector() {
     this(new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null));
   }
@@ -229,6 +239,7 @@ public class NullVector implements FieldVector, ValueIterableVector<Object> {
    *     vectors.
    */
   @Deprecated
+  @SuppressWarnings("InlineMeSuggester")
   @Override
   public List<BufferBacked> getFieldInnerVectors() {
     return Collections.emptyList();
@@ -336,7 +347,9 @@ public class NullVector implements FieldVector, ValueIterableVector<Object> {
 
     @Deprecated
     public TransferImpl() {
-      to = new NullVector();
+      to =
+          new NullVector(
+              new Field(DATA_VECTOR_NAME, FieldType.nullable(new ArrowType.Null()), null));
     }
 
     public TransferImpl(NullVector to) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
@@ -126,6 +126,7 @@ public final class TimeStampSecTZVector extends TimeStampVector
    * @param index position of element
    * @return element at given index
    */
+  @Override
   public Long getObject(int index) {
     if (isSet(index) == 0) {
       return null;

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -94,6 +94,7 @@ public final class VarBinaryVector extends BaseVariableWidthVector
    * @param index position of element to get
    * @return array of bytes for non-null element, null otherwise
    */
+  @Override
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -96,6 +96,7 @@ public final class VarCharVector extends BaseVariableWidthVector
    * @param index position of element to get
    * @return array of bytes for non-null element, null otherwise
    */
+  @Override
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -347,11 +347,15 @@ public class VectorSchemaRoot implements AutoCloseable {
     return new VectorSchemaRoot(sliceVectors);
   }
 
-  /** Determine if two VectorSchemaRoots are exactly equal. */
-  public boolean equals(VectorSchemaRoot other) {
-    if (other == null) {
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof VectorSchemaRoot)) {
       return false;
     }
+    VectorSchemaRoot other = (VectorSchemaRoot) obj;
 
     if (!this.schema.equals(other.schema)) {
       return false;
@@ -370,6 +374,16 @@ public class VectorSchemaRoot implements AutoCloseable {
     }
 
     return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = schema.hashCode();
+    result = 31 * result + rowCount;
+    for (FieldVector vector : fieldVectors) {
+      result = 31 * result + (vector != null ? vector.hashCode() : 0);
+    }
+    return result;
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarBinaryVector.java
@@ -18,6 +18,7 @@ package org.apache.arrow.vector;
 
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
+import com.google.errorprone.annotations.DoNotCall;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReusableBuffer;
 import org.apache.arrow.vector.complex.impl.ViewVarBinaryReaderImpl;
@@ -94,6 +95,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    * @param index position of an element to get
    * @return array of bytes for a non-null element, null otherwise
    */
+  @Override
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
@@ -131,6 +133,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    * @param index position of an element to get
    * @param holder data holder to be populated by this function
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void get(int index, NullableViewVarBinaryHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40936
     throw new UnsupportedOperationException("Unsupported operation");
@@ -149,6 +152,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void set(int index, ViewVarBinaryHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40936
     throw new UnsupportedOperationException("Unsupported operation");
@@ -161,6 +165,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void setSafe(int index, ViewVarBinaryHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40936
     throw new UnsupportedOperationException("Unsupported operation");
@@ -173,6 +178,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void set(int index, NullableViewVarBinaryHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40936
     throw new UnsupportedOperationException("Unsupported operation");
@@ -185,6 +191,7 @@ public final class ViewVarBinaryVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void setSafe(int index, NullableViewVarBinaryHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40936
     throw new UnsupportedOperationException("Unsupported operation");

--- a/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ViewVarCharVector.java
@@ -18,6 +18,7 @@ package org.apache.arrow.vector;
 
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
+import com.google.errorprone.annotations.DoNotCall;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReusableBuffer;
 import org.apache.arrow.vector.complex.impl.ViewVarCharReaderImpl;
@@ -98,6 +99,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
    * @param index position of an element to get
    * @return array of bytes for a non-null element, null otherwise
    */
+  @Override
   public byte[] get(int index) {
     assert index >= 0;
     if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
@@ -142,6 +144,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
    * @param index position of an element to get
    * @param holder data holder to be populated by this function
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void get(int index, NullableViewVarCharHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40937
     throw new UnsupportedOperationException(
@@ -161,6 +164,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void set(int index, ViewVarCharHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40937
     throw new UnsupportedOperationException("ViewVarCharHolder set operation not supported");
@@ -173,6 +177,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void setSafe(int index, ViewVarCharHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40937
     throw new UnsupportedOperationException("ViewVarCharHolder setSafe operation not supported");
@@ -185,6 +190,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void set(int index, NullableViewVarCharHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40937
     throw new UnsupportedOperationException(
@@ -198,6 +204,7 @@ public final class ViewVarCharVector extends BaseVariableWidthViewVector
    * @param index position of the element to set
    * @param holder holder that carries data buffer.
    */
+  @DoNotCall("Always throws java.lang.UnsupportedOperationException")
   public void setSafe(int index, NullableViewVarCharHolder holder) {
     // TODO: https://github.com/apache/arrow/issues/40937
     throw new UnsupportedOperationException(

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -57,6 +57,7 @@ public final class ZeroVector extends NullVector {
   }
 
   @Deprecated
+  @SuppressWarnings("InlineMeInliner")
   public ZeroVector() {}
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -478,12 +478,15 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
       int offsetWidth = BaseVariableWidthVector.OFFSET_WIDTH;
 
       if (!isNull) {
-        final int startIndexLeft = leftVector.getOffsetBuffer().getInt(leftIndex * offsetWidth);
-        final int endIndexLeft = leftVector.getOffsetBuffer().getInt((leftIndex + 1) * offsetWidth);
+        final int startIndexLeft =
+            leftVector.getOffsetBuffer().getInt((long) leftIndex * offsetWidth);
+        final int endIndexLeft =
+            leftVector.getOffsetBuffer().getInt((long) (leftIndex + 1) * offsetWidth);
 
-        final int startIndexRight = rightVector.getOffsetBuffer().getInt(rightIndex * offsetWidth);
+        final int startIndexRight =
+            rightVector.getOffsetBuffer().getInt((long) rightIndex * offsetWidth);
         final int endIndexRight =
-            rightVector.getOffsetBuffer().getInt((rightIndex + 1) * offsetWidth);
+            rightVector.getOffsetBuffer().getInt((long) (rightIndex + 1) * offsetWidth);
 
         int ret =
             ByteFunctionHelpers.equal(
@@ -657,12 +660,15 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
       int offsetWidth = BaseRepeatedValueVector.OFFSET_WIDTH;
 
       if (!isNull) {
-        final int startIndexLeft = leftVector.getOffsetBuffer().getInt(leftIndex * offsetWidth);
-        final int endIndexLeft = leftVector.getOffsetBuffer().getInt((leftIndex + 1) * offsetWidth);
+        final int startIndexLeft =
+            leftVector.getOffsetBuffer().getInt((long) leftIndex * offsetWidth);
+        final int endIndexLeft =
+            leftVector.getOffsetBuffer().getInt((long) (leftIndex + 1) * offsetWidth);
 
-        final int startIndexRight = rightVector.getOffsetBuffer().getInt(rightIndex * offsetWidth);
+        final int startIndexRight =
+            rightVector.getOffsetBuffer().getInt((long) rightIndex * offsetWidth);
         final int endIndexRight =
-            rightVector.getOffsetBuffer().getInt((rightIndex + 1) * offsetWidth);
+            rightVector.getOffsetBuffer().getInt((long) (rightIndex + 1) * offsetWidth);
 
         if ((endIndexLeft - startIndexLeft) != (endIndexRight - startIndexRight)) {
           return false;

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
@@ -62,8 +62,21 @@ public class TypeEqualsVisitor implements VectorVisitor<Boolean, Void> {
   }
 
   /** Check type equals without passing IN param in VectorVisitor. */
-  public boolean equals(ValueVector left) {
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof ValueVector)) {
+      return false;
+    }
+    ValueVector left = (ValueVector) obj;
     return left.accept(this, null);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(right, checkName, checkMetadata);
   }
 
   @Override
@@ -138,12 +151,12 @@ public class TypeEqualsVisitor implements VectorVisitor<Boolean, Void> {
 
   private boolean compareField(Field leftField, Field rightField) {
 
-    if (leftField == rightField) {
+    if (leftField.equals(rightField)) {
       return true;
     }
 
     return (!checkName || Objects.equals(leftField.getName(), rightField.getName()))
-        && Objects.equals(leftField.isNullable(), rightField.isNullable())
+        && (leftField.isNullable() == rightField.isNullable())
         && Objects.equals(leftField.getType(), rightField.getType())
         && Objects.equals(leftField.getDictionary(), rightField.getDictionary())
         && (!checkMetadata || Objects.equals(leftField.getMetadata(), rightField.getMetadata()))

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
@@ -62,15 +62,8 @@ public class TypeEqualsVisitor implements VectorVisitor<Boolean, Void> {
   }
 
   /** Check type equals without passing IN param in VectorVisitor. */
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (!(obj instanceof ValueVector)) {
-      return false;
-    }
-    ValueVector left = (ValueVector) obj;
+  @SuppressWarnings("NonOverridingEquals")
+  public boolean equals(ValueVector left) {
     return left.accept(this, null);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseLargeRepeatedValueViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseLargeRepeatedValueViewVector.java
@@ -182,8 +182,8 @@ public abstract class BaseLargeRepeatedValueViewVector extends BaseValueVector
 
   @Override
   public void setInitialCapacity(int numRecords) {
-    offsetAllocationSizeInBytes = (long) (numRecords) * OFFSET_WIDTH;
-    sizeAllocationSizeInBytes = (long) (numRecords) * SIZE_WIDTH;
+    offsetAllocationSizeInBytes = (long) numRecords * OFFSET_WIDTH;
+    sizeAllocationSizeInBytes = (long) numRecords * SIZE_WIDTH;
     if (vector instanceof BaseFixedWidthVector || vector instanceof BaseVariableWidthVector) {
       vector.setInitialCapacity(numRecords * RepeatedValueVector.DEFAULT_REPEAT_PER_RECORD);
     } else {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueViewVector.java
@@ -181,8 +181,8 @@ public abstract class BaseRepeatedValueViewVector extends BaseValueVector
 
   @Override
   public void setInitialCapacity(int numRecords) {
-    offsetAllocationSizeInBytes = (numRecords) * OFFSET_WIDTH;
-    sizeAllocationSizeInBytes = (numRecords) * SIZE_WIDTH;
+    offsetAllocationSizeInBytes = (long) numRecords * OFFSET_WIDTH;
+    sizeAllocationSizeInBytes = (long) numRecords * SIZE_WIDTH;
     if (vector instanceof BaseFixedWidthVector || vector instanceof BaseVariableWidthVector) {
       vector.setInitialCapacity(numRecords * RepeatedValueVector.DEFAULT_REPEAT_PER_RECORD);
     } else {
@@ -196,8 +196,8 @@ public abstract class BaseRepeatedValueViewVector extends BaseValueVector
       throw new OversizedAllocationException("Requested amount of memory is more than max allowed");
     }
 
-    offsetAllocationSizeInBytes = numRecords * OFFSET_WIDTH;
-    sizeAllocationSizeInBytes = numRecords * SIZE_WIDTH;
+    offsetAllocationSizeInBytes = (long) numRecords * OFFSET_WIDTH;
+    sizeAllocationSizeInBytes = (long) numRecords * SIZE_WIDTH;
 
     int innerValueCapacity = Math.max((int) (numRecords * density), 1);
 
@@ -222,8 +222,8 @@ public abstract class BaseRepeatedValueViewVector extends BaseValueVector
    *     all records.
    */
   public void setInitialTotalCapacity(int numRecords, int totalNumberOfElements) {
-    offsetAllocationSizeInBytes = numRecords * OFFSET_WIDTH;
-    sizeAllocationSizeInBytes = numRecords * SIZE_WIDTH;
+    offsetAllocationSizeInBytes = (long) numRecords * OFFSET_WIDTH;
+    sizeAllocationSizeInBytes = (long) numRecords * SIZE_WIDTH;
     vector.setInitialCapacity(totalNumberOfElements);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListViewVector.java
@@ -739,8 +739,8 @@ public class LargeListViewVector extends BaseLargeRepeatedValueViewVector
       return null;
     }
     final List<Object> vals = new JsonStringArrayList<>();
-    final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);
-    final int end = start + sizeBuffer.getInt((index) * SIZE_WIDTH);
+    final int start = offsetBuffer.getInt((long) index * OFFSET_WIDTH);
+    final int end = start + sizeBuffer.getInt((long) index * SIZE_WIDTH);
     final ValueVector vv = getDataVector();
     for (int i = start; i < end; i++) {
       vals.add(vv.getObject(checkedCastToInt(i)));

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListViewVector.java
@@ -499,7 +499,6 @@ public class ListViewVector extends BaseRepeatedValueViewVector
           valueCount);
       to.clear();
       if (length > 0) {
-        final int startPoint = offsetBuffer.getInt((long) startIndex * OFFSET_WIDTH);
         // we have to scan by index since there are out-of-order offsets
         to.offsetBuffer = to.allocateBuffers((long) length * OFFSET_WIDTH);
         to.sizeBuffer = to.allocateBuffers((long) length * SIZE_WIDTH);
@@ -744,8 +743,8 @@ public class ListViewVector extends BaseRepeatedValueViewVector
       return null;
     }
     final List<Object> vals = new JsonStringArrayList<>();
-    final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);
-    final int end = start + sizeBuffer.getInt((index) * SIZE_WIDTH);
+    final int start = offsetBuffer.getInt((long) index * OFFSET_WIDTH);
+    final int end = start + sizeBuffer.getInt((long) index * SIZE_WIDTH);
     final ValueVector vv = getDataVector();
     for (int i = start; i < end; i++) {
       vals.add(vv.getObject(i));

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -37,7 +37,10 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
   Mode mode = Mode.INIT;
   private final String name;
+
+  @SuppressWarnings("UnusedVariable")
   private final boolean unionEnabled;
+
   private final NullableStructWriterFactory nullableStructWriterFactory;
 
   private enum Mode {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/StructOrListWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/StructOrListWriterImpl.java
@@ -51,6 +51,7 @@ public class StructOrListWriterImpl implements StructOrListWriter {
   }
 
   /** Start writing to either the list or the struct. */
+  @Override
   public void start() {
     if (struct != null) {
       struct.start();
@@ -60,6 +61,7 @@ public class StructOrListWriterImpl implements StructOrListWriter {
   }
 
   /** Finish writing to the list or struct. */
+  @Override
   public void end() {
     if (struct != null) {
       struct.end();
@@ -69,6 +71,7 @@ public class StructOrListWriterImpl implements StructOrListWriter {
   }
 
   /** Creates a new writer for a struct with the given name. */
+  @Override
   public StructOrListWriter struct(final String name) {
     assert struct != null;
     return new StructOrListWriterImpl(struct.struct(name));
@@ -81,6 +84,7 @@ public class StructOrListWriterImpl implements StructOrListWriter {
    * @deprecated use {@link #listOfStruct(String)} instead.
    */
   @Deprecated
+  @SuppressWarnings({"InlineMeValidator", "InlineMeSuggester"})
   public StructOrListWriter listoftstruct(final String name) {
     return listOfStruct(name);
   }
@@ -90,48 +94,59 @@ public class StructOrListWriterImpl implements StructOrListWriter {
    *
    * @param name Unused.
    */
+  @Override
   public StructOrListWriter listOfStruct(final String name) {
     assert list != null;
     return new StructOrListWriterImpl(list.struct());
   }
 
+  @Override
   public StructOrListWriter list(final String name) {
     assert struct != null;
     return new StructOrListWriterImpl(struct.list(name));
   }
 
+  @Override
   public boolean isStructWriter() {
     return struct != null;
   }
 
+  @Override
   public boolean isListWriter() {
     return list != null;
   }
 
+  @Override
   public VarCharWriter varChar(final String name) {
     return (struct != null) ? struct.varChar(name) : list.varChar();
   }
 
+  @Override
   public IntWriter integer(final String name) {
     return (struct != null) ? struct.integer(name) : list.integer();
   }
 
+  @Override
   public BigIntWriter bigInt(final String name) {
     return (struct != null) ? struct.bigInt(name) : list.bigInt();
   }
 
+  @Override
   public Float4Writer float4(final String name) {
     return (struct != null) ? struct.float4(name) : list.float4();
   }
 
+  @Override
   public Float8Writer float8(final String name) {
     return (struct != null) ? struct.float8(name) : list.float8();
   }
 
+  @Override
   public BitWriter bit(final String name) {
     return (struct != null) ? struct.bit(name) : list.bit();
   }
 
+  @Override
   public VarBinaryWriter binary(final String name) {
     return (struct != null) ? struct.varBinary(name) : list.varBinary();
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionCodec.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compression/CompressionCodec.java
@@ -80,7 +80,8 @@ public interface CompressionCodec {
           try {
             factory.createCodec(codecType); // will throw if not supported
             factories.putIfAbsent(codecType, factory);
-          } catch (Throwable ignored) {
+          } catch (Throwable expected) {
+            // ignore
           }
         }
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
@@ -246,6 +246,7 @@ public class DictionaryHashTable {
       return hash;
     }
 
+    @Override
     public final boolean equals(Object o) {
       if (!(o instanceof DictionaryHashTable.Entry)) {
         return false;

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/StructSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/StructSubfieldEncoder.java
@@ -80,7 +80,7 @@ public class StructSubfieldEncoder {
     StructVector cloned =
         (StructVector)
             fieldType.createNewSingleVector(
-                vector.getField().getName(), allocator, /*schemaCallback=*/ null);
+                vector.getField().getName(), allocator, /* schemaCallBack= */ null);
 
     final ArrowFieldNode fieldNode =
         new ArrowFieldNode(vector.getValueCount(), vector.getNullCount());

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
@@ -139,6 +139,7 @@ public class ArrowStreamReader extends ArrowReader {
    * @return true if a batch was read, false on EOS
    * @throws IOException on error
    */
+  @Override
   public boolean loadNextBatch() throws IOException {
     prepareLoadNextBatch();
     MessageResult result = messageReader.readNext();

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -155,15 +155,8 @@ public abstract class ArrowWriter implements AutoCloseable {
     VectorUnloader unloader =
         new VectorUnloader(dictRoot, /*includeNullCount*/ true, this.codec, /*alignBuffers*/ true);
     ArrowRecordBatch batch = unloader.getRecordBatch();
-    ArrowDictionaryBatch dictionaryBatch = new ArrowDictionaryBatch(id, batch, false);
-    try {
+    try (ArrowDictionaryBatch dictionaryBatch = new ArrowDictionaryBatch(id, batch, false)) {
       writeDictionaryBatch(dictionaryBatch);
-    } finally {
-      try {
-        dictionaryBatch.close();
-      } catch (Exception e) {
-        throw new RuntimeException("Error occurred while closing dictionary.", e);
-      }
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -351,10 +351,7 @@ public class JsonFileWriter implements AutoCloseable {
   }
 
   private void writeValueToViewGenerator(
-      ArrowBuf viewBuffer,
-      List<ArrowBuf> dataBuffers,
-      FieldVector vector,
-      final int index)
+      ArrowBuf viewBuffer, List<ArrowBuf> dataBuffers, FieldVector vector, final int index)
       throws IOException {
     Preconditions.checkNotNull(viewBuffer);
     byte[] b = getView(viewBuffer, dataBuffers, index);
@@ -392,8 +389,7 @@ public class JsonFileWriter implements AutoCloseable {
   }
 
   private void writeValueToDataBufferGenerator(
-      BufferType bufferType, ArrowBuf viewBuffer, List<ArrowBuf> dataBuffers)
-      throws IOException {
+      BufferType bufferType, ArrowBuf viewBuffer, List<ArrowBuf> dataBuffers) throws IOException {
     if (bufferType.equals(VARIADIC_DATA_BUFFERS)) {
       Preconditions.checkNotNull(viewBuffer);
       Preconditions.checkArgument(!dataBuffers.isEmpty());

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -23,8 +23,6 @@ import java.nio.channels.WritableByteChannel;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.ipc.message.FBSerializable;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper around a WritableByteChannel that maintains the position as well adding some common
@@ -37,7 +35,6 @@ import org.slf4j.LoggerFactory;
  * <p>Please note that objects of this class are not thread-safe.
  */
 public class WriteChannel implements AutoCloseable {
-  private static final Logger LOGGER = LoggerFactory.getLogger(WriteChannel.class);
 
   private static final byte[] ZERO_BYTES = new byte[8];
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBlock.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBlock.java
@@ -75,7 +75,7 @@ public class ArrowBlock implements FBSerializable {
     if (obj == null) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof ArrowBlock)) {
       return false;
     }
     ArrowBlock other = (ArrowBlock) obj;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBuffer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBuffer.java
@@ -62,7 +62,7 @@ public class ArrowBuffer implements FBSerializable {
     if (obj == null) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof ArrowBuffer)) {
       return false;
     }
     ArrowBuffer other = (ArrowBuffer) obj;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
@@ -16,6 +16,7 @@
  */
 package org.apache.arrow.vector.ipc.message;
 
+import com.google.errorprone.annotations.InlineMe;
 import com.google.flatbuffers.FlatBufferBuilder;
 import org.apache.arrow.flatbuf.DictionaryBatch;
 import org.apache.arrow.flatbuf.MessageHeader;
@@ -31,6 +32,7 @@ public class ArrowDictionaryBatch implements ArrowMessage {
   private final boolean isDelta;
 
   @Deprecated
+  @InlineMe(replacement = "this(dictionaryId, dictionary, false)")
   public ArrowDictionaryBatch(long dictionaryId, ArrowRecordBatch dictionary) {
     this(dictionaryId, dictionary, false);
   }
@@ -46,6 +48,7 @@ public class ArrowDictionaryBatch implements ArrowMessage {
     return isDelta;
   }
 
+  @Override
   public byte getMessageType() {
     return MessageHeader.DictionaryBatch;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFooter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFooter.java
@@ -190,7 +190,7 @@ public class ArrowFooter implements FBSerializable {
     if (obj == null) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof ArrowFooter)) {
       return false;
     }
     ArrowFooter other = (ArrowFooter) obj;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -182,6 +182,7 @@ public class ArrowRecordBatch implements ArrowMessage {
   // this constructor is different from the public ones in that the reference manager's
   // <code>retain</code> method is not called, so the first <code>dummy</code> parameter is used
   // to distinguish this from the public constructor.
+  @SuppressWarnings("UnusedVariable")
   private ArrowRecordBatch(
       boolean dummy,
       int length,
@@ -206,6 +207,7 @@ public class ArrowRecordBatch implements ArrowMessage {
     this.buffersLayout = Collections.unmodifiableList(arrowBuffers);
   }
 
+  @Override
   public byte getMessageType() {
     return org.apache.arrow.flatbuf.MessageHeader.RecordBatch;
   }
@@ -261,9 +263,9 @@ public class ArrowRecordBatch implements ArrowMessage {
         buffers.stream()
             .map(
                 buf ->
-                    (buf.getReferenceManager()
-                            .transferOwnership(buf, allocator)
-                            .getTransferredBuffer())
+                    buf.getReferenceManager()
+                        .transferOwnership(buf, allocator)
+                        .getTransferredBuffer()
                         .writerIndex(buf.writerIndex()))
             .collect(Collectors.toList());
     close();

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -18,6 +18,7 @@ package org.apache.arrow.vector.ipc.message;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 
+import com.google.errorprone.annotations.InlineMe;
 import com.google.flatbuffers.FlatBufferBuilder;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -63,7 +64,7 @@ public class MessageSerializer {
     return ((bytes[3] & 255) << 24)
         + ((bytes[2] & 255) << 16)
         + ((bytes[1] & 255) << 8)
-        + ((bytes[0] & 255));
+        + (bytes[0] & 255);
   }
 
   /**
@@ -76,7 +77,7 @@ public class MessageSerializer {
     bytes[3] = (byte) (value >>> 24);
     bytes[2] = (byte) (value >>> 16);
     bytes[1] = (byte) (value >>> 8);
-    bytes[0] = (byte) (value);
+    bytes[0] = (byte) value;
   }
 
   /**
@@ -93,7 +94,7 @@ public class MessageSerializer {
     bytes[3] = (byte) (value >>> 24);
     bytes[2] = (byte) (value >>> 16);
     bytes[1] = (byte) (value >>> 8);
-    bytes[0] = (byte) (value);
+    bytes[0] = (byte) value;
   }
 
   public static int writeMessageBuffer(
@@ -166,6 +167,12 @@ public class MessageSerializer {
 
   /** Returns the serialized flatbuffer bytes of the schema wrapped in a message table. */
   @Deprecated
+  @InlineMe(
+      replacement = "MessageSerializer.serializeMetadata(schema, IpcOption.DEFAULT)",
+      imports = {
+        "org.apache.arrow.vector.ipc.message.IpcOption",
+        "org.apache.arrow.vector.ipc.message.MessageSerializer"
+      })
   public static ByteBuffer serializeMetadata(Schema schema) {
     return serializeMetadata(schema, IpcOption.DEFAULT);
   }
@@ -314,6 +321,12 @@ public class MessageSerializer {
    * org.apache.arrow.flatbuf.Message}.
    */
   @Deprecated
+  @InlineMe(
+      replacement = "MessageSerializer.serializeMetadata(message, IpcOption.DEFAULT)",
+      imports = {
+        "org.apache.arrow.vector.ipc.message.IpcOption",
+        "org.apache.arrow.vector.ipc.message.MessageSerializer"
+      })
   public static ByteBuffer serializeMetadata(ArrowMessage message) {
     return serializeMetadata(message, IpcOption.DEFAULT);
   }
@@ -655,6 +668,13 @@ public class MessageSerializer {
   }
 
   @Deprecated
+  @InlineMe(
+      replacement =
+          "MessageSerializer.serializeMessage(builder, headerType, headerOffset, bodyLength, IpcOption.DEFAULT)",
+      imports = {
+        "org.apache.arrow.vector.ipc.message.IpcOption",
+        "org.apache.arrow.vector.ipc.message.MessageSerializer"
+      })
   public static ByteBuffer serializeMessage(
       FlatBufferBuilder builder, byte headerType, int headerOffset, long bodyLength) {
     return serializeMessage(builder, headerType, headerOffset, bodyLength, IpcOption.DEFAULT);
@@ -719,9 +739,6 @@ public class MessageSerializer {
         if (in.readFully(messageBuffer) != messageLength) {
           throw new IOException("Unexpected end of stream trying to read message.");
         }
-        // see https://github.com/apache/arrow/issues/41717 for reason why we cast to
-        // java.nio.Buffer
-        ByteBuffer rewindBuffer = (ByteBuffer) ((java.nio.Buffer) messageBuffer).rewind();
 
         // Load the message.
         Message message = Message.getRootAsMessage(messageBuffer);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -740,7 +740,6 @@ public class MessageSerializer {
         if (in.readFully(messageBuffer) != messageLength) {
           throw new IOException("Unexpected end of stream trying to read message.");
         }
-
         // see https://github.com/apache/arrow/issues/41717 for reason why we cast to
         // java.nio.Buffer
         ByteBuffer rewindBuffer = (ByteBuffer) ((java.nio.Buffer) messageBuffer).rewind();

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -715,6 +715,7 @@ public class MessageSerializer {
    *     valid Message was read, or null if end-of-stream
    * @throws IOException on error
    */
+  @SuppressWarnings("UnusedVariable")
   public static MessageMetadataResult readMessage(ReadChannel in) throws IOException {
 
     // Read the message size. There is an i32 little endian prefix.
@@ -739,6 +740,10 @@ public class MessageSerializer {
         if (in.readFully(messageBuffer) != messageLength) {
           throw new IOException("Unexpected end of stream trying to read message.");
         }
+
+        // see https://github.com/apache/arrow/issues/41717 for reason why we cast to
+        // java.nio.Buffer
+        ByteBuffer rewindBuffer = (ByteBuffer) ((java.nio.Buffer) messageBuffer).rewind();
 
         // Load the message.
         Message message = Message.getRootAsMessage(messageBuffer);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -787,6 +787,7 @@ public class Types {
       }
     },
     ;
+
     private final ArrowType type;
 
     MinorType(ArrowType type) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -787,7 +787,6 @@ public class Types {
       }
     },
     ;
-
     private final ArrowType type;
 
     MinorType(ArrowType type) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
+import com.google.errorprone.annotations.InlineMe;
 import com.google.flatbuffers.FlatBufferBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -90,6 +91,9 @@ public class Schema {
    * @return The deserialized schema.
    */
   @Deprecated
+  @InlineMe(
+      replacement = "Schema.convertSchema(org.apache.arrow.flatbuf.Schema.getRootAsSchema(buffer))",
+      imports = "org.apache.arrow.vector.types.pojo.Schema")
   public static Schema deserialize(ByteBuffer buffer) {
     return convertSchema(org.apache.arrow.flatbuf.Schema.getRootAsSchema(buffer));
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
@@ -27,12 +27,12 @@ import org.apache.arrow.memory.util.MemoryUtil;
 public class DecimalUtility {
   private DecimalUtility() {}
 
-  public static final byte[] zeroes =
+  private static final byte[] zeroes =
       new byte[] {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
       };
-  public static final byte[] minus_one =
+  private static final byte[] minus_one =
       new byte[] {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
@@ -172,11 +172,11 @@ public class DecimalUtility {
     if (LITTLE_ENDIAN) {
       MemoryUtil.putLong(addressOfValue, value);
       for (int i = 1; i <= (byteWidth - 8) / 8; i++) {
-        MemoryUtil.putLong(addressOfValue + Long.BYTES * i, padValue);
+        MemoryUtil.putLong(addressOfValue + Long.BYTES * ((long) i), padValue);
       }
     } else {
       for (int i = 0; i < (byteWidth - 8) / 8; i++) {
-        MemoryUtil.putLong(addressOfValue + Long.BYTES * i, padValue);
+        MemoryUtil.putLong(addressOfValue + Long.BYTES * ((long) i), padValue);
       }
       MemoryUtil.putLong(addressOfValue + Long.BYTES * (byteWidth - 8) / 8, value);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/IntObjectHashMap.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/IntObjectHashMap.java
@@ -412,8 +412,8 @@ class IntObjectHashMap<V> implements IntObjectMap<V> {
     for (V value = values[i]; value != null; value = values[i = probeNext(i)]) {
       int key = keys[i];
       int bucket = hashIndex(key);
-      if (i < bucket && (bucket <= nextFree || nextFree <= i)
-          || bucket <= nextFree && nextFree <= i) {
+      if ((i < bucket && (bucket <= nextFree || nextFree <= i))
+          || (bucket <= nextFree && nextFree <= i)) {
         // Move the displaced entry "back" to the first available position.
         keys[nextFree] = key;
         values[nextFree] = value;

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
@@ -200,8 +200,12 @@ public class Text extends ReusableByteArray {
   public void set(String string) {
     try {
       ByteBuffer bb = encode(string, true);
-      bytes = bb.array();
-      length = bb.limit();
+      byte[] bytes = new byte[bb.remaining()];
+      int originalPosition = bb.position();
+      bb.get(bytes);
+      bb.position(originalPosition); // Restores the buffer position
+      this.bytes = bytes;
+      this.length = bb.limit();
     } catch (CharacterCodingException e) {
       throw new RuntimeException("Should not have happened ", e);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
@@ -252,7 +252,6 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
-  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(ListVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),
@@ -322,7 +321,6 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
-  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(LargeListVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),
@@ -394,7 +392,6 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
-  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(FixedSizeListVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),
@@ -441,7 +438,6 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
-  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(NonNullableStructVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
@@ -96,8 +96,8 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
       MemoryUtil.copyMemory(
           deltaVector.getDataBuffer().memoryAddress(),
           targetVector.getDataBuffer().memoryAddress()
-              + deltaVector.getTypeWidth() * targetVector.getValueCount(),
-          deltaVector.getTypeWidth() * deltaVector.getValueCount());
+              + (long) deltaVector.getTypeWidth() * targetVector.getValueCount(),
+          (long) deltaVector.getTypeWidth() * deltaVector.getValueCount());
     }
     targetVector.setValueCount(newValueCount);
     return targetVector;
@@ -151,8 +151,8 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
     MemoryUtil.copyMemory(
         deltaVector.getOffsetBuffer().memoryAddress() + BaseVariableWidthVector.OFFSET_WIDTH,
         targetVector.getOffsetBuffer().memoryAddress()
-            + (targetVector.getValueCount() + 1) * BaseVariableWidthVector.OFFSET_WIDTH,
-        deltaVector.getValueCount() * BaseVariableWidthVector.OFFSET_WIDTH);
+            + (long) (targetVector.getValueCount() + 1) * BaseVariableWidthVector.OFFSET_WIDTH,
+        (long) deltaVector.getValueCount() * BaseVariableWidthVector.OFFSET_WIDTH);
 
     // increase each offset from the second buffer
     for (int i = 0; i < deltaVector.getValueCount(); i++) {
@@ -223,8 +223,8 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
     MemoryUtil.copyMemory(
         deltaVector.getOffsetBuffer().memoryAddress() + BaseLargeVariableWidthVector.OFFSET_WIDTH,
         targetVector.getOffsetBuffer().memoryAddress()
-            + (targetVector.getValueCount() + 1) * BaseLargeVariableWidthVector.OFFSET_WIDTH,
-        deltaVector.getValueCount() * BaseLargeVariableWidthVector.OFFSET_WIDTH);
+            + (long) (targetVector.getValueCount() + 1) * BaseLargeVariableWidthVector.OFFSET_WIDTH,
+        (long) deltaVector.getValueCount() * BaseLargeVariableWidthVector.OFFSET_WIDTH);
 
     // increase each offset from the second buffer
     for (int i = 0; i < deltaVector.getValueCount(); i++) {
@@ -252,6 +252,7 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
+  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(ListVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),
@@ -321,6 +322,7 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
+  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(LargeListVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),
@@ -392,6 +394,7 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
+  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(FixedSizeListVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),
@@ -438,6 +441,7 @@ public class VectorAppender implements VectorVisitor<ValueVector, Void> {
   }
 
   @Override
+  @SuppressWarnings("EqualsIncompatibleType")
   public ValueVector visit(NonNullableStructVector deltaVector, Void value) {
     Preconditions.checkArgument(
         typeVisitor.equals(deltaVector),

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateUtil.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateUtil.java
@@ -16,6 +16,8 @@
  */
 package org.apache.arrow.vector.validate;
 
+import com.google.errorprone.annotations.FormatMethod;
+
 /** Utilities for vector validation. */
 public class ValidateUtil {
 
@@ -42,6 +44,7 @@ public class ValidateUtil {
    * @param args the error message arguments.
    * @throws ValidateException if the expression evaluates to false.
    */
+  @FormatMethod
   public static void validateOrThrow(boolean expression, String errorMessage, Object... args) {
     if (!expression) {
       throw new ValidateException(String.format(errorMessage, args));

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
@@ -131,7 +131,7 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
     int lastOffset =
         valueCount == 0
             ? 0
-            : vector.getOffsetBuffer().getInt(valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
+            : vector.getOffsetBuffer().getInt((long) valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
     validateDataBuffer(vector, lastOffset);
     return null;
   }
@@ -172,7 +172,7 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
     int lastOffset =
         valueCount == 0
             ? 0
-            : vector.getOffsetBuffer().getInt(valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
+            : vector.getOffsetBuffer().getInt((long) valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
     int dataVectorLength = dataVector == null ? 0 : dataVector.getValueCount();
     validateOrThrow(
         dataVectorLength >= lastOffset,
@@ -219,7 +219,7 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
             ? 0
             : vector
                 .getOffsetBuffer()
-                .getLong(valueCount * BaseLargeVariableWidthVector.OFFSET_WIDTH);
+                .getLong((long) valueCount * BaseLargeVariableWidthVector.OFFSET_WIDTH);
     int dataVectorLength = dataVector == null ? 0 : dataVector.getValueCount();
     validateOrThrow(
         dataVectorLength >= lastOffset,
@@ -283,6 +283,7 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
   }
 
   @Override
+  @SuppressWarnings("VoidUsed")
   public Void visit(ExtensionTypeVector<?> vector, Void value) {
     vector.getUnderlyingVector().accept(this, value);
     return null;

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
@@ -131,7 +131,9 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
     int lastOffset =
         valueCount == 0
             ? 0
-            : vector.getOffsetBuffer().getInt((long) valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
+            : vector
+                .getOffsetBuffer()
+                .getInt((long) valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
     validateDataBuffer(vector, lastOffset);
     return null;
   }
@@ -172,7 +174,9 @@ public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
     int lastOffset =
         valueCount == 0
             ? 0
-            : vector.getOffsetBuffer().getInt((long) valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
+            : vector
+                .getOffsetBuffer()
+                .getInt((long) valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
     int dataVectorLength = dataVector == null ? 0 : dataVector.getValueCount();
     validateOrThrow(
         dataVectorLength >= lastOffset,

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
@@ -46,7 +46,7 @@ public class ValidateVectorDataVisitor implements VectorVisitor<Void, Void> {
     // verify that the values in the offset buffer is non-decreasing
     int prevValue = offsetBuffer.getInt(0);
     for (int i = 1; i <= valueCount; i++) {
-      int curValue = offsetBuffer.getInt(i * 4);
+      int curValue = offsetBuffer.getInt(i * 4L);
       validateOrThrow(
           curValue >= 0,
           "The value at position %s of the offset buffer is negative: %s.",
@@ -202,6 +202,7 @@ public class ValidateVectorDataVisitor implements VectorVisitor<Void, Void> {
   }
 
   @Override
+  @SuppressWarnings("VoidUsed")
   public Void visit(ExtensionTypeVector<?> vector, Void value) {
     vector.getUnderlyingVector().accept(this, value);
     return null;

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorVisitor.java
@@ -79,7 +79,7 @@ public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
       int lastOffset =
           vector
               .getOffsetBuffer()
-              .getInt(vector.getValueCount() * BaseVariableWidthVector.OFFSET_WIDTH);
+              .getInt((long) vector.getValueCount() * BaseVariableWidthVector.OFFSET_WIDTH);
 
       if (firstOffset < 0 || lastOffset < 0) {
         throw new IllegalArgumentException("Negative offsets in vector");
@@ -136,7 +136,7 @@ public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
       int lastOffset =
           vector
               .getOffsetBuffer()
-              .getInt(vector.getValueCount() * BaseVariableWidthVector.OFFSET_WIDTH);
+              .getInt((long) vector.getValueCount() * BaseVariableWidthVector.OFFSET_WIDTH);
 
       if (firstOffset < 0 || lastOffset < 0) {
         throw new IllegalArgumentException("Negative offsets in list vector");
@@ -169,7 +169,7 @@ public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
     if (vector.getValueCount() > 0) {
 
       ArrowBuf offsetBuf = vector.getOffsetBuffer();
-      long minBufferSize = (vector.getValueCount() + 1) * LargeListVector.OFFSET_WIDTH;
+      long minBufferSize = (long) (vector.getValueCount() + 1) * LargeListVector.OFFSET_WIDTH;
 
       if (offsetBuf.capacity() < minBufferSize) {
         throw new IllegalArgumentException(
@@ -184,7 +184,7 @@ public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
 
       long firstOffset = vector.getOffsetBuffer().getLong(0);
       long lastOffset =
-          vector.getOffsetBuffer().getLong(vector.getValueCount() * LargeListVector.OFFSET_WIDTH);
+          vector.getOffsetBuffer().getLong((long) vector.getValueCount() * LargeListVector.OFFSET_WIDTH);
 
       if (firstOffset < 0 || lastOffset < 0) {
         throw new IllegalArgumentException("Negative offsets in list vector");
@@ -314,6 +314,7 @@ public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
   }
 
   @Override
+  @SuppressWarnings("VoidUsed")
   public Void visit(ExtensionTypeVector<?> vector, Void value) {
     vector.getUnderlyingVector().accept(this, value);
     return null;

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorVisitor.java
@@ -184,7 +184,9 @@ public class ValidateVectorVisitor implements VectorVisitor<Void, Void> {
 
       long firstOffset = vector.getOffsetBuffer().getLong(0);
       long lastOffset =
-          vector.getOffsetBuffer().getLong((long) vector.getValueCount() * LargeListVector.OFFSET_WIDTH);
+          vector
+              .getOffsetBuffer()
+              .getLong((long) vector.getValueCount() * LargeListVector.OFFSET_WIDTH);
 
       if (firstOffset < 0 || lastOffset < 0) {
         throw new IllegalArgumentException("Negative offsets in list vector");

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -180,7 +180,7 @@ public class TestCopyFrom {
       /* set lesser initial capacity than actually needed
        * to trigger reallocs in copyFromSafe()
        */
-      vector2.allocateNew((initialCapacity / 4) * 10, initialCapacity / 4);
+      vector2.allocateNew((initialCapacity / 4) * 10L, initialCapacity / 4);
 
       capacity = vector2.getValueCapacity();
       assertTrue(capacity >= initialCapacity / 4);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDecimal256Vector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDecimal256Vector.java
@@ -380,8 +380,8 @@ public class TestDecimal256Vector {
     decimalVector.allocateNew();
     for (int i = 0; i < expectedValues.length; i++) {
       byte[] bigEndianBytes = expectedValues[i].unscaledValue().toByteArray();
-      buf.setBytes(length * i, bigEndianBytes, 0, bigEndianBytes.length);
-      decimalVector.setBigEndianSafe(i, length * i, buf, bigEndianBytes.length);
+      buf.setBytes((long) length * i, bigEndianBytes, 0, bigEndianBytes.length);
+      decimalVector.setBigEndianSafe(i, (long) length * i, buf, bigEndianBytes.length);
     }
 
     decimalVector.setValueCount(3);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -376,8 +376,8 @@ public class TestDecimalVector {
     decimalVector.allocateNew();
     for (int i = 0; i < expectedValues.length; i++) {
       byte[] bigEndianBytes = expectedValues[i].unscaledValue().toByteArray();
-      buf.setBytes(length * i, bigEndianBytes, 0, bigEndianBytes.length);
-      decimalVector.setBigEndianSafe(i, length * i, buf, bigEndianBytes.length);
+      buf.setBytes((long) length * i, bigEndianBytes, 0, bigEndianBytes.length);
+      decimalVector.setBigEndianSafe(i, (long) length * i, buf, bigEndianBytes.length);
     }
 
     decimalVector.setValueCount(3);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestLargeListVector.java
@@ -773,7 +773,7 @@ public class TestLargeListVector {
     try (final LargeListVector vector = LargeListVector.empty("", allocator)) {
       vector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
 
-      /**
+      /*
        * use the default multiplier of 5, 512 * 5 => 2560 * 4 => 10240 bytes => 16KB => 4096 value
        * capacity.
        */
@@ -788,7 +788,7 @@ public class TestLargeListVector {
       assertEquals(512, vector.getValueCapacity());
       assertTrue(vector.getDataVector().getValueCapacity() >= 512 * 4);
 
-      /**
+      /*
        * inner value capacity we pass to data vector is 512 * 0.1 => 51 For an int vector this is
        * 204 bytes of memory for data buffer and 7 bytes for validity buffer. and with power of 2
        * allocation, we allocate 256 bytes and 8 bytes for the data buffer and validity buffer of
@@ -799,7 +799,7 @@ public class TestLargeListVector {
       assertEquals(512, vector.getValueCapacity());
       assertTrue(vector.getDataVector().getValueCapacity() >= 51);
 
-      /**
+      /*
        * inner value capacity we pass to data vector is 512 * 0.01 => 5 For an int vector this is 20
        * bytes of memory for data buffer and 1 byte for validity buffer. and with power of 2
        * allocation, we allocate 32 bytes and 1 bytes for the data buffer and validity buffer of the
@@ -810,7 +810,7 @@ public class TestLargeListVector {
       assertEquals(512, vector.getValueCapacity());
       assertTrue(vector.getDataVector().getValueCapacity() >= 5);
 
-      /**
+      /*
        * inner value capacity we pass to data vector is 5 * 0.1 => 0 which is then rounded off to 1.
        * So we pass value count as 1 to the inner int vector. the offset buffer of the list vector
        * is allocated for 6 values which is 24 bytes and then rounded off to 32 bytes (8 values) the

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestLargeListViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestLargeListViewVector.java
@@ -1653,7 +1653,7 @@ public class TestLargeListViewVector {
 
     for (int i = 0; i < splitLength; i++) {
       fromDataLength = fromSizeBuffer.getInt((long) (start + i) * LargeListViewVector.SIZE_WIDTH);
-      toDataLength = toSizeBuffer.getInt((long) (i) * LargeListViewVector.SIZE_WIDTH);
+      toDataLength = toSizeBuffer.getInt((long) i * LargeListViewVector.SIZE_WIDTH);
 
       /* validate size */
       assertEquals(
@@ -1683,7 +1683,7 @@ public class TestLargeListViewVector {
 
     for (int i = 0; i < splitLength; i++) {
       offset1 = fromOffsetBuffer.getInt((long) (start + i) * LargeListViewVector.OFFSET_WIDTH);
-      offset2 = toOffsetBuffer.getInt((long) (i) * LargeListViewVector.OFFSET_WIDTH);
+      offset2 = toOffsetBuffer.getInt((long) i * LargeListViewVector.OFFSET_WIDTH);
       assertEquals(
           offset1 - minOffset,
           offset2,

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListViewVector.java
@@ -384,12 +384,6 @@ public class TestListViewVector {
     }
   }
 
-  private void setValuesInBuffer(int[] bufValues, ArrowBuf buffer, long bufWidth) {
-    for (int i = 0; i < bufValues.length; i++) {
-      buffer.setInt(i * bufWidth, bufValues[i]);
-    }
-  }
-
   /*
    * Setting up the buffers directly needs to be validated with the base method used in
    * the ListVector class where we use the approach of startListView(),
@@ -1667,7 +1661,7 @@ public class TestListViewVector {
 
     for (int i = 0; i < splitLength; i++) {
       fromDataLength = fromSizeBuffer.getInt((long) (start + i) * ListViewVector.SIZE_WIDTH);
-      toDataLength = toSizeBuffer.getInt((long) (i) * ListViewVector.SIZE_WIDTH);
+      toDataLength = toSizeBuffer.getInt((long) i * ListViewVector.SIZE_WIDTH);
 
       /* validate size */
       assertEquals(
@@ -1696,7 +1690,7 @@ public class TestListViewVector {
 
     for (int i = 0; i < splitLength; i++) {
       offset1 = fromOffsetBuffer.getInt((long) (start + i) * ListViewVector.OFFSET_WIDTH);
-      offset2 = toOffsetBuffer.getInt((long) (i) * ListViewVector.OFFSET_WIDTH);
+      offset2 = toOffsetBuffer.getInt((long) i * ListViewVector.OFFSET_WIDTH);
       assertEquals(
           offset1 - minOffset,
           offset2,

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
@@ -54,19 +54,19 @@ public class TestPeriodDuration {
         new PeriodDuration(Period.ZERO, Duration.ofNanos(123)).toISO8601IntervalString());
     assertEquals(
         "PT1.000000123S",
-        new PeriodDuration(Period.ZERO, Duration.ofSeconds(1).withNanos(123))
+        new PeriodDuration(Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(1).getSeconds(), 123))
             .toISO8601IntervalString());
     assertEquals(
         "PT1H1.000000123S",
-        new PeriodDuration(Period.ZERO, Duration.ofSeconds(3601).withNanos(123))
+        new PeriodDuration(Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(3601).getSeconds(), 123))
             .toISO8601IntervalString());
     assertEquals(
         "PT24H1M1.000000123S",
-        new PeriodDuration(Period.ZERO, Duration.ofSeconds(86461).withNanos(123))
+        new PeriodDuration(Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123))
             .toISO8601IntervalString());
     assertEquals(
         "P1Y2M3DT24H1M1.000000123S",
-        new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(86461).withNanos(123))
+        new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123))
             .toISO8601IntervalString());
 
     assertEquals(
@@ -77,11 +77,11 @@ public class TestPeriodDuration {
         new PeriodDuration(Period.ZERO, Duration.ofNanos(-123)).toISO8601IntervalString());
     assertEquals(
         "PT-24H-1M-0.999999877S",
-        new PeriodDuration(Period.ZERO, Duration.ofSeconds(-86461).withNanos(123))
+        new PeriodDuration(Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(-86461).getSeconds(), 123))
             .toISO8601IntervalString());
     assertEquals(
         "P-1Y-2M-3DT-0.999999877S",
-        new PeriodDuration(Period.of(-1, -2, -3), Duration.ofSeconds(-1).withNanos(123))
+        new PeriodDuration(Period.of(-1, -2, -3), Duration.ofSeconds(Duration.ofSeconds(-1).getSeconds(), 123))
             .toISO8601IntervalString());
   }
 
@@ -95,8 +95,7 @@ public class TestPeriodDuration {
     PeriodDuration pd2 = new PeriodDuration(Period.ZERO, Duration.ofMinutes(1));
     assertEquals(LocalDateTime.of(2024, 1, 2, 3, 3), pd2.subtractFrom(dateTime));
 
-    PeriodDuration pd3 =
-        new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(86461).withNanos(123));
+    PeriodDuration pd3 = new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123));
     assertEquals(pd3.get(ChronoUnit.YEARS), 1);
     assertEquals(pd3.get(ChronoUnit.MONTHS), 2);
     assertEquals(pd3.get(ChronoUnit.DAYS), 3);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestPeriodDuration.java
@@ -58,15 +58,18 @@ public class TestPeriodDuration {
             .toISO8601IntervalString());
     assertEquals(
         "PT1H1.000000123S",
-        new PeriodDuration(Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(3601).getSeconds(), 123))
+        new PeriodDuration(
+                Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(3601).getSeconds(), 123))
             .toISO8601IntervalString());
     assertEquals(
         "PT24H1M1.000000123S",
-        new PeriodDuration(Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123))
+        new PeriodDuration(
+                Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123))
             .toISO8601IntervalString());
     assertEquals(
         "P1Y2M3DT24H1M1.000000123S",
-        new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123))
+        new PeriodDuration(
+                Period.of(1, 2, 3), Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123))
             .toISO8601IntervalString());
 
     assertEquals(
@@ -77,11 +80,13 @@ public class TestPeriodDuration {
         new PeriodDuration(Period.ZERO, Duration.ofNanos(-123)).toISO8601IntervalString());
     assertEquals(
         "PT-24H-1M-0.999999877S",
-        new PeriodDuration(Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(-86461).getSeconds(), 123))
+        new PeriodDuration(
+                Period.ZERO, Duration.ofSeconds(Duration.ofSeconds(-86461).getSeconds(), 123))
             .toISO8601IntervalString());
     assertEquals(
         "P-1Y-2M-3DT-0.999999877S",
-        new PeriodDuration(Period.of(-1, -2, -3), Duration.ofSeconds(Duration.ofSeconds(-1).getSeconds(), 123))
+        new PeriodDuration(
+                Period.of(-1, -2, -3), Duration.ofSeconds(Duration.ofSeconds(-1).getSeconds(), 123))
             .toISO8601IntervalString());
   }
 
@@ -95,7 +100,9 @@ public class TestPeriodDuration {
     PeriodDuration pd2 = new PeriodDuration(Period.ZERO, Duration.ofMinutes(1));
     assertEquals(LocalDateTime.of(2024, 1, 2, 3, 3), pd2.subtractFrom(dateTime));
 
-    PeriodDuration pd3 = new PeriodDuration(Period.of(1, 2, 3), Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123));
+    PeriodDuration pd3 =
+        new PeriodDuration(
+            Period.of(1, 2, 3), Duration.ofSeconds(Duration.ofSeconds(86461).getSeconds(), 123));
     assertEquals(pd3.get(ChronoUnit.YEARS), 1);
     assertEquals(pd3.get(ChronoUnit.MONTHS), 2);
     assertEquals(pd3.get(ChronoUnit.DAYS), 3);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -18,6 +18,7 @@ package org.apache.arrow.vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -175,12 +176,12 @@ public class TestTypeLayout {
     try (ViewVarCharVector viewVarCharVector = new ViewVarCharVector("myvector", allocator)) {
       viewVarCharVector.allocateNew(32, 6);
 
-      viewVarCharVector.setSafe(0, generateRandomString(8).getBytes());
-      viewVarCharVector.setSafe(1, generateRandomString(12).getBytes());
-      viewVarCharVector.setSafe(2, generateRandomString(14).getBytes());
-      viewVarCharVector.setSafe(3, generateRandomString(18).getBytes());
-      viewVarCharVector.setSafe(4, generateRandomString(22).getBytes());
-      viewVarCharVector.setSafe(5, generateRandomString(24).getBytes());
+      viewVarCharVector.setSafe(0, generateRandomString(8).getBytes(StandardCharsets.UTF_8));
+      viewVarCharVector.setSafe(1, generateRandomString(12).getBytes(StandardCharsets.UTF_8));
+      viewVarCharVector.setSafe(2, generateRandomString(14).getBytes(StandardCharsets.UTF_8));
+      viewVarCharVector.setSafe(3, generateRandomString(18).getBytes(StandardCharsets.UTF_8));
+      viewVarCharVector.setSafe(4, generateRandomString(22).getBytes(StandardCharsets.UTF_8));
+      viewVarCharVector.setSafe(5, generateRandomString(24).getBytes(StandardCharsets.UTF_8));
 
       viewVarCharVector.setValueCount(6);
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -381,6 +381,7 @@ public class TestUnionVector {
   }
 
   @Test
+  @SuppressWarnings("EnumOrdinal")
   public void testGetFieldTypeInfo() throws Exception {
     Map<String, String> metadata = new HashMap<>();
     metadata.put("key1", "value1");

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -1908,7 +1908,7 @@ public class TestValueVector {
       }
       fromVector.setValueCount(numValues);
       ArrowBuf fromDataBuffer = fromVector.getDataBuffer();
-      assertTrue(numValues * valueBytesLength <= fromDataBuffer.capacity());
+      assertTrue((long) numValues * valueBytesLength <= fromDataBuffer.capacity());
 
       /*
        * Copy the entries one-by-one from 'fromVector' to 'toVector', but use the setSafe with
@@ -2398,11 +2398,11 @@ public class TestValueVector {
    */
   public static void setBytes(int index, byte[] bytes, VarCharVector vector) {
     final int currentOffset =
-        vector.offsetBuffer.getInt(index * BaseVariableWidthVector.OFFSET_WIDTH);
+        vector.offsetBuffer.getInt((long) index * BaseVariableWidthVector.OFFSET_WIDTH);
 
     BitVectorHelper.setBit(vector.validityBuffer, index);
     vector.offsetBuffer.setInt(
-        (index + 1) * BaseVariableWidthVector.OFFSET_WIDTH, currentOffset + bytes.length);
+        (long) (index + 1) * BaseVariableWidthVector.OFFSET_WIDTH, currentOffset + bytes.length);
     vector.valueBuffer.setBytes(currentOffset, bytes, 0, bytes.length);
   }
 
@@ -2669,8 +2669,8 @@ public class TestValueVector {
 
     try (VarCharVector vec1 = new VarCharVector("vec1", allocator);
         VarCharVector vec2 = new VarCharVector("vec2", allocator)) {
-      vec1.allocateNew(sampleData.length * 10, sampleData.length);
-      vec2.allocateNew(sampleData.length * 10, sampleData.length);
+      vec1.allocateNew(sampleData.length * 10L, sampleData.length);
+      vec2.allocateNew(sampleData.length * 10L, sampleData.length);
 
       for (int i = 0; i < sampleData.length; i++) {
         String str = sampleData[i];

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVectorIterable.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVectorIterable.java
@@ -172,7 +172,7 @@ public class TestValueVectorIterable {
       durationVector.setSafe(2, 555);
       durationVector.setValueCount(3);
 
-      final Duration value1 = Duration.ofMillis(30000);
+      final Duration value1 = Duration.ofSeconds(30);
       final Duration value3 = Duration.ofMillis(555);
       assertThat(
           durationVector.getValueIterable(),

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharViewVector.java
@@ -544,7 +544,7 @@ public class TestVarCharViewVector {
       }
       fromVector.setValueCount(numValues);
       ArrowBuf fromDataBuffer = fromVector.getDataBuffer();
-      assertTrue(numValues * valueBytesLength <= fromDataBuffer.capacity());
+      assertTrue((long) numValues * valueBytesLength <= fromDataBuffer.capacity());
 
       /*
        * Copy the entries one-by-one from 'fromVector' to 'toVector', but use the setSafe with
@@ -1668,20 +1668,20 @@ public class TestVarCharViewVector {
     return Stream.of(
         Arguments.of(
             (Function<BufferAllocator, BaseVariableWidthViewVector>)
-                (allocator ->
+                allocator ->
                     newVector(
                         ViewVarBinaryVector.class,
                         EMPTY_SCHEMA_PATH,
                         Types.MinorType.VIEWVARBINARY,
-                        allocator))),
+                        allocator)),
         Arguments.of(
             (Function<BufferAllocator, BaseVariableWidthViewVector>)
-                (allocator ->
+                allocator ->
                     newVector(
                         ViewVarCharVector.class,
                         EMPTY_SCHEMA_PATH,
                         Types.MinorType.VIEWVARCHAR,
-                        allocator))));
+                        allocator)));
   }
 
   @ParameterizedTest

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -216,7 +216,7 @@ public class TestVectorUnloadLoad {
     ArrowBuf[] values = new ArrowBuf[4];
     for (int i = 0; i < 4; i += 2) {
       ArrowBuf buf1 = allocator.buffer(BitVectorHelper.getValidityBufferSize(count));
-      ArrowBuf buf2 = allocator.buffer(count * 4); // integers
+      ArrowBuf buf2 = allocator.buffer(count * 4L); // integers
       buf1.setZero(0, buf1.capacity());
       buf2.setZero(0, buf2.capacity());
       values[i] = buf1;
@@ -228,10 +228,10 @@ public class TestVectorUnloadLoad {
           BitVectorHelper.setBit(buf1, j);
         }
 
-        buf2.setInt(j * 4, j);
+        buf2.setInt(j * 4L, j);
       }
-      buf1.writerIndex((int) Math.ceil(count / 8));
-      buf2.writerIndex(count * 4);
+      buf1.writerIndex((int) Math.ceil(count / 8.0));
+      buf2.writerIndex(count * 4L);
     }
 
     /*

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -136,8 +136,8 @@ public class TestComplexCopier {
         mapWriter.value().integer().writeInt(i);
         mapWriter.endEntry();
         mapWriter.startEntry();
-        mapWriter.key().decimal().writeDecimal(BigDecimal.valueOf(i * 2));
-        mapWriter.value().decimal().writeDecimal(BigDecimal.valueOf(i * 2));
+        mapWriter.key().decimal().writeDecimal(BigDecimal.valueOf(i * 2L));
+        mapWriter.value().decimal().writeDecimal(BigDecimal.valueOf(i * 2L));
         mapWriter.endEntry();
         mapWriter.endMap();
       }
@@ -176,13 +176,13 @@ public class TestComplexCopier {
 
         listWriter.list().startList();
         listWriter.list().bigInt().writeBigInt(i);
-        listWriter.list().bigInt().writeBigInt(i * 2);
-        listWriter.list().bigInt().writeBigInt(i * 3);
+        listWriter.list().bigInt().writeBigInt(i * 2L);
+        listWriter.list().bigInt().writeBigInt(i * 3L);
         listWriter.list().endList();
 
         listWriter.list().startList();
-        listWriter.list().decimal().writeDecimal(BigDecimal.valueOf(i * 4));
-        listWriter.list().decimal().writeDecimal(BigDecimal.valueOf(i * 5));
+        listWriter.list().decimal().writeDecimal(BigDecimal.valueOf(i * 4L));
+        listWriter.list().decimal().writeDecimal(BigDecimal.valueOf(i * 5L));
         listWriter.list().endList();
         listWriter.endList();
       }
@@ -597,7 +597,7 @@ public class TestComplexCopier {
         writer
             .decimal()
             .writeBigEndianBytesToDecimal(
-                BigDecimal.valueOf(i * 4).unscaledValue().toByteArray(), arrowType);
+                BigDecimal.valueOf(i * 4L).unscaledValue().toByteArray(), arrowType);
 
         writer.endList();
       }
@@ -631,12 +631,12 @@ public class TestComplexCopier {
         listWriter.setPosition(i);
         listWriter.startList();
 
-        listWriter.decimal().writeDecimal(BigDecimal.valueOf(i * 2));
+        listWriter.decimal().writeDecimal(BigDecimal.valueOf(i * 2L));
         listWriter.integer().writeInt(i);
         listWriter
             .decimal()
             .writeBigEndianBytesToDecimal(
-                BigDecimal.valueOf(i * 3).unscaledValue().toByteArray(),
+                BigDecimal.valueOf(i * 3L).unscaledValue().toByteArray(),
                 new ArrowType.Decimal(3, 0, 128));
 
         listWriter.endList();
@@ -671,15 +671,15 @@ public class TestComplexCopier {
         structWriter.setPosition(i);
         structWriter.start();
         structWriter.integer("int").writeInt(i);
-        structWriter.decimal("dec", 0, 38).writeDecimal(BigDecimal.valueOf(i * 2));
+        structWriter.decimal("dec", 0, 38).writeDecimal(BigDecimal.valueOf(i * 2L));
         StructWriter innerStructWriter = structWriter.struct("struc");
         innerStructWriter.start();
         innerStructWriter.integer("innerint").writeInt(i * 3);
-        innerStructWriter.decimal("innerdec", 0, 38).writeDecimal(BigDecimal.valueOf(i * 4));
+        innerStructWriter.decimal("innerdec", 0, 38).writeDecimal(BigDecimal.valueOf(i * 4L));
         innerStructWriter
             .decimal("innerdec", 0, 38)
             .writeBigEndianBytesToDecimal(
-                BigDecimal.valueOf(i * 4).unscaledValue().toByteArray(),
+                BigDecimal.valueOf(i * 4L).unscaledValue().toByteArray(),
                 new ArrowType.Decimal(3, 0, 128));
         innerStructWriter.end();
         structWriter.end();

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -510,7 +510,7 @@ public class BaseFileTest {
 
     for (int i = 0; i < count; i++) {
       decimalVector1.setSafe(i, new BigDecimal(BigInteger.valueOf(i), 3));
-      decimalVector2.setSafe(i, new BigDecimal(BigInteger.valueOf(i * (1 << 10)), 2));
+      decimalVector2.setSafe(i, new BigDecimal(BigInteger.valueOf(i * ((long) (1 << 10))), 2));
       decimalVector3.setSafe(i, new BigDecimal(BigInteger.valueOf(i * 1111111111111111L), 8));
     }
 
@@ -543,7 +543,7 @@ public class BaseFileTest {
       // Verify decimal 2 vector
       readValue = decimalVector2.getObject(i);
       type = (ArrowType.Decimal) decimalVector2.getField().getType();
-      genValue = new BigDecimal(BigInteger.valueOf(i * (1 << 10)), type.getScale());
+      genValue = new BigDecimal(BigInteger.valueOf(i * ((long) (1 << 10))), type.getScale());
       assertEquals(genValue, readValue);
 
       // Verify decimal 3 vector

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -783,7 +783,7 @@ public class TestArrowReaderWriter {
             Collections.singletonList(dictVector1),
             dictVector1.getValueCount());
     ArrowDictionaryBatch dictionaryBatch1 =
-        new ArrowDictionaryBatch(1, new VectorUnloader(dictRoot1).getRecordBatch());
+        new ArrowDictionaryBatch(1, new VectorUnloader(dictRoot1).getRecordBatch(), false);
     MessageSerializer.serialize(out, dictionaryBatch1);
     dictionaryBatch1.close();
     dictRoot1.close();
@@ -799,7 +799,7 @@ public class TestArrowReaderWriter {
             Collections.singletonList(dictVector2),
             dictVector2.getValueCount());
     ArrowDictionaryBatch dictionaryBatch2 =
-        new ArrowDictionaryBatch(2, new VectorUnloader(dictRoot2).getRecordBatch());
+        new ArrowDictionaryBatch(2, new VectorUnloader(dictRoot2).getRecordBatch(), false);
     MessageSerializer.serialize(out, dictionaryBatch2);
     dictionaryBatch2.close();
     dictRoot2.close();

--- a/java/vector/src/test/java/org/apache/arrow/vector/pojo/TestConvert.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/pojo/TestConvert.java
@@ -101,7 +101,10 @@ public class TestConvert {
     org.apache.arrow.vector.types.pojo.Schema schema =
         new org.apache.arrow.vector.types.pojo.Schema(tempSchema.getFields());
     schemaBuilder.finish(schema.getSchema(schemaBuilder));
-    Schema finalSchema = Schema.deserialize(ByteBuffer.wrap(schemaBuilder.sizedByteArray()));
+    Schema finalSchema =
+        Schema.convertSchema(
+            org.apache.arrow.flatbuf.Schema.getRootAsSchema(
+                ByteBuffer.wrap(schemaBuilder.sizedByteArray())));
     assertFalse(finalSchema.toString().contains("[DEFAULT]"));
   }
 
@@ -131,6 +134,7 @@ public class TestConvert {
   }
 
   @Test
+  @SuppressWarnings("EnumOrdinal")
   public void nestedSchema() {
     java.util.List<Field> children = new ArrayList<>();
     children.add(new Field("child1", FieldType.nullable(Utf8.INSTANCE), null));

--- a/java/vector/src/test/java/org/apache/arrow/vector/table/RowTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/table/RowTest.java
@@ -790,6 +790,7 @@ class RowTest {
   }
 
   @Test
+  @SuppressWarnings("FloatingPointLiteralPrecision")
   void testExtensionTypeVector() {
     TestExtensionType.LocationVector vector =
         new TestExtensionType.LocationVector("location", allocator);

--- a/java/vector/src/test/java/org/apache/arrow/vector/testing/TestValueVectorPopulator.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/testing/TestValueVectorPopulator.java
@@ -141,7 +141,7 @@ public class TestValueVectorPopulator {
         if (i % 2 == 0) {
           vector1.setNull(i);
         } else {
-          vector1.set(i, i * 1000);
+          vector1.set(i, i * 1000L);
         }
       }
       vector1.setValueCount(10);
@@ -334,7 +334,7 @@ public class TestValueVectorPopulator {
         if (i % 2 == 0) {
           vector1.setNull(i);
         } else {
-          vector1.set(i, i * 10000);
+          vector1.set(i, i * 10000L);
         }
       }
       vector1.setValueCount(10);
@@ -372,7 +372,7 @@ public class TestValueVectorPopulator {
         if (i % 2 == 0) {
           vector1.setNull(i);
         } else {
-          vector1.set(i, i * 10000);
+          vector1.set(i, i * 10000L);
         }
       }
       vector1.setValueCount(10);
@@ -410,7 +410,7 @@ public class TestValueVectorPopulator {
         if (i % 2 == 0) {
           vector1.setNull(i);
         } else {
-          vector1.set(i, i * 10000);
+          vector1.set(i, i * 10000L);
         }
       }
       vector1.setValueCount(10);
@@ -429,7 +429,7 @@ public class TestValueVectorPopulator {
         if (i % 2 == 0) {
           vector1.setNull(i);
         } else {
-          vector1.set(i, i * 10000);
+          vector1.set(i, i * 10000L);
         }
       }
       vector1.setValueCount(10);
@@ -448,7 +448,7 @@ public class TestValueVectorPopulator {
         if (i % 2 == 0) {
           vector1.setNull(i);
         } else {
-          vector1.set(i, i * 10000);
+          vector1.set(i, i * 10000L);
         }
       }
       vector1.setValueCount(10);
@@ -467,7 +467,7 @@ public class TestValueVectorPopulator {
         if (i % 2 == 0) {
           vector1.setNull(i);
         } else {
-          vector1.set(i, i * 100);
+          vector1.set(i, i * 100L);
         }
       }
       vector1.setValueCount(10);

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -194,6 +194,7 @@ public class TestExtensionType {
 
   /** Test that a custom Location type can be round-tripped through a temporary file. */
   @Test
+  @SuppressWarnings("FloatingPointLiteralPrecision")
   public void roundtripLocation() throws IOException {
     ExtensionTypeRegistry.register(new LocationType());
     final Schema schema =

--- a/java/vector/src/test/java/org/apache/arrow/vector/util/TestValidator.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/util/TestValidator.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 public class TestValidator {
 
   @Test
+  @SuppressWarnings("FloatingPointLiteralPrecision")
   public void testFloatComp() {
     assertTrue(equalEnough(912.4140000000002F, 912.414F));
     assertTrue(equalEnough(912.4140000000002D, 912.414D));


### PR DESCRIPTION
### Rationale for this change

A series of PRs have been created to mark warnings as errors in a module-based approach. As this step has been completed, moving the config back to the parent pom would be the best to keep things clean and easy to maintain. 

### What changes are included in this PR?

Removing the pom changes in each module and updating the parent pom with the required configurations. 

### Are these changes tested?

Tested from existing test cases. 

### Are there any user-facing changes?

N/A
* GitHub Issue: apache/arrow-java#53
* GitHub Issue: #53