### PR TITLE
GH-44464: [C++] Added rvalue-reference-qualified overload for arrow::Result::status() returning value instead of reference

### DIFF
--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -294,7 +294,18 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   ///
   /// \return The stored non-OK status object, or an OK status if this object
   ///         has a value.
-  constexpr const Status& status() const { return status_; }
+  constexpr const Status& status() const& { return status_; }
+
+  /// Gets the stored status object, or an OK status if a `T` value is stored.
+  ///
+  /// \return The stored non-OK status object, or an OK status if this object
+  ///         has a value.
+  Status status() && {
+    if (ok()) return Status::OK();
+    auto tmp = Status::UnknownError("Uninitialized Result<T>");
+    std::swap(status_, tmp);
+    return tmp;
+  }
 
   /// Gets the stored `T` value.
   ///
@@ -350,7 +361,7 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
                             std::is_constructible<U, T>::value>::type>
   Status Value(U* out) && {
     if (!ok()) {
-      return status();
+      return std::move(*this).status();
     }
     *out = U(MoveValueUnsafe());
     return Status::OK();
@@ -380,7 +391,7 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   typename EnsureResult<decltype(std::declval<M&&>()(std::declval<T&&>()))>::type Map(
       M&& m) && {
     if (!ok()) {
-      return status();
+      return std::move(*this).status();
     }
     return std::forward<M>(m)(MoveValueUnsafe());
   }
@@ -402,7 +413,7 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
                             std::is_constructible<U, T>::value>::type>
   Result<U> As() && {
     if (!ok()) {
-      return status();
+      return std::move(*this).status();
     }
     return U(MoveValueUnsafe());
   }


### PR DESCRIPTION
### Rationale for this change

In the current implementation, `arrow::Result::status()` always returns the internal `status_` field by a const lvalue reference, regardless of the value category of `Result`. This can lead to potential bugs. For example, consider the following code:
```c++
if (auto&& status = functionReturningArrowResult().status(); status.ok())
  return 0;
return -1;
```
In this case, the call to `status.ok()` results in undefined behavior because `status` is a dangling const lvalue reference that points to an object returned by `functionReturningArrowResult()`, which is destroyed after the semicolon.

If `arrow::Result` had two overloads of the `status()` method for different reference qualifiers:
```c++
template <…>
class Result {
  …
  auto status() const & -> const Status& { ... }
  auto status() && -> Status { ... }
  …
};
```
This would prevent such bugs and potentially allow for better optimization, as the `Status` could be moved from an expiring `Result` object.

### What changes are included in this PR?

This PR adds the proposed overload for the `arrow::Result::status()` method and makes other rvalue-qualified `arrow::Result` methods preserve object ref-category during tail `status()` calls.

Unfortunately, we can't move the `status_` field in the rvalue-qualified `status()` method, as the state of `status_` must be preserved until the destructor is called. This is because the `storage_` field is either destructed or considered empty based on the state of `status_`.

### Are these changes tested?

Since this change is trivial (the new overload doesn't modify the `Result` object and returns `Status` by value), there's nothing significant to test, so no new tests were added.

### Are there any user-facing changes?

No existing code will be broken by this change. In all cases where `status()` is called on an lvalue `Result`, the same reference-returning overload will be called. Meanwhile, code calling `status()` on an rvalue `Result` will invoke the new overload, returning `Status` by value instead.
* GitHub Issue: #44464