### PR TITLE
GH-44528: [Dev] Introduce a new feature: specific language reformatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,7 @@ repos:
     hooks:
       - id: clang-format
         name: C++ Format
+        alias: cpp-format
         types_or:
           - c++
           # - json
@@ -103,6 +104,7 @@ repos:
     hooks:
       - id: clang-format
         name: C/GLib Format
+        alias: c-glib-format
         files: >-
           ^c_glib/
   - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -110,6 +112,7 @@ repos:
     hooks:
       - id: clang-format
         name: MATLAB (C++) Format
+        alias: matlab-format
         files: >-
           ^matlab/src/cpp/
   - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -117,6 +120,7 @@ repos:
     hooks:
       - id: clang-format
         name: Python (C++) Format
+        alias: python-format
         files: >-
           ^python/pyarrow/src/
         exclude: >-
@@ -130,6 +134,7 @@ repos:
     hooks:
       - id: clang-format
         name: R (C++) Format
+        alias: r-format
         files: >-
           ^r/src/
         exclude: >-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
     hooks:
       - id: clang-format
         name: C/GLib Format
-        alias: c-glib-format
+        alias: c-glib-cpp-format
         files: >-
           ^c_glib/
   - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -112,7 +112,7 @@ repos:
     hooks:
       - id: clang-format
         name: MATLAB (C++) Format
-        alias: matlab-format
+        alias: matlab-cpp-format
         files: >-
           ^matlab/src/cpp/
   - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -120,7 +120,7 @@ repos:
     hooks:
       - id: clang-format
         name: Python (C++) Format
-        alias: python-format
+        alias: python-cpp-format
         files: >-
           ^python/pyarrow/src/
         exclude: >-
@@ -134,7 +134,7 @@ repos:
     hooks:
       - id: clang-format
         name: R (C++) Format
-        alias: r-format
+        alias: r-cpp-format
         files: >-
           ^r/src/
         exclude: >-


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

This change implements GH-44528.

`pre-commit run --color=always --all-files c-glib-cpp-format`

Languages:  
* C++ (`cpp-format`)
* c_glib(`c-glib-cpp-format`)
* MATLAB(`matlab-cpp-format`)
* Python (`python-cpp-format`)
* R(`r-cpp-format`)


<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Add aliases to the `clang-format` in the pre-commit configuration file.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44528