### PR TITLE
GH-43631: [C++] Add C++ implementation of Async C Data Interface

### DIFF
--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -338,7 +338,7 @@ struct ArrowAsyncProducer {
 // defined callbacks, this is intended to be created by the consumer instead.
 // The consumer passes this handler to the producer, which in turn uses the
 // callbacks to inform the consumer of events in the stream.
-struct ArrowAsyncDeviceStreamHandler {  
+struct ArrowAsyncDeviceStreamHandler {
   // Handler for receiving a schema. The passed in stream_schema must be
   // released or moved by the handler (producer is giving ownership of the schema to
   // the handler, but not ownership of the top level object itself).

--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -280,6 +280,9 @@ struct ArrowAsyncTask {
 // control on the asynchronous stream processing. This object must be owned by the
 // producer who creates it, and thus is responsible for cleaning it up.
 struct ArrowAsyncProducer {
+  // The device type that this stream produces data on.
+  ArrowDeviceType device_type;
+
   // A consumer must call this function to start receiving on_next_task calls.
   //
   // It *must* be valid to call this synchronously from within `on_next_task` or
@@ -335,7 +338,7 @@ struct ArrowAsyncProducer {
 // defined callbacks, this is intended to be created by the consumer instead.
 // The consumer passes this handler to the producer, which in turn uses the
 // callbacks to inform the consumer of events in the stream.
-struct ArrowAsyncDeviceStreamHandler {
+struct ArrowAsyncDeviceStreamHandler {  
   // Handler for receiving a schema. The passed in stream_schema must be
   // released or moved by the handler (producer is giving ownership of the schema to
   // the handler, but not ownership of the top level object itself).

--- a/cpp/src/arrow/c/abi.h
+++ b/cpp/src/arrow/c/abi.h
@@ -269,7 +269,7 @@ struct ArrowAsyncTask {
   // calling this, and so it must be released separately.
   //
   // It is only valid to call this method exactly once.
-  int (*extract_data)(struct ArrowArrayTask* self, struct ArrowDeviceArray* out);
+  int (*extract_data)(struct ArrowAsyncTask* self, struct ArrowDeviceArray* out);
 
   // opaque task-specific data
   void* private_data;

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2545,7 +2545,7 @@ class AsyncRecordBatchIterator {
 
   const std::shared_ptr<Schema>& schema() const { return state_->schema_; }
 
-  const DeviceAllocationType device_type() const { return state_->device_type_; }
+  DeviceAllocationType device_type() const { return state_->device_type_; }
 
   Result<RecordBatchWithMetadata> Next() {
     std::pair<ArrowAsyncTask, std::shared_ptr<KeyValueMetadata>> task;

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2622,7 +2622,7 @@ class AsyncRecordBatchIterator {
       private_data->fut_iterator_.MarkFinished(maybe_schema.status());
       return EINVAL;
     }
-    
+
     private_data->state_->schema_ = maybe_schema.MoveValueUnsafe();
     private_data->fut_iterator_.MarkFinished(private_data->state_);
     self->producer->request(self->producer,
@@ -2783,7 +2783,8 @@ struct AsyncProducer {
   }
 
   static int extract_data(struct ArrowAsyncTask* task, struct ArrowDeviceArray* out) {
-    std::unique_ptr<PrivateTaskData> private_data{reinterpret_cast<PrivateTaskData*>(task->private_data)};
+    std::unique_ptr<PrivateTaskData> private_data{
+        reinterpret_cast<PrivateTaskData*>(task->private_data)};
     int ret = 0;
     if (out != nullptr) {
       auto status = ExportDeviceRecordBatch(*private_data->record_,
@@ -2793,7 +2794,7 @@ struct AsyncProducer {
         private_data->producer_->error_ = status;
       }
     }
-    
+
     return ret;
   }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2570,10 +2570,8 @@ class AsyncRecordBatchIterator {
     state_->producer_->request(state_->producer_, 1);
     ArrowDeviceArray out;
     if (task.first.extract_data(&task.first, &out) != 0) {
-      std::unique_lock<std::mutex> lock(state_->mutex_);
-      if (state_->error_.ok()) {
-        state_->cv_.wait(lock, [&] { return !state_->error_.ok(); });
-      }
+      std::unique_lock<std::mutex> lock(state_->mutex_);      
+      state_->cv_.wait(lock, [&] { return !state_->error_.ok(); });      
       return state_->error_;
     }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2540,7 +2540,7 @@ class AsyncRecordBatchIterator {
   AsyncRecordBatchIterator(uint64_t queue_size, const DeviceMemoryMapper mapper)
       : state_{std::make_shared<State>(queue_size, std::move(mapper))} {}
 
-  AsyncRecordBatchIterator(std::shared_ptr<State> state) : state_{std::move(state)} {}
+  explicit AsyncRecordBatchIterator(std::shared_ptr<State> state) : state_{std::move(state)} {}
 
   const std::shared_ptr<Schema>& schema() const { return state_->schema_; }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2715,7 +2715,7 @@ struct AsyncProducer {
     ARROW_DISALLOW_COPY_AND_ASSIGN(PrivateTaskData);
   };
 
-  Status operator()(const std::shared_ptr<RecordBatch>& record) {    
+  Status operator()(const std::shared_ptr<RecordBatch>& record) {
     std::unique_lock<std::mutex> lock(state_->mutex_);
     if (state_->pending_requests_ == 0) {
       state_->cv_.wait(lock, [this]() -> bool {
@@ -2789,7 +2789,7 @@ struct AsyncProducer {
     return ret;
   }
 
-  struct ArrowAsyncDeviceStreamHandler* handler_;  
+  struct ArrowAsyncDeviceStreamHandler* handler_;
   std::shared_ptr<State> state_;
 };
 
@@ -2798,7 +2798,8 @@ struct AsyncProducer {
 Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
     struct ArrowAsyncDeviceStreamHandler* handler, internal::Executor* executor,
     uint64_t queue_size, const DeviceMemoryMapper mapper) {
-  auto iterator = std::make_shared<AsyncRecordBatchIterator>(queue_size, std::move(mapper));
+  auto iterator =
+      std::make_shared<AsyncRecordBatchIterator>(queue_size, std::move(mapper));
   return AsyncRecordBatchIterator::Make(*iterator, handler)
       .Then([executor](std::shared_ptr<AsyncRecordBatchIterator::State> state)
                 -> Result<AsyncRecordBatchGenerator> {
@@ -2831,9 +2832,9 @@ Future<> ExportAsyncRecordBatchReader(
             int status = handler->on_next_task(handler, nullptr, nullptr);
             handler->release(handler);
             if (status != 0) {
-              return Status::UnknownError(
-                  "Received error from handler::on_next_task ", status);
-            }            
+              return Status::UnknownError("Received error from handler::on_next_task ",
+                                          status);
+            }
             return Future<>::MakeFinished();
           },
           [handler](const Status status) -> Future<> {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2605,8 +2605,7 @@ class AsyncRecordBatchIterator {
   };
 
   static int on_schema(struct ArrowAsyncDeviceStreamHandler* self,
-                       struct ArrowSchema* stream_schema,
-                       const char* additional_metadata) {
+                       struct ArrowSchema* stream_schema) {
     auto* private_data = reinterpret_cast<PrivateData*>(self->private_data);
     if (self->producer != nullptr) {
       private_data->state_->producer_ = self->producer;
@@ -2713,7 +2712,7 @@ struct AsyncProducer {
     state_->producer_.cancel = AsyncProducer::cancel;
     handler_->producer = &state_->producer_;
 
-    if (int status = handler_->on_schema(handler_, schema, nullptr) != 0) {
+    if (int status = handler_->on_schema(handler_, schema) != 0) {
       state_->error_ =
           Status::UnknownError("Received error from handler::on_schema ", status);
     }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2572,7 +2572,7 @@ class AsyncRecordBatchIterator {
     Status error_{Status::OK()};
   };
 
-  AsyncRecordBatchIterator(uint64_t queue_size, const DeviceMemoryMapper mapper)
+  AsyncRecordBatchIterator(uint64_t queue_size, DeviceMemoryMapper mapper)
       : state_{std::make_shared<State>(queue_size, std::move(mapper))} {}
 
   explicit AsyncRecordBatchIterator(std::shared_ptr<State> state)

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2540,7 +2540,8 @@ class AsyncRecordBatchIterator {
   AsyncRecordBatchIterator(uint64_t queue_size, const DeviceMemoryMapper mapper)
       : state_{std::make_shared<State>(queue_size, std::move(mapper))} {}
 
-  explicit AsyncRecordBatchIterator(std::shared_ptr<State> state) : state_{std::move(state)} {}
+  explicit AsyncRecordBatchIterator(std::shared_ptr<State> state)
+      : state_{std::move(state)} {}
 
   const std::shared_ptr<Schema>& schema() const { return state_->schema_; }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2570,8 +2570,8 @@ class AsyncRecordBatchIterator {
     state_->producer_->request(state_->producer_, 1);
     ArrowDeviceArray out;
     if (task.first.extract_data(&task.first, &out) != 0) {
-      std::unique_lock<std::mutex> lock(state_->mutex_);      
-      state_->cv_.wait(lock, [&] { return !state_->error_.ok(); });      
+      std::unique_lock<std::mutex> lock(state_->mutex_);
+      state_->cv_.wait(lock, [&] { return !state_->error_.ok(); });
       return state_->error_;
     }
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -2790,7 +2790,7 @@ struct AsyncProducer {
 
 Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
     struct ArrowAsyncDeviceStreamHandler* handler, internal::Executor* executor,
-    uint64_t queue_size, const DeviceMemoryMapper mapper) {
+    uint64_t queue_size, DeviceMemoryMapper mapper) {
   auto iterator =
       std::make_shared<AsyncRecordBatchIterator>(queue_size, std::move(mapper));
   return AsyncRecordBatchIterator::Make(*iterator, handler)

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -443,7 +443,7 @@ class Executor;
 /// The ArrowAsyncDeviceStreamHandler struct is intended to have its callbacks populated
 /// and then be passed to a producer to call the appropriate callbacks when data is ready.
 /// This inverts the traditional flow of control, and so we construct a corresponding
-/// AsyncRecordBatchReader to provide an interface for the consumer to retrieve data as it
+/// AsyncRecordBatchGenerator to provide an interface for the consumer to retrieve data as it
 /// is pushed to the handler.
 ///
 /// \param[in,out] handler C struct to be populated

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -412,13 +412,19 @@ Result<std::shared_ptr<ChunkedArray>> ImportDeviceChunkedArray(
 ///
 /// @{
 
+/// \brief AsyncErrorDetail is a StatusDetail that contains an error code and message
+/// from an asynchronous operation.
 class AsyncErrorDetail : public StatusDetail {
  public:
   AsyncErrorDetail(int code, std::string message, std::string metadata)
       : code_(code), message_(std::move(message)), metadata_(std::move(metadata)) {}
   const char* type_id() const override { return "AsyncErrorDetail"; }
+  // ToString just returns the error message that was returned with the error
   std::string ToString() const override { return message_; }
+  // code is an errno-compatible error code
   int code() const { return code_; }
+  // returns any metadata that was returned with the error, likely in a
+  // key-value format similar to ArrowSchema metadata
   const std::string& ErrorMetadata() const { return metadata_; }
 
  private:
@@ -443,8 +449,8 @@ class Executor;
 /// The ArrowAsyncDeviceStreamHandler struct is intended to have its callbacks populated
 /// and then be passed to a producer to call the appropriate callbacks when data is ready.
 /// This inverts the traditional flow of control, and so we construct a corresponding
-/// AsyncRecordBatchGenerator to provide an interface for the consumer to retrieve data as it
-/// is pushed to the handler.
+/// AsyncRecordBatchGenerator to provide an interface for the consumer to retrieve data as
+/// it is pushed to the handler.
 ///
 /// \param[in,out] handler C struct to be populated
 /// \param[in] executor the executor to use for waiting and populating record batches

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -26,6 +26,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/async_generator_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
@@ -406,12 +407,75 @@ Result<std::shared_ptr<ChunkedArray>> ImportDeviceChunkedArray(
 
 /// @}
 
-
-/// \defgroup c-async-stream-interface Functions for working with the async C data interface.
+/// \defgroup c-async-stream-interface Functions for working with the async C data
+/// interface.
 ///
 /// @{
 
+class AsyncErrorDetail : public StatusDetail {
+ public:
+  AsyncErrorDetail(int code, std::string message, std::string metadata)
+      : code_(code), message_(std::move(message)), metadata_(std::move(metadata)) {}
+  const char* type_id() const override { return "AsyncErrorDetail"; }
+  std::string ToString() const override { return message_; }
 
+  const std::string& ErrorMetadata() const { return metadata_; }
+
+ private:
+  int code_{0};
+  std::string message_;
+  std::string metadata_;
+};
+
+struct AsyncRecordBatchGenerator {
+  std::shared_ptr<Schema> schema;
+  DeviceAllocationType device_type;
+  AsyncGenerator<RecordBatchWithMetadata> generator;
+};
+
+namespace internal {
+class Executor;
+}
+
+/// \brief Create an AsyncRecordBatchReader and populate a corresponding handler to pass
+/// to a producer
+///
+/// The ArrowAsyncDeviceStreamHandler struct is intended to have its callbacks populated
+/// and then be passed to a producer to call the appropriate callbacks when data is ready.
+/// This inverts the traditional flow of control, and so we construct a corresponding
+/// AsyncRecordBatchReader to provide an interface for the consumer to retrieve data as it
+/// is pushed to the handler.
+///
+/// \param[in,out] handler C struct to be populated
+/// \param[in] executor the executor to use for waiting and populating record batches
+/// \param[in] queue_size initial number of record batches to request for queueing
+/// \param[in] mapper mapping from device type and ID to memory manager
+/// \return Future that resolves to either an error or AsyncRecordBatchGenerator once a
+/// schema is available or an error is received.
+ARROW_EXPORT
+Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
+    struct ArrowAsyncDeviceStreamHandler* handler, internal::Executor* executor,
+    uint64_t queue_size = 5,
+    const DeviceMemoryMapper mapper = DefaultDeviceMemoryMapper);
+
+/// \brief Export an AsyncGenerator of record batches using a provided handler
+///
+/// This function calls the callbacks on the consumer-provided async handler as record
+/// batches become available from the AsyncGenerator which is provided. It will first call
+/// on_schema using the provided schema, and then serially visit each record batch from
+/// the generator, calling the on_next_task callback. If an error occurs, on_error will be
+/// called appropriately.
+///
+/// \param[in] schema the schema of the stream being exported
+/// \param[in] generator a generator that asynchronously produces record batches
+/// \param[in] device_type the device type that the record batches will be located on
+/// \param[in] handler the handler whose callbacks to utilize as data is available
+/// \return Future that will resolve once the generator is exhausted or an error occurs
+ARROW_EXPORT
+Future<> ExportAsyncRecordBatchReader(
+    std::shared_ptr<Schema> schema,
+    AsyncGenerator<std::shared_ptr<RecordBatch>> generator,
+    DeviceAllocationType device_type, struct ArrowAsyncDeviceStreamHandler* handler);
 
 /// @}
 

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -412,8 +412,8 @@ Result<std::shared_ptr<ChunkedArray>> ImportDeviceChunkedArray(
 ///
 /// @{
 
-/// \brief EXPERIMENTAL: AsyncErrorDetail is a StatusDetail that contains an error code and message
-/// from an asynchronous operation.
+/// \brief EXPERIMENTAL: AsyncErrorDetail is a StatusDetail that contains an error code
+/// and message from an asynchronous operation.
 class AsyncErrorDetail : public StatusDetail {
  public:
   AsyncErrorDetail(int code, std::string message, std::string metadata)
@@ -444,8 +444,8 @@ namespace internal {
 class Executor;
 }
 
-/// \brief EXPERIMENTAL: Create an AsyncRecordBatchReader and populate a corresponding handler to pass
-/// to a producer
+/// \brief EXPERIMENTAL: Create an AsyncRecordBatchReader and populate a corresponding
+/// handler to pass to a producer
 ///
 /// The ArrowAsyncDeviceStreamHandler struct is intended to have its callbacks populated
 /// and then be passed to a producer to call the appropriate callbacks when data is ready.
@@ -464,7 +464,8 @@ Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
     struct ArrowAsyncDeviceStreamHandler* handler, internal::Executor* executor,
     uint64_t queue_size = 5, DeviceMemoryMapper mapper = DefaultDeviceMemoryMapper);
 
-/// \brief EXPERIMENTAL: Export an AsyncGenerator of record batches using a provided handler
+/// \brief EXPERIMENTAL: Export an AsyncGenerator of record batches using a provided
+/// handler
 ///
 /// This function calls the callbacks on the consumer-provided async handler as record
 /// batches become available from the AsyncGenerator which is provided. It will first call

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -406,4 +406,13 @@ Result<std::shared_ptr<ChunkedArray>> ImportDeviceChunkedArray(
 
 /// @}
 
+
+/// \defgroup c-async-stream-interface Functions for working with the async C data interface.
+///
+/// @{
+
+
+
+/// @}
+
 }  // namespace arrow

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -418,7 +418,7 @@ class AsyncErrorDetail : public StatusDetail {
       : code_(code), message_(std::move(message)), metadata_(std::move(metadata)) {}
   const char* type_id() const override { return "AsyncErrorDetail"; }
   std::string ToString() const override { return message_; }
-
+  int code() const { return code_; }
   const std::string& ErrorMetadata() const { return metadata_; }
 
  private:
@@ -455,8 +455,7 @@ class Executor;
 ARROW_EXPORT
 Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
     struct ArrowAsyncDeviceStreamHandler* handler, internal::Executor* executor,
-    uint64_t queue_size = 5,
-    const DeviceMemoryMapper mapper = DefaultDeviceMemoryMapper);
+    uint64_t queue_size = 5, const DeviceMemoryMapper mapper = DefaultDeviceMemoryMapper);
 
 /// \brief Export an AsyncGenerator of record batches using a provided handler
 ///

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -412,7 +412,7 @@ Result<std::shared_ptr<ChunkedArray>> ImportDeviceChunkedArray(
 ///
 /// @{
 
-/// \brief AsyncErrorDetail is a StatusDetail that contains an error code and message
+/// \brief EXPERIMENTAL: AsyncErrorDetail is a StatusDetail that contains an error code and message
 /// from an asynchronous operation.
 class AsyncErrorDetail : public StatusDetail {
  public:
@@ -444,7 +444,7 @@ namespace internal {
 class Executor;
 }
 
-/// \brief Create an AsyncRecordBatchReader and populate a corresponding handler to pass
+/// \brief EXPERIMENTAL: Create an AsyncRecordBatchReader and populate a corresponding handler to pass
 /// to a producer
 ///
 /// The ArrowAsyncDeviceStreamHandler struct is intended to have its callbacks populated
@@ -464,7 +464,7 @@ Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
     struct ArrowAsyncDeviceStreamHandler* handler, internal::Executor* executor,
     uint64_t queue_size = 5, DeviceMemoryMapper mapper = DefaultDeviceMemoryMapper);
 
-/// \brief Export an AsyncGenerator of record batches using a provided handler
+/// \brief EXPERIMENTAL: Export an AsyncGenerator of record batches using a provided handler
 ///
 /// This function calls the callbacks on the consumer-provided async handler as record
 /// batches become available from the AsyncGenerator which is provided. It will first call

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -425,7 +425,8 @@ class AsyncErrorDetail : public StatusDetail {
   int code() const { return code_; }
   // returns any metadata that was returned with the error, likely in a
   // key-value format similar to ArrowSchema metadata
-  const std::string& ErrorMetadata() const { return metadata_; }
+  const std::string& ErrorMetadataString() const { return metadata_; }
+  std::shared_ptr<KeyValueMetadata> ErrorMetadata() const;
 
  private:
   int code_{0};

--- a/cpp/src/arrow/c/bridge.h
+++ b/cpp/src/arrow/c/bridge.h
@@ -461,7 +461,7 @@ class Executor;
 ARROW_EXPORT
 Future<AsyncRecordBatchGenerator> CreateAsyncDeviceStreamHandler(
     struct ArrowAsyncDeviceStreamHandler* handler, internal::Executor* executor,
-    uint64_t queue_size = 5, const DeviceMemoryMapper mapper = DefaultDeviceMemoryMapper);
+    uint64_t queue_size = 5, DeviceMemoryMapper mapper = DefaultDeviceMemoryMapper);
 
 /// \brief Export an AsyncGenerator of record batches using a provided handler
 ///

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5368,7 +5368,7 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, Simple) {
   }));
 
   ASSERT_OK_AND_ASSIGN(auto generator, fut_gen.result());
-  AssertSchemaEqual(*orig_schema, *generator.schema);
+  ASSERT_NO_FATAL_FAILURE(AssertSchemaEqual(*orig_schema, *generator.schema));
 
   auto collect_fut = CollectAsyncGenerator(generator.generator);
   ASSERT_OK_AND_ASSIGN(auto results, collect_fut.result());

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5367,13 +5367,13 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, Simple) {
                                         device->device_type(), &handler);
   }));
 
-  ASSERT_OK_AND_ASSIGN(auto generator, fut_gen.result());
+  ASSERT_FINISHES_OK_AND_ASSIGN(auto generator, fut_gen);
   ASSERT_NO_FATAL_FAILURE(AssertSchemaEqual(*orig_schema, *generator.schema));
 
   auto collect_fut = CollectAsyncGenerator(generator.generator);
-  ASSERT_OK_AND_ASSIGN(auto results, collect_fut.result());
-  ASSERT_OK(fut.status());
-  ASSERT_OK(fut_gen.status());
+  ASSERT_FINISHES_OK_AND_ASSIGN(auto results, collect_fut);
+  ASSERT_FINISHES_OK(fut);
+  ASSERT_FINISHES_OK(fut_gen);
 
   ASSERT_EQ(results.size(), 2);
   AssertBatchesEqual(*results[0].batch, *batches[0]);

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5393,9 +5393,8 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, NullSchema) {
 }
 
 TEST_F(TestAsyncDeviceArrayStreamRoundTrip, PropagateError) {
-  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);  
+  std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
   auto orig_schema = arrow::schema({field("ints", int32())});
-
 
   struct ArrowAsyncDeviceStreamHandler handler;
   auto fut_gen = CreateAsyncDeviceStreamHandler(&handler, internal::GetCpuThreadPool(), 1,

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5378,6 +5378,8 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, Simple) {
   ASSERT_EQ(results.size(), 2);
   AssertBatchesEqual(*results[0].batch, *batches[0]);
   AssertBatchesEqual(*results[1].batch, *batches[1]);
+
+  internal::GetCpuThreadPool()->WaitForIdle();
 }
 
 TEST_F(TestAsyncDeviceArrayStreamRoundTrip, NullSchema) {
@@ -5415,6 +5417,8 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, PropagateError) {
   auto collect_fut = CollectAsyncGenerator(generator.generator);
   ASSERT_FINISHES_AND_RAISES(UnknownError, collect_fut);
   ASSERT_FINISHES_AND_RAISES(UnknownError, fut);
+
+  internal::GetCpuThreadPool()->WaitForIdle();
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5363,8 +5363,7 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, Simple) {
   ASSERT_FALSE(fut_gen.is_finished());
 
   ASSERT_OK_AND_ASSIGN(auto fut, internal::GetCpuThreadPool()->Submit([&]() {
-    return ExportAsyncRecordBatchReader(orig_schema,
-                                        MakeVectorGenerator(batches),
+    return ExportAsyncRecordBatchReader(orig_schema, MakeVectorGenerator(batches),
                                         device->device_type(), &handler);
   }));
 

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -296,6 +297,14 @@ struct ARROW_EXPORT RecordBatchWithMetadata {
   std::shared_ptr<RecordBatch> batch;
   std::shared_ptr<KeyValueMetadata> custom_metadata;
 };
+
+
+template <>
+struct IterationTraits<RecordBatchWithMetadata> {
+  static RecordBatchWithMetadata End() { return {nullptr, nullptr}; }
+  static bool IsEnd(const RecordBatchWithMetadata& val) { return val.batch == nullptr; }
+};
+
 
 /// \brief Abstract interface for reading stream of record batches
 class ARROW_EXPORT RecordBatchReader {

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -300,8 +300,8 @@ struct ARROW_EXPORT RecordBatchWithMetadata {
 
 template <>
 struct IterationTraits<RecordBatchWithMetadata> {
-  static RecordBatchWithMetadata End() { return {nullptr, nullptr}; }
-  static bool IsEnd(const RecordBatchWithMetadata& val) { return val.batch == nullptr; }
+  static RecordBatchWithMetadata End() { return {NULLPTR, NULLPTR}; }
+  static bool IsEnd(const RecordBatchWithMetadata& val) { return val.batch == NULLPTR; }
 };
 
 /// \brief Abstract interface for reading stream of record batches

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -298,13 +298,11 @@ struct ARROW_EXPORT RecordBatchWithMetadata {
   std::shared_ptr<KeyValueMetadata> custom_metadata;
 };
 
-
 template <>
 struct IterationTraits<RecordBatchWithMetadata> {
   static RecordBatchWithMetadata End() { return {nullptr, nullptr}; }
   static bool IsEnd(const RecordBatchWithMetadata& val) { return val.batch == nullptr; }
 };
-
 
 /// \brief Abstract interface for reading stream of record batches
 class ARROW_EXPORT RecordBatchReader {

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -79,7 +79,9 @@ using ScalarVector = std::vector<std::shared_ptr<Scalar>>;
 
 class ChunkedArray;
 class RecordBatch;
+struct RecordBatchWithMetadata;
 class RecordBatchReader;
+class AsyncRecordBatchReader;
 class Table;
 
 struct Datum;

--- a/docs/source/format/CDeviceDataInterface.rst
+++ b/docs/source/format/CDeviceDataInterface.rst
@@ -695,6 +695,8 @@ The C device async stream interface consists of three ``struct`` definitions:
     };
 
     struct ArrowAsyncProducer {
+      ArrowDeviceType device_type;
+
       void (*request)(struct ArrowAsyncProducer* self, int64_t n);
       void (*cancel)(struct ArrowAsyncProducer* self);
 
@@ -868,6 +870,12 @@ The ArrowAsyncProducer structure
 ''''''''''''''''''''''''''''''''
 
 This producer-provided and managed object has the following fields:
+
+.. c:member:: ArrowDeviceType ArrowAsyncProducer.device_type
+
+  *Mandatory.* The device type that this producer will provide data on. All
+  ``ArrowDeviceArray`` structs that are produced by this producer should have the
+  same device type as is set here.
 
 .. c:member:: void (*ArrowAsyncProducer.request)(struct ArrowAsyncProducer*, uint64_t)
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Building on #43632 which created the Async C Data Structures, this adds functions to `bridge.h`/`bridge.cc` to implement helpers for managing the Async C Data interfaces 
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
Two functions added to bridge.h:

1. `CreateAsyncDeviceStreamHandler` populates a `ArrowAsyncDeviceStreamHandler` and an `Executor` to provide a future that resolves to an `AsyncRecordBatchGenerator` to produce record batches as they are pushed asynchronously. The `ArrowAsyncDeviceStreamHandler` can then be passed to any asynchronous producer.
2. `ExportAsyncRecordBatchReader` takes a record batch generator and a schema, along with an `ArrowAsyncDeviceStreamHandler` to use for calling the callbacks to push data as it is available from the generator. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Unit tests are added (currently only one test, more tests to be added)

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
4. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43631