### PR TITLE
GH-44338: [Python][Parquet] Read encrypted parquet datasets via _metadata

### DIFF
--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -589,6 +589,14 @@ Status WriteMetaDataFile(const FileMetaData& file_metadata,
   return Status::OK();
 }
 
+Status WriteEncryptedMetadataFile(
+    const FileMetaData& file_metadata, std::shared_ptr<::arrow::io::OutputStream> sink,
+    std::shared_ptr<FileEncryptionProperties> file_encryption_properties) {
+  PARQUET_CATCH_NOT_OK(::parquet::WriteEncryptedMetadataFile(file_metadata, sink,
+                                                             file_encryption_properties));
+  return Status::OK();
+}
+
 Status WriteTable(const ::arrow::Table& table, ::arrow::MemoryPool* pool,
                   std::shared_ptr<::arrow::io::OutputStream> sink, int64_t chunk_size,
                   std::shared_ptr<WriterProperties> properties,

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -153,6 +153,12 @@ PARQUET_EXPORT
 ::arrow::Status WriteMetaDataFile(const FileMetaData& file_metadata,
                                   ::arrow::io::OutputStream* sink);
 
+/// \brief Write encrypted metadata-only Parquet file to indicated Arrow OutputStream
+PARQUET_EXPORT
+::arrow::Status WriteEncryptedMetadataFile(
+    const FileMetaData& file_metadata, std::shared_ptr<::arrow::io::OutputStream> sink,
+    std::shared_ptr<FileEncryptionProperties> file_encryption_properties);
+
 /// \brief Write a Table to Parquet.
 ///
 /// This writes one table in a single shot. To write a Parquet file with

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -619,8 +619,6 @@ void WriteEncryptedMetadataFile(
     auto footer_signing_encryptor = file_encryptor->GetFooterSigningEncryptor();
     WriteEncryptedFileMetadata(metadata, sink.get(), footer_signing_encryptor, false);
   }
-
-  file_encryptor->WipeOutEncryptionKeys();
 }
 
 void WriteFileCryptoMetaData(const FileCryptoMetaData& crypto_metadata,

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -118,6 +118,11 @@ void WriteMetaDataFile(const FileMetaData& file_metadata,
                        ::arrow::io::OutputStream* sink);
 
 PARQUET_EXPORT
+void WriteEncryptedMetadataFile(
+    const FileMetaData& file_metadata, std::shared_ptr<::arrow::io::OutputStream> sink,
+    std::shared_ptr<FileEncryptionProperties> file_encryption_properties);
+
+PARQUET_EXPORT
 void WriteEncryptedFileMetadata(const FileMetaData& file_metadata,
                                 ArrowOutputStream* sink,
                                 const std::shared_ptr<Encryptor>& encryptor,
@@ -125,9 +130,10 @@ void WriteEncryptedFileMetadata(const FileMetaData& file_metadata,
 
 PARQUET_EXPORT
 void WriteEncryptedFileMetadata(const FileMetaData& file_metadata,
-                                ::arrow::io::OutputStream* sink,
+                                std::shared_ptr<::arrow::io::OutputStream> sink,
                                 const std::shared_ptr<Encryptor>& encryptor = NULLPTR,
                                 bool encrypt_footer = false);
+
 PARQUET_EXPORT
 void WriteFileCryptoMetaData(const FileCryptoMetaData& crypto_metadata,
                              ::arrow::io::OutputStream* sink);

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -905,6 +905,13 @@ class FileMetaData::FileMetaDataImpl {
     out->impl_->key_value_metadata_ = key_value_metadata_;
     out->impl_->file_decryptor_ = file_decryptor_;
 
+    if (key_value_metadata_ && key_value_metadata_->Contains("row_group_aad_0")) {
+      PARQUET_ASSIGN_OR_THROW(
+          auto aad,
+          key_value_metadata_->Get("row_group_aad_" + std::to_string(row_groups[0])));
+      out->set_file_decryptor_aad(aad);
+    }
+
     return out;
   }
 
@@ -1029,6 +1036,10 @@ EncryptionAlgorithm FileMetaData::encryption_algorithm() const {
   return impl_->encryption_algorithm();
 }
 
+const std::string& FileMetaData::file_aad() const {
+  return impl_->file_decryptor()->file_aad();
+}
+
 const std::string& FileMetaData::footer_signing_key_metadata() const {
   return impl_->footer_signing_key_metadata();
 }
@@ -1036,6 +1047,13 @@ const std::string& FileMetaData::footer_signing_key_metadata() const {
 void FileMetaData::set_file_decryptor(
     std::shared_ptr<InternalFileDecryptor> file_decryptor) {
   impl_->set_file_decryptor(std::move(file_decryptor));
+}
+
+void FileMetaData::set_file_decryptor_aad(const std::string& aad) {
+  auto fd = impl_->file_decryptor();
+  auto file_decryptor = std::make_shared<parquet::InternalFileDecryptor>(
+      fd->properties(), aad, fd->algorithm(), fd->footer_key_metadata(), fd->pool());
+  set_file_decryptor(file_decryptor);
 }
 
 const std::shared_ptr<InternalFileDecryptor>& FileMetaData::file_decryptor() const {
@@ -1087,6 +1105,36 @@ std::string FileMetaData::SerializeUnencrypted(bool scrub, bool debug) const {
 void FileMetaData::WriteTo(::arrow::io::OutputStream* dst,
                            const std::shared_ptr<Encryptor>& encryptor) const {
   return impl_->WriteTo(dst, encryptor);
+}
+
+::arrow::Result<std::shared_ptr<parquet::FileMetaData>> FileMetaData::CoalesceMetadata(
+    std::vector<std::shared_ptr<parquet::FileMetaData>>& metadata_list,
+    std::shared_ptr<parquet::WriterProperties>& writer_props) {
+  if (metadata_list.empty()) {
+    return ::arrow::Status::Invalid("No metadata to coalesce");
+  }
+
+  std::vector<std::string> values, keys;
+
+  // Read metadata from all dataset files and store AADs.
+  for (size_t i = 0; i < metadata_list.size(); i++) {
+    const auto& file_metadata = metadata_list[i];
+    keys.push_back("row_group_aad_" + std::to_string(i));
+    values.push_back(file_metadata->file_aad());
+    if (i > 0) {
+      metadata_list[0]->AppendRowGroups(*file_metadata);
+    }
+  }
+
+  // Create a new FileMetadata object with the created AADs as key_value_metadata.
+  auto fmd_builder =
+      parquet::FileMetaDataBuilder::Make(metadata_list[0]->schema(), writer_props);
+  const std::shared_ptr<const KeyValueMetadata> file_aad_metadata =
+      ::arrow::key_value_metadata(keys, values);
+  auto metadata = fmd_builder->Finish(file_aad_metadata);
+  metadata->AppendRowGroups(*metadata_list[0]);
+
+  return metadata;
 }
 
 class FileCryptoMetaData::FileCryptoMetaDataImpl {

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -328,6 +328,8 @@ class PARQUET_EXPORT FileMetaData {
   EncryptionAlgorithm encryption_algorithm() const;
   const std::string& footer_signing_key_metadata() const;
 
+  const std::string& file_aad() const;
+
   /// \brief Verify signature of FileMetaData when file is encrypted but footer
   /// is not encrypted (plaintext footer).
   bool VerifySignature(const void* signature);
@@ -376,6 +378,23 @@ class PARQUET_EXPORT FileMetaData {
   /// \param[in] debug whether to serialize the metadata as Thrift (if false) or
   /// debug text (if true).
   std::string SerializeUnencrypted(bool scrub, bool debug) const;
+
+  /// \brief Coalesce metadata from multiple files into a single metadata file by
+  /// appending row groups.
+  ///
+  /// \param[in] metadata_list list of FileMetaData objects to coalesce.
+  /// \param[in] writer_props WriterProperties to use to create coalesced FileMetaData
+  /// object.
+  /// \return a new FileMetaData object containing all row groups from the input
+  /// FileMetaData objects.
+  static ::arrow::Result<std::shared_ptr<FileMetaData>> CoalesceMetadata(
+      std::vector<std::shared_ptr<FileMetaData>>& metadata_list,
+      std::shared_ptr<WriterProperties>& writer_props);
+
+  /// \brief Set the AAD of decryptor of the file.
+  ///
+  /// \param[in] aad AAD to set on the decryptor.
+  void set_file_decryptor_aad(const std::string& aad);
 
  private:
   friend FileMetaDataBuilder;

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -364,6 +364,10 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         inline EncryptionAlgorithm encryption_algorithm() const
         inline const c_string& footer_signing_key_metadata() const
 
+    cdef CResult[shared_ptr[CFileMetaData]] CFileMetaData_CoalesceMetadata \
+        " parquet::FileMetaData::CoalesceMetadata"(const vector[shared_ptr[CFileMetaData]]& metadata_list,
+                                                   const shared_ptr[WriterProperties]& properties)
+
     cdef shared_ptr[CFileMetaData] CFileMetaData_Make \
         " parquet::FileMetaData::Make"(const void* serialized_metadata,
                                        uint32_t* metadata_len)
@@ -564,6 +568,11 @@ cdef extern from "parquet/arrow/writer.h" namespace "parquet::arrow" nogil:
     CStatus WriteMetaDataFile(
         const CFileMetaData& file_metadata,
         const COutputStream* sink)
+
+    CStatus WriteEncryptedMetadataFile(
+        const CFileMetaData& file_metadata,
+        shared_ptr[COutputStream] sink,
+        shared_ptr[CFileEncryptionProperties] encryption_properties)
 
 cdef class FileEncryptionProperties:
     """File-level encryption properties for the low-level API"""

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1070,7 +1070,26 @@ cdef class FileMetaData(_Weakrefable):
         c_metadata = other.sp_metadata
         self._metadata.AppendRowGroups(deref(c_metadata))
 
-    def write_metadata_file(self, where):
+    @classmethod
+    def coalesce_metadata(cls, metadata_list):
+        """
+
+        """
+        cdef:
+            FileMetaData metadata = FileMetaData.__new__(FileMetaData)
+            vector[shared_ptr[CFileMetaData]] c_metadata_list
+            shared_ptr[WriterProperties] c_properties = _create_writer_properties()
+            shared_ptr[CFileMetaData] c_metadata
+
+        for metadata in metadata_list:
+            c_metadata_list.push_back((<FileMetaData> metadata).sp_metadata)
+
+        c_metadata = GetResultValue(
+            CFileMetaData_CoalesceMetadata(c_metadata_list, c_properties))
+        metadata.init(c_metadata)
+        return metadata
+
+    def write_metadata_file(self, where, encryption_properties=None):
         """
         Write the metadata to a metadata-only Parquet file.
 
@@ -1079,10 +1098,13 @@ cdef class FileMetaData(_Weakrefable):
         where : path or file-like object
             Where to write the metadata.  Should be a writable path on
             the local filesystem, or a writable file-like object.
+        encryption_properties : EncryptionProperties
+            Optional encryption properties to use when encrypting metadata.
         """
         cdef:
             shared_ptr[COutputStream] sink
             c_string c_where
+            shared_ptr[CFileEncryptionProperties] c_properties
 
         try:
             where = _stringify_path(where)
@@ -1093,9 +1115,15 @@ cdef class FileMetaData(_Weakrefable):
             with nogil:
                 sink = GetResultValue(FileOutputStream.Open(c_where))
 
+        if encryption_properties is not None:
+            c_properties = (<FileEncryptionProperties> encryption_properties).unwrap()
+
         with nogil:
-            check_status(
-                WriteMetaDataFile(deref(self._metadata), sink.get()))
+            if encryption_properties is not None:
+                check_status(
+                    WriteEncryptedMetadataFile(deref(self._metadata), sink, c_properties))
+            else:
+                check_status(WriteMetaDataFile(deref(self._metadata), sink.get()))
 
 
 cdef class ParquetSchema(_Weakrefable):


### PR DESCRIPTION
### Rationale for this change

Once https://github.com/apache/arrow/issues/41719 is resolved we will have necessary c++ code path to read and write  datasets with metadata stored in encrypted _metadata file. We want to provide the same functionality from Python and this change provides it.

### What changes are included in this PR?

This adds python code to read and write dataset metadata into encrypted `_metadata` file.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

This adds a new functionality to the users.
* GitHub Issue: #44338