### PR TITLE
GH-44268: [Release][Ruby][CI] Pin version of glib used in verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -831,6 +831,8 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
+  # We can remove '==2.80.5' once https://github.com/conda-forge/glib-feedstock/issues/191
+  # is fixed.
   maybe_setup_conda glib==2.80.5 gobject-introspection meson ninja ruby
   maybe_setup_virtualenv meson
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -831,7 +831,7 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
-  maybe_setup_conda glib gobject-introspection meson ninja ruby
+  maybe_setup_conda glib==2.80.5 gobject-introspection meson ninja ruby
   maybe_setup_virtualenv meson
 
   # Install bundler if doesn't exist


### PR DESCRIPTION
### Rationale for this change

Fixes failing verification task for ruby+conda, see https://github.com/apache/arrow/issues/44268. cc @raulcd 

### What changes are included in this PR?

It looks like the proximate cause of the failure was a buggy release of glib (2.82.1) on conda-forge, see https://github.com/conda-forge/glib-feedstock/issues/191. Pinning the version of glib we install inside the verification script to the previous version seems to work (verification passes locally now). Once the glib feedstock pushes a new release with the fix we can unpin this.

### Are these changes tested?

Yes, locally under docker.

### Are there any user-facing changes?

No.
* GitHub Issue: #44268