### PR TITLE
GH-44256: [C++][FS][Azure] Fix edgecase where GetFileInfo incorrectly returns NotFound on flat namespace and Azurite

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1806,8 +1806,8 @@ class AzureFileSystem::Impl {
       // BlobPrefixes. A BlobPrefix always ends with kDelimiter ("/"), so we can
       // distinguish between a directory and a file by checking if we received a
       // prefix or a blob.
-      // This strategy allows us to implement GetFileInfo with just 1 blob storage 
-      // operation in almost every case. 
+      // This strategy allows us to implement GetFileInfo with just 1 blob storage
+      // operation in almost every case.
       if (!list_response.BlobPrefixes.empty()) {
         // Ensure the returned BlobPrefixes[0] string doesn't contain more characters than
         // the requested Prefix. For instance, if we request with Prefix="dir/abra" and
@@ -1830,17 +1830,17 @@ class AzureFileSystem::Impl {
               std::chrono::system_clock::time_point{blob.Details.LastModified});
           return info;
         } else if (blob.Name[options.Prefix.Value().length()] < internal::kSep) {
-          // First list result did not indicate a directory and there is definitely no 
-          // exactly matching blob. However, there may still be a directory that we 
-          // initially missed because the first list result came before 
+          // First list result did not indicate a directory and there is definitely no
+          // exactly matching blob. However, there may still be a directory that we
+          // initially missed because the first list result came before
           // `options.Prefix + internal::kSep` lexigraphically.
           // For example the flat namespace storage account has the following blobs:
           // - container/dir.txt
           // - container/dir/file.txt
-          // GetFileInfo(container/dir) should return FileType::Directory but in this 
-          // edge case `blob = "dir.txt"`, so without further checks we would incorrectly 
+          // GetFileInfo(container/dir) should return FileType::Directory but in this
+          // edge case `blob = "dir.txt"`, so without further checks we would incorrectly
           // return FileType::NotFound.
-          // Therefore we make an extra list operation with the trailing slash to confirm 
+          // Therefore we make an extra list operation with the trailing slash to confirm
           // whether the path is a directory.
           options.Prefix = internal::EnsureTrailingSlash(location.path);
           auto list_with_trailing_slash_response = container_client.ListBlobs(options);

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1823,18 +1823,17 @@ class AzureFileSystem::Impl {
       }
       if (!list_response.Blobs.empty()) {
         const auto& blob = list_response.Blobs[0];
-        const auto next_character = blob.Name[options.Prefix.Value().length()];
         if (blob.Name == location.path) {
           info.set_type(FileType::File);
           info.set_size(blob.BlobSize);
           info.set_mtime(
               std::chrono::system_clock::time_point{blob.Details.LastModified});
           return info;
-        } else if (next_character < '/') {
+        } else if (blob.Name[options.Prefix.Value().length()] < internal::kSep) {
           // First list result did not indicate a directory and there is definitely no 
           // exactly matching blob. However, there may still be a directory that we 
           // initially missed because the first list result came before 
-          // `options.Prefix + '/'` lexigraphically.
+          // `options.Prefix + internal::kSep` lexigraphically.
           // For example the flat namespace storage account has the following blobs:
           // - container/dir.txt
           // - container/dir/file.txt

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -2080,7 +2080,7 @@ void TestAzureFileSystem::TestGetFileInfoObjectWithNestedStructure() {
   ASSERT_OK(output->Close());
 
   // . is immediately before "/" lexicographically, ensure that this doesn't
-  // cause unexpected issues. NOTE: Its seems real Azure blob storage doesn't 
+  // cause unexpected issues. NOTE: Its seems real Azure blob storage doesn't
   // allow blob names to end in `.`
   ASSERT_OK_AND_ASSIGN(output, fs()->OpenOutputStream(
                                    data.ContainerPath("test-object-dir/some_other_dir.a"),

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -949,15 +949,11 @@ class TestAzureFileSystem : public ::testing::Test {
   void CreateHierarchicalData(HierarchicalPaths* paths) {
     auto data = SetUpPreexistingData();
     const auto directory_path = data.RandomDirectoryPath(rng_);
-    const auto directory_adjacent_path = directory_path + ".txt";
     const auto sub_directory_path = ConcatAbstractPath(directory_path, "new-sub");
     const auto sub_blob_path = ConcatAbstractPath(sub_directory_path, "sub.txt");
     const auto top_blob_path = ConcatAbstractPath(directory_path, "top.txt");
     ASSERT_OK(fs()->CreateDir(sub_directory_path, true));
-    ASSERT_OK_AND_ASSIGN(auto output, fs()->OpenOutputStream(directory_adjacent_path));
-    ASSERT_OK(output->Write(std::string_view("directory adjacent")));
-    ASSERT_OK(output->Close());
-    ASSERT_OK_AND_ASSIGN(output, fs()->OpenOutputStream(sub_blob_path));
+    ASSERT_OK_AND_ASSIGN(auto output, fs()->OpenOutputStream(sub_blob_path));
     ASSERT_OK(output->Write(std::string_view("sub")));
     ASSERT_OK(output->Close());
     ASSERT_OK_AND_ASSIGN(output, fs()->OpenOutputStream(top_blob_path));
@@ -966,7 +962,6 @@ class TestAzureFileSystem : public ::testing::Test {
 
     AssertFileInfo(fs(), data.container_name, FileType::Directory);
     AssertFileInfo(fs(), directory_path, FileType::Directory);
-    AssertFileInfo(fs(), directory_adjacent_path, FileType::File);
     AssertFileInfo(fs(), sub_directory_path, FileType::Directory);
     AssertFileInfo(fs(), sub_blob_path, FileType::File);
     AssertFileInfo(fs(), top_blob_path, FileType::File);

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -949,11 +949,15 @@ class TestAzureFileSystem : public ::testing::Test {
   void CreateHierarchicalData(HierarchicalPaths* paths) {
     auto data = SetUpPreexistingData();
     const auto directory_path = data.RandomDirectoryPath(rng_);
+    const auto directory_adjacent_path = directory_path + ".txt";
     const auto sub_directory_path = ConcatAbstractPath(directory_path, "new-sub");
     const auto sub_blob_path = ConcatAbstractPath(sub_directory_path, "sub.txt");
     const auto top_blob_path = ConcatAbstractPath(directory_path, "top.txt");
     ASSERT_OK(fs()->CreateDir(sub_directory_path, true));
-    ASSERT_OK_AND_ASSIGN(auto output, fs()->OpenOutputStream(sub_blob_path));
+    ASSERT_OK_AND_ASSIGN(auto output, fs()->OpenOutputStream(directory_adjacent_path));
+    ASSERT_OK(output->Write(std::string_view("directory adjacent")));
+    ASSERT_OK(output->Close());
+    ASSERT_OK_AND_ASSIGN(output, fs()->OpenOutputStream(sub_blob_path));
     ASSERT_OK(output->Write(std::string_view("sub")));
     ASSERT_OK(output->Close());
     ASSERT_OK_AND_ASSIGN(output, fs()->OpenOutputStream(top_blob_path));
@@ -962,6 +966,7 @@ class TestAzureFileSystem : public ::testing::Test {
 
     AssertFileInfo(fs(), data.container_name, FileType::Directory);
     AssertFileInfo(fs(), directory_path, FileType::Directory);
+    AssertFileInfo(fs(), directory_adjacent_path, FileType::File);
     AssertFileInfo(fs(), sub_directory_path, FileType::Directory);
     AssertFileInfo(fs(), sub_blob_path, FileType::File);
     AssertFileInfo(fs(), top_blob_path, FileType::File);

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -2084,6 +2084,19 @@ void TestAzureFileSystem::TestGetFileInfoObjectWithNestedStructure() {
   ASSERT_OK(output->Write(lorem_ipsum));
   ASSERT_OK(output->Close());
 
+  // . is immediately before "/" lexicographically, ensure that this doesn't
+  // cause unexpected issues.
+  ASSERT_OK_AND_ASSIGN(output, fs()->OpenOutputStream(
+                                   data.ContainerPath("test-object-dir/some_other_dir."),
+                                   /*metadata=*/{}));
+  ASSERT_OK(output->Write(lorem_ipsum));
+  ASSERT_OK(output->Close());
+  ASSERT_OK_AND_ASSIGN(output,
+                       fs()->OpenOutputStream(data.ContainerPath(kObjectName + "."),
+                                              /*metadata=*/{}));
+  ASSERT_OK(output->Write(lorem_ipsum));
+  ASSERT_OK(output->Close());
+
   AssertFileInfo(fs(), data.ContainerPath(kObjectName), FileType::File);
   AssertFileInfo(fs(), data.ContainerPath(kObjectName) + "/", FileType::NotFound);
   AssertFileInfo(fs(), data.ContainerPath("test-object-dir"), FileType::Directory);

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -2080,14 +2080,15 @@ void TestAzureFileSystem::TestGetFileInfoObjectWithNestedStructure() {
   ASSERT_OK(output->Close());
 
   // . is immediately before "/" lexicographically, ensure that this doesn't
-  // cause unexpected issues.
+  // cause unexpected issues. NOTE: Its seems real Azure blob storage doesn't 
+  // allow blob names to end in `.`
   ASSERT_OK_AND_ASSIGN(output, fs()->OpenOutputStream(
-                                   data.ContainerPath("test-object-dir/some_other_dir."),
+                                   data.ContainerPath("test-object-dir/some_other_dir.a"),
                                    /*metadata=*/{}));
   ASSERT_OK(output->Write(lorem_ipsum));
   ASSERT_OK(output->Close());
   ASSERT_OK_AND_ASSIGN(output,
-                       fs()->OpenOutputStream(data.ContainerPath(kObjectName + "."),
+                       fs()->OpenOutputStream(data.ContainerPath(kObjectName + ".a"),
                                               /*metadata=*/{}));
   ASSERT_OK(output->Write(lorem_ipsum));
   ASSERT_OK(output->Close());


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Fix a bug where `GetFileInfo` incorrectly returns `FileType::NotFound` on flat namespace and Azurite.

### What changes are included in this PR?
Fix by detecting the exact edgecase and doing an extra listing operation to disambiguate. 

### Are these changes tested?
Yes, updated automated test

### Are there any user-facing changes?
Only a bug fix.
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44256