### PR TITLE
GH-44415: [Release][Ruby] Remove pins from glib section of release verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -775,9 +775,7 @@ test_glib() {
   show_header "Build and test C GLib libraries"
 
   # Build and test C GLib
-  # We can remove '==2.80.5' and 'python<3.13' once
-  # https://github.com/conda-forge/glib-feedstock/issues/191 is fixed.
-  maybe_setup_conda glib==2.80.5 gobject-introspection meson ninja 'python<3.13' ruby
+  maybe_setup_conda glib gobject-introspection meson ninja ruby
   maybe_setup_virtualenv meson
 
   # Install bundler if doesn't exist


### PR DESCRIPTION
### Rationale for this change

We can remove these pins now that https://github.com/conda-forge/glib-feedstock/issues/191 has been closed. I've tested on my own crossbow and will test here momentarily. This effectively reverts https://github.com/apache/arrow/pull/44270 and https://github.com/apache/arrow/issues/44268.

### What changes are included in this PR?

Tweaks to release release verification script, specifically removing recently-added pins.

### Are these changes tested?

Yes: https://github.com/amoeba/crossbow/actions/runs/11335070956/job/31522511285.

### Are there any user-facing changes?

No.

Closes #44415.
* GitHub Issue: #44415