### PR TITLE
MINOR: [Docs][Python] Fix return type in docstring for Array.slice

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1437,7 +1437,8 @@ cdef class Array(_PandasConvertible):
 
         Returns
         -------
-        sliced : RecordBatch
+        sliced : Array
+            An array with the same datatype, containing the sliced values.
         """
         cdef shared_ptr[CArray] result
 


### PR DESCRIPTION
### Rationale for this change

Currently the docstring for Array.slice says it returns a RecordBatch. I don't see how this is possible with the existing code. My guess is that this was a copy-and-paste error back when the Array and RecordBatch slice impls were added in https://issues.apache.org/jira/browse/ARROW-547.

### What changes are included in this PR?

Just a docstring change. I copied the language from the take method so things are consistent.

### Are these changes tested?

No.

### Are there any user-facing changes?

Just docs.