### PR TITLE
GH-36412: [Python][CI] Fix deprecation warning about day freq alias with latest pandas

### DIFF
--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2417,7 +2417,7 @@ def _check_temporal_rounding(ts, values, unit):
         "millisecond": "s",
         "second": "min",
         "minute": "h",
-        "hour": "d",
+        "hour": "D",
     }
     ta = pa.array(ts)
 


### PR DESCRIPTION
### Rationale for this change

Updating our pandas usage to follow pandas' changes (they are deprecating the `"d"` alias as alternative for `"D"`)

* GitHub Issue: #36412