### PR TITLE
GH-44455: [C++] Update vendored date to 3.0.3

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -139,7 +139,7 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 
 @rem Download IANA Timezone Database to a non-standard location to
 @rem test the configurability of the timezone database path
-curl https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz --output tzdata.tar.gz || exit /B
+curl https://data.iana.org/time-zones/releases/tzdata2024b.tar.gz --output tzdata.tar.gz || exit /B
 mkdir %USERPROFILE%\Downloads\test\tzdata
 tar --extract --file tzdata.tar.gz --directory %USERPROFILE%\Downloads\test\tzdata
 curl https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml ^

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -460,7 +460,7 @@ endif()
 
 set(ARROW_VENDORED_SRCS
     vendored/base64.cpp
-    vendored/datetime/tz.cpp
+    vendored/datetime.cpp
     vendored/double-conversion/bignum-dtoa.cc
     vendored/double-conversion/bignum.cc
     vendored/double-conversion/cached-powers.cc
@@ -488,7 +488,7 @@ set(ARROW_VENDORED_SRCS
 if(APPLE)
   list(APPEND ARROW_VENDORED_SRCS vendored/datetime/ios.mm)
 endif()
-set_source_files_properties(vendored/datetime/tz.cpp
+set_source_files_properties(vendored/datetime.cpp
                             PROPERTIES SKIP_PRECOMPILE_HEADERS ON
                                        SKIP_UNITY_BUILD_INCLUSION ON)
 arrow_add_object_library(ARROW_VENDORED ${ARROW_VENDORED_SRCS})

--- a/cpp/src/arrow/vendored/datetime.cpp
+++ b/cpp/src/arrow/vendored/datetime.cpp
@@ -15,16 +15,5 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
-
-#ifndef _WIN32
-#  define USE_OS_TZDB 1
-#endif
-
-#if defined(ARROW_STATIC)
-// intentially empty
-#elif defined(ARROW_EXPORTING)
-#  define DATE_BUILD_DLL
-#else
-#  define DATE_USE_DLL
-#endif
+#include "datetime/visibility.h"
+#include "datetime/tz.cpp"

--- a/cpp/src/arrow/vendored/datetime.h
+++ b/cpp/src/arrow/vendored/datetime.h
@@ -17,10 +17,11 @@
 
 #pragma once
 
-#include "arrow/vendored/datetime/date.h"  // IWYU pragma: export
-#include "arrow/vendored/datetime/tz.h"    // IWYU pragma: export
+#include "arrow/vendored/datetime/visibility.h"  // IWYU pragma: export
+#include "arrow/vendored/datetime/date.h"        // IWYU pragma: export
+#include "arrow/vendored/datetime/tz.h"          // IWYU pragma: export
 
 // Can be defined by date.h.
 #ifdef NOEXCEPT
-#undef NOEXCEPT
+#  undef NOEXCEPT
 #endif

--- a/cpp/src/arrow/vendored/datetime/README.md
+++ b/cpp/src/arrow/vendored/datetime/README.md
@@ -17,12 +17,16 @@ copies or substantial portions of the Software.
 Sources for datetime are adapted from Howard Hinnant's date library
 (https://github.com/HowardHinnant/date).
 
-Sources are taken from changeset 1ead6715dec030d340a316c927c877a3c4e5a00c
+Sources are taken from changeset 5bdb7e6f31fac909c090a46dbd9fea27b6e609a4
 of the above project.
 
 The following changes are made:
 - fix internal inclusion paths (from "date/xxx.h" to simply "xxx.h")
 - enclose the `date` namespace inside the `arrow_vendored` namespace
-- include a custom "visibility.h" header from "tz.cpp" for proper DLL
-  exports on Windows
-- disable curl-based database downloading in "tz.h"
+
+## How to update
+
+```console
+$ cd cpp/src/arrow/vendored/datetime
+$ ./update.sh 3.0.3
+```

--- a/cpp/src/arrow/vendored/datetime/date.h
+++ b/cpp/src/arrow/vendored/datetime/date.h
@@ -84,9 +84,7 @@
 #   pragma warning(disable : 4127)
 #endif
 
-namespace arrow_vendored
-{
-namespace date
+namespace arrow_vendored::date
 {
 
 //---------------+
@@ -8234,8 +8232,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
                  detail::get_units<CharT>(typename Period::type{});
 }
 
-}  // namespace date
-}  // namespace arrow_vendored
+}  // namespace arrow_vendored::date
 
 #ifdef _MSC_VER
 #   pragma warning(pop)

--- a/cpp/src/arrow/vendored/datetime/ios.h
+++ b/cpp/src/arrow/vendored/datetime/ios.h
@@ -32,9 +32,7 @@
 # if TARGET_OS_IPHONE
 #   include <string>
 
-    namespace arrow_vendored
-    {
-    namespace date
+    namespace arrow_vendored::date
     {
     namespace iOSUtils
     {
@@ -43,8 +41,7 @@
     std::string get_current_timezone();
 
     }  // namespace iOSUtils
-    }  // namespace date
-    }  // namespace arrow_vendored
+    }  // namespace arrow_vendored::date
 
 # endif  // TARGET_OS_IPHONE
 #else   // !__APPLE__

--- a/cpp/src/arrow/vendored/datetime/ios.mm
+++ b/cpp/src/arrow/vendored/datetime/ios.mm
@@ -47,9 +47,7 @@
 #define TAR_SIZE_POSITION               124
 #define TAR_SIZE_SIZE                   12
 
-namespace arrow_vendored
-{
-namespace date
+namespace arrow_vendored::date
 {
     namespace iOSUtils
     {
@@ -334,7 +332,6 @@ namespace date
         }
 
     }  // namespace iOSUtils
-}  // namespace date
-}  // namespace arrow_vendored
+}  // namespace arrow_vendored::date
 
 #endif  // TARGET_OS_IPHONE

