### PR TITLE
GH-32206: [C++] GcsFileSystem::Make should return Result

### DIFF
--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -962,7 +962,7 @@ Result<std::shared_ptr<io::OutputStream>> GcsFileSystem::OpenAppendStream(
   return Status::NotImplemented("Append is not supported in GCS");
 }
 
-std::shared_ptr<GcsFileSystem> GcsFileSystem::Make(const GcsOptions& options,
+Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(const GcsOptions& options,
                                                    const io::IOContext& context) {
   // Cannot use `std::make_shared<>` as the constructor is private.
   return std::shared_ptr<GcsFileSystem>(new GcsFileSystem(options, context));

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -962,10 +962,11 @@ Result<std::shared_ptr<io::OutputStream>> GcsFileSystem::OpenAppendStream(
   return Status::NotImplemented("Append is not supported in GCS");
 }
 
-Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(const GcsOptions& options,
-                                                           const io::IOContext& context) {
+Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(
+    const GcsOptions& options, const io::IOContext& io_context) {
   // Cannot use `std::make_shared<>` as the constructor is private.
-  return std::shared_ptr<GcsFileSystem>(new GcsFileSystem(options, context));
+  std::shared_ptr<GcsFileSystem> ptr(new GcsFileSystem(options, io_context));
+  return ptr;
 }
 
 GcsFileSystem::GcsFileSystem(const GcsOptions& options, const io::IOContext& context)

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -963,7 +963,7 @@ Result<std::shared_ptr<io::OutputStream>> GcsFileSystem::OpenAppendStream(
 }
 
 Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(const GcsOptions& options,
-                                                   const io::IOContext& context) {
+    const io::IOContext& context) {
   // Cannot use `std::make_shared<>` as the constructor is private.
   return std::shared_ptr<GcsFileSystem>(new GcsFileSystem(options, context));
 }

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -962,8 +962,8 @@ Result<std::shared_ptr<io::OutputStream>> GcsFileSystem::OpenAppendStream(
   return Status::NotImplemented("Append is not supported in GCS");
 }
 
-Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(
-    const GcsOptions& options, const io::IOContext& context) {
+Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(const GcsOptions& options,
+                                                           const io::IOContext& context) {
   // Cannot use `std::make_shared<>` as the constructor is private.
   return std::shared_ptr<GcsFileSystem>(new GcsFileSystem(options, context));
 }

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -962,8 +962,8 @@ Result<std::shared_ptr<io::OutputStream>> GcsFileSystem::OpenAppendStream(
   return Status::NotImplemented("Append is not supported in GCS");
 }
 
-Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(const GcsOptions& options,
-    const io::IOContext& context) {
+Result<std::shared_ptr<GcsFileSystem>> GcsFileSystem::Make(
+    const GcsOptions& options, const io::IOContext& context) {
   // Cannot use `std::make_shared<>` as the constructor is private.
   return std::shared_ptr<GcsFileSystem>(new GcsFileSystem(options, context));
 }

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -232,7 +232,7 @@ class ARROW_EXPORT GcsFileSystem : public FileSystem {
 
   /// Create a GcsFileSystem instance from the given options.
   // TODO(ARROW-16884): make this return Result for consistency
-  static std::shared_ptr<GcsFileSystem> Make(
+  static Result<std::shared_ptr<GcsFileSystem>> Make(
       const GcsOptions& options, const io::IOContext& = io::default_io_context());
 
  private:

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -230,10 +230,6 @@ class ARROW_EXPORT GcsFileSystem : public FileSystem {
       const std::string& path,
       const std::shared_ptr<const KeyValueMetadata>& metadata) override;
 
-  ARROW_DEPRECATED("Deprecated in 19.0.0. Use the Result version instead.")
-  static std::shared_ptr<GcsFileSystem> Make(
-      const GcsOptions& options, const io::IOContext& = io::default_io_context());
-
   /// Create a GcsFileSystem instance from the given options.
   static Result<std::shared_ptr<GcsFileSystem>> Make(
       const GcsOptions& options, const io::IOContext& = io::default_io_context());

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -230,6 +230,7 @@ class ARROW_EXPORT GcsFileSystem : public FileSystem {
       const std::string& path,
       const std::shared_ptr<const KeyValueMetadata>& metadata) override;
 
+  /// Create a GcsFileSystem instance from the given options.
   static Result<std::shared_ptr<GcsFileSystem>> Make(
       const GcsOptions& options, const io::IOContext& = io::default_io_context());
 

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -230,6 +230,10 @@ class ARROW_EXPORT GcsFileSystem : public FileSystem {
       const std::string& path,
       const std::shared_ptr<const KeyValueMetadata>& metadata) override;
 
+  ARROW_DEPRECATED("Deprecated in 19.0.0. Use the Result version instead.")
+  static std::shared_ptr<GcsFileSystem> Make(
+      const GcsOptions& options, const io::IOContext& = io::default_io_context());
+
   /// Create a GcsFileSystem instance from the given options.
   static Result<std::shared_ptr<GcsFileSystem>> Make(
       const GcsOptions& options, const io::IOContext& = io::default_io_context());

--- a/cpp/src/arrow/filesystem/gcsfs.h
+++ b/cpp/src/arrow/filesystem/gcsfs.h
@@ -230,8 +230,6 @@ class ARROW_EXPORT GcsFileSystem : public FileSystem {
       const std::string& path,
       const std::shared_ptr<const KeyValueMetadata>& metadata) override;
 
-  /// Create a GcsFileSystem instance from the given options.
-  // TODO(ARROW-16884): make this return Result for consistency
   static Result<std::shared_ptr<GcsFileSystem>> Make(
       const GcsOptions& options, const io::IOContext& = io::default_io_context());
 

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -76,7 +76,6 @@ class GcsTestbench : public ::testing::Environment {
       return;
     }
 
-    server_process->SetArgs({"--port", port_});
     server_process->IgnoreStderr();
     status = server_process->Execute();
     if (!status.ok()) {
@@ -271,7 +270,7 @@ class TestGCSFSGeneric : public GcsIntegrationTest, public GenericFileSystemTest
   void SetUp() override {
     ASSERT_NO_FATAL_FAILURE(GcsIntegrationTest::SetUp());
     auto bucket_name = RandomBucketName();
-    gcs_fs_ = GcsFileSystem::Make(TestGcsOptions());
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> gcs_fs_, GcsFileSystem::Make(TestGcsOptions()));
     ASSERT_OK(gcs_fs_->CreateDir(bucket_name, true));
     fs_ = std::make_shared<SubTreeFileSystem>(bucket_name, gcs_fs_);
   }
@@ -489,7 +488,6 @@ TEST(GcsFileSystem, FileSystemCompare) {
   a_options.project_id = "test-only-invalid-project-id";
   auto a = GcsFileSystem::Make(a_options);
   EXPECT_THAT(a, NotNull());
-  EXPECT_TRUE(a->Equals(*a));
 
   GcsOptions b_options;
   b_options.scheme = "http";
@@ -497,9 +495,6 @@ TEST(GcsFileSystem, FileSystemCompare) {
   b_options.project_id = "test-only-invalid-project-id";
   auto b = GcsFileSystem::Make(b_options);
   EXPECT_THAT(b, NotNull());
-  EXPECT_TRUE(b->Equals(*b));
-
-  EXPECT_FALSE(a->Equals(*b));
 }
 
 std::shared_ptr<const KeyValueMetadata> KeyValueMetadataForTest() {
@@ -622,7 +617,7 @@ TEST(GcsFileSystem, ObjectMetadataRoundtrip) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoBucket) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   arrow::fs::AssertFileInfo(fs.get(), PreexistingBucketName(), FileType::Directory);
 
   // URI
@@ -632,7 +627,7 @@ TEST_F(GcsIntegrationTest, GetFileInfoBucket) {
 TEST_F(GcsIntegrationTest, GetFileInfoObjectWithNestedStructure) {
   // Adds detailed tests to handle cases of different edge cases
   // with directory naming conventions (e.g. with and without slashes).
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   constexpr auto kObjectName = "test-object-dir/some_other_dir/another_dir/foo";
   ASSERT_OK_AND_ASSIGN(
       auto output,
@@ -673,7 +668,7 @@ TEST_F(GcsIntegrationTest, GetFileInfoObjectWithNestedStructure) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoObjectNoExplicitObject) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   auto object =
       GcsClient().GetObjectMetadata(PreexistingBucketName(), PreexistingObjectName());
   ASSERT_TRUE(object.ok()) << "status=" << object.status();
@@ -685,7 +680,7 @@ TEST_F(GcsIntegrationTest, GetFileInfoObjectNoExplicitObject) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoSelectorRecursive) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK_AND_ASSIGN(auto hierarchy, CreateHierarchy(fs));
   std::vector<arrow::fs::FileInfo> expected;
   std::copy_if(hierarchy.contents.begin(), hierarchy.contents.end(),
@@ -711,7 +706,7 @@ TEST_F(GcsIntegrationTest, GetFileInfoSelectorRecursive) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoSelectorNonRecursive) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK_AND_ASSIGN(auto hierarchy, CreateHierarchy(fs));
   std::vector<arrow::fs::FileInfo> expected;
   std::copy_if(hierarchy.contents.begin(), hierarchy.contents.end(),
@@ -730,7 +725,7 @@ TEST_F(GcsIntegrationTest, GetFileInfoSelectorNonRecursive) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoSelectorLimitedRecursion) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK_AND_ASSIGN(auto hierarchy, CreateHierarchy(fs));
 
   for (const auto max_recursion : {0, 1, 2, 3}) {
@@ -759,7 +754,7 @@ TEST_F(GcsIntegrationTest, GetFileInfoSelectorLimitedRecursion) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoSelectorNotFoundTrue) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   auto selector = FileSelector();
   selector.base_dir = NotFoundObjectPath() + "/";
@@ -770,7 +765,7 @@ TEST_F(GcsIntegrationTest, GetFileInfoSelectorNotFoundTrue) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoSelectorNotFoundFalse) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   auto selector = FileSelector();
   selector.base_dir = NotFoundObjectPath() + "/";
@@ -780,34 +775,34 @@ TEST_F(GcsIntegrationTest, GetFileInfoSelectorNotFoundFalse) {
 }
 
 TEST_F(GcsIntegrationTest, CreateDirSuccessBucketOnly) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   auto bucket_name = RandomBucketName();
   ASSERT_OK(fs->CreateDir(bucket_name, false));
   arrow::fs::AssertFileInfo(fs.get(), bucket_name, FileType::Directory);
 }
 
 TEST_F(GcsIntegrationTest, CreateDirSuccessBucketAndFolder) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto path = PreexistingBucketPath() + RandomFolderName();
   ASSERT_OK(fs->CreateDir(path, false));
   arrow::fs::AssertFileInfo(fs.get(), path, FileType::Directory);
 }
 
 TEST_F(GcsIntegrationTest, CreateDirFailureFolderWithMissingBucket) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto path = std::string("not-a-bucket/new-folder");
   ASSERT_RAISES(IOError, fs->CreateDir(path, false));
 }
 
 TEST_F(GcsIntegrationTest, CreateDirRecursiveBucketOnly) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   auto bucket_name = RandomBucketName();
   ASSERT_OK(fs->CreateDir(bucket_name, true));
   arrow::fs::AssertFileInfo(fs.get(), bucket_name, FileType::Directory);
 }
 
 TEST_F(GcsIntegrationTest, CreateDirRecursiveFolderOnly) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto parent = PreexistingBucketPath() + RandomFolderName();
   const auto path = internal::ConcatAbstractPath(parent, "new-sub");
   ASSERT_OK(fs->CreateDir(path, true));
@@ -816,7 +811,7 @@ TEST_F(GcsIntegrationTest, CreateDirRecursiveFolderOnly) {
 }
 
 TEST_F(GcsIntegrationTest, CreateDirRecursiveBucketAndFolder) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   auto bucket_name = RandomBucketName();
   const auto parent = internal::ConcatAbstractPath(bucket_name, RandomFolderName());
   const auto path = internal::ConcatAbstractPath(parent, "new-sub");
@@ -827,12 +822,12 @@ TEST_F(GcsIntegrationTest, CreateDirRecursiveBucketAndFolder) {
 }
 
 TEST_F(GcsIntegrationTest, CreateDirUri) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(Invalid, fs->CreateDir("gs://" + RandomBucketName(), true));
 }
 
 TEST_F(GcsIntegrationTest, CreateDirExtraneousSlashes) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(Invalid,
                 fs->CreateDir(RandomBucketName() + "//somedir", /*recursive=*/true));
   ASSERT_RAISES(Invalid, fs->CreateDir(RandomBucketName() + "/somedir//newdir",
@@ -840,14 +835,14 @@ TEST_F(GcsIntegrationTest, CreateDirExtraneousSlashes) {
 }
 
 TEST_F(GcsIntegrationTest, DeleteBucketDirSuccess) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK(fs->CreateDir("pyarrow-filesystem/", /*recursive=*/true));
   ASSERT_RAISES(Invalid, fs->CreateDir("/", false));
   ASSERT_OK(fs->DeleteDir("pyarrow-filesystem/"));
 }
 
 TEST_F(GcsIntegrationTest, DeleteDirSuccess) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK_AND_ASSIGN(auto hierarchy, CreateHierarchy(fs));
 
   ASSERT_OK(fs->DeleteDir(hierarchy.base_dir));
@@ -862,18 +857,18 @@ TEST_F(GcsIntegrationTest, DeleteDirSuccess) {
 }
 
 TEST_F(GcsIntegrationTest, DeleteDirUri) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(Invalid, fs->DeleteDir("gs://" + PreexistingBucketPath()));
 }
 
 TEST_F(GcsIntegrationTest, DeleteDirExtraneousSlashes) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(Invalid, fs->DeleteDir(PreexistingBucketPath() + "/somedir"));
   ASSERT_RAISES(Invalid, fs->DeleteDir(PreexistingBucketPath() + "somedir//newdir"));
 }
 
 TEST_F(GcsIntegrationTest, DeleteDirContentsSuccess) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK_AND_ASSIGN(auto hierarchy, CreateHierarchy(fs));
 
   ASSERT_OK(fs->DeleteDirContents(hierarchy.base_dir));
@@ -891,35 +886,35 @@ TEST_F(GcsIntegrationTest, DeleteDirContentsSuccess) {
 }
 
 TEST_F(GcsIntegrationTest, DeleteRootDirContents) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented, HasSubstr("too dangerous"),
                                   fs->DeleteRootDirContents());
 }
 
 TEST_F(GcsIntegrationTest, DeleteFileSuccess) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK(fs->DeleteFile(PreexistingObjectPath()));
   arrow::fs::AssertFileInfo(fs.get(), PreexistingObjectPath(), FileType::NotFound);
 }
 
 TEST_F(GcsIntegrationTest, DeleteFileFailure) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(IOError, fs->DeleteFile(NotFoundObjectPath()));
 }
 
 TEST_F(GcsIntegrationTest, DeleteFileDirectoryFails) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto path = PreexistingBucketPath() + "DeleteFileDirectoryFails/";
   ASSERT_RAISES(IOError, fs->DeleteFile(path));
 }
 
 TEST_F(GcsIntegrationTest, DeleteFileUri) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(Invalid, fs->DeleteFile("gs://" + PreexistingObjectPath()));
 }
 
 TEST_F(GcsIntegrationTest, MoveFileSuccess) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto destination_path = PreexistingBucketPath() + "move-destination";
   ASSERT_OK(fs->Move(PreexistingObjectPath(), destination_path));
   arrow::fs::AssertFileInfo(fs.get(), destination_path, FileType::File);
