### PR TITLE
GH-44555: [C++][Compute] Allow casting struct to bigger nullable struct

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -367,16 +367,18 @@ struct CastStruct {
           }
           // Found matching in_field and out_field.
           fields_to_select[out_field_index++] = in_field_index;
-          // Using the same in_field for multiple out_fields is not allowed. 
+          // Using the same in_field for multiple out_fields is not allowed.
           in_field_index++;
           continue;
         }
       }
       if (all_in_field_names.count(out_field->name()) == 0 && out_field->nullable()) {
-        // Didn't match current in_field, but we can fill with null. 
-        // Filling with null is only acceptable on nuallable fields when there 
+        // Didn't match current in_field, but we can fill with null.
+        // Filling with null is only acceptable on nuallable fields when there
         // is definitely no in_field with matching name.
-        fields_to_select[out_field_index++] = -2;  // -2 is a sentinel value for fill with null. 
+
+        // -2 is a sentinel value indicating fill with null.
+        fields_to_select[out_field_index++] = -2;
       } else if (in_field_index < in_field_count) {
         // Didn't match current in_field, and the we cannot fill with null, so
         // try next in_field.

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -349,7 +349,6 @@ struct CastStruct {
 
     std::vector<int> fields_to_select(out_field_count, -1);
 
-    // create a set of field names
     std::set<std::string> in_field_names;
     for (int in_field_index = 0; in_field_index < in_field_count; ++in_field_index) {
       in_field_names.insert(in_type.field(in_field_index)->name());
@@ -357,8 +356,7 @@ struct CastStruct {
 
     int out_field_index = 0;
     for (int in_field_index = 0;
-         in_field_index < in_field_count && out_field_index < out_field_count;
-         ++in_field_index) {
+         in_field_index < in_field_count && out_field_index < out_field_count;) {
       const auto& in_field = in_type.field(in_field_index);
       const auto& out_field = out_type.field(out_field_index);
       if (in_field->name() == out_field->name()) {
@@ -367,6 +365,7 @@ struct CastStruct {
                                    in_type.ToString(), " ", out_type.ToString());
         }
         fields_to_select[out_field_index++] = in_field_index;
+        in_field_index++;
       } else if (in_field_names.count(out_field->name()) == 0) {
         if (out_field->nullable()) {
           fields_to_select[out_field_index++] = -2;
@@ -375,6 +374,8 @@ struct CastStruct {
               "struct fields don't match or are in the wrong order: Input fields: ",
               in_type.ToString(), " output fields: ", out_type.ToString());
         }
+      } else {
+        in_field_index++;
       }
     }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -374,7 +374,7 @@ struct CastStruct {
       }
       if (all_in_field_names.count(out_field->name()) == 0 && out_field->nullable()) {
         // Didn't match current in_field, but we can fill with null.
-        // Filling with null is only acceptable on nuallable fields when there
+        // Filling with null is only acceptable on nullable fields when there
         // is definitely no in_field with matching name.
 
         // -2 is a sentinel value indicating fill with null.

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -363,8 +363,6 @@ struct CastStruct {
       }
     }
 
-
-
     const ArraySpan& in_array = batch[0].array;
     ArrayData* out_array = out->array_data().get();
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -371,7 +371,7 @@ struct CastStruct {
         }
       }
       if (in_field_names.count(out_field->name()) == 0 && out_field->nullable()) {
-        // There will not be any matching in_field but we can fill with null.
+        // Didn't match current in_field, but we can will with null.
         fields_to_select[out_field_index++] = -2;
       } else if (in_field_index < in_field_count) {
         // Didn't match current in_field, and the we cannot fill with null, so

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -340,9 +340,9 @@ struct CastFixedList {
 };
 
 struct CastStruct {
-  static constexpr int kFillNullSentinel = -2;
-
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+    static constexpr int kFillNullSentinel = -2;
+
     const CastOptions& options = CastState::Get(ctx);
     const auto& in_type = checked_cast<const StructType&>(*batch[0].type());
     const auto& out_type = checked_cast<const StructType&>(*out->type());

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2571,34 +2571,34 @@ static void CheckStructToStructSubset(
                            StructArray::Make({a1, d1, nulls}, {"a", "d", "f"}));
       CheckCast(src, dest6);
 
-      const auto dest6_5 = arrow::struct_(
+      const auto dest7 = arrow::struct_(
           {std::make_shared<Field>("a", int8()), std::make_shared<Field>("d", int16()),
            std::make_shared<Field>("f", int64(), /*nullable=*/false)});
-      const auto options6_5 = CastOptions::Safe(dest6_5);
-      EXPECT_RAISES_WITH_MESSAGE_THAT(
-          TypeError,
-          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
-          Cast(src, options6_5));
-
-      // fields in wrong order
-      const auto dest7 = arrow::struct_({std::make_shared<Field>("a", int8()),
-                                         std::make_shared<Field>("c", int16()),
-                                         std::make_shared<Field>("b", int64())});
       const auto options7 = CastOptions::Safe(dest7);
       EXPECT_RAISES_WITH_MESSAGE_THAT(
           TypeError,
           ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
           Cast(src, options7));
 
-      // duplicate missing field names
-      const auto dest8 = arrow::struct_(
-          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("c", int16()),
-           std::make_shared<Field>("d", int32()), std::make_shared<Field>("a", int64())});
+      // fields in wrong order
+      const auto dest8 = arrow::struct_({std::make_shared<Field>("a", int8()),
+                                         std::make_shared<Field>("c", int16()),
+                                         std::make_shared<Field>("b", int64())});
       const auto options8 = CastOptions::Safe(dest8);
       EXPECT_RAISES_WITH_MESSAGE_THAT(
           TypeError,
           ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
           Cast(src, options8));
+
+      // duplicate missing field names
+      const auto dest9 = arrow::struct_(
+          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("c", int16()),
+           std::make_shared<Field>("d", int32()), std::make_shared<Field>("a", int64())});
+      const auto options9 = CastOptions::Safe(dest9);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src, options9));
 
       // duplicate present field names
       ASSERT_OK_AND_ASSIGN(
@@ -2687,34 +2687,34 @@ static void CheckStructToStructSubsetWithNulls(
           StructArray::Make({a1, d1, nulls}, {"a", "d", "f"}, null_bitmap));
       CheckCast(src_null, dest6_null);
 
-      const auto dest6_5_null = arrow::struct_(
+      const auto dest7_null = arrow::struct_(
           {std::make_shared<Field>("a", int8()), std::make_shared<Field>("d", int16()),
            std::make_shared<Field>("f", int64(), /*nullable=*/false)});
-      const auto options6_5_null = CastOptions::Safe(dest6_5_null);
-      EXPECT_RAISES_WITH_MESSAGE_THAT(
-          TypeError,
-          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
-          Cast(src_null, options6_5_null));
-
-      // fields in wrong order
-      const auto dest7_null = arrow::struct_({std::make_shared<Field>("a", int8()),
-                                              std::make_shared<Field>("c", int16()),
-                                              std::make_shared<Field>("b", int64())});
       const auto options7_null = CastOptions::Safe(dest7_null);
       EXPECT_RAISES_WITH_MESSAGE_THAT(
           TypeError,
           ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
           Cast(src_null, options7_null));
 
-      // duplicate missing field names
-      const auto dest8_null = arrow::struct_(
-          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("c", int16()),
-           std::make_shared<Field>("d", int32()), std::make_shared<Field>("a", int64())});
+      // fields in wrong order
+      const auto dest8_null = arrow::struct_({std::make_shared<Field>("a", int8()),
+                                              std::make_shared<Field>("c", int16()),
+                                              std::make_shared<Field>("b", int64())});
       const auto options8_null = CastOptions::Safe(dest8_null);
       EXPECT_RAISES_WITH_MESSAGE_THAT(
           TypeError,
           ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
           Cast(src_null, options8_null));
+
+      // duplicate missing field names
+      const auto dest9_null = arrow::struct_(
+          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("c", int16()),
+           std::make_shared<Field>("d", int32()), std::make_shared<Field>("a", int64())});
+      const auto options9_null = CastOptions::Safe(dest9_null);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src_null, options9_null));
 
       // duplicate present field values
       ASSERT_OK_AND_ASSIGN(
@@ -2746,7 +2746,7 @@ TEST(Cast, StructToSameSizedAndNamedStruct) { CheckStructToStruct(NumericTypes()
 TEST(Cast, StructToStructSubset) { CheckStructToStructSubset(NumericTypes()); }
 
 TEST(Cast, StructToStructSubsetWithNulls) {
-  CheckStructToStructSubsetWithNulls({int8()});
+  CheckStructToStructSubsetWithNulls(NumericTypes());
 }
 
 TEST(Cast, StructToSameSizedButDifferentNamedStruct) {
@@ -2757,9 +2757,9 @@ TEST(Cast, StructToSameSizedButDifferentNamedStruct) {
   auto nulls = ArrayFromJSON(int8(), "[null, null]");
   ASSERT_OK_AND_ASSIGN(auto src, StructArray::Make({a, b}, src_field_names));
 
-  std::vector<std::string> dest_field_names = {"c", "d"};
-  ASSERT_OK_AND_ASSIGN(auto dest, StructArray::Make({nulls, nulls}, dest_field_names));
-  CheckCast(src, dest);
+  std::vector<std::string> dest1_field_names = {"c", "d"};
+  ASSERT_OK_AND_ASSIGN(auto dest1, StructArray::Make({nulls, nulls}, dest1_field_names));
+  CheckCast(src, dest1);
 
   const auto dest2 = arrow::struct_(
       {std::make_shared<Field>("c", int8(), /*nullable=*/false), std::make_shared<Field>("d", int8())});
@@ -2778,15 +2778,15 @@ TEST(Cast, StructToBiggerStruct) {
   b = ArrayFromJSON(int8(), "[3, 4]");
   ASSERT_OK_AND_ASSIGN(auto src, StructArray::Make({a, b}, field_names));
 
-  const auto dest = arrow::struct_(
+  const auto dest1 = arrow::struct_(
       {std::make_shared<Field>("a", int8()), std::make_shared<Field>("b", int8()),
        std::make_shared<Field>("c", int8(), /*nullable=*/false)});
-  const auto options = CastOptions::Safe(dest);
+  const auto options1 = CastOptions::Safe(dest1);
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       TypeError,
       ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
-      Cast(src, options));
+      Cast(src, options1));
 
   const auto dest2 =
       arrow::struct_({std::make_shared<Field>("a", int8()),

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2760,9 +2760,10 @@ TEST(Cast, StructToBiggerStruct) {
   b = ArrayFromJSON(int8(), "[3, 4]");
   ASSERT_OK_AND_ASSIGN(auto src, StructArray::Make({a, b}, field_names));
 
-  const auto dest = arrow::struct_({std::make_shared<Field>("a", int8(), /*nullable=*/false),
-                                    std::make_shared<Field>("b", int8(), /*nullable=*/false),
-                                    std::make_shared<Field>("c", int8(), /*nullable=*/false)});
+  const auto dest =
+      arrow::struct_({std::make_shared<Field>("a", int8()),
+                      std::make_shared<Field>("b", int8()),
+                      std::make_shared<Field>("c", int8(), /*nullable=*/false)});
   const auto options = CastOptions::Safe(dest);
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(
@@ -2776,26 +2777,16 @@ TEST(Cast, StructToBiggerNullableStruct) {
   std::shared_ptr<Array> a, b, c;
   a = ArrayFromJSON(int8(), "[1, 2]");
   b = ArrayFromJSON(int8(), "[3, 4]");
-  c = ArrayFromJSON(int8(), "[null, null]");
   ASSERT_OK_AND_ASSIGN(auto src, StructArray::Make({a, b}, field_names));
 
-  const auto fields_dest = arrow::struct_({std::make_shared<Field>("a", int8()),
-                                    std::make_shared<Field>("b", int8()),
-                                    std::make_shared<Field>("c", int8())});
-  const auto options = CastOptions::Safe(fields_dest);
+  const auto type_dest = arrow::struct_(
+      {std::make_shared<Field>("a", int8()), std::make_shared<Field>("b", int8()),
+       std::make_shared<Field>("c", int8(), /*nullable=*/true)});
+  const auto options = CastOptions::Safe(type_dest);
 
-  // std::vector<std::shared_ptr<Field>> fields_src_nullable = {
-  //       std::make_shared<Field>("a", int8(), true),
-  //       std::make_shared<Field>("b", int8(), true),
-  //       std::make_shared<Field>("c", int8(), true)};
-
-  ASSERT_OK_AND_ASSIGN(auto out, Cast(src, options));
-  std::cout << out.ToString() << std::endl;
-
-  // ASSERT_OK_AND_ASSIGN(
-  //   auto dest,
-  //   StructArray::Make({a, b, c}, {"a", "b", "c"}));
-  // CheckCast(src, dest, options);
+  c = ArrayFromJSON(int8(), "[null, null]");
+  ASSERT_OK_AND_ASSIGN(auto dest, StructArray::Make({a, b, c}, {"a", "b", "c"}));
+  CheckCast(src, dest);
 }
 
 TEST(Cast, StructToDifferentNullabilityStruct) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2761,8 +2761,9 @@ TEST(Cast, StructToSameSizedButDifferentNamedStruct) {
   ASSERT_OK_AND_ASSIGN(auto dest1, StructArray::Make({nulls, nulls}, dest1_field_names));
   CheckCast(src, dest1);
 
-  const auto dest2 = arrow::struct_(
-      {std::make_shared<Field>("c", int8(), /*nullable=*/false), std::make_shared<Field>("d", int8())});
+  const auto dest2 =
+      arrow::struct_({std::make_shared<Field>("c", int8(), /*nullable=*/false),
+                      std::make_shared<Field>("d", int8())});
   const auto options2 = CastOptions::Safe(dest2);
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2760,6 +2760,17 @@ TEST(Cast, StructToBiggerStruct) {
       TypeError,
       ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
       Cast(src, options));
+
+  const auto dest2 =
+      arrow::struct_({std::make_shared<Field>("a", int8()),
+                      std::make_shared<Field>("c", int8(), /*nullable=*/false),
+                      std::make_shared<Field>("b", int8())});
+  const auto options2 = CastOptions::Safe(dest2);
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      TypeError,
+      ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+      Cast(src, options2));
 }
 
 TEST(Cast, StructToBiggerNullableStruct) {
@@ -2772,6 +2783,9 @@ TEST(Cast, StructToBiggerNullableStruct) {
   c = ArrayFromJSON(int8(), "[null, null]");
   ASSERT_OK_AND_ASSIGN(auto dest, StructArray::Make({a, b, c}, {"a", "b", "c"}));
   CheckCast(src, dest);
+
+  ASSERT_OK_AND_ASSIGN(auto dest2, StructArray::Make({a, c, b}, {"a", "c", "b"}));
+  CheckCast(src, dest2);
 }
 
 TEST(Cast, StructToDifferentNullabilityStruct) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2728,7 +2728,7 @@ TEST(Cast, StructToSameSizedAndNamedStruct) { CheckStructToStruct(NumericTypes()
 TEST(Cast, StructToStructSubset) { CheckStructToStructSubset(NumericTypes()); }
 
 TEST(Cast, StructToStructSubsetWithNulls) {
-  CheckStructToStructSubsetWithNulls({int16()});
+  CheckStructToStructSubsetWithNulls(NumericTypes());
 }
 
 TEST(Cast, StructToSameSizedButDifferentNamedStruct) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -2571,6 +2571,15 @@ static void CheckStructToStructSubset(
                            StructArray::Make({a1, d1, nulls}, {"a", "d", "f"}));
       CheckCast(src, dest6);
 
+      const auto dest6_5 = arrow::struct_(
+          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("d", int16()),
+           std::make_shared<Field>("f", int64(), /*nullable=*/false)});
+      const auto options6_5 = CastOptions::Safe(dest6_5);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src, options6_5));
+
       // fields in wrong order
       const auto dest7 = arrow::struct_({std::make_shared<Field>("a", int8()),
                                          std::make_shared<Field>("c", int16()),
@@ -2678,6 +2687,15 @@ static void CheckStructToStructSubsetWithNulls(
           StructArray::Make({a1, d1, nulls}, {"a", "d", "f"}, null_bitmap));
       CheckCast(src_null, dest6_null);
 
+      const auto dest6_5_null = arrow::struct_(
+          {std::make_shared<Field>("a", int8()), std::make_shared<Field>("d", int16()),
+           std::make_shared<Field>("f", int64(), /*nullable=*/false)});
+      const auto options6_5_null = CastOptions::Safe(dest6_5_null);
+      EXPECT_RAISES_WITH_MESSAGE_THAT(
+          TypeError,
+          ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+          Cast(src_null, options6_5_null));
+
       // fields in wrong order
       const auto dest7_null = arrow::struct_({std::make_shared<Field>("a", int8()),
                                               std::make_shared<Field>("c", int16()),
@@ -2728,7 +2746,7 @@ TEST(Cast, StructToSameSizedAndNamedStruct) { CheckStructToStruct(NumericTypes()
 TEST(Cast, StructToStructSubset) { CheckStructToStructSubset(NumericTypes()); }
 
 TEST(Cast, StructToStructSubsetWithNulls) {
-  CheckStructToStructSubsetWithNulls(NumericTypes());
+  CheckStructToStructSubsetWithNulls({int8()});
 }
 
 TEST(Cast, StructToSameSizedButDifferentNamedStruct) {
@@ -2742,6 +2760,15 @@ TEST(Cast, StructToSameSizedButDifferentNamedStruct) {
   std::vector<std::string> dest_field_names = {"c", "d"};
   ASSERT_OK_AND_ASSIGN(auto dest, StructArray::Make({nulls, nulls}, dest_field_names));
   CheckCast(src, dest);
+
+  const auto dest2 = arrow::struct_(
+      {std::make_shared<Field>("c", int8(), /*nullable=*/false), std::make_shared<Field>("d", int8())});
+  const auto options2 = CastOptions::Safe(dest2);
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      TypeError,
+      ::testing::HasSubstr("struct fields don't match or are in the wrong order"),
+      Cast(src, options2));
 }
 
 TEST(Cast, StructToBiggerStruct) {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -2557,7 +2557,7 @@ TEST(ScanNode, MaterializationOfNestedVirtualColumn) {
     auto c_data = batch.values[2].array()->Copy();
     c_data->child_data.insert(c_data->child_data.begin(), nulls->data());
     c_data->type = nested.dataset->schema()->field(2)->type();
-    auto c_array = std::make_shared<Int64Array>(c_data);
+    auto c_array = std::make_shared<StructArray>(c_data);
     batch.values[2] = c_array;
   }
 

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -2549,7 +2549,7 @@ TEST(ScanNode, MaterializationOfNestedVirtualColumn) {
   auto expected = nested.batches;
 
   for (auto& batch : expected) {
-    // Scan will fill in "c.d" with nulls. 
+    // Scan will fill in "c.d" with nulls.
     ASSERT_OK_AND_ASSIGN(auto nulls,
                          MakeArrayOfNull(int64()->GetSharedPtr(), batch.length));
     auto c_data = batch.values[2].array()->Copy();

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -2343,17 +2343,17 @@ DatasetAndBatches MakeNestedDataset() {
                                    {
                                        {
                                            R"([{"a": 1,    "b": null,  "c": {"e": 0}},
-                  {"a": 2,    "b": true,  "c": {"e": 1}}])",
+                                               {"a": 2,    "b": true,  "c": {"e": 1}}])",
                                            R"([{"a": null, "b": true,  "c": {"e": 2}},
-                  {"a": 3,    "b": false, "c": {"e": null}}])",
+                                               {"a": 3,    "b": false, "c": {"e": null}}])",
                                            R"([{"a": null, "b": null,  "c": null}])",
                                        },
                                        {
                                            R"([{"a": null, "b": true,  "c": {"e": 4}},
-                  {"a": 4,    "b": false, "c": null}])",
+                                               {"a": 4,    "b": false, "c": null}])",
                                            R"([{"a": 5,    "b": null,  "c": {"e": 6}},
-                  {"a": 6,    "b": false, "c": {"e": 7}},
-                  {"a": 7,    "b": false, "c": {"e": null}}])",
+                                               {"a": 6,    "b": false, "c": {"e": 7}},
+                                               {"a": 7,    "b": false, "c": {"e": null}}])",
                                        },
                                    },
                                    /*guarantees=*/{});
@@ -2536,17 +2536,15 @@ TEST(ScanNode, MaterializationOfNestedVirtualColumn) {
   auto options = std::make_shared<ScanOptions>();
   options->projection = Materialize({"a", "b", "c"}, /*include_aug_fields=*/true);
 
-  ASSERT_OK(
-      acero::Declaration::Sequence({
-                                       {"scan", ScanNodeOptions{nested.dataset, options}},
-                                       {"augmented_project", acero::ProjectNodeOptions{{
-                                                                 field_ref("a"),
-                                                                 field_ref("b"),
-                                                                 field_ref("c"),
-                                                             }}},
-                                       {"sink", acero::SinkNodeOptions{&plan.sink_gen}},
-                                   })
-          .AddToPlan(plan.get()));
+  ASSERT_OK(acero::Declaration::Sequence(
+                {
+                    {"scan", ScanNodeOptions{nested.dataset, options}},
+                    {"augmented_project",
+                     acero::ProjectNodeOptions{
+                         {field_ref("a"), field_ref("b"), field_ref("c")}}},
+                    {"sink", acero::SinkNodeOptions{&plan.sink_gen}},
+                })
+                .AddToPlan(plan.get()));
 
   auto expected = nested.batches;
 

--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -164,8 +164,10 @@ bool Datum::Equals(const Datum& other) const {
       return true;
     case Datum::SCALAR:
       return internal::SharedPtrEquals(this->scalar(), other.scalar());
-    case Datum::ARRAY:
-      return internal::SharedPtrEquals(this->make_array(), other.make_array());
+    case Datum::ARRAY: {
+      bool equal = internal::SharedPtrEquals(this->make_array(), other.make_array());
+      return equal;
+    }
     case Datum::CHUNKED_ARRAY:
       return internal::SharedPtrEquals(this->chunked_array(), other.chunked_array());
     case Datum::RECORD_BATCH:

--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -164,10 +164,8 @@ bool Datum::Equals(const Datum& other) const {
       return true;
     case Datum::SCALAR:
       return internal::SharedPtrEquals(this->scalar(), other.scalar());
-    case Datum::ARRAY: {
-      bool equal = internal::SharedPtrEquals(this->make_array(), other.make_array());
-      return equal;
-    }
+    case Datum::ARRAY:
+      return internal::SharedPtrEquals(this->make_array(), other.make_array());
     case Datum::CHUNKED_ARRAY:
       return internal::SharedPtrEquals(this->chunked_array(), other.chunked_array());
     case Datum::RECORD_BATCH:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
Sometimes its useful to add a column full of nulls in a cast. Currently this is supported in top level columns but not inside structs. Example where this is important: https://github.com/delta-io/delta-rs/issues/1610

### What changes are included in this PR?
Add support for filling in columns full of null for nullable struct fields. 
I've gone for a fairly minimal change that achieves what I needed but I wonder if there should be a more significant change so that this casting is done by field name and ignore the field order. 

### Are these changes tested?
Yes. The expected behaviour in several existing tests has been altered and a couple of new tests have been added.

I also rolled out a custom build with this change internally because it suddenly became a critical problem. 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
Yes. There are scenarios that previously failed with `struct fields don't match or are in the wrong order` but now succeed after filling in `null`s.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44555