### PR TITLE
GH-44372: [C++] Fix unaligned load/store implementation for clang-18

### DIFF
--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -63,7 +63,7 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoadAs(
 template <typename T>
 inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoad(const T* unaligned) {
   std::remove_const_t<T> ret;
-  std::memcpy(&ret, unaligned, sizeof(T));
+  std::memcpy(&ret, reinterpret_cast<const void*>(unaligned), sizeof(T));
   return ret;
 }
 
@@ -73,7 +73,7 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T> &&
                         U>
 SafeCopy(T value) {
   std::remove_const_t<U> ret;
-  std::memcpy(&ret, &value, sizeof(T));
+  std::memcpy(&ret, reinterpret_cast<const void*>(&value), sizeof(T));
   return ret;
 }
 

--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -63,7 +63,7 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoadAs(
 template <typename T>
 inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoad(const T* unaligned) {
   std::remove_const_t<T> ret;
-  std::memcpy(&ret, reinterpret_cast<const void*>(unaligned), sizeof(T));
+  std::memcpy(&ret, static_cast<const void*>(unaligned), sizeof(T));
   return ret;
 }
 
@@ -73,7 +73,7 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T> &&
                         U>
 SafeCopy(T value) {
   std::remove_const_t<U> ret;
-  std::memcpy(&ret, reinterpret_cast<const void*>(&value), sizeof(T));
+  std::memcpy(&ret, static_cast<const void*>(&value), sizeof(T));
   return ret;
 }
 


### PR DESCRIPTION
### Rationale for this change

CLang 18 complains about undefined behavior when memcpy is called on a T-unaligned `T*` pointer.
This is due to this upstream change: https://github.com/llvm/llvm-project/pull/67766

### What changes are included in this PR?

Workaround by casting to `void*`.

### Are these changes tested?

By existing CI tests.

### Are there any user-facing changes?

No.

* GitHub Issue: #44372