### PR TITLE
GH-44590: [C++] Add `const` and `&` to `arrow::Array::statistics()` return type

### DIFF
--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -237,8 +237,8 @@ class ARROW_EXPORT Array {
   /// This just delegates to calling statistics on the underlying ArrayData
   /// object which backs this Array.
   ///
-  /// \return const ArrayStatistics&
-  std::shared_ptr<ArrayStatistics> statistics() const { return data_->statistics; }
+  /// \return const std::shared_ptr<ArrayStatistics>&
+  const std::shared_ptr<ArrayStatistics>& statistics() const { return data_->statistics; }
 
  protected:
   Array() = default;


### PR DESCRIPTION
### Rationale for this change

It must be immutable.

### What changes are included in this PR?

Add missing `const` and `&`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**
* GitHub Issue: #44590