### PR TITLE
GH-43876: [CI][Swift] Use apache/arrow-go remote repository instead of arrow/go subfolder

### DIFF
--- a/ci/scripts/swift_test.sh
+++ b/ci/scripts/swift_test.sh
@@ -22,9 +22,11 @@ set -ex
 data_gen_dir=${1}/swift/data-generator/swift-datagen
 export GOPATH=/
 pushd ${data_gen_dir}
-go get -d ./...
+git clone https://github.com/apache/arrow-go.git /arrow-go
+go get -d ./..../arrow-go/go
 go run .
 cp *.arrow ../../Arrow
+rm -rf /arrow-go
 popd
 
 source_dir=${1}/swift


### PR DESCRIPTION
### Rationale for this change

The Go implementation is moving to apache/arrow-go from go/ in apache/arrow.

### What changes are included in this PR?

Use clone for apache/arrow-go instead of code from arrow/go subfolder

### Are these changes tested?

Yes, CI

### Are there any user-facing changes?

No
* GitHub Issue: #43876