### PR TITLE
GH-44568: [Docs][Website] Remove 16.0 entry

### DIFF
--- a/docs/source/_static/versions.json
+++ b/docs/source/_static/versions.json
@@ -21,11 +21,6 @@
         "url": "https://arrow.apache.org/docs/16.1/"
     },
     {
-        "name": "16.0",
-        "version": "16.0/",
-        "url": "https://arrow.apache.org/docs/16.0/"
-    },
-    {
         "name": "15.0",
         "version": "15.0/",
         "url": "https://arrow.apache.org/docs/15.0/"


### PR DESCRIPTION
### Rationale for this change

Because https://arrow.apache.org/docs/16.0/ doesn't exist.

### What changes are included in this PR?

Remove the 16.0 entry.

### Are these changes tested?

No.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44568