### PR TITLE
GH-44506: [Docs][C++] Fix documentation directive for ChunkLocation

### DIFF
--- a/docs/source/cpp/api/array.rst
+++ b/docs/source/cpp/api/array.rst
@@ -88,9 +88,8 @@ Chunked Arrays
    :project: arrow_cpp
    :members:
 
-.. doxygenstruct:: arrow::ChunkLocation
+.. doxygentypedef:: arrow::ChunkLocation
    :project: arrow_cpp
-   :members:
 
 .. doxygenstruct:: arrow::TypedChunkLocation
    :project: arrow_cpp


### PR DESCRIPTION
### Rationale for this change

Since ChunkLocation is a typedef/alias, it needs to use the `doxygentypedef` Sphinx directive rather than `doxygenstruct` in order for it to show up in the generated HTML. Otherwise we get an error.

### What changes are included in this PR?

Just docs:

- Replace `doxygenstruct` directive with `doxygentypedef`
- Remove `:members:` directive as it's not needed

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes, though just docs.
* GitHub Issue: #44506