### PR TITLE
GH-43872: [Go][CI] Disable Dependabot for Go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,13 +24,6 @@ updates:
     commit-message:
       prefix: "MINOR: [CI] "
     open-pull-requests-limit: 10
-  - package-ecosystem: "gomod"
-    directory: "/go/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "MINOR: [Go] "
-    open-pull-requests-limit: 10
   - package-ecosystem: "maven"
     directory: "/java/"
     schedule:


### PR DESCRIPTION
### Rationale for this change

As part of moving the go implementation to `arrow-go` we should disable new commits to the main arrow repository.

### What changes are included in this PR?

Remove go config for dependabot.

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #43872