### PR TITLE
GH-44206: [CI][macOS] Drop support for macOS 12

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -190,18 +190,15 @@ jobs:
           docker compose run --rm minimal
 
   macos:
-    name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++
+    name: ARM64 macOS ${{ matrix.macos-version }} C++
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - architecture: AMD64
-            macos-version: "12"
-          - architecture: ARM64
-            macos-version: "14"
+        macos-version:
+          - "14"
     env:
       ARROW_AZURE: ON
       ARROW_BUILD_TESTS: ON

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -190,15 +190,18 @@ jobs:
           docker compose run --rm minimal
 
   macos:
-    name: ARM64 macOS ${{ matrix.macos-version }} C++
+    name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} C++
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
-        macos-version:
-          - "14"
+        include:
+          - architecture: AMD64
+            macos-version: "13"
+          - architecture: ARM64
+            macos-version: "14"
     env:
       ARROW_AZURE: ON
       ARROW_BUILD_TESTS: ON

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -94,8 +94,8 @@ jobs:
         run: ci/scripts/csharp_test.sh $(pwd)
 
   macos:
-    name: AMD64 macOS 13 C# ${{ matrix.dotnet }}
-    runs-on: macos-13 # Pending https://github.com/pythonnet/pythonnet/issues/2396
+    name: ARM64 macOS 14 C# ${{ matrix.dotnet }}
+    runs-on: macos-14
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -94,8 +94,8 @@ jobs:
         run: ci/scripts/csharp_test.sh $(pwd)
 
   macos:
-    name: ARM64 macOS 14 C# ${{ matrix.dotnet }}
-    runs-on: macos-14
+    name: AMD64 macOS 13 C# ${{ matrix.dotnet }}
+    runs-on: macos-13
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -106,8 +106,8 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: ARM64 macOS 14 Java JDK ${{ matrix.jdk }}
-    runs-on: macos-14
+    name: AMD64 macOS 13 Java JDK ${{ matrix.jdk }}
+    runs-on: macos-13
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -106,8 +106,8 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: AMD64 macOS 12 Java JDK ${{ matrix.jdk }}
-    runs-on: macos-12
+    name: ARM64 macOS 14 Java JDK ${{ matrix.jdk }}
+    runs-on: macos-14
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -81,8 +81,8 @@ jobs:
         run: archery docker push debian-js
 
   macos:
-    name: ARM64 macOS 14 NodeJS ${{ matrix.node }}
-    runs-on: macos-14
+    name: AMD64 macOS 13 NodeJS ${{ matrix.node }}
+    runs-on: macos-13
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -81,8 +81,8 @@ jobs:
         run: archery docker push debian-js
 
   macos:
-    name: AMD64 macOS 12 NodeJS ${{ matrix.node }}
-    runs-on: macos-12
+    name: ARM64 macOS 14 NodeJS ${{ matrix.node }}
+    runs-on: macos-14
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -98,13 +98,16 @@ jobs:
           select-by-folder: matlab/test
           strict: true
   macos:
-    name: ARM64 macOS ${{ matrix.macos-version }} MATLAB
+    name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} MATLAB
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       matrix:
-        macos-version:
-          - "14"
+        include:
+          - architecture: AMD64
+            macos-version: "13"
+          - architecture: ARM64
+            macos-version: "14"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -98,16 +98,13 @@ jobs:
           select-by-folder: matlab/test
           strict: true
   macos:
-    name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} MATLAB
+    name: ARM64 macOS ${{ matrix.macos-version }} MATLAB
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       matrix:
-        include:
-            - architecture: AMD64
-              macos-version: "12"
-            - architecture: ARM64
-              macos-version: "14"
+        macos-version:
+          - "14"
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -134,18 +134,15 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} Python 3
+    name: ARM64 macOS ${{ matrix.macos-version }} Python 3
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - architecture: AMD64
-            macos-version: "12"
-          - architecture: ARM64
-            macos-version: "14"
+        macos-version:
+          - "14"
     env:
       ARROW_HOME: /tmp/local
       ARROW_AZURE: ON

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -134,15 +134,18 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: ARM64 macOS ${{ matrix.macos-version }} Python 3
+    name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} Python 3
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        macos-version:
-          - "14"
+        include:
+          - architecture: AMD64
+            macos-version: "13"
+          - architecture: ARM64
+            macos-version: "14"
     env:
       ARROW_HOME: /tmp/local
       ARROW_AZURE: ON

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -117,7 +117,7 @@ jobs:
         run: archery docker push ubuntu-ruby
 
   macos:
-    name: AMD64 macOS 14 GLib & Ruby
+    name: ARM64 macOS 14 GLib & Ruby
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -208,7 +208,7 @@ jobs:
       matrix:
         platform:
           - { runs_on: 'windows-latest', name: "Windows"}
-          - { runs_on: macos-12, name: "macOS x86_64"}
+          - { runs_on: macos-13, name: "macOS x86_64"}
           - { runs_on: macos-14, name: "macOS arm64" }
         r_version: [oldrel, release]
     steps:
@@ -389,7 +389,7 @@ jobs:
       matrix:
         platform:
           - {runs_on: "ubuntu-latest", name: "Linux"}
