### PR TITLE
MINOR: [Docs][Python] Document type aliasing in pa.field/pa.schema

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -1153,6 +1153,13 @@ def test_field_basic():
         pa.field('foo', None)
 
 
+def test_field_datatype_alias():
+    f = pa.field('foo', 'string')
+
+    assert f.name == 'foo'
+    assert f.type is pa.string()
+
+
 def test_field_equals():
     meta1 = {b'foo': b'bar'}
     meta2 = {b'bizz': b'bazz'}

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -5722,6 +5722,25 @@ def schema(fields, metadata=None):
     some_int: int32
     some_string: string
 
+    DataTypes can also be passed as strings. The following is equivalent to the
+    above example:
+
+    >>> pa.schema([
+    ...     pa.field('some_int', "int32"),
+    ...     pa.field('some_string', "string")
+    ... ])
+    some_int: int32
+    some_string: string
+
+    Or more concisely:
+
+    >>> pa.schema([
+    ...     ('some_int', "int32"),
+    ...     ('some_string', "string")
+    ... ])
+    some_int: int32
+    some_string: string
+
     Returns
     -------
     schema : pyarrow.Schema

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -3713,8 +3713,8 @@ def field(name, type=None, nullable=None, metadata=None):
         Name of the field.
         Alternatively, you can also pass an object that implements the Arrow
         PyCapsule Protocol for schemas (has an ``__arrow_c_schema__`` method).
-    type : pyarrow.DataType
-        Arrow datatype of the field.
+    type : pyarrow.DataType or str
+        Arrow datatype of the field or a string matching one.
     nullable : bool, default True
         Whether the field's values are nullable.
     metadata : dict, default None
@@ -3746,6 +3746,11 @@ def field(name, type=None, nullable=None, metadata=None):
 
     >>> pa.struct([field])
     StructType(struct<key: int32>)
+
+    A str can also be passed for the type parameter:
+
+    >>> pa.field('key', 'int32')
+    pyarrow.Field<key: int32>
     """
     if hasattr(name, "__arrow_c_schema__"):
         if type is not None:


### PR DESCRIPTION
### Rationale for this change

PyArrow supports a set of type aliases, e.g., "string" aliases to pa.string() and these type aliases are triggered in calls to `pa.field` and `pa.schema`. Prior to this change, these weren't documented.

Note: I didn't think we wanted to deprecate these but if any reviewers want to discuss that let me know. The R package doesn't support a similar aliasing mechanism.

### What changes are included in this PR?

Updates to docs. One regression test.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Better docs.