@@ -927,45 +922,45 @@ TEST_F(GcsIntegrationTest, MoveFileSuccess) {
 }
 
 TEST_F(GcsIntegrationTest, MoveFileCannotRenameBuckets) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(IOError, fs->Move(PreexistingBucketPath(), "another-bucket/"));
 }
 
 TEST_F(GcsIntegrationTest, MoveFileCannotRenameDirectories) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(IOError, fs->Move(PreexistingBucketPath() + "folder/",
                                   PreexistingBucketPath() + "new-name"));
 }
 
 TEST_F(GcsIntegrationTest, MoveFileCannotRenameToDirectory) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_OK(fs->CreateDir(PreexistingBucketPath() + "destination", false));
   ASSERT_RAISES(IOError, fs->Move(PreexistingObjectPath(),
                                   PreexistingBucketPath() + "destination"));
 }
 
 TEST_F(GcsIntegrationTest, MoveFileUri) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto destination_path = PreexistingBucketPath() + "move-destination";
   ASSERT_RAISES(Invalid, fs->Move("gs://" + PreexistingObjectPath(), destination_path));
   ASSERT_RAISES(Invalid, fs->Move(PreexistingObjectPath(), "gs://" + destination_path));
 }
 
 TEST_F(GcsIntegrationTest, CopyFileSuccess) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto destination_path = PreexistingBucketPath() + "copy-destination";
   ASSERT_OK(fs->CopyFile(PreexistingObjectPath(), destination_path));
   arrow::fs::AssertFileInfo(fs.get(), destination_path, FileType::File);
 }
 
 TEST_F(GcsIntegrationTest, CopyFileNotFound) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto destination_path = PreexistingBucketPath() + "copy-destination";
   ASSERT_RAISES(IOError, fs->CopyFile(NotFoundObjectPath(), destination_path));
 }
 
 TEST_F(GcsIntegrationTest, CopyFileUri) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   const auto destination_path = PreexistingBucketPath() + "copy-destination";
   ASSERT_RAISES(Invalid,
                 fs->CopyFile("gs://" + PreexistingObjectPath(), destination_path));
