### PR TITLE
GH-32276: [C++][FlightRPC] Add option to align RecordBatch buffers given to IPC reader

### DIFF
--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -31,7 +31,6 @@
 #include "arrow/type_fwd.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/macros.h"
-#include "arrow/util/range.h"
 #include "arrow/util/span.h"
 #include "arrow/util/visibility.h"
 
@@ -234,21 +233,6 @@ struct ARROW_EXPORT ArrayData {
       return !internal::IsNullRunEndEncoded(*this, i);
     }
     return null_count.load() != length;
-  }
-
-  Status AlignBuffers() {
-    // align buffers according to their data type's layout
-    for (auto&& [buffer, layout] : internal::Zip(buffers, type->layout().buffers)) {
-      if (layout.kind == DataTypeLayout::FIXED_WIDTH &&
-          buffer->address() % layout.byte_width) {
-        RETURN_NOT_OK(Buffer::Copy(buffer, buffer->memory_manager()).Value(&buffer));
-      }
-    }
-    // align children data recursively
-    for (const auto& child : child_data) {
-      RETURN_NOT_OK(child->AlignBuffers());
-    }
-    return Status::OK();
   }
 
   /// \brief Access a buffer's data as a typed C pointer

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <arrow/util/range.h>
 #include <atomic>  // IWYU pragma: export
 #include <cassert>
 #include <cstdint>
@@ -32,6 +31,7 @@
 #include "arrow/type_fwd.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/range.h"
 #include "arrow/util/span.h"
 #include "arrow/util/visibility.h"
 
@@ -245,8 +245,8 @@ struct ARROW_EXPORT ArrayData {
       }
     }
     // align children data recursively
-    for (unsigned int i = 0; i < child_data.size(); i++) {
-      RETURN_NOT_OK(child_data[i]->AlignBuffers());
+    for (const auto& child : child_data) {
+      RETURN_NOT_OK(child->AlignBuffers());
     }
     return Status::OK();
   }

