### PR TITLE
GH-44355: [Packaging][Python] Disable interactive deb configuration in wheel-manylinux-*-cp313t-*

### DIFF
--- a/ci/docker/python-free-threaded-wheel-manylinux-test-imports.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-manylinux-test-imports.dockerfile
@@ -18,6 +18,8 @@
 ARG base
 FROM ${base}
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y -q && \
     apt install -y -q --no-install-recommends software-properties-common gpg-agent && \
     add-apt-repository -y ppa:deadsnakes/ppa && \


### PR DESCRIPTION
### Rationale for this change

If interactive deb configuration is used, CI is blocked by waiting an user input.

### What changes are included in this PR?

Disable interactive deb configuration.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44355