### PR TITLE
GH-43519: [Python][Packaging] Use official Python 3.13 version instead of Release Candidates

### DIFF
--- a/ci/docker/python-wheel-windows-test-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2019.dockerfile
@@ -53,8 +53,8 @@ ARG python=3.9
 RUN (if "%python%"=="3.9" setx PYTHON_VERSION "3.9.13") & \
     (if "%python%"=="3.10" setx PYTHON_VERSION "3.10.11") & \
     (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.9") & \
-    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.5") & \
-    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc1")
+    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.6") & \
+    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc2")
 
 # Install archiver to extract xz archives
 RUN choco install -r -y --pre --no-progress --force python --version=%PYTHON_VERSION% && \

--- a/ci/docker/python-wheel-windows-vs2019.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2019.dockerfile
@@ -83,8 +83,8 @@ ARG python=3.9
 RUN (if "%python%"=="3.9" setx PYTHON_VERSION "3.9.13" && setx PATH "%PATH%;C:\Python39;C:\Python39\Scripts") & \
     (if "%python%"=="3.10" setx PYTHON_VERSION "3.10.11" && setx PATH "%PATH%;C:\Python310;C:\Python310\Scripts") & \
     (if "%python%"=="3.11" setx PYTHON_VERSION "3.11.9" && setx PATH "%PATH%;C:\Python311;C:\Python311\Scripts") & \
-    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.5" && setx PATH "%PATH%;C:\Python312;C:\Python312\Scripts") & \
-    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc1" && setx PATH "%PATH%;C:\Python313;C:\Python313\Scripts")
+    (if "%python%"=="3.12" setx PYTHON_VERSION "3.12.6" && setx PATH "%PATH%;C:\Python312;C:\Python312\Scripts") & \
+    (if "%python%"=="3.13" setx PYTHON_VERSION "3.13.0-rc2" && setx PATH "%PATH%;C:\Python313;C:\Python313\Scripts")
 RUN choco install -r -y --pre --no-progress python --version=%PYTHON_VERSION%
 RUN python -m pip install -U pip setuptools
 

--- a/ci/scripts/install_python.sh
+++ b/ci/scripts/install_python.sh
@@ -28,7 +28,7 @@ declare -A versions
 versions=([3.9]=3.9.13
           [3.10]=3.10.11
           [3.11]=3.11.9
-          [3.12]=3.12.5
+          [3.12]=3.12.7
           [3.13]=3.13.0
           [3.13t]=3.13.0)
 
@@ -47,13 +47,11 @@ full_version=${versions[$2]}
 if [ $platform = "macOS" ]; then
     echo "Downloading Python installer..."
 
-    if [ "$version" = "3.13" ] || [ "$version" = "3.13t" ];
-    then
-        fname="python-${full_version}rc2-macos11.pkg"
-    elif [ "$(uname -m)" = "arm64" ] || \
+    if [ "$(uname -m)" = "arm64" ] || \
          [ "$version" = "3.10" ] || \
          [ "$version" = "3.11" ] || \
-         [ "$version" = "3.12" ];
+         [ "$version" = "3.12" ] || \
+         [ "$version" = "3.13" ];
     then
         fname="python-${full_version}-macos11.pkg"
     else

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -37,7 +37,6 @@ jobs:
       PYTHON: "{{ python_version }}"
       PYTHON_ABI_TAG: "{{ python_abi_tag }}"
       PYTHON_IMAGE_TAG: "{{ python_version }}"
-      {% endif %}
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -36,9 +36,6 @@ jobs:
       {% endif %}
       PYTHON: "{{ python_version }}"
       PYTHON_ABI_TAG: "{{ python_abi_tag }}"
-      {% if python_version == "3.13" %}
-      PYTHON_IMAGE_TAG: "3.13-rc"
-      {% else %}
       PYTHON_IMAGE_TAG: "{{ python_version }}"
       {% endif %}
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1213,7 +1213,7 @@ tasks:
         UBUNTU: 22.04
       image: ubuntu-cpp-emscripten
 
-{% for python_version in ["3.9", "3.10", "3.11", "3.12"] %}
+{% for python_version in ["3.9", "3.10", "3.11", "3.12", "3.13"] %}
   test-conda-python-{{ python_version }}:
     ci: github
     template: docker-tests/github.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1213,7 +1213,7 @@ tasks:
         UBUNTU: 22.04
       image: ubuntu-cpp-emscripten
 
-{% for python_version in ["3.9", "3.10", "3.11", "3.12", "3.13"] %}
+{% for python_version in ["3.9", "3.10", "3.11", "3.12"] %}
   test-conda-python-{{ python_version }}:
     ci: github
     template: docker-tests/github.linux.yml


### PR DESCRIPTION
### Rationale for this change

Python 3.13 has officially been released

### What changes are included in this PR?

Move from 3.13 RC(s) to official release.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #43519