--- a/cpp/src/arrow/flight/integration_tests/flight_integration_test.cc
+++ b/cpp/src/arrow/flight/integration_tests/flight_integration_test.cc
@@ -53,6 +53,8 @@ TEST(FlightIntegration, AuthBasicProto) { ASSERT_OK(RunScenario("auth:basic_prot
 
 TEST(FlightIntegration, Middleware) { ASSERT_OK(RunScenario("middleware")); }
 
+TEST(FlightIntegration, Alignment) { ASSERT_OK(RunScenario("alignment")); }
+
 TEST(FlightIntegration, Ordered) { ASSERT_OK(RunScenario("ordered")); }
 
 TEST(FlightIntegration, ExpirationTimeDoGet) {

--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -294,7 +294,8 @@ class AlignmentServer : public FlightServerBase {
                        const FlightDescriptor& descriptor,
                        std::unique_ptr<FlightInfo>* result) override {
     auto schema = BuildSchema();
-    std::vector<FlightEndpoint> endpoints{FlightEndpoint{{"foo"}, {}, std::nullopt, ""}};
+    std::vector<FlightEndpoint> endpoints{
+        FlightEndpoint{{"align-data"}, {}, std::nullopt, ""}};
     ARROW_ASSIGN_OR_RAISE(
         auto info, FlightInfo::Make(*schema, descriptor, endpoints, -1, -1, false));
     *result = std::make_unique<FlightInfo>(info);
@@ -303,7 +304,7 @@ class AlignmentServer : public FlightServerBase {
 
   Status DoGet(const ServerCallContext& context, const Ticket& request,
                std::unique_ptr<FlightDataStream>* stream) override {
-    if (request.ticket != "foo") {
+    if (request.ticket != "align-data") {
       return Status::KeyError("Could not find flight: ", request.ticket);
     }
     auto record_batch = RecordBatchFromJSON(BuildSchema(), R"([

--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -369,9 +369,10 @@ class AlignmentScenario : public Scenario {
   }
 
   Status RunClient(std::unique_ptr<FlightClient> client) override {
-    for (bool ensure_alignment : {true, false}) {
+    for (ipc::Alignment ensure_alignment :
+         {ipc::Alignment::kAnyAlignment, ipc::Alignment::kDataTypeSpecificAlignment}) {
       auto call_options = FlightCallOptions();
-      call_options.read_options.ensure_memory_alignment = ensure_alignment;
+      call_options.read_options.ensure_alignment = ensure_alignment;
       ARROW_ASSIGN_OR_RAISE(auto table, GetTable(client.get(), call_options));
 
       // Check read data
@@ -388,7 +389,7 @@ class AlignmentScenario : public Scenario {
       }
       // Check data alignment
       std::vector<bool> needs_alignment;
-      if (ensure_alignment) {
+      if (ensure_alignment == ipc::Alignment::kDataTypeSpecificAlignment) {
         // with ensure_alignment=true, we require data to be aligned
         if (!util::CheckAlignment(*table, arrow::util::kValueAlignment,
                                   &needs_alignment)) {

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -165,6 +165,8 @@ struct ARROW_EXPORT IpcReadOptions {
   ///
   /// Received mis-aligned data is copied to aligned memory locations allocated via the
   /// MemoryPool configured as \ref arrow::ipc::IpcReadOptions::memory_pool.
+  /// Some use cases might require data to have data type-specific alignment, for example,
+  /// for the data buffer of an Int32 array to be aligned on a 4-byte boundary.
   bool ensure_memory_alignment = false;
 
   /// \brief Options to control caching behavior when pre-buffering is requested

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -131,7 +131,7 @@ struct ARROW_EXPORT IpcWriteOptions {
 /// \brief Alignment of data in memory
 /// Alignment values larger than 0 are taken directly as byte alignment value
 /// See util::EnsureAlignment(..., int64_t alignment, ...)
-enum class Alignment {
+enum class Alignment : int64_t {
   /// \brief data is aligned depending on the actual data type
   kDataTypeSpecificAlignment = -3,  /// arrow::util::kValueAlignment
   /// \brief no particular alignment enforced

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -25,7 +25,7 @@
 #include "arrow/ipc/type_fwd.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
-#include <arrow/util/align_util.h>
+#include "arrow/util/align_util.h"
 #include "arrow/util/compression.h"
 #include "arrow/util/visibility.h"
 

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -129,11 +129,15 @@ struct ARROW_EXPORT IpcWriteOptions {
 };
 
 /// \brief Alignment of data in memory
+/// Alignment values larger than 0 are taken directly as byte alignment value
+/// See util::EnsureAlignment(..., int64_t alignment, ...)
 enum class Alignment {
   /// \brief data is aligned depending on the actual data type
   kDataTypeSpecificAlignment = -3,  /// arrow::util::kValueAlignment
   /// \brief no particular alignment enforced
   kAnyAlignment = 0,
+  /// \brief data is aligned to 64-byte boundary
+  k64ByteAlignment = 64
 };
 
 /// \brief Options for reading Arrow IPC messages
@@ -173,7 +177,7 @@ struct ARROW_EXPORT IpcReadOptions {
   ///
   /// Data is copied to aligned memory locations allocated via the
   /// MemoryPool configured as \ref arrow::ipc::IpcReadOptions::memory_pool.
-  /// Some use cases might require data to have data type-specific alignment, for example,
+  /// Some use cases might require data to have a specific alignment, for example,
   /// for the data buffer of an Int32 array to be aligned on a 4-byte boundary.
   ///
   /// Default (kAnyAlignment) keeps the alignment as is, so no copy of data occurs.

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -161,6 +161,11 @@ struct ARROW_EXPORT IpcReadOptions {
   /// RecordBatchStreamReader and StreamDecoder classes.
   bool ensure_native_endian = true;
 
+  /// \brief Whether to align incoming data if mis-aligned
+  ///
+  /// Received mis-aligned data is copied to aligned memory locations.
+  bool ensure_memory_alignment = true;
+
   /// \brief Options to control caching behavior when pre-buffering is requested
   ///
   /// The lazy property will always be reset to true to deliver the expected behavior

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -128,6 +128,14 @@ struct ARROW_EXPORT IpcWriteOptions {
   static IpcWriteOptions Defaults();
 };
 
+/// \brief Alignment of data in memory
+enum class Alignment {
+  /// \brief data is aligned depending on the actual data type
+  kDataTypeSpecificAlignment = -3,  /// arrow::util::kValueAlignment
+  /// \brief no particular alignment enforced
+  kAnyAlignment = 0,
+};
+
 /// \brief Options for reading Arrow IPC messages
 struct ARROW_EXPORT IpcReadOptions {
   /// \brief The maximum permitted schema nesting depth.
@@ -161,13 +169,15 @@ struct ARROW_EXPORT IpcReadOptions {
   /// RecordBatchStreamReader and StreamDecoder classes.
   bool ensure_native_endian = true;
 
-  /// \brief Whether to align incoming data if mis-aligned
+  /// \brief How to align data if mis-aligned
   ///
-  /// Received mis-aligned data is copied to aligned memory locations allocated via the
+  /// Data is copied to aligned memory locations allocated via the
   /// MemoryPool configured as \ref arrow::ipc::IpcReadOptions::memory_pool.
   /// Some use cases might require data to have data type-specific alignment, for example,
   /// for the data buffer of an Int32 array to be aligned on a 4-byte boundary.
-  bool ensure_memory_alignment = false;
+  ///
+  /// Default (kAnyAlignment) keeps the alignment as is, so no copy of data occurs.
+  Alignment ensure_alignment = Alignment::kAnyAlignment;
 
   /// \brief Options to control caching behavior when pre-buffering is requested
   ///

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -163,8 +163,9 @@ struct ARROW_EXPORT IpcReadOptions {
 
   /// \brief Whether to align incoming data if mis-aligned
   ///
-  /// Received mis-aligned data is copied to aligned memory locations.
-  bool ensure_memory_alignment = true;
+  /// Received mis-aligned data is copied to aligned memory locations allocated via the
+  /// MemoryPool configured as \ref arrow::ipc::IpcReadOptions::memory_pool.
+  bool ensure_memory_alignment = false;
 
   /// \brief Options to control caching behavior when pre-buffering is requested
   ///

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -25,6 +25,7 @@
 #include "arrow/ipc/type_fwd.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
+#include <arrow/util/align_util.h>
 #include "arrow/util/compression.h"
 #include "arrow/util/visibility.h"
 
@@ -133,7 +134,7 @@ struct ARROW_EXPORT IpcWriteOptions {
 /// See util::EnsureAlignment(..., int64_t alignment, ...)
 enum class Alignment : int64_t {
   /// \brief data is aligned depending on the actual data type
-  kDataTypeSpecificAlignment = -3,  /// arrow::util::kValueAlignment
+  kDataTypeSpecificAlignment = util::kValueAlignment,
   /// \brief no particular alignment enforced
   kAnyAlignment = 0,
   /// \brief data is aligned to 64-byte boundary

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -601,6 +601,9 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
         return Status::IOError("Array length did not match record batch length");
       }
       columns[i] = std::move(column);
+      if (context.options.ensure_memory_alignment) {
+        RETURN_NOT_OK(columns[i]->AlignBuffers());
+      }
       if (inclusion_mask) {
         filtered_columns.push_back(columns[i]);
         filtered_fields.push_back(schema->field(i));

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -640,7 +640,7 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
   auto batch = RecordBatch::Make(std::move(filtered_schema), metadata->length(),
     std::move(filtered_columns));
   if (context.options.ensure_memory_alignment) {
-    return util::EnsureAlignment(batch, arrow::util::kValueAlignment, default_memory_pool());
+    return util::EnsureAlignment(batch, arrow::util::kValueAlignment, context.options.memory_pool);
   }
   return batch;
 }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -638,9 +638,10 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
     }
   }
   auto batch = RecordBatch::Make(std::move(filtered_schema), metadata->length(),
-    std::move(filtered_columns));
+                                 std::move(filtered_columns));
   if (context.options.ensure_memory_alignment) {
-    return util::EnsureAlignment(batch, arrow::util::kValueAlignment, context.options.memory_pool);
+    return util::EnsureAlignment(batch, arrow::util::kValueAlignment,
+                                 context.options.memory_pool);
   }
   return batch;
 }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -639,11 +639,13 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
   }
   auto batch = RecordBatch::Make(std::move(filtered_schema), metadata->length(),
                                  std::move(filtered_columns));
-  if (context.options.ensure_memory_alignment) {
-    return util::EnsureAlignment(batch, arrow::util::kValueAlignment,
-                                 context.options.memory_pool);
+
+  if (context.options.ensure_alignment == Alignment::kAnyAlignment) {
+    return batch;
   }
-  return batch;
+  return util::EnsureAlignment(batch,
+                               static_cast<int64_t>(context.options.ensure_alignment),
+                               context.options.memory_pool);
 }
 
 Result<std::shared_ptr<RecordBatch>> LoadRecordBatch(

--- a/cpp/src/arrow/util/align_util.cc
+++ b/cpp/src/arrow/util/align_util.cc
@@ -49,7 +49,7 @@ Type::type GetTypeForBuffers(const ArrayData& array) {
   if (type_id == Type::DICTIONARY) {
     // return index type id, provided by the DictionaryType array.type or
     // array.type->storage_type() if array.type is an ExtensionType
-    const std::shared_ptr<DataType>& dict_type = array.type;
+    std::shared_ptr<DataType> dict_type = array.type;
     if (array.type->id() == Type::EXTENSION) {
       dict_type = checked_pointer_cast<ExtensionType>(array.type)->storage_type();
     }

--- a/cpp/src/arrow/util/align_util.cc
+++ b/cpp/src/arrow/util/align_util.cc
@@ -49,7 +49,7 @@ Type::type GetTypeForBuffers(const ArrayData& array) {
   if (type_id == Type::DICTIONARY) {
     // return index type id, provided by the DictionaryType array.type or
     // array.type->storage_type() if array.type is an ExtensionType
-    std::shared_ptr<DataType> dict_type = array.type;
+    const std::shared_ptr<DataType>& dict_type = array.type;
     if (array.type->id() == Type::EXTENSION) {
       dict_type = checked_pointer_cast<ExtensionType>(array.type)->storage_type();
     }

--- a/cpp/src/arrow/util/align_util.cc
+++ b/cpp/src/arrow/util/align_util.cc
@@ -49,11 +49,11 @@ Type::type GetTypeForBuffers(const ArrayData& array) {
   if (type_id == Type::DICTIONARY) {
     // return index type id, provided by the DictionaryType array.type or
     // array.type->storage_type() if array.type is an ExtensionType
-    std::shared_ptr<DataType> dict_type = array.type;
+    DataType* dict_type = array.type.get();
     if (array.type->id() == Type::EXTENSION) {
-      dict_type = checked_pointer_cast<ExtensionType>(array.type)->storage_type();
+      dict_type = dynamic_cast<ExtensionType*>(dict_type)->storage_type().get();
     }
-    return checked_pointer_cast<DictionaryType>(dict_type)->index_type()->id();
+    return dynamic_cast<DictionaryType*>(dict_type)->index_type()->id();
   }
   return type_id;
 }

--- a/cpp/src/arrow/util/align_util.cc
+++ b/cpp/src/arrow/util/align_util.cc
@@ -29,7 +29,7 @@
 
 namespace arrow {
 
-using internal::checked_pointer_cast;
+using internal::checked_cast;
 
 namespace util {
 
@@ -51,9 +51,9 @@ Type::type GetTypeForBuffers(const ArrayData& array) {
     // array.type->storage_type() if array.type is an ExtensionType
     DataType* dict_type = array.type.get();
     if (array.type->id() == Type::EXTENSION) {
-      dict_type = dynamic_cast<ExtensionType*>(dict_type)->storage_type().get();
+      dict_type = checked_cast<ExtensionType*>(dict_type)->storage_type().get();
     }
-    return dynamic_cast<DictionaryType*>(dict_type)->index_type()->id();
+    return checked_cast<DictionaryType*>(dict_type)->index_type()->id();
   }
   return type_id;
 }

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -246,8 +246,8 @@ on a 4-byte boundary), which can be enforced
 by setting :member:`arrow::ipc::IpcReadOptions::ensure_alignment`
 to :member:`arrow::ipc::Alignment::kDataTypeSpecificAlignment`.
 This uses the :member:`arrow::ipc::IpcReadOptions::memory_pool`
-to a allocate memory with aligned addresses, but only for mis-alligned data.
-However, this creates data copies of your data recieved via Flight.
+to allocate memory with aligned addresses, but only for mis-aligned data.
+However, this creates data copies of your data received via Flight.
 
 Unless gRPC data are copied as described above, allocations made by gRPC may not
 be tracked by the Arrow memory pool, and that memory usage behavior,

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -239,7 +239,16 @@ Memory management
 -----------------
 
 Flight tries to reuse allocations made by gRPC to avoid redundant
-data copies. However, this means that those allocations may not
+data copies. Experience shows that Arrow data in those allocations are not
+found at aligned addresses. Some Flight client use cases may require `data alignment`_,
+which can be enforced by setting :member:`arrow::ipc::IpcReadOptions::ensure_memory_alignment`
+to ``true``. This uses the :member:`arrow::ipc::IpcReadOptions::memory_pool`
+to a allocate memory with aligned addresses, but only for mis-alligned data.
+However, this creates data copies of your data recieved via Flight.
+
+.. note:: Ensuring memory alignment is not supported for non-CPU Flight data.
+
+Unless gRPC data are copied as described above, allocations made by gRPC may not
 be tracked by the Arrow memory pool, and that memory usage behavior,
 such as whether free memory is returned to the system, is dependent
 on the allocator that gRPC uses (usually the system allocator).
@@ -361,5 +370,5 @@ Closing unresponsive connections
 .. _ARROW-15764: https://issues.apache.org/jira/browse/ARROW-15764
 .. _ARROW-16697: https://issues.apache.org/jira/browse/ARROW-16697
 .. _ARROW-6062: https://issues.apache.org/jira/browse/ARROW-6062
-
+.. _data alignment: https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
 .. _gRPC: https://grpc.io/

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -239,9 +239,11 @@ Memory management
 -----------------
 
 Flight tries to reuse allocations made by gRPC to avoid redundant
-data copies. Experience shows that Arrow data in those allocations are not
-found at aligned addresses. Some Flight client use cases may require `data alignment`_,
-which can be enforced by setting :member:`arrow::ipc::IpcReadOptions::ensure_memory_alignment`
+data copies. However, experience shows that such data is frequently
+misaligned. Some use cases might require data to have data type-specific
+alignment (for example, for the data buffer of an Int32 array to be aligned
+on a 4-byte boundary), which can be enforced
+by setting :member:`arrow::ipc::IpcReadOptions::ensure_memory_alignment`
 to ``true``. This uses the :member:`arrow::ipc::IpcReadOptions::memory_pool`
 to a allocate memory with aligned addresses, but only for mis-alligned data.
 However, this creates data copies of your data recieved via Flight.
@@ -370,5 +372,4 @@ Closing unresponsive connections
 .. _ARROW-15764: https://issues.apache.org/jira/browse/ARROW-15764
 .. _ARROW-16697: https://issues.apache.org/jira/browse/ARROW-16697
 .. _ARROW-6062: https://issues.apache.org/jira/browse/ARROW-6062
-.. _data alignment: https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding
 .. _gRPC: https://grpc.io/

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -249,8 +249,6 @@ This uses the :member:`arrow::ipc::IpcReadOptions::memory_pool`
 to a allocate memory with aligned addresses, but only for mis-alligned data.
 However, this creates data copies of your data recieved via Flight.
 
-.. note:: Ensuring memory alignment is not supported for non-CPU Flight data.
-
 Unless gRPC data are copied as described above, allocations made by gRPC may not
 be tracked by the Arrow memory pool, and that memory usage behavior,
 such as whether free memory is returned to the system, is dependent

--- a/docs/source/cpp/flight.rst
+++ b/docs/source/cpp/flight.rst
@@ -243,8 +243,9 @@ data copies. However, experience shows that such data is frequently
 misaligned. Some use cases might require data to have data type-specific
 alignment (for example, for the data buffer of an Int32 array to be aligned
 on a 4-byte boundary), which can be enforced
-by setting :member:`arrow::ipc::IpcReadOptions::ensure_memory_alignment`
-to ``true``. This uses the :member:`arrow::ipc::IpcReadOptions::memory_pool`
+by setting :member:`arrow::ipc::IpcReadOptions::ensure_alignment`
+to :member:`arrow::ipc::Alignment::kDataTypeSpecificAlignment`.
+This uses the :member:`arrow::ipc::IpcReadOptions::memory_pool`
 to a allocate memory with aligned addresses, but only for mis-alligned data.
 However, this creates data copies of your data recieved via Flight.
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1880,6 +1880,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         vector[int] included_fields
         c_bool use_threads
         c_bool ensure_native_endian
+        c_bool ensure_memory_alignment
 
         @staticmethod
         CIpcReadOptions Defaults()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1877,6 +1877,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     ctypedef enum CAlignment" arrow::ipc::Alignment":
         CAlignment_Any" arrow::ipc::Alignment::kAnyAlignment"
         CAlignment_DataTypeSpecific" arrow::ipc::Alignment::kDataTypeSpecificAlignment"
+        CAlignment_64Byte" arrow::ipc::Alignment::k64ByteAlignment"
 
     cdef cppclass CIpcReadOptions" arrow::ipc::IpcReadOptions":
         int max_recursion_depth

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1874,13 +1874,17 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         @staticmethod
         CIpcWriteOptions Defaults()
 
+    ctypedef enum CAlignment" arrow::ipc::Alignment":
+        CAlignment_Any" arrow::ipc::Alignment::kAnyAlignment"
+        CAlignment_DataTypeSpecific" arrow::ipc::Alignment::kDataTypeSpecificAlignment"
+
     cdef cppclass CIpcReadOptions" arrow::ipc::IpcReadOptions":
         int max_recursion_depth
         CMemoryPool* memory_pool
         vector[int] included_fields
         c_bool use_threads
         c_bool ensure_native_endian
-        c_bool ensure_memory_alignment
+        CAlignment ensure_alignment
 
         @staticmethod
         CIpcReadOptions Defaults()

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -120,7 +120,7 @@ cdef class IpcReadOptions(_Weakrefable):
     ----------
     ensure_native_endian : bool, default True
         Whether to convert incoming data to platform-native endianness.
-    ensure_memory_alignment : bool, default True
+    ensure_memory_alignment : bool, default False
         Whether to align incoming data to data type-specific alignment, if mis-aligned.
         Some use cases might require data to have data type-specific alignment, for example,
         for the data buffer of an int32 array to be aligned on a 4-byte boundary.
@@ -137,7 +137,7 @@ cdef class IpcReadOptions(_Weakrefable):
     # cdef block is in lib.pxd
 
     def __init__(self, *, bint ensure_native_endian=True,
-                 bint ensure_memory_alignment=True,
+                 bint ensure_memory_alignment=False,
                  bint use_threads=True, list included_fields=None):
         self.c_options = CIpcReadOptions.Defaults()
         self.ensure_native_endian = ensure_native_endian

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -49,13 +49,13 @@ cdef CMetadataVersion _unwrap_metadata_version(
 
 
 cpdef enum Alignment:
-    Any = <int8_t> CAlignment_Any
-    DataTypeSpecific = <int8_t> CAlignment_DataTypeSpecific
-    At64Byte = <int8_t> CAlignment_64Byte
+    Any = <int64_t> CAlignment_Any
+    DataTypeSpecific = <int64_t> CAlignment_DataTypeSpecific
+    At64Byte = <int64_t> CAlignment_64Byte
 
 
 cdef object _wrap_alignment(CAlignment alignment):
-    return Alignment(<char> alignment)
+    return Alignment(<int64_t> alignment)
 
 
 cdef CAlignment _unwrap_alignment(Alignment alignment) except *:

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -120,6 +120,8 @@ cdef class IpcReadOptions(_Weakrefable):
     ----------
     ensure_native_endian : bool, default True
         Whether to convert incoming data to platform-native endianness.
+    ensure_memory_alignment : bool, default True
+        Whether to align incoming data if mis-aligned.
     use_threads : bool
         Whether to use the global CPU thread pool to parallelize any
         computational tasks like decompression
@@ -133,9 +135,11 @@ cdef class IpcReadOptions(_Weakrefable):
     # cdef block is in lib.pxd
 
     def __init__(self, *, bint ensure_native_endian=True,
+                 bint ensure_memory_alignment=True,
                  bint use_threads=True, list included_fields=None):
         self.c_options = CIpcReadOptions.Defaults()
         self.ensure_native_endian = ensure_native_endian
+        self.ensure_memory_alignment = ensure_memory_alignment
         self.use_threads = use_threads
         if included_fields is not None:
             self.included_fields = included_fields
@@ -147,6 +151,14 @@ cdef class IpcReadOptions(_Weakrefable):
     @ensure_native_endian.setter
     def ensure_native_endian(self, bint value):
         self.c_options.ensure_native_endian = value
+
+    @property
+    def ensure_memory_alignment(self):
+        return self.c_options.ensure_memory_alignment
+
+    @ensure_memory_alignment.setter
+    def ensure_memory_alignment(self, bint value):
+        self.c_options.ensure_memory_alignment = value
 
     @property
     def use_threads(self):

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -121,7 +121,9 @@ cdef class IpcReadOptions(_Weakrefable):
     ensure_native_endian : bool, default True
         Whether to convert incoming data to platform-native endianness.
     ensure_memory_alignment : bool, default True
-        Whether to align incoming data if mis-aligned.
+        Whether to align incoming data to data type-specific alignment, if mis-aligned.
+        Some use cases might require data to have data type-specific alignment, for example,
+        for the data buffer of an int32 array to be aligned on a 4-byte boundary.
     use_threads : bool
         Whether to use the global CPU thread pool to parallelize any
         computational tasks like decompression

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -51,6 +51,7 @@ cdef CMetadataVersion _unwrap_metadata_version(
 cpdef enum Alignment:
     Any = <int8_t> CAlignment_Any
     DataTypeSpecific = <int8_t> CAlignment_DataTypeSpecific
+    At64Byte = <int8_t> CAlignment_64Byte
 
 
 cdef object _wrap_alignment(CAlignment alignment):
@@ -62,6 +63,8 @@ cdef CAlignment _unwrap_alignment(Alignment alignment) except *:
         return CAlignment_Any
     elif alignment == Alignment.DataTypeSpecific:
         return CAlignment_DataTypeSpecific
+    elif alignment == Alignment.At64Byte:
+        return CAlignment_64Byte
     raise ValueError("Not an alignment: " + repr(alignment))
 
 
@@ -139,7 +142,7 @@ cdef class IpcReadOptions(_Weakrefable):
         Whether to convert incoming data to platform-native endianness.
     ensure_alignment : Alignment, default Alignment.Any
         Data is copied to aligned memory locations if mis-aligned.
-        Some use cases might require data to have data type-specific alignment, for example,
+        Some use cases might require data to have a specific alignment, for example,
         for the data buffer of an int32 array to be aligned on a 4-byte boundary.
     use_threads : bool
         Whether to use the global CPU thread pool to parallelize any

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -24,7 +24,7 @@ import pyarrow as pa
 from pyarrow.lib import (IpcReadOptions, IpcWriteOptions, ReadStats, WriteStats,  # noqa
                          Message, MessageReader,
                          RecordBatchReader, _ReadPandasMixin,
-                         MetadataVersion,
+                         MetadataVersion, Alignment,
                          read_message, read_record_batch, read_schema,
                          read_tensor, write_tensor,
                          get_record_batch_size, get_tensor_size)

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -535,14 +535,15 @@ def test_read_options():
     options = pa.ipc.IpcReadOptions()
     assert options.use_threads is True
     assert options.ensure_native_endian is True
-    assert options.ensure_memory_alignment is False
+    assert options.ensure_alignment == pa.ipc.Alignment.Any
     assert options.included_fields == []
+    pa.ipc.MetadataVersion
 
     options.ensure_native_endian = False
     assert options.ensure_native_endian is False
 
-    options.ensure_memory_alignment = True
-    assert options.ensure_memory_alignment is True
+    options.ensure_alignment = pa.ipc.Alignment.DataTypeSpecific
+    assert options.ensure_alignment == pa.ipc.Alignment.DataTypeSpecific
 
     options.use_threads = False
     assert options.use_threads is False
@@ -555,11 +556,11 @@ def test_read_options():
 
     options = pa.ipc.IpcReadOptions(
         use_threads=False, ensure_native_endian=False,
-        ensure_memory_alignment=True, included_fields=[1]
+        ensure_alignment=pa.ipc.Alignment.DataTypeSpecific, included_fields=[1]
     )
     assert options.use_threads is False
     assert options.ensure_native_endian is False
-    assert options.ensure_memory_alignment is True
+    assert options.ensure_alignment == pa.ipc.Alignment.DataTypeSpecific
     assert options.included_fields == [1]
 
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -537,7 +537,6 @@ def test_read_options():
     assert options.ensure_native_endian is True
     assert options.ensure_alignment == pa.ipc.Alignment.Any
     assert options.included_fields == []
-    pa.ipc.MetadataVersion
 
     options.ensure_native_endian = False
     assert options.ensure_native_endian is False

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -544,6 +544,8 @@ def test_read_options():
 
     options.ensure_alignment = pa.ipc.Alignment.DataTypeSpecific
     assert options.ensure_alignment == pa.ipc.Alignment.DataTypeSpecific
+    options.ensure_alignment = pa.ipc.Alignment.At64Byte
+    assert options.ensure_alignment == pa.ipc.Alignment.At64Byte
 
     options.use_threads = False
     assert options.use_threads is False

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -535,10 +535,15 @@ def test_read_options():
     options = pa.ipc.IpcReadOptions()
     assert options.use_threads is True
     assert options.ensure_native_endian is True
+    assert options.ensure_memory_alignment is True
+    assert options.ens is True
     assert options.included_fields == []
 
     options.ensure_native_endian = False
     assert options.ensure_native_endian is False
+
+    options.ensure_memory_alignment = False
+    assert options.ensure_memory_alignment is False
 
     options.use_threads = False
     assert options.use_threads is False
@@ -551,10 +556,11 @@ def test_read_options():
 
     options = pa.ipc.IpcReadOptions(
         use_threads=False, ensure_native_endian=False,
-        included_fields=[1]
+        ensure_memory_alignment=False, included_fields=[1]
     )
     assert options.use_threads is False
     assert options.ensure_native_endian is False
+    assert options.ensure_memory_alignment is False
     assert options.included_fields == [1]
 
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -536,7 +536,6 @@ def test_read_options():
     assert options.use_threads is True
     assert options.ensure_native_endian is True
     assert options.ensure_memory_alignment is True
-    assert options.ens is True
     assert options.included_fields == []
 
     options.ensure_native_endian = False

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -535,14 +535,14 @@ def test_read_options():
     options = pa.ipc.IpcReadOptions()
     assert options.use_threads is True
     assert options.ensure_native_endian is True
-    assert options.ensure_memory_alignment is True
+    assert options.ensure_memory_alignment is False
     assert options.included_fields == []
 
     options.ensure_native_endian = False
     assert options.ensure_native_endian is False
 
-    options.ensure_memory_alignment = False
-    assert options.ensure_memory_alignment is False
+    options.ensure_memory_alignment = True
+    assert options.ensure_memory_alignment is True
 
     options.use_threads = False
     assert options.use_threads is False
@@ -555,11 +555,11 @@ def test_read_options():
 
     options = pa.ipc.IpcReadOptions(
         use_threads=False, ensure_native_endian=False,
-        ensure_memory_alignment=False, included_fields=[1]
+        ensure_memory_alignment=True, included_fields=[1]
     )
     assert options.use_threads is False
     assert options.ensure_native_endian is False
-    assert options.ensure_memory_alignment is False
+    assert options.ensure_memory_alignment is True
     assert options.included_fields == [1]
 
 


### PR DESCRIPTION
### Rationale for this change
Data retrieved via IPC is expected to provide memory-aligned arrays, but data retrieved via C++ Flight client is mis-aligned. Datafusion (Rust), which requires data type-specific alignment, cannot handle such data: #43552.
https://arrow.apache.org/docs/format/Columnar.html#buffer-alignment-and-padding

### What changes are included in this PR?
This adds option `arrow::ipc::IpcReadOptions.ensure_alignment` of type `arrow::ipc::Alignment` to configure how RecordBatch array buffers decoded by IPC are realigned. It supports no realignment (default), data type-specific alignment and 64-byte alignment.

Implementation mirrors that of [`align_buffers` in arrow-rs](https://github.com/apache/arrow-rs/blob/3293a8c2f9062fca93bee2210d540a1d25155bf5/arrow-data/src/data.rs#L698-L711) (https://github.com/apache/arrow-rs/pull/4681).

### Are these changes tested?
Configuration flag tested in unit test. Integration test with Flight server.
Manually end-to-end tested that memory alignment fixes issue with reproduction code provided in #43552.

### Are there any user-facing changes?
Adds option `IpcReadOptions.ensure_alignment` and enum type `Alignment`.

* GitHub Issue: #32276