### PR TITLE
GH-44422: [Packaging][Release][Linux] Upload artifacts before test

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -122,7 +122,6 @@ case "${distribution}-${distribution_version}" in
   centos-*)
     distribution_prefix="centos"
     repository_version+="-stream"
-    dnf update -y
     ;;
 esac
 if [ "$(arch)" = "aarch64" ]; then

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -122,6 +122,7 @@ case "${distribution}-${distribution_version}" in
   centos-*)
     distribution_prefix="centos"
     repository_version+="-stream"
+    dnf update -y
     ;;
 esac
 if [ "$(arch)" = "aarch64" ]; then

--- a/dev/tasks/linux-packages/github.linux.yml
+++ b/dev/tasks/linux-packages/github.linux.yml
@@ -83,6 +83,10 @@ jobs:
           APT_TARGETS: {{ target }}
           REPO: {{ '${{ secrets.REPO }}' }}
           YUM_TARGETS: {{ target }}
+
+      {% set patterns = upload_extensions | format_all("arrow/dev/tasks/linux-packages/*/*/repositories/**/*{}") %}
+      {{ macros.github_upload_releases(patterns)|indent }}
+
       - name: Set up test
         run: |
           sudo apt install -y \
@@ -123,6 +127,3 @@ jobs:
           APT_TARGETS: {{ target }}
           ARROW_VERSION: {{ arrow.version }}
           YUM_TARGETS: {{ target }}
-
-      {% set patterns = upload_extensions | format_all("arrow/dev/tasks/linux-packages/*/*/repositories/**/*{}") %}
-      {{ macros.github_upload_releases(patterns)|indent }}


### PR DESCRIPTION
### Rationale for this change

It seems that the current `quay.io/centos/centos:stream9` for `linux/aarch64` is broken.

We use it for building and testing but testing is only broken for now. Because we use cached (a bit old) `quay.io/centos/centos:stream9` for now. Building will be failed when the cache is expired.

### What changes are included in this PR?

Change upload phase to after the build from after the test. Test is still failing but we can proceed our release process by this.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44422