### PR TITLE
GH-43519: [Python][CI] Update Python 3.13 rc to final 3.13.2

### DIFF
--- a/ci/scripts/install_python.sh
+++ b/ci/scripts/install_python.sh
@@ -28,9 +28,9 @@ declare -A versions
 versions=([3.9]=3.9.13
           [3.10]=3.10.11
           [3.11]=3.11.9
-          [3.12]=3.12.5
-          [3.13]=3.13.0
-          [3.13t]=3.13.0)
+          [3.12]=3.12.9
+          [3.13]=3.13.2
+          [3.13t]=3.13.2)
 
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <platform> <version>"
@@ -47,17 +47,11 @@ full_version=${versions[$2]}
 if [ $platform = "macOS" ]; then
     echo "Downloading Python installer..."
 
-    if [ "$version" = "3.13" ] || [ "$version" = "3.13t" ];
+    if [ "$(uname -m)" = "x86_64" ] && [ "$version" = "3.9" ];
     then
-        fname="python-${full_version}rc2-macos11.pkg"
-    elif [ "$(uname -m)" = "arm64" ] || \
-         [ "$version" = "3.10" ] || \
-         [ "$version" = "3.11" ] || \
-         [ "$version" = "3.12" ];
-    then
-        fname="python-${full_version}-macos11.pkg"
-    else
         fname="python-${full_version}-macosx10.9.pkg"
+    else
+        fname="python-${full_version}-macos11.pkg"
     fi
     wget "https://www.python.org/ftp/python/${full_version}/${fname}"
 

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -39,11 +39,7 @@ jobs:
       {% endif %}
       PYTHON: "{{ python_version }}"
       PYTHON_ABI_TAG: "{{ python_abi_tag }}"
-      {% if python_version == "3.13" %}
-      PYTHON_IMAGE_TAG: "3.13-rc"
-      {% else %}
       PYTHON_IMAGE_TAG: "{{ python_version }}"
-      {% endif %}
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}


### PR DESCRIPTION
### Rationale for this change

The final Python 3.13.0 is out now, so we can update those versions

* GitHub Issue: #43519