### PR TITLE
GH-44428: [CI][C#] Use setup-python to use "pip install"

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
 
   ubuntu:
-    name: AMD64 Ubuntu 18.04 C# ${{ matrix.dotnet }}
+    name: AMD64 Ubuntu 24.04 C# ${{ matrix.dotnet }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
@@ -52,6 +52,10 @@ jobs:
         uses: actions/setup-dotnet@v4.0.1
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - name: Setup Python
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: 3
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Rationale for this change

We can't use `pip install` with Ubuntu 24.04's Python.

### What changes are included in this PR?

Use `actions/setup-python` instead of Ubuntu 24.04's Python.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44428