### PR TITLE
MINOR: [Release] Fix issue listing versions in post-10-docs.sh

### DIFF
--- a/dev/release/post-10-docs.sh
+++ b/dev/release/post-10-docs.sh
@@ -56,7 +56,7 @@ git branch -D ${branch_name} || :
 git checkout -b ${branch_name}
 # list and remove previous versioned docs
 versioned_paths=()
-for versioned_path in docs/*.0/; do
+for versioned_path in docs/*.*/; do
   versioned_paths+=(${versioned_path})
   rm -rf ${versioned_path}
 done


### PR DESCRIPTION
### Rationale for this change

While testing the docs script (post-10-docs.sh) during the 18 release process, I noticed that the 16.1 docs got moved underneath the 17.0 docs folder. i.e., moved to `docs/17.0/16.1`. Which isn't right. This is because the previous glob pattern was `*.0` which doesn't match `16.1`.

### What changes are included in this PR?

Just a change to post-10-docs.sh updating the glob.

### Are these changes tested?

Yes, locally. I used this updated script to generate https://github.com/apache/arrow-site/pull/553.

### Are there any user-facing changes?

No.