### PR TITLE
MINOR: [Docs] Update URL to Go libraries in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Major components of the project include:
  - [C# .NET libraries](https://github.com/apache/arrow/tree/main/csharp)
  - [Gandiva](https://github.com/apache/arrow/tree/main/cpp/src/gandiva):
    an [LLVM](https://llvm.org)-based Arrow expression compiler, part of the C++ codebase
- - [Go libraries](https://github.com/apache/arrow/tree/main/go)
+ - [Go libraries](https://github.com/apache/arrow-go)
  - [Java libraries](https://github.com/apache/arrow/tree/main/java)
  - [JavaScript libraries](https://github.com/apache/arrow/tree/main/js)
  - [Python libraries](https://github.com/apache/arrow/tree/main/python)


### PR DESCRIPTION
### Rationale for this change
Adapt the documentation to the new url to reflect the change made in #44293 (moving the Go libraries to a separate repository)

### What changes are included in this PR?
I updated the url to the Go libraries in the README.md file

### Are these changes tested?
N/A

### Are there any user-facing changes?
N/A
