### PR TITLE
GH-44480: [Release][Packaging] Use `--platform` explicitly for `docker run`

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -185,88 +185,79 @@ test_binary() {
 test_apt() {
   show_header "Testing APT packages"
 
-  for target in "debian:bookworm" \
-                "arm64v8/debian:bookworm" \
-                "debian:trixie" \
-                "arm64v8/debian:trixie" \
-                "ubuntu:focal" \
-                "arm64v8/ubuntu:focal" \
-                "ubuntu:jammy" \
-                "arm64v8/ubuntu:jammy" \
-                "ubuntu:noble" \
-                "arm64v8/ubuntu:noble"; do \
-    case "${target}" in
-      arm64v8/*)
-        if [ "$(arch)" = "aarch64" -o -e /usr/bin/qemu-aarch64-static ]; then
-          case "${target}" in
-            arm64v8/ubuntu:focal)
-              : # OK
-              ;;
-            *)
-              # qemu-user-static in Ubuntu 20.04 has a crash bug:
-              #   https://bugs.launchpad.net/qemu/+bug/1749393
-              continue
-              ;;
-          esac
-        else
-          continue
-        fi
-        ;;
-    esac
-    if ! docker run --rm -v "${ARROW_DIR}":/arrow:delegated \
-           --security-opt="seccomp=unconfined" \
-           "${target}" \
-           /arrow/dev/release/verify-apt.sh \
-           "${VERSION}" \
-           "rc"; then
-      echo "Failed to verify the APT repository for ${target}"
-      exit 1
-    fi
-  done
+  if [ "$(arch)" = "x86_64" ]; then
+    for target in "debian:bookworm" \
+                  "debian:trixie" \
+                  "ubuntu:focal" \
+                  "ubuntu:jammy" \
+                  "ubuntu:noble"; do \
+      if ! docker run \
+             --platform=linux/x86_64 \
+             --rm \
+             --security-opt="seccomp=unconfined" \
+             --volume "${ARROW_DIR}":/arrow:delegated \
+             "${target}" \
+             /arrow/dev/release/verify-apt.sh \
+             "${VERSION}" \
+             "rc"; then
+        echo "Failed to verify the APT repository for ${target} on x86_64"
+        exit 1
+      fi
+    done
+  fi
+
+  if [ "$(arch)" = "aarch64" -o -e /usr/bin/qemu-aarch64-static ]; then
+    for target in "arm64v8/debian:bookworm" \
+                  "arm64v8/debian:trixie" \
+                  "arm64v8/ubuntu:focal" \
+                  "arm64v8/ubuntu:jammy" \
+                  "arm64v8/ubuntu:noble"; do \
+      if ! docker run \
+             --platform=linux/arm64 \
+             --rm \
+             --security-opt="seccomp=unconfined" \
+             --volume "${ARROW_DIR}":/arrow:delegated \
+             "${target}" \
+             /arrow/dev/release/verify-apt.sh \
+             "${VERSION}" \
+             "rc"; then
+        echo "Failed to verify the APT repository for ${target} on arm64"
+        exit 1
+      fi
+    done
+  fi
 }
 
 test_yum() {
   show_header "Testing Yum packages"
 
-  for target in "almalinux:9" \
-                "arm64v8/almalinux:9" \
-                "almalinux:8" \
-                "arm64v8/almalinux:8" \
-                "amazonlinux:2023" \
-                "quay.io/centos/centos:stream9" \
-                "quay.io/centos/centos:stream8" \
-                "centos:7"; do
-    case "${target}" in
-      arm64v8/*)
-        if [ "$(arch)" = "aarch64" -o -e /usr/bin/qemu-aarch64-static ]; then
-          : # OK
-        else
-          continue
-        fi
-        ;;
-      centos:7)
-        if [ "$(arch)" = "x86_64" ]; then
-          : # OK
-        else
-          continue
-        fi
-        ;;
-    esac
-    if ! docker run \
-           --rm \
-           --security-opt="seccomp=unconfined" \
-           --volume "${ARROW_DIR}":/arrow:delegated \
-           "${target}" \
-           /arrow/dev/release/verify-yum.sh \
-           "${VERSION}" \
-           "rc"; then
-      echo "Failed to verify the Yum repository for ${target}"
-      exit 1
-    fi
-  done
+  if [ "$(arch)" = "x86_64" ]; then
+    for target in "almalinux:9" \
+                  "almalinux:8" \
+                  "amazonlinux:2023" \
+                  "quay.io/centos/centos:stream9" \
+                  "quay.io/centos/centos:stream8" \
+                  "centos:7"; do
+      if ! docker run \
+             --platform linux/x86_64 \
+             --rm \
+             --security-opt="seccomp=unconfined" \
+             --volume "${ARROW_DIR}":/arrow:delegated \
+             "${target}" \
+             /arrow/dev/release/verify-yum.sh \
+             "${VERSION}" \
+             "rc"; then
+        echo "Failed to verify the Yum repository for ${target} on x86_64"
+        exit 1
+      fi
+    done
+  fi
 
-  if [ "$(arch)" != "aarch64" -a -e /usr/bin/qemu-aarch64-static ]; then
-    for target in "quay.io/centos/centos:stream9" \
+  if [ "$(arch)" = "aarch64" -o -e /usr/bin/qemu-aarch64-static ]; then
+    for target in "arm64v8/almalinux:9" \
+                  "arm64v8/almalinux:8" \
+                  "arm64v8/amazonlinux:2023" \
+                  "quay.io/centos/centos:stream9" \
                   "quay.io/centos/centos:stream8"; do
       if ! docker run \
              --platform linux/arm64 \
@@ -277,7 +268,7 @@ test_yum() {
              /arrow/dev/release/verify-yum.sh \
              "${VERSION}" \
              "rc"; then
-        echo "Failed to verify the Yum repository for ${target} arm64"
+        echo "Failed to verify the Yum repository for ${target} on arm64"
         exit 1
       fi
     done


### PR DESCRIPTION
### Rationale for this change

It seems that recent Docker requires `--platform` to run different architecture images with QEMU.

### What changes are included in this PR?

Use `--platform` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44480