### PR TITLE
GH-44491: [C++] StatusConstant- cheaply copied const Status

### DIFF
--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -511,13 +511,8 @@ TEST(TestBuffer, CopySliceEmpty) {
 }
 
 TEST(TestBuffer, ToHexString) {
-  const uint8_t data_array[] = "\a0hex string\xa9";
-  std::basic_string<uint8_t> data_str = data_array;
-
-  auto data = reinterpret_cast<const uint8_t*>(data_str.c_str());
-
-  Buffer buf(data, data_str.size());
-
+  const std::string data_str = "\a0hex string\xa9";
+  Buffer buf(data_str);
   ASSERT_EQ(buf.ToHexString(), std::string("073068657820737472696E67A9"));
 }
 

--- a/cpp/src/arrow/result.cc
+++ b/cpp/src/arrow/result.cc
@@ -19,8 +19,8 @@
 
 #include <string>
 
-#include "arrow/util/logging.h"
 #include "arrow/status_internal.h"
+#include "arrow/util/logging.h"
 
 namespace arrow::internal {
 

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -39,6 +39,8 @@ ARROW_EXPORT void DieWithMessage(const std::string& msg);
 
 ARROW_EXPORT void InvalidValueOrDie(const Status& st);
 
+ARROW_EXPORT Status UninitializedResult();
+
 }  // namespace internal
 
 /// A class for representing either a usable value, or an error.
@@ -112,7 +114,7 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   /// an empty vector, it will actually invoke the default constructor of
   /// Result.
   explicit Result() noexcept  // NOLINT(runtime/explicit)
-      : status_(Status::UnknownError("Uninitialized Result<T>")) {}
+      : status_(internal::UninitializedResult()) {}
 
   ~Result() noexcept { Destroy(); }
 
