### PR TITLE
MINOR: [CI][Python] Install pyuwsgi instead of uwsgi

### DIFF
--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -3,5 +3,4 @@ hypothesis
 pandas
 pytest
 pytz
-# uwsgi disabled on macOS because of GH-44218
-uwsgi; sys.platform != 'win32' and sys.platform != 'darwin' and python_version < '3.13'
+pyuwsgi; sys.platform != 'win32' and python_version < '3.13'

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -9,8 +9,8 @@ cython
 hypothesis
 pytest
 pytz
+pyuwsgi; sys.platform != 'win32' and python_version < '3.13'
 tzdata; sys_platform == 'win32'
-uwsgi; sys.platform != 'win32' and python_version < '3.13'
 
 # We generally test with the oldest numpy version that supports a given Python
 # version. However, there is no need to make this strictly the oldest version,


### PR DESCRIPTION
The `pyuwsgi` distribution provides binary wheels of `uwsgi`, avoiding the need to compile when installing.
