### PR TITLE
GH-44581: [C++] Minor: ArrayData ctor can assign null_count directly

### DIFF
--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -150,25 +150,23 @@ struct ARROW_EXPORT ArrayData {
   ArrayData(ArrayData&& other) noexcept
       : type(std::move(other.type)),
         length(other.length),
+        null_count(other.null_count.load()),
         offset(other.offset),
         buffers(std::move(other.buffers)),
         child_data(std::move(other.child_data)),
         dictionary(std::move(other.dictionary)),
-        statistics(std::move(other.statistics)) {
-    SetNullCount(other.null_count);
-  }
+        statistics(std::move(other.statistics)) {}
 
   // Copy constructor
   ArrayData(const ArrayData& other) noexcept
       : type(other.type),
         length(other.length),
+        null_count(other.null_count.load()),
         offset(other.offset),
         buffers(other.buffers),
         child_data(other.child_data),
         dictionary(other.dictionary),
-        statistics(other.statistics) {
-    SetNullCount(other.null_count);
-  }
+        statistics(other.statistics) {}
 
   // Move assignment
   ArrayData& operator=(ArrayData&& other) {
@@ -324,7 +322,7 @@ struct ARROW_EXPORT ArrayData {
 
   /// \brief Return true if the validity bitmap may have 0's in it, or if the
   /// child arrays (in the case of types without a validity bitmap) may have
-  /// nulls, or if the dictionary of dictionay array may have nulls.
+  /// nulls, or if the dictionary of dictionary array may have nulls.
   ///
   /// This is not a drop-in replacement for MayHaveNulls, as historically
   /// MayHaveNulls() has been used to check for the presence of a validity
@@ -639,7 +637,7 @@ struct ARROW_EXPORT ArraySpan {
   bool HasVariadicBuffers() const;
 
  private:
-  ARROW_FRIEND_EXPORT friend bool internal::IsNullRunEndEncoded(const ArrayData& span,
+  ARROW_FRIEND_EXPORT friend bool internal::IsNullRunEndEncoded(const ArrayData& data,
                                                                 int64_t i);
 
   bool IsNullSparseUnion(int64_t i) const;

--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -98,7 +98,7 @@ class ARROW_EXPORT ExtensionType : public DataType {
 
  protected:
   explicit ExtensionType(std::shared_ptr<DataType> storage_type)
-      : DataType(Type::EXTENSION), storage_type_(storage_type) {}
+      : DataType(Type::EXTENSION), storage_type_(std::move(storage_type)) {}
 
   std::shared_ptr<DataType> storage_type_;
 };


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

See https://godbolt.org/z/37reoKTfK

The `ArrayData` ctor can assign `null_count` directly, rather than `SetNullCount`.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Change `null_count` assigned directly

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Covered by existing

### Are there any user-facing changes?

No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44581