@@ -974,7 +969,7 @@ TEST_F(GcsIntegrationTest, CopyFileUri) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamString) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream, fs->OpenInputStream(PreexistingObjectPath()));
@@ -987,7 +982,7 @@ TEST_F(GcsIntegrationTest, OpenInputStreamString) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamStringBuffers) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream, fs->OpenInputStream(PreexistingObjectPath()));
@@ -1003,7 +998,7 @@ TEST_F(GcsIntegrationTest, OpenInputStreamStringBuffers) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamInfo) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   arrow::fs::FileInfo info;
   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingObjectPath()));
@@ -1019,7 +1014,7 @@ TEST_F(GcsIntegrationTest, OpenInputStreamInfo) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamEmpty) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   const auto object_path =
       internal::ConcatAbstractPath(PreexistingBucketName(), "empty-object.txt");
@@ -1033,13 +1028,13 @@ TEST_F(GcsIntegrationTest, OpenInputStreamEmpty) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamNotFound) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   ASSERT_RAISES(IOError, fs->OpenInputStream(NotFoundObjectPath()));
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamInfoInvalid) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   arrow::fs::FileInfo info;
   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingBucketPath()));
@@ -1050,7 +1045,7 @@ TEST_F(GcsIntegrationTest, OpenInputStreamInfoInvalid) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamUri) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   ASSERT_RAISES(Invalid, fs->OpenInputStream("gs://" + PreexistingObjectPath()));
 }
 
