### PR TITLE
GH-44253: [CI][Release][Python] Do not verify Python on Ubuntu 20.04

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -922,6 +922,9 @@ tasks:
                     "js",
                     "python",
                     "ruby"] %}
+    # Skip verification for python and integration on Ubuntu 20.04
+    # GH-44253. Remove once we drop support for 20.04
+    {% if not (target in ["python", "integration"] and version == "20.04") %}
   verify-rc-source-{{ target }}-linux-{{ distribution }}-{{ version }}-amd64:
     ci: github
     template: verify-rc/github.linux.amd64.docker.yml
@@ -930,15 +933,20 @@ tasks:
         {{ distribution.upper() }}: "{{ version }}"
       target: {{ target }}
       distro: {{ distribution }}
+    {% endif %}
   {% endfor %}
 
   {% for target in ["jars", "wheels"] %}
+    # Skip verification for wheels on Ubuntu 20.04
+    # GH-44253. Remove once we drop support for 20.04
+    {% if not (target == "wheels" and version == "20.04") %}
   verify-rc-binaries-{{ target }}-linux-{{ distribution }}-{{ version }}-amd64:
     ci: github
     template: verify-rc/github.linux.amd64.docker.yml
     params:
       target: {{ target }}
       distro: {{ distribution }}
+    {% endif %}
   {% endfor %}
 
 {% endfor %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -914,8 +914,7 @@ tasks:
 {% for distribution, version in [("conda", "latest"),
                                  ("almalinux", "8"),
                                  ("ubuntu", "20.04"),
-                                 ("ubuntu", "22.04"),
-                                 ("ubuntu", "24.04")] %}
+                                 ("ubuntu", "22.04")] %}
   {% for target in ["cpp",
                     "csharp",
                     "integration",

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -914,7 +914,8 @@ tasks:
 {% for distribution, version in [("conda", "latest"),
                                  ("almalinux", "8"),
                                  ("ubuntu", "20.04"),
-                                 ("ubuntu", "22.04")] %}
+                                 ("ubuntu", "22.04"),
+                                 ("ubuntu", "24.04")] %}
   {% for target in ["cpp",
                     "csharp",
                     "integration",


### PR DESCRIPTION
### Rationale for this change
Python 3.8 is no longer supported for Pyarrow. Ubuntu 20.04 ships with Python 3.8

### What changes are included in this PR?

Remove verification checks on Ubuntu 20.04

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #44253