### PR TITLE
GH-44018: [R] Treat builds on R-universe as like `NOT_CRAN=true`

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -926,7 +926,9 @@ options(.arrow.cleanup = character())
 on.exit(unlink(getOption(".arrow.cleanup"), recursive = TRUE), add = TRUE)
 
 not_cran <- env_is("NOT_CRAN", "true")
-if (not_cran) {
+on_r_universe <- !env_is("MY_UNIVERSE", "")
+
+if (not_cran || on_r_universe) {
   # Set more eager defaults
   if (env_is("LIBARROW_BINARY", "")) {
     Sys.setenv(LIBARROW_BINARY = "true")


### PR DESCRIPTION
### Rationale for this change

R-universe mimics CRAN's behavior quite well, but unlike CRAN, it does not reject external binary downloads.
So allowing automatic download of libarrow binaries on R-universe may reduce CI run time on R-universe.

### What changes are included in this PR?

Change to attempt to download libarrow binaries on R-universe.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #44018