### PR TITLE
GH-44416: [C++][Docs] Update the URL to C++ Development in README.md

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -31,4 +31,4 @@ to install pre-compiled binary versions of the library.
 
 Please refer to our latest [C++ Development Documentation][1].
 
-[1]: https://github.com/apache/arrow/blob/main/docs/source/developers/cpp
+[1]: https://arrow.apache.org/docs/dev/developers/cpp/


### PR DESCRIPTION
### Rationale for this change

A new developer can find proper documentation more easily.

### What changes are included in this PR?

Change the reference URL link to the official documentation page instead of the GitHub project page.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #44416