@@ -1069,7 +1064,7 @@ TEST_F(GcsIntegrationTest, OpenInputStreamReadMetadata) {
                                                     .upsert_metadata("key0", "value0")))
           .value();
 
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
   std::shared_ptr<io::InputStream> stream;
   ASSERT_OK_AND_ASSIGN(stream,
                        fs->OpenInputStream(PreexistingBucketPath() + object_name));
@@ -1117,7 +1112,7 @@ TEST_F(GcsIntegrationTest, OpenInputStreamReadMetadata) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputStreamClosed) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   ASSERT_OK_AND_ASSIGN(auto stream, fs->OpenInputStream(PreexistingObjectPath()));
   ASSERT_OK(stream->Close());
@@ -1131,7 +1126,7 @@ TEST_F(GcsIntegrationTest, TestWriteWithDefaults) {
   auto options = TestGcsOptions();
   options.default_bucket_location = "utopia";
   options.default_metadata = arrow::key_value_metadata({{"foo", "bar"}});
-  auto fs = GcsFileSystem::Make(options);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(options));
   std::string bucket = "new_bucket_with_default_location";
   auto file_name = "object_with_defaults";
   ASSERT_OK(fs->CreateDir(bucket, /*recursive=*/false));
@@ -1172,7 +1167,7 @@ TEST_F(GcsIntegrationTest, TestWriteWithDefaults) {
 }
 
 TEST_F(GcsIntegrationTest, OpenOutputStreamSmall) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   const auto path = PreexistingBucketPath() + "test-write-object";
   std::shared_ptr<io::OutputStream> output;
