### PR TITLE
GH-44269: [C++][FS][Azure] Catch missing exceptions on HNS support check

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -295,7 +295,7 @@ std::string BuildBaseUrl(const std::string& scheme, const std::string& authority
 }
 
 template <typename... PrefixArgs>
-Status ExceptionToStatus(const Storage::StorageException& exception,
+Status ExceptionToStatus(const Azure::Core::RequestFailedException& exception,
                          PrefixArgs&&... prefix_args) {
   return Status::IOError(std::forward<PrefixArgs>(prefix_args)..., " Azure Error: [",
                          exception.ErrorCode, "] ", exception.what());
@@ -1401,6 +1401,13 @@ Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
                                  "Check for Hierarchical Namespace support on '",
                                  adlfs_client.GetUrl(), "' failed.");
     }
+  } catch (const Azure::Core::Http::TransportException& exception) {
+    return ExceptionToStatus(exception, "Check for Hierarchical Namespace support on '",
+                             adlfs_client.GetUrl(), "' failed.");
+  } catch (const std::exception& exception) {
+    return Status::UnknownError(
+        "Check for Hierarchical Namespace support on '", adlfs_client.GetUrl(),
+        "' failed: ", typeid(exception).name(), ": ", exception.what());
   }
 }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -2322,6 +2322,24 @@ TYPED_TEST(TestAzureFileSystemOnAllScenarios, MovePath) { this->TestMovePath(); 
 
 // Tests using Azurite (the local Azure emulator)
 
+TEST_F(TestAzuriteFileSystem, CheckIfHierarchicalNamespaceIsEnabledRuntimeError) {
+  ASSERT_OK(options_.ConfigureAccountKeyCredential("not-base64"));
+  ASSERT_OK_AND_ASSIGN(auto datalake_service_client,
+                       options_.MakeDataLakeServiceClient());
+  auto adlfs_client = datalake_service_client->GetFileSystemClient("nonexistent");
+  ASSERT_RAISES(UnknownError,
+                internal::CheckIfHierarchicalNamespaceIsEnabled(adlfs_client, options_));
+}
+
+TEST_F(TestAzuriteFileSystem, CheckIfHierarchicalNamespaceIsEnabledTransportError) {
+  options_.dfs_storage_authority = "127.0.0.1:20000";  // Wrong port
+  ASSERT_OK_AND_ASSIGN(auto datalake_service_client,
+                       options_.MakeDataLakeServiceClient());
+  auto adlfs_client = datalake_service_client->GetFileSystemClient("nonexistent");
+  ASSERT_RAISES(IOError,
+                internal::CheckIfHierarchicalNamespaceIsEnabled(adlfs_client, options_));
+}
+
 TEST_F(TestAzuriteFileSystem, GetFileInfoSelector) {
   SetUpSmallFileSystemTree();
 


### PR DESCRIPTION
### Rationale for this change

`Azure::Storage::Files::DataLake::DataLakeDirectoryClient` may throw `Azure::Core::Http::TransportException` and `std::runtime_error` exceptions but they aren't caught. Arrow C++ uses `arrow::Status` not C++ exception. So we must catch all exceptions from Azure SDK for C++.

### What changes are included in this PR?

Add catches `Azure::Core::Http::TransportException` and `std::exception`. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44269