### PR TITLE
GH-44474: [Website][Docs] Improve project description in more places

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@
 
 ## Powering In-Memory Analytics
 
-Apache Arrow is a development platform for in-memory analytics. It contains a
-set of technologies that enable big data systems to process and move data fast.
+Apache Arrow is a universal columnar format and multi-language toolbox for fast
+data interchange and in-memory analytics. It contains a set of technologies that
+enable data systems to efficiently store, process, and move data.
 
 Major components of the project include:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,7 +103,7 @@ Implementations
    C/GLib <c_glib/index>
    C++ <cpp/index>
    C# <https://github.com/apache/arrow/blob/main/csharp/README.md>
-   Go <https://pkg.go.dev/github.com/apache/arrow/go/v18>
+   Go <https://arrow.apache.org/go/>
    Java <java/index>
    JavaScript <js/index>
    Julia <https://arrow.apache.org/julia/>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,15 +20,14 @@
 Apache Arrow
 ============
 
-Apache Arrow is a development platform for in-memory analytics. It contains a
-set of technologies that enable big data systems to process and move data
-fast. It specifies a standardized language-independent columnar memory format
-for flat and hierarchical data, organized for efficient analytic operations on
-modern hardware.
+Apache Arrow is a universal columnar format and multi-language toolbox for fast
+data interchange and in-memory analytics.
 
-The project is developing a multi-language collection of libraries for solving
-systems problems related to in-memory analytical data processing. This includes
-such topics as:
+The project specifies a language-independent column-oriented memory format
+for flat and hierarchical data, organized for efficient analytic operations on
+modern hardware. The project houses an actively developed collection of
+libraries in many languages for solving problems related to data transfer and
+in-memory analytical processing. This includes such topics as:
 
 * Zero-copy shared memory and RPC-based data movement
 * Reading and writing file formats (like CSV, Apache ORC, and Apache Parquet)
@@ -104,7 +103,7 @@ Implementations
    C/GLib <c_glib/index>
    C++ <cpp/index>
    C# <https://github.com/apache/arrow/blob/main/csharp/README.md>
-   Go <https://arrow.apache.org/go/>
+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v18>
    Java <java/index>
    JavaScript <js/index>
    Julia <https://arrow.apache.org/julia/>

--- a/docs/source/python/index.rst
+++ b/docs/source/python/index.rst
@@ -25,8 +25,9 @@ PyArrow - Apache Arrow Python bindings
 
 This is the documentation of the Python API of Apache Arrow.
 
-Apache Arrow is a development platform for in-memory analytics.
-It contains a set of technologies that enable big data systems to store, process and move data fast.
+Apache Arrow is a universal columnar format and multi-language toolbox for fast
+data interchange and in-memory analytics. It contains a set of technologies that
+enable data systems to efficiently store, process, and move data.
 
 See the :doc:`parent documentation <../index>` for additional details on
 the Arrow Project itself, on the Arrow format and the other language bindings.


### PR DESCRIPTION
This is a follow-up to https://github.com/apache/arrow-site/pull/549 and https://github.com/apache/arrow/pull/44492. This updates the project description in a few other places where it appears prominently in the website and docs.
* GitHub Issue: #44474