### PR TITLE
GH-44381: [Ruby][Release] Pin not only glib but also python on verification jobs

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -775,9 +775,7 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
-  # We can remove '==2.80.5' once https://github.com/conda-forge/glib-feedstock/issues/191
-  # is fixed.
-  maybe_setup_conda glib==2.80.5 gobject-introspection meson ninja ruby
+  maybe_setup_conda glib gobject-introspection meson ninja ruby
   maybe_setup_virtualenv meson
 
   # Install bundler if doesn't exist

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -775,7 +775,9 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
-  maybe_setup_conda glib gobject-introspection meson ninja ruby
+  # We can remove '==2.80.5' and 'python<3.13' once
+  # https://github.com/conda-forge/glib-feedstock/issues/191 is fixed.
+  maybe_setup_conda glib==2.80.5 gobject-introspection meson ninja 'python<3.13' ruby
   maybe_setup_virtualenv meson
 
   # Install bundler if doesn't exist


### PR DESCRIPTION
### Rationale for this change

Verification job is currently failing for Ruby.

### What changes are included in this PR?

We can't use Python 3.13 and `glib==2.80.5`. So we use old Python as a workaround.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #44381