### PR TITLE
GH-44297: [Integration][CI] Skip nanoarrow IPC integration tests for compressed/dictionary-encoded files

### DIFF
--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -193,12 +193,16 @@ class IntegrationRunner(object):
                 skip_testers.add("Rust")
             if prefix == '2.0.0-compression':
                 skip_testers.add("JS")
+                # https://github.com/apache/arrow-nanoarrow/issues/621
+                skip_testers.add("nanoarrow")
 
             # See https://github.com/apache/arrow/pull/9822 for how to
             # disable specific compression type tests.
 
             if prefix == '4.0.0-shareddict':
                 skip_testers.add("C#")
+                # https://github.com/apache/arrow-nanoarrow/issues/622
+                skip_testers.add("nanoarrow")
 
             quirks = set()
             if prefix in {'0.14.1', '0.17.1',


### PR DESCRIPTION
### Rationale for this change

There are a few remaining failures when testing nanoarrow against itself: https://github.com/apache/arrow-nanoarrow/pull/643 . Our IPC reader doesn't support dictionaries or compression, so we can't run those tests.

### What changes are included in this PR?

Skips were added to the archery code that runs the tests.

### Are these changes tested?

Yes (integration tests run on every commit)

### Are there any user-facing changes?

No!
* GitHub Issue: #44297