### PR TITLE
GH-43846: [Python][Packaging] Remove numpy dependency from pyarrow packaging

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -71,12 +71,9 @@ See :ref:`python-development`.
 Dependencies
 ------------
 
-Required dependency
-
-* **NumPy 1.16.6** or higher.
-
 Optional dependencies
 
+* **NumPy 1.16.6** or higher.
 * **pandas 1.0** or higher,
 * **cffi**.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,9 +35,6 @@ build-backend = "setuptools.build_meta"
 name = "pyarrow"
 dynamic = ["version"]
 requires-python = ">=3.9"
-dependencies = [
-    "numpy >= 1.16.6"
-]
 description = "Python library for Apache Arrow"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "Apache Software License"}


### PR DESCRIPTION
## WIP

Creating the PR to validate if / what are the CI failures 


### Rationale for this change
Once the issue has been merged:
- https://github.com/apache/arrow/issues/25118

We do not require numpy as a pyarrow dependency.

### What changes are included in this PR?

Remove numpy as a required dependency

### Are these changes tested?

Via CI

### Are there any user-facing changes?

Yes, pyarrow won't install numpy as a required dependency.
* GitHub Issue: #43846