### PR TITLE
GH-44449: [Release] Retry on HTTP error in binary upload

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -532,7 +532,8 @@ class BinaryTask
              OpenSSL::OpenSSLError,
              SocketError,
              SystemCallError,
-             Timeout::Error => error
+             Timeout::Error,
+             Error => error
         n_retries += 1
         if n_retries <= max_n_retries
           $stderr.puts


### PR DESCRIPTION
### Rationale for this change

Artifactory sometimes reports the following 503 HTTP error:

```text
BinaryTask::ArtifactoryClient::Error: failed to request: https://apache.jfrog.io/artifactory/arrow/debian-rc/pool/bookworm/main/a/apache-arrow/libparquet-glib1800_18.0.0-1_arm64.deb: PUT:  503
{
  "errors" : [ {
    "status" : 503,
    "message" : "503 : Failed during addStream to bucket"
  } ]
}
```

It seems that this is a temporary error. So we can retry on this type error for stable upload.

### What changes are included in this PR?

Retry on HTTP error.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44449