-          - {runs_on: "macos-12" , name: "macOS"}
+          - {runs_on: "macos-13" , name: "macOS"}
     steps:
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -970,6 +970,7 @@ tasks:
   {% for target in ["cpp",
                     "csharp",
                     "integration",
+                    "java",
                     "js",
                     "python",
                     "ruby"] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -416,25 +416,6 @@ tasks:
 
 {############################## Wheel macOS ####################################}
 
-{% for macos_version, macos_codename in [("12.0", "monterey")] %}
-  {% set platform_tag = "macosx_{}_x86_64".format(macos_version.replace('.', '_')) %}
-
-  wheel-macos-{{ macos_codename }}-{{ python_tag }}-{{ abi_tag }}-amd64:
-    ci: github
-    template: python-wheels/github.osx.yml
-    params:
-      arch: "x86_64"
-      arrow_jemalloc: "ON"
-      python_version: "{{ python_version }}"
-      python_abi_tag: "{{ abi_tag }}"
-      macos_deployment_target: "{{ macos_version }}"
-      runs_on: "macos-12"
-      vcpkg_arch: "amd64"
-    artifacts:
-      - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-{{ platform_tag }}.whl
-
-{% endfor %}
-
   wheel-macos-monterey-{{ python_tag }}-{{ abi_tag }}-arm64:
     ci: github
     template: python-wheels/github.osx.yml
@@ -957,31 +938,6 @@ tasks:
 
   ######################## macOS verification ################################
 
-  {% for target in ["cpp", "integration", "python"] %}
-  verify-rc-source-{{ target }}-macos-conda-amd64:
-    ci: github
-    template: verify-rc/github.macos.yml
-    params:
-      target: {{ target }}
-      use_conda: True
-      github_runner: "macos-12"
-  {% endfor %}
-
-  {% for target in ["cpp",
-                    "csharp",
-                    "integration",
-                    "java",
-                    "js",
-                    "python",
-                    "ruby"] %}
-  verify-rc-source-{{ target }}-macos-amd64:
-    ci: github
-    template: verify-rc/github.macos.yml
-    params:
-      target: {{ target }}
-      github_runner: "macos-12"
-  {% endfor %}
-
   {% for target in ["cpp",
                     "csharp",
                     "integration",
@@ -999,15 +955,6 @@ tasks:
         PYTEST_ADDOPTS: "-k 'not test_cancellation'"
       target: {{ target }}
       github_runner: "macos-14"
-  {% endfor %}
-
-  {% for macos_version in ["12"] %}
-  verify-rc-binaries-wheels-macos-{{ macos_version }}-amd64:
-    ci: github
-    template: verify-rc/github.macos.yml
-    params:
-      github_runner: "macos-{{ macos_version }}"
-      target: "wheels"
   {% endfor %}
 
   {% for macos_version in ["14"] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -416,6 +416,25 @@ tasks:
 
 {############################## Wheel macOS ####################################}
 
+{% for macos_version, macos_codename in [("13.0", "ventura")] %}
+  {% set platform_tag = "macosx_{}_x86_64".format(macos_version.replace('.', '_')) %}
+
+  wheel-macos-{{ macos_codename }}-{{ python_tag }}-{{ abi_tag }}-amd64:
+    ci: github
+    template: python-wheels/github.osx.yml
+    params:
+      arch: "x86_64"
+      arrow_jemalloc: "ON"
+      python_version: "{{ python_version }}"
+      python_abi_tag: "{{ abi_tag }}"
+      macos_deployment_target: "{{ macos_version }}"
+      runs_on: "macos-13"
+      vcpkg_arch: "amd64"
+    artifacts:
+      - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-{{ platform_tag }}.whl
+
+{% endfor %}
+
   wheel-macos-monterey-{{ python_tag }}-{{ abi_tag }}-arm64:
     ci: github
     template: python-wheels/github.osx.yml
@@ -938,6 +957,16 @@ tasks:
 
   ######################## macOS verification ################################
 
+  {% for target in ["cpp", "integration", "python"] %}
+  verify-rc-source-{{ target }}-macos-conda-amd64:
+    ci: github
+    template: verify-rc/github.macos.yml
+    params:
+      target: {{ target }}
+      use_conda: True
+      github_runner: "macos-13"
+  {% endfor %}
+
   {% for target in ["cpp",
                     "csharp",
                     "integration",
@@ -955,6 +984,15 @@ tasks:
         PYTEST_ADDOPTS: "-k 'not test_cancellation'"
       target: {{ target }}
       github_runner: "macos-14"
+  {% endfor %}
+
+  {% for macos_version in ["13"] %}
+  verify-rc-binaries-wheels-macos-{{ macos_version }}-amd64:
+    ci: github
+    template: verify-rc/github.macos.yml
+    params:
+      github_runner: "macos-{{ macos_version }}"
+      target: "wheels"
   {% endfor %}
 
   {% for macos_version in ["14"] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -973,6 +973,20 @@ tasks:
                     "js",
                     "python",
                     "ruby"] %}
+  verify-rc-source-{{ target }}-macos-amd64:
+    ci: github
+    template: verify-rc/github.macos.yml
+    params:
+      target: {{ target }}
+      github_runner: "macos-13"
+  {% endfor %}
+
+  {% for target in ["cpp",
+                    "csharp",
+                    "integration",
+                    "js",
+                    "python",
+                    "ruby"] %}
   verify-rc-source-{{ target }}-macos-arm64:
     ci: github
     template: verify-rc/github.macos.yml


### PR DESCRIPTION
### Rationale for this change

Homebrew dropped support for macOS 12 (Monterey): https://github.com/Homebrew/brew/pull/18314

### What changes are included in this PR?

Use macOS 13 instead of macOS 12 as much as possible.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44206