### PR TITLE
GH-44314: [Packaging][Python] Use macOS 12 as deployment target to have macOS 12 pyarrow wheels

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -416,10 +416,7 @@ tasks:
 
 {############################## Wheel macOS ####################################}
 
-{% for macos_version, macos_codename in [("12.0", "monterey")] %}
-  {% set platform_tag = "macosx_{}_x86_64".format(macos_version.replace('.', '_')) %}
-
-  wheel-macos-{{ macos_codename }}-{{ python_tag }}-{{ abi_tag }}-amd64:
+  wheel-macos-monterey-{{ python_tag }}-{{ abi_tag }}-amd64:
     ci: github
     template: python-wheels/github.osx.yml
     params:
@@ -427,11 +424,11 @@ tasks:
       arrow_jemalloc: "ON"
       python_version: "{{ python_version }}"
       python_abi_tag: "{{ abi_tag }}"
-      macos_deployment_target: "{{ macos_version }}"
+      macos_deployment_target: "12.0"
       runs_on: "macos-13"
       vcpkg_arch: "amd64"
     artifacts:
-      - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-{{ platform_tag }}.whl
+      - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-macosx_12_0_x86_64.whl
 
 {% endfor %}
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -416,7 +416,7 @@ tasks:
 
 {############################## Wheel macOS ####################################}
 
-{% for macos_version, macos_codename in [("13.0", "ventura")] %}
+{% for macos_version, macos_codename in [("12.0", "monterey")] %}
   {% set platform_tag = "macosx_{}_x86_64".format(macos_version.replace('.', '_')) %}
 
   wheel-macos-{{ macos_codename }}-{{ python_tag }}-{{ abi_tag }}-amd64:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -430,8 +430,6 @@ tasks:
     artifacts:
       - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-macosx_12_0_x86_64.whl
 
-{% endfor %}
-
   wheel-macos-monterey-{{ python_tag }}-{{ abi_tag }}-arm64:
     ci: github
     template: python-wheels/github.osx.yml


### PR DESCRIPTION
### Rationale for this change

We did just bump MACOSX_DEPLOYMENT_TARGET from 10 to 12 for pyarrow wheels on 18.0.0, we probably should wait a little before dropping.

### What changes are included in this PR?

Revert moving macOS deployment target to 12

### Are these changes tested?

Will trigger wheel jobs on archery

### Are there any user-facing changes?

Yes, wheels will be available for macOS 12.
* GitHub Issue: #44314