### PR TITLE
MINOR: [Java] Update mockito version to 5.14.2

### DIFF
--- a/java/flight/flight-sql-jdbc-core/pom.xml
+++ b/java/flight/flight-sql-jdbc-core/pom.xml
@@ -102,13 +102,6 @@ under the License.
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>${mockito.inline.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
     </dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -108,8 +108,7 @@ under the License.
     <checkstyle.version>10.18.2</checkstyle.version>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <error_prone_core.version>2.31.0</error_prone_core.version>
-    <mockito.core.version>5.11.0</mockito.core.version>
-    <mockito.inline.version>5.2.0</mockito.inline.version>
+    <mockito.core.version>5.14.2</mockito.core.version>
     <checker.framework.version>3.48.1</checker.framework.version>
     <logback.version>1.5.11</logback.version>
     <doclint>none</doclint>


### PR DESCRIPTION
### What changes are included in this PR?

Update Mockito version to latest/current version (5.14.2).

Also remove mockito-inline dependency as the code is now part of mockito-core.

Fixes Java 23 compatibility

### Are these changes tested?

CI/CD (no new tests)

### Are there any user-facing changes?

No