### PR TITLE
Implement 64-bit integer based replacements for .NET memory types

### DIFF
--- a/csharp/src/Apache.Arrow/Memory/LongMemory.cs
+++ b/csharp/src/Apache.Arrow/Memory/LongMemory.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Apache.Arrow.Memory
+{
+    internal readonly struct LongMemory<T>
+    {
+        private readonly T[] _array;
+        private readonly long _length;
+
+        public LongMemory(long length)
+        {
+            if (length < 0 || length > _array.Length) throw new ArgumentOutOfRangeException(nameof(length));
+            _array = new T[length];
+            _length = length;
+        }
+
+        public long Length
+        {
+            get { return _length; }
+        }
+
+        public T this[long index]
+        {
+            get
+            {
+                if (index < 0 || index >= _array.Length)
+                {
+                    throw new IndexOutOfRangeException("Index is out of range.");
+                }
+                return _array[index];
+            }
+
+            set
+            {
+                if (index < 0 || index >= _length)
+                    throw new IndexOutOfRangeException("Index is out of range.");
+                _array[index] = value;
+            }
+        }
+
+        public void CopyTo(LongMemory<T> destination)
+        {
+            if (destination.Length < _length)
+            {
+                throw new ArgumentException("Destination memory is not long enough.", nameof(destination));
+            }
+
+            for (long i = 0; i < _length; i++)
+            {
+                destination[i] = _array[i];
+            }
+        }
+
+        public Span<T> Span
+        {
+            get { return _array.AsSpan(0, (int)_length); }
+        }   
+        public void Clear()
+        {
+            for (long i = 0; i < _length; i++)
+            {
+                _array[i] = default!;
+            }
+        }
+    }
+}

--- a/csharp/src/Apache.Arrow/Memory/LongMemoryManager.cs
+++ b/csharp/src/Apache.Arrow/Memory/LongMemoryManager.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Apache.Arrow.Memory
+{
+    internal class LongMemoryManager: MemoryManager<byte>
+    {
+        private readonly LongMemory<byte> _memory;
+
+        public LongMemoryManager(long length)
+        {
+            _memory = new LongMemory<byte>(length);
+        }
+
+        public override MemoryHandle Pin(int elementIndex = 0)
+        {
+            
+        }
+        public override void Unpin()
+        {
+
+        }
+        public override Memory<byte> Memory
+        {
+            
+        }
+        public override Span<byte> GetSpan()
+        {
+            return _memory.Span;
+        }
+
+        public override void Dispose(bool Disposing)
+        {
+
+        }
+
+    }
+}

--- a/csharp/src/Apache.Arrow/Memory/LongMemoryOwner.cs
+++ b/csharp/src/Apache.Arrow/Memory/LongMemoryOwner.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Apache.Arrow.Memory
+{
+    internal class LongMemoryOwner<T>: IMemoryOwner<T>
+    {
+        private readonly LongMemory<T> _memory;
+
+        public LongMemoryOwner(long length)
+        {
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), "Length must be non-negative.");
+
+            _memory = new LongMemory<T>(length);
+        }
+
+        public Memory<T> Memory
+        {
+            get { return new Memory<T>(); }
+        }
+
+        public void Dispose()
+        {
+
+        }
+    }
+}

--- a/csharp/src/Apache.Arrow/Memory/LongReadOnlyMemory.cs
+++ b/csharp/src/Apache.Arrow/Memory/LongReadOnlyMemory.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Apache.Arrow.Memory
+{
+    internal readonly struct LongReadOnlyMemory<T>
+    {
+        private readonly LongMemory<T> _memory;
+        public LongReadOnlyMemory(LongMemory<T> memory)
+        {
+            _memory = memory;
+        }
+
+        public long Length
+        {
+            get { return _memory.Length; }
+        }
+
+        public T this[long index]
+        {
+            get
+            {
+                if (index < 0 || index >= Length)
+                    throw new IndexOutOfRangeException("Index is out of range.");
+                return _memory[index];
+            }
+        }
+
+        public LongSpan<T> Span {
+            get
+            {
+                return new LongSpan<T>(_memory);
+            }
+        }
+
+        public LongReadOnlySpan<T> ReadOnlySpan
+        {
+            get { return new LongReadOnlySpan<T>(_memory); }
+        }
+
+    }
+}

--- a/csharp/src/Apache.Arrow/Memory/LongReadOnlySpan.cs
+++ b/csharp/src/Apache.Arrow/Memory/LongReadOnlySpan.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Apache.Arrow.Memory
+{
+    internal readonly struct LongReadOnlySpan<T>
+    {
+        private readonly LongMemory<T> _memory;
+
+        public LongReadOnlySpan(LongMemory<T> memory)
+        {
+            _memory = memory;
+        }
+
+        public long length
+        {
+            get { return _memory.Length; }
+        }
+
+        public T this[long index]
+        {
+            get
+            {
+                if (index < 0 || index >= _memory.Length)
+                {
+                    throw new IndexOutOfRangeException("Index is out of range.");
+                }
+                return _memory[index];
+            }
+        }
+
+        public Span<T> AsSpan()
+        {
+            return _memory.Span;
+        }
+
+    }
+}

--- a/csharp/src/Apache.Arrow/Memory/LongSpan.cs
+++ b/csharp/src/Apache.Arrow/Memory/LongSpan.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Apache.Arrow.Memory
+{
+    internal readonly struct LongSpan<T>
+    {
+        private readonly LongMemory<T> _memory;
+
+        public LongSpan(LongMemory<T> memory)
+        {
+            _memory = memory;
+        }
+
+        public long Length
+        {
+            get { return _memory.Length; }
+        }
+
+        public T this[long index]
+        {
+            get
+            {
+                if (index < 0 || index >= Length)
+                {
+                    throw new IndexOutOfRangeException("Index is out of range.");
+                }
+                return _memory[index];
+            }
+        }
+
+        public Span<T> AsSpan()
+        {
+            return _memory.Span;
+        }
+    }
+}


### PR DESCRIPTION
This PR implements 64-bit integer based replacements for .NET memory types for Span, ReadOnlySpan, Memory, ReadOnlyMemory, MemoryOwner and MemoryManager.