### PR TITLE
GH-44178: [GLib][FlightRPC] Add GAFlightCallOptions:timeout

### DIFF
--- a/c_glib/test/flight/test-call-options.rb
+++ b/c_glib/test/flight/test-call-options.rb
@@ -44,4 +44,10 @@ class TestFlightCallOptions < Test::Unit::TestCase
     @options.clear_headers
     assert_equal([], collect_headers)
   end
+
+  def test_timeout
+    assert_in_delta(-1, @options.timeout)
+    @options.timeout = 10.1
+    assert_in_delta(10.1, @options.timeout)
+  end
 end


### PR DESCRIPTION
### Rationale for this change

It's the bindings of `arrow::flight::FlightCallOptions::timeout`.

### What changes are included in this PR?

Add `GAFlightCallOptions:timeout` property.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44178