### PR TITLE
GH-44277: [CI] Use Miniforge instead of Mambaforge

### DIFF
--- a/ci/docker/conda.dockerfile
+++ b/ci/docker/conda.dockerfile
@@ -25,9 +25,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# install conda and mamba via mambaforge
+# install conda and mamba via miniforge
 COPY ci/scripts/install_conda.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_conda.sh mambaforge latest /opt/conda
+RUN /arrow/ci/scripts/install_conda.sh miniforge3 latest /opt/conda
 ENV PATH=/opt/conda/bin:$PATH
 
 # create a conda environment

--- a/ci/scripts/install_conda.sh
+++ b/ci/scripts/install_conda.sh
@@ -20,7 +20,7 @@
 set -e
 
 if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <installer: miniforge or mambaforge> <version> <prefix>"
+  echo "Usage: $0 <installer: miniforge3> <version> <prefix>"
   exit 1
 fi
 
@@ -30,8 +30,11 @@ installer=$1
 version=$2
 prefix=$3
 
-echo "Downloading Miniconda installer..."
-wget -nv https://github.com/conda-forge/miniforge/releases/latest/download/${installer^}-${platform}-${arch}.sh -O /tmp/installer.sh
+download_url=https://github.com/conda-forge/miniforge/releases/latest/download/${installer^}-${platform}-${arch}.sh
+
+echo "Downloading Miniconda installer from ${download_url} ..."
+
+wget -nv ${download_url} -O /tmp/installer.sh
 bash /tmp/installer.sh -b -p ${prefix}
 rm /tmp/installer.sh
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -441,7 +441,7 @@ install_go() {
 install_conda() {
   # Setup short-lived miniconda for Python and integration tests
   show_info "Ensuring that Conda is installed..."
-  local prefix=$ARROW_TMPDIR/mambaforge
+  local prefix=$ARROW_TMPDIR/miniforge
 
   # Setup miniconda only if the directory doesn't exist yet
   if [ "${CONDA_ALREADY_INSTALLED:-0}" -eq 0 ]; then
@@ -449,7 +449,7 @@ install_conda() {
       show_info "Installing miniconda at ${prefix}..."
       local arch=$(uname -m)
       local platform=$(uname)
-      local url="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-${platform}-${arch}.sh"
+      local url="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${platform}-${arch}.sh"
       curl -sL -o miniconda.sh $url
       bash miniconda.sh -b -p $prefix
       rm -f miniconda.sh

--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -19,7 +19,7 @@ jobs:
         scriptSource: inline
         script: |
           import urllib.request
-          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Windows-x86_64.exe'
+          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe'
           path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
           urllib.request.urlretrieve(url, path)
 

--- a/python/examples/minimal_build/build_conda.sh
+++ b/python/examples/minimal_build/build_conda.sh
@@ -34,7 +34,7 @@ git config --global --add safe.directory $ARROW_ROOT
 # Run these only once
 
 function setup_miniconda() {
-  MINICONDA_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh"
+  MINICONDA_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"
   wget -O miniconda.sh $MINICONDA_URL
   bash miniconda.sh -b -p $MINICONDA
   rm -f miniconda.sh


### PR DESCRIPTION
Mambaforge is being deprecated upstream in favor of Miniforge: https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

* GitHub Issue: #44277