### PR TITLE
GH-44168: [Python][Acero] Provide method to perform aggregations with acero for datasets

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -948,8 +948,7 @@ cdef class Dataset(_Weakrefable):
         """
         Perform an aggregation over the grouped columns of the dataset.
 
-        Result of the join will be a new dataset, where further
-        operations can be applied.
+        Result of the aggregations will be a table.
 
         Parameters
         ----------

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -944,6 +944,67 @@ cdef class Dataset(_Weakrefable):
                                          right_dataset, right_on, right_by,
                                          tolerance, output_type=InMemoryDataset)
 
+    def aggregate(self, aggregations, keys=None, use_threads=True):
+        """
+        Perform an aggregation over the grouped columns of the dataset.
+
+        Result of the join will be a new dataset, where further
+        operations can be applied.
+
+        Parameters
+        ----------
+        aggregations : list[tuple(str, str)] or \
+list[tuple(str, str, FunctionOptions)]
+            List of tuples, where each tuple is one aggregation specification
+            and consists of: aggregation column name followed
+            by function name and optionally aggregation function option.
+            Pass empty list to get a single row for each group.
+            The column name can be a string, an empty list or a list of
+            column names, for unary, nullary and n-ary aggregation functions
+            respectively.
+
+            For the list of function names and respective aggregation
+            function options see :ref:`py-grouped-aggrs`.
+        keys : list[str], default None
+            List of names of columns by which aggregations will be grouped.
+        use_threads : bool, default True
+            Whenever to use multithreading or not.
+
+        Returns
+        -------
+        Table
+            Results of the aggregation functions.
+        """
+        if keys is None:
+            keys = []
+        group_by_aggrs = []
+        for aggr in aggregations:
+            # Set opt to None if not specified
+            if len(aggr) == 2:
+                target, func = aggr
+                opt = None
+            else:
+                target, func, opt = aggr
+            # Ensure target is a list
+            if not isinstance(target, (list, tuple)):
+                target = [target]
+            # Ensure aggregate function is hash_ if needed
+            if len(keys) > 0 and not func.startswith("hash_"):
+                func = "hash_" + func
+            if len(keys) == 0 and func.startswith("hash_"):
+                func = func[5:]
+            # Determine output field name
+            func_nohash = func if not func.startswith("hash_") else func[5:]
+            if len(target) == 0:
+                aggr_name = func_nohash
+            else:
+                aggr_name = "_".join(target) + "_" + func_nohash
+            group_by_aggrs.append((target, func, opt, aggr_name))
+
+        return _pac()._group_by(
+            self, group_by_aggrs, keys, use_threads=use_threads
+        )
+
 
 cdef class InMemoryDataset(Dataset):
     """

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -394,10 +394,16 @@ def _sort_source(table_or_dataset, sort_keys, output_type=Table, **kwargs):
         raise TypeError("Unsupported output type")
 
 
-def _group_by(table, aggregates, keys, use_threads=True):
+def _group_by(table_or_dataset, aggregates, keys, use_threads=True):
 
-    decl = Declaration.from_sequence([
-        Declaration("table_source", TableSourceNodeOptions(table)),
-        Declaration("aggregate", AggregateNodeOptions(aggregates, keys=keys))
-    ])
+    if isinstance(table_or_dataset, ds.Dataset):
+        data_source = _dataset_to_decl(table_or_dataset, use_threads=True)
+    else:
+        data_source = Declaration(
+            "table_source", TableSourceNodeOptions(table_or_dataset)
+        )
+
+    aggregate = Declaration("aggregate", AggregateNodeOptions(aggregates, keys=keys))
+
+    decl = Declaration.from_sequence([data_source, aggregate])
     return decl.to_table(use_threads=use_threads)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5330,6 +5330,192 @@ def test_union_dataset_filter(tempdir, dstype):
         ds.dataset((filtered_ds1, filtered_ds2))
 
 
