### PR TITLE
GH-33618: [C++] Refactor LocalFileSystem internals to improve recursive listing performance

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -134,8 +134,14 @@ struct ARROW_EXPORT FileSelector {
   bool recursive;
   /// The maximum number of subdirectories to recurse into.
   int32_t max_recursion;
+  /// If true, use stat() to obtain extended file metadata.
+  bool needs_extended_file_info;
 
-  FileSelector() : allow_not_found(false), recursive(false), max_recursion(INT32_MAX) {}
+  FileSelector()
+      : allow_not_found(false),
+        recursive(false),
+        max_recursion(INT32_MAX),
+        needs_extended_file_info(true) {}
 };
 
 /// \brief FileSystem, path pair

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cerrno>
 #include <chrono>
+#include <cstdio>
 #include <string>
 #include <utility>
 #include <vector>
@@ -26,6 +27,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/buffer.h"
+#include "arrow/filesystem/filesystem.h"
 #include "arrow/filesystem/mockfs.h"
 #include "arrow/filesystem/test_util.h"
 #include "arrow/io/interfaces.h"
@@ -48,9 +50,15 @@ std::vector<FileInfo> GetAllWithType(FileSystem* fs, FileType type) {
   FileSelector selector;
   selector.base_dir = "";
   selector.recursive = true;
-  std::vector<FileInfo> infos = std::move(fs->GetFileInfo(selector)).ValueOrDie();
+  auto infos_result = (fs->GetFileInfo(selector));
+  if (!infos_result.ok()) {
+    puts("Error in GetFileInfo\n");
+    puts(infos_result.status().ToString().c_str());
+    assert(false);
+    return {};
+  }
   std::vector<FileInfo> result;
-  for (const auto& info : infos) {
+  for (const auto& info : infos_result.ValueUnsafe()) {
     if (info.type() == type) {
       result.push_back(info);
     }

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -16,6 +16,9 @@
 // under the License.
 
 // Ensure 64-bit off_t for platforms where it matters
+#include <sys/dirent.h>
+#include "arrow/filesystem/filesystem.h"
+#include "arrow/status.h"
 #ifdef _FILE_OFFSET_BITS
 #undef _FILE_OFFSET_BITS
 #endif

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -806,6 +806,7 @@ class UnixDirIterator : public DirIterator {
 
   Status Next() override {
     DCHECK(!Done());
+    errno = 0;
     struct dirent* entry = readdir(directory_);
 
     if (entry == nullptr) {

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1027,9 +1027,9 @@ Status DeleteDirTreeInternal(const PlatformFilename& dir_path) {
   ARROW_ASSIGN_OR_RAISE(auto children, ListDir(dir_path));
   for (const auto& child : children) {
     struct stat lst;
-    PlatformFilename full_path = dir_path.Join(child);
-    RETURN_NOT_OK(LinkStat(full_path, &lst));
-    RETURN_NOT_OK(DeleteDirEntry(full_path, lst));
+
+    RETURN_NOT_OK(LinkStat(child, &lst));
+    RETURN_NOT_OK(DeleteDirEntry(child, lst));
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -865,7 +865,7 @@ class UnixDirIterator : public DirIterator {
   struct dirent* entry_;
 };
 
-}
+}  // namespace
 
 Result<std::vector<PlatformFilename>> ListDir(const PlatformFilename& dir_path) {
   std::vector<PlatformFilename> results;

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -22,6 +22,7 @@
 #endif
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -115,6 +116,26 @@ Result<bool> DeleteDirTree(const PlatformFilename& dir_path, bool allow_not_foun
 // The returned names are the children's base names, not including dir_path.
 ARROW_EXPORT
 Result<std::vector<PlatformFilename>> ListDir(const PlatformFilename& dir_path);
+
+/// TODO(bryce): docs
+class ARROW_EXPORT DirIterator {
+ public:
+  virtual ~DirIterator() {}
+  /// \pre !Done()
+  virtual std::string name() const = 0;
+  /// \pre !Done()
+  virtual bool is_directory() const = 0;
+  /// \pre !Done()
+  virtual Status Next() = 0;
+  virtual bool Done() const = 0;
+  static Result<std::unique_ptr<DirIterator>> Open(const PlatformFilename& path,
+                                                   bool allow_not_found);
+};
+
+// TODO: Docs
+ARROW_EXPORT
+Status ListDir(const PlatformFilename& base_dir, bool allow_not_found,
+               const std::function<Status(const DirIterator&)>& callback);
 
 /// Delete a file if it exists.
 ///


### PR DESCRIPTION
### Rationale for this change

WIP changes. No need for review at the moment.

This is an experiment which builds on top of and takes a slightly different approach from https://github.com/apache/arrow/pull/34170 which the initial PR intended to resolve https://github.com/apache/arrow/issues/33618. This PR should dramatically speed up Arrow's LocalFS implementation and makes the internals more flexible.

### What changes are included in this PR?

- Adds new option `needs_extended_file_info` to FileSelector for tracking whether operations need extended information such as size and mtime or not
- Rewrites internals of LocalFS' GetFileInfo/ListDir to use a callback-based implementation

### Are these changes tested?

Yes, but there are more tests to write.

### Are there any user-facing changes?

TODO
* GitHub Issue: #33618