### PR TITLE
GH-40570: [CI] Default environment to Ubuntu 22.04 instead of 20.04

### DIFF
--- a/.env
+++ b/.env
@@ -50,7 +50,7 @@ ALMALINUX=8
 ALPINE_LINUX=3.16
 DEBIAN=12
 FEDORA=39
-UBUNTU=20.04
+UBUNTU=22.04
 
 # Default versions for various dependencies
 CLANG_TOOLS=14

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -93,7 +93,7 @@ jobs:
             python: "3.11"
     env:
       PYTHON: ${{ matrix.python || 3.9 }}
-      UBUNTU: ${{ matrix.ubuntu || 20.04 }}
+      UBUNTU: ${{ matrix.ubuntu || 22.04 }}
       PANDAS: ${{ matrix.pandas || 'latest' }}
       NUMPY: ${{ matrix.numpy || 'latest' }}
     steps:

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -119,6 +119,7 @@ RUN apt-get update -y -q && \
         rapidjson-dev \
         rsync \
         tzdata \
+        uuid-runtime \
         wget \
         xz-utils && \
     apt-get clean && \

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -91,6 +91,7 @@ RUN apt-get update -y -q && \
         libprotobuf-dev \
         libprotoc-dev \
         libpsl-dev \
+        libradospp-dev \
         libre2-dev \
         librtmp-dev \
         libsnappy-dev \
@@ -112,7 +113,9 @@ RUN apt-get update -y -q && \
         protobuf-compiler-grpc \
         python3-dev \
         python3-pip \
+        python3-rados \
         python3-venv \
+        rados-objclass-dev \
         rapidjson-dev \
         rsync \
         tzdata \

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update -y -q && \
         ca-certificates \
         ccache \
         ceph \
+        ceph-mds \
         cmake \
         curl \
         gdb \

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update -y -q && \
         ca-certificates \
         ccache \
         ceph \
+        ceph-fuse \
         ceph-mds \
         cmake \
         curl \

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update -y -q && \
         bzip2 \
         ca-certificates \
         ccache \
+        ceph \
         cmake \
         curl \
         gdb \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update -y -q && \
         autoconf \
         ca-certificates \
         ccache \
+        ceph \
         cmake \
         curl \
         gdb \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -91,6 +91,7 @@ RUN apt-get update -y -q && \
         libprotobuf-dev \
         libprotoc-dev \
         libpsl-dev \
+        libradospp-dev \
         libre2-dev \
         librtmp-dev \
         libsnappy-dev \
@@ -112,7 +113,9 @@ RUN apt-get update -y -q && \
         protobuf-compiler-grpc \
         python3-dev \
         python3-pip \
+        python3-rados \
         python3-venv \
+        rados-objclass-dev \
         rapidjson-dev \
         rsync \
         tzdata \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -120,6 +120,7 @@ RUN apt-get update -y -q && \
         rsync \
         tzdata \
         tzdata-legacy \
+        uuid-runtime \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update -y -q && \
         ca-certificates \
         ccache \
         ceph \
+        ceph-mds \
         cmake \
         curl \
         gdb \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -69,6 +69,7 @@ RUN apt-get update -y -q && \
         ca-certificates \
         ccache \
         ceph \
+        ceph-fuse \
         ceph-mds \
         cmake \
         curl \

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1118,7 +1118,7 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 22.04
+        UBUNTU: 20.04
       flags: >-
         -e ARROW_AZURE=OFF
         -e ARROW_GANDIVA=OFF

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1509,6 +1509,8 @@ tasks:
     ci: github
     template: docker-tests/github.cuda.yml
     params:
+      env:
+        UBUNTU: 20.04
       image: ubuntu-cuda-cpp
 
   test-cuda-cpp-ubuntu-22.04-cuda-11.7.1:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1188,12 +1188,12 @@ tasks:
         UBUNTU: 24.04
       image: ubuntu-cpp-thread-sanitizer
 
-  test-ubuntu-20.04-cpp-minimal-with-formats:
+  test-ubuntu-24.04-cpp-minimal-with-formats:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 20.04
+        UBUNTU: 24.04
       flags: "-e ARROW_CSV=ON -e ARROW_PARQUET=ON"
       image: ubuntu-cpp-minimal
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1118,7 +1118,7 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 24.04
+        UBUNTU: 22.04
       flags: >-
         -e ARROW_AZURE=OFF
         -e ARROW_GANDIVA=OFF

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1118,7 +1118,7 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 20.04
+        UBUNTU: 22.04
       flags: >-
         -e ARROW_AZURE=OFF
         -e ARROW_GANDIVA=OFF

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1118,7 +1118,7 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        UBUNTU: 20.04
+        UBUNTU: 24.04
       flags: >-
         -e ARROW_AZURE=OFF
         -e ARROW_GANDIVA=OFF


### PR DESCRIPTION
### Rationale for this change

Ubuntu 20.04 will be end of standard support on April 2025. Ubuntu 22.04 and 24.04 have been already released.

We should make our default .env to UBUNTU=22.04.

### What changes are included in this PR?

Update .env default to Ubuntu 22.04 and a couple other minor updates to use Ubuntu 22.04

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #40570