### PR TITLE
GH-44114: [R] Add Rocky and opensuse to the allowlist for libarrow binaries

### DIFF
--- a/r/tools/nixlibs-allowlist.txt
+++ b/r/tools/nixlibs-allowlist.txt
@@ -2,3 +2,5 @@ ubuntu
 centos
 redhat
 rhel
+rocky
+opensuse-leap

--- a/r/tools/nixlibs-allowlist.txt
+++ b/r/tools/nixlibs-allowlist.txt
@@ -3,4 +3,4 @@ centos
 redhat
 rhel
 rocky
-opensuse-leap
+opensuse

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -217,12 +217,12 @@ identify_binary <- function(lib = Sys.getenv("LIBARROW_BINARY"), info = distro()
   lib
 }
 
-check_allowlist <- function(os, allowed = "https://raw.githubusercontent.com/apache/arrow/main/r/tools/nixlibs-allowlist.txt") {
+check_allowlist <- function(os, allowed = "https://raw.githubusercontent.com/apache/arrow/main/r/tools/nixibs-allowlist.txt") {
   allowlist <- tryCatch(
     # Try a remote allowlist so that we can add/remove without a release
     suppressWarnings(readLines(allowed)),
-    # Fallback to default: allowed only on Ubuntu and CentOS/RHEL
-    error = function(e) c("ubuntu", "centos", "redhat", "rhel", "rocky", "opensuse-leap")
+    # Fallback to default allow list shipped with the package
+    error = function(e) readLines("tools/nixlibs-allowlist.txt")
   )
   # allowlist should contain valid regular expressions (plain strings ok too)
   any(grepl(paste(allowlist, collapse = "|"), os))

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -222,7 +222,7 @@ check_allowlist <- function(os, allowed = "https://raw.githubusercontent.com/apa
     # Try a remote allowlist so that we can add/remove without a release
     suppressWarnings(readLines(allowed)),
     # Fallback to default: allowed only on Ubuntu and CentOS/RHEL
-    error = function(e) c("ubuntu", "centos", "redhat", "rhel")
+    error = function(e) c("ubuntu", "centos", "redhat", "rhel", "rocky", "opensuse-leap")
   )
   # allowlist should contain valid regular expressions (plain strings ok too)
   any(grepl(paste(allowlist, collapse = "|"), os))

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -217,7 +217,7 @@ identify_binary <- function(lib = Sys.getenv("LIBARROW_BINARY"), info = distro()
   lib
 }
 
-check_allowlist <- function(os, allowed = "https://raw.githubusercontent.com/apache/arrow/main/r/tools/nixibs-allowlist.txt") {
+check_allowlist <- function(os, allowed = "https://raw.githubusercontent.com/apache/arrow/main/r/tools/nixlibs-allowlist.txt") {
   allowlist <- tryCatch(
     # Try a remote allowlist so that we can add/remove without a release
     suppressWarnings(readLines(allowed)),

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -152,7 +152,7 @@ test_that("check_allowlist", {
   # (which is one level higher, so we can find `tools/nixlibs.R`)
   # TODO: it's possible that we don't want to run this whole file in that directory
   # like we do currently.
-  local_dir("..")
+  withr::local_dir("..")
 
   tf <- tempfile()
   cat("tu$\n^cent\n^dar\n", file = tf)

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -147,6 +147,13 @@ test_that("select_binary() with test program", {
 })
 
 test_that("check_allowlist", {
+  # because we read from a file when we can't get the allow list from github,
+  # we need to make sure we are in the same directory as we would be when building
+  # (which is one level higher, so we can find `tools/nixlibs.R`)
+  # TODO: it's possible that we don't want to run this whole file in that directory
+  # like we do currently.
+  local_dir("..")
+
   tf <- tempfile()
   cat("tu$\n^cent\n^dar\n", file = tf)
   expect_true(check_allowlist("ubuntu", tf))


### PR DESCRIPTION
### Rationale for this change

Add two distros not checked on CRAN to our allow list for easier binary installs

### What changes are included in this PR?

Added to distro names

### Are these changes tested?

These configurations are tested elsewhere, the real test will come later if CRAN somehow runs these covertly

### Are there any user-facing changes?

Faster, more reliably installs without intervention
* GitHub Issue: #44114