### PR TITLE
GH-44432: [Swift] Use flatbuffers v24.3.7

### DIFF
--- a/swift/Arrow/Package.swift
+++ b/swift/Arrow/Package.swift
@@ -31,11 +31,10 @@ let package = Package(
             targets: ["Arrow"])
     ],
     dependencies: [
-        // The latest version of flatbuffers v23.5.26 was built in May 26, 2023
-        // and therefore doesn't include the unaligned buffer swift changes.
-        // This can be changed back to using the tag once a new version of
-        // flatbuffers has been released.
-        .package(url: "https://github.com/google/flatbuffers.git", branch: "master"),
+        .package(
+              url: "https://github.com/google/flatbuffers.git",
+              .upToNextMajor(from: "v24.3.7")
+            ),
         .package(
               url: "https://github.com/apple/swift-atomics.git",
               .upToNextMajor(from: "1.2.0") // or `.upToNextMinor

--- a/swift/Arrow/Package.swift
+++ b/swift/Arrow/Package.swift
@@ -31,10 +31,7 @@ let package = Package(
             targets: ["Arrow"])
     ],
     dependencies: [
-        .package(
-              url: "https://github.com/google/flatbuffers.git",
-              .upToNextMajor(from: "v24.3.7")
-            ),
+        .package(url: "https://github.com/google/flatbuffers.git", branch: "v24.3.7"),
         .package(
               url: "https://github.com/apple/swift-atomics.git",
               .upToNextMajor(from: "1.2.0") // or `.upToNextMinor


### PR DESCRIPTION
### Rationale for this change

flatbuffers v24.3.7 includes https://github.com/google/flatbuffers/pull/8134 .

The current master has a build error:

https://github.com/apache/arrow/actions/runs/11357784776/job/31591213976?pr=44431#step:5:1114

```text
[51/77] Compiling Arrow ArrowType.swift
/arrow/swift/Arrow/Sources/Arrow/File_generated.swift:107:206: error: value of type 'Table' has no member 'postion'
  public var schema: org_apache_arrow_flatbuf_Schema? { let o = _accessor.offset(VTOFFSET.schema.v); return o == 0 ? nil : org_apache_arrow_flatbuf_Schema(_accessor.bb, o: _accessor.indirect(o + _accessor.postion)) }
                                                                                                                                                                                                   ~~~~~~~~~ ^~~~~~~
```

### What changes are included in this PR?

Use v24.3.7 instead of master.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44432