### PR TITLE
GH-44188: [Python] Fix pandas roundtrip with bytes column names

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -1163,7 +1163,7 @@ def _reconstruct_columns_from_metadata(columns, column_indexes):
         if dtype == np.bytes_:
             level = level.map(encoder)
         # ARROW-13756: if index is timezone aware DataTimeIndex
-        if pandas_dtype == "datetimetz":
+        elif pandas_dtype == "datetimetz":
             tz = pa.lib.string_to_tzinfo(
                 column_indexes[0]['metadata']['timezone'])
             level = pd.to_datetime(level, utc=True).tz_convert(tz)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -5244,6 +5244,7 @@ def test_nested_chunking_valid():
 def test_bytes_column_name_to_pandas():
     df = pd.DataFrame([[0.1, 0.2], [0.3, 0.4]], columns=[b'col1', b'col2'])
     table = pa.Table.from_pandas(df)
+    assert table.column_names == ['col1', 'col2']
     assert table.to_pandas().equals(df)
 
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -5241,6 +5241,12 @@ def test_nested_chunking_valid():
               schema=schema)
 
 
+def test_bytes_column_name_to_pandas():
+    df = pd.DataFrame([[0.1, 0.2], [0.3, 0.4]], columns=[b'col1', b'col2'])
+    table = pa.Table.from_pandas(df)
+    assert table.to_pandas().equals(df)
+
+
 @pytest.mark.processes
 def test_is_data_frame_race_condition():
     # See https://github.com/apache/arrow/issues/39313


### PR DESCRIPTION
### Rationale for this change

There is a bug that when column dtype is np.bytes，it will goto the final branch and run level=level.astype(dtype)


### Are these changes tested?
Yes
* GitHub Issue: #44188