+@pytest.mark.dataset
+def test_dataset_aggregate(tempdir):
+    def sorted_by_keys(d):
+        # Ensure a guaranteed order of keys for aggregation results.
+        if "keys2" in d:
+            keys = tuple(zip(d["keys"], d["keys2"]))
+        else:
+            keys = d["keys"]
+        sorted_keys = sorted(keys)
+        sorted_d = {"keys": sorted(d["keys"])}
+        for entry in d:
+            if entry == "keys":
+                continue
+            values = dict(zip(keys, d[entry]))
+            for k in sorted_keys:
+                sorted_d.setdefault(entry, []).append(values[k])
+        return sorted_d
+
+    t1 = pa.table([
+        pa.array(["a", "a", "b", "b", "c"]),
+        pa.array(["X", "X", "Y", "Z", "Z"]),
+        pa.array([1, 2, 3, 4, 5]),
+        pa.array([10, 20, 30, 40, 50])
+    ], names=["keys", "keys2", "values", "bigvalues"])
+    ds.write_dataset(t1, tempdir / "t1", format="ipc")
+    ds1 = ds.dataset(tempdir / "t1", format="ipc")
+
+    r = ds1.aggregate(
+        [("values", "hash_sum")],
+        keys=["keys"]
+    )
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b", "c"],
+        "values_sum": [3, 7, 5]
+    }
+
+    r = ds1.aggregate(
+        [
+            ("values", "hash_sum"),
+            ("values", "hash_count")
+        ],
+        keys=["keys"]
+    )
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b", "c"],
+        "values_sum": [3, 7, 5],
+        "values_count": [2, 2, 1]
+    }
+
+    # Test without hash_ prefix
+    r = ds1.aggregate(
+        [("values", "sum")],
+        keys=["keys"]
+    )
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b", "c"],
+        "values_sum": [3, 7, 5]
+    }
+
+    r = ds1.aggregate(
+        [
+            ("values", "max"),
+            ("bigvalues", "sum")
+        ],
+        keys=["keys"],
+    )
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b", "c"],
+        "values_max": [2, 4, 5],
+        "bigvalues_sum": [30, 70, 50]
+    }
+
+    r = ds1.aggregate(
+        [
+            ("bigvalues", "max"),
+            ("values", "sum")
+        ],
+        keys=["keys"],
+    )
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b", "c"],
+        "values_sum": [3, 7, 5],
+        "bigvalues_max": [20, 40, 50]
+    }
+
+    r = ds1.aggregate(
+        [("values", "sum")],
+        keys=["keys", "keys2"]
+    )
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b", "b", "c"],
+        "keys2": ["X", "Y", "Z", "Z"],
+        "values_sum": [3, 3, 4, 5]
+    }
+
+    # Test many arguments
+    r = ds1.aggregate(
+        [
+            ("values", "max"),
+            ("bigvalues", "sum"),
+            ("bigvalues", "max"),
+            ([], "count_all"),
+            ("values", "sum")
+        ],
+        keys=["keys"],
+    )
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b", "c"],
+        "values_max": [2, 4, 5],
+        "bigvalues_sum": [30, 70, 50],
+        "bigvalues_max": [20, 40, 50],
+        "count_all": [2, 2, 1],
+        "values_sum": [3, 7, 5]
+    }
+
+    table_with_nulls = pa.table([
+        pa.array(["a", "a", "a"]),
+        pa.array([1, None, None])
+    ], names=["keys", "values"])
+    ds.write_dataset(table_with_nulls, tempdir / "t2", format="ipc")
+    ds2 = ds.dataset(tempdir / "t2", format="ipc")
+
+    r = ds2.aggregate(
+        [("values", "count", pc.CountOptions(mode="all"))],
+        keys=["keys"]
+    )
+    assert r.to_pydict() == {
+        "keys": ["a"],
+        "values_count": [3]
+    }
+
+    r = ds2.aggregate(
+        [("values", "count", pc.CountOptions(mode="only_null"))],
+        keys=["keys"]
+    )
+    assert r.to_pydict() == {
+        "keys": ["a"],
+        "values_count": [2]
+    }
+
+    r = ds2.aggregate(
+        [("values", "count", pc.CountOptions(mode="only_valid"))],
+        keys=["keys"],
+    )
+    assert r.to_pydict() == {
+        "keys": ["a"],
+        "values_count": [1]
+    }
+
+    r = ds2.aggregate(
+        [
+            ([], "count_all"),  # nullary count that takes no parameters
+            ("values", "count", pc.CountOptions(mode="only_valid"))
+        ],
+        keys=["keys"],
+    )
+    assert r.to_pydict() == {
+        "keys": ["a"],
+        "count_all": [3],
+        "values_count": [1]
+    }
+
+    r = ds2.aggregate(
+        [([], "count_all")],
+        keys=["keys"]
+    )
+    assert r.to_pydict() == {
+        "keys": ["a"],
+        "count_all": [3]
+    }
+
+    table = pa.table({
+        'keys': ['a', 'b', 'a', 'b', 'a', 'b'],
+        'values': range(6)})
+    table_with_chunks = pa.Table.from_batches(
+        table.to_batches(max_chunksize=3))
+    ds.write_dataset(table_with_chunks, tempdir / "t3", format="ipc")
+    ds3 = ds.dataset(tempdir / "t3", format="ipc")
+
+    r = ds3.aggregate([('values', 'sum')], keys=["keys"])
+    assert sorted_by_keys(r.to_pydict()) == {
+        "keys": ["a", "b"],
+        "values_sum": [6, 9]
+    }
+
+
 def test_parquet_dataset_filter(tempdir):
     root_path = tempdir / "test_parquet_dataset_filter"
     metadata_path, _ = _create_parquet_dataset_simple(root_path)


### PR DESCRIPTION
### Rationale for this change

See #44168 – implement an `aggregate` method for `Dataset` to facilitate out of core aggregations of arbitrary datasets using Acero.

### What changes are included in this PR?

New `aggregate` method of `Dataset` and associated tests.

### Are these changes tested?

Equivalent tests to those existing for the `group_by`/`aggregate` idiom of `Table` have been added to the dataset tests.

### Are there any user-facing changes?

New method of `Dataset`

* GitHub Issue: #44168