### PR TITLE
GH-44461: [Release][Packacing][Python] Set PARQUET_TEST_DATA on verify-release-candidate-wheels.bat

### DIFF
--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -20,7 +20,7 @@
 set -ex
 
 # Download database
-curl https://data.iana.org/time-zones/releases/tzdata2024e.tar.gz --output ~/Downloads/tzdata2024b.tar.gz
+curl https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz --output ~/Downloads/tzdata2024b.tar.gz
 
 # Extract
 mkdir -p ~/Downloads/tzdata

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -24,7 +24,8 @@ curl https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz --output ~/Dow
 
 # Extract
 mkdir -p ~/Downloads/tzdata
-tar --extract --file ~/Downloads/tzdata2024b.tar.gz --directory ~/Downloads/tzdata
+ls -lah ~/Downloads/tzdata
+tar --extract --file ~/Downloads/tzdata2024b.tar.gz --directory ~/Downloads/tzdata --verbose
 
 # Download Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml --output ~/Downloads/tzdata/windowsZones.xml

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -26,6 +26,7 @@ curl https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz --output ~/Dow
 mkdir -p ~/Downloads/tzdata
 ls -lah ~/Downloads/tzdata
 tar --extract --file ~/Downloads/tzdata2024b.tar.gz --directory ~/Downloads/tzdata --verbose
+grep -r Mexico ~/Downloads/tzdata
 
 # Download Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml --output ~/Downloads/tzdata/windowsZones.xml

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -20,13 +20,12 @@
 set -ex
 
 # Download database
-curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output ~/Downloads/tzdata2021e.tar.gz
+curl https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz --output ~/Downloads/tzdata.tar.gz
 
 # Extract
 mkdir -p ~/Downloads/tzdata
 ls -lah ~/Downloads/tzdata
-tar --extract --file ~/Downloads/tzdata2021e.tar.gz --directory ~/Downloads/tzdata --verbose
-grep -r Mexico ~/Downloads/tzdata
+tar --extract --file ~/Downloads/tzdata.tar.gz --directory ~/Downloads/tzdata
 
 # Download Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml --output ~/Downloads/tzdata/windowsZones.xml

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -20,11 +20,11 @@
 set -ex
 
 # Download database
-curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output ~/Downloads/tzdata2021e.tar.gz
+curl https://data.iana.org/time-zones/releases/tzdata2024e.tar.gz --output ~/Downloads/tzdata2024b.tar.gz
 
 # Extract
 mkdir -p ~/Downloads/tzdata
-tar --extract --file ~/Downloads/tzdata2021e.tar.gz --directory ~/Downloads/tzdata
+tar --extract --file ~/Downloads/tzdata2024b.tar.gz --directory ~/Downloads/tzdata
 
 # Download Windows timezone mapping
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml --output ~/Downloads/tzdata/windowsZones.xml

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -24,7 +24,6 @@ curl https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz --output ~/Dow
 
 # Extract
 mkdir -p ~/Downloads/tzdata
-ls -lah ~/Downloads/tzdata
 tar --extract --file ~/Downloads/tzdata.tar.gz --directory ~/Downloads/tzdata
 
 # Download Windows timezone mapping

--- a/ci/scripts/download_tz_database.sh
+++ b/ci/scripts/download_tz_database.sh
@@ -20,12 +20,12 @@
 set -ex
 
 # Download database
-curl https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz --output ~/Downloads/tzdata2024b.tar.gz
+curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output ~/Downloads/tzdata2021e.tar.gz
 
 # Extract
 mkdir -p ~/Downloads/tzdata
 ls -lah ~/Downloads/tzdata
-tar --extract --file ~/Downloads/tzdata2024b.tar.gz --directory ~/Downloads/tzdata --verbose
+tar --extract --file ~/Downloads/tzdata2021e.tar.gz --directory ~/Downloads/tzdata --verbose
 grep -r Mexico ~/Downloads/tzdata
 
 # Download Windows timezone mapping

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -60,7 +60,7 @@ set PARQUET_TEST_DATA=%cd%\arrow\cpp\submodules\parquet-testing\data
 @rem Download IANA Timezone Database for ORC C++
 curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B
 mkdir %USERPROFILE%\Downloads\test\tzdata
