### PR TITLE
GH-44378: [CI][C++] Add clang-cl job

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -283,12 +283,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - windows-2019
         include:
-          - os: windows-2019
+          - compiler: msvc
+            orc: ON
+            os: windows-2019
             simd-level: AVX2
-            title: AMD64 Windows 2019 C++17 AVX2
+            substrait: ON
+            title: AMD64 Windows 2019 C++ MSVC AVX2
+          - compiler: clang-cl
+            # /bigobj related build error with Protobuf
+            orc: OFF
+            os: windows-2019
+            simd-level:
+            # /bigobj related build error with Protobuf
+            substrait: OFF
+            title: AMD64 Windows 2019 C++ clang-cl
     env:
       ARROW_BOOST_USE_SHARED: OFF
       ARROW_BUILD_BENCHMARKS: ON
@@ -301,10 +310,10 @@ jobs:
       ARROW_HOME: /usr
       ARROW_JEMALLOC: OFF
       ARROW_MIMALLOC: ON
-      ARROW_ORC: ON
+      ARROW_ORC: ${{ matrix.orc }}
       ARROW_PARQUET: ON
       ARROW_SIMD_LEVEL: ${{ matrix.simd-level }}
-      ARROW_SUBSTRAIT: ON
+      ARROW_SUBSTRAIT: ${{ matrix.substrait }}
       ARROW_USE_GLOG: OFF
       ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
       ARROW_WITH_BROTLI: OFF
@@ -354,8 +363,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-windows-${{ env.CACHE_VERSION }}-${{ hashFiles('cpp/**') }}
-          restore-keys: cpp-ccache-windows-${{ env.CACHE_VERSION }}-
+          key: cpp-ccache-windows-${{ matrix.compiler }}-${{ env.CACHE_VERSION }}-${{ hashFiles('cpp/**') }}
+          restore-keys: cpp-ccache-windows-${{ matrix.compiler }}-${{ env.CACHE_VERSION }}-
         env:
           # We can invalidate the current cache by updating this.
           CACHE_VERSION: "2022-09-13"
@@ -363,6 +372,9 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          if ${{ matrix.compiler }}==clang-cl (
+            set ARROW_CMAKE_ARGS=-DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+          )
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Test
         shell: bash

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -249,8 +249,11 @@ if(WIN32)
       endforeach()
     endif()
 
-    # Support large object code
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /bigobj")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      # Support large object code.
+      # clang-cl doesn't support /bigobj.
+      set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /bigobj")
+    endif()
 
     # We may use UTF-8 in source code such as
     # cpp/src/arrow/compute/kernels/scalar_string_test.cc


### PR DESCRIPTION
### Rationale for this change

We have a document that uses clang-cl: https://arrow.apache.org/docs/developers/cpp/windows.html#building-on-windows-arm64-using-ninja-and-clang

But we don't have a job that uses clang-cl. So clang-cl build may be broken unexpectedly.

### What changes are included in this PR?

Add clang-cl job. But Protobuf is disabled because we have the following error with Protobuf:

```text
[32/208] Building RC object CMakeFiles\libprotobuf-lite.dir\version.rc.res
FAILED: CMakeFiles/libprotobuf-lite.dir/version.rc.res 
C:/PROGRA~1/CMake/bin/cmcldeps.exe RC D:\a\arrow\arrow\build\cpp\protobuf_ep-prefix\src\protobuf_ep\cmake\version.rc CMakeFiles\libprotobuf-lite.dir\version.rc.res.d CMakeFiles\libprotobuf-lite.dir\version.rc.res "Note: including file: " "C:/Program Files/LLVM/bin/clang-cl.exe" C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe -DGOOGLE_PROTOBUF_CMAKE_BUILD -I D:\a\arrow\arrow\build\cpp\protobuf_ep-prefix\src\protobuf_ep\cmake -I D:\a\arrow\arrow\build\cpp\protobuf_ep-prefix\src\protobuf_ep\src -DWIN32 -D_DEBUG   /utf-8 /wd4065 /wd4244 /wd4251 /wd4267 /wd4305 /wd4307 /wd4309 /wd4334 /wd4355 /wd4506 /wd4800 /wd4996 /bigobj /fo CMakeFiles\libprotobuf-lite.dir\version.rc.res D:\a\arrow\arrow\build\cpp\protobuf_ep-prefix\src\protobuf_ep\cmake\version.rc
fatal error RC1106: invalid option: /bigobj
```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44378