### PR TITLE
GH-44412: [CI][R] Use Ubuntu 22.04 not 24.04 for Arrow C++ 15.0.2 deb packages

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -59,7 +59,9 @@ env:
 jobs:
   ubuntu-minimum-cpp-version:
     name: Check minimum supported Arrow C++ Version (${{ matrix.cpp_version }})
-    runs-on: ubuntu-latest
+    # We don't provide Apache Arrow C++ 15.0.2 deb packages for Ubuntu 24.04.
+    # So we use ubuntu-22.04 here.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
### Rationale for this change

Because we don't provide Arrow C++ 15.0.2 for Ubuntu 24.04.

### What changes are included in this PR?

Use `ubuntu-22.04` instead of `ubuntu-latest`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44412