### PR TITLE
GH-43874: [CI][Integration][Go] Use apache/arrow-go

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -81,6 +81,11 @@ jobs:
         with:
           repository: apache/arrow-nanoarrow
           path: nanoarrow
+      - name: Checkout Arrow Go
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          repository: apache/arrow-go
+          path: go
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -104,6 +109,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run \
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
+            -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
             -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             conda-integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -82,7 +82,7 @@ jobs:
           repository: apache/arrow-nanoarrow
           path: nanoarrow
       - name: Checkout Arrow Go
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: apache/arrow-go
           path: go

--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -26,11 +26,10 @@ gold_dir=$arrow_dir/testing/data/arrow-ipc-stream/integration
 
 : ${ARROW_INTEGRATION_CPP:=ON}
 : ${ARROW_INTEGRATION_CSHARP:=ON}
-: ${ARROW_INTEGRATION_GO:=ON}
 : ${ARROW_INTEGRATION_JAVA:=ON}
 : ${ARROW_INTEGRATION_JS:=ON}
 
-: ${ARCHERY_INTEGRATION_TARGET_LANGUAGES:=cpp,csharp,go,java,js}
+: ${ARCHERY_INTEGRATION_TARGET_LANGUAGES:=cpp,csharp,java,js}
 export ARCHERY_INTEGRATION_TARGET_LANGUAGES
 
 . ${arrow_dir}/ci/scripts/util_log.sh
@@ -67,7 +66,6 @@ time archery integration \
     --run-flight \
     --with-cpp=$([ "$ARROW_INTEGRATION_CPP" == "ON" ] && echo "1" || echo "0") \
     --with-csharp=$([ "$ARROW_INTEGRATION_CSHARP" == "ON" ] && echo "1" || echo "0") \
-    --with-go=$([ "$ARROW_INTEGRATION_GO" == "ON" ] && echo "1" || echo "0") \
     --with-java=$([ "$ARROW_INTEGRATION_JAVA" == "ON" ] && echo "1" || echo "0") \
     --with-js=$([ "$ARROW_INTEGRATION_JS" == "ON" ] && echo "1" || echo "0") \
     --gold-dirs=$gold_dir/0.14.1 \

--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -24,7 +24,6 @@ build_dir=${2}
 
 : ${ARROW_INTEGRATION_CPP:=ON}
 : ${ARROW_INTEGRATION_CSHARP:=ON}
-: ${ARROW_INTEGRATION_GO:=ON}
 : ${ARROW_INTEGRATION_JAVA:=ON}
 : ${ARROW_INTEGRATION_JS:=ON}
 
@@ -38,6 +37,12 @@ github_actions_group_begin "Integration: Build: nanoarrow"
 ${arrow_dir}/ci/scripts/nanoarrow_build.sh ${arrow_dir} ${build_dir}
 github_actions_group_end
 
+github_actions_group_begin "Integration: Build: Go"
+if [ "${ARCHERY_INTEGRATION_WITH_GO}" -gt "0" ]; then
+    ${arrow_dir}/go/ci/scripts/build.sh ${arrow_dir} ${build_dir}
+fi
+github_actions_group_end
+
 github_actions_group_begin "Integration: Build: C++"
 if [ "${ARROW_INTEGRATION_CPP}" == "ON" ]; then
     ${arrow_dir}/ci/scripts/cpp_build.sh ${arrow_dir} ${build_dir}
@@ -47,12 +52,6 @@ github_actions_group_end
 github_actions_group_begin "Integration: Build: C#"
 if [ "${ARROW_INTEGRATION_CSHARP}" == "ON" ]; then
     ${arrow_dir}/ci/scripts/csharp_build.sh ${arrow_dir} ${build_dir}
-fi
-github_actions_group_end
-
-github_actions_group_begin "Integration: Build: Go"
-if [ "${ARROW_INTEGRATION_GO}" == "ON" ]; then
-    ${arrow_dir}/ci/scripts/go_build.sh ${arrow_dir} ${build_dir}
 fi
 github_actions_group_end
 

--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -39,7 +39,7 @@ github_actions_group_end
 
 github_actions_group_begin "Integration: Build: Go"
 if [ "${ARCHERY_INTEGRATION_WITH_GO}" -gt "0" ]; then
-    ${arrow_dir}/go/ci/scripts/build.sh ${arrow_dir} ${build_dir}
+    ${arrow_dir}/go/ci/scripts/build.sh ${arrow_dir}/go
 fi
 github_actions_group_end
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -737,7 +737,8 @@ def _set_default(opt, default):
 @click.option('--with-js', type=bool, default=False,
               help='Include JavaScript in integration tests')
 @click.option('--with-go', type=bool, default=False,
-              help='Include Go in integration tests')
+              help='Include Go in integration tests',
+              envvar="ARCHERY_INTEGRATION_WITH_GO")
 @click.option('--with-nanoarrow', type=bool, default=False,
               help='Include nanoarrow in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_NANOARROW")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1870,6 +1870,7 @@ services:
     volumes: *conda-volumes
     environment:
       <<: [*common, *ccache]
+      ARCHERY_INTEGRATION_WITH_GO: 0
       ARCHERY_INTEGRATION_WITH_NANOARROW: 0
       ARCHERY_INTEGRATION_WITH_RUST: 0
       # Tell Archery where Arrow binaries are located

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1878,7 +1878,8 @@ services:
       ARROW_NANOARROW_PATH: /build/nanoarrow
       ARROW_RUST_EXE_PATH: /build/rust/debug
     command:
-      ["/arrow/ci/scripts/integration_arrow_build.sh /arrow /build &&
+      ["git config --global --add safe.directory /arrow/go &&
+        /arrow/ci/scripts/integration_arrow_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_arrow.sh /arrow /build"]
 
   ################################ Docs #######################################


### PR DESCRIPTION
### Rationale for this change

The Go implementation is moving to apache/arrow-go from go/ in apache/arrow.

### What changes are included in this PR?

Use apache/arrow-go for integration test.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43874