### PR TITLE
GH-44389: [Java][Integration][Release] Use Python 3.12 for verify-rc-source-integration-linux-conda-latest-amd64

### DIFF
--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -42,11 +42,12 @@ jobs:
             -e ARROW_GANDIVA=OFF \
             {% endif %}
             {% if distro == "conda" and target == "integration" %}
-            # JPype doesn't work with Python 3.13. \
-            # See also: \
-            # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5 \
-            # * GH-44386 \
-            # * GH-44389 \
+            {# JPype doesn't work with Python 3.13.
+             # See also:
+             # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5
+             # * GH-44386
+             # * GH-44389
+            #}
             -e PYTHON_VERSION="3.12" \
             {% endif %}
             -e VERIFY_RC="{{ rc|default("") }}" \

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -28,14 +28,6 @@ jobs:
     {% for key, value in env.items() %}
       {{ key }}: {{ value }}
     {% endfor %}
-      {% if distro == "conda" and target == "integration" %}
-      # JPype doesn't work with Python 3.13.
-      # See also:
-      # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5
-      # * GH-44386
-      # * GH-44389
-      PYTHON_VERSION: "3.12"
-      {% endif %}
     {% endif %}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=0)|indent }}
@@ -48,6 +40,14 @@ jobs:
             -e VERIFY_VERSION="{{ release|default("") }}" \
             {% if distro == 'almalinux' and target|upper == 'PYTHON' %}
             -e ARROW_GANDIVA=OFF \
+            {% endif %}
+            {% if distro == "conda" and target == "integration" %}
+            # JPype doesn't work with Python 3.13. \
+            # See also: \
+            # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5 \
+            # * GH-44386 \
+            # * GH-44389 \
+            -e PYTHON_VERSION="3.12" \
             {% endif %}
             -e VERIFY_RC="{{ rc|default("") }}" \
             -e TEST_DEFAULT=0 \

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -28,6 +28,14 @@ jobs:
     {% for key, value in env.items() %}
       {{ key }}: {{ value }}
     {% endfor %}
+      {% if distro == "conda" and target == "integration" %}
+      # JPype doesn't work with Python 3.13.
+      # See also:
+      # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5
+      # * GH-44386
+      # * GH-44389
+      PYTHON_VERSION: "3.12"
+      {% endif %}
     {% endif %}
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=0)|indent }}

--- a/dev/tasks/verify-rc/github.linux.amd64.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.yml
@@ -65,6 +65,14 @@ jobs:
           TEST_DEFAULT: 0
           TEST_{{ target|upper }}: 1
         {% if use_conda %}
+          {% if target == "integration" %}
+          # JPype doesn't work with Python 3.13.
+          # See also:
+          # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5
+          # * GH-44386
+          # * GH-44389
+          PYTHON_VERSION: "3.12"
+          {% endif %}
           USE_CONDA: 1
         {% endif %}
         run: |

--- a/dev/tasks/verify-rc/github.linux.amd64.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.yml
@@ -65,14 +65,6 @@ jobs:
           TEST_DEFAULT: 0
           TEST_{{ target|upper }}: 1
         {% if use_conda %}
-          {% if target == "integration" %}
-          # JPype doesn't work with Python 3.13.
-          # See also:
-          # * https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5
-          # * GH-44386
-          # * GH-44389
-          PYTHON_VERSION: "3.12"
-          {% endif %}
           USE_CONDA: 1
         {% endif %}
         run: |

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -65,7 +65,6 @@ jobs:
           TEST_DEFAULT: 0
           TEST_{{ target|upper }}: 1
         {% if use_conda %}
-          USE_CONDA: 1
           {% if target == "integration" %}
           # JPype doesn't work with Python 3.13.
           # See also:
@@ -74,6 +73,7 @@ jobs:
           # * GH-44389
           PYTHON_VERSION: "3.12"
           {% endif %}
+          USE_CONDA: 1
         {% endif %}
         run: |
           arrow/dev/release/verify-release-candidate.sh {{ release|default("") }} {{ rc|default("") }}


### PR DESCRIPTION
### Rationale for this change

Because JPype doesn't support Python 3.13 yet.

See also:
* GH-44389
* https://discuss.python.org/t/api-for-python-3-13-prevents-use-of-3rd-party-gc-allocators/62709/5

### What changes are included in this PR?

Pin Python 3.12.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44389