### PR TITLE
MINOR: [C#] Target net472 with Flight instead of net462

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Server/GrpcCoreFlightServerExtensions.cs
+++ b/csharp/src/Apache.Arrow.Flight/Server/GrpcCoreFlightServerExtensions.cs
@@ -1,4 +1,19 @@
-﻿#if NET46_OR_GREATER
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if NET46_OR_GREATER
 
 using Apache.Arrow.Flight.Protocol;
 using Apache.Arrow.Flight.Server.Internal;


### PR DESCRIPTION
### Rationale for this change

.NET 4.6.2 is not really netstandard2.0-compatible; it works, but only by bringing in a ridiculous number of facade assemblies. The downlevel web server support for gPRC falls into this category, so bump the required version for Flight from 462 to 472.

### What changes are included in this PR?

Changes the targeting of the build for the C# Arrow Flight support.

### Are these changes tested?

N/A

### Are there any user-facing changes?

The underlying feature is first shipping in Arrow 18 so existing users are unaffected.