### PR TITLE
GH-44451: [Release] Retry on HTTP error in Java upload

### DIFF
--- a/dev/release/06-java-upload.sh
+++ b/dev/release/06-java-upload.sh
@@ -107,8 +107,9 @@ for pom in *.pom; do
   classifiers=""
   args=()
   args+=(deploy:deploy-file)
-  args+=(-Durl=https://repository.apache.org/service/local/staging/deploy/maven2)
   args+=(-DrepositoryId=apache.releases.https)
+  args+=(-DretryFailedDeploymentCount=10)
+  args+=(-Durl=https://repository.apache.org/service/local/staging/deploy/maven2)
   pom="${PWD}/${pom}"
   args+=(-DpomFile="${pom}")
   if [ -f "${base}.jar" ]; then
@@ -139,7 +140,7 @@ for pom in *.pom; do
   args+=(-Dtypes="${types}")
   args+=(-Dclassifiers="${classifiers}")
   pushd "${SOURCE_DIR}"
-  mvn deploy:deploy-file "${args[@]}"
+  mvn "${args[@]}"
   popd
 done
 


### PR DESCRIPTION
### Rationale for this change

`dev/release/06-java-upload.sh` sometimes failed with the following HTTP error:

```text
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy-file (default-cli) on project standalone-pom: Failed to deploy artifacts: Could not transfer artifact org.apache.arrow:arrow-compression:pom:18.0.0 from/to apache.releases.https (https://repository.apache.org/service/local/staging/deploy/maven2): transfer failed for https://repository.apache.org/service/local/staging/deploy/maven2/org/apache/arrow/arrow-compression/18.0.0/arrow-compression-18.0.0.pom, status: 408 Request Timeout -> [Help 1]
```

### What changes are included in this PR?

Use `-DretryFailedDeploymentCount=10` for retry on HTTP error.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44451