@@ -302,7 +304,7 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   ///         has a value.
   Status status() && {
     if (ok()) return Status::OK();
-    auto tmp = Status::UnknownError("Uninitialized Result<T>");
+    auto tmp = internal::UninitializedResult();
     std::swap(status_, tmp);
     return tmp;
   }

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -303,7 +303,7 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   /// \return The stored non-OK status object, or an OK status if this object
   ///         has a value.
   Status status() && {
-    if (ok()) return Status::OK();
+    if (ARROW_PREDICT_TRUE(ok())) return Status::OK();
     auto tmp = internal::UninitializedResult();
     std::swap(status_, tmp);
     return tmp;

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -15,7 +15,9 @@
 #include <cassert>
 #include <cstdlib>
 #include <iostream>
-#include <sstream>
+#ifdef ARROW_EXTRA_ERROR_CONTEXT
+#  include <sstream>
+#endif
 
 #include "arrow/util/logging.h"
 
@@ -26,18 +28,19 @@ Status::Status(StatusCode code, const std::string& msg)
 
 Status::Status(StatusCode code, std::string msg, std::shared_ptr<StatusDetail> detail) {
   ARROW_CHECK_NE(code, StatusCode::OK) << "Cannot construct ok status with message";
-  state_ = new State;
-  state_->code = code;
-  state_->msg = std::move(msg);
-  if (detail != nullptr) {
-    state_->detail = std::move(detail);
-  }
+  state_ = new State{code, std::move(msg), std::move(detail)};
 }
 
+// We would prefer that this destructor *not* be inlined, since the vast majority of
+// Statuses are OK and so inlining would superflously increase binary size.
+Status::State::~State() = default;
+
 void Status::CopyFrom(const Status& s) {
-  delete state_;
+  DeleteState();
   if (s.state_ == nullptr) {
     state_ = nullptr;
+  } else if (s.state_->is_constant) {
+    state_ = s.state_;
   } else {
     state_ = new State(*s.state_);
   }
@@ -160,7 +163,11 @@ void Status::AddContextLine(const char* filename, int line, const char* expr) {
   ARROW_CHECK(!ok()) << "Cannot add context line to ok status";
   std::stringstream ss;
   ss << "\n" << filename << ":" << line << "  " << expr;
-  state_->msg += ss.str();
+  if (state_->is_constant) {
+    // We can't add context lines to a StatusConstant's state, so copy it now
+    state_ = new State{code(), message(), detail()};
+  }
+  const_cast<State*>(state_)->msg += ss.str();
 }
 #endif
 

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -28,7 +28,7 @@ Status::Status(StatusCode code, const std::string& msg)
 
 Status::Status(StatusCode code, std::string msg, std::shared_ptr<StatusDetail> detail) {
   ARROW_CHECK_NE(code, StatusCode::OK) << "Cannot construct ok status with message";
-  state_ = new State{code, std::move(msg), std::move(detail)};
+  state_ = new State{code, /*is_constant=*/false, std::move(msg), std::move(detail)};
 }
 
 void Status::CopyFrom(const Status& s) {
@@ -165,7 +165,7 @@ void Status::AddContextLine(const char* filename, int line, const char* expr) {
   ss << "\n" << filename << ":" << line << "  " << expr;
   if (state_->is_constant) {
     // We can't add context lines to a StatusConstant's state, so copy it now
-    state_ = new State{code(), message(), detail()};
+    state_ = new State{code(), /*is_constant=*/false, message(), detail()};
   }
   const_cast<State*>(state_)->msg += ss.str();
 }

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -31,12 +31,12 @@ Status::Status(StatusCode code, std::string msg, std::shared_ptr<StatusDetail> d
   state_ = new State{code, std::move(msg), std::move(detail)};
 }
 
-// We would prefer that this destructor *not* be inlined, since the vast majority of
-// Statuses are OK and so inlining would superflously increase binary size.
-Status::State::~State() = default;
-
 void Status::CopyFrom(const Status& s) {
-  DeleteState();
+  if (ARROW_PREDICT_FALSE(state_ != NULL)) {
+    if (!state_->is_constant) {
+      DeleteState();
+    }
+  }
   if (s.state_ == nullptr) {
     state_ = nullptr;
   } else if (s.state_->is_constant) {

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -167,7 +167,7 @@ void Status::AddContextLine(const char* filename, int line, const char* expr) {
     // We can't add context lines to a StatusConstant's state, so copy it now
     state_ = new State{code(), /*is_constant=*/false, message(), detail()};
   }
-  const_cast<State*>(state_)->msg += ss.str();
+  state_->msg += ss.str();
 }
 #endif
 

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -369,9 +369,9 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
  private:
   struct State {
     StatusCode code;
+    bool is_constant;
     std::string msg;
     std::shared_ptr<StatusDetail> detail;
-    bool is_constant = false;
   };
   // OK status has a `NULL` state_.  Otherwise, `state_` points to
   // a `State` structure containing the error code and message(s)

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -372,7 +372,7 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
   // a `State` structure containing the error code and message(s)
   const State* state_;
 
-  void DeleteState() {
+  void DeleteState() noexcept {
     // ARROW-2400: On certain compilers, splitting off the slow path improves
     // performance significantly.
     if (ARROW_PREDICT_FALSE(state_ != NULLPTR)) {

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -375,7 +375,7 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
   };
   // OK status has a `NULL` state_.  Otherwise, `state_` points to
   // a `State` structure containing the error code and message(s)
-  const State* state_;
+  State* state_;
 
   void DeleteState() noexcept {
     // ARROW-2400: On certain compilers, splitting off the slow path improves

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -361,7 +361,7 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
 #endif
 
  private:
-  struct State {
+  struct ARROW_EXPORT State {
     StatusCode code;
     std::string msg;
     std::shared_ptr<StatusDetail> detail;

--- a/cpp/src/arrow/status_internal.h
+++ b/cpp/src/arrow/status_internal.h
@@ -26,7 +26,7 @@ class StatusConstant {
  public:
   StatusConstant(StatusCode code, std::string msg,
                  std::shared_ptr<StatusDetail> detail = nullptr)
-      : state_{code, std::move(msg), std::move(detail), /*is_constant=*/true} {
+      : state_{code, /*is_constant=*/true, std::move(msg), std::move(detail)} {
     ARROW_CHECK_NE(code, StatusCode::OK)
         << "StatusConstant is not intended for use with OK status codes";
   }

--- a/cpp/src/arrow/status_internal.h
+++ b/cpp/src/arrow/status_internal.h
@@ -31,7 +31,7 @@ class StatusConstant {
         << "StatusConstant is not intended for use with OK status codes";
   }
 
-  operator Status() const {  // NOLINT(runtime/explicit)
+  operator Status() {  // NOLINT(runtime/explicit)
     Status st;
     st.state_ = &state_;
     return st;

--- a/cpp/src/arrow/status_internal.h
+++ b/cpp/src/arrow/status_internal.h
@@ -27,7 +27,8 @@ class StatusConstant {
   StatusConstant(StatusCode code, std::string msg,
                  std::shared_ptr<StatusDetail> detail = nullptr)
       : state_{code, std::move(msg), std::move(detail), /*is_constant=*/true} {
-    ARROW_CHECK_NE(code, StatusCode::OK) << "Cannot construct ok status constant";
+    ARROW_CHECK_NE(code, StatusCode::OK)
+        << "StatusConstant is not intended for use with OK status codes";
   }
 
   operator Status() const {  // NOLINT(runtime/explicit)

--- a/cpp/src/arrow/status_test.cc
+++ b/cpp/src/arrow/status_test.cc
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/status.h"
+#include "arrow/status_internal.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
 
@@ -74,6 +75,18 @@ TEST(StatusTest, TestWithDetail) {
 
 TEST(StatusTest, TestCoverageWarnNotOK) {
   ARROW_WARN_NOT_OK(Status::Invalid("invalid"), "Expected warning");
+}
+
+TEST(StatusTest, StatusConstant) {
+  internal::StatusConstant constant{StatusCode::Invalid, "default error"};
+  Status st = constant;
+
+  ASSERT_EQ(st.code(), StatusCode::Invalid);
+  ASSERT_EQ(st.message(), "default error");
+  ASSERT_EQ(st.detail(), nullptr);
+
+  Status copy = st;
+  ASSERT_EQ(&st.message(), &copy.message());
 }
 
 TEST(StatusTest, AndStatus) {

--- a/cpp/src/arrow/status_test.cc
+++ b/cpp/src/arrow/status_test.cc
@@ -87,6 +87,15 @@ TEST(StatusTest, StatusConstant) {
 
   Status copy = st;
   ASSERT_EQ(&st.message(), &copy.message());
+  Status moved = std::move(st);
+  ASSERT_EQ(&copy.message(), &moved.message());
+  ASSERT_OK(st);
+
+  Status other = constant;
+  ASSERT_EQ(other.code(), StatusCode::Invalid);
+  ASSERT_EQ(other.message(), "default error");
+  ASSERT_EQ(other.detail(), nullptr);
+  ASSERT_EQ(&other.message(), &moved.message());
 }
 
 TEST(StatusTest, AndStatus) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

It'd be convenient to construct placeholder error Status cheaply.

### What changes are included in this PR?

A constant error Status can now be constructed wrapped in a function like
```c++
Status UninitializedResult() {
  static StatusConstant uninitialized_result{StatusCode::UnknownError,
                                             "Uninitialized Result<T>"};
  return uninitialized_result;
}
```

Copying the constant status is relatively cheap (no heap interaction), so it's suitable for use as a placeholder error status.

Added `bool Status::State::is_constant` which causes copies to be shallow and skips destruction. Also `Status::state_` is a const pointer now; this helps to ensure that it is obvious when we mutate state_ (as in AddContextLine).

### Are these changes tested?

Minimal unit test added. The main consideration is probably benchmarks to make sure hot paths don't get much slower.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

This API is not currently public; no user-facing changes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44491