### PR TITLE
MINOR: [C#] Fix Flight to target net472 intead of net462

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Apache.Arrow.Flight.csproj
+++ b/csharp/src/Apache.Arrow.Flight/Apache.Arrow.Flight.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
     <PackageReference Include="Grpc.Core" Version="2.46.6" />
   </ItemGroup>
 

--- a/csharp/src/Apache.Arrow.Flight/Server/GrpcCoreFlightServerExtensions.cs
+++ b/csharp/src/Apache.Arrow.Flight/Server/GrpcCoreFlightServerExtensions.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NET46_OR_GREATER
+#if NET47_OR_GREATER
 
 using Apache.Arrow.Flight.Protocol;
 using Apache.Arrow.Flight.Server.Internal;


### PR DESCRIPTION
### Rationale for this change

.NET 4.6.2 is not really netstandard2.0-compatible; it works, but only by bringing in a ridiculous number of facade assemblies. The downlevel web server support for gPRC falls into this category, so bump the required version for Flight from 462 to 472.

### What changes are included in this PR?

Changes the targeting of the build for the C# Arrow Flight support.

### Are these changes tested?

N/A

### Are there any user-facing changes?

The underlying feature is first shipping in Arrow 18 so existing users are unaffected.