### PR TITLE
GH-44386: [Integration][Release] Pin Python 3.12 for Integration verification when using Conda

### DIFF
--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -67,6 +67,11 @@ jobs:
         {% if use_conda %}
           USE_CONDA: 1
           {% if target == "integration" %}
+          # JPype doesn't work with Python 3.13.
+          # See also:
+          # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5
+          # * GH-44386
+          # * GH-44389
           PYTHON_VERSION: "3.12"
           {% endif %}
         {% endif %}

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -66,6 +66,9 @@ jobs:
           TEST_{{ target|upper }}: 1
         {% if use_conda %}
           USE_CONDA: 1
+          {% if target == "integration" %}
+          PYTHON_VERSION: "3.12"
+          {% endif %}
         {% endif %}
         run: |
           arrow/dev/release/verify-release-candidate.sh {{ release|default("") }} {{ rc|default("") }}


### PR DESCRIPTION
### Rationale for this change

Conda Python 3.13 fails when running verification tasks for Java. It's related to JPype.

See also:
* GH-44389
* https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5

### What changes are included in this PR?

Pin Python 3.12 on Conda integration jobs because JPype doesn't work with Python 3.13. We can use Python 3.13 again once JPype supports Python 3.13.

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?

No
* GitHub Issue: #44386