### PR TITLE
GH-36628: disallows direct instantation of classes Statistics, FileMetadata, Co…

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -50,7 +50,15 @@ _DEFAULT_ROW_GROUP_SIZE = 1024*1024
 _MAX_ROW_GROUP_SIZE = 64*1024*1024
 
 cdef class Statistics(_Weakrefable):
-    """Statistics for a single column in a single row group."""
+    """Statistics for a single column in a single row group.
+
+    Warnings
+    --------
+    Do not call this class's constructor directly."""
+
+    def __init__(self):
+        raise TypeError("Statistics is not supposed to be instantiated directly,"
+                        "but be used through the statistics attribute of FileMetaData.")
 
     def __cinit__(self):
         pass
@@ -216,7 +224,16 @@ cdef class Statistics(_Weakrefable):
 
 
 cdef class ParquetLogicalType(_Weakrefable):
-    """Logical type of parquet type."""
+    """Logical type of parquet type.
+
+    Warnings
+    --------
+    Do not call this class's constructor directly."""
+
+    def __init__(self):
+        raise TypeError(
+            "ParquetLogicalType is not supposed to be instantiated directly")
+
     cdef:
         shared_ptr[const CParquetLogicalType] type
 
@@ -253,7 +270,7 @@ cdef class ParquetLogicalType(_Weakrefable):
 
 
 cdef wrap_logical_type(const shared_ptr[const CParquetLogicalType]& type):
-    cdef ParquetLogicalType out = ParquetLogicalType()
+    cdef ParquetLogicalType out = ParquetLogicalType.__new__(ParquetLogicalType)
     out.init(type)
     return out
 
@@ -313,7 +330,15 @@ cdef _box_flba(ParquetFLBA val, uint32_t len):
 
 
 cdef class ColumnChunkMetaData(_Weakrefable):
-    """Column metadata for a single row group."""
+    """Column metadata for a single row group.
+
+    Warnings
+    --------
+    Do not call this class's constructor directly."""
+
+    def __init__(self):
+        raise TypeError("ColumnChunkMetaData is not supposed to be instantiated directly,"
+                        "but be used through the column attribute of RowGroupMetaData.")
 
     def __cinit__(self):
         pass
@@ -436,7 +461,8 @@ cdef class ColumnChunkMetaData(_Weakrefable):
         """Statistics for column chunk (:class:`Statistics`)."""
         if not self.metadata.is_stats_set():
             return None
-        statistics = Statistics()
+
+        cdef Statistics statistics = Statistics.__new__(Statistics)
         statistics.init(self.metadata.statistics(), self)
         return statistics
 
@@ -787,7 +813,8 @@ cdef class RowGroupMetaData(_Weakrefable):
         """
         if i < 0 or i >= self.num_columns:
             raise IndexError('{0} out of bounds'.format(i))
-        chunk = ColumnChunkMetaData()
+
+        cdef ColumnChunkMetaData chunk = ColumnChunkMetaData.__new__(ColumnChunkMetaData)
         chunk.init(self, i)
         return chunk
 
@@ -864,7 +891,15 @@ def _reconstruct_filemetadata(Buffer serialized):
 
 
 cdef class FileMetaData(_Weakrefable):
-    """Parquet metadata for a single file."""
+    """Parquet metadata for a single file.
+
+    Warnings
+    --------
+    Do not call this class's constructor directly."""
+
+    def __init__(self):
+        raise TypeError("FileMetaData is not supposed to be instantiated directly,"
+                        "but be used through the metadata attribute of ParquetReader and ParquetWriter.")
 
     def __cinit__(self):
         pass
@@ -1516,7 +1551,9 @@ cdef class ParquetReader(_Weakrefable):
         # Set up metadata
         with nogil:
             c_metadata = builder.raw_reader().metadata()
-        self._metadata = result = FileMetaData()
+
+        cdef FileMetaData result = FileMetaData.__new__(FileMetaData)
+        self._metadata = result
         result.init(c_metadata)
 
         if read_dictionary is not None:
@@ -2259,7 +2296,7 @@ cdef class ParquetWriter(_Weakrefable):
         with nogil:
             metadata = self.writer.get().metadata()
         if metadata:
-            result = FileMetaData()
+            result = FileMetaData.__new__(FileMetaData)
             result.init(metadata)
             return result
         raise RuntimeError(

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -794,3 +794,17 @@ def test_column_chunk_key_value_metadata(parquet_test_datadir):
     assert key_value_metadata1 == {b'foo': b'bar', b'thisiskeywithoutvalue': b''}
     key_value_metadata2 = metadata.row_group(0).column(1).metadata
     assert key_value_metadata2 is None
+
+
+def test_class_methods_instantiation():
+    with pytest.raises(TypeError):
+        _ = pq.Statistics()
+
+    with pytest.raises(TypeError):
+        _ = pq.FileMetaData()
+
+    with pytest.raises(TypeError):
+        _ = pq.ColumnChunkMetaData()
+
+    with pytest.raises(TypeError):
+        _ = pq.ParquetLogicalType()


### PR DESCRIPTION
disallows direct instantation of classes Statistics, FileMetadata, ColumnChunkMetadta, ParquetLogicalType; Reserved to be called from inside _parquet.pyx

Also solves issue GH-40081

Previously a `segmentation fault` would be produced when trying to instantiate these classes directly, now it raises a TypeError.

Include tests on python/pyarrow/tests/parquet/test_metadata.py

* GitHub Issue: #36628