### PR TITLE
GH-41643: [Python][Docs] Document Timezone Handling in Nested Arrays with to_pandas()

### DIFF
--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -208,6 +208,24 @@ In this example the Pandas Timestamp is time zone aware
 (``UTC`` on this case), and this information is used to create the Arrow
 :class:`~.TimestampArray`.
 
+When converting nested Timestamp arrays using :meth:`to_pandas()`, timezone information is **not preserved**. For example:
+
+.. ipython:: python
+
+    ts = pd.Timestamp('2024-01-01 12:00:00+0000', tz='Europe/Paris')
+    arr = pa.array([[ts]])
+    arr.to_pandas()[0][0]  # Returns timezone-naive numpy.datetime64
+
+In this case, the conversion defaults to ``numpy.datetime64``, which drops the timezone information. This happens because NumPy does not support timezones in its ``datetime64`` format, and PyArrow inherits this limitation when converting nested arrays - this is unlikely to change in the near future.
+
+To preserve the timezone information when converting nested arrays, the ``timestamp_as_object=True`` argument can be used. This converts the timestamps to Python ``datetime`` objects, which are timezone-aware:
+
+.. ipython:: python
+
+    arr.to_pandas(timestamp_as_object=True)[0][0]  # Returns timezone-aware Python datetime
+
+While this retains timezone information, it comes with a performance trade-off due to the use of ``object-dtype`` arrays in pandas, which are less efficient than ``numpy.datetime64`` arrays.
+
 Date types
 ~~~~~~~~~~
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Issue links to #41162, which describes the current behaviour of timezone information being dropped from nested Timestamp arrays is unlikely to change in the near future, as such, requires documentation.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Documentation added in [pandas.rst](https://github.com/apache/arrow/blob/main/docs/source/python/pandas.rst) outlining the unintended behaviour.
- Looking to close #41643 

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No, this is a documentation change.

### Are there any user-facing changes?

Yes, it will update part of the [Pandas Integration](https://arrow.apache.org/docs/dev/python/pandas.html) documentation page.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #41643