### PR TITLE
GH-44334: [C++] Fix S3 error handling in `ObjectOutputStream`

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -572,7 +572,10 @@ class TestS3FS : public S3TestMixin {
   void TestOpenOutputStream(bool allow_delayed_open) {
     std::shared_ptr<io::OutputStream> stream;
 
-    if (!allow_delayed_open) {
+    if (allow_delayed_open) {
+      ASSERT_OK_AND_ASSIGN(stream, fs_->OpenOutputStream("nonexistent-bucket/somefile"));
+      ASSERT_RAISES(IOError, stream->Close());
+    } else {
       // Nonexistent
       ASSERT_RAISES(IOError, fs_->OpenOutputStream("nonexistent-bucket/somefile"));
     }


### PR DESCRIPTION
### Rationale for this change

See [#GH-44334](https://github.com/apache/arrow/issues/44334). Errors from the AWS SDK are not correctly propagated onto the user of the `ObjectOutputStream`, not indicating an error even though there was one in some cases.

### What changes are included in this PR?

- Directly pass the outcome of the AWS SDK to `HandleUploadUsingSingleRequestOutcome` aswell as `HandleUploadPartOutcome` instead of wrapping it in a arrow `Result` class which has been constructed implictily, always indicating success.
- Adjust cleanup handling in `Close` so that the output stream is closed if there was an error in any of the called methods. Otherwise, destructing the output stream in debug builds fails as we abort if `Close()` returns something else than `Status::OK()`. See the [code pointer here](https://github.com/apache/arrow/blob/64891d1d176dd45f3fae574e1bcfac6fee197e5f/cpp/src/arrow/io/interfaces.cc#L293).

### Are these changes tested?

- Added assertions for catching exceptions on `Close()` in case `delayed_open` is enabled.

### Are there any user-facing changes?

No.
* GitHub Issue: #44334