-arc unarchive tzdata.tar.xz %USERPROFILE%\Downloads\test\tzdata
+tar --extract --file tzdata.tar.xz --directory %USERPROFILE%\Downloads\test\tzdata
 set TZDIR=%USERPROFILE%\Downloads\test\tzdata\usr\share\zoneinfo
 
 CALL :verify_wheel 3.9

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -57,6 +57,7 @@ call deactivate
 set ARROW_TEST_DATA=%cd%\arrow\testing\data
 set PARQUET_TEST_DATA=%cd%\arrow\cpp\submodules\parquet-testing\data
 
+
 CALL :verify_wheel 3.9
 if errorlevel 1 GOTO error
 

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -55,6 +55,7 @@ python arrow\dev\release\download_rc_binaries.py %ARROW_VERSION% %RC_NUMBER% ^
 call deactivate
 
 set ARROW_TEST_DATA=%cd%\arrow\testing\data
+set PARQUET_TEST_DATA=%cd%\arrow\cpp\submodules\parquet-testing\data
 
 
 CALL :verify_wheel 3.9

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -56,12 +56,7 @@ call deactivate
 
 set ARROW_TEST_DATA=%cd%\arrow\testing\data
 set PARQUET_TEST_DATA=%cd%\arrow\cpp\submodules\parquet-testing\data
-
-@rem Download IANA Timezone Database for ORC C++
-curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B
-mkdir %USERPROFILE%\Downloads\test\tzdata
-tar --extract --file tzdata.tar.xz --directory %USERPROFILE%\Downloads\test\tzdata
-set TZDIR=%USERPROFILE%\Downloads\test\tzdata\usr\share\zoneinfo
+set TZDIR=c:\msys64\usr\share\zoneinfo
 
 CALL :verify_wheel 3.9
 if errorlevel 1 GOTO error

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -107,6 +107,7 @@ python -c "import pyarrow.dataset" || EXIT /B 1
 pip install -r arrow\python\requirements-test.txt || EXIT /B 1
 
 set PYARROW_TEST_CYTHON=OFF
+dir %USERPROFILE%\Downloads\tzdata
 pytest %CONDA_ENV_PATH%\Lib\site-packages\pyarrow --pdb -v || EXIT /B 1
 
 :done

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -107,7 +107,7 @@ python -c "import pyarrow.dataset" || EXIT /B 1
 pip install -r arrow\python\requirements-test.txt || EXIT /B 1
 
 set PYARROW_TEST_CYTHON=OFF
-dir %USERPROFILE%\Downloads\tzdata
+set TZDIR=%CONDA_ENV_PATH%\share\zoneinfo
 pytest %CONDA_ENV_PATH%\Lib\site-packages\pyarrow --pdb -v || EXIT /B 1
 
 :done

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -56,7 +56,6 @@ call deactivate
 
 set ARROW_TEST_DATA=%cd%\arrow\testing\data
 set PARQUET_TEST_DATA=%cd%\arrow\cpp\submodules\parquet-testing\data
-set TZDIR=c:\msys64\usr\share\zoneinfo
 
 CALL :verify_wheel 3.9
 if errorlevel 1 GOTO error

--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -57,6 +57,11 @@ call deactivate
 set ARROW_TEST_DATA=%cd%\arrow\testing\data
 set PARQUET_TEST_DATA=%cd%\arrow\cpp\submodules\parquet-testing\data
 
+@rem Download IANA Timezone Database for ORC C++
+curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B
+mkdir %USERPROFILE%\Downloads\test\tzdata
+arc unarchive tzdata.tar.xz %USERPROFILE%\Downloads\test\tzdata
+set TZDIR=%USERPROFILE%\Downloads\test\tzdata\usr\share\zoneinfo
 
 CALL :verify_wheel 3.9
 if errorlevel 1 GOTO error

--- a/dev/tasks/verify-rc/github.win.yml
+++ b/dev/tasks/verify-rc/github.win.yml
@@ -29,6 +29,7 @@ jobs:
       {{ key }}: {{ value }}
     {% endfor %}
     {% endif %}
+    timeout-minutes: 60
 
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=0)|indent }}


### PR DESCRIPTION
### Rationale for this change

The Windows wheel verification fails due to missing `PARQUET_TEST_DATA`

### What changes are included in this PR?

Add `PARQUET_TEST_DATA` to `verify-release-candidate-wheels.bat` which is only tested on the binary verification job.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #44461