### PR TITLE
GH-44234: [CI][C++][AppVeyor] Use conda instead of Mamba

### DIFF
--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -44,16 +44,12 @@ conda config --append disallowed_packages pypy3
 conda info -a
 
 @rem
-@rem Install mamba to the base environment
+@rem Install Python to the base environment
 @rem
-conda install -q -y -c conda-forge mamba python=%PYTHON% || exit /B
-
-@rem Ensure using the latest information. If there are invalid caches,
-@rem mamba may use invalid download URL.
-mamba clean --all -y
+conda install -q -y -c conda-forge python=%PYTHON% || exit /B
 
 @rem Update for newer CA certificates
-mamba update -q -y -c conda-forge --all || exit /B
+conda update -q -y -c conda-forge --all || exit /B
 
 @rem
 @rem Create conda environment
@@ -71,7 +67,7 @@ set CONDA_PACKAGES=%CONDA_PACKAGES% --file=ci\conda_env_cpp.txt
 conda config --add channels conda-forge
 conda config --remove channels defaults
 @rem Arrow conda environment
-mamba create -n arrow -y -c conda-forge ^
+conda create -n arrow -y -c conda-forge ^
   --file=ci\conda_env_python.txt ^
   %CONDA_PACKAGES%  ^
   "ccache" ^

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -41,14 +41,15 @@ conda config --set show_channel_urls True
 conda config --set remote_connect_timeout_secs 12
 @rem Workaround for ARROW-13636
 conda config --append disallowed_packages pypy3
-@rem Can't use conda-libmamba-solver 2.0.0
-conda config --set solver classic
 conda info -a
 
 @rem
 @rem Install Python to the base environment
 @rem
 conda install -q -y -c conda-forge python=%PYTHON% || exit /B
+
+@rem Can't use conda-libmamba-solver 2.0.0
+conda config --set solver classic
 
 @rem Update for newer CA certificates
 conda update -q -y -c conda-forge --all || exit /B

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -46,8 +46,11 @@ conda info -a
 @rem
 @rem Install mamba to the base environment
 @rem
-@rem GH-44234: "mamba update" with Mamba 2.0.0 failed
-conda install -q -y -c conda-forge mamba=1.5.10 python=%PYTHON% || exit /B
+conda install -q -y -c conda-forge mamba python=%PYTHON% || exit /B
+
+@rem Ensure using the latest information. If there are invalid caches,
+@rem mamba may use invalid download URL.
+mamba clean --all -y
 
 @rem Update for newer CA certificates
 mamba update -q -y -c conda-forge --all || exit /B
@@ -67,9 +70,6 @@ set CONDA_PACKAGES=%CONDA_PACKAGES% --file=ci\conda_env_cpp.txt
 @rem Force conda to use conda-forge
 conda config --add channels conda-forge
 conda config --remove channels defaults
-@rem Ensure using the latest information. If there are invalid caches,
-@rem mamba may use invalid download URL.
-mamba clean --all -y
 @rem Arrow conda environment
 mamba create -n arrow -y -c conda-forge ^
   --file=ci\conda_env_python.txt ^

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -46,7 +46,8 @@ conda info -a
 @rem
 @rem Install mamba to the base environment
 @rem
-conda install -q -y -c conda-forge mamba python=%PYTHON% || exit /B
+@rem GH-44234: "mamba update" with Mamba 2.0.0 failed
+conda install -q -y -c conda-forge mamba=1.5.10 python=%PYTHON% || exit /B
 
 @rem Update for newer CA certificates
 mamba update -q -y -c conda-forge --all || exit /B

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -41,6 +41,8 @@ conda config --set show_channel_urls True
 conda config --set remote_connect_timeout_secs 12
 @rem Workaround for ARROW-13636
 conda config --append disallowed_packages pypy3
+@rem Can't use conda-libmamba-solver 2.0.0
+conda config --set solver classic
 conda info -a
 
 @rem


### PR DESCRIPTION
### Rationale for this change

`mamba update` with Mamba 2.0.0 failed.

### What changes are included in this PR?

Use conda instead of Mamba. "conda-libmamba-solver" isn't used too. "classic" solver is used.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44234