### PR TITLE
GH-44430: [CI][Swfit] Use setup-python to use "pip install"

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -58,6 +58,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Setup Python on hosted runner
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: 3
       - name: Setup Archery
         run: pip install -e dev/archery[docker]
       - name: Execute Docker Build


### PR DESCRIPTION
### Rationale for this change

We can't use `pip install` with Ubuntu 24.04's Python.

### What changes are included in this PR?

Use `actions/setup-python` instead of Ubuntu 24.04's Python.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44430