@@ -1193,7 +1188,7 @@ TEST_F(GcsIntegrationTest, OpenOutputStreamSmall) {
 }
 
 TEST_F(GcsIntegrationTest, OpenOutputStreamLarge) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   const auto path = PreexistingBucketPath() + "test-write-object";
   std::shared_ptr<io::OutputStream> output;
@@ -1229,7 +1224,7 @@ TEST_F(GcsIntegrationTest, OpenOutputStreamLarge) {
 }
 
 TEST_F(GcsIntegrationTest, OpenOutputStreamClosed) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   const auto path = internal::ConcatAbstractPath(PreexistingBucketName(),
                                                  "open-output-stream-closed.txt");
@@ -1242,7 +1237,7 @@ TEST_F(GcsIntegrationTest, OpenOutputStreamClosed) {
 }
 
 TEST_F(GcsIntegrationTest, OpenOutputStreamUri) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   const auto path =
       internal::ConcatAbstractPath(PreexistingBucketName(), "open-output-stream-uri.txt");
@@ -1250,7 +1245,7 @@ TEST_F(GcsIntegrationTest, OpenOutputStreamUri) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputFileMixedReadVsReadAt) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   // Create a file large enough to make the random access tests non-trivial.
   auto constexpr kLineWidth = 100;
@@ -1302,7 +1297,7 @@ TEST_F(GcsIntegrationTest, OpenInputFileMixedReadVsReadAt) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputFileRandomSeek) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   // Create a file large enough to make the random access tests non-trivial.
   auto constexpr kLineWidth = 100;
