### PR TITLE
MINOR: [Docs] Remove mention of JIRA issues in the contributing PR checklist

### DIFF
--- a/docs/source/developers/overview.rst
+++ b/docs/source/developers/overview.rst
@@ -100,9 +100,6 @@ When contributing a patch, use this list as a checklist of Apache Arrow workflow
 * So that your pull request syncs with the GitHub issue, **prefix your pull request
   title with the GitHub issue id** (ex:
   `GH-14866: [C++] Remove internal GroupBy implementation <https://github.com/apache/arrow/pull/14867>`_).
-  Similarly **prefix your pull request name with the JIRA issue id** (ex:
-  `ARROW-767: [C++] Filesystem abstraction <https://github.com/apache/arrow/pull/4225>`_)
-  in case the issue is still located in Jira.
 * Give the pull request a **clear, brief description**: when the pull request is
   merged, this will be retained in the extended commit message.
 * Make sure that your code **passes the unit tests**. You can find instructions how


### PR DESCRIPTION
### Rationale for this change

We no longer have any remaining JIRA issues, so this sentence can be removed.
