### PR TITLE
GH-44574: [Release] Ensure using the release tag to build binaries

### DIFF
--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -32,7 +32,8 @@ release_tag="apache-arrow-${version}-rc${rc}"
 rc_branch="release-${version_with_rc}"
 
 : ${ARROW_REPOSITORY:="apache/arrow"}
-: ${ARROW_BRANCH:=$release_tag}
+: ${ARROW_BRANCH:=${release_tag}}
+: ${ARROW_SHA:=${release_tag}}
 
 # archery will submit a job with id: "${crossbow_job_prefix}-0" unless there
 # are jobs submitted with the same prefix (the integer at the end is auto
@@ -43,6 +44,7 @@ archery crossbow submit \
     --arrow-version ${version_with_rc} \
     --arrow-remote "https://github.com/${ARROW_REPOSITORY}" \
     --arrow-branch ${ARROW_BRANCH} \
+    --arrow-sha ${ARROW_SHA} \
     --group packaging
 
 # archery will add a comment to the automatically generated PR to track


### PR DESCRIPTION
### Rationale for this change

We may use wrong commit with the current `dev/release/03-binary-submit.sh` because it uses the current commit on the checkout-ed branch.

### What changes are included in this PR?

Specify `--arrow-sha` explicitly to ensure using the release tag.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44574