### PR TITLE
GH-44624: [CI][JS] Increase "AMD64 macOS 13 NodeJS 18" timeout

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -89,7 +89,7 @@ jobs:
     name: AMD64 macOS 13 NodeJS ${{ matrix.node }}
     runs-on: macos-13
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Rationale for this change

It took about 25m when it succeeded.

We need to increase timeout for stable CI.

### What changes are included in this PR?

Increase timeout to 45m from 30m.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44624