### PR TITLE
GH-44214: [C++] JsonExtensionType equality check ignores storage type

### DIFF
--- a/cpp/src/arrow/extension/json.cc
+++ b/cpp/src/arrow/extension/json.cc
@@ -58,7 +58,7 @@ Result<std::shared_ptr<DataType>> JsonExtensionType::Make(
 }
 
 std::shared_ptr<DataType> json(std::shared_ptr<DataType> storage_type) {
-  return JsonExtensionType::Make(storage_type).ValueOrDie();
+  return JsonExtensionType::Make(std::move(storage_type)).ValueOrDie();
 }
 
 }  // namespace arrow::extension

--- a/cpp/src/arrow/extension/json.cc
+++ b/cpp/src/arrow/extension/json.cc
@@ -34,7 +34,7 @@ bool JsonExtensionType::ExtensionEquals(const ExtensionType& other) const {
 
 Result<std::shared_ptr<DataType>> JsonExtensionType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
-  return JsonExtensionType::Make(storage_type);
+  return JsonExtensionType::Make(std::move(storage_type));
 }
 
 std::string JsonExtensionType::Serialize() const { return ""; }
@@ -54,7 +54,7 @@ Result<std::shared_ptr<DataType>> JsonExtensionType::Make(
     return Status::Invalid("Invalid storage type for JsonExtensionType: ",
                            storage_type->ToString());
   }