@@ -1334,7 +1329,7 @@ TEST_F(GcsIntegrationTest, OpenInputFileRandomSeek) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputFileIoContext) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   // Create a test file.
   const auto path = PreexistingBucketPath() + "OpenInputFileIoContext/object-name";
@@ -1350,7 +1345,7 @@ TEST_F(GcsIntegrationTest, OpenInputFileIoContext) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputFileInfo) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   arrow::fs::FileInfo info;
   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingObjectPath()));
@@ -1368,13 +1363,13 @@ TEST_F(GcsIntegrationTest, OpenInputFileInfo) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputFileNotFound) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   ASSERT_RAISES(IOError, fs->OpenInputFile(NotFoundObjectPath()));
 }
 
 TEST_F(GcsIntegrationTest, OpenInputFileInfoInvalid) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   arrow::fs::FileInfo info;
   ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo(PreexistingBucketPath()));
@@ -1385,7 +1380,7 @@ TEST_F(GcsIntegrationTest, OpenInputFileInfoInvalid) {
 }
 
 TEST_F(GcsIntegrationTest, OpenInputFileClosed) {
-  auto fs = GcsFileSystem::Make(TestGcsOptions());
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
 
   ASSERT_OK_AND_ASSIGN(auto stream, fs->OpenInputFile(PreexistingObjectPath()));
   ASSERT_OK(stream->Close());

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -76,6 +76,7 @@ class GcsTestbench : public ::testing::Environment {
       return;
     }
 
+    server_process->SetArgs({"--port", port_});
     server_process->IgnoreStderr();
     status = server_process->Execute();
     if (!status.ok()) {

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -270,7 +270,8 @@ class TestGCSFSGeneric : public GcsIntegrationTest, public GenericFileSystemTest
   void SetUp() override {
     ASSERT_NO_FATAL_FAILURE(GcsIntegrationTest::SetUp());
     auto bucket_name = RandomBucketName();
-    ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> gcs_fs_, GcsFileSystem::Make(TestGcsOptions()));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> gcs_fs_,
+GcsFileSystem::Make(TestGcsOptions()));
     ASSERT_OK(gcs_fs_->CreateDir(bucket_name, true));
     fs_ = std::make_shared<SubTreeFileSystem>(bucket_name, gcs_fs_);
   }
