### PR TITLE
GH-44396: [CI][C++] Use setup-python on hosted runner

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -141,7 +141,15 @@ jobs:
           path: .docker
           key: ${{ matrix.image }}-${{ hashFiles('cpp/**') }}
           restore-keys: ${{ matrix.image }}-
-      - name: Setup Python
+      - name: Setup Python on hosted runner
+        if: |
+          matrix.runs-on == 'ubuntu-latest'
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: 3
+      - name: Setup Python on self-hosted runner
+        if: |
+          contains(matrix.runs-on, 'self-hosted')
         run: |
           sudo apt update
           sudo apt install -y --no-install-recommends python3 python3-dev python3-pip


### PR DESCRIPTION
### Rationale for this change

We can't install packages by `pip install` with Ubuntu 24.04's pip by default.

### What changes are included in this PR?

Use `actions/setup-python` instead. We can install packages by `pip install` with `actions/setup-python` by default.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44396