### PR TITLE
MINOR: [Python][CI] Avoid unconditional use of precompiled headers

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -454,7 +454,7 @@ endif()
 add_library(arrow_python SHARED ${PYARROW_CPP_SRCS})
 target_include_directories(arrow_python PUBLIC ${PYARROW_CPP_ROOT_DIR}
                                                ${CMAKE_CURRENT_BINARY_DIR}/pyarrow/src)
-if(NOT CMAKE_VERSION VERSION_LESS 3.16)
+if(ARROW_USE_PRECOMPILED_HEADERS)
   target_precompile_headers(arrow_python PUBLIC
                             "$<$<COMPILE_LANGUAGE:CXX>:arrow/python/pch.h>")
 endif()

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -16,6 +16,8 @@
 // under the License.
 
 #include "arrow/python/udf.h"
+
+#include "arrow/array/array_nested.h"
 #include "arrow/array/builder_base.h"
 #include "arrow/buffer_builder.h"
 #include "arrow/compute/api_aggregate.h"


### PR DESCRIPTION
The precompiled headers generated during the PyArrow build phase seem to take a lot of disk space (more than 2 GB).

Avoiding their unconditional generation should make disk space issues on CI less likely.

Here is an example failing build due to exhausted disk space: https://github.com/apache/arrow/actions/runs/11128048506/job/30921855648?pr=44250
