### PR TITLE
GH-30863: [JS] Use a singleton StructRow proxy handler

### DIFF
--- a/js/src/row/struct.ts
+++ b/js/src/row/struct.ts
@@ -39,7 +39,7 @@ export class StructRow<T extends TypeMap = any> {
     constructor(parent: Data<Struct<T>>, rowIndex: number) {
         this[kParent] = parent;
         this[kRowIndex] = rowIndex;
-        return new Proxy(this, new StructRowProxyHandler());
+        return new Proxy(this, structRowProxyHandler);
     }
 
     public toArray() { return Object.values(this.toJSON()); }
@@ -157,3 +157,5 @@ class StructRowProxyHandler<T extends TypeMap = any> implements ProxyHandler<Str
         return false;
     }
 }
+
+const structRowProxyHandler = new StructRowProxyHandler();


### PR DESCRIPTION
### Rationale for this change

Fixes #30863 by using a singleton proxy handler in `StructRow`'s constructor. Since the handler is stateless, there is no need to create a new instance for each row.

### What changes are included in this PR?

Refactoring `StructRow`'s constructor to extract the proxy handler.

### Are these changes tested?

No additional tests since this is an internal refactoring, but `yarn test` runs successfully.

### Are there any user-facing changes?

No.

* GitHub Issue: #30863