### PR TITLE
GH-44246: [JS] Add a lightweight array view to Table

### DIFF
--- a/js/perf/index.ts
+++ b/js/perf/index.ts
@@ -205,6 +205,10 @@ for (const { name, table, counts } of config) {
             table.toArray();
         }),
 
+        b.add(`toArrayView, dataset: ${name}, numRows: ${formatNumber(table.numRows)}`, () => {
+            table.toArrayView();
+        }),
+
         b.add(`get, dataset: ${name}, numRows: ${formatNumber(table.numRows)}`, () => {
             for (let i = -1, n = table.numRows; ++i < n;) {
                 table.get(i);

--- a/js/src/row/struct.ts
+++ b/js/src/row/struct.ts
@@ -39,7 +39,7 @@ export class StructRow<T extends TypeMap = any> {
     constructor(parent: Data<Struct<T>>, rowIndex: number) {
         this[kParent] = parent;
         this[kRowIndex] = rowIndex;
-        return new Proxy(this, new StructRowProxyHandler());
+        return new Proxy(this, structRowProxyHandler);
     }
 
     public toArray() { return Object.values(this.toJSON()); }
@@ -157,3 +157,5 @@ class StructRowProxyHandler<T extends TypeMap = any> implements ProxyHandler<Str
         return false;
     }
 }
+
+const structRowProxyHandler = new StructRowProxyHandler();

--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -238,7 +238,7 @@ export class Table<T extends TypeMap = any> {
      *
      * @returns An Array of Table rows.
      */
-    public toArray(): Array<Struct<T>['TValue']> {
+    public toArray() {
         return [...this];
     }
 
@@ -251,7 +251,7 @@ export class Table<T extends TypeMap = any> {
      *
      * @returns An Array proxy to the Table rows.
      */
-    public toArrayView(): Array<Struct<T>['TValue']> {
+    public toArrayView() {
         return new Proxy([] as Array<Struct<T>['TValue']>, new TableArrayProxyHandler(this));
     }
 

--- a/js/test/unit/table/table-test.ts
+++ b/js/test/unit/table/table-test.ts
@@ -79,3 +79,61 @@ describe('tableFromJSON()', () => {
         expect(table.getChild('c')!.type).toBeInstanceOf(Dictionary);
     });
 });
+
+describe('table views', () => {
+    const table = tableFromJSON([{
+        a: 42,
+        b: true,
+        c: 'foo',
+    }, {
+        a: 12,
+        b: false,
+        c: 'bar',
+    }]);
+
+    function checkArrayValues(arr: Array<any>) {
+        expect(arr).toHaveLength(2);
+        expect(arr[0].a).toBe(42);
+        expect(arr[0].b).toBe(true);
+        expect(arr[0].c).toBe('foo');
+        expect(arr[1].a).toBe(12);
+        expect(arr[1].b).toBe(false);
+        expect(arr[1].c).toBe('bar');
+    }
+
+    function checkArray(arr: Array<any>) {
+        test('Wrapper', () => checkArrayValues(arr));
+
+        test('Iterator', () => {
+            const arr2 = [];
+            for (let item of arr) {
+                arr2.push(item);
+            }
+            checkArrayValues(arr);
+        });
+
+        test('Array index', () => {
+            const arr2 = new Array(arr.length);
+            for (let i = 0; i < arr2.length; i++) {
+                arr2[i] = arr[i];
+            }
+            checkArrayValues(arr2);
+        });
+
+        test('Keys', () => {
+            const arr2: any[] = new Array(arr.length);
+            let keys = Object.keys(arr);
+            for (let k in keys) {
+                arr2[k] = arr[k];
+            }
+            checkArrayValues(arr2);
+        });
+    }
+
+    describe('table.toArray()', () => {
+        checkArray(table.toArray());
+    });
+    describe('table.toArrayView()', () => {
+        checkArray(table.toArrayView());
+    });
+});


### PR DESCRIPTION
### Rationale for this change

`Table.toArray()` provides the convenience of using Arrow tables as common object arrays. However it does allocate an array of the size of the table that hold proxies to the table rows. This array can consume a significant amount of memory with large tables.

Providing an array proxy that wraps the table and creates struct row proxies on demand would avoid this and provide a object array view on top of a table at almost zero memory cost.

### What changes are included in this PR?

This PR adds a new `Table.toArrayView()` method that returns an array proxy to the table rows.

It complements `Table.toArray()` and doesn't replace it for the following reasons:
* this is a read-only view, while `toArray()` returns a plain mutable array. Replacing it would be a breaking change.
* the proxy adds some overhead to direct array access. Tests on iterator loops show that access via the array proxy takes 5 more time than direct array access. This can be a concern for some applications, even if it should generally be negligible, and if applications seeking maximum performance should avoid using these convenience wrappers.

Also fixes apache/arrow#30863 by using a singleton proxy handler for `StructRowProxyHandler`, which further reduces memory usage.

### Are these changes tested?

Yes. New tests are added to `js/test/unit/table/table-test.ts` for both `toArrayView()` and `toArray()` that was not tested.

### Are there any user-facing changes?

This adds a new `Table.toArrayView()` method.

* GitHub Issue: apache/arrow-js#48
* GitHub Issue: #48