-  return std::make_shared<JsonExtensionType>(storage_type);
+  return std::make_shared<JsonExtensionType>(std::move(storage_type));
 }
 
 std::shared_ptr<DataType> json(std::shared_ptr<DataType> storage_type) {

--- a/cpp/src/arrow/extension/json.cc
+++ b/cpp/src/arrow/extension/json.cc
@@ -48,7 +48,7 @@ std::shared_ptr<Array> JsonExtensionType::MakeArray(
 }
 
 Result<std::shared_ptr<DataType>> JsonExtensionType::Make(
-    const std::shared_ptr<DataType>& storage_type) {
+    std::shared_ptr<DataType> storage_type) {
   if (storage_type->id() != Type::STRING && storage_type->id() != Type::STRING_VIEW &&
       storage_type->id() != Type::LARGE_STRING) {
     return Status::Invalid("Invalid storage type for JsonExtensionType: ",

--- a/cpp/src/arrow/extension/json.cc
+++ b/cpp/src/arrow/extension/json.cc
@@ -28,17 +28,13 @@
 namespace arrow::extension {
 
 bool JsonExtensionType::ExtensionEquals(const ExtensionType& other) const {
-  return other.extension_name() == this->extension_name();
+  return other.extension_name() == this->extension_name() &&
+         other.storage_type()->Equals(storage_type_);
 }
 
 Result<std::shared_ptr<DataType>> JsonExtensionType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
-  if (storage_type->id() != Type::STRING && storage_type->id() != Type::STRING_VIEW &&
-      storage_type->id() != Type::LARGE_STRING) {
-    return Status::Invalid("Invalid storage type for JsonExtensionType: ",
-                           storage_type->ToString());
-  }
-  return std::make_shared<JsonExtensionType>(storage_type);
+  return JsonExtensionType::Make(storage_type);
 }
 
 std::string JsonExtensionType::Serialize() const { return ""; }
@@ -51,11 +47,18 @@ std::shared_ptr<Array> JsonExtensionType::MakeArray(
   return std::make_shared<ExtensionArray>(data);
 }
 
-std::shared_ptr<DataType> json(const std::shared_ptr<DataType> storage_type) {
-  ARROW_CHECK(storage_type->id() != Type::STRING ||
-              storage_type->id() != Type::STRING_VIEW ||
-              storage_type->id() != Type::LARGE_STRING);
+Result<std::shared_ptr<DataType>> JsonExtensionType::Make(
+    const std::shared_ptr<DataType>& storage_type) {
+  if (storage_type->id() != Type::STRING && storage_type->id() != Type::STRING_VIEW &&
+      storage_type->id() != Type::LARGE_STRING) {
+    return Status::Invalid("Invalid storage type for JsonExtensionType: ",
+                           storage_type->ToString());
+  }
   return std::make_shared<JsonExtensionType>(storage_type);
+}
+
+std::shared_ptr<DataType> json(const std::shared_ptr<DataType>& storage_type) {
+  return JsonExtensionType::Make(storage_type).ValueOrDie();
 }
 
 }  // namespace arrow::extension

--- a/cpp/src/arrow/extension/json.cc
+++ b/cpp/src/arrow/extension/json.cc
@@ -47,10 +47,14 @@ std::shared_ptr<Array> JsonExtensionType::MakeArray(
   return std::make_shared<ExtensionArray>(data);
 }
 
+bool JsonExtensionType::IsSupportedStorageType(Type::type type_id) {
+  return type_id == Type::STRING || type_id == Type::STRING_VIEW ||
+         type_id == Type::LARGE_STRING;
+}
+
 Result<std::shared_ptr<DataType>> JsonExtensionType::Make(
     std::shared_ptr<DataType> storage_type) {
-  if (storage_type->id() != Type::STRING && storage_type->id() != Type::STRING_VIEW &&
-      storage_type->id() != Type::LARGE_STRING) {
+  if (!IsSupportedStorageType(storage_type->id())) {
     return Status::Invalid("Invalid storage type for JsonExtensionType: ",
                            storage_type->ToString());
   }

--- a/cpp/src/arrow/extension/json.cc
+++ b/cpp/src/arrow/extension/json.cc
@@ -57,7 +57,7 @@ Result<std::shared_ptr<DataType>> JsonExtensionType::Make(
   return std::make_shared<JsonExtensionType>(storage_type);
 }
 
-std::shared_ptr<DataType> json(const std::shared_ptr<DataType>& storage_type) {
+std::shared_ptr<DataType> json(std::shared_ptr<DataType> storage_type) {
   return JsonExtensionType::Make(storage_type).ValueOrDie();
 }
 

--- a/cpp/src/arrow/extension/json.h
+++ b/cpp/src/arrow/extension/json.h
@@ -45,8 +45,7 @@ class ARROW_EXPORT JsonExtensionType : public ExtensionType {
 
   std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override;
 
-  static Result<std::shared_ptr<DataType>> Make(
-      const std::shared_ptr<DataType>& storage_type);
+  static Result<std::shared_ptr<DataType>> Make(std::shared_ptr<DataType> storage_type);
 
  private:
   std::shared_ptr<DataType> storage_type_;

--- a/cpp/src/arrow/extension/json.h
+++ b/cpp/src/arrow/extension/json.h
@@ -53,6 +53,6 @@ class ARROW_EXPORT JsonExtensionType : public ExtensionType {
 
 /// \brief Return a JsonExtensionType instance.
 ARROW_EXPORT std::shared_ptr<DataType> json(
-    const std::shared_ptr<DataType>& storage_type = utf8());
+    std::shared_ptr<DataType> storage_type = utf8());
 
 }  // namespace arrow::extension

--- a/cpp/src/arrow/extension/json.h
+++ b/cpp/src/arrow/extension/json.h
@@ -45,12 +45,14 @@ class ARROW_EXPORT JsonExtensionType : public ExtensionType {
 
   std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override;
 
+  static Result<std::shared_ptr<DataType>> Make(const std::shared_ptr<DataType>& storage_type);
+
  private:
   std::shared_ptr<DataType> storage_type_;
 };
 
 /// \brief Return a JsonExtensionType instance.
 ARROW_EXPORT std::shared_ptr<DataType> json(
-    std::shared_ptr<DataType> storage_type = utf8());
+    const std::shared_ptr<DataType>& storage_type = utf8());
 
 }  // namespace arrow::extension

--- a/cpp/src/arrow/extension/json.h
+++ b/cpp/src/arrow/extension/json.h
@@ -47,6 +47,8 @@ class ARROW_EXPORT JsonExtensionType : public ExtensionType {
 
   static Result<std::shared_ptr<DataType>> Make(std::shared_ptr<DataType> storage_type);
 
+  static bool IsSupportedStorageType(Type::type type_id);
+
  private:
   std::shared_ptr<DataType> storage_type_;
 };

--- a/cpp/src/arrow/extension/json.h
+++ b/cpp/src/arrow/extension/json.h
@@ -45,7 +45,8 @@ class ARROW_EXPORT JsonExtensionType : public ExtensionType {
 
   std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override;
 
-  static Result<std::shared_ptr<DataType>> Make(const std::shared_ptr<DataType>& storage_type);
+  static Result<std::shared_ptr<DataType>> Make(
+      const std::shared_ptr<DataType>& storage_type);
 
  private:
   std::shared_ptr<DataType> storage_type_;

--- a/cpp/src/arrow/extension/json_test.cc
+++ b/cpp/src/arrow/extension/json_test.cc
@@ -80,4 +80,18 @@ TEST_F(TestJsonExtensionType, InvalidUTF8) {
   }
 }
 
+TEST_F(TestJsonExtensionType, StorageTypeValidation) {
+  ASSERT_TRUE(json(utf8())->Equals(json(utf8())));
+  ASSERT_FALSE(json(large_utf8())->Equals(json(utf8())));
+  ASSERT_FALSE(json(utf8_view())->Equals(json(utf8())));
+  ASSERT_FALSE(json(utf8_view())->Equals(json(large_utf8())));
+
+  for (const auto& storage_type : {int16(), binary(), float64(), null()}) {
+    ASSERT_RAISES_WITH_MESSAGE(Invalid,
+                               "Invalid: Invalid storage type for JsonExtensionType: " +
+                                   storage_type->ToString(),
+                               extension::JsonExtensionType::Make(storage_type));
+  }
+}
+
 }  // namespace arrow

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -763,7 +763,7 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
     props.set_arrow_extensions_enabled(true);
     auto arrow_schema = ::arrow::schema(
         {::arrow::field("json_1", ::arrow::extension::json(), true),
-         ::arrow::field("json_2", ::arrow::extension::json(::arrow::utf8()),
+         ::arrow::field("json_2", ::arrow::extension::json(::arrow::large_utf8()),
                         true)});
     std::shared_ptr<KeyValueMetadata> metadata{};
     ASSERT_OK(ConvertSchema(parquet_fields, metadata, props));
@@ -780,7 +780,7 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
         ::arrow::key_value_metadata({"foo", "bar"}, {"biz", "baz"});
     auto arrow_schema = ::arrow::schema(
         {::arrow::field("json_1", ::arrow::extension::json(), true, field_metadata),
-         ::arrow::field("json_2", ::arrow::extension::json(::arrow::utf8()),
+         ::arrow::field("json_2", ::arrow::extension::json(::arrow::large_utf8()),
                         true)});
 
     std::shared_ptr<KeyValueMetadata> metadata;
@@ -798,7 +798,7 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
         ::arrow::key_value_metadata({"foo", "bar"}, {"biz", "baz"});
     auto arrow_schema = ::arrow::schema(
         {::arrow::field("json_1", ::arrow::extension::json(), true, field_metadata),
-         ::arrow::field("json_2", ::arrow::extension::json(::arrow::utf8()),
+         ::arrow::field("json_2", ::arrow::extension::json(::arrow::large_utf8()),
                         true)});
 
     std::shared_ptr<KeyValueMetadata> metadata;

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -776,6 +776,8 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
                         true)});
     metadata = std::shared_ptr<KeyValueMetadata>{};
     ASSERT_OK(ConvertSchema(parquet_fields, metadata, props));
+    EXPECT_TRUE(result_schema_->field(1)->type()->Equals(
+        ::arrow::extension::json(::arrow::utf8())));
     EXPECT_FALSE(
         result_schema_->field(1)->type()->Equals(arrow_schema->field(1)->type()));
   }

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -776,6 +776,8 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
                         true)});
     metadata = std::shared_ptr<KeyValueMetadata>{};
     ASSERT_OK(ConvertSchema(parquet_fields, metadata, props));
