### PR TITLE
GH-44459: [Release][Packaging] Do not check wheel content when verifying binary wheels

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1057,6 +1057,10 @@ test_linux_wheels() {
   local python_versions="${TEST_PYTHON_VERSIONS:-3.9 3.10 3.11 3.12 3.13}"
   local platform_tags="${TEST_WHEEL_PLATFORM_TAGS:-manylinux_2_17_${arch}.manylinux2014_${arch} manylinux_2_28_${arch}}"
 
+  if [ "${SOURCE_KIND}" != "local" ]; then
+    local wheel_content="OFF"
+  fi
+
   for python in ${python_versions}; do
     local pyver=${python/m}
     for platform in ${platform_tags}; do
@@ -1066,7 +1070,8 @@ test_linux_wheels() {
         continue
       fi
       pip install pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-${platform}.whl
-      INSTALL_PYARROW=OFF ARROW_GCS=${check_gcs} ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
+      CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} INSTALL_PYARROW=OFF ARROW_GCS=${check_gcs} \
+        ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done
   done
 }
@@ -1086,6 +1091,10 @@ test_macos_wheels() {
     local platform_tags="macosx_10_15_x86_64"
   fi
 
+  if [ "${SOURCE_KIND}" != "local" ]; then
+    local wheel_content="OFF"
+  fi
+
   # verify arch-native wheels inside an arch-native conda environment
   for python in ${python_versions}; do
     local pyver=${python/m}
@@ -1102,7 +1111,8 @@ test_macos_wheels() {
       fi
 
       pip install pyarrow-${VERSION}-cp${pyver/.}-cp${python/.}-${platform}.whl
-      INSTALL_PYARROW=OFF ARROW_FLIGHT=${check_flight} ARROW_GCS=${check_gcs} ARROW_S3=${check_s3} \
+      CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} INSTALL_PYARROW=OFF ARROW_FLIGHT=${check_flight} \
+        ARROW_GCS=${check_gcs} ARROW_S3=${check_s3} \
         ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done
   done

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1084,11 +1084,11 @@ test_macos_wheels() {
   # apple silicon processor
   if [ "$(uname -m)" = "arm64" ]; then
     local python_versions="3.9 3.10 3.11 3.12 3.13"
-    local platform_tags="macosx_11_0_arm64"
+    local platform_tags="macosx_12_0_arm64"
     local check_flight=OFF
   else
     local python_versions="3.9 3.10 3.11 3.12 3.13"
-    local platform_tags="macosx_10_15_x86_64"
+    local platform_tags="macosx_12_0_x86_64"
   fi
 
   if [ "${SOURCE_KIND}" != "local" ]; then


### PR DESCRIPTION
### Rationale for this change

Currently the folder used to verify the contents of the wheels is not correct when doing a release verification of the wheels and the verification fails. The script is supposed to check wheels individually and we are already verifying the contents on the wheels individually when generating the wheels.

### What changes are included in this PR?

Stop checking wheel content on release verification as the wheel content has already been validated when generating the wheels.

There is also a minor fix on the platform tags for the macOS wheels that was missed when we updated the MACOSX_DEPLOYMENT_TARGET.

### Are these changes tested?

Yes via archery.

### Are there any user-facing changes?

No
* GitHub Issue: #44459