### PR TITLE
GH-43509: [R]  Add link to ?acero from ?list_compute_functions

### DIFF
--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -88,6 +88,7 @@ call_function <- function(function_name, ..., args = list(...), options = empty_
 #' @param pattern Optional regular expression to filter the function list
 #' @param ... Additional parameters passed to `grep()`
 #' @return A character vector of available Arrow C++ function names
+#' @seealso [acero] for R bindings for Arrow functions
 #' @examples
 #' available_funcs <- list_compute_functions()
 #' utf8_funcs <- list_compute_functions(pattern = "^UTF8", ignore.case = TRUE)

--- a/r/man/list_compute_functions.Rd
+++ b/r/man/list_compute_functions.Rd
@@ -41,3 +41,6 @@ available inside \code{dplyr} verbs.
 available_funcs <- list_compute_functions()
 utf8_funcs <- list_compute_functions(pattern = "^UTF8", ignore.case = TRUE)
 }
+\seealso{
+\link{acero} for R bindings for Arrow functions
+}


### PR DESCRIPTION
### Rationale for this change

Add link between docs pages to make it easier to find relevant information

### What changes are included in this PR?

Update docs 

### Are these changes tested?

Nope

### Are there any user-facing changes?

Sure, to the docs
* GitHub Issue: #43509