+    EXPECT_FALSE(result_schema_->field(1)->type()->Equals(
+        arrow_schema->field(1)->type()));
     EXPECT_TRUE(result_schema_->field(1)->type()->Equals(
         ::arrow::extension::json(::arrow::utf8())));
   }

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -757,14 +757,13 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
 
   {
     // Parquet file does not contain Arrow schema.
-    // If Arrow extensions are enabled, both fields should be treated as json() extension
-    // fields.
+    // If Arrow extensions are enabled, fields will be interpreted as json(utf8())
+    // extension fields.
     ArrowReaderProperties props;
     props.set_arrow_extensions_enabled(true);
     auto arrow_schema = ::arrow::schema(
         {::arrow::field("json_1", ::arrow::extension::json(), true),
-         ::arrow::field("json_2", ::arrow::extension::json(::arrow::large_utf8()),
-                        true)});
+         ::arrow::field("json_2", ::arrow::extension::json(::arrow::utf8()), true)});
     std::shared_ptr<KeyValueMetadata> metadata{};
     ASSERT_OK(ConvertSchema(parquet_fields, metadata, props));
     CheckFlatSchema(arrow_schema);
@@ -772,8 +771,8 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
 
   {
     // Parquet file contains Arrow schema.
-    // Both json_1 and json_2 should be returned as a json() field
-    // even though extensions are not enabled.
+    // json_1 and json_2 will be interpreted as json(utf8()) and json(large_utf8())
+    // fields even though extensions are not enabled.
     ArrowReaderProperties props;
     props.set_arrow_extensions_enabled(false);
     std::shared_ptr<KeyValueMetadata> field_metadata =
@@ -791,7 +790,7 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
 
   {
     // Parquet file contains Arrow schema. Extensions are enabled.
-    // Both json_1 and json_2 should be returned as a json() field
+    // json_1 and json_2 will be interpreted as json(utf8()) and json(large_utf8()).
     ArrowReaderProperties props;
     props.set_arrow_extensions_enabled(true);
     std::shared_ptr<KeyValueMetadata> field_metadata =

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -763,7 +763,7 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
     props.set_arrow_extensions_enabled(true);
     auto arrow_schema = ::arrow::schema(
         {::arrow::field("json_1", ::arrow::extension::json(), true),
-         ::arrow::field("json_2", ::arrow::extension::json(::arrow::large_utf8()),
+         ::arrow::field("json_2", ::arrow::extension::json(::arrow::utf8()),
                         true)});
     std::shared_ptr<KeyValueMetadata> metadata{};
     ASSERT_OK(ConvertSchema(parquet_fields, metadata, props));
@@ -780,7 +780,7 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
         ::arrow::key_value_metadata({"foo", "bar"}, {"biz", "baz"});
     auto arrow_schema = ::arrow::schema(
         {::arrow::field("json_1", ::arrow::extension::json(), true, field_metadata),
-         ::arrow::field("json_2", ::arrow::extension::json(::arrow::large_utf8()),
+         ::arrow::field("json_2", ::arrow::extension::json(::arrow::utf8()),
                         true)});
 
     std::shared_ptr<KeyValueMetadata> metadata;
@@ -798,7 +798,7 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
         ::arrow::key_value_metadata({"foo", "bar"}, {"biz", "baz"});
     auto arrow_schema = ::arrow::schema(
         {::arrow::field("json_1", ::arrow::extension::json(), true, field_metadata),
-         ::arrow::field("json_2", ::arrow::extension::json(::arrow::large_utf8()),
+         ::arrow::field("json_2", ::arrow::extension::json(::arrow::utf8()),
                         true)});
 
     std::shared_ptr<KeyValueMetadata> metadata;

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -776,10 +776,8 @@ TEST_F(TestConvertParquetSchema, ParquetSchemaArrowExtensions) {
                         true)});
     metadata = std::shared_ptr<KeyValueMetadata>{};
     ASSERT_OK(ConvertSchema(parquet_fields, metadata, props));
-    EXPECT_FALSE(result_schema_->field(1)->type()->Equals(
-        arrow_schema->field(1)->type()));
-    EXPECT_TRUE(result_schema_->field(1)->type()->Equals(
-        ::arrow::extension::json(::arrow::utf8())));
+    EXPECT_FALSE(
+        result_schema_->field(1)->type()->Equals(arrow_schema->field(1)->type()));
   }
 
   {

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -1017,7 +1017,9 @@ Result<bool> ApplyOriginalMetadata(const Field& origin_field, SchemaField* infer
 
       // Restore extension type, if the storage type is the same as inferred
       // from the Parquet type
-      if (ex_type.storage_type()->Equals(*inferred->field->type())) {
+      if (ex_type.storage_type()->Equals(*inferred->field->type()) ||
+          (ex_type.extension_name() == "arrow.json" &&
+           !ex_type.storage_type()->Equals(*inferred->field->type()))) {
         inferred->field = inferred->field->WithType(origin_type);
       }
     }

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -1009,9 +1009,7 @@ Result<bool> ApplyOriginalMetadata(const Field& origin_field, SchemaField* infer
       inferred->field = inferred->field->WithType(origin_type);
       RETURN_NOT_OK(ApplyOriginalStorageMetadata(origin_field, inferred));
     } else if (inferred_type->id() == ::arrow::Type::EXTENSION &&
-               ex_type.extension_name() == std::string("arrow.json") &&
-               ::arrow::extension::JsonExtensionType::IsSupportedStorageType(
-                   inferred_type->storage_id())) {
+               ex_type.extension_name() == std::string("arrow.json")) {
       // Potential schema mismatch.
       //
       // Arrow extensions are ENABLED in Parquet.

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -1018,8 +1018,10 @@ Result<bool> ApplyOriginalMetadata(const Field& origin_field, SchemaField* infer
       // Restore extension type, if the storage type is the same as inferred
       // from the Parquet type
       if (ex_type.storage_type()->Equals(*inferred->field->type()) ||
-          (ex_type.extension_name() == "arrow.json" &&
-           !ex_type.storage_type()->Equals(*inferred->field->type()))) {
+          ((ex_type.extension_name() == "arrow.json") &&
+           (inferred->field->type()->storage_id() == ::arrow::Type::STRING ||
+            inferred->field->type()->storage_id() == ::arrow::Type::LARGE_STRING ||
+            inferred->field->type()->storage_id() == ::arrow::Type::STRING_VIEW))) {
         inferred->field = inferred->field->WithType(origin_type);
       }
     }

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -997,9 +997,8 @@ Result<bool> ApplyOriginalMetadata(const Field& origin_field, SchemaField* infer
     const auto& ex_type = checked_cast<const ::arrow::ExtensionType&>(*origin_type);
     if (inferred_type->id() != ::arrow::Type::EXTENSION &&
         ex_type.extension_name() == std::string("arrow.json") &&
-        (inferred_type->id() == ::arrow::Type::STRING ||
-         inferred_type->id() == ::arrow::Type::LARGE_STRING ||
-         inferred_type->id() == ::arrow::Type::STRING_VIEW)) {
+        ::arrow::extension::JsonExtensionType::IsSupportedStorageType(
+            inferred_type->id())) {
       // Schema mismatch.
       //
       // Arrow extensions are DISABLED in Parquet.
@@ -1019,9 +1018,8 @@ Result<bool> ApplyOriginalMetadata(const Field& origin_field, SchemaField* infer
       // from the Parquet type
       if (ex_type.storage_type()->Equals(*inferred->field->type()) ||
           ((ex_type.extension_name() == "arrow.json") &&
-           (inferred->field->type()->storage_id() == ::arrow::Type::STRING ||
-            inferred->field->type()->storage_id() == ::arrow::Type::LARGE_STRING ||
-            inferred->field->type()->storage_id() == ::arrow::Type::STRING_VIEW))) {
+           ::arrow::extension::JsonExtensionType::IsSupportedStorageType(
+               inferred->field->type()->storage_id()))) {
         inferred->field = inferred->field->WithType(origin_type);
       }
     }

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -1017,9 +1017,7 @@ Result<bool> ApplyOriginalMetadata(const Field& origin_field, SchemaField* infer
       // Restore extension type, if the storage type is the same as inferred
       // from the Parquet type
       if (ex_type.storage_type()->Equals(*inferred->field->type()) ||
-          ((ex_type.extension_name() == "arrow.json") &&
-           ::arrow::extension::JsonExtensionType::IsSupportedStorageType(
-               inferred->field->type()->storage_id()))) {
+          (ex_type.extension_name() == "arrow.json")) {
         inferred->field = inferred->field->WithType(origin_type);
       }
     }


### PR DESCRIPTION
### Rationale for this change

As noted in https://github.com/apache/arrow/pull/13901#pullrequestreview-2324294761:
```cpp
bool JsonExtensionType::ExtensionEquals(const ExtensionType& other) const {
  return other.extension_name() == this->extension_name();
}
```
> This equality check does not take into account the storage type, but only the name.
> As a consequence, a JsonExtensionType<string> type will be seen as equal to JsonExtensionType<large_string>.

### What changes are included in this PR?

This change introduces storage equality check into `JsonExtensionType` equality check.

This also fixes a storage type check in `JsonExtensionType::Make`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44214