### PR TITLE
GH-43949: [C++] io::BufferedInput: Fix invalid state after SetBufferSize

### DIFF
--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -51,7 +51,7 @@ class BufferedBase {
     return !is_open_;
   }
 
-  // Reset the `buffer_` to a new buffer of size `buffer_size_`
+  // Allocate buffer_ if needed, and resize it to buffer_size_ if required.
   Status ResetBuffer() {
     if (!buffer_) {
       // On first invocation, or if the buffer has been released, we allocate a
@@ -284,9 +284,9 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   // Resize internal read buffer. Note that the internal buffer-size
-  // should be not larger than the raw_read_bound_.
-  //
-  // SetBufferSize will not change the buffer_pos_ and bytes_buffered_.
+  // should not be larger than the raw_read_bound_.
+  // It might change the buffer_size_, but will not change buffer states
+  // buffer_pos_ and bytes_buffered_.
   Status SetBufferSize(int64_t new_buffer_size) {
     if (new_buffer_size <= 0) {
       return Status::Invalid("Buffer size should be positive");
@@ -301,13 +301,14 @@ class BufferedInputStream::Impl : public BufferedBase {
       // No need to reserve space for more than the total remaining number of bytes.
       if (bytes_buffered_ == 0) {
         // Special case: we can not keep the current buffer because it does not
-        // contains any required data.
+        // contain any required data.
         new_buffer_size = std::min(new_buffer_size, raw_read_bound_ - raw_read_total_);
       } else {
-        // We should keeping the current buffer because it contains data that
+        // We should keep the current buffer because it contains data that
         // can be read.
         new_buffer_size =
-            std::min(new_buffer_size, buffer_size_ + (raw_read_bound_ - raw_read_total_));
+            std::min(new_buffer_size,
+                     buffer_pos_ + bytes_buffered_ + (raw_read_bound_ - raw_read_total_));
       }
     }
     return ResizeBuffer(new_buffer_size);
@@ -325,7 +326,7 @@ class BufferedInputStream::Impl : public BufferedBase {
     }
 
     // Increase the buffer size if needed.
-    if (nbytes > buffer_->size() - buffer_pos_) {
+    if (nbytes > buffer_size_ - buffer_pos_) {
       RETURN_NOT_OK(SetBufferSize(nbytes + buffer_pos_));
       DCHECK(buffer_->size() - buffer_pos_ >= nbytes);
     }
@@ -364,7 +365,7 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   Status DoBuffer() {
-    // Refill the buffer from the raw stream with `buffer_size_` bytes.
+    // Fill the buffer from the raw stream with at most `buffer_size_` bytes.
     if (!buffer_) {
       RETURN_NOT_OK(ResetBuffer());
     }
@@ -458,8 +459,8 @@ class BufferedInputStream::Impl : public BufferedBase {
   // The default -1 indicates that it is unbounded
   int64_t raw_read_bound_;
 
-  // Number of remaining bytes in the buffer, to be reduced on each read from
-  // the buffer
+  // Number of remaining valid bytes in the buffer, to be reduced on each read
+  // from the buffer.
   int64_t bytes_buffered_;
 };
 

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -51,6 +51,7 @@ class BufferedBase {
     return !is_open_;
   }
 
+  // Reset the `buffer_` to a new buffer of size `buffer_size_`
   Status ResetBuffer() {
     if (!buffer_) {
       // On first invocation, or if the buffer has been released, we allocate a
@@ -284,17 +285,30 @@ class BufferedInputStream::Impl : public BufferedBase {
 
   // Resize internal read buffer. Note that the internal buffer-size
   // should be not larger than the raw_read_bound_.
+  //
+  // SetBufferSize will not change the buffer_pos_ and bytes_buffered_.
   Status SetBufferSize(int64_t new_buffer_size) {
     if (new_buffer_size <= 0) {
       return Status::Invalid("Buffer size should be positive");
     }
     if ((buffer_pos_ + bytes_buffered_) >= new_buffer_size) {
-      return Status::Invalid("Cannot shrink read buffer if buffered data remains");
+      return Status::Invalid(
+          "Cannot shrink read buffer if buffered data remains, new_buffer_size:",
+          new_buffer_size, ", buffer_pos:", buffer_pos_,
+          ", bytes_buffered:", bytes_buffered_, ", buffer_size:", buffer_size_);
     }
     if (raw_read_bound_ >= 0) {
       // No need to reserve space for more than the total remaining number of bytes.
-      new_buffer_size = std::min(new_buffer_size,
-                                 bytes_buffered_ + (raw_read_bound_ - raw_read_total_));
+      if (bytes_buffered_ == 0) {
+        // Special case: we can not keep the current buffer because it does not
+        // contains any required data.
+        new_buffer_size = std::min(new_buffer_size, raw_read_bound_ - raw_read_total_);
+      } else {
+        // We should keeping the current buffer because it contains data that
+        // can be read.
+        new_buffer_size =
+            std::min(new_buffer_size, buffer_size_ + (raw_read_bound_ - raw_read_total_));
+      }
     }
     return ResizeBuffer(new_buffer_size);
   }
@@ -350,7 +364,7 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   Status DoBuffer() {
-    // Fill buffer
+    // Refill the buffer from the raw stream with `buffer_size_` bytes.
     if (!buffer_) {
       RETURN_NOT_OK(ResetBuffer());
     }

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -293,9 +293,9 @@ class BufferedInputStream::Impl : public BufferedBase {
     }
     if ((buffer_pos_ + bytes_buffered_) >= new_buffer_size) {
       return Status::Invalid(
-          "Cannot shrink read buffer if buffered data remains, new_buffer_size:",
-          new_buffer_size, ", buffer_pos:", buffer_pos_,
-          ", bytes_buffered:", bytes_buffered_, ", buffer_size:", buffer_size_);
+          "Cannot shrink read buffer if buffered data remains, new_buffer_size: ",
+          new_buffer_size, ", buffer_pos: ", buffer_pos_,
+          ", bytes_buffered: ", bytes_buffered_, ", buffer_size: ", buffer_size_);
     }
     if (raw_read_bound_ >= 0) {
       // No need to reserve space for more than the total remaining number of bytes.

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -326,7 +326,7 @@ class BufferedInputStream::Impl : public BufferedBase {
     }
 
     // Increase the buffer size if needed.
-    if (nbytes > buffer_size_ - buffer_pos_) {
+    if (nbytes > buffer_->size() - buffer_pos_) {
       RETURN_NOT_OK(SetBufferSize(nbytes + buffer_pos_));
       DCHECK(buffer_->size() - buffer_pos_ >= nbytes);
     }

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -111,6 +111,7 @@ class ARROW_EXPORT BufferedInputStream
       int64_t raw_read_bound = -1);
 
   /// \brief Resize internal read buffer; calls to Read(...) will read at least
+  ///        this many bytes from the raw InputStream if possible.
   /// \param[in] new_buffer_size the new read buffer size
   /// \return Status
   Status SetBufferSize(int64_t new_buffer_size);

--- a/cpp/src/arrow/io/buffered_test.cc
+++ b/cpp/src/arrow/io/buffered_test.cc
@@ -496,8 +496,7 @@ TEST_F(TestBufferedInputStream, PeekPastBufferedBytes) {
   // buffered bytes.
   MakeExample1(/*buffer_size=*/10, default_memory_pool(), /*raw_read_bound=*/15);
   ASSERT_OK_AND_ASSIGN(auto bytes, buffered_->Read(9));
-  EXPECT_EQ(std::string_view(bytes->data_as<char>(), bytes->size()),
-            kExample1.substr(0, 9));
+  EXPECT_EQ(std::string_view(*bytes), kExample1.substr(0, 9));
   ASSERT_EQ(1, buffered_->bytes_buffered());
   ASSERT_EQ(10, buffered_->buffer_size());
   ASSERT_OK_AND_ASSIGN(auto view, buffered_->Peek(3));
@@ -505,13 +504,13 @@ TEST_F(TestBufferedInputStream, PeekPastBufferedBytes) {
   ASSERT_EQ(3, buffered_->bytes_buffered());
   ASSERT_EQ(12, buffered_->buffer_size());
   ASSERT_OK_AND_ASSIGN(view, buffered_->Peek(10));
+  // Peek() cannot go past the `raw_read_bound`
   EXPECT_EQ(view, kExample1.substr(9, 6));
   ASSERT_EQ(6, buffered_->bytes_buffered());
   ASSERT_EQ(15, buffered_->buffer_size());
   // Do read
   ASSERT_OK_AND_ASSIGN(bytes, buffered_->Read(6));
-  EXPECT_EQ(std::string_view(bytes->data_as<char>(), bytes->size()),
-            kExample1.substr(9, 6));
+  EXPECT_EQ(std::string_view(*bytes), kExample1.substr(9, 6));
   ASSERT_EQ(0, buffered_->bytes_buffered());
 }
 

--- a/cpp/src/arrow/io/buffered_test.cc
+++ b/cpp/src/arrow/io/buffered_test.cc
@@ -491,6 +491,19 @@ TEST_F(TestBufferedInputStream, BufferSizeLimit) {
   }
 }
 
+TEST_F(TestBufferedInputStream, PeekPastBufferedBytesTwice) {
+  MakeExample1(/*buffer_size=*/10, default_memory_pool(), /*raw_read_bound=*/15);
+  ASSERT_OK(buffered_->Read(9));
+  ASSERT_EQ(1, buffered_->bytes_buffered());
+  ASSERT_EQ(10, buffered_->buffer_size());
+  ASSERT_OK(buffered_->Peek(6));
+  ASSERT_EQ(6, buffered_->bytes_buffered());
+  ASSERT_EQ(15, buffered_->buffer_size());
+  ASSERT_OK(buffered_->Peek(6));
+  ASSERT_EQ(6, buffered_->bytes_buffered());
+  ASSERT_EQ(15, buffered_->buffer_size());
+}
+
 class TestBufferedInputStreamBound : public ::testing::Test {
  public:
   void SetUp() { CreateExample(/*bounded=*/true); }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://github.com/apache/arrow/issues/43949

The problem is `Peek` and `Read` both calls `SetBufferSize`, however:
1. `Read` implicit says that, when `SetBufferSize` or read, the previous buffer is not being required. In this scenerio, `bytes_buffered_` is always 0, since `Read` will consume all data. And `new_buffer_size == std::min(new_buffer_size, (raw_read_bound_ - raw_read_total_))`
2. `Peek` still requires the buffer-size here. So, `bytes_buffered_` might not 0. When `Peek`, the `new_buffer_size` would less than expected, which shrinks the buffer

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Update the Logic of `SetBufferSize`

1. If `bytes_buffered_ == 0`, `SetBufferSize` can discard the current buffer
2. Otherwise, `SetBufferSize` should resize minimal to `buffer_size_ + (raw_read_bound_ - raw_read_total_)`, since it should considering the current buffer

### Are these changes tested?

Yes

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
3. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Bugfix

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43949