### PR TITLE
MINOR: [Format][Docs] Fix a typo in `JSON` extension type docs

### DIFF
--- a/docs/source/format/CanonicalExtensions.rst
+++ b/docs/source/format/CanonicalExtensions.rst
@@ -259,7 +259,7 @@ JSON
 * Extension name: ``arrow.json``.
 
 * The storage type of this extension is ``String`` or
-  or ``LargeString`` or ``StringView``.
+  ``LargeString`` or ``StringView``.
   Only UTF-8 encoded JSON as specified in `rfc8259`_ is supported.
 
 * Extension type parameters:


### PR DESCRIPTION
### Rationale for this change

Noticed a typo in the docs for the `JSON` extension type.

### What changes are included in this PR?

Removed the double `or`.

### Are these changes tested?

No.

### Are there any user-facing changes?

Typo fixed.