### PR TITLE
MINOR: [CI] Use new boost feedstock

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -22,7 +22,7 @@ azure-storage-blobs-cpp>=12.10.0
 azure-storage-common-cpp>=12.5.0
 azure-storage-files-datalake-cpp>=12.9.0
 benchmark>=1.6.0,!=1.8.4
-boost-cpp>=1.68.0
+libboost-devel=1.68.0
 brotli
 bzip2
 c-ares

--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -22,7 +22,7 @@ azure-storage-blobs-cpp>=12.10.0
 azure-storage-common-cpp>=12.5.0
 azure-storage-files-datalake-cpp>=12.9.0
 benchmark>=1.6.0,!=1.8.4
-libboost-devel=1.68.0
+libboost-devel>=1.68.0
 brotli
 bzip2
 c-ares

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -99,7 +99,7 @@ outputs:
         - llvmdev {{ llvm_version }}
         - aws-crt-cpp
         - aws-sdk-cpp
-        - boost-cpp >=1.70
+        - libboost-devel >=1.70
         - brotli
         - bzip2
         # not yet: https://github.com/conda-forge/cpp-opentelemetry-sdk-feedstock/issues/38

--- a/python/asv.conf.json
+++ b/python/asv.conf.json
@@ -85,7 +85,7 @@
     "matrix": {
         // Use older boost since it works on more editions of the project
         "aws-sdk-cpp": [],
-        "boost-cpp": ["1.68.0"],
+        "libboost-devel": ["1.68.0"],
         "brotli": [],
         "cmake": [],
         "cython": [],

--- a/python/asv.conf.json
+++ b/python/asv.conf.json
@@ -85,7 +85,7 @@
     "matrix": {
         // Use older boost since it works on more editions of the project
         "aws-sdk-cpp": [],
-        "libboost-devel": ["1.68.0"],
+        "libboost-devel": ["1.82.0"],
         "brotli": [],
         "cmake": [],
         "cython": [],


### PR DESCRIPTION
### Rationale for this change
The boost-cpp feedstock was archived.

### What changes are included in this PR?

Switch to the new package name `libboost-devel`.

### Are these changes tested?
CI

### Are there any user-facing changes?
No