### PR TITLE
GH-44483: [GLib] Don't check invalid decimal precision message in test

### DIFF
--- a/c_glib/test/test-decimal128-data-type.rb
+++ b/c_glib/test/test-decimal128-data-type.rb
@@ -47,9 +47,7 @@ class TestDecimal128DataType < Test::Unit::TestCase
   end
 
   def test_invalid_precision
-    message =
-      "[decimal128-data-type][new]: Invalid: Decimal precision out of range [1, 38]: 39"
-    assert_raise(Arrow::Error::Invalid.new(message)) do
+    assert_raise(Arrow::Error::Invalid) do
       Arrow::Decimal128DataType.new(39, 1)
     end
   end

--- a/c_glib/test/test-decimal256-data-type.rb
+++ b/c_glib/test/test-decimal256-data-type.rb
@@ -47,9 +47,7 @@ class TestDecimal256DataType < Test::Unit::TestCase
   end
 
   def test_invalid_precision
-    message =
-      "[decimal256-data-type][new]: Invalid: Decimal precision out of range [1, 76]: 77"
-    assert_raise(Arrow::Error::Invalid.new(message)) do
+    assert_raise(Arrow::Error::Invalid) do
       Arrow::Decimal256DataType.new(77, 1)
     end
   end


### PR DESCRIPTION
### Rationale for this change

Two tests failed if `-DARROW_EXTRA_ERROR_CONTEXT=ON` in the C++ build.

### What changes are included in this PR?

Don't check invalid decimal precision message in test. Because it depends on `-DARROW_EXTRA_ERROR_CONTEXT={ON,OFF}`. Our tests should be stable whether the option value. 

Before this change: compare the exception class and message.
After this change: compare the exception class only.

### Are these changes tested?

YES

Before this change

```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1962 tests, 2148 assertions, 2 failures, 0 errors, 0 pendings, 14 omissions, 0 notifications
99.8973% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
23.71 tests/s, 25.95 assertions/s
```

After this change


```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1962 tests, 2148 assertions, 0 failures, 0 errors, 0 pendings, 14 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
23.75 tests/s, 26.00 assertions/s
```


### Are there any user-facing changes?

No.
* GitHub Issue: #44483

Co-Authored-by: Sutou Kouhei <kou@clear-code.com>
