### PR TITLE
GH-44227: [Python] Update create_library_symlinks() to fix broken symlinks

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -380,6 +380,9 @@ def create_library_symlinks():
         if _os.path.exists(symlink_path):
             continue
         try:
+            if _os.path.islink(symlink_path):
+                # broken symlink
+                _os.unlink(symlink_path)
             _os.symlink(lib_hard_path, symlink_path)
         except PermissionError:
             print("Tried creating symlink {}. If you need to link to "


### PR DESCRIPTION
### Rationale for this change

When updating/re-installing `pyarrow` using e.g. pip, symlinks created by previous invocations of `pyarrow.create_library_symlinks()` are left dangling.

Unfortunately, fixing these links currently requires manual user intervention, as subsequent calls to `pyarrow.create_library_symlinks()` do not attempt to fix broken links.

### What changes are included in this PR?

This PR updates `pyarrow.create_library_symlinks()` to detect and fix broken symlinks.

Closes https://github.com/apache/arrow/issues/44227.

### Are these changes tested?

I tested the changes locally using the official python:3.12 docker image.
Let me know if automated tests are needed.

### Are there any user-facing changes?

Yes, running `pyarrow.create_library_symlinks()` after installing a different version of `pyarrow` should no longer result in `FileExistsError`s.

* GitHub Issue: #44227