### PR TITLE
GH-44404: [CI] Stop running CI "push" jobs for Dependabot

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -19,6 +19,11 @@ name: Archery & Crossbow
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/archery.yml'

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -19,6 +19,11 @@ name: C++
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/cpp.yml'

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,6 +19,11 @@ name: C#
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.github/workflows/csharp.yml'
       - 'ci/scripts/csharp_*'

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,8 +18,13 @@
 name: Dev
 
 on:
-  # always trigger
+  # always trigger except Dependabot "push"
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
   pull_request:
 
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,11 @@ name: Integration
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/integration.yml'

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -19,6 +19,11 @@ name: Java
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/java.yml'

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -19,6 +19,11 @@ name: Java JNI
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/java_jni.yml'

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -19,6 +19,11 @@ name: NodeJS
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/js.yml'

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -19,6 +19,11 @@ name: MATLAB
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.github/workflows/matlab.yml'
       - 'ci/scripts/matlab*.sh'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,11 @@ name: Python
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/python.yml'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -19,6 +19,11 @@ name: R
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - ".github/workflows/r.yml"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,11 @@ name: C GLib & Ruby
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/ruby.yml'

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,6 +19,11 @@ name: Swift
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
     paths:
       - '.dockerignore'
       - '.github/workflows/swift.yml'


### PR DESCRIPTION
### Rationale for this change

They are redundant. We have the same jobs for "push" and "pull_request". We don't need either of them.

### What changes are included in this PR?

Ignore `dependabot/**` branches for "push".

We need to define not only `branches:` but also `tags:`. If we don't define `tags:`, the target workflows aren't trigger by tag push.

See also: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

> If you define only tags/tags-ignore or only branches/branches-ignore, the workflow won't run for events affecting the undefined Git ref. If you define neither tags/tags-ignore or branches/branches-ignore, the workflow will run for events affecting either branches or tags. If you define both branches/branches-ignore and [paths/paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), the workflow will only run when both filters are satisfied.

### Are these changes tested?

No. Let's try on apache/arrow main.

### Are there any user-facing changes?

No.
* GitHub Issue: #44404