### PR TITLE
GH-44353: [Java] Implement `map()` for `UnionMapWriter`

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -219,4 +219,16 @@ public class UnionMapWriter extends UnionListWriter {
         return super.map();
     }
   }
+
+  @Override
+  public MapWriter map() {
+    switch (mode) {
+      case KEY:
+        return entryWriter.map(MapVector.KEY_NAME);
+      case VALUE:
+        return entryWriter.map(MapVector.VALUE_NAME);
+      default:
+        return super.map();
+    }
+  }
 }


### PR DESCRIPTION
### Rationale for this change

See #44353 

`UnionMapWriter` does not override `map()` and falls back to implementation in `UnionListWriter` which causes exception when used.

### What changes are included in this PR?

Implement `map()` for `UnionMapWriter`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Changed behavior of the related function. 

* GitHub Issue: #44353