### PR TITLE
MINOR: [R] Trim news for 18.0 release

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -23,7 +23,6 @@
 
 * Fix bindings to allow filtering a factor column in a Dataset using `%in%` (#43446)
 * Update `str_sub` binding to properly handle negative `end` values (@coussens, #44141)
-* Fix summarize() performance regression (pushdown) (#43649)
 * Fix altrep string columns from readr (#43351)
 * Fix crash in ParquetFileWriter$WriteTable and add WriteBatch (#42241)
 * Fix bindings in Math group generics (@aboyoun, #43162)


### PR DESCRIPTION
### Rationale for this change

The referenced change was included in the 17.0.0.1 CRAN submission (https://github.com/apache/arrow/issues/43317#issuecomment-2289034257) so we don't need to announce it here. As far as CRAN releases go, the performance regression was never released.

### What changes are included in this PR?

rm

### Are these changes tested?

🙅 

### Are there any user-facing changes?

Words