--- a/cpp/src/arrow/vendored/datetime/tz.h
+++ b/cpp/src/arrow/vendored/datetime/tz.h
@@ -43,19 +43,13 @@
 // required. On Windows, the names are never "Standard" so mapping is always required.
 // Technically any OS may use the mapping process but currently only Windows does use it.
 
-// NOTE(ARROW): If this is not set, then the library will attempt to
-// use libcurl to obtain a timezone database, and we probably do not want this.
-#ifndef _WIN32
-#define USE_OS_TZDB 1
-#endif
-
 #ifndef USE_OS_TZDB
 #  define USE_OS_TZDB 0
 #endif
 
 #ifndef HAS_REMOTE_API
 #  if USE_OS_TZDB == 0
-#    ifdef _WIN32
+#    if defined _WIN32 || defined __ANDROID__
 #      define HAS_REMOTE_API 0
 #    else
 #      define HAS_REMOTE_API 1
@@ -140,12 +134,17 @@ static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,
 #  endif
 #endif
 
-namespace arrow_vendored
-{
-namespace date
+namespace arrow_vendored::date
 {
 
 enum class choose {earliest, latest};
+
+#if defined(BUILD_TZ_LIB)
+# if defined(ANDROID) || defined(__ANDROID__)
+struct tzdb;
+static std::unique_ptr<tzdb> init_tzdb();
+# endif // defined(ANDROID) || defined(__ANDROID__)
+#endif // defined(BUILD_TZ_LIB)
 
 namespace detail
 {
@@ -829,6 +828,12 @@ public:
 
 #if !USE_OS_TZDB
     DATE_API void add(const std::string& s);
+#else
+# if defined(BUILD_TZ_LIB)
+#  if defined(ANDROID) || defined(__ANDROID__)
+    friend std::unique_ptr<tzdb> init_tzdb();
+#  endif // defined(ANDROID) || defined(__ANDROID__)
+# endif // defined(BUILD_TZ_LIB)
 #endif  // !USE_OS_TZDB
 
 private:
@@ -852,6 +857,9 @@ private:
     DATE_API void
     load_data(std::istream& inf, std::int32_t tzh_leapcnt, std::int32_t tzh_timecnt,
                                  std::int32_t tzh_typecnt, std::int32_t tzh_charcnt);
+# if defined(ANDROID) || defined(__ANDROID__)
+    void parse_from_android_tzdata(std::ifstream& inf, const std::size_t off);
+# endif // defined(ANDROID) || defined(__ANDROID__)
 #else  // !USE_OS_TZDB
     DATE_API sys_info   get_info_impl(sys_seconds tp, int tz_int) const;
     DATE_API void adjust_infos(const std::vector<detail::Rule>& rules);
@@ -1198,11 +1206,11 @@ struct tzdb
 #endif  // defined(_MSC_VER) && (_MSC_VER < 1900)
 
 #if HAS_STRING_VIEW
-    const time_zone* locate_zone(std::string_view tz_name) const;
+    DATE_API const time_zone* locate_zone(std::string_view tz_name) const;
 #else
-    const time_zone* locate_zone(const std::string& tz_name) const;
+    DATE_API const time_zone* locate_zone(const std::string& tz_name) const;
 #endif
-    const time_zone* current_zone() const;
+    DATE_API const time_zone* current_zone() const;
 };
 
 using TZ_DB = tzdb;
@@ -1217,9 +1225,9 @@ class tzdb_list
     std::atomic<tzdb*> head_{nullptr};
 
 public:
-    ~tzdb_list();
+    DATE_API ~tzdb_list();
     tzdb_list() = default;
-    tzdb_list(tzdb_list&& x) NOEXCEPT;
+    DATE_API tzdb_list(tzdb_list&& x) NOEXCEPT;
 
     const tzdb& front() const NOEXCEPT {return *head_;}
           tzdb& front()       NOEXCEPT {return *head_;}
@@ -1232,7 +1240,7 @@ public:
     const_iterator cbegin() const NOEXCEPT;
     const_iterator cend() const NOEXCEPT;
 
-    const_iterator erase_after(const_iterator p) NOEXCEPT;
+    DATE_API const_iterator erase_after(const_iterator p) NOEXCEPT;
 
     struct undocumented_helper;
 private:
@@ -2795,7 +2803,6 @@ to_gps_time(const tai_time<Duration>& t)
     return gps_clock::from_utc(tai_clock::to_utc(t));
 }
 
-}  // namespace date
-}  // namespace arrow_vendored
+}  // namespace arrow_vendored::date
 
 #endif  // TZ_H

