### PR TITLE
GH-44218: [Benchmarking][Python] Avoid uwsgi install failure on macOS

### DIFF
--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -3,4 +3,5 @@ hypothesis
 pandas
 pytest
 pytz
-uwsgi; sys.platform != 'win32' and python_version < '3.13'
+# uwsgi disabled on macOS because of GH-44218
+uwsgi; sys.platform != 'win32' and sys.platform != 'darwin' and python_version < '3.13'


### PR DESCRIPTION

* GitHub Issue: #44218