### PR TITLE
GH-44558: [Release][Website] Remove needless "Apache Arrow ${VERSION}" section

### DIFF
--- a/dev/release/post-04-website.sh
+++ b/dev/release/post-04-website.sh
@@ -157,8 +157,11 @@ cat <<ANNOUNCE >> "${announce_file}"
 
 ANNOUNCE
 
+# Remove the "# Apache Arrow ..." line and increment section level
+# of "## Bug Fixes"/"## New Features and Improvements" to "### ...".
 archery release changelog generate ${version} | \
-  sed -e 's/^#/##/g' >> "${announce_file}"
+  sed -e '/^# /d' \
+      -e 's/^#/##/g' >> "${announce_file}"
 
 cat <<ANNOUNCE >> "${announce_file}"
 [1]: https://www.apache.org/dyn/closer.lua/arrow/arrow-${version}/


### PR DESCRIPTION
### Rationale for this change

`dev/release/post-04-website.sh` generates wrong section levels:

```markdown
...
## Changelog
## Apache Arrow 18.0.0 (2024-10-28 07:00:00+00:00)
...
### Bug Fixes
...
### New Features and Improvements
...
```

### What changes are included in this PR?

Remove the `## Apache Arrow ${VERSION}` section:

```markdown
...
## Changelog
...
### Bug Fixes
...
### New Features and Improvements
...
```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44558