### PR TITLE
GH-44364: [C++] Don't export template class

### DIFF
--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -43,7 +43,7 @@ namespace arrow {
 // VarLengthListLikeBuilder
 
 template <typename TYPE>
-class ARROW_EXPORT VarLengthListLikeBuilder : public ArrayBuilder {
+class VarLengthListLikeBuilder : public ArrayBuilder {
  public:
   using TypeClass = TYPE;
   using offset_type = typename TypeClass::offset_type;
@@ -261,7 +261,7 @@ class ARROW_EXPORT VarLengthListLikeBuilder : public ArrayBuilder {
 // ListBuilder / LargeListBuilder
 
 template <typename TYPE>
-class ARROW_EXPORT BaseListBuilder : public VarLengthListLikeBuilder<TYPE> {
+class BaseListBuilder : public VarLengthListLikeBuilder<TYPE> {
  private:
   using BASE = VarLengthListLikeBuilder<TYPE>;
 
@@ -401,7 +401,7 @@ class ARROW_EXPORT LargeListBuilder : public BaseListBuilder<LargeListType> {
 // ListViewBuilder / LargeListViewBuilder
 
 template <typename TYPE>
-class ARROW_EXPORT BaseListViewBuilder : public VarLengthListLikeBuilder<TYPE> {
+class BaseListViewBuilder : public VarLengthListLikeBuilder<TYPE> {
  private:
   using BASE = VarLengthListLikeBuilder<TYPE>;
 

--- a/cpp/src/arrow/compute/row/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.h
@@ -137,7 +137,7 @@ struct ARROW_EXPORT DictionaryKeyEncoder : FixedWidthKeyEncoder {
 };
 
 template <typename T>
-struct ARROW_EXPORT VarLengthKeyEncoder : KeyEncoder {
+struct VarLengthKeyEncoder : KeyEncoder {
   using Offset = typename T::offset_type;
 
   void AddLength(const ExecValue& data, int64_t batch_length, int32_t* lengths) override {

--- a/cpp/src/arrow/io/concurrency.h
+++ b/cpp/src/arrow/io/concurrency.h
@@ -89,7 +89,7 @@ class ARROW_EXPORT SharedExclusiveChecker {
 // wrappers between those two classes.
 
 template <class Derived>
-class ARROW_EXPORT InputStreamConcurrencyWrapper : public InputStream {
+class InputStreamConcurrencyWrapper : public InputStream {
  public:
   Status Close() final {
     auto guard = lock_.exclusive_guard();
@@ -159,7 +159,7 @@ class ARROW_EXPORT InputStreamConcurrencyWrapper : public InputStream {
 };
 
 template <class Derived>
-class ARROW_EXPORT RandomAccessFileConcurrencyWrapper : public RandomAccessFile {
+class RandomAccessFileConcurrencyWrapper : public RandomAccessFile {
  public:
   Status Close() final {
     auto guard = lock_.exclusive_guard();

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -134,7 +134,7 @@ namespace internal {
 constexpr auto kScalarScratchSpaceSize = sizeof(int64_t) * 2;
 
 template <typename Impl>
-struct ARROW_EXPORT ArraySpanFillFromScalarScratchSpace {
+struct ArraySpanFillFromScalarScratchSpace {
   //  16 bytes of scratch space to enable ArraySpan to be a view onto any
   //  Scalar- including binary scalars where we need to create a buffer
   //  that looks like two 32-bit or 64-bit offsets.
@@ -163,7 +163,7 @@ struct ARROW_EXPORT PrimitiveScalarBase : public Scalar {
 };
 
 template <typename T, typename CType = typename T::c_type>
-struct ARROW_EXPORT PrimitiveScalar : public PrimitiveScalarBase {
+struct PrimitiveScalar : public PrimitiveScalarBase {
   using PrimitiveScalarBase::PrimitiveScalarBase;
   using TypeClass = T;
   using ValueType = CType;
@@ -464,7 +464,7 @@ struct ARROW_EXPORT Date64Scalar : public DateScalar<Date64Type> {
 };
 
 template <typename T>
-struct ARROW_EXPORT TimeScalar : public TemporalScalar<T> {
+struct TimeScalar : public TemporalScalar<T> {
   using TemporalScalar<T>::TemporalScalar;
 
   TimeScalar(typename TemporalScalar<T>::ValueType value, TimeUnit::type unit)
@@ -543,7 +543,7 @@ struct ARROW_EXPORT DurationScalar : public TemporalScalar<DurationType> {
 };
 
 template <typename TYPE_CLASS, typename VALUE_TYPE>
-struct ARROW_EXPORT DecimalScalar : public internal::PrimitiveScalarBase {
+struct DecimalScalar : public internal::PrimitiveScalarBase {
   using internal::PrimitiveScalarBase::PrimitiveScalarBase;
   using TypeClass = TYPE_CLASS;
   using ValueType = VALUE_TYPE;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -548,7 +548,7 @@ ARROW_EXPORT void PrintTo(const Field& field, std::ostream* os);
 namespace detail {
 
 template <typename DERIVED, typename BASE, Type::type TYPE_ID, typename C_TYPE>
-class ARROW_EXPORT CTypeImpl : public BASE {
+class CTypeImpl : public BASE {
  public:
   static constexpr Type::type type_id = TYPE_ID;
   using c_type = C_TYPE;

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -40,7 +40,7 @@ enum class DecimalStatus {
 };
 
 template <typename Derived, int BIT_WIDTH, int NWORDS = BIT_WIDTH / 64>
-class ARROW_EXPORT GenericBasicDecimal {
+class GenericBasicDecimal {
  protected:
   struct LittleEndianArrayTag {};
 
@@ -168,7 +168,7 @@ class ARROW_EXPORT GenericBasicDecimal {
 };
 
 template <typename DigitType>
-class ARROW_EXPORT SmallBasicDecimal {
+class SmallBasicDecimal {
  public:
   static_assert(
       std::is_same_v<DigitType, int32_t> || std::is_same_v<DigitType, int64_t>,

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -168,7 +168,7 @@ class GenericBasicDecimal {
 };
 
 template <typename DigitType>
-class SmallBasicDecimal {
+class ARROW_EXPORT SmallBasicDecimal {
  public:
   static_assert(
       std::is_same_v<DigitType, int32_t> || std::is_same_v<DigitType, int64_t>,


### PR DESCRIPTION
### Rationale for this change

It works with MSVC but doesn't work with clang-cl.

### What changes are included in this PR?

Remove `ARROW_EXPORT` from template classes.

### Are these changes tested?

Yes but with only MSVC. We don't have clang-cl CI jobs.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44364