### PR TITLE
GH-44578: [Release][Packaging] Verify wheel version

### DIFF
--- a/ci/scripts/python_wheel_unix_test.sh
+++ b/ci/scripts/python_wheel_unix_test.sh
@@ -91,6 +91,8 @@ fi
 if [ "${CHECK_VERSION}" == "ON" ]; then
   pyarrow_version=$(python -c "import pyarrow; print(pyarrow.__version__)")
   [ "${pyarrow_version}" = "${ARROW_VERSION}" ]
+  arrow_cpp_version=$(python -c "import pyarrow; print(pyarrow.cpp_build_info.version)")
+  [ "${arrow_cpp_version}" = "${ARROW_VERSION}" ]
 fi
 
 if [ "${CHECK_WHEEL_CONTENT}" == "ON" ]; then

--- a/ci/scripts/python_wheel_unix_test.sh
+++ b/ci/scripts/python_wheel_unix_test.sh
@@ -88,6 +88,11 @@ import pyarrow.parquet
   fi
 fi
 
+if [ "${CHECK_VERSION}" == "ON" ]; then
+  pyarrow_version=$(python -c "import pyarrow; print(pyarrow.__version__)")
+  [ "${pyarrow_version}" = "${ARROW_VERSION}" ]
+fi
+
 if [ "${CHECK_WHEEL_CONTENT}" == "ON" ]; then
   python ${source_dir}/ci/scripts/python_wheel_validate_contents.py \
     --path ${source_dir}/python/repaired_wheels

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1107,12 +1107,12 @@ test_macos_wheels() {
 
       pip install pyarrow-${VERSION}-cp${pyver/.}-cp${python/.}-${platform}.whl
       ARROW_FLIGHT=${check_flight} \
-        ARROW_GCS=${check_gcs}
+        ARROW_GCS=${check_gcs} \
         ARROW_S3=${check_s3} \
         ARROW_VERSION=${VERSION} \
         CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} \
         CHECK_VERSION=ON \
-        INSTALL_PYARROW=OFF
+        INSTALL_PYARROW=OFF \
         ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done
   done

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1061,7 +1061,11 @@ test_linux_wheels() {
         continue
       fi
       pip install pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-${platform}.whl
-      CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} INSTALL_PYARROW=OFF ARROW_GCS=${check_gcs} \
+      ARROW_GCS=${check_gcs} \
+        ARROW_VERSION=${VERSION} \
+        CHECK_VERSION=ON \
+        CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} \
+        INSTALL_PYARROW=OFF \
         ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done
   done
@@ -1102,8 +1106,13 @@ test_macos_wheels() {
       fi
 
       pip install pyarrow-${VERSION}-cp${pyver/.}-cp${python/.}-${platform}.whl
-      CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} INSTALL_PYARROW=OFF ARROW_FLIGHT=${check_flight} \
-        ARROW_GCS=${check_gcs} ARROW_S3=${check_s3} \
+      ARROW_FLIGHT=${check_flight} \
+        ARROW_GCS=${check_gcs}
+        ARROW_S3=${check_s3} \
+        ARROW_VERSION=${VERSION} \
+        CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} \
+        CHECK_VERSION=ON \
+        INSTALL_PYARROW=OFF
         ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done
   done

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1052,6 +1052,12 @@ test_linux_wheels() {
     local wheel_content="OFF"
   fi
 
+  if [ "${SOURCE_KIND}" = "tarball" ]; then
+    local check_version="ON"
+  else
+    local check_version="OFF"
+  fi
+
   for python in ${python_versions}; do
     local pyver=${python/m}
     for platform in ${platform_tags}; do
@@ -1063,7 +1069,7 @@ test_linux_wheels() {
       pip install pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-${platform}.whl
       ARROW_GCS=${check_gcs} \
         ARROW_VERSION=${VERSION} \
-        CHECK_VERSION=ON \
+        CHECK_VERSION=${check_version} \
         CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} \
         INSTALL_PYARROW=OFF \
         ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
@@ -1090,6 +1096,12 @@ test_macos_wheels() {
     local wheel_content="OFF"
   fi
 
+  if [ "${SOURCE_KIND}" = "tarball" ]; then
+    local check_version="ON"
+  else
+    local check_version="OFF"
+  fi
+
   # verify arch-native wheels inside an arch-native conda environment
   for python in ${python_versions}; do
     local pyver=${python/m}
@@ -1111,7 +1123,7 @@ test_macos_wheels() {
         ARROW_S3=${check_s3} \
         ARROW_VERSION=${VERSION} \
         CHECK_WHEEL_CONTENT=${wheel_content:-"ON"} \
-        CHECK_VERSION=ON \
+        CHECK_VERSION=${check_version} \
         INSTALL_PYARROW=OFF \
         ${ARROW_DIR}/ci/scripts/python_wheel_unix_test.sh ${ARROW_SOURCE_DIR}
     done


### PR DESCRIPTION
### Rationale for this change

We want to detect binary build from wrong source. 

### What changes are included in this PR?

Add version check. If we use wrong source, binary's version is `X.Y.Z-SNAPSHOT` not `X.Y.Z`. So the added check is failed.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44578