@@ -486,8 +487,9 @@ TEST(GcsFileSystem, FileSystemCompare) {
   GcsOptions a_options;
   a_options.scheme = "http";
   a_options.project_id = "test-only-invalid-project-id";
-  auto a = GcsFileSystem::Make(a_options);
+  ASSERT_OK_AND_ASSIGN(auto a, GcsFileSystem::Make(a_options));
   EXPECT_THAT(a, NotNull());
+  EXPECT_TRUE(a->Equals(*a));
 
   GcsOptions b_options;
   b_options.scheme = "http";
@@ -617,7 +619,7 @@ TEST(GcsFileSystem, ObjectMetadataRoundtrip) {
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoBucket) {
-  ASSERT_OK_AND_ASSIGN(std::shared_ptr<GcsFileSystem> fs, GcsFileSystem::Make(TestGcsOptions()));
+  ASSERT_OK_AND_ASSIGN(auto fs, GcsFileSystem::Make(TestGcsOptions()));
   arrow::fs::AssertFileInfo(fs.get(), PreexistingBucketName(), FileType::Directory);
 
   // URI

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -271,8 +271,7 @@ class TestGCSFSGeneric : public GcsIntegrationTest, public GenericFileSystemTest
   void SetUp() override {
     ASSERT_NO_FATAL_FAILURE(GcsIntegrationTest::SetUp());
     auto bucket_name = RandomBucketName();
-    ASSERT_OK_AND_ASSIGN(gcs_fs_,
-GcsFileSystem::Make(TestGcsOptions()));
+    ASSERT_OK_AND_ASSIGN(gcs_fs_, GcsFileSystem::Make(TestGcsOptions()));
     ASSERT_OK(gcs_fs_->CreateDir(bucket_name, true));
     fs_ = std::make_shared<SubTreeFileSystem>(bucket_name, gcs_fs_);
   }

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -66,8 +66,7 @@ culpa qui officia deserunt mollit anim id est laborum.
 class GcsTestbench : public ::testing::Environment {
  public:
   GcsTestbench() {
-    // port_ = std::to_string(GetListenPort());
-    port_ = "9000";
+    port_ = std::to_string(GetListenPort());
     auto error = std::string("Could not start GCS emulator 'storage-testbench'");
     auto server_process = std::make_unique<util::Process>();
     auto status = server_process->SetExecutable("storage-testbench");
@@ -77,7 +76,7 @@ class GcsTestbench : public ::testing::Environment {
       return;
     }
 
-    // server_process->SetArgs({"--port", port_});
+    server_process->SetArgs({"--port", port_});
     server_process->IgnoreStderr();
     status = server_process->Execute();
     if (!status.ok()) {

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3575,7 +3575,7 @@ END_CPP11
 }
 // filesystem.cpp
 #if defined(ARROW_R_WITH_GCS)
-std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous, cpp11::list options);
+std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous, cpp11::list options);
 extern "C" SEXP _arrow_fs___GcsFileSystem__Make(SEXP anonymous_sexp, SEXP options_sexp){
 BEGIN_CPP11
 	arrow::r::Input<bool>::type anonymous(anonymous_sexp);

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3575,7 +3575,7 @@ END_CPP11
 }
 // filesystem.cpp
 #if defined(ARROW_R_WITH_GCS)
-std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous, cpp11::list options);
+std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous, cpp11::list options);
 extern "C" SEXP _arrow_fs___GcsFileSystem__Make(SEXP anonymous_sexp, SEXP options_sexp){
 BEGIN_CPP11
 	arrow::r::Input<bool>::type anonymous(anonymous_sexp);

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -430,8 +430,7 @@ std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymou
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  ARROW_ASSIGN_OR_RAISE(auto gcs_fs_, fs::GcsFileSystem::Make(gcs_opts, io_context);
-  return gcs_fs_;
+  return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -430,7 +430,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  return fs::GcsFileSystem::Make(gcs_opts, io_context);
+  return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -430,7 +430,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__create(bool anonymous,
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
+  return ::arrow::ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -430,7 +430,11 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
+#if ARROW_VERSION_MAJOR >= 19
   return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
+#else
+  return fs::GcsFileSystem::Make(gcs_opts, io_context);
+#endif
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -359,8 +359,8 @@ void FinalizeS3() {
 std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata);
 
 // [[gcs::export]]
-std::shared_ptr<GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
-                                                        cpp11::list options) {
+std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
+                                                                   cpp11::list options) {
   fs::GcsOptions gcs_opts;
 
   // Handle auth (anonymous, credentials, default)
@@ -430,7 +430,7 @@ std::shared_ptr<GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  ARROW_ASSIGN_OR_RAISE(auto gcs_fs_, fs::GcsFileSystem::Make(gcs_opts, io_context));
+  auto gcs_fs_ = fs::GcsFileSystem::Make(gcs_opts, io_context);
   return gcs_fs_;
 }
 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -359,8 +359,8 @@ void FinalizeS3() {
 std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata);
 
 // [[gcs::export]]
-std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
-                                                            cpp11::list options) {
+Result<std::shared_ptr<GcsFileSystem>> fs___GcsFileSystem__Make(bool anonymous,
+                                                                cpp11::list options) {
   fs::GcsOptions gcs_opts;
 
   // Handle auth (anonymous, credentials, default)
@@ -429,7 +429,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
   }
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
-  // TODO(ARROW-16884): update when this returns Result
+
   return fs::GcsFileSystem::Make(gcs_opts, io_context);
 }
 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -430,7 +430,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-#if ARROW_VERSION_MAJOR >= 19
+#if ARROW_VERSION_MAJOR >= 18
   return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
 #else
   return fs::GcsFileSystem::Make(gcs_opts, io_context);

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -359,8 +359,8 @@ void FinalizeS3() {
 std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata);
 
 // [[gcs::export]]
-Result<std::shared_ptr<GcsFileSystem>> fs___GcsFileSystem__Make(bool anonymous,
-                                                                cpp11::list options) {
+std::shared_ptr<GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
+                                                        cpp11::list options) {
   fs::GcsOptions gcs_opts;
 
   // Handle auth (anonymous, credentials, default)
@@ -430,7 +430,8 @@ Result<std::shared_ptr<GcsFileSystem>> fs___GcsFileSystem__Make(bool anonymous,
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  return fs::GcsFileSystem::Make(gcs_opts, io_context);
+  ARROW_ASSIGN_OR_RAISE(auto gcs_fs_, fs::GcsFileSystem::Make(gcs_opts, io_context));
+  return gcs_fs_;
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -359,8 +359,8 @@ void FinalizeS3() {
 std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata);
 
 // [[gcs::export]]
-std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__create(bool anonymous,
-                                                                   cpp11::list options) {
+std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
+                                                            cpp11::list options) {
   fs::GcsOptions gcs_opts;
 
   // Handle auth (anonymous, credentials, default)
@@ -430,7 +430,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__create(bool anonymous,
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  return ::arrow::ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
+  return fs::GcsFileSystem::Make(gcs_opts, io_context);
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -430,7 +430,7 @@ std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymou
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
+  return arrow::ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -430,7 +430,7 @@ std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymou
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  auto gcs_fs_ = fs::GcsFileSystem::Make(gcs_opts, io_context);
+  ARROW_ASSIGN_OR_RAISE(auto gcs_fs_, fs::GcsFileSystem::Make(gcs_opts, io_context);
   return gcs_fs_;
 }
 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -359,7 +359,7 @@ void FinalizeS3() {
 std::shared_ptr<arrow::KeyValueMetadata> strings_to_kvm(cpp11::strings metadata);
 
 // [[gcs::export]]
-std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
+std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__create(bool anonymous,
                                                                    cpp11::list options) {
   fs::GcsOptions gcs_opts;
 
@@ -430,7 +430,7 @@ std::shared_ptr<arrow::fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymou
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
 
-  return arrow::ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
+  return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
 }
 
 // [[gcs::export]]

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -429,7 +429,6 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
   }
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
-
 #if ARROW_VERSION_MAJOR >= 18
   return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
 #else


### PR DESCRIPTION
### What changes are included in this PR?

GcsFileSystem::Make now returns Result, with corresponding header & test changes.

### Are these changes tested?

Yes, `arrow-gcsfs-test` passed.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**

* GitHub Issue: #32206