### PR TITLE
GH-44076: [CI] Remove verify-rc-binaries-wheel-macos-11 which is now deprecated

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -996,7 +996,7 @@ tasks:
       github_runner: "macos-14"
   {% endfor %}
 
-  {% for macos_version in ["11", "12"] %}
+  {% for macos_version in ["12"] %}
   verify-rc-binaries-wheels-macos-{{ macos_version }}-amd64:
     ci: github
     template: verify-rc/github.macos.yml


### PR DESCRIPTION
### Rationale for this change

Our wheels deployment target is now MACOSX_DEPLOYMENT_TARGET=12.0 and the macOS 11 runner is deprecated.

### What changes are included in this PR?

Remove macos-11 from CI matrix.

### Are these changes tested?

No, those jobs are triggered on release and is just removing a job from the matrix.

### Are there any user-facing changes?

No
* GitHub Issue: #44076