### PR TITLE
GH-44085: [CI][R] Update Ubuntu version for R force test

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         r: ["4.4"]
-        ubuntu: [20.04]
+        ubuntu: [24.04]
         force-tests: ["true"]
     env:
       R: ${{ matrix.r }}

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -26,6 +26,10 @@ pushd ${source_dir}
 
 printenv
 
+if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  . "${ARROW_PYTHON_VENV}/bin/activate"
+fi
+
 # Run the nixlibs.R test suite, which is not included in the installed package
 ${R_BIN} -e 'setwd("tools"); testthat::test_dir(".", stop_on_warning = TRUE)'
 


### PR DESCRIPTION
### Rationale for this change

We want to update the Ubuntu version to run the R force tests in order to be able to test pyarrow once it drops Python 3.8.

### What changes are included in this PR?

Bumping Ubuntu to 24.04 and use virtualenv in order to avoid installing requirements at the system python which fails on newer Ubuntu.

### Are these changes tested?

Yes, on CI

### Are there any user-facing changes?

No
* GitHub Issue: #44085