### PR TITLE
GH-44111: [CI][Python] Enable S3 tests on macOS CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Install MinIO
         run: |
           $(brew --prefix bash)/bin/bash \
-            ci/scripts/install_minio.sh latest ${ARROW_HOME}
+            ci/scripts/install_minio.sh latest /usr/local
       - name: Setup ccache
         shell: bash
         run: ci/scripts/ccache_setup.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -188,6 +188,10 @@ jobs:
           python -m pip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt
+      - name: Install MinIO
+        run: |
+          $(brew --prefix bash)/bin/bash \
+            ci/scripts/install_minio.sh latest ${ARROW_HOME}
       - name: Setup ccache
         shell: bash
         run: ci/scripts/ccache_setup.sh

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -69,4 +69,4 @@ export PYARROW_TEST_PARQUET_ENCRYPTION
 export PYARROW_TEST_S3
 
 # Testing PyArrow
-pytest -r s -vs --pyargs pyarrow.tests.test_fs
+pytest -r s ${PYTEST_ARGS} --pyargs pyarrow

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -69,4 +69,4 @@ export PYARROW_TEST_PARQUET_ENCRYPTION
 export PYARROW_TEST_S3
 
 # Testing PyArrow
-pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
+pytest -r s -vs --pyargs pyarrow.tests.test_fs

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -122,16 +122,16 @@ jobs:
           python-version: 3.12
           update-environment: false
 
-      - name: Install MinIO
-        run: |
-          $(brew --prefix bash)/bin/bash \
-            arrow/ci/scripts/install_minio.sh latest /usr/local
-
       - name: Install GCS testbench
         env:
           PIPX_BIN_DIR: /usr/local/bin
           PIPX_BASE_PYTHON: {{ '${{ steps.gcs-python-install.outputs.python-path }}' }}
         run: arrow/ci/scripts/install_gcs_testbench.sh default
+
+      - name: Install MinIO
+        run: |
+          $(brew --prefix bash)/bin/bash \
+            arrow/ci/scripts/install_minio.sh latest /usr/local
 
       - name: Test Wheel
         env:

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -122,6 +122,11 @@ jobs:
           python-version: 3.12
           update-environment: false
 
+      - name: Install MinIO
+        run: |
+          $(brew --prefix bash)/bin/bash \
+            arrow/ci/scripts/install_minio.sh latest /usr/local
+
       - name: Install GCS testbench
         env:
           PIPX_BIN_DIR: /usr/local/bin


### PR DESCRIPTION
### Rationale for this change

S3 support is enabled when building PyArrow for macOS (both on PR builds and in Crossbow wheel builds), but minio wan't installed before testing, therefore S3 support in PyArrow was not tested at all.

### What changes are included in this PR?

Ensure Minio is installed before running PyArrow tests on macOS builds.

### Are these changes tested?

Yes, by construction.

### Are there any user-facing changes?

No.

* GitHub Issue: #44111