### PR TITLE
GH-44337: [CI][GLib] Fix a flaky StreamDecoder and Buffer test

### DIFF
--- a/c_glib/test/test-stream-decoder.rb
+++ b/c_glib/test/test-stream-decoder.rb
@@ -79,8 +79,15 @@ class TestStreamDecoder < Test::Unit::TestCase
   end
 
   def test_consume_buffer
+    # We need to keep data that aren't processed yet.
+    data = []
     @buffer.data.to_s.each_byte do |byte|
-      @decoder.consume_buffer(Arrow::Buffer.new(byte.chr))
+      data << byte.chr
+      can_clear = (@decoder.next_required_size == 1)
+      @decoder.consume_buffer(Arrow::Buffer.new(data.last))
+      # We can release a reference for kept data after they are
+      # processed.
+      data.clear if can_clear
     end
     assert_equal([
                    [:schema_decoded, @schema, @schema],


### PR DESCRIPTION
### Rationale for this change

It's related to GC.

StreamDecoder accepts incomplete data. They are kept until enough data are provided. A caller must not release the incomplete data before they are processed. If they are released, StreamDecoder may touch unexpected data.

### What changes are included in this PR?

Refer unprocessed data until they are processed.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44337