### PR TITLE
GH-44358: [Packaging][Debian] Add workaround for CUDA include path

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-trixie/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-trixie/Dockerfile
@@ -82,6 +82,9 @@ RUN \
     valac \
     zlib1g-dev && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt install -y -V ${quiet} nvidia-cuda-toolkit && \
+    # GH-44358: Workaround for non-existent path error
+    mkdir -p \
+      /usr/lib/nvidia-cuda-toolkit/include/$(dpkg-architecture -qDEB_HOST_MULTIARCH); \
   fi && \
   apt clean


### PR DESCRIPTION
### Rationale for this change

This is not happen on Debian GNU/Linux stable and unstable. This is happen only on Debian GNU/Linux testing. So this may be a temporary problem.

### What changes are included in this PR?

Create a non-existent path manually as a workaround.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44358