### PR TITLE
GH-44368: [C++] Use "lib" for generating bundled dependencies even with "clang-cl"

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -119,6 +119,17 @@ function(arrow_create_merged_static_lib output_target)
 
     set(BUNDLE_COMMAND ${LIBTOOL_MACOS} "-no_warning_for_no_symbols" "-static" "-o"
                        ${output_lib_path} ${all_library_paths})
+  elseif(MSVC)
+    if(CMAKE_LIBTOOL)
+      set(BUNDLE_TOOL ${CMAKE_LIBTOOL})
+    else()
+      find_program(BUNDLE_TOOL lib HINTS "${CMAKE_CXX_COMPILER}/..")
+      if(NOT BUNDLE_TOOL)
+        message(FATAL_ERROR "Cannot locate lib.exe to bundle libraries")
+      endif()
+    endif()
+    set(BUNDLE_COMMAND ${BUNDLE_TOOL} /NOLOGO /OUT:${output_lib_path}
+                       ${all_library_paths})
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|GNU|Intel|IntelLLVM)$")
     set(ar_script_path ${CMAKE_BINARY_DIR}/${ARG_NAME}.ar)
 
@@ -140,18 +151,6 @@ function(arrow_create_merged_static_lib output_target)
     endif()
 
     set(BUNDLE_COMMAND ${ar_tool} -M < ${ar_script_path})
-
-  elseif(MSVC)
-    if(CMAKE_LIBTOOL)
-      set(BUNDLE_TOOL ${CMAKE_LIBTOOL})
-    else()
-      find_program(BUNDLE_TOOL lib HINTS "${CMAKE_CXX_COMPILER}/..")
-      if(NOT BUNDLE_TOOL)
-        message(FATAL_ERROR "Cannot locate lib.exe to bundle libraries")
-      endif()
-    endif()
-    set(BUNDLE_COMMAND ${BUNDLE_TOOL} /NOLOGO /OUT:${output_lib_path}
-                       ${all_library_paths})
   else()
     message(FATAL_ERROR "Unknown bundle scenario!")
   endif()


### PR DESCRIPTION
### Rationale for this change

We need to use "clang-cl" for Windows ARM64. We can use MSVC tool such as "lib" for generating bundled dependencies with "clang-cl" build because it's a MSVC like build.

### What changes are included in this PR?

Prefer "lib" to `${CMAKE_AR}` with "clang-cl" for generating bundled dependencies. It seems that `${CMAKE_AR}` doesn't generate `arrow_bundled_dependencies.lib`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44368