### PR TITLE
GH-44155: [Archery][Integration] Rename "language" to "implementation"

### DIFF
--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -29,8 +29,8 @@ gold_dir=$arrow_dir/testing/data/arrow-ipc-stream/integration
 : ${ARROW_INTEGRATION_JAVA:=ON}
 : ${ARROW_INTEGRATION_JS:=ON}
 
-: ${ARCHERY_INTEGRATION_TARGET_LANGUAGES:=cpp,csharp,java,js}
-export ARCHERY_INTEGRATION_TARGET_LANGUAGES
+: ${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp,java,js}
+export ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS
 
 . ${arrow_dir}/ci/scripts/util_log.sh
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -724,7 +724,7 @@ def _set_default(opt, default):
 
 @archery.command(short_help="Execute protocol and Flight integration tests")
 @click.option('--with-all', is_flag=True, default=False,
-              help=('Include all known languages by default '
+              help=('Include all known implementations by default '
                     'in integration tests'))
 @click.option('--random-seed', type=int, default=12345,
               help="Seed for PRNG when generating test data")
@@ -745,9 +745,9 @@ def _set_default(opt, default):
 @click.option('--with-rust', type=bool, default=False,
               help='Include Rust in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_RUST")
-@click.option('--target-languages', default='',
-              help=('Target languages in this integration tests'),
-              envvar="ARCHERY_INTEGRATION_TARGET_LANGUAGES")
+@click.option('--target-implementations', default='',
+              help=('Target implementations in this integration tests'),
+              envvar="ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS")
 @click.option('--write_generated_json', default="",
               help='Generate test JSON to indicated path')
 @click.option('--run-ipc', is_flag=True, default=False,
@@ -783,15 +783,15 @@ def integration(with_all=False, random_seed=12345, **args):
 
     gen_path = args['write_generated_json']
 
-    languages = ['cpp', 'csharp', 'java', 'js', 'go', 'nanoarrow', 'rust']
+    implementations = ['cpp', 'csharp', 'java', 'js', 'go', 'nanoarrow', 'rust']
     formats = ['ipc', 'flight', 'c_data']
 
-    enabled_languages = 0
-    for lang in languages:
+    enabled_implementations = 0
+    for lang in implementations:
         param = f'with_{lang}'
         if with_all:
             args[param] = with_all
-        enabled_languages += args[param]
+        enabled_implementations += args[param]
 
     enabled_formats = 0
     for fmt in formats:
@@ -808,9 +808,9 @@ def integration(with_all=False, random_seed=12345, **args):
             raise click.UsageError(
                 "Need to enable at least one format to test "
                 "(IPC, Flight, C Data Interface); try --help")
-        if enabled_languages == 0:
+        if enabled_implementations == 0:
             raise click.UsageError(
-                "Need to enable at least one language to test; try --help")
+                "Need to enable at least one implementation to test; try --help")
         run_all_tests(**args)
 
 

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -586,7 +586,8 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
                   run_c_data=False, tempdir=None, target_implementations="",
                   **kwargs):
     tempdir = tempdir or tempfile.mkdtemp(prefix='arrow-integration-')
-    target_implementations = list(filter(len, target_implementations.split(",")))
+    target_implementations = \
+        target_implementations.split(",") if target_implementations else []
 
     testers: List[Tester] = []
     other_testers: List[Tester] = []

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -583,16 +583,16 @@ def get_static_json_files():
 def run_all_tests(with_cpp=True, with_java=True, with_js=True,
                   with_csharp=True, with_go=True, with_rust=False,
                   with_nanoarrow=False, run_ipc=False, run_flight=False,
-                  run_c_data=False, tempdir=None, target_languages="",
+                  run_c_data=False, tempdir=None, target_implementations="",
                   **kwargs):
     tempdir = tempdir or tempfile.mkdtemp(prefix='arrow-integration-')
-    target_languages = list(filter(len, target_languages.split(",")))
+    target_implementations = list(filter(len, target_implementations.split(",")))
 
     testers: List[Tester] = []
     other_testers: List[Tester] = []
 
-    def append_tester(language, tester):
-        if len(target_languages) == 0 or language in target_languages:
+    def append_tester(implementation, tester):
+        if len(target_implementations) == 0 or implementation in target_implementations:
             testers.append(tester)
         else:
             other_testers.append(tester)


### PR DESCRIPTION
### Rationale for this change

Because there is not a language, nanoarrow, for integration test targets.

### What changes are included in this PR?

* Rename "language" to "implementation" in documents and variable names
* Rename `--target-languages` to `--target-implementations`
* Rename `ARCHERY_INTEGRATION_TARGET_LANGUAGES` to `ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44155