### PR TITLE
MINOR: [CI][R] Increase timeout for ubuntu-r-valgrind

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1327,7 +1327,7 @@ tasks:
       env:
         ARROW_R_DEV: "TRUE"
       image: ubuntu-r-valgrind
-      timeout: 300 # 5 hours
+      timeout: 330 # 5.5 hours
 
   test-r-linux-rchk:
     ci: github


### PR DESCRIPTION
### Rationale for this change

test-r-linux-valgrind has been failing consistently due to timeout since September 20th.
See [first failure](https://github.com/ursacomputing/crossbow/actions/runs/10951024478/job/30407361495) and [last failure](https://github.com/ursacomputing/crossbow/actions/runs/11206537690/job/31147433866)

### What changes are included in this PR?

Increase timeout

### Are these changes tested?

Will validate via archery

### Are there any user-facing changes?

No