### PR TITLE
GH-44441: [Release] Add missing `--repo apache/arrow` in `02-source.sh`

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -90,7 +90,7 @@ if [ ${SOURCE_UPLOAD} -gt 0 ]; then
   ${sha512_generate} $tarball > ${tarball}.sha512
 
   # Upload signed tarballs to GitHub Release
-  gh release upload ${tag} ${tarball}.sha256 ${tarball}.sha512
+  gh release upload --repo apache/arrow ${tag} ${tarball}.sha256 ${tarball}.sha512
 
   # check out the arrow RC folder
   svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow tmp


### PR DESCRIPTION
### Rationale for this change

We need to specify `--repo apache/arrow` to ensure using apache/arrow.

### What changes are included in this PR?

Add `--repo apache/arrow`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44441