### PR TITLE
GH-44478: [GLib] Prevent Arrow::ExtensionType.new

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -1660,9 +1660,9 @@ enum {
   PROP_STORAGE_DATA_TYPE = 1
 };
 
-G_DEFINE_TYPE_WITH_PRIVATE(GArrowExtensionDataType,
-                           garrow_extension_data_type,
-                           GARROW_TYPE_DATA_TYPE)
+G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GArrowExtensionDataType,
+                                    garrow_extension_data_type,
+                                    GARROW_TYPE_DATA_TYPE)
 
 #define GARROW_EXTENSION_DATA_TYPE_GET_PRIVATE(obj)                                      \
   static_cast<GArrowExtensionDataTypePrivate *>(                                         \

--- a/c_glib/test/test-extension-data-type.rb
+++ b/c_glib/test/test-extension-data-type.rb
@@ -105,7 +105,7 @@ class TestExtensionDataType < Test::Unit::TestCase
 
   def test_abstract_class
     assert_raise(TypeError) do
-      Arrow::ExtensionDataType.new.name
+      Arrow::ExtensionDataType.new
     end
   end
 end

--- a/c_glib/test/test-extension-data-type.rb
+++ b/c_glib/test/test-extension-data-type.rb
@@ -102,4 +102,11 @@ class TestExtensionDataType < Test::Unit::TestCase
                    extension_chunked_array.chunks.collect(&:class),
                  ])
   end
+
+  # GH-44478 test https://github.com/apache/arrow/issues/44478
+  def test_abstract_class_init
+    assert_raise(TypeError) do
+      Arrow::ExtensionDataType.new.name
+    end
+  end
 end

--- a/c_glib/test/test-extension-data-type.rb
+++ b/c_glib/test/test-extension-data-type.rb
@@ -103,8 +103,7 @@ class TestExtensionDataType < Test::Unit::TestCase
                  ])
   end
 
-  # GH-44478 test https://github.com/apache/arrow/issues/44478
-  def test_abstract_class_init
+  def test_abstract_class
     assert_raise(TypeError) do
       Arrow::ExtensionDataType.new.name
     end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->


### Rationale for this change

This change fixes GH-44478

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->


### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This change Prevent `Arrow::ExtensionType.new`. This change fixes segmentation fault.

### Are these changes tested?

YES

Before this change: Cause segmentation fault.
After this change: raise the exception(TypeError)

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

N/A

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

Co-Authored-by: Sutou Kouhei <kou@clear-code.com>
* GitHub Issue: #44478