--- a/cpp/src/arrow/vendored/datetime/tz_private.h
+++ b/cpp/src/arrow/vendored/datetime/tz_private.h
@@ -34,9 +34,7 @@
 #include <vector>
 #endif
 
-namespace arrow_vendored
-{
-namespace date
+namespace arrow_vendored::date
 {
 
 namespace detail
@@ -308,8 +306,7 @@ struct transition
 
 }  // namespace detail
 
-}  // namespace date
-}  // namespace arrow_vendored
+}  // namespace arrow_vendored::date
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #include "tz.h"

--- a/cpp/src/arrow/vendored/datetime/update.sh
+++ b/cpp/src/arrow/vendored/datetime/update.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -eux
+
+source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 VERSION"
+  echo " e.g.: $0 3.0.3"
+  exit 1
+fi
+
+version="$1"
+
+pushd "${source_dir}"
+rm -rf date
+git clone \
+    --branch "v${version}" \
+    --depth 1 \
+    https://github.com/HowardHinnant/date.git
+commit_id=$(git -C date log -1 --format=format:%H)
+mv date/include/date/date.h ./
+mv date/include/date/ios.h ./
+mv date/include/date/tz.h ./
+mv date/include/date/tz_private.h ./
+mv date/src/* ./
+rm -rf date
+sed -i.bak -E \
+    -e 's/namespace date/namespace arrow_vendored::date/g' \
+    -e 's,include "date/,include ",g' \
+    *.{cpp,h,mm}
+sed -i.bak -E \
+    -e "s/changeset [0-9a-f]+/changeset ${commit_id}/g" \
+    README.md
+rm *.bak
+popd

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -63,7 +63,7 @@ add_gandiva_test(precompiled-test
                  time.cc
                  timestamp_arithmetic.cc
                  ../cast_time.cc
-                 ../../arrow/vendored/datetime/tz.cpp
+                 ../../arrow/vendored/datetime.cpp
                  hash_test.cc
                  hash.cc
                  string_ops_test.cc


### PR DESCRIPTION
### Rationale for this change

IANA tzdata changed its data format. So we need to update vendored date to parse it.

### What changes are included in this PR?

Update vendored date to 3.0.3.

Update script is added. So all our changes are automated now.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44455