### PR TITLE
GH-43808: [C++] skip `-0117` in StrptimeZoneOffset for old glibc

### DIFF
--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -844,7 +844,7 @@ TEST(TimestampParser, StrptimeZoneOffset) {
 #if defined(__GLIBC__) && defined(__GLIBC_MINOR__)
 // glibc < 2.28 doesn't support "-0117" timezone offset.
 // See also: https://github.com/apache/arrow/issues/43808
-#  if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 28)
+#  if ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 28)) || (__GLIBC__ >= 3)
     "2018-01-01 00:00:00-0117",
 #  endif
 #else

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -842,11 +842,10 @@ TEST(TimestampParser, StrptimeZoneOffset) {
     "2018-01-01 00:00:00+0000",
     "2018-01-01 00:00:00+0100",
 #if defined(__GLIBC__) && defined(__GLIBC_MINOR__)
+// glibc < 2.28 doesn't support "-0117" timezone offset.
+// See also: https://github.com/apache/arrow/issues/43808
 #  if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 28)
     "2018-01-01 00:00:00-0117",
-#  else
-    // glibc < 2.28 doesn't support "-0117" timezone offset.
-    // See also: https://github.com/apache/arrow/issues/43808
 #  endif
 #else
     "2018-01-01 00:00:00-0117",

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -838,12 +838,26 @@ TEST(TimestampParser, StrptimeZoneOffset) {
   std::string format = "%Y-%d-%m %H:%M:%S%z";
   auto parser = TimestampParser::MakeStrptime(format);
 
+  std::vector<std::string> values = {
+    "2018-01-01 00:00:00+0000",
+    "2018-01-01 00:00:00+0100",
+#if defined(__GLIBC__) && defined(__GLIBC_MINOR__)
+#  if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ >= 28)
+    "2018-01-01 00:00:00-0117",
+#  else
+    // glibc < 2.28 doesn't support "-0117" timezone offset.
+    // See also: https://github.com/apache/arrow/issues/43808
+#  endif
+#else
+    "2018-01-01 00:00:00-0117",
+#endif
+    "2018-01-01 00:00:00+0130"
+  };
+
   // N.B. GNU %z supports ISO8601 format while BSD %z supports only
   // +HHMM or -HHMM and POSIX doesn't appear to define %z at all
   for (auto unit : TimeUnit::values()) {
-    for (const std::string value :
-         {"2018-01-01 00:00:00+0000", "2018-01-01 00:00:00+0100",
-          "2018-01-01 00:00:00+0130", "2018-01-01 00:00:00-0117"}) {
+    for (const std::string& value : values) {
       SCOPED_TRACE(value);
       int64_t converted = 0;
       int64_t expected = 0;


### PR DESCRIPTION
### Rationale for this change

Enable tests for libarrow in conda-forge: https://github.com/apache/arrow/issues/35587

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

old glibc does not actually support timezones like `-0117` (used in `StrptimeZoneOffset` test). The exact lower bound for glibc is hard for me to determine; I know that it passes with 2.28 and that it fails with 2.17. Anything in between is an open question. I went with the conservative option here.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Tested in https://github.com/conda-forge/arrow-cpp-